### PR TITLE
Fix changelog containing duplicate entries

### DIFF
--- a/.github/workflows/weekly-changelog.yml
+++ b/.github/workflows/weekly-changelog.yml
@@ -2,7 +2,7 @@ name: "Weekly changelog update"
 
 on:
   schedule:
-    - cron: "45 0 * * 1"
+    - cron: "45 2 * * 1"
   push:
     branches:
       - master
@@ -17,7 +17,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
       - name: "Get current date"
-        uses: 1466587594/get-current-time@v2
+        uses: josStorer/get-current-time@v2
         id: current-date
         with:
           format: 'YYYYMMDD'
@@ -26,8 +26,9 @@ jobs:
         env:
           CURR_DATE: ${{ steps.current-date.outputs.formattedTime }}
         run: |
+          YESTERDAY="$(date -d "@$(( $(date +%s -d $CURR_DATE) - (60*60*24*1) ))" +"%Y-%m-%d")"
           LAST_WEEK="$(date -d "@$(( $(date +%s -d $CURR_DATE) - (60*60*24*7) ))" +"%Y-%m-%d")"
-          tools/generate_changelog.py -f --by-date /tmp/changelog.txt -T "${{ secrets.GITHUB_TOKEN }}" "$LAST_WEEK"
+          tools/generate_changelog.py -f --by-date /tmp/changelog.txt --end-date "$YESTERDAY" -T "${{ secrets.GITHUB_TOKEN }}" "$LAST_WEEK"
           tac /tmp/changelog.txt > /tmp/changelog_rev.txt
           tools/merge_summaries.sh /tmp/changelog_rev.txt data/changelog.txt
           echo "date=$( date +"%Y-%m-%d" -d $CURR_DATE )" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The current changelog generation creates duplicate entries for a few PRs, this change should stop generating them. I have recently removed one myself https://github.com/CleverRaven/Cataclysm-DDA/pull/76628 , but I also see others removing them whenever the changelog PR is generated as well.
https://github.com/CleverRaven/Cataclysm-DDA/pull/76132/commits/029bbf6dc3041ef87d401314641bd26332e5f32e#diff-3354596d88cb4568685606d2658c8c78dff17ca1d8f58edd133c019c568b5600L415-L416

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The weekly changelog seems to be generated at around 01:00 GMT each Monday, which is usually Sunday at ~19:00 in the US.

`josStorer/get-current-time` action generates the date for the Monday during which it is run, eg. `2024-09-02`. `LAST_WEEK` variable then represents the previous Monday eg. `2024-08-26` and `generate_changelog.py` then uses `LAST_WEEK` date to generate the changelog.

The problem is that `generate_changelog.py` generates a changelog from `2024-08-26` including, to `2024-09-02` including because it uses the day when it was run as a default for `--end-date` argument. Meaning that every PR that gets merged between Monday 2024-09-02 00:00 GMT and 1AM GMT or whenever the github action runs, gets to be included in the change log. This is technically fine, but when the weekly changelog generation runs again next week, the Monday `2024-09-02` gets to be included again, and thus also the changes that were already added in the previous changelog generation, thus duplicating some entries.

I am basically setting the `--end-date` to the day before Monday so the final changelog doesnt include also PRs that are merged on Monday between 00:00 and 01:00 . I have also changed the execution time from 0:45 every Monday to 2:45 every Monday to avoid any more issues with summer time, although I hope everything uses UNIX timestamps so there should be no issues. I would like to have @dseguin blessing that it is okay to change the time and there is no hidden reason they chose it. I would also like them to bless the change from  `1466587594` to `josStorer` since the repo seems to redirect there, and the seemingly random number looks a bit less user friendly and "suspicious" if that makes any sense. Those two changes though are very much optional and the fix should work without them as well, so just let me know your thoughts. The changelog generation was also added a year ago, so I dont expect anyone to remember anything about it, and "idk" is more than a valid answer :D


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Maybe the changelog merge script could use a 'delete or ignore duplicates' feature, but I believe that would be more complicated, than just removing the extra day from the changelog.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested locally to see what was causing the issue, so if needed I can share even more of the code I used specifically, but basically you can just run
```
tools/generate_changelog.py -f --by-date /tmp/changelogONE.txt --end-date "2024-08-26" -T "$GITHUB_TOKEN" "2024-08-19"
```
or something similar to see that `changelogONE.txt` includes both Mondays, and then
```
tools/generate_changelog.py -f --by-date /tmp/changelogTWO.txt --end-date "2024-09-02" -T "$GITHUB_TOKEN" "2024-08-26"
```
`changelogTWO.txt` includes the `2024-08-26` Monday as well, and the merge script just merges it together, so if you just use `2024-08-25` instead of `2024-08-26`, or basically Sunday date, it will stop duplicating the Monday entries that were submitted between 00:00 - 01:00

Let me know if more explanation is needed, because dates are always confusing, add to it the fact that the cron doesnt get always executed at the same time, github shows your local time and not UTC or GMT, and only a few PRs features are duplicated, so it is just not clear, confusing, and hard to replicate locally


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
If this gets merged, next week there still might be duplicate entries seen because Monday 23rd Sept 00:00 - 01:00 changes are already included, and the script needs to include the previous Monday to work properly, so we will see changes only the week afterwards.

There are also still some duplicate entries in the changelog that I have not yet removed, although I dont think they are that important so unless someone wants to beat me to it, I will remove them when I get to them again. 

Off topic, but if Maleclypse reviews this PR, purely our of curiosity how do you decide what you delete from the changelog and what to keep? Surely it is hard to say what is relevant and what not for anyone really, just want to know if the decision is purely yours or if there is some discussion somewhere else on what is relevant and what not. No problem either way, but it helps me when reading the changelog.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
