### PR TITLE
Night vision goggles no longer draw green overlay after their batteries ran out of energy

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11648,7 +11648,7 @@ bool Character::unload( item_location &loc, bool bypass_activity,
 
     // Turn off any active tools
     if( target->is_tool() && target->active && target->ammo_remaining() == 0 ) {
-        target->type->invoke( this, *target, this->pos() );
+        target->deactivate( this );
     }
 
     add_msg( _( "You unload your %s." ), target->tname() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -674,7 +674,7 @@ item &item::convert( const itype_id &new_type, Character *carrier )
     return *this;
 }
 
-item &item::deactivate( const Character *ch, bool alert )
+item &item::deactivate( Character *ch, bool alert )
 {
     if( !active ) {
         return *this; // no-op
@@ -687,6 +687,9 @@ item &item::deactivate( const Character *ch, bool alert )
         convert( *type->revert_to );
         active = false;
 
+        if( ch ) {
+            ch->clear_inventory_search_cache();
+        }
     }
     return *this;
 }
@@ -14085,7 +14088,7 @@ bool item::process_tool( Character *carrier, const tripoint &pos )
             carrier->add_msg_if_player( m_info, _( "The %s ran out of energy!" ), tname() );
         }
         if( type->revert_to.has_value() ) {
-            type->invoke( carrier, *this, pos );
+            deactivate( carrier );
             return false;
         } else {
             return true;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14085,7 +14085,7 @@ bool item::process_tool( Character *carrier, const tripoint &pos )
             carrier->add_msg_if_player( m_info, _( "The %s ran out of energy!" ), tname() );
         }
         if( type->revert_to.has_value() ) {
-            deactivate( carrier );
+            type->invoke( carrier, *this, pos );
             return false;
         } else {
             return true;

--- a/src/item.h
+++ b/src/item.h
@@ -251,7 +251,7 @@ class item : public visitable
          * @param alert whether to display any messages
          * @return same instance to allow method chaining
          */
-        item &deactivate( const Character *ch = nullptr, bool alert = true );
+        item &deactivate( Character *ch = nullptr, bool alert = true );
 
         /** Filter converting instance to active state */
         item &activate();

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -198,7 +198,7 @@ std::optional<int> itype::invoke( Character *p, item &it, const tripoint &pos ) 
         return 0;
     }
     if( use_methods.find( "transform" ) != use_methods.end() ) {
-        return  invoke( p, it, pos, "transform" );
+        return invoke( p, it, pos, "transform" );
     } else {
         return invoke( p, it, pos, use_methods.begin()->first );
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Night vision goggles no longer draw green overlay after their batteries ran out of energy"

#### Purpose of change
* Closes #76608.

#### Describe the solution
Added clearing of inventory search cache after deactivating tools.
Also, while I'm here, I replaced `invoke` with `deactivate` while unloading. `invoke` didn't work as it should with items that use eocs to transform, such as chainsaws.

#### Describe alternatives you've considered
None.

#### Testing
Got army helmet, night vision goggles and light battery for it. Worn helmet with goggles, turned goggles on. Waited for batteries in goggles to ran out of energy, checked that green overlay is turned off.
Also checked case from https://github.com/CleverRaven/Cataclysm-DDA/issues/76608#issuecomment-2368653710 by @CoroNaut. Unloaded battery from UPS (on) while goggles were turned on, checked that green overlay has gone.

#### Additional context
None.