### PR TITLE
Adjusted item grid connection points on grid merge

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6036,9 +6036,8 @@ void map::process_items_in_submap( submap &current_submap, const tripoint_rel_sm
 std::vector<item_reference> map::item_network_connections( vehicle *power_grid )
 {
     std::vector<item_reference> result;
-    for( auto iter = submaps_with_active_items.begin(); iter != submaps_with_active_items.end();
-         iter++ ) {
-        tripoint_abs_sm const abs_pos = *iter;
+    for( auto &iter : submaps_with_active_items ) {
+        tripoint_abs_sm const abs_pos = iter;
         const tripoint_rel_sm local_pos = abs_pos - abs_sub.xy();
         submap *const current_submap = get_submap_at_grid( local_pos );
         std::vector<item_reference> active_items = current_submap->active_items.get_for_processing();
@@ -6047,9 +6046,9 @@ std::vector<item_reference> map::item_network_connections( vehicle *power_grid )
                 continue;
             }
 
-            if( active_item_ref.item_ref.get()->has_link_data() &&
-                active_item_ref.item_ref.get()->link().t_veh &&
-                active_item_ref.item_ref.get()->link().t_veh.get()->pos_bub() == power_grid->pos_bub() ) {
+            if( active_item_ref.item_ref->has_link_data() &&
+                active_item_ref.item_ref->link().t_veh &&
+                active_item_ref.item_ref->link().t_veh.get()->pos_bub() == power_grid->pos_bub() ) {
                 result.emplace_back( active_item_ref );
             }
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6036,7 +6036,7 @@ void map::process_items_in_submap( submap &current_submap, const tripoint_rel_sm
 std::vector<item_reference> map::item_network_connections( vehicle *power_grid )
 {
     std::vector<item_reference> result;
-    for( auto &iter : submaps_with_active_items ) {
+    for( const auto &iter : submaps_with_active_items ) {
         tripoint_abs_sm const abs_pos = iter;
         const tripoint_rel_sm local_pos = abs_pos - abs_sub.xy();
         submap *const current_submap = get_submap_at_grid( local_pos );
@@ -6048,7 +6048,7 @@ std::vector<item_reference> map::item_network_connections( vehicle *power_grid )
 
             if( active_item_ref.item_ref->has_link_data() &&
                 active_item_ref.item_ref->link().t_veh &&
-                active_item_ref.item_ref->link().t_veh.get()->pos_bub() == power_grid->pos_bub() ) {
+                active_item_ref.item_ref->link().t_veh->pos_bub() == power_grid->pos_bub() ) {
                 result.emplace_back( active_item_ref );
             }
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6033,6 +6033,31 @@ void map::process_items_in_submap( submap &current_submap, const tripoint_rel_sm
     }
 }
 
+std::vector<item_reference> map::item_network_connections( vehicle *power_grid )
+{
+    std::vector<item_reference> result;
+    for( auto iter = submaps_with_active_items.begin(); iter != submaps_with_active_items.end();
+         iter++ ) {
+        tripoint_abs_sm const abs_pos = *iter;
+        const tripoint_rel_sm local_pos = abs_pos - abs_sub.xy();
+        submap *const current_submap = get_submap_at_grid( local_pos );
+        std::vector<item_reference> active_items = current_submap->active_items.get_for_processing();
+        for( item_reference &active_item_ref : active_items ) {
+            if( !active_item_ref.item_ref ) {
+                continue;
+            }
+
+            if( active_item_ref.item_ref.get()->has_link_data() &&
+                active_item_ref.item_ref.get()->link().t_veh &&
+                active_item_ref.item_ref.get()->link().t_veh.get()->pos_bub() == power_grid->pos_bub() ) {
+                result.emplace_back( active_item_ref );
+            }
+        }
+    }
+
+    return result;
+}
+
 void map::process_items_in_vehicles( submap &current_submap )
 {
     // a copy, important if the vehicle list changes because a

--- a/src/map.h
+++ b/src/map.h
@@ -20,6 +20,7 @@
 #include <variant>
 #include <vector>
 
+#include "active_item_cache.h"
 #include "calendar.h"
 #include "cata_assert.h"
 #include "cata_type_traits.h"
@@ -2545,6 +2546,8 @@ class map
 
     public:
         void process_items();
+        // All active items connected to the power_grid with their connection points.
+        std::vector<item_reference> item_network_connections( vehicle *power_grid );
     private:
         // Iterates over every item on the map, passing each item to the provided function.
         void process_items_in_submap( submap &current_submap, const tripoint_rel_sm &gridp );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1923,8 +1923,8 @@ bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
             debugmsg( "failed to merge vehicle parts" );
         } else {
             //  Adjust the connections after the change of the power_grid origo.
-            for( item_reference item_ref : network_connections ) {
-                item_ref.item_ref.get()->link().t_mount += ( old_grid_reference - this->pos_bub() ).xy().raw();
+            for( const item_reference &item_ref : network_connections ) {
+                item_ref.item_ref->link().t_mount += ( old_grid_reference - this->pos_bub() ).xy().raw();
             }
 
             //Keep wall wiring sections from losing their flag

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1916,9 +1916,17 @@ bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
 
     //Make sure the resulting vehicle would not be too large
     if( size.x <= MAX_WIRE_VEHICLE_SIZE && size.y <= MAX_WIRE_VEHICLE_SIZE ) {
+        // Find all item connections to the merging network so they can be updated after merge.
+        std::vector<item_reference> network_connections = get_map().item_network_connections( &veh_target );
+        tripoint_bub_ms old_grid_reference{veh_target.pos_bub()};
         if( !merge_vehicle_parts( &veh_target ) ) {
             debugmsg( "failed to merge vehicle parts" );
         } else {
+            //  Adjust the connections after the change of the power_grid origo.
+            for( item_reference item_ref : network_connections ) {
+                item_ref.item_ref.get()->link().t_mount += ( old_grid_reference - this->pos_bub() ).xy().raw();
+            }
+
             //Keep wall wiring sections from losing their flag
             //A grid with only wires needs this flag to count as a powergrid
             //But it's not a problem if a grid without any has this flag, thus we can add it without issue


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #76512, i.e. extension of grid causes connected items to get their cables stretched beyond the disconnection point.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Locate all active items connected to the original grid.
- Determine the offset between the original grid origo and the origo of the new grid (that of the new appliance).
- Apply the offset to the connection mount point of all items connected to the original grid so their absolute position remains the same.
- Repeat for all grids merged.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Look for other things that may be affected by the merging dance. Nothing obvious seen.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Using the save in the bug report and verified the item cable length remained the same as storage batteries were added to the grid.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The code is based on the map handling code of active items called rather frequently. This checks all submaps in the reality bubble, which may be more than needed, but a more limited processing would require knowledge of how long cables are permitted to be, as well as the maximum extent of the grid (seems to be 24 map tiles). Given that this is a fairly infrequent player activated action performance shouldn't be an issue.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
