### PR TITLE
Fix error popping up when trying to draw blood from acidic zombie

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4551,6 +4551,7 @@ std::optional<int> iuse::blood_draw( Character *p, item *it, const tripoint & )
             }
             p->add_msg_if_player( m_info, _( "…but acidic blood damages the %s!" ), it->tname() );
         }
+        return 1;
     }
 
     if( vampire ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #76275.

#### Describe the solution
Exit from blood drawing function if we already drew acid blood and don't try to put `blood` item in the same vacutainer.

#### Describe alternatives you've considered
None.

#### Testing
Got blood draw kit, got dead acidic zombie. Drew blood from it. No errors.

#### Additional context
None.