### PR TITLE
fix gun shy trait

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1697,7 +1697,7 @@ static void fire()
         add_msg( m_bad, _( "You refuse to use ranged weapons." ) );
         return;
     }
-    if( you.has_trait( trait_GUNSHY ) && weapon->is_firearm() ) {
+    if( you.has_trait( trait_GUNSHY ) && weapon && weapon->is_firearm() ) {
         add_msg( m_bad, _( "You refuse to use firearms." ) );
         return;
     }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -4179,7 +4179,7 @@ bool gunmode_checks_common( avatar &you, const map &m, std::vector<std::string> 
         result = false;
     }
 
-    if( you.has_trait( trait_GUNSHY ) && !gmode->has_flag( flag_PRIMITIVE_RANGED_WEAPON ) ) {
+    if( you.has_trait( trait_GUNSHY ) && gmode->is_firearm() ) {
         messages.push_back( string_format( _( "You're too gun-shy to use this." ) ) );
         result = false;
     }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -4179,9 +4179,8 @@ bool gunmode_checks_common( avatar &you, const map &m, std::vector<std::string> 
         result = false;
     }
 
-    if( you.has_trait( trait_GUNSHY ) ) {
-        messages.push_back( string_format( _( "You're too gun-shy to use this." ),
-                                           gmode->tname() ) );
+    if( you.has_trait( trait_GUNSHY ) && !gmode->has_flag( flag_PRIMITIVE_RANGED_WEAPON ) ) {
+        messages.push_back( string_format( _( "You're too gun-shy to use this." ) ) );
         result = false;
     }
 

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -418,9 +418,8 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
         return false;
     }
     if( player_character.has_trait( trait_GUNSHY ) ) {
-        // Check if any turret is a firearm
         player_character.add_msg_if_player(
-            _( "Firing a gun isn't any better, even if it's mounted." ) );
+            _( "You refuse to use a firearm even when it's mounted." ) );
         return false;
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix gun shy trait"

#### Purpose of change
Even when your weapon is not a firearm, gun shy trait prevented you from shooting it. It also crashes the game when you try to fire any turret mounted weapon
And oh my god it crashes when you try to draw out(f) a weapon as well, so fixing tis as well
fixes #76651

#### Describe the solution
Add the firearm condition along with the gun shy trait in gunmode_checks_common
include holding a firearm in gunshy condition in fire() (this fixes the holster and turret issues as well)

#### Describe alternatives you've considered
All bows use gunpowder to shoot

#### Testing
Bows and other stuff work and game no longer crashes hen firing a turret/drawing out a weapon

#### Additional context
glad to see that im still squeezed onto seats as a normal sized character