### PR TITLE
Evolution fixes part 2

### DIFF
--- a/data/json/monstergroups/zanimal_upgrades.json
+++ b/data/json/monstergroups/zanimal_upgrades.json
@@ -4,11 +4,11 @@
     "name": "GROUP_ZOMBIE_DOG_UPGRADE",
     "//": "No bionics or fungal",
     "monsters": [
-      { "monster": "mon_dog_skeleton", "weight": 340, "cost_multiplier": 5 },
-      { "monster": "mon_dog_zombie_brute", "weight": 330, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_dog_acidic", "weight": 330, "cost_multiplier": 2 },
-      { "monster": "mon_dog_cuspated", "weight": 330, "cost_multiplier": 2 },
-      { "monster": "mon_dog_howling", "weight": 330, "cost_multiplier": 2 }
+      { "monster": "mon_dog_skeleton", "weight": 200, "cost_multiplier": 5 },
+      { "monster": "mon_dog_zombie_brute", "weight": 200, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_dog_acidic", "weight": 200, "cost_multiplier": 2 },
+      { "monster": "mon_dog_cuspated", "weight": 200, "cost_multiplier": 2 },
+      { "monster": "mon_dog_howling", "weight": 200, "cost_multiplier": 2 }
     ]
   },
   {
@@ -16,9 +16,8 @@
     "name": "GROUP_ZOMBIE_PIG_UPGRADE",
     "//": "No bionics or fungal",
     "monsters": [
-      { "monster": "mon_zombie_pig", "weight": 910, "cost_multiplier": 5 },
-      { "monster": "mon_zpig_brute", "weight": 45, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_pig_gas", "weight": 45, "cost_multiplier": 2 }
+      { "monster": "mon_zpig_brute", "weight": 500, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_pig_gas", "weight": 500, "cost_multiplier": 2 }
     ]
   },
   {

--- a/data/json/monstergroups/zanimal_upgrades.json
+++ b/data/json/monstergroups/zanimal_upgrades.json
@@ -4,11 +4,11 @@
     "name": "GROUP_ZOMBIE_DOG_UPGRADE",
     "//": "No bionics or fungal",
     "monsters": [
-      { "monster": "mon_dog_skeleton", "weight": 200, "cost_multiplier": 5 },
-      { "monster": "mon_dog_zombie_brute", "weight": 200, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_dog_acidic", "weight": 200, "cost_multiplier": 2 },
-      { "monster": "mon_dog_cuspated", "weight": 200, "cost_multiplier": 2 },
-      { "monster": "mon_dog_howling", "weight": 200, "cost_multiplier": 2 }
+      { "monster": "mon_dog_skeleton", "weight": 340, "cost_multiplier": 5 },
+      { "monster": "mon_dog_zombie_brute", "weight": 330, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_dog_acidic", "weight": 330, "cost_multiplier": 2 },
+      { "monster": "mon_dog_cuspated", "weight": 330, "cost_multiplier": 2 },
+      { "monster": "mon_dog_howling", "weight": 330, "cost_multiplier": 2 }
     ]
   },
   {
@@ -16,8 +16,8 @@
     "name": "GROUP_ZOMBIE_PIG_UPGRADE",
     "//": "No bionics or fungal",
     "monsters": [
-      { "monster": "mon_zpig_brute", "weight": 500, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_pig_gas", "weight": 500, "cost_multiplier": 2 }
+      { "monster": "mon_zpig_brute", "weight": 45, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_pig_gas", "weight": 45, "cost_multiplier": 2 }
     ]
   },
   {

--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -38,7 +38,6 @@
     "default": "mon_zombie_crawler",
     "//": "crawling zombie upgrades",
     "monsters": [
-      { "monster": "mon_zombie_crawler" },
       { "monster": "mon_zombie_crawler_pupa", "weight": 500 },
       { "monster": "mon_zombie_crawler_pupa_decoy", "weight": 500 }
     ]
@@ -47,11 +46,7 @@
     "type": "monstergroup",
     "name": "GROUP_ZOMBIE_BRAINLESS_UPGRADE",
     "//": "No bionics or fungal",
-    "monsters": [
-      { "monster": "mon_zombie_brainless", "weight": 715 },
-      { "monster": "mon_zombie_ears", "weight": 245 },
-      { "monster": "mon_afs_headless_horror", "weight": 40 }
-    ]
+    "monsters": [ { "monster": "mon_zombie_ears", "weight": 245 }, { "monster": "mon_afs_headless_horror", "weight": 40 } ]
   },
   {
     "type": "monstergroup",
@@ -121,7 +116,6 @@
     "default": "mon_zombie_brute",
     "//": "Brute upgrades.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
-      { "monster": "mon_zombie_brute" },
       { "monster": "mon_zombie_brute_grappler", "weight": 240 },
       { "monster": "mon_zombie_brute_ninja", "weight": 175 },
       { "monster": "mon_brute_pupa", "weight": 100 },
@@ -166,7 +160,6 @@
     "default": "mon_spawn_raptor",
     "//": "Raptor upgrades.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
-      { "monster": "mon_spawn_raptor" },
       { "monster": "mon_spawn_raptor_shady", "weight": 333 },
       { "monster": "mon_spawn_raptor_electric", "weight": 333 },
       { "monster": "mon_spawn_raptor_unstable", "weight": 333 }
@@ -178,7 +171,6 @@
     "default": "mon_zombie_shady",
     "//": "Shady upgrades.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
-      { "monster": "mon_zombie_shady" },
       { "monster": "mon_zombie_brute_ninja", "weight": 500 },
       { "monster": "mon_zombie_pupa_decoy_shady", "weight": 250 },
       { "monster": "mon_zombie_pupa_shady", "weight": 250 },
@@ -189,9 +181,9 @@
     "name": "GROUP_FERROUS_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie_shell", "weight": 500 },
-      { "monster": "mon_zombie_urchin", "weight": 250, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_hammer_hands", "weight": 250, "cost_multiplier": 2 }
+      { "monster": "mon_zombie_shell", "weight": 250 },
+      { "monster": "mon_zombie_urchin", "weight": 75, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_hammer_hands", "weight": 75, "cost_multiplier": 2 }
     ]
   },
   {
@@ -200,7 +192,6 @@
     "default": "mon_boomer",
     "//": "Boomer upgrades.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
-      { "monster": "mon_boomer" },
       { "monster": "mon_boomer_glutton", "weight": 245 },
       { "monster": "mon_boomer_huge", "weight": 310 },
       { "monster": "mon_zombie_necro_boomer", "weight": 25 },
@@ -214,19 +205,19 @@
     "name": "GROUP_SKELETON_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_skeleton_slasher", "weight": 300, "cost_multiplier": 2 },
-      { "monster": "mon_skeleton_brute", "weight": 400, "cost_multiplier": 2 },
-      { "monster": "mon_skeleton_master", "weight": 150, "cost_multiplier": 2 },
-      { "monster": "mon_skeleton_necro", "weight": 150, "cost_multiplier": 2 }
+      { "monster": "mon_skeleton_slasher", "weight": 120, "cost_multiplier": 2 },
+      { "monster": "mon_skeleton_brute", "weight": 160, "cost_multiplier": 2 },
+      { "monster": "mon_skeleton_master", "weight": 60, "cost_multiplier": 2 },
+      { "monster": "mon_skeleton_necro", "weight": 60, "cost_multiplier": 2 }
     ]
   },
   {
     "name": "GROUP_ZOMBIE_MINER_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie_shady", "weight": 450 },
-      { "monster": "mon_zombie_rust", "weight": 350 },
-      { "monster": "mon_zombie_tough", "weight": 200 }
+      { "monster": "mon_zombie_shady", "weight": 150 },
+      { "monster": "mon_zombie_rust", "weight": 110 },
+      { "monster": "mon_zombie_tough", "weight": 60 }
     ]
   }
 ]

--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -189,11 +189,9 @@
     "name": "GROUP_FERROUS_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie_rust", "weight": 600 },
-      { "monster": "mon_zombie_shell", "weight": 175 },
-      { "monster": "mon_zombie_plated", "weight": 75, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_urchin", "weight": 75, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_hammer_hands", "weight": 75, "cost_multiplier": 2 }
+      { "monster": "mon_zombie_shell", "weight": 500 },
+      { "monster": "mon_zombie_urchin", "weight": 250, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_hammer_hands", "weight": 250, "cost_multiplier": 2 }
     ]
   },
   {
@@ -216,21 +214,19 @@
     "name": "GROUP_SKELETON_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_skeleton", "weight": 600 },
-      { "monster": "mon_skeleton_slasher", "weight": 120, "cost_multiplier": 2 },
-      { "monster": "mon_skeleton_brute", "weight": 160, "cost_multiplier": 2 },
-      { "monster": "mon_skeleton_master", "weight": 60, "cost_multiplier": 2 },
-      { "monster": "mon_skeleton_necro", "weight": 60, "cost_multiplier": 2 }
+      { "monster": "mon_skeleton_slasher", "weight": 300, "cost_multiplier": 2 },
+      { "monster": "mon_skeleton_brute", "weight": 400, "cost_multiplier": 2 },
+      { "monster": "mon_skeleton_master", "weight": 150, "cost_multiplier": 2 },
+      { "monster": "mon_skeleton_necro", "weight": 150, "cost_multiplier": 2 }
     ]
   },
   {
     "name": "GROUP_ZOMBIE_MINER_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie_miner" },
-      { "monster": "mon_zombie_shady", "weight": 150 },
-      { "monster": "mon_zombie_rust", "weight": 110 },
-      { "monster": "mon_zombie_tough", "weight": 60 }
+      { "monster": "mon_zombie_shady", "weight": 450 },
+      { "monster": "mon_zombie_rust", "weight": 350 },
+      { "monster": "mon_zombie_tough", "weight": 200 }
     ]
   }
 ]

--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -95,6 +95,7 @@
     "color": "i_brown",
     "melee_skill": 3,
     "bleed_rate": 25,
+    "upgrades": false,
     "armor": { "bash": 2, "cut": 4, "acid": 3, "heat": 15, "bullet": 2, "electric": 3 },
     "extend": { "flags": [ "REVIVES_HEALTHY", "NO_NECRO" ] }
   },
@@ -161,6 +162,7 @@
         "damage_max_instance": [ { "damage_type": "cut", "amount": 15, "armor_multiplier": 0.6 } ]
       }
     ],
+    "upgrades": false,
     "armor": { "stab": 30, "bash": 12, "cut": 30, "acid": 1, "bullet": 24, "electric": 2 }
   },
   {
@@ -182,6 +184,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ], { "id": "impale" } ],
+    "upgrades": false,
     "extend": { "flags": [ "GROUP_BASH", "PUSH_VEH", "HIT_AND_RUN" ] }
   },
   {
@@ -199,6 +202,7 @@
     "death_function": { "effect": { "id": "death_tearburst", "hit_self": true }, "message": "The %s explodes!", "corpse_type": "NO_CORPSE" },
     "death_drops": "explode_zed_beast",
     "special_attacks": [ { "id": "impale" } ],
+    "upgrades": false,
     "extend": { "flags": [ "HIT_AND_RUN" ] }
   },
   {
@@ -251,6 +255,7 @@
         "damage_max_instance": [ { "damage_type": "stab", "amount": 12, "armor_multiplier": 0.7 } ]
       }
     ],
+    "upgrades": false,
     "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "CLIMBS", "PUSH_MON", "FILTHY" ]
   },
   {
@@ -277,6 +282,7 @@
       { "id": "bite_grab", "move_cost": 150, "cooldown": 5, "min_mul": 1, "max_mul": 1.8 },
       { "id": "scratch", "cooldown": 10, "min_mul": 1, "max_mul": 1.8 }
     ],
+    "upgrades": false,
     "flags": [ "SEES", "HEARS", "GRABS", "REVIVES", "NO_BREATHE", "POISON", "FILTHY" ],
     "armor": { "bash": 2, "cut": 17, "stab": 30, "acid": 3, "bullet": 32, "electric": 3 }
   },
@@ -291,6 +297,7 @@
     "bleed_rate": 50,
     "vision_night": 45,
     "harvest": "zombie_fur_shadow",
+    "upgrades": false,
     "flags": [
       "SEES",
       "HEARS",
@@ -328,6 +335,7 @@
       { "id": "bite_grab", "move_cost": 150, "cooldown": 3, "min_mul": 0.75, "max_mul": 1.5 },
       { "id": "scratch" }
     ],
+    "upgrades": false,
     "extend": { "flags": [ "ACIDPROOF", "ACID_BLOOD" ] },
     "death_function": { "message": "The %s's body leaks acid.", "effect": { "id": "death_acid", "hit_self": true } }
   },
@@ -345,6 +353,7 @@
     "bleed_rate": 40,
     "harvest": "zombie_animal_acid",
     "special_attacks": [ [ "ACID", 15 ] ],
+    "upgrades": false,
     "death_function": { "message": "The %s's body leaks acid.", "effect": { "id": "death_acid", "hit_self": true } },
     "flags": [
       "SEES",
@@ -376,6 +385,7 @@
     "harvest": "zombie_animal",
     "special_attacks": [ { "id": "smash", "throw_strength": 91, "cooldown": 30 } ],
     "regenerates": 9,
+    "upgrades": false,
     "flags": [ "SEES", "HEARS", "SMELLS", "BASHES", "NO_BREATHE", "REVIVES" ]
   },
   {
@@ -388,6 +398,7 @@
     "hp": 75,
     "color": "blue_white",
     "dodge": 3,
+    "upgrades": false,
     "emit_fields": [ { "emit_id": "emit_smoke_stream", "delay": "1 s" } ],
     "death_function": { "effect": { "id": "death_smokeburst", "hit_self": true }, "message": "The %s explodes!" },
     "flags": [ "SEES", "HEARS", "SMELLS", "BASHES", "POISON", "HARDTOSHOOT", "NO_BREATHE", "REVIVES" ]
@@ -407,6 +418,7 @@
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
     "harvest": "puppy_bones",
     "special_attacks": [ { "id": "smash", "throw_strength": 91, "cooldown": 30 } ],
+    "upgrades": false,
     "flags": [ "SEES", "HEARS", "BASHES", "GROUP_BASH", "HARDTOSHOOT", "REVIVES", "NO_BREATHE", "POISON", "FILTHY" ],
     "armor": { "bash": 5, "electric": 2, "cut": 16, "stab": 30, "acid": 2, "bullet": 24 }
   },
@@ -430,6 +442,7 @@
     "//grab": "Assuming it's grabbing with its mouth a bit grabbier than a zed should be about right",
     "grab_strength": 30,
     "special_attacks": [ { "id": "smash", "throw_strength": 108, "cooldown": 30 }, { "id": "grab", "cooldown": 7 } ],
+    "upgrades": false,
     "flags": [
       "SEES",
       "HEARS",
@@ -468,6 +481,7 @@
     "//grab": "Let's say the thorns make it half again as grabby",
     "grab_strength": 45,
     "special_attacks": [ { "id": "scratch" }, { "id": "grab", "cooldown": 7 }, [ "PARA_STING", 30 ] ],
+    "upgrades": false,
     "flags": [
       "SEES",
       "HEARS",

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -160,7 +160,7 @@
     "melee_dice_sides": 4,
     "bleed_rate": 50,
     "vision_day": 30,
-    "upgrades": { "half_life": 42, "into": "mon_dog_zombie_brute" },
+    "upgrades": { "half_life": 42, "into": "mon_zombie_dog_acidic" },
     "fungalize_into": "mon_zombie_dog_fungus"
   },
   {

--- a/data/json/monsters/zed_ferrous.json
+++ b/data/json/monsters/zed_ferrous.json
@@ -31,6 +31,7 @@
     "harvest": "zombie_rust",
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 10 } ],
     "burn_into": "mon_zombie_scorched_rust",
+    "upgrades": { "half_life": 30, "into": "mon_zombie_plated" },
     "armor": { "bash": 14, "cut": 14, "stab": 14, "bullet": 14 },
     "extend": { "weakpoint_sets": [ "wps_metal_shell_armor" ], "families": [ "prof_wp_nat_armored" ] }
   },
@@ -53,6 +54,7 @@
     "grab_strength": 30,
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 10 } ],
     "burn_into": "mon_zombie_scorched_rust",
+    "upgrades": false,
     "armor": { "bash": 18, "cut": 18, "stab": 18, "bullet": 18 },
     "extend": { "flags": [ "SMELLS" ], "weakpoint_sets": [ "wps_metal_shell_armor" ], "families": [ "prof_wp_nat_armored" ] }
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Fix upgrading of zombie animals, ferrous zombies and some monstergroups tweaks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

A lot of evolved monsters can evolve into different variants back and forth after "copy-from" was introduced for them. 
I believe it is an unintended side effect, that for example skeletal zombears transform into acidic ones and vice-versa (or into themselves).

Rust shell and rust plated zombies had regular, standard zed evolution options.

Festering boar, rust zeds and skeletal zeds had their evolutiongroup written in a way that additionally limits their chance to evolve when evolving.

Some evolutiongroups didnt sum up to 1000. And miner group had one non-functional line.

#### Describe the solution

Give upgrades:false where it felt appropriate. To remove this side-effect of copy-from.

Make rust plated zombie an evolution of rust shell zed. Remove rust plated zed from rust zombie evolutiongroup.

Remove skelly, rust and festering boars from their evolutiongroups. If they are meant to have lower chance of evolving, it should be done with longer half-life. Checked that their evolutiongroups are not used as spawngroups anywhere.

Rot-weiler now evolves into acid dog, not brute-dog.

Made some monstergroups sum up to 1000. Kept the original ratio.

#### Describe alternatives you've considered

Remove cost modifier from groups that are only evolutiongroups and not spawngroups. I believe it does nothing?

#### Testing

Spawned some monsters and masters, watched them evolve. No errors. Debugged some time flow. 

#### Additional context

Part 2 of #76180

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
