### PR TITLE
Remove THRESH_SPECIES_ELF from ANIMALEMPATH2

### DIFF
--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -429,7 +429,7 @@
     "type": "mutation",
     "id": "ANIMALEMPATH2",
     "copy-from": "ANIMALEMPATH2",
-    "extend": { "category": [ "SPECIES_ELF" ], "threshreq": [ "THRESH_SPECIES_ELF" ] }
+    "extend": { "category": [ "SPECIES_ELF" ] }
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Bugfixes "Remove Magiclysm elf threshold requirement on Animal Kinship"

#### Purpose of change

The base `ANIMALEMPATH2` trait does not have a threshold requirement and is in the LUPINE and ELFA categories. When Magiclysm is enabled, it adds the `SPECIES_ELF` category, but it also adds the `THRESH_SPECIES_ELF` requirement, blocking the `ELFA` and `LUPINE` categories from accessing it. This seems to be unintentional.

#### Describe the solution

This commit removes the threshold requirement introduced by Magiclysm.

#### Describe alternatives you've considered

There is no alternative, as the effects of the `ANIMALEMPATH` and `ANIMALEMPATH2` traits are hard-coded.
Adding the THRESH_ELF and THRESH_LUPINE requirements is not acceptable.

#### Testing

1. Create a character
2. Debug add the debug mutations for HP, regen and needs
3. Debug add 100000 mutagen, 100000 primer for either `ELFA` or `LUPINE`
4. Verify ANIMALEMPATHY2 can be obtained by passing a lot of time.

#### Additional context

None of the other traits added in Magiclysm by species cause this problem.