### PR TITLE
[MoM] Blazing Aura is an actual aura effect and harms anyone nearby

### DIFF
--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1351,22 +1351,28 @@
     "rating": "good",
     "max_duration": "7 days",
     "max_intensity": 31,
+    "removes_effects": [ "effect_pyrokinetic_aura_damage" ],
     "enchantments": [
       {
         "values": [
           {
             "value": "LUMINATION",
             "add": {
-              "math": [ "(u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling * 5) + 10" ]
+              "math": [
+                "(u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling * 5) + 10"
+              ]
             }
           },
           {
             "value": "CLIMATE_CONTROL_CHILL",
             "add": {
-              "math": [ "(u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling * 12) + 20" ]
+              "math": [
+                "(u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling * 12) + 20"
+              ]
             }
           }
-        ]
+        ],
+        "hit_you_effect": [ { "id": "pyro_aura_attack", "hit_self": false } ]
       },
       {
         "condition": {
@@ -1613,15 +1619,15 @@
   },
   {
     "type": "effect_type",
-    "id": "effect_pyrokinetic_aura_damage"
+    "id": "effect_pyrokinetic_aura_damage",
     "name": [ "Burning Air" ],
-    "desc": [ "The heat is intolerablely hot." ],
+    "desc": [ "The air is intolerably hot." ],
     "apply_message": "",
     "remove_message": "The air cools down.",
     "max_duration": "2 seconds",
     "max_intensity": 12,
-    "base_mods": { "hurt_min": [ 1 ], "hurt_max": [ 2 ], "hurt_chance": [ 2 ] },
-    "scaling_mods": { "hurt_min": [ 0.15 ], "hurt_max": [ 0.3 ] }
+    "base_mods": { "hurt_min": [ 1 ], "hurt_max": [ 3 ], "hurt_chance": [ 2 ] },
+    "scaling_mods": { "hurt_min": [ 0.2 ], "hurt_max": [ 0.4 ] }
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1610,6 +1610,18 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_pyrokinetic_aura_damage"
+    "name": [ "Burning Air" ],
+    "desc": [ "The heat is intolerablely hot." ],
+    "apply_message": "",
+    "remove_message": "The air cools down.",
+    "max_duration": "2 seconds",
+    "max_intensity": 12,
+    "base_mods": { "hurt_min": [ 1 ], "hurt_max": [ 2 ], "hurt_chance": [ 2 ] },
+    "scaling_mods": { "hurt_min": [ 0.15 ], "hurt_max": [ 0.3 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "effect_pyrokinetic_flame_immunity",
     "name": [ "Flame Immunity" ],
     "desc": [ "You are completely immune to fire." ],

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1351,7 +1351,262 @@
     "rating": "good",
     "max_duration": "7 days",
     "max_intensity": 31,
-    "enchantments": [ "enchant_pyrokinetic_aura" ]
+    "enchantments": [
+      { "values": [ { "value": "LUMINATION", "add": 10 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 20 } ] },
+      {
+        "condition": {
+          "math": [
+            "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+            "<=",
+            "3"
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 5 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 10 } ],
+        "emitter": "emit_pyrokinetic_aura_1"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "3"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "6"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 10 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 20 } ],
+        "emitter": "emit_pyrokinetic_aura_2"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "6"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "9"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 15 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 30 } ],
+        "emitter": "emit_pyrokinetic_aura_3"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "9"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "12"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 20 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 40 } ],
+        "emitter": "emit_pyrokinetic_aura_4"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "12"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "15"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 25 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 50 } ],
+        "emitter": "emit_pyrokinetic_aura_5"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "15"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "18"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 30 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 60 } ],
+        "emitter": "emit_pyrokinetic_aura_6"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "18"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "21"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 35 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 70 } ],
+        "emitter": "emit_pyrokinetic_aura_7"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "21"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "24"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 40 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 80 } ],
+        "emitter": "emit_pyrokinetic_aura_8"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "24"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "27"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 45 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 90 } ],
+        "emitter": "emit_pyrokinetic_aura_9"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "27"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "30"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 50 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 100 } ],
+        "emitter": "emit_pyrokinetic_aura_10"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "30"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "33"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 55 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 110 } ],
+        "emitter": "emit_pyrokinetic_aura_11"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">",
+                "33"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<=",
+                "36"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "LUMINATION", "add": 60 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 120 } ],
+        "emitter": "emit_pyrokinetic_aura_12"
+      }
+    ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1352,7 +1352,22 @@
     "max_duration": "7 days",
     "max_intensity": 31,
     "enchantments": [
-      { "values": [ { "value": "LUMINATION", "add": 10 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 20 } ] },
+      {
+        "values": [
+          {
+            "value": "LUMINATION",
+            "add": {
+              "math": [ "(u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling * 5) + 10" ]
+            }
+          },
+          {
+            "value": "CLIMATE_CONTROL_CHILL",
+            "add": {
+              "math": [ "(u_spell_level('pyrokinetic_aura') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling * 12) + 20" ]
+            }
+          }
+        ]
+      },
       {
         "condition": {
           "math": [
@@ -1361,7 +1376,6 @@
             "3"
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 5 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 10 } ],
         "emitter": "emit_pyrokinetic_aura_1"
       },
       {
@@ -1383,7 +1397,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 10 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 20 } ],
         "emitter": "emit_pyrokinetic_aura_2"
       },
       {
@@ -1405,7 +1418,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 15 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 30 } ],
         "emitter": "emit_pyrokinetic_aura_3"
       },
       {
@@ -1427,7 +1439,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 20 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 40 } ],
         "emitter": "emit_pyrokinetic_aura_4"
       },
       {
@@ -1449,7 +1460,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 25 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 50 } ],
         "emitter": "emit_pyrokinetic_aura_5"
       },
       {
@@ -1471,7 +1481,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 30 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 60 } ],
         "emitter": "emit_pyrokinetic_aura_6"
       },
       {
@@ -1493,7 +1502,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 35 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 70 } ],
         "emitter": "emit_pyrokinetic_aura_7"
       },
       {
@@ -1515,7 +1523,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 40 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 80 } ],
         "emitter": "emit_pyrokinetic_aura_8"
       },
       {
@@ -1537,7 +1544,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 45 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 90 } ],
         "emitter": "emit_pyrokinetic_aura_9"
       },
       {
@@ -1559,7 +1565,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 50 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 100 } ],
         "emitter": "emit_pyrokinetic_aura_10"
       },
       {
@@ -1581,7 +1586,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 55 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 110 } ],
         "emitter": "emit_pyrokinetic_aura_11"
       },
       {
@@ -1603,7 +1607,6 @@
             }
           ]
         },
-        "values": [ { "value": "LUMINATION", "add": 60 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 120 } ],
         "emitter": "emit_pyrokinetic_aura_12"
       }
     ]

--- a/data/mods/MindOverMatter/emits.json
+++ b/data/mods/MindOverMatter/emits.json
@@ -44,85 +44,85 @@
   {
     "id": "emit_pyrokinetic_aura_1",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_1",
+    "field": "fd_pyrokinetic_aura",
     "intensity": 1,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_2",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_2",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 2,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_3",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_3",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 3,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_4",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_4",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 4,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_5",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_5",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 5,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_6",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_6",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 6,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_7",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_7",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 7,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_8",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_8",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 8,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_9",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_9",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 9,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_10",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_10",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 10,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_11",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_11",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 11,
     "qty": 20
   },
   {
     "id": "emit_pyrokinetic_aura_12",
     "type": "emit",
-    "field": "fd_pyrokinetic_aura_12",
-    "intensity": 1,
+    "field": "fd_pyrokinetic_aura",
+    "intensity": 12,
     "qty": 20
   },
   {

--- a/data/mods/MindOverMatter/emits.json
+++ b/data/mods/MindOverMatter/emits.json
@@ -42,6 +42,90 @@
     "qty": 20
   },
   {
+    "id": "emit_pyrokinetic_aura_1",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_1",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_2",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_2",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_3",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_3",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_4",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_4",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_5",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_5",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_6",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_6",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_7",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_7",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_8",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_8",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_9",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_9",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_10",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_10",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_11",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_11",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
+    "id": "emit_pyrokinetic_aura_12",
+    "type": "emit",
+    "field": "fd_pyrokinetic_aura_12",
+    "intensity": 1,
+    "qty": 20
+  },
+  {
     "id": "emit_cold_nether_water",
     "type": "emit",
     "field": "fd_cold_air2",

--- a/data/mods/MindOverMatter/fields.json
+++ b/data/mods/MindOverMatter/fields.json
@@ -97,6 +97,7 @@
         "name": "burning air",
         "sym": "&",
         "convection_temperature_mod": 10,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -150,6 +151,7 @@
       {
         "color": "yellow",
         "convection_temperature_mod": 20,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -203,6 +205,7 @@
       {
         "color": "yellow",
         "convection_temperature_mod": 30,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -256,6 +259,7 @@
       {
         "color": "yellow",
         "convection_temperature_mod": 40,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -309,6 +313,7 @@
       {
         "color": "yellow",
         "convection_temperature_mod": 50,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -362,6 +367,7 @@
       {
         "color": "red",
         "convection_temperature_mod": 60,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -415,6 +421,7 @@
       {
         "color": "red",
         "convection_temperature_mod": 70,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -468,6 +475,7 @@
       {
         "color": "red",
         "convection_temperature_mod": 80,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -521,6 +529,7 @@
       {
         "color": "red",
         "convection_temperature_mod": 90,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -574,6 +583,7 @@
       {
         "color": "red",
         "convection_temperature_mod": 100,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -627,6 +637,7 @@
       {
         "color": "magenta",
         "convection_temperature_mod": 110,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
@@ -680,6 +691,7 @@
       {
         "color": "magenta",
         "convection_temperature_mod": 120,
+        "dangerous": true,
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",

--- a/data/mods/MindOverMatter/fields.json
+++ b/data/mods/MindOverMatter/fields.json
@@ -90,6 +90,176 @@
     "phase": "gas"
   },
   {
+    "id": "fd_pyrokinetic_aura",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "burning air",
+        "sym": "&",
+        "convection_temperature_mod": 10,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "yellow",
+        "convection_temperature_mod": 20,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "yellow",
+        "convection_temperature_mod": 30,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "yellow",
+        "convection_temperature_mod": 40,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "yellow",
+        "convection_temperature_mod": 50,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "convection_temperature_mod": 60,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "convection_temperature_mod": 70,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "convection_temperature_mod": 80,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "convection_temperature_mod": 90,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "convection_temperature_mod": 100,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "magenta",
+        "convection_temperature_mod": 110,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "magenta",
+        "convection_temperature_mod": 120,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          }
+        ]
+      }
+    ],
+    "immunity_data": { "flags": [ "HEAT_IMMUNE", "HEATSINK", "FIREPROOF", "FIREY" ] },
+    "decay_amount_factor": 5,
+    "has_fire": true,
+    "percent_spread": 10,
+    "priority": -1,
+    "half_life": "1 seconds",
+    "phase": "gas"
+  },
+  {
     "id": "fd_cold_air_nether_deep",
     "type": "field_type",
     "intensity_levels": [

--- a/data/mods/MindOverMatter/fields.json
+++ b/data/mods/MindOverMatter/fields.json
@@ -104,6 +104,46 @@
             "max_duration": "2 seconds",
             "intensity": 1,
             "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
           }
         ]
       },
@@ -113,6 +153,46 @@
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
             "min_duration": "1 seconds",
             "max_duration": "2 seconds",
             "intensity": 2,
@@ -130,6 +210,46 @@
             "max_duration": "2 seconds",
             "intensity": 3,
             "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
           }
         ]
       },
@@ -139,6 +259,46 @@
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
             "min_duration": "1 seconds",
             "max_duration": "2 seconds",
             "intensity": 4,
@@ -156,6 +316,46 @@
             "max_duration": "2 seconds",
             "intensity": 5,
             "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
           }
         ]
       },
@@ -165,6 +365,46 @@
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
             "min_duration": "1 seconds",
             "max_duration": "2 seconds",
             "intensity": 6,
@@ -182,6 +422,46 @@
             "max_duration": "2 seconds",
             "intensity": 7,
             "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
           }
         ]
       },
@@ -191,6 +471,46 @@
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
             "min_duration": "1 seconds",
             "max_duration": "2 seconds",
             "intensity": 8,
@@ -208,6 +528,46 @@
             "max_duration": "2 seconds",
             "intensity": 9,
             "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
           }
         ]
       },
@@ -217,6 +577,46 @@
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
             "min_duration": "1 seconds",
             "max_duration": "2 seconds",
             "intensity": 10,
@@ -234,6 +634,46 @@
             "max_duration": "2 seconds",
             "intensity": 11,
             "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
           }
         ]
       },
@@ -243,6 +683,46 @@
         "effects": [
           {
             "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
             "min_duration": "1 seconds",
             "max_duration": "2 seconds",
             "intensity": 12,

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -1101,7 +1101,7 @@
     "regeneration_modifiers": [ [ "effect_vitakin_hurt", -7 ], [ "effect_psi_null", -15 ] ],
     "bleed_rate": 0,
     "harvest": "human",
-    "emit_fields": [ { "emit_id": "emit_smoke_stream", "delay": "8 s" } ],
+    "emit_fields": [ { "emit_id": "emit_pyrokinetic_aura_7", "delay": "2 s" } ],
     "dissect": "dissect_human_sample_single",
     "vision_day": 45,
     "vision_night": 3,

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -1097,8 +1097,6 @@
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
     "dodge": 3,
     "armor": { "heat": 50 },
-    "regenerates": 15,
-    "regeneration_modifiers": [ [ "effect_vitakin_hurt", -7 ], [ "effect_psi_null", -15 ] ],
     "bleed_rate": 0,
     "harvest": "human",
     "emit_fields": [ { "emit_id": "emit_pyrokinetic_aura_7", "delay": "2 s" } ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Blazing Aura is an actual aura effect and harms anyone nearby"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Having only targets that hit you take damage was what I knew to do at the time, but it turns out that it's possible to use the fields that Blazing Aura already puts out to make it cause damage, simulating the pyrokinetic superheating the air so hot it burns. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the hit_me effect (hit_you is kept). Edit the fields so they apply an effect that causes damage (being fire or heat immune prevents this), scaling with power level and intelligence etc as normal. Label the fields as fire so monsters that fear fire won't approach while the air around you is literally burning. Scale the light Blazing Aura casts with how powerful the effect is. 

Add this emit to the unending conflagration and remove its regeneration. That means that it will passively kill any zombies that it's near--but it's feral, it's not like it cares or has any concept of tactics. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Effect works--nearby targets take damage passively and extra when directly attacked. NPCs take damage on every body part, as does the player when they are near an unending conflagration
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Learned that NPCs do not react to the player emitting damaging fields (they react if it's tagged `dangerous`, but still don't know what the source is), so going to bug report that once this is merged.

The line count is for scaling reasons (different emits at different power levels) and because the field needed to apply the damaging effect six times (once per body part, per intensity level--72 entries). 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
