### PR TITLE
Fix the Kord mission

### DIFF
--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -292,7 +292,11 @@
     "responses": [
       { "text": "What's with all the weapons and armor?", "topic": "TALK_BLACKSMITH_SHOP_ABOUT" },
       { "text": "Who are you?", "topic": "TALK_BLACKSMITH_ABOUT" },
-      { "text": "Are you and Jay close?", "topic": "TALK_BLACKSMITH_JAY" },
+      {
+        "text": "Are you and Jay close?",
+        "topic": "TALK_BLACKSMITH_JAY",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_accepted_quest" } ] } }
+      },
       { "text": "Alright.", "topic": "TALK_BLACKSMITH_SERVICES" }
     ]
   },

--- a/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
@@ -22,7 +22,8 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "broken_kord", "count": 1 } },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_mentioned_quest" } ] } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_mentioned_quest" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_completed_quest" } ] }
           ]
         },
         "topic": "TALK_GUNSMITH_KORD"

--- a/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
@@ -26,6 +26,7 @@
             { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_completed_quest" } ] }
           ]
         },
+        "effect": { "u_sell_item": "broken_kord" },
         "topic": "TALK_GUNSMITH_KORD"
       },
       {
@@ -200,7 +201,6 @@
         "text": "I'm listening.",
         "effect": [
           { "add_mission": "MISSION_GUNSMITH_1" },
-          { "u_sell_item": "broken_kord" },
           { "u_add_var": "dialogue_artisans_gunsmith_accepted_quest", "value": "yes" }
         ],
         "topic": "TALK_GUNSMITH_Q1_DETAILS"

--- a/data/json/npcs/isolated_road/isolated_road_missions.json
+++ b/data/json/npcs/isolated_road/isolated_road_missions.json
@@ -24,7 +24,8 @@
       "success": "Thanks, darlin'.  If you could show it to Jay, that would mean a lot to me.  If there's anything I could ever make for you as payment after that, just let me know.",
       "success_lie": "That's great!  Make sure to show it to Jay.",
       "failure": "Well you tried at least…"
-    }
+    },
+    "end": { "effect": { "u_add_var": "dialogue_artisans_blacksmith_completed_quest", "value": "yes" } }
   },
   {
     "id": "MISSION_GUNSMITH_1",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #76316 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
It is checked that the player has already accepted the kord mission in the Cody's first topic, but not in the topic about the location. So the mission can be accepted infinitely. 
If the player give the broken kord to Jay before complete Cody's mission, they cannot it complete anymore.
The player receives repaired kord when the debug software mission is completed, but they can accept this mission without giving the broken kord to Jay.

#### Describe the solution
Add that check to the topic about the location.
Ensure the player give the broken kord to Jay after the mission is completed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Go to Cody and accept the kord mission. It is not offered anymore once accpeted.
Jay does not receive the broken kord before it is completed, and after it he always receives.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
