### PR TITLE
Refactor: Remove unnecessary parameter `avatar` and `map`

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -395,7 +395,7 @@ void aim_activity_actor::do_turn( player_activity &act, Character &who )
     avatar &you = get_avatar();
 
     item_location weapon = get_weapon();
-    if( !weapon || !avatar_action::can_fire_weapon( you, get_map(), *weapon ) ) {
+    if( !weapon || !avatar_action::can_fire_weapon( *weapon ) ) {
         aborted = true;
         act.moves_left = 0;
         return;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -417,7 +417,7 @@ void aim_activity_actor::do_turn( player_activity &act, Character &who )
     }
 
     g->temp_exit_fullscreen();
-    target_handler::trajectory trajectory = target_handler::mode_fire( you, *this );
+    target_handler::trajectory trajectory = target_handler::mode_fire( *this );
     g->reenter_fullscreen();
 
     if( aborted ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2817,16 +2817,14 @@ void activity_handlers::eat_menu_do_turn( player_activity *, Character *you )
 
 void activity_handlers::consume_food_menu_do_turn( player_activity *, Character * )
 {
-    avatar &player_character = get_avatar();
     item_location loc = game_menus::inv::consume_food();
-    avatar_action::eat( player_character, loc );
+    avatar_action::eat( loc );
 }
 
 void activity_handlers::consume_drink_menu_do_turn( player_activity *, Character * )
 {
-    avatar &player_character = get_avatar();
     item_location loc = game_menus::inv::consume_drink();
-    avatar_action::eat( player_character, loc );
+    avatar_action::eat( loc );
 }
 
 void activity_handlers::consume_meds_menu_do_turn( player_activity *, Character * )

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2810,9 +2810,7 @@ void activity_handlers::eat_menu_do_turn( player_activity *, Character *you )
         you->cancel_activity();
         return;
     }
-
-    avatar &player_character = get_avatar();
-    avatar_action::eat_or_use( player_character, game_menus::inv::consume() );
+    avatar_action::eat_or_use( game_menus::inv::consume() );
 }
 
 void activity_handlers::consume_food_menu_do_turn( player_activity *, Character * )
@@ -2829,8 +2827,7 @@ void activity_handlers::consume_drink_menu_do_turn( player_activity *, Character
 
 void activity_handlers::consume_meds_menu_do_turn( player_activity *, Character * )
 {
-    avatar &player_character = get_avatar();
-    avatar_action::eat_or_use( player_character, game_menus::inv::consume_meds() );
+    avatar_action::eat_or_use( game_menus::inv::consume_meds() );
 }
 
 void activity_handlers::move_loot_do_turn( player_activity *act, Character *you )

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -221,7 +221,7 @@ void avatar::longpull( const std::string &name )
 {
     item wtmp( itype_mut_longpull );
     g->temp_exit_fullscreen();
-    target_handler::trajectory traj = target_handler::mode_throw( *this, wtmp, false );
+    target_handler::trajectory traj = target_handler::mode_throw( wtmp, false );
     g->reenter_fullscreen();
     if( traj.empty() ) {
         return; // cancel

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -826,9 +826,9 @@ bool avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret
     return true;
 }
 
-void avatar_action::mend( avatar &you, item_location loc )
+void avatar_action::mend( item_location loc )
 {
-
+    avatar &you = get_avatar();
     if( you.fine_detail_vision_mod() > 4 ) {
         add_msg( m_bad, _( "It's too dark to work on mending this." ) );
         return;

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -778,9 +778,9 @@ void avatar_action::fire_ranged_mutation( Character &you, const item &fake_gun )
     you.assign_activity( aim_activity_actor::use_mutation( fake_gun ) );
 }
 
-void avatar_action::fire_ranged_bionic( avatar &you, const item &fake_gun )
+void avatar_action::fire_ranged_bionic( const item &fake_gun )
 {
-    you.assign_activity( aim_activity_actor::use_bionic( fake_gun ) );
+    get_avatar().assign_activity( aim_activity_actor::use_bionic( fake_gun ) );
 }
 
 bool avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret )

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -716,8 +716,10 @@ void avatar_action::autoattack()
 }
 
 // TODO: Move data/functions related to targeting out of game class
-bool avatar_action::can_fire_weapon( avatar &you, const map &m, const item &weapon )
+bool avatar_action::can_fire_weapon( const item &weapon )
 {
+    avatar &you = get_avatar();
+    const map &m = get_map();
     if( !weapon.is_gun() ) {
         debugmsg( "Expected item to be a gun" );
         return false;

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -718,15 +718,13 @@ void avatar_action::autoattack()
 // TODO: Move data/functions related to targeting out of game class
 bool avatar_action::can_fire_weapon( const item &weapon )
 {
-    avatar &you = get_avatar();
-    const map &m = get_map();
     if( !weapon.is_gun() ) {
         debugmsg( "Expected item to be a gun" );
         return false;
     }
 
-    if( !you.try_break_relax_gas( _( "Your eyes steel, and you raise your weapon!" ),
-                                  _( "You can't fire your weapon, it's too heavy…" ) ) ) {
+    if( !get_avatar().try_break_relax_gas( _( "Your eyes steel, and you raise your weapon!" ),
+                                           _( "You can't fire your weapon, it's too heavy…" ) ) ) {
         return false;
     }
 
@@ -734,7 +732,7 @@ bool avatar_action::can_fire_weapon( const item &weapon )
 
     for( const std::pair<const gun_mode_id, gun_mode> &mode_map : weapon.gun_all_modes() ) {
         bool check_common = gunmode_checks_common( messages, mode_map.second );
-        bool check_weapon = gunmode_checks_weapon( you, m, messages, mode_map.second );
+        bool check_weapon = gunmode_checks_weapon( messages, mode_map.second );
         bool can_use_mode = check_common && check_weapon;
         if( can_use_mode ) {
             return true;

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -747,8 +747,9 @@ bool avatar_action::can_fire_weapon( const item &weapon )
     return false;
 }
 
-void avatar_action::fire_wielded_weapon( avatar &you )
+void avatar_action::fire_wielded_weapon()
 {
+    avatar &you = get_avatar();
     const item_location weapon = you.get_wielded_item();
 
     if( !weapon ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -733,7 +733,7 @@ bool avatar_action::can_fire_weapon( const item &weapon )
     std::vector<std::string> messages;
 
     for( const std::pair<const gun_mode_id, gun_mode> &mode_map : weapon.gun_all_modes() ) {
-        bool check_common = gunmode_checks_common( you, m, messages, mode_map.second );
+        bool check_common = gunmode_checks_common( messages, mode_map.second );
         bool check_weapon = gunmode_checks_weapon( you, m, messages, mode_map.second );
         bool can_use_mode = check_common && check_weapon;
         if( can_use_mode ) {
@@ -808,8 +808,8 @@ bool avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret
     std::vector<std::string> messages;
     const std::map<gun_mode_id, gun_mode> gunmodes = turret.base()->gun_all_modes();
     if( !std::any_of( gunmodes.begin(), gunmodes.end(),
-    [&you, &m, &messages]( const std::pair<const gun_mode_id, gun_mode> &p ) {
-    return gunmode_checks_common( you, m, messages, p.second );
+    [&messages]( const std::pair<const gun_mode_id, gun_mode> &p ) {
+    return gunmode_checks_common( messages, p.second );
     } ) ) {
         // no gunmode is usable, dump reason messages why not
         for( const std::string &msg : messages ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -904,22 +904,24 @@ bool avatar_action::eat_here( avatar &you )
     return false;
 }
 
-void avatar_action::eat( avatar &you, item_location &loc )
+void avatar_action::eat( item_location &loc )
 {
+    avatar &you = get_avatar();
     std::string filter;
     if( !you.activity.str_values.empty() ) {
         filter = you.activity.str_values.back();
     }
-    avatar_action::eat( you, loc, you.activity.values, you.activity.targets, filter,
+    avatar_action::eat( loc, you.activity.values, you.activity.targets, filter,
                         you.activity.id() );
 }
 
-void avatar_action::eat( avatar &you, item_location &loc,
+void avatar_action::eat( item_location &loc,
                          const std::vector<int> &consume_menu_selections,
                          const std::vector<item_location> &consume_menu_selected_items,
                          const std::string &consume_menu_filter,
                          activity_id type )
 {
+    avatar &you = get_avatar();
     if( !loc ) {
         you.cancel_activity();
         add_msg( _( "Never mind." ) );
@@ -936,7 +938,7 @@ void avatar_action::eat_or_use( avatar &you, item_location loc )
     if( loc && loc->is_medical_tool() ) {
         avatar_action::use_item( you, loc, "heal" );
     } else {
-        avatar_action::eat( you, loc );
+        avatar_action::eat( loc );
     }
 }
 

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1181,8 +1181,9 @@ void avatar_action::use_item( item_location &loc, std::string const &method )
     you.invalidate_crafting_inventory();
 }
 
-void avatar_action::unload( avatar &you )
+void avatar_action::unload()
 {
+    avatar &you = get_avatar();
     std::pair<item_location, bool> ret = game_menus::inv::unload( you );
     if( !ret.first ) {
         add_msg( _( "Never mind." ) );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -677,8 +677,9 @@ static float rate_critter( const Creature &c )
     return m->type->difficulty;
 }
 
-void avatar_action::autoattack( avatar &you, map &m )
+void avatar_action::autoattack()
 {
+    avatar &you = get_avatar();
     const item_location weapon = you.get_wielded_item();
     int reach = weapon ? weapon->reach_range( you ) : 1;
     std::vector<Creature *> critters = you.get_targetable_creatures( reach, true );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -485,7 +485,7 @@ bool avatar_action::move( const tripoint &d )
                 add_msg( m_info, _( "%s to dive underwater." ),
                          press_x( ACTION_MOVE_DOWN ) );
             }
-            avatar_action::swim( get_map(), get_avatar(), dest_loc.raw() );
+            avatar_action::swim( dest_loc.raw() );
         }
 
         g->on_move_effects();
@@ -573,8 +573,10 @@ bool avatar_action::move( const tripoint &d )
     return false;
 }
 
-void avatar_action::swim( map &m, avatar &you, const tripoint &p )
+void avatar_action::swim( const tripoint &p )
 {
+    avatar &you = get_avatar();
+    map &m = get_map();
     if( !m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, p ) ) {
         dbg( D_ERROR ) << "game:plswim: Tried to swim in "
                        << m.tername( p ) << "!";

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -843,8 +843,9 @@ void avatar_action::mend( avatar &you, item_location loc )
     }
 }
 
-bool avatar_action::eat_here( avatar &you )
+bool avatar_action::eat_here()
 {
+    avatar &you = get_avatar();
     map &here = get_map();
     if( ( you.has_active_mutation( trait_RUMINANT ) || you.has_active_mutation( trait_GRAZER ) ) &&
         ( here.has_flag( ter_furn_flag::TFLAG_SHRUB, you.pos_bub() ) &&

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -820,7 +820,7 @@ bool avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret
 
     // all checks passed - start aiming
     g->temp_exit_fullscreen();
-    target_handler::trajectory trajectory = target_handler::mode_turret_manual( you, turret );
+    target_handler::trajectory trajectory = target_handler::mode_turret_manual( turret );
 
     if( !trajectory.empty() ) {
         turret.fire( you, trajectory.back() );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -176,8 +176,10 @@ static bool check_water_affect_items( avatar &you )
     return true;
 }
 
-bool avatar_action::move( avatar &you, map &m, const tripoint &d )
+bool avatar_action::move( const tripoint &d )
 {
+    avatar &you = get_avatar();
+    map &m = get_map();
     bool in_shell = you.has_active_mutation( trait_SHELL2 ) ||
                     you.has_active_mutation( trait_SHELL3 );
     if( ( !g->check_safe_mode_allowed() ) || in_shell ) {
@@ -703,7 +705,7 @@ void avatar_action::autoattack( avatar &you, map &m )
 
     const tripoint diff = best.pos() - you.pos();
     if( std::abs( diff.x ) <= 1 && std::abs( diff.y ) <= 1 && diff.z == 0 ) {
-        move( you, m, tripoint( diff.xy(), 0 ) );
+        move( tripoint( diff.xy(), 0 ) );
         return;
     }
 

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1039,7 +1039,7 @@ void avatar_action::plthrow( item_location loc,
     g->temp_exit_fullscreen();
 
     item_location weapon = you.get_wielded_item();
-    target_handler::trajectory trajectory = target_handler::mode_throw( you, *weapon,
+    target_handler::trajectory trajectory = target_handler::mode_throw( *weapon,
                                             blind_throw_from_pos.has_value() );
 
     // If we previously shifted our position, put ourselves back now that we've picked our target.

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -937,7 +937,7 @@ void avatar_action::eat( item_location &loc,
 void avatar_action::eat_or_use( avatar &you, item_location loc )
 {
     if( loc && loc->is_medical_tool() ) {
-        avatar_action::use_item( you, loc, "heal" );
+        avatar_action::use_item( loc, "heal" );
     } else {
         avatar_action::eat( loc );
     }
@@ -1065,14 +1065,15 @@ static void update_lum( item_location loc, bool add )
     }
 }
 
-void avatar_action::use_item( avatar &you )
+void avatar_action::use_item()
 {
     item_location loc;
-    avatar_action::use_item( you, loc );
+    avatar_action::use_item( loc );
 }
 
-void avatar_action::use_item( avatar &you, item_location &loc, std::string const &method )
+void avatar_action::use_item( item_location &loc, std::string const &method )
 {
+    avatar &you = get_avatar();
     if( you.has_effect( effect_incorporeal ) ) {
         you.add_msg_if_player( m_bad, _( "You can't use anything while incorporeal." ) );
         return;

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -949,9 +949,10 @@ void avatar_action::eat_or_use( item_location loc )
     }
 }
 
-void avatar_action::plthrow( avatar &you, item_location loc,
+void avatar_action::plthrow( item_location loc,
                              const std::optional<tripoint_bub_ms> &blind_throw_from_pos )
 {
+    avatar &you = get_avatar();
     bool in_shell = you.has_active_mutation( trait_SHELL2 ) ||
                     you.has_active_mutation( trait_SHELL3 );
     if( in_shell ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -781,7 +781,7 @@ void avatar_action::fire_ranged_bionic( const item &fake_gun )
     get_avatar().assign_activity( aim_activity_actor::use_bionic( fake_gun ) );
 }
 
-bool avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret )
+bool avatar_action::fire_turret_manual( turret_data &turret )
 {
     if( !turret.base()->is_gun() ) {
         debugmsg( "Expected turret base to be a gun." );
@@ -821,7 +821,7 @@ bool avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret
     target_handler::trajectory trajectory = target_handler::mode_turret_manual( turret );
 
     if( !trajectory.empty() ) {
-        turret.fire( you, trajectory.back() );
+        turret.fire( get_avatar(), trajectory.back() );
     }
     g->reenter_fullscreen();
     return true;

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -934,7 +934,7 @@ void avatar_action::eat( item_location &loc,
     you.last_item = item( *loc ).typeId();
 }
 
-void avatar_action::eat_or_use( avatar &you, item_location loc )
+void avatar_action::eat_or_use( item_location loc )
 {
     if( loc && loc->is_medical_tool() ) {
         avatar_action::use_item( loc, "heal" );

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -36,7 +36,7 @@ void eat_or_use( item_location loc );
 bool move( const tripoint &d );
 
 /** Handles swimming by the player. Called by avatar_action::move(). */
-void swim( map &m, avatar &you, const tripoint &p );
+void swim( const tripoint &p );
 
 void autoattack( avatar &you, map &m );
 

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -11,7 +11,6 @@
 #include "point.h"
 
 class Character;
-class avatar;
 class item;
 class item_location;
 class turret_data;
@@ -72,7 +71,7 @@ void plthrow( item_location loc,
  * Opens up a menu to Unload a container, gun, or tool
  * If it's a gun, some gunmods can also be loaded
  */
-void unload( avatar &you );
+void unload();
 
 // Use item; also tries E,R,W  'a'
 void use_item( item_location &loc, std::string const &method = {} );

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -40,7 +40,7 @@ void swim( const tripoint &p );
 
 void autoattack();
 
-void mend( avatar &you, item_location loc );
+void mend( item_location loc );
 
 /**
  * Checks if the weapon is valid and if the player meets certain conditions for firing it.

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -28,7 +28,7 @@ void eat( item_location &loc,
           const std::string &consume_menu_filter, activity_id type );
 // special rules for eating: grazing etc
 // returns false if no rules are needed
-bool eat_here( avatar &you );
+bool eat_here();
 void eat_or_use( avatar &you, item_location loc );
 
 // Standard movement; handles attacks, traps, &c. Returns false if auto move

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -21,8 +21,8 @@ namespace avatar_action
 {
 
 /** Eat food or fuel  'E' (or 'a') */
-void eat( avatar &you, item_location &loc );
-void eat( avatar &you, item_location &loc,
+void eat( item_location &loc );
+void eat( item_location &loc,
           const std::vector<int> &consume_menu_selections,
           const std::vector<item_location> &consume_menu_selected_items,
           const std::string &consume_menu_filter, activity_id type );

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -80,8 +80,8 @@ void plthrow( avatar &you, item_location loc,
 void unload( avatar &you );
 
 // Use item; also tries E,R,W  'a'
-void use_item( avatar &you, item_location &loc, std::string const &method = {} );
-void use_item( avatar &you );
+void use_item( item_location &loc, std::string const &method = {} );
+void use_item();
 
 /** Check if avatar is stealing a weapon. */
 bool check_stealing( Character &who, item &weapon );

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -50,7 +50,7 @@ void mend( item_location loc );
 bool can_fire_weapon( const item &weapon );
 
 /** Checks if the wielded weapon is a gun and can be fired then starts interactive aiming */
-void fire_wielded_weapon( avatar &you );
+void fire_wielded_weapon();
 
 /** Stores fake gun specified by the mutation and starts interactive aiming */
 void fire_ranged_mutation( Character &you, const item &fake_gun );

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -47,7 +47,7 @@ void mend( item_location loc );
  * Used for validating ACT_AIM and turret weapon
  * @return True if all conditions are true, otherwise false.
  */
-bool can_fire_weapon( avatar &you, const map &m, const item &weapon );
+bool can_fire_weapon( const item &weapon );
 
 /** Checks if the wielded weapon is a gun and can be fired then starts interactive aiming */
 void fire_wielded_weapon( avatar &you );

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -38,7 +38,7 @@ bool move( const tripoint &d );
 /** Handles swimming by the player. Called by avatar_action::move(). */
 void swim( const tripoint &p );
 
-void autoattack( avatar &you, map &m );
+void autoattack();
 
 void mend( avatar &you, item_location loc );
 

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -33,11 +33,7 @@ void eat_or_use( item_location loc );
 
 // Standard movement; handles attacks, traps, &c. Returns false if auto move
 // should be canceled
-bool move( avatar &you, map &m, const tripoint &d );
-inline bool move( avatar &you, map &m, const point &d )
-{
-    return move( you, m, tripoint( d, 0 ) );
-}
+bool move( const tripoint &d );
 
 /** Handles swimming by the player. Called by avatar_action::move(). */
 void swim( map &m, avatar &you, const tripoint &p );

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -66,7 +66,7 @@ void fire_ranged_bionic( const item &fake_gun );
 bool fire_turret_manual( turret_data &turret );
 
 // Throw an item  't'
-void plthrow( avatar &you, item_location loc,
+void plthrow( item_location loc,
               const std::optional<tripoint_bub_ms> &blind_throw_from_pos = std::nullopt );
 /**
  * Opens up a menu to Unload a container, gun, or tool

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -29,7 +29,7 @@ void eat( item_location &loc,
 // special rules for eating: grazing etc
 // returns false if no rules are needed
 bool eat_here();
-void eat_or_use( avatar &you, item_location loc );
+void eat_or_use( item_location loc );
 
 // Standard movement; handles attacks, traps, &c. Returns false if auto move
 // should be canceled

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -14,7 +14,6 @@ class Character;
 class avatar;
 class item;
 class item_location;
-class map;
 class turret_data;
 
 namespace avatar_action
@@ -64,7 +63,7 @@ void fire_ranged_bionic( const item &fake_gun );
  * Assumes that the turret is on player position.
  * @return true if attempt to fire was successful (aim then cancel is also considered success)
  */
-bool fire_turret_manual( avatar &you, map &m, turret_data &turret );
+bool fire_turret_manual( turret_data &turret );
 
 // Throw an item  't'
 void plthrow( avatar &you, item_location loc,

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -56,7 +56,7 @@ void fire_wielded_weapon();
 void fire_ranged_mutation( Character &you, const item &fake_gun );
 
 /** Stores fake gun specified by the bionic and starts interactive aiming */
-void fire_ranged_bionic( avatar &you, const item &fake_gun );
+void fire_ranged_bionic( const item &fake_gun );
 
 /**
  * Checks if the player can manually (with their 2 hands, not via vehicle controls)

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -812,7 +812,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         if( close_bionics_ui ) {
             *close_bionics_ui = true;
         }
-        avatar_action::fire_ranged_bionic( player_character, bio.get_weapon() );
+        avatar_action::fire_ranged_bionic( bio.get_weapon() );
     } else if( bio.info().has_flag( json_flag_BIONIC_WEAPON ) ) {
         if( !bio.has_weapon() ) {
             debugmsg( "tried to activate weapon bionic \"%s\" without fake_weapon",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -12640,7 +12640,7 @@ void Character::knock_back_to( const tripoint &to )
     if( here.has_flag( ter_furn_flag::TFLAG_LIQUID, to ) &&
         here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, to ) ) {
         if( !is_npc() ) {
-            avatar_action::swim( here, get_avatar(), to );
+            avatar_action::swim( to );
         }
         // TODO: NPCs can't swim!
     } else if( here.impassable( to ) ) { // Wait, it's a wall

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1637,7 +1637,6 @@ conditional_t::func f_query_tile( const JsonObject &jo, std::string_view member,
         std::optional<tripoint> loc;
         Character *ch = d.actor( is_npc )->get_character();
         if( ch && ch->as_avatar() ) {
-            avatar *you = ch->as_avatar();
             if( type == "anywhere" ) {
                 if( !message.empty() ) {
                     static_popup popup;
@@ -1653,7 +1652,7 @@ conditional_t::func f_query_tile( const JsonObject &jo, std::string_view member,
                     popup.on_top( true );
                     popup.message( "%s", message );
                 }
-                target_handler::trajectory traj = target_handler::mode_select_only( *you, range.evaluate( d ) );
+                target_handler::trajectory traj = target_handler::mode_select_only( range.evaluate( d ) );
                 if( !traj.empty() ) {
                     loc = traj.back().raw();
                 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2286,7 +2286,7 @@ int game::inventory_item_menu( item_location locThisItem,
                 }
                 case 'E':
                     if( !locThisItem.get_item()->is_container() ) {
-                        avatar_action::eat( u, locThisItem );
+                        avatar_action::eat( locThisItem );
                     } else {
                         avatar_action::eat_or_use( u, game_menus::inv::consume( locThisItem ) );
                     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8165,7 +8165,7 @@ void game::list_items_monsters()
     }
 
     if( ret == game::vmenu_ret::FIRE ) {
-        avatar_action::fire_wielded_weapon( u );
+        avatar_action::fire_wielded_weapon();
     }
     reenter_fullscreen();
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2311,7 +2311,7 @@ int game::inventory_item_menu( item_location locThisItem,
                 case 't': {
                     contents_change_handler handler;
                     handler.unseal_pocket_containing( locThisItem );
-                    avatar_action::plthrow( u, locThisItem );
+                    avatar_action::plthrow( locThisItem );
                     handler.handle_by( u );
                     break;
                 }
@@ -6156,7 +6156,7 @@ void game::peek( const tripoint_bub_ms &p )
 
     if( result.peek_action && *result.peek_action == PA_BLIND_THROW ) {
         item_location loc;
-        avatar_action::plthrow( u, loc, p );
+        avatar_action::plthrow( loc, p );
     }
     m.invalidate_map_cache( p.z() );
     m.invalidate_visibility_cache();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4884,7 +4884,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
                 break;
             }
             if( m.has_flag( ter_furn_flag::TFLAG_LIQUID, u.pos_bub() ) && force_remaining == 0 ) {
-                avatar_action::swim( m, u, u.pos() );
+                avatar_action::swim( u.pos() );
             } else {
                 u.setpos( traj[i] );
             }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2334,7 +2334,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     reload( locThisItem, true );
                     break;
                 case 'm':
-                    avatar_action::mend( u, locThisItem );
+                    avatar_action::mend( locThisItem );
                     break;
                 case 'R':
                     u.read( locThisItem );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2272,11 +2272,11 @@ int game::inventory_item_menu( item_location locThisItem,
                     if( locThisItem.get_item()->type->has_use() &&
                         !locThisItem.get_item()->item_has_uses_recursive( true ) ) { // NOLINT(bugprone-branch-clone)
                         // Item has uses and none of its contents (if any) has uses.
-                        avatar_action::use_item( u, locThisItem );
+                        avatar_action::use_item( locThisItem );
                     } else if( locThisItem.get_item()->item_has_uses_recursive() ) {
                         game::item_action_menu( locThisItem );
                     } else if( locThisItem.get_item()->has_relic_activation() ) {
-                        avatar_action::use_item( u, locThisItem );
+                        avatar_action::use_item( locThisItem );
                     } else {
                         add_msg( m_info, _( "You can't use a %s there." ), locThisItem->tname() );
                         break;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2288,7 +2288,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     if( !locThisItem.get_item()->is_container() ) {
                         avatar_action::eat( locThisItem );
                     } else {
-                        avatar_action::eat_or_use( u, game_menus::inv::consume( locThisItem ) );
+                        avatar_action::eat_or_use( game_menus::inv::consume( locThisItem ) );
                     }
                     break;
                 case 'W': {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2494,13 +2494,13 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_EAT:
-            if( !avatar_action::eat_here( player_character ) ) {
+            if( !avatar_action::eat_here() ) {
                 avatar_action::eat_or_use( player_character, game_menus::inv::consume() );
             }
             break;
 
         case ACTION_OPEN_CONSUME:
-            if( !avatar_action::eat_here( player_character ) ) {
+            if( !avatar_action::eat_here() ) {
                 open_consume_item_menu();
             }
             break;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1710,7 +1710,7 @@ static void fire()
     // try firing turrets
     if( const optional_vpart_position ovp = here.veh_at( you.pos_bub() ) ) {
         if( turret_data turret_here = ovp->vehicle().turret_query( you.pos() ) ) {
-            if( avatar_action::fire_turret_manual( you, here, turret_here ) ) {
+            if( avatar_action::fire_turret_manual( turret_here ) ) {
                 return;
             }
         } else if( ovp.part_with_feature( VPFLAG_CONTROLS, true ) ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2997,7 +2997,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_AUTOATTACK:
-            avatar_action::autoattack( player_character, m );
+            avatar_action::autoattack();
             break;
 
         default:

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1898,7 +1898,6 @@ void game::open_consume_item_menu()
     as_m.entries.emplace_back( 2, true, 'm', _( "Medication" ) );
     as_m.query();
 
-    avatar &player_character = get_avatar();
     switch( as_m.ret ) {
         case 0: {
             item_location loc = game_menus::inv::consume_food();
@@ -1911,7 +1910,7 @@ void game::open_consume_item_menu()
             break;
         }
         case 2:
-            avatar_action::eat_or_use( player_character, game_menus::inv::consume_meds() );
+            avatar_action::eat_or_use( game_menus::inv::consume_meds() );
             break;
         default:
             break;
@@ -2495,7 +2494,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_EAT:
             if( !avatar_action::eat_here() ) {
-                avatar_action::eat_or_use( player_character, game_menus::inv::consume() );
+                avatar_action::eat_or_use( game_menus::inv::consume() );
             }
             break;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2539,7 +2539,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_THROW: {
             item_location loc;
-            avatar_action::plthrow( player_character, loc );
+            avatar_action::plthrow( loc );
             break;
         }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2530,7 +2530,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_UNLOAD:
-            avatar_action::unload( player_character );
+            avatar_action::unload();
             break;
 
         case ACTION_MEND:

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1670,7 +1670,7 @@ static void reach_attack( avatar &you )
 {
     g->temp_exit_fullscreen();
 
-    target_handler::trajectory traj = target_handler::mode_reach( you, you.get_wielded_item() );
+    target_handler::trajectory traj = target_handler::mode_reach( you.get_wielded_item() );
 
     if( !traj.empty() ) {
         you.reach_attack( traj.back() );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2478,7 +2478,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_USE:
             // Shell-users are presumed to be able to mess with their inventories, etc
             // while in the shell.  Eating, gear-changing, and item use are OK.
-            avatar_action::use_item( player_character );
+            avatar_action::use_item();
             break;
 
         case ACTION_USE_WIELDED:

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2534,7 +2534,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_MEND:
-            avatar_action::mend( player_character, item_location() );
+            avatar_action::mend( item_location() );
             break;
 
         case ACTION_THROW: {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1902,12 +1902,12 @@ void game::open_consume_item_menu()
     switch( as_m.ret ) {
         case 0: {
             item_location loc = game_menus::inv::consume_food();
-            avatar_action::eat( player_character, loc );
+            avatar_action::eat( loc );
             break;
         }
         case 1: {
             item_location loc = game_menus::inv::consume_drink();
-            avatar_action::eat( player_character, loc );
+            avatar_action::eat( loc );
             break;
         }
         case 2:

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1704,7 +1704,7 @@ static void fire()
     }
     // try firing gun
     if( weapon && weapon->is_gun() && !weapon->gun_current_mode().melee() ) {
-        avatar_action::fire_wielded_weapon( you );
+        avatar_action::fire_wielded_weapon();
         return;
     }
     // try firing turrets
@@ -2555,7 +2555,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             if( weapon ) {
                 gun_mode_id original_mode = weapon->gun_get_mode_id();
                 if( weapon->gun_set_mode( gun_mode_AUTO ) ) {
-                    avatar_action::fire_wielded_weapon( player_character );
+                    avatar_action::fire_wielded_weapon();
                     weapon->gun_set_mode( original_mode );
                 }
             }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2278,7 +2278,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     }
                     dest_delta = dest_next;
                 }
-                if( !avatar_action::move( player_character, m, dest_delta ) ) {
+                if( !avatar_action::move( tripoint( dest_delta, 0 ) ) ) {
                     // auto-move should be canceled due to a failed move or obstacle
                     player_character.abort_automove();
                 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2232,7 +2232,7 @@ class exosuit_interact
                     return to_moves<int>( 5_seconds );
                 } else if( ret == 2 ) {
                     if( !!loc_it ) {
-                        avatar_action::use_item( get_avatar(), loc_it );
+                        avatar_action::use_item( loc_it );
                     }
                     return 0;
                 } else if( ret == 3 ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -828,8 +828,7 @@ std::optional<tripoint_bub_ms> spell::select_target( Creature *source )
         if( source->is_avatar() ) {
             do {
                 avatar &source_avatar = *source->as_avatar();
-                std::vector<tripoint_bub_ms> trajectory = target_handler::mode_spell( source_avatar, *this, true,
-                        true );
+                std::vector<tripoint_bub_ms> trajectory = target_handler::mode_spell( *this, true, true );
                 if( !trajectory.empty() ) {
                     target = trajectory.back();
                     target_is_valid = is_valid_target( source_avatar, target );

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -963,9 +963,8 @@ void Character::disp_medical()
             }
             info_scroll_position = 0;
         } else if( action == "APPLY" ) {
-            avatar *a = this->as_avatar();
-            if( a ) {
-                avatar_action::use_item( *a );
+            if( this->as_avatar() ) {
+                avatar_action::use_item();
             } else {
                 popup( _( "Applying not implemented for NPCs." ) );
             }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -473,16 +473,15 @@ target_handler::trajectory target_handler::mode_fire( aim_activity_actor &activi
     return ui.run();
 }
 
-target_handler::trajectory target_handler::mode_throw( avatar &you, item &relevant,
-        bool blind_throwing )
+target_handler::trajectory target_handler::mode_throw( item &relevant, bool blind_throwing )
 {
     target_ui ui = target_ui();
-    ui.you = &you;
+    ui.you = &get_avatar();
     ui.mode = blind_throwing ? target_ui::TargetMode::ThrowBlind : target_ui::TargetMode::Throw;
     ui.relevant = &relevant;
-    ui.range = you.throw_range( relevant );
+    ui.range = ui.you->throw_range( relevant );
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( ui.you->view_offset );
     return ui.run();
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -459,15 +459,15 @@ target_handler::trajectory target_handler::mode_select_only( int range )
     return ui.run();
 }
 
-target_handler::trajectory target_handler::mode_fire( avatar &you, aim_activity_actor &activity )
+target_handler::trajectory target_handler::mode_fire( aim_activity_actor &activity )
 {
     target_ui ui = target_ui();
-    ui.you = &you;
+    ui.you = &get_avatar();
     ui.mode = target_ui::TargetMode::Fire;
     ui.activity = &activity;
     ui.relevant = &*activity.get_weapon();
     gun_mode gun = ui.relevant->gun_current_mode();
-    ui.range = gun.target->gun_range( &you );
+    ui.range = gun.target->gun_range( ui.you );
     ui.ammo = gun->ammo_data();
 
     return ui.run();

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -511,9 +511,10 @@ target_handler::trajectory target_handler::mode_turret_manual( turret_data &turr
     return ui.run();
 }
 
-target_handler::trajectory target_handler::mode_turrets( avatar &you, vehicle &veh,
+target_handler::trajectory target_handler::mode_turrets( vehicle &veh,
         const std::vector<vehicle_part *> &turrets )
 {
+    avatar &you = get_avatar();
     // Find radius of a circle centered at u encompassing all points turrets can aim at
     // FIXME: this calculation is fine for square distances, but results in an underestimation
     //        when used with real circles

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -485,15 +485,15 @@ target_handler::trajectory target_handler::mode_throw( item &relevant, bool blin
     return ui.run();
 }
 
-target_handler::trajectory target_handler::mode_reach( avatar &you, item_location weapon )
+target_handler::trajectory target_handler::mode_reach( item_location weapon )
 {
     target_ui ui = target_ui();
-    ui.you = &you;
+    ui.you = &get_avatar();
     ui.mode = target_ui::TargetMode::Reach;
     ui.relevant = weapon.get_item();
-    ui.range = weapon ? weapon->current_reach_range( you ) : 1;
+    ui.range = weapon ? weapon->current_reach_range( *ui.you ) : 1;
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( ui.you->view_offset );
     return ui.run();
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3214,7 +3214,7 @@ void target_ui::update_status()
         status = Status::OutOfRange;
     } else if( mode == TargetMode::Fire &&
                ( !gunmode_checks_common( msgbuf, relevant->gun_current_mode() ) ||
-                 !gunmode_checks_weapon( *you, get_map(), msgbuf, relevant->gun_current_mode() ) )
+                 !gunmode_checks_weapon( msgbuf, relevant->gun_current_mode() ) )
              ) { // NOLINT(bugprone-branch-clone)
         // Selected gun mode is empty
         // TODO: it might be some other error, but that's highly unlikely to happen, so a catch-all 'Out of ammo' is fine
@@ -4211,9 +4211,10 @@ bool gunmode_checks_common( std::vector<std::string> &messages, const gun_mode &
     return result;
 }
 
-bool gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::string> &messages,
-                            const gun_mode &gmode )
+bool gunmode_checks_weapon( std::vector<std::string> &messages, const gun_mode &gmode )
 {
+    avatar &you = get_avatar();
+    const map &m = get_map();
     bool result = true;
     if( !gmode->ammo_sufficient( &you ) &&
         !gmode->has_flag( flag_RELOAD_AND_SHOOT ) ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -542,18 +542,17 @@ target_handler::trajectory target_handler::mode_turrets( vehicle &veh,
     return ui.run();
 }
 
-target_handler::trajectory target_handler::mode_spell( avatar &you, spell &casting, bool no_fail,
-        bool no_mana )
+target_handler::trajectory target_handler::mode_spell( spell &casting, bool no_fail, bool no_mana )
 {
     target_ui ui = target_ui();
-    ui.you = &you;
+    ui.you = &get_avatar();
     ui.mode = target_ui::TargetMode::Spell;
     ui.casting = &casting;
-    ui.range = casting.range( you );
+    ui.range = casting.range( *ui.you );
     ui.no_fail = no_fail;
     ui.no_mana = no_mana;
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( ui.you->view_offset );
     return ui.run();
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -498,17 +498,17 @@ target_handler::trajectory target_handler::mode_reach( avatar &you, item_locatio
     return ui.run();
 }
 
-target_handler::trajectory target_handler::mode_turret_manual( avatar &you, turret_data &turret )
+target_handler::trajectory target_handler::mode_turret_manual( turret_data &turret )
 {
     target_ui ui = target_ui();
-    ui.you = &you;
+    ui.you = &get_avatar();
     ui.mode = target_ui::TargetMode::TurretManual;
     ui.turret = &turret;
     ui.relevant = &*turret.base();
     ui.range = turret.range();
     ui.ammo = turret.ammo_data();
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( ui.you->view_offset );
     return ui.run();
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3213,14 +3213,14 @@ void target_ui::update_status()
         // None of the turrets are in range
         status = Status::OutOfRange;
     } else if( mode == TargetMode::Fire &&
-               ( !gunmode_checks_common( *you, get_map(), msgbuf, relevant->gun_current_mode() ) ||
+               ( !gunmode_checks_common( msgbuf, relevant->gun_current_mode() ) ||
                  !gunmode_checks_weapon( *you, get_map(), msgbuf, relevant->gun_current_mode() ) )
              ) { // NOLINT(bugprone-branch-clone)
         // Selected gun mode is empty
         // TODO: it might be some other error, but that's highly unlikely to happen, so a catch-all 'Out of ammo' is fine
         status = Status::OutOfAmmo;
     } else if( mode == TargetMode::TurretManual && ( turret->query() != turret_data::status::ready ||
-               !gunmode_checks_common( *you, get_map(), msgbuf, relevant->gun_current_mode() ) ) ) {
+               !gunmode_checks_common( msgbuf, relevant->gun_current_mode() ) ) ) {
         status = Status::OutOfAmmo;
     } else if( ( src == dst ) && !( mode == TargetMode::Spell &&
                                     casting->is_valid_target( spell_target::self ) ) ) {
@@ -4171,9 +4171,9 @@ void target_ui::on_target_accepted( bool harmful ) const
     }
 }
 
-bool gunmode_checks_common( avatar &you, const map &m, std::vector<std::string> &messages,
-                            const gun_mode &gmode )
+bool gunmode_checks_common( std::vector<std::string> &messages, const gun_mode &gmode )
 {
+    avatar &you = get_avatar();
     bool result = true;
     if( you.has_trait( trait_BRAWLER ) ) {
         messages.push_back( string_format( _( "Pfft.  You are a brawler; using this %s is beneath you." ),
@@ -4193,7 +4193,7 @@ bool gunmode_checks_common( avatar &you, const map &m, std::vector<std::string> 
         result = false;
     }
 
-    const optional_vpart_position vp = m.veh_at( you.pos_bub() );
+    const optional_vpart_position vp = get_map().veh_at( you.pos_bub() );
     if( vp && vp->vehicle().player_in_control( you ) && ( gmode->is_two_handed( you ) ||
             gmode->has_flag( flag_FIRE_TWOHAND ) ) ) {
         messages.push_back( string_format( _( "You can't fire your %s while driving." ),

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -448,14 +448,14 @@ class target_ui
         void on_target_accepted( bool harmful ) const;
 };
 
-target_handler::trajectory target_handler::mode_select_only( avatar &you, int range )
+target_handler::trajectory target_handler::mode_select_only( int range )
 {
     target_ui ui = target_ui();
-    ui.you = &you;
+    ui.you = &get_avatar();
     ui.mode = target_ui::TargetMode::SelectOnly;
     ui.range = range;
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( ui.you->view_offset );
     return ui.run();
 }
 

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -43,7 +43,7 @@ trajectory mode_throw( avatar &you, item &relevant, bool blind_throwing );
 trajectory mode_reach( avatar &you, item_location weapon );
 
 /** Manually firing vehicle turret */
-trajectory mode_turret_manual( avatar &you, turret_data &turret );
+trajectory mode_turret_manual( turret_data &turret );
 
 /** Selecting target for turrets (when using vehicle controls) */
 trajectory mode_turrets( avatar &you, vehicle &veh, const std::vector<vehicle_part *> &turrets );

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -14,7 +14,6 @@ class Character;
 class gun_mode;
 class item;
 class item_location;
-class map;
 class spell;
 class turret_data;
 class vehicle;
@@ -68,8 +67,7 @@ bool gunmode_checks_common( std::vector<std::string> &messages, const gun_mode &
  * @param messages Used to store messages describing failed checks
  * @return True if all conditions are true
  */
-bool gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::string> &messages,
-                            const gun_mode &gmode );
+bool gunmode_checks_weapon( std::vector<std::string> &messages, const gun_mode &gmode );
 
 int throw_cost( const Character &c, const item &to_throw );
 

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -28,7 +28,7 @@ namespace target_handler
 using trajectory = std::vector<tripoint_bub_ms>;
 
 /** Generic target select without fire something */
-trajectory mode_select_only( avatar &you, int range );
+trajectory mode_select_only( int range );
 
 /**
  * Firing ranged weapon. This mode allows spending moves on aiming.

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -9,7 +9,6 @@
 #include "point.h"
 
 class aim_activity_actor;
-class avatar;
 class Character;
 class gun_mode;
 class item;
@@ -48,7 +47,7 @@ trajectory mode_turret_manual( turret_data &turret );
 trajectory mode_turrets( vehicle &veh, const std::vector<vehicle_part *> &turrets );
 
 /** Casting a spell */
-trajectory mode_spell( avatar &you, spell &casting, bool no_fail, bool no_mana );
+trajectory mode_spell( spell &casting, bool no_fail, bool no_mana );
 } // namespace target_handler
 
 void practice_archery_proficiency( Character &p, const item &relevant );

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -36,7 +36,7 @@ trajectory mode_select_only( int range );
 trajectory mode_fire( aim_activity_actor &activity );
 
 /** Throwing item */
-trajectory mode_throw( avatar &you, item &relevant, bool blind_throwing );
+trajectory mode_throw( item &relevant, bool blind_throwing );
 
 /** Reach attacking */
 trajectory mode_reach( avatar &you, item_location weapon );

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -61,8 +61,7 @@ int range_with_even_chance_of_good_hit( int dispersion );
  * @param messages Used to store messages describing failed checks
  * @return True if all conditions are true
  */
-bool gunmode_checks_common( avatar &you, const map &m, std::vector<std::string> &messages,
-                            const gun_mode &gmode );
+bool gunmode_checks_common( std::vector<std::string> &messages, const gun_mode &gmode );
 
 /**
  * Various checks for gunmode when firing a weapon

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -45,7 +45,7 @@ trajectory mode_reach( item_location weapon );
 trajectory mode_turret_manual( turret_data &turret );
 
 /** Selecting target for turrets (when using vehicle controls) */
-trajectory mode_turrets( avatar &you, vehicle &veh, const std::vector<vehicle_part *> &turrets );
+trajectory mode_turrets( vehicle &veh, const std::vector<vehicle_part *> &turrets );
 
 /** Casting a spell */
 trajectory mode_spell( avatar &you, spell &casting, bool no_fail, bool no_mana );

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -39,7 +39,7 @@ trajectory mode_fire( aim_activity_actor &activity );
 trajectory mode_throw( item &relevant, bool blind_throwing );
 
 /** Reach attacking */
-trajectory mode_reach( avatar &you, item_location weapon );
+trajectory mode_reach( item_location weapon );
 
 /** Manually firing vehicle turret */
 trajectory mode_turret_manual( turret_data &turret );

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -33,7 +33,7 @@ trajectory mode_select_only( int range );
 /**
  * Firing ranged weapon. This mode allows spending moves on aiming.
  */
-trajectory mode_fire( avatar &you, aim_activity_actor &activity );
+trajectory mode_fire( aim_activity_actor &activity );
 
 /** Throwing item */
 trajectory mode_throw( avatar &you, item &relevant, bool blind_throwing );

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -256,7 +256,7 @@ void timed_event::actualize()
                     get_memorial().add(
                         pgettext( "memorial_male", "Water level reached the ceiling." ),
                         pgettext( "memorial_female", "Water level reached the ceiling." ) );
-                    avatar_action::swim( here, player_character, player_character.pos() );
+                    avatar_action::swim( player_character.pos() );
                 }
             }
             // flood_buf is filled with correct tiles; now copy them back to here

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -424,8 +424,7 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
     }
 
     // Get target
-    target_handler::trajectory trajectory = target_handler::mode_turrets( player_character, *this,
-                                            turrets );
+    target_handler::trajectory trajectory = target_handler::mode_turrets( *this, turrets );
 
     bool got_target = !trajectory.empty();
     if( got_target ) {

--- a/tests/gates_test.cpp
+++ b/tests/gates_test.cpp
@@ -165,7 +165,7 @@ TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows
         REQUIRE( here.ter_set( pos, ter_t_door_c ) );
         REQUIRE( here.ter( pos ).obj().id == ter_t_door_c->id );
 
-        REQUIRE( avatar_action::move( they, here, tripoint_east ) );
+        REQUIRE( avatar_action::move( tripoint_east ) );
 
         THEN( "avatar should spend move points" ) {
             CHECK( they.get_moves() == -open_move_cost );
@@ -175,7 +175,7 @@ TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows
         REQUIRE( here.ter_set( pos, ter_t_door_locked ) );
         REQUIRE( here.ter( pos ).obj().id == ter_t_door_locked->id );
 
-        REQUIRE_FALSE( avatar_action::move( they, here, tripoint_east ) );
+        REQUIRE_FALSE( avatar_action::move( tripoint_east ) );
 
         THEN( "avatar should not spend move points" ) {
             CHECK( they.get_moves() == 0 );
@@ -188,7 +188,7 @@ TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows
             REQUIRE( here.ter_set( pos, ter_t_window_no_curtains ) );
             REQUIRE( here.ter( pos ).obj().id == ter_t_window_no_curtains->id );
 
-            REQUIRE_FALSE( avatar_action::move( they, here, tripoint_east ) );
+            REQUIRE_FALSE( avatar_action::move( tripoint_east ) );
 
             THEN( "avatar should spend move points" ) {
                 CHECK( they.get_moves() == 0 );
@@ -227,7 +227,7 @@ TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows
             REQUIRE( here.ter_set( pos, ter_t_window_no_curtains ) );
             REQUIRE( here.ter( pos ).obj().id == ter_t_window_no_curtains->id );
 
-            REQUIRE( avatar_action::move( they, here, tripoint_east ) );
+            REQUIRE( avatar_action::move( tripoint_east ) );
 
             THEN( "avatar should spend move points" ) {
                 CHECK( they.get_moves() == -open_move_cost );

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -866,7 +866,7 @@ TEST_CASE( "module_inheritance", "[item][armor]" )
     guy.wear_item( hat_hard );
     item_location worn_hat = guy.worn.top_items_loc( guy ).front();
     item_location worn_muffs( worn_hat, &worn_hat->only_item() );
-    avatar_action::use_item( guy, worn_muffs, "transform" );
+    avatar_action::use_item( worn_muffs, "transform" );
     CHECK( worn_hat->has_flag( json_flag_DEAF ) );
 }
 

--- a/tests/move_cost_test.cpp
+++ b/tests/move_cost_test.cpp
@@ -216,7 +216,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -225,7 +225,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -234,7 +234,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 600 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -600 );
             }
         }
@@ -251,7 +251,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -260,7 +260,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -269,7 +269,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 660 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -660 );
             }
         }
@@ -285,7 +285,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 154 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -154 );
             }
         }
@@ -294,7 +294,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 309 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -309 );
             }
         }
@@ -303,7 +303,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 932 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -932 );
             }
         }
@@ -321,7 +321,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -330,7 +330,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -339,7 +339,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 803 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -803 );
             }
         }
@@ -357,7 +357,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -366,7 +366,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -375,7 +375,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 818 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -818 );
             }
         }
@@ -392,7 +392,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 154 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -154 );
             }
         }
@@ -401,7 +401,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 309 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -309 );
             }
         }
@@ -410,7 +410,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1246 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -1246 );
             }
         }
@@ -430,7 +430,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1000 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -1000 );
             }
         }
@@ -450,7 +450,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1179 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -1179 );
             }
         }
@@ -469,7 +469,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1561 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( tripoint_south );
                 CHECK( u.get_moves() == -1561 );
             }
         }

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -272,10 +272,10 @@ static int swimming_steps( avatar &swimmer )
     while( swimmer.get_stamina() > 0 && !swimmer.has_effect( effect_winded ) && steps < STOP_STEPS ) {
         if( steps % 2 == 0 ) {
             REQUIRE( swimmer.pos() == left );
-            REQUIRE( avatar_action::move( swimmer, here, tripoint_east ) );
+            REQUIRE( avatar_action::move( tripoint_east ) );
         } else {
             REQUIRE( swimmer.pos() == right );
-            REQUIRE( avatar_action::move( swimmer, here, tripoint_west ) );
+            REQUIRE( avatar_action::move( tripoint_west ) );
         }
         ++steps;
         REQUIRE( swimmer.get_moves() < last_moves );

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -260,7 +260,6 @@ struct swim_scenario {
 
 static int swimming_steps( avatar &swimmer )
 {
-    map &here = get_map();
     const tripoint left = swimmer.pos();
     const tripoint right = left + tripoint_east;
     int steps = 0;


### PR DESCRIPTION
#### Summary
Infrastructure  "Refactor: Remove unnecessary parameter `avatar` and `map`"

#### Purpose of change

 - Continuation of #76498

#### Describe the solution

Removed all mentions of `avatar` and `map` from `src/ranged.h` and `src/avatar_action.h`. Replaced with `get_avatar()` and `get_map()` in implementations.

#### Describe alternatives you've considered

Remove more.

#### Testing

If it compiles, it should be good.

#### Additional context
 - Found dead code again - removal moved to #76789
