### PR TITLE
Use typed tripoints in ranged.h and adjacent code

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1216,10 +1216,10 @@ std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
                 message, allow_vertical, /*allow_mouse=*/true, timeout,
     [&]( const input_context & ctxt, const std::string & action ) {
         if( action == "SELECT" ) {
-            const std::optional<tripoint> mouse_pos = ctxt.get_coordinates(
+            const std::optional<tripoint_bub_ms> mouse_pos = ctxt.get_coordinates(
                         g->w_terrain, g->ter_view_p.xy(), true );
             if( mouse_pos ) {
-                const tripoint_rel_ms vec = tripoint_bub_ms( *mouse_pos ) - pos;
+                const tripoint_rel_ms vec = *mouse_pos - pos;
                 if( vec.x() >= -1 && vec.x() <= 1
                     && vec.y() >= -1 && vec.y() <= 1
                     && ( allow_vertical ? vec.z() >= -1 && vec.y() <= 1 : vec.z() == 0 ) ) {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -542,10 +542,10 @@ item_location aim_activity_actor::get_weapon()
 void aim_activity_actor::restore_view() const
 {
     avatar &player_character = get_avatar();
-    bool changed_z = player_character.view_offset.z != initial_view_offset.z;
+    bool changed_z = player_character.view_offset.z() != initial_view_offset.z();
     player_character.view_offset = initial_view_offset;
     if( changed_z ) {
-        get_map().invalidate_map_cache( player_character.view_offset.z );
+        get_map().invalidate_map_cache( player_character.view_offset.z() );
         g->invalidate_main_ui_adaptor();
     }
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -45,7 +45,7 @@ class aim_activity_actor : public activity_actor
 {
     private:
         std::optional<item> fake_weapon;
-        std::vector<tripoint> fin_trajectory;
+        std::vector<tripoint_bub_ms> fin_trajectory;
 
     public:
         std::string action;
@@ -56,7 +56,7 @@ class aim_activity_actor : public activity_actor
         /* Item location for RAS weapon reload */
         item_location reload_loc = item_location();
         bool shifting_view = false;
-        tripoint initial_view_offset;
+        tripoint_rel_ms initial_view_offset;
         /** Target UI requested to abort aiming */
         bool aborted = false;
         /** if true abort if no targets are available when re-entering aiming ui after shooting */

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3679,7 +3679,7 @@ void activity_handlers::pull_creature_finish( player_activity *act, Character *y
         you->as_avatar()->longpull( act->name );
     } else {
         // TODO: fix point types
-        you->longpull( act->name, get_map().bub_from_abs( act->placement ).raw() );
+        you->longpull( act->name, get_map().bub_from_abs( act->placement ) );
     }
     act->set_to_null();
 }

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -121,8 +121,7 @@ bool is_layer_visible( const std::map<tripoint_bub_ms, explosion_tile> &layer )
 //! Get p relative to u's current position and view
 tripoint_rel_ms relative_view_pos( const avatar &u, const tripoint_bub_ms &p ) noexcept
 {
-    return tripoint_rel_ms( p.raw() - u.view_offset + tripoint( POSX - u.posx(), POSY - u.posy(),
-                            -u.posz() ) );
+    return p - u.pos_bub() - u.view_offset + point_rel_ms( POSX, POSY );
 }
 
 // Convert p to screen position relative to the current terrain view
@@ -806,6 +805,11 @@ void game::draw_line( const tripoint &p, const std::vector<tripoint> &points )
     draw_line_curses( *this, temp );
     tilecontext->init_draw_line( tripoint_bub_ms( p ), temp, "line_trail", false );
 }
+void game::draw_line( const tripoint_bub_ms &p, const std::vector<tripoint_bub_ms> &points )
+{
+    draw_line_curses( *this, points );
+    tilecontext->init_draw_line( p, points, "line_trail", false );
+}
 #else
 void game::draw_line( const tripoint &/*p*/, const std::vector<tripoint> &points )
 {
@@ -816,6 +820,10 @@ void game::draw_line( const tripoint &/*p*/, const std::vector<tripoint> &points
         temp.emplace_back( tmp );
     }
     draw_line_curses( *this, temp );
+}
+void game::draw_line( const tripoint_bub_ms &/*p*/, const std::vector<tripoint_bub_ms> &points )
+{
+    draw_line_curses( *this, points );
 }
 #endif
 

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1227,10 +1227,10 @@ void avatar::rebuild_aim_cache()
 
     double pi = 2 * acos( 0.0 );
 
-    const tripoint local_last_target = get_map().bub_from_abs( last_target_pos.value() ).raw();
+    const tripoint_bub_ms local_last_target = get_map().bub_from_abs( last_target_pos.value() );
 
-    float base_angle = atan2f( local_last_target.y - posy(),
-                               local_last_target.x - posx() );
+    float base_angle = atan2f( local_last_target.y() - posy(),
+                               local_last_target.x() - posx() );
 
     // move from -pi to pi, to 0 to 2pi for angles
     if( base_angle < 0 ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -762,7 +762,7 @@ void avatar_action::autoattack( avatar &you, map &m )
         return;
     }
 
-    you.reach_attack( best.pos() );
+    you.reach_attack( best.pos_bub() );
 }
 
 // TODO: Move data/functions related to targeting out of game class
@@ -996,7 +996,7 @@ void avatar_action::eat_or_use( avatar &you, item_location loc )
 }
 
 void avatar_action::plthrow( avatar &you, item_location loc,
-                             const std::optional<tripoint> &blind_throw_from_pos )
+                             const std::optional<tripoint_bub_ms> &blind_throw_from_pos )
 {
     bool in_shell = you.has_active_mutation( trait_SHELL2 ) ||
                     you.has_active_mutation( trait_SHELL3 );

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "activity_type.h"
+#include "coordinates.h"
 #include "point.h"
 
 class Character;
@@ -74,7 +75,7 @@ bool fire_turret_manual( avatar &you, map &m, turret_data &turret );
 
 // Throw an item  't'
 void plthrow( avatar &you, item_location loc,
-              const std::optional<tripoint> &blind_throw_from_pos = std::nullopt );
+              const std::optional<tripoint_bub_ms> &blind_throw_from_pos = std::nullopt );
 
 void unload( avatar &you );
 

--- a/src/ballistics.h
+++ b/src/ballistics.h
@@ -40,9 +40,9 @@ projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersi
  *  dispersion.
  *  Returns the rolled dispersion of the shot and the actually hit point.
  */
-dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tripoint &source,
-        const tripoint &target_arg, const dispersion_sources &dispersion,
-        Creature *origin = nullptr, const vehicle *in_veh = nullptr,
+dealt_projectile_attack projectile_attack( const projectile &proj_arg,
+        const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
+        const dispersion_sources &dispersion, Creature *origin = nullptr, const vehicle *in_veh = nullptr,
         const weakpoint_attack &attack = weakpoint_attack(), bool first = true );
 
 /* Used for selecting which part to target in a projectile attack

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -997,7 +997,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         { material_iron, material_steel, material_lc_steel, material_mc_steel, material_hc_steel, material_ch_steel, material_qt_steel, material_budget_steel };
         // Remember all items that will be affected, then affect them
         // Don't "snowball" by affecting some items multiple times
-        std::vector<std::pair<item, tripoint>> affected;
+        std::vector<std::pair<item, tripoint_bub_ms>> affected;
         const units::mass weight_cap = weight_capacity();
         for( const tripoint_bub_ms &p : here.points_in_radius( pos_bub(), 10 ) ) {
             if( p == pos_bub() || !here.has_items( p ) || here.has_flag( ter_furn_flag::TFLAG_SEALED, p ) ) {
@@ -1008,25 +1008,25 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             for( auto it = stack.begin(); it != stack.end(); it++ ) {
                 if( it->weight() < weight_cap &&
                     it->made_of_any( affected_materials ) ) {
-                    affected.emplace_back( *it, p.raw() );
+                    affected.emplace_back( *it, p );
                     stack.erase( it );
                     break;
                 }
             }
         }
 
-        for( const std::pair<item, tripoint> &pr : affected ) {
+        for( const std::pair<item, tripoint_bub_ms> &pr : affected ) {
             projectile proj;
             proj.speed  = 50;
             proj.impact = damage_instance();
             // FIXME: Hardcoded damage type
             proj.impact.add_damage( STATIC( damage_type_id( "bash" ) ), pr.first.weight() / 250_gram );
             // make the projectile stop one tile short to prevent hitting the player
-            proj.range = rl_dist( pr.second, pos() ) - 1;
+            proj.range = rl_dist( pr.second, pos_bub() ) - 1;
             proj.proj_effects = {{ ammo_effect_NO_ITEM_DAMAGE, ammo_effect_DRAW_AS_LINE, ammo_effect_NO_DAMAGE_SCALING, ammo_effect_JET }};
 
             dealt_projectile_attack dealt = projectile_attack(
-                                                proj, pr.second, pos(), dispersion_sources{ 0 }, this );
+                                                proj, pr.second, pos_bub(), dispersion_sources{ 0 }, this );
             here.add_item_or_charges( dealt.end_point, pr.first );
         }
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1237,7 +1237,7 @@ void tileset_cache::loader::load_tile_spritelists( const JsonObject &entry,
     }
 }
 
-static std::map<tripoint, int> display_npc_attack_potential()
+static std::map<tripoint_bub_ms, int> display_npc_attack_potential()
 {
     avatar &you = get_avatar();
     npc avatar_as_npc;
@@ -1248,7 +1248,7 @@ static std::map<tripoint, int> display_npc_attack_potential()
     jsin.read( avatar_as_npc );
     avatar_as_npc.regen_ai_cache();
     avatar_as_npc.evaluate_best_attack( nullptr );
-    std::map<tripoint, int> effectiveness_map;
+    std::map<tripoint_bub_ms, int> effectiveness_map;
     std::vector<npc_attack_rating> effectiveness =
         avatar_as_npc.get_current_attack()->all_evaluations( avatar_as_npc, nullptr );
     for( const npc_attack_rating &effectiveness_at_point : effectiveness ) {
@@ -1409,11 +1409,11 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                would_apply_vision_effects( here.get_visibility( ch.visibility_cache[np.x][np.y],
                                            cache ) );
     };
-    std::map<tripoint, int> npc_attack_rating_map;
+    std::map<tripoint_bub_ms, int> npc_attack_rating_map;
     int max_npc_effectiveness = 0;
     if( g->display_overlay_state( ACTION_DISPLAY_NPC_ATTACK_POTENTIAL ) ) {
         npc_attack_rating_map = display_npc_attack_potential();
-        for( const std::pair<const tripoint, int> &pair : npc_attack_rating_map ) {
+        for( const std::pair<const tripoint_bub_ms, int> &pair : npc_attack_rating_map ) {
             max_npc_effectiveness = std::max( pair.second, max_npc_effectiveness );
         }
     }
@@ -1453,6 +1453,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     continue;
                 }
                 for( int zlevel = center.z; zlevel >= draw_min_z; zlevel -- ) {
+                    // todo: conversion slightly simplified, a couple of calls already use pos as tripoint_bub_ms
                     const tripoint pos( temp.value(), zlevel );
                     const tripoint_abs_ms pos_global = here.getglobal( pos );
                     const int &x = pos.x;
@@ -1526,8 +1527,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         }
 
                         if( g->display_overlay_state( ACTION_DISPLAY_NPC_ATTACK_POTENTIAL ) ) {
-                            if( npc_attack_rating_map.count( pos ) ) {
-                                const int val = npc_attack_rating_map.at( pos );
+                            if( npc_attack_rating_map.count( tripoint_bub_ms( pos ) ) ) {
+                                const int val = npc_attack_rating_map.at( tripoint_bub_ms( pos ) );
                                 short color;
                                 if( val <= 0 ) {
                                     color = catacurses::red;
@@ -1893,7 +1894,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         if( do_draw_async_anim ) {
             draw_async_anim();
         }
-    } else if( you.view_offset != tripoint_zero && !you.in_vehicle ) {
+    } else if( you.view_offset != tripoint_rel_ms_zero && !you.in_vehicle ) {
         // check to see if player is located at ter
         draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
                              tripoint( g->ter_view_p.xy(), center.z ), 0, 0, lit_level::LIT,

--- a/src/character.h
+++ b/src/character.h
@@ -1152,7 +1152,7 @@ class Character : public Creature, public visitable
                                     bool allow_unarmed = true, int forced_movecost = -1 );
 
         /** Handles reach melee attacks */
-        void reach_attack( const tripoint &p, int forced_movecost = -1 );
+        void reach_attack( const tripoint_bub_ms &p, int forced_movecost = -1 );
 
         /**
          * Calls the to other melee_attack function with an empty technique id (meaning no specific
@@ -2720,7 +2720,7 @@ class Character : public Creature, public visitable
         // Items currently being hauled
         std::vector<item_location> haul_list;
 
-        tripoint view_offset;
+        tripoint_rel_ms view_offset;
 
         player_activity stashed_outbounds_activity;
         player_activity stashed_outbounds_backlog;
@@ -3140,7 +3140,7 @@ class Character : public Creature, public visitable
          *  @return number of shots actually fired
          */
 
-        int fire_gun( const tripoint &target, int shots = 1 );
+        int fire_gun( const tripoint_bub_ms &target, int shots = 1 );
         /**
          *  Fires a gun or auxiliary gunmod (ignoring any current mode)
          *  @param target where the first shot is aimed at (may vary for later shots)
@@ -3148,10 +3148,11 @@ class Character : public Creature, public visitable
          *  @param gun item to fire (which does not necessary have to be in the players possession)
          *  @return number of shots actually fired
          */
-        int fire_gun( const tripoint &target, int shots, item &gun, item_location ammo = item_location() );
+        int fire_gun( const tripoint_bub_ms &target, int shots, item &gun,
+                      item_location ammo = item_location() );
         /** Execute a throw */
-        dealt_projectile_attack throw_item( const tripoint &target, const item &to_throw,
-                                            const std::optional<tripoint> &blind_throw_from_pos = std::nullopt );
+        dealt_projectile_attack throw_item( const tripoint_bub_ms &target, const item &to_throw,
+                                            const std::optional<tripoint_bub_ms> &blind_throw_from_pos = std::nullopt );
 
     protected:
         void on_damage_of_type( const effect_source &source, int adjusted_damage,

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1655,7 +1655,7 @@ conditional_t::func f_query_tile( const JsonObject &jo, std::string_view member,
                 }
                 target_handler::trajectory traj = target_handler::mode_select_only( *you, range.evaluate( d ) );
                 if( !traj.empty() ) {
-                    loc = traj.back();
+                    loc = traj.back().raw();
                 }
             } else if( type == "around" ) {
                 if( !message.empty() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -536,8 +536,8 @@ construction_id construction_menu( const bool blueprint )
     tilecontext->set_disable_occlusion( true );
     g->invalidate_main_ui_adaptor();
 #endif
-    std::unique_ptr<restore_on_out_of_scope<tripoint>> restore_view
-            = std::make_unique<restore_on_out_of_scope<tripoint>>( player_character.view_offset );
+    std::unique_ptr<restore_on_out_of_scope<tripoint_rel_ms>> restore_view
+            = std::make_unique<restore_on_out_of_scope<tripoint_rel_ms>>( player_character.view_offset );
 
     const auto recalc_buffer = [&]() {
         //leave room for top and bottom UI text
@@ -777,9 +777,9 @@ construction_id construction_menu( const bool blueprint )
                                         visible_center,
                                         ter_dims.scaled_font_size, ter_dims.window_size_pixel,
                                         player_character.pos_bub().xy(), g->is_tileset_isometric() );
-        player_character.view_offset = tripoint( ( player_character.pos_bub().xy() - target ).raw(), 0 );
+        player_character.view_offset = tripoint_rel_ms( player_character.pos_bub().xy() - target, 0 );
 #else
-        player_character.view_offset = tripoint( 0, ( w_height + 1 ) / 2, 0 );
+        player_character.view_offset = tripoint_rel_ms( 0, ( w_height + 1 ) / 2, 0 );
 #endif
         g->invalidate_main_ui_adaptor();
 
@@ -1230,12 +1230,12 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
             blink = true;
         }
         if( action == "MOUSE_MOVE" ) {
-            const std::optional<tripoint> mouse_pos_raw = ctxt.get_coordinates(
+            const std::optional<tripoint_bub_ms> mouse_pos_raw = ctxt.get_coordinates(
                         g->w_terrain, g->ter_view_p.xy(), true );
-            if( mouse_pos_raw.has_value() && mouse_pos_raw->z == loc.z()
-                && mouse_pos_raw->x >= loc.x() - 1 && mouse_pos_raw->x <= loc.x() + 1
-                && mouse_pos_raw->y >= loc.y() - 1 && mouse_pos_raw->y <= loc.y() + 1 ) {
-                mouse_pos = tripoint_bub_ms( *mouse_pos_raw );
+            if( mouse_pos_raw.has_value() && mouse_pos_raw->z() == loc.z()
+                && mouse_pos_raw->x() >= loc.x() - 1 && mouse_pos_raw->x() <= loc.x() + 1
+                && mouse_pos_raw->y() >= loc.y() - 1 && mouse_pos_raw->y() <= loc.y() + 1 ) {
+                mouse_pos = *mouse_pos_raw;
             } else {
                 mouse_pos = std::nullopt;
             }

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -801,6 +801,13 @@ inline int rl_dist( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
 }
 
 template<typename Point, coords::origin Origin, coords::scale Scale>
+inline int rl_dist_exact( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
+                          const coords::coord_point_ob<Point, Origin, Scale> &loc2 )
+{
+    return rl_dist_exact( loc1.raw(), loc2.raw() );
+}
+
+template<typename Point, coords::origin Origin, coords::scale Scale>
 inline int manhattan_dist( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
                            const coords::coord_point_ob<Point, Origin, Scale> &loc2 )
 {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1447,16 +1447,16 @@ void Creature::heal_bp( bodypart_id /* bp */, int /* dam */ )
 {
 }
 
-void Creature::longpull( const std::string &name, const tripoint &p )
+void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
 {
-    if( pos() == p ) {
+    if( pos_bub() == p ) {
         add_msg_if_player( _( "You try to pull yourself together." ) );
         return;
     }
 
-    std::vector<tripoint> path = line_to( pos(), p, 0, 0 );
+    std::vector<tripoint_bub_ms> path = line_to( pos_bub(), p, 0, 0 );
     Creature *c = nullptr;
-    for( const tripoint &path_p : path ) {
+    for( const tripoint_bub_ms &path_p : path ) {
         c = get_creature_tracker().creature_at( path_p );
         if( c == nullptr && get_map().impassable( path_p ) ) {
             add_msg_if_player( m_warning, _( "There's an obstacle in the way!" ) );

--- a/src/creature.h
+++ b/src/creature.h
@@ -502,7 +502,7 @@ class Creature : public viewer
          * @param name Name of the implement used to pull the target.
          * @param p Position of the target creature.
         */
-        void longpull( const std::string &name, const tripoint &p );
+        void longpull( const std::string &name, const tripoint_bub_ms &p );
 
         /**
          * If training_level is anything but 0, the check will only train target's skill to that level

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3436,7 +3436,7 @@ static void show_sound()
 
     shared_ptr_fast<game::draw_callback_t> sound_cb = make_shared_fast<game::draw_callback_t>( [&]() {
         const point offset {
-            player_character.view_offset.xy() + point( POSX - player_character.posx(), POSY - player_character.posy() )
+            player_character.view_offset.xy().raw() + point( POSX - player_character.posx(), POSY - player_character.posy() )
         };
         for( const tripoint &sound : sounds_to_draw.first ) {
             mvwputch( g->w_terrain, offset + sound.xy(), c_yellow, '?' );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -347,7 +347,7 @@ shared_ptr_fast<ui_adaptor> editmap::create_or_get_ui_adaptor()
 std::optional<tripoint_bub_ms> editmap::edit()
 {
     avatar &player_character = get_avatar();
-    restore_on_out_of_scope<tripoint> view_offset_prev( player_character.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( player_character.view_offset );
     target = player_character.pos_bub() + player_character.view_offset;
     input_context ctxt( "EDITMAP" );
     ctxt.set_iso( true );
@@ -507,7 +507,7 @@ void editmap::uber_draw_ter( const catacurses::window &w, map *m )
 void editmap::do_ui_invalidation()
 {
     avatar &player_character = get_avatar();
-    player_character.view_offset = ( target - player_character.pos_bub() ).raw();
+    player_character.view_offset = target - player_character.pos_bub();
     g->invalidate_main_ui_adaptor();
     create_or_get_ui_adaptor()->invalidate_ui();
 }

--- a/src/game.h
+++ b/src/game.h
@@ -610,7 +610,7 @@ class game
         void update_overmap_seen(); // Update which overmap tiles we can see
 
         void peek();
-        void peek( const tripoint &p );
+        void peek( const tripoint_bub_ms &p );
         std::optional<tripoint_bub_ms> look_debug();
 
         bool check_zone( const zone_type_id &type, const tripoint &where ) const;
@@ -776,6 +776,7 @@ class game
                         const std::vector<tripoint_bub_ms> &points, bool noreveal = false );
         // TODO: Change to typed when single user is updated.
         void draw_line( const tripoint &p, const std::vector<tripoint> &points );
+        void draw_line( const tripoint_bub_ms &p, const std::vector<tripoint_bub_ms> &points );
         void draw_weather( const weather_printable &wPrint ) const;
         void draw_sct() const;
         void draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -295,7 +295,7 @@ input_context game::get_player_input( std::string &action )
 
         //x% of the Viewport, only shown on visible areas
         const weather_animation_t weather_info = weather.weather_id->weather_animation;
-        point offset( u.view_offset.xy() + point( -getmaxx( w_terrain ) / 2 + u.posx(),
+        point offset( u.view_offset.xy().raw() + point( -getmaxx( w_terrain ) / 2 + u.posx(),
                       -getmaxy( w_terrain ) / 2 + u.posy() ) );
 
 #if defined(TILES)
@@ -2061,8 +2061,8 @@ static void do_deathcam_action( const action_id &act, avatar &player_character )
             break;
 
         case ACTION_CENTER:
-            player_character.view_offset.x = g->driving_view_offset.x;
-            player_character.view_offset.y = g->driving_view_offset.y;
+            player_character.view_offset.x() = g->driving_view_offset.x;
+            player_character.view_offset.y() = g->driving_view_offset.y;
             break;
 
         case ACTION_SHIFT_N:
@@ -3053,7 +3053,7 @@ bool game::handle_action()
 
     // If performing an action with right mouse button, co-ordinates
     // of location clicked.
-    std::optional<tripoint> mouse_target;
+    std::optional<tripoint_bub_ms> mouse_target;
 
     if( uquit == QUIT_WATCH && action == "QUIT" ) {
         uquit = QUIT_DIED;
@@ -3129,7 +3129,8 @@ bool game::handle_action()
                 return false;
             }
 
-            const std::optional<tripoint> mouse_pos = ctxt.get_coordinates( w_terrain, ter_view_p.xy(), true );
+            const std::optional<tripoint_bub_ms> mouse_pos = ctxt.get_coordinates( w_terrain, ter_view_p.xy(),
+                    true );
             if( !mouse_pos ) {
                 return false;
             }
@@ -3144,12 +3145,12 @@ bool game::handle_action()
                 // setting auto-move destination state in addition to setting
                 // act.
                 // TODO: fix point types
-                if( !try_get_left_click_action( act, tripoint_bub_ms( *mouse_target ) ) ) {
+                if( !try_get_left_click_action( act, *mouse_target ) ) {
                     return false;
                 }
             } else if( act == ACTION_SEC_SELECT ) {
                 // TODO: fix point types
-                if( !try_get_right_click_action( act, tripoint_bub_ms( *mouse_target ) ) ) {
+                if( !try_get_right_click_action( act, *mouse_target ) ) {
                     return false;
                 }
             }
@@ -3196,7 +3197,8 @@ bool game::handle_action()
 
     // actions allowed only while alive
     if( !player_character.is_dead_state() ) {
-        if( !do_regular_action( act, player_character, mouse_target ) ) {
+        if( !do_regular_action( act, player_character,
+                                mouse_target ? std::make_optional( mouse_target->raw() ) : std::nullopt ) ) {
             return false;
         }
     }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2119,7 +2119,7 @@ void iexamine::door_peephole( Character &you, const tripoint &examp )
     } );
     if( choice == 0 ) {
         // Peek
-        g->peek( examp );
+        g->peek( tripoint_bub_ms( examp ) );
         you.add_msg_if_player( _( "You peek through the peephole." ) );
     } else if( choice == 1 ) {
         here.open_door( you, examp, true, false );
@@ -4942,7 +4942,7 @@ void iexamine::curtains( Character &you, const tripoint &examp )
 
     if( choice == 0 ) {
         // Peek
-        g->peek( examp );
+        g->peek( tripoint_bub_ms( examp ) );
         you.add_msg_if_player( _( "You carefully peek through the curtains." ) );
     } else if( choice == 1 ) {
         // Mr. Gorbachev, tear down those curtains!
@@ -5538,7 +5538,7 @@ void iexamine::ledge( Character &you, const tripoint &examp )
                 return;
             }
 
-            g->peek( where );
+            g->peek( tripoint_bub_ms( where ) );
             you.add_msg_if_player( _( "You peek over the ledge." ) );
             break;
         }

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -1142,8 +1142,8 @@ bool gamepad_available()
     return false;
 }
 
-std::optional<tripoint> input_context::get_coordinates( const catacurses::window &capture_win,
-        const point &offset, const bool center_cursor ) const
+std::optional<tripoint_bub_ms> input_context::get_coordinates( const catacurses::window
+        &capture_win, const point &offset, const bool center_cursor ) const
 {
     if( !coordinate_input_received ) {
         return std::nullopt;
@@ -1165,7 +1165,7 @@ std::optional<tripoint> input_context::get_coordinates( const catacurses::window
     if( center_cursor ) {
         p -= view_size / 2;
     }
-    return tripoint( p, get_map().get_abs_sub().z() );
+    return tripoint_bub_ms( p.x, p.y, get_map().get_abs_sub().z() );
 }
 #endif
 
@@ -1173,9 +1173,9 @@ std::optional<point> input_context::get_coordinates_text( const catacurses::wind
         &capture_win ) const
 {
 #if !defined( TILES )
-    std::optional<tripoint> coord3d = get_coordinates( capture_win );
+    std::optional<tripoint_bub_ms> coord3d = get_coordinates( capture_win );
     if( coord3d.has_value() ) {
-        return get_coordinates( capture_win )->xy();
+        return coord3d->xy().raw();
     } else {
         return std::nullopt;
     }

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -306,7 +306,7 @@ class input_context
         /**
          * Get the coordinates associated with the last mouse click (if any).
          */
-        std::optional<tripoint> get_coordinates( const catacurses::window &capture_win_,
+        std::optional<tripoint_bub_ms> get_coordinates( const catacurses::window &capture_win_,
                 const point &offset = point_zero, bool center_cursor = false ) const;
 
         // Below here are shortcuts for registering common key combinations.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12616,7 +12616,7 @@ bool item::detonate( const tripoint &p, std::vector<item> &drops )
         const int rounds_exploded = rng( 1, charges_remaining / 2 );
         if( type->ammo->special_cookoff ) {
             // If it has a special effect just trigger it.
-            apply_ammo_effects( nullptr, p, type->ammo->ammo_effects, 1 );
+            apply_ammo_effects( nullptr, tripoint_bub_ms( p ), type->ammo->ammo_effects, 1 );
         }
         if( type->ammo->cookoff ) {
             // If ammo type can burn, then create an explosion proportional to quantity.

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7428,7 +7428,7 @@ std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint &pos 
     }
 
     avatar &player_character = get_avatar();
-    point p2( player_character.view_offset.xy() );
+    tripoint_rel_ms stored_view_offset( player_character.view_offset );
 
     vehicle *veh = pickveh( pos, choice == 0 );
 
@@ -7463,8 +7463,7 @@ std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint &pos 
         }
     }
 
-    player_character.view_offset.x = p2.x;
-    player_character.view_offset.y = p2.y;
+    player_character.view_offset = stored_view_offset;
     return 1;
 }
 

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -351,6 +351,19 @@ static std::tuple<double, double, double> slope_of( const std::vector<tripoint> 
     return std::make_tuple( normDx, normDy, normDz );
 }
 
+// returns the normalized dx, dy, dz for the current line vector.
+// todo: make it templated to work with all tripoint types?
+static std::tuple<double, double, double> slope_of( const std::vector<tripoint_bub_ms> &line )
+{
+    cata_assert( !line.empty() && line.front() != line.back() );
+    const double len = trig_dist( line.front(), line.back() );
+    double normDx = ( line.back().x() - line.front().x() ) / len;
+    double normDy = ( line.back().y() - line.front().y() ) / len;
+    double normDz = ( line.back().z() - line.front().z() ) / len;
+    // slope of <x, y, z>
+    return std::make_tuple( normDx, normDy, normDz );
+}
+
 float get_normalized_angle( const point &start, const point &end )
 {
     // Taking the abs value of the difference puts the values in the first quadrant.
@@ -377,7 +390,26 @@ tripoint move_along_line( const tripoint &loc, const std::vector<tripoint> &line
     return res;
 }
 
+tripoint_bub_ms move_along_line( const tripoint_bub_ms &loc,
+                                 const std::vector<tripoint_bub_ms> &line, const int distance )
+{
+    // May want to optimize this, but it's called fairly infrequently as part of specific attack
+    // routines, erring on the side of readability.
+    tripoint_bub_ms res( loc );
+    const auto slope = slope_of( line );
+    res.x() += distance * std::get<0>( slope );
+    res.y() += distance * std::get<1>( slope );
+    res.z() += distance * std::get<2>( slope );
+    return res;
+}
+
 std::vector<tripoint> continue_line( const std::vector<tripoint> &line, const int distance )
+{
+    return line_to( line.back(), move_along_line( line.back(), line, distance ) );
+}
+
+std::vector<tripoint_bub_ms> continue_line( const std::vector<tripoint_bub_ms> &line,
+        const int distance )
 {
     return line_to( line.back(), move_along_line( line.back(), line, distance ) );
 }

--- a/src/line.h
+++ b/src/line.h
@@ -8,6 +8,7 @@
 #include <iosfwd>
 #include <vector>
 
+#include "coordinates.h"
 #include "point.h"
 #include "units_fwd.h"
 
@@ -148,6 +149,8 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
 
 tripoint move_along_line( const tripoint &loc, const std::vector<tripoint> &line,
                           int distance );
+tripoint_bub_ms move_along_line( const tripoint_bub_ms &loc,
+                                 const std::vector<tripoint_bub_ms> &line, int distance );
 // The "t" value decides WHICH Bresenham line is used.
 std::vector<point> line_to( const point &p1, const point &p2, int t = 0 );
 // t and t2 decide which Bresenham line is used.
@@ -262,6 +265,8 @@ units::angle atan2( const rl_vec2d & );
 // Get the magnitude of the slope ranging from 0.0 to 1.0
 float get_normalized_angle( const point &start, const point &end );
 std::vector<tripoint> continue_line( const std::vector<tripoint> &line, int distance );
+std::vector<tripoint_bub_ms> continue_line( const std::vector<tripoint_bub_ms> &line,
+        int distance );
 std::vector<point> squares_in_direction( const point &p1, const point &p2 );
 // Returns a vector of squares adjacent to @from that are closer to @to than @from is.
 // Currently limited to the same z-level as @from.
@@ -275,6 +280,12 @@ void calc_ray_end( units::angle, int range, const tripoint &p, tripoint &out );
  * The function currently ignores the z component.
  */
 units::angle coord_to_angle( const tripoint &a, const tripoint &b );
+template<typename Point, coords::origin Origin, coords::scale Scale>
+units::angle coord_to_angle( const coords::coord_point_ob<Point, Origin, Scale> &a,
+                             const coords::coord_point_ob<Point, Origin, Scale> &b )
+{
+    return coord_to_angle( a.raw(), b.raw() );
+}
 
 // weird class for 2d vectors where dist is derived from rl_dist
 struct rl_vec2d {

--- a/src/magic.h
+++ b/src/magic.h
@@ -235,8 +235,8 @@ class spell_type
         bool teachable;
         // NOLINTNEXTLINE(cata-serialize)
         std::function<void( const spell &, Creature &, const tripoint & )> effect;
-        std::function<std::set<tripoint>( const spell_effect::override_parameters &params,
-                                          const tripoint &source, const tripoint &target )>
+        std::function<std::set<tripoint_bub_ms>( const spell_effect::override_parameters &params,
+                const tripoint &source, const tripoint &target )>
         spell_area_function; // NOLINT(cata-serialize)
         // the spell shape found in the json
         spell_shape spell_area = spell_shape::line;
@@ -518,10 +518,10 @@ class spell
         std::optional<tripoint> select_target( Creature *source );
         // how big is the spell's radius
         int aoe( const Creature &caster ) const;
-        std::set<tripoint> effect_area( const spell_effect::override_parameters &params,
-                                        const tripoint &source, const tripoint &target ) const;
-        std::set<tripoint> effect_area( const tripoint &source, const tripoint &target,
-                                        const Creature &caster ) const;
+        std::set<tripoint_bub_ms> effect_area( const spell_effect::override_parameters &params,
+                                               const tripoint &source, const tripoint &target ) const;
+        std::set<tripoint_bub_ms> effect_area( const tripoint &source, const tripoint &target,
+                                               const Creature &caster ) const;
         // distance spell can be cast
         int range( const Creature &caster ) const;
         /**
@@ -529,7 +529,7 @@ class spell
          *  if the spell can't be cast through walls, does not return anything behind walls
          *  if the spell can't target the ground, can't target unseen locations, etc.
          */
-        std::vector<tripoint> targetable_locations( const Character &source ) const;
+        std::vector<tripoint_bub_ms> targetable_locations( const Character &source ) const;
         // how much energy does the spell cost
         int energy_cost( const Character &guy ) const;
         // how long does this spell's effect last
@@ -653,7 +653,7 @@ class spell
         bool ignore_by_species_id( const tripoint &p ) const;
 
         // picks a random valid tripoint from @area
-        std::optional<tripoint> random_valid_target( const Creature &caster,
+        std::optional<tripoint_bub_ms> random_valid_target( const Creature &caster,
                 const tripoint &caster_pos ) const;
 };
 
@@ -774,12 +774,12 @@ void area_pull( const spell &sp, Creature &caster, const tripoint &center );
 void area_push( const spell &sp, Creature &caster, const tripoint &center );
 void directed_push( const spell &sp, Creature &caster, const tripoint &target );
 
-std::set<tripoint> spell_effect_blast( const override_parameters &params, const tripoint &,
-                                       const tripoint &target );
-std::set<tripoint> spell_effect_cone( const override_parameters &params, const tripoint &source,
-                                      const tripoint &target );
-std::set<tripoint> spell_effect_line( const override_parameters &params, const tripoint &source,
-                                      const tripoint &target );
+std::set<tripoint_bub_ms> spell_effect_blast( const override_parameters &params, const tripoint &,
+        const tripoint &target );
+std::set<tripoint_bub_ms> spell_effect_cone( const override_parameters &params,
+        const tripoint &source, const tripoint &target );
+std::set<tripoint_bub_ms> spell_effect_line( const override_parameters &params,
+        const tripoint &source, const tripoint &target );
 
 void spawn_ethereal_item( const spell &sp, Creature &, const tripoint & );
 void recover_energy( const spell &sp, Creature &, const tripoint &target );
@@ -820,7 +820,7 @@ void effect_on_condition( const spell &sp, Creature &caster, const tripoint &tar
 void none( const spell &sp, Creature &, const tripoint &target );
 void slime_split_on_death( const spell &sp, Creature &, const tripoint &target );
 
-inline const std::map<spell_shape, std::function<std::set<tripoint>
+inline const std::map<spell_shape, std::function<std::set<tripoint_bub_ms>
 ( const override_parameters &, const tripoint &, const tripoint & )>> shape_map = {
     { spell_shape::blast, spell_effect_blast },
     { spell_shape::line, spell_effect_line },

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -136,7 +136,7 @@ static bool between_or_on( const point &a0, const point &a1, const point &d, con
 // Builds line until obstructed or outside of region bound by near and far lines. Stores result in set
 static void build_line( spell_detail::line_iterable line, const tripoint &source,
                         const point &delta, const point &delta_perp, bool ( *test )( const tripoint & ),
-                        std::set<tripoint> &result )
+                        std::set<tripoint_bub_ms> &result )
 {
     while( between_or_on( point_zero, delta, delta_perp, line.get() ) ) {
         if( !test( source + line.get() ) ) {
@@ -158,9 +158,9 @@ void spell_effect::short_range_teleport( const spell &sp, Creature &caster, cons
             return;
         }
 
-        std::set<tripoint> potential_targets = calculate_spell_effect_area( sp, target, caster );
-        tripoint where = random_entry( potential_targets );
-        teleport::teleport_to_point( caster, where, safe, false );
+        std::set<tripoint_bub_ms> potential_targets = calculate_spell_effect_area( sp, target, caster );
+        tripoint_bub_ms where = random_entry( potential_targets );
+        teleport::teleport_to_point( caster, where.raw(), safe, false );
         return;
     }
     const int min_distance = sp.range( caster );
@@ -225,11 +225,11 @@ static bool in_spell_aoe( const tripoint &start, const tripoint &end, const int 
     return true;
 }
 
-std::set<tripoint> spell_effect::spell_effect_blast( const override_parameters &params,
+std::set<tripoint_bub_ms> spell_effect::spell_effect_blast( const override_parameters &params,
         const tripoint &,
         const tripoint &target )
 {
-    std::set<tripoint> targets;
+    std::set<tripoint_bub_ms> targets;
     // TODO: Make this breadth-first
     for( const tripoint &potential_target : get_map().points_in_radius( target, params.aoe_radius ) ) {
         if( in_spell_aoe( target, potential_target, params.aoe_radius, params.ignore_walls ) ) {
@@ -239,11 +239,10 @@ std::set<tripoint> spell_effect::spell_effect_blast( const override_parameters &
     return targets;
 }
 
-static std::set<tripoint> spell_effect_cone_range_override( const spell_effect::override_parameters
-        &params,
-        const tripoint &source, const tripoint &target )
+static std::set<tripoint_bub_ms> spell_effect_cone_range_override(
+    const spell_effect::override_parameters &params, const tripoint &source, const tripoint &target )
 {
-    std::set<tripoint> targets;
+    std::set<tripoint_bub_ms> targets;
     const units::angle initial_angle = coord_to_angle( source, target );
     const units::angle half_width = units::from_degrees( params.aoe_radius / 2.0 );
     const units::angle start_angle = initial_angle - half_width;
@@ -274,11 +273,11 @@ static std::set<tripoint> spell_effect_cone_range_override( const spell_effect::
         }
     }
     // we don't want to hit ourselves in the blast!
-    targets.erase( source );
+    targets.erase( tripoint_bub_ms( source ) );
     return targets;
 }
 
-std::set<tripoint> spell_effect::spell_effect_cone( const override_parameters &params,
+std::set<tripoint_bub_ms> spell_effect::spell_effect_cone( const override_parameters &params,
         const tripoint &source,
         const tripoint &target )
 {
@@ -295,7 +294,7 @@ static bool test_passable( const tripoint &p )
     return get_map().passable( p );
 }
 
-std::set<tripoint> spell_effect::spell_effect_line( const override_parameters &params,
+std::set<tripoint_bub_ms> spell_effect::spell_effect_line( const override_parameters &params,
         const tripoint &source,
         const tripoint &target )
 {
@@ -303,7 +302,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const override_parameters &p
     const int dist = square_dist( point_zero, delta );
     // Early out to prevent unnecessary calculations
     if( dist == 0 ) {
-        return std::set<tripoint>();
+        return std::set<tripoint_bub_ms>();
     }
     // Clockwise Perpendicular of Delta vector
     const point delta_perp( -delta.y, delta.x );
@@ -337,7 +336,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const override_parameters &p
 
     spell_detail::line_iterable base_line( point_zero, delta, path_to_target );
 
-    std::set<tripoint> result;
+    std::set<tripoint_bub_ms> result;
 
     // Add midline points (source -> target )
     spell_detail::build_line( base_line, source, delta, delta_perp, test, result );
@@ -420,13 +419,13 @@ std::set<tripoint> spell_effect::spell_effect_line( const override_parameters &p
         }
     }
 
-    result.erase( source );
+    result.erase( tripoint_bub_ms( source ) );
     return result;
 }
 
 // spells do not reduce in damage the further away from the epicenter the targets are
 // rather they do their full damage in the entire area of effect
-std::set<tripoint> calculate_spell_effect_area( const spell &sp, const tripoint &target,
+std::set<tripoint_bub_ms> calculate_spell_effect_area( const spell &sp, const tripoint &target,
         const Creature &caster )
 {
     // the actual target that the spell will hit.
@@ -447,15 +446,15 @@ std::set<tripoint> calculate_spell_effect_area( const spell &sp, const tripoint 
         }
     }
 
-    std::set<tripoint> targets = { epicenter }; // initialize with epicenter
+    std::set<tripoint_bub_ms> targets = { tripoint_bub_ms( epicenter ) }; // initialize with epicenter
     if( sp.aoe( caster ) < 1 && sp.shape() != spell_shape::line ) {
         return targets;
     }
 
     targets = sp.effect_area( caster.pos(), target, caster );
 
-    for( std::set<tripoint>::iterator it = targets.begin(); it != targets.end(); ) {
-        if( !sp.is_valid_target( caster, *it ) ) {
+    for( std::set<tripoint_bub_ms>::iterator it = targets.begin(); it != targets.end(); ) {
+        if( !sp.is_valid_target( caster, it->raw() ) ) {
             it = targets.erase( it );
         } else {
             ++it;
@@ -465,16 +464,16 @@ std::set<tripoint> calculate_spell_effect_area( const spell &sp, const tripoint 
     return targets;
 }
 
-static std::set<tripoint> spell_effect_area( const spell &sp, const tripoint &target,
+static std::set<tripoint_bub_ms> spell_effect_area( const spell &sp, const tripoint &target,
         const Creature &caster )
 {
     // calculate spell's effect area
-    std::set<tripoint> targets = calculate_spell_effect_area( sp, target, caster );
+    std::set<tripoint_bub_ms> targets = calculate_spell_effect_area( sp, target, caster );
     if( !sp.has_flag( spell_flag::NO_EXPLOSION_SFX ) ) {
         // Draw the explosion
         std::map<tripoint, nc_color> explosion_colors;
-        for( const tripoint &pt : targets ) {
-            explosion_colors[pt] = sp.damage_type_color();
+        for( const tripoint_bub_ms &pt : targets ) {
+            explosion_colors[pt.raw()] = sp.damage_type_color();
         }
 
         std::string exp_name = "explosion_" + sp.id().str();
@@ -509,16 +508,16 @@ static void add_effect_to_target( const tripoint &target, const spell &sp, Creat
 }
 
 static void damage_targets( const spell &sp, Creature &caster,
-                            const std::set<tripoint> &targets )
+                            const std::set<tripoint_bub_ms> &targets )
 {
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &target : targets ) {
-        if( !sp.is_valid_target( caster, target ) ) {
+    for( const tripoint_bub_ms &target : targets ) {
+        if( !sp.is_valid_target( caster, target.raw() ) ) {
             continue;
         }
-        sp.make_sound( target, caster );
-        sp.create_field( target, caster );
+        sp.make_sound( target.raw(), caster );
+        sp.create_field( target.raw(), caster );
         if( sp.has_flag( spell_flag::IGNITE_FLAMMABLE ) && here.is_flammable( target ) ) {
             here.add_field( target, fd_fire, 1, 10_minutes );
 
@@ -536,11 +535,11 @@ static void damage_targets( const spell &sp, Creature &caster,
             continue;
         }
 
-        dealt_projectile_attack atk = sp.get_projectile_attack( target, *cr, caster );
+        dealt_projectile_attack atk = sp.get_projectile_attack( target.raw(), *cr, caster );
         const int spell_accuracy = sp.accuracy( caster );
 
         if( !sp.effect_data().empty() ) {
-            add_effect_to_target( target, sp, caster );
+            add_effect_to_target( target.raw(), sp, caster );
         }
         if( sp.damage( caster ) > 0 ) {
             // calculate damage mitigation from various sources
@@ -572,7 +571,7 @@ static void damage_targets( const spell &sp, Creature &caster,
             }
             cr->deal_projectile_attack( &caster, atk, true );
         } else if( sp.damage( caster ) < 0 ) {
-            sp.heal( target, caster );
+            sp.heal( target.raw(), caster );
             add_msg_if_player_sees( cr->pos(), m_good, _( "%s wounds are closing up!" ),
                                     cr->disp_name( true ) );
         }
@@ -984,7 +983,7 @@ static void character_push_effects( Creature *caster, Character &guy, tripoint &
 
 void spell_effect::directed_push( const spell &sp, Creature &caster, const tripoint &target )
 {
-    std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     // this group of variables is for deferring movement of the avatar
     int pushed_distance = 0;
     tripoint push_to;
@@ -998,8 +997,8 @@ void spell_effect::directed_push( const spell &sp, Creature &caster, const tripo
     const int sign = sp.damage( caster ) > 0 ? -1 : 1;
 
     std::multimap<int, tripoint> targets_ordered_by_range;
-    for( const tripoint &pt : area ) {
-        targets_ordered_by_range.emplace( sign * rl_dist( pt, caster.pos() ), pt );
+    for( const tripoint_bub_ms &pt : area ) {
+        targets_ordered_by_range.emplace( sign * rl_dist( pt, caster.pos_bub() ), pt.raw() );
     }
 
     creature_tracker &creatures = get_creature_tracker();
@@ -1236,7 +1235,7 @@ static bool add_summoned_mon( const tripoint &pos, const time_duration &time, co
 void spell_effect::spawn_summoned_monster( const spell &sp, Creature &caster,
         const tripoint &target )
 {
-    std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     // this should never be negative, but this'll keep problems from happening
     size_t num_mons = std::abs( sp.damage( caster ) );
     const time_duration summon_time = sp.duration_turns( caster );
@@ -1244,9 +1243,9 @@ void spell_effect::spawn_summoned_monster( const spell &sp, Creature &caster,
         const size_t mon_spot = rng( 0, area.size() - 1 );
         auto iter = area.begin();
         std::advance( iter, mon_spot );
-        if( add_summoned_mon( *iter, summon_time, sp, caster ) ) {
+        if( add_summoned_mon( iter->raw(), summon_time, sp, caster ) ) {
             num_mons--;
-            sp.make_sound( *iter, caster );
+            sp.make_sound( iter->raw(), caster );
         } else {
             debugmsg( "failed to place monster" );
         }
@@ -1311,10 +1310,10 @@ void spell_effect::transform_blast( const spell &sp, Creature &caster,
                                     const tripoint &target )
 {
     ter_furn_transform_id transform( sp.effect_data() );
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
-    for( const tripoint &location : area ) {
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
+    for( const tripoint_bub_ms &location : area ) {
         if( one_in( sp.damage( caster ) ) ) {
-            transform->transform( get_map(), tripoint_bub_ms{ location } );
+            transform->transform( get_map(), location );
         }
     }
 }
@@ -1326,10 +1325,10 @@ void spell_effect::noise( const spell &sp, Creature &caster, const tripoint &tar
 
 void spell_effect::vomit( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &potential_target : area ) {
-        if( !sp.is_valid_target( caster, potential_target ) ) {
+    for( const tripoint_bub_ms &potential_target : area ) {
+        if( !sp.is_valid_target( caster, potential_target.raw() ) ) {
             continue;
         }
         Character *const ch = creatures.creature_at<Character>( potential_target );
@@ -1343,7 +1342,7 @@ void spell_effect::vomit( const spell &sp, Creature &caster, const tripoint &tar
 
 void spell_effect::pull_to_caster( const spell &sp, Creature &caster, const tripoint &target )
 {
-    caster.longpull( sp.name(), target );
+    caster.longpull( sp.name(), tripoint_bub_ms( target ) );
 }
 
 void spell_effect::explosion( const spell &sp, Creature &caster, const tripoint &target )
@@ -1359,17 +1358,17 @@ void spell_effect::flashbang( const spell &sp, Creature &caster, const tripoint 
 
 void spell_effect::mod_moves( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &potential_target : area ) {
-        if( !sp.is_valid_target( caster, potential_target ) ) {
+    for( const tripoint_bub_ms &potential_target : area ) {
+        if( !sp.is_valid_target( caster, potential_target.raw() ) ) {
             continue;
         }
         Creature *critter = creatures.creature_at<Creature>( potential_target );
         if( !critter ) {
             continue;
         }
-        sp.make_sound( potential_target, caster );
+        sp.make_sound( potential_target.raw(), caster );
         critter->mod_moves( sp.damage( caster ) );
     }
 }
@@ -1387,7 +1386,7 @@ void spell_effect::map( const spell &sp, Creature &caster, const tripoint & )
 
 void spell_effect::morale( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     if( sp.effect_data().empty() ) {
         debugmsg( "ERROR: %s must have a valid morale_type as effect_str.  None specified.",
                   sp.id().c_str() );
@@ -1399,32 +1398,32 @@ void spell_effect::morale( const spell &sp, Creature &caster, const tripoint &ta
         return;
     }
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &potential_target : area ) {
+    for( const tripoint_bub_ms &potential_target : area ) {
         Character *player_target;
-        if( !( sp.is_valid_target( caster, potential_target ) &&
+        if( !( sp.is_valid_target( caster, potential_target.raw() ) &&
                ( player_target = creatures.creature_at<Character>( potential_target ) ) ) ) {
             continue;
         }
         player_target->add_morale( morale_type( sp.effect_data() ), sp.damage( caster ), 0,
                                    sp.duration_turns( caster ),
                                    sp.duration_turns( caster ) / 10, false );
-        sp.make_sound( potential_target, caster );
+        sp.make_sound( potential_target.raw(), caster );
     }
 }
 
 void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &potential_target : area ) {
-        if( !sp.is_valid_target( caster, potential_target ) ) {
+    for( const tripoint_bub_ms &potential_target : area ) {
+        if( !sp.is_valid_target( caster, potential_target.raw() ) ) {
             continue;
         }
         monster *mon = creatures.creature_at<monster>( potential_target );
         if( !mon ) {
             continue;
         }
-        sp.make_sound( potential_target, caster );
+        sp.make_sound( potential_target.raw(), caster );
         if( ( mon->friendly == 0 || ( mon->friendly != 0 && sp.has_flag( spell_flag::RECHARM ) ) ) &&
             mon->get_hp() <= sp.damage( caster ) ) {
             mon->unset_dest();
@@ -1435,10 +1434,10 @@ void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripo
 
 void spell_effect::revive( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     ::map &here = get_map();
     const species_id spec( sp.effect_data() );
-    for( const tripoint &aoe : area ) {
+    for( const tripoint_bub_ms &aoe : area ) {
         for( item &corpse : here.i_at( aoe ) ) {
             const mtype *mt = corpse.get_mtype();
             if( !( corpse.is_corpse() && corpse.can_revive() && corpse.active &&
@@ -1446,7 +1445,7 @@ void spell_effect::revive( const spell &sp, Creature &caster, const tripoint &ta
                    !mt->has_flag( mon_flag_NO_NECRO ) ) ) {
                 continue;
             }
-            if( g->revive_corpse( aoe, corpse ) ) {
+            if( g->revive_corpse( aoe.raw(), corpse ) ) {
                 here.i_rem( aoe, &corpse );
                 break;
             }
@@ -1457,10 +1456,10 @@ void spell_effect::revive( const spell &sp, Creature &caster, const tripoint &ta
 // identical to above, but checks for REVIVES && DORMANT flag. Ignores NO_NECRO.
 void spell_effect::revive_dormant( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     ::map &here = get_map();
     const species_id spec( sp.effect_data() );
-    for( const tripoint &aoe : area ) {
+    for( const tripoint_bub_ms &aoe : area ) {
         for( item &corpse : here.i_at( aoe ) ) {
             const mtype *mt = corpse.get_mtype();
             if( !( corpse.is_corpse() && corpse.can_revive() && corpse.active &&
@@ -1468,7 +1467,7 @@ void spell_effect::revive_dormant( const spell &sp, Creature &caster, const trip
                 continue;
             }
             // relaxed revive with radius.
-            if( g->revive_corpse( aoe, corpse, 3 ) ) {
+            if( g->revive_corpse( aoe.raw(), corpse, 3 ) ) {
                 here.i_rem( aoe, &corpse );
                 break;
             }
@@ -1487,9 +1486,9 @@ void spell_effect::add_trap( const spell &sp, Creature &, const tripoint &target
 
 void spell_effect::upgrade( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &aoe : area ) {
+    for( const tripoint_bub_ms &aoe : area ) {
         monster *mon = creatures.creature_at<monster>( aoe );
         if( mon != nullptr && rng( 1, 10000 ) < sp.damage( caster ) ) {
             mon->allow_upgrade();
@@ -1500,13 +1499,13 @@ void spell_effect::upgrade( const spell &sp, Creature &caster, const tripoint &t
 
 void spell_effect::guilt( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     if( !caster.is_monster() ) {
         // only monsters cause the guilt morale effect
         return;
     }
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &aoe : area ) {
+    for( const tripoint_bub_ms &aoe : area ) {
         Character *guilt_target = creatures.creature_at<Character>( aoe );
         if( guilt_target == nullptr ) {
             continue;
@@ -1595,9 +1594,9 @@ void spell_effect::guilt( const spell &sp, Creature &caster, const tripoint &tar
 
 void spell_effect::remove_effect( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &aoe : area ) {
+    for( const tripoint_bub_ms &aoe : area ) {
         if( Creature *critter = creatures.creature_at( aoe ) ) {
             critter->remove_effect( efftype_id( sp.effect_data() ) );
         }
@@ -1606,27 +1605,27 @@ void spell_effect::remove_effect( const spell &sp, Creature &caster, const tripo
 
 void spell_effect::emit( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
-    for( const tripoint &aoe : area ) {
-        get_map().emit_field( aoe, emit_id( sp.effect_data() ) );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
+    for( const tripoint_bub_ms &aoe : area ) {
+        get_map().emit_field( aoe.raw(), emit_id( sp.effect_data() ) );
     }
 }
 
 void spell_effect::fungalize( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     fungal_effects fe;
-    for( const tripoint &aoe : area ) {
-        fe.fungalize( aoe, &caster, sp.damage( caster ) / 10000.0 );
+    for( const tripoint_bub_ms &aoe : area ) {
+        fe.fungalize( aoe.raw(), &caster, sp.damage( caster ) / 10000.0 );
     }
 }
 
 void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &potential_target : area ) {
-        if( !sp.is_valid_target( caster, potential_target ) ) {
+    for( const tripoint_bub_ms &potential_target : area ) {
+        if( !sp.is_valid_target( caster, potential_target.raw() ) ) {
             continue;
         }
         Character *guy = creatures.creature_at<Character>( potential_target );
@@ -1647,16 +1646,16 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
                 guy->mutate_category( mutation_category_id( sp.effect_data() ) );
             }
         }
-        sp.make_sound( potential_target, caster );
+        sp.make_sound( potential_target.raw(), caster );
     }
 }
 
 void spell_effect::bash( const spell &sp, Creature &caster, const tripoint &target )
 {
     ::map &here = get_map();
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
-    for( const tripoint &potential_target : area ) {
-        if( !sp.is_valid_target( caster, potential_target ) ) {
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
+    for( const tripoint_bub_ms &potential_target : area ) {
+        if( !sp.is_valid_target( caster, potential_target.raw() ) ) {
             continue;
         }
         // the bash already makes noise, so no need for spell::make_sound()
@@ -1711,7 +1710,8 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint &targ
 
     spell_effect::override_parameters params( sp, caster );
     params.range = sp.aoe( caster );
-    const std::set<tripoint> hit_area = spell_effect_cone_range_override( params, source, far_target );
+    const std::set<tripoint_bub_ms> hit_area = spell_effect_cone_range_override( params, source,
+            far_target );
     damage_targets( sp, caster, hit_area );
 }
 
@@ -1722,12 +1722,12 @@ void spell_effect::banishment( const spell &sp, Creature &caster, const tripoint
         debugmsg( "ERROR: Banishment has negative or 0 damage value" );
     }
 
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
 
     std::vector<monster *> target_mons;
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &potential_target : area ) {
-        if( !sp.is_valid_target( caster, potential_target ) ) {
+    for( const tripoint_bub_ms &potential_target : area ) {
+        if( !sp.is_valid_target( caster, potential_target.raw() ) ) {
             continue;
         }
         // you can't banish npcs.
@@ -1791,11 +1791,11 @@ void spell_effect::banishment( const spell &sp, Creature &caster, const tripoint
 void spell_effect::effect_on_condition( const spell &sp, Creature &caster,
                                         const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_area( sp, target, caster );
+    const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
 
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &potential_target : area ) {
-        if( !sp.is_valid_target( caster, potential_target ) ) {
+    for( const tripoint_bub_ms &potential_target : area ) {
+        if( !sp.is_valid_target( caster, potential_target.raw() ) ) {
             continue;
         }
         Creature *victim = creatures.creature_at<Creature>( potential_target );

--- a/src/magic_spell_effect_helpers.h
+++ b/src/magic_spell_effect_helpers.h
@@ -5,13 +5,15 @@
 #include <functional>
 #include <set>
 
+#include "coords_fwd.h"
+
 class Creature;
 class spell;
 struct tripoint;
 
 // spells do not reduce in damage the further away from the epicenter the targets are
 // rather they do their full damage in the entire area of effect
-std::set<tripoint> calculate_spell_effect_area( const spell &sp, const tripoint &target,
+std::set<tripoint_bub_ms> calculate_spell_effect_area( const spell &sp, const tripoint &target,
         const Creature &caster );
 
 #endif // CATA_SRC_MAGIC_SPELL_EFFECT_HELPERS_H

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -92,7 +92,7 @@ bool teleporter_list::place_avatar_overmap( Character &you, const tripoint_abs_o
     return true;
 }
 
-void teleporter_list::translocate( const std::set<tripoint> &targets )
+void teleporter_list::translocate( const std::set<tripoint_bub_ms> &targets )
 {
     if( known_teleporters.empty() ) {
         // we can't go somewhere if we don't know how to get there!
@@ -106,14 +106,14 @@ void teleporter_list::translocate( const std::set<tripoint> &targets )
     }
 
     bool valid_targets = false;
-    for( const tripoint &pt : targets ) {
+    for( const tripoint_bub_ms &pt : targets ) {
         Character *you = get_creature_tracker().creature_at<Character>( pt );
 
         if( you && you->is_avatar() ) {
             valid_targets = true;
             if( !place_avatar_overmap( *you, *omt_dest ) ) {
                 add_msg( _( "Failed to teleport.  Teleporter obstructed or destroyed." ) );
-                deactivate_teleporter( *omt_dest, pt );
+                deactivate_teleporter( *omt_dest, pt.raw() );
             }
         }
     }

--- a/src/magic_teleporter_list.h
+++ b/src/magic_teleporter_list.h
@@ -33,7 +33,7 @@ class teleporter_list
 
         // calls the necessary functions to select translocator location
         // and teleports the target(s) there
-        void translocate( const std::set<tripoint> &targets );
+        void translocate( const std::set<tripoint_bub_ms> &targets );
 
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &data );

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -1111,7 +1111,7 @@ int gun_actor::get_max_range()  const
 bool gun_actor::call( monster &z ) const
 {
     Creature *target;
-    tripoint aim_at;
+    tripoint_bub_ms aim_at;
     bool untargeted = false;
 
     if( has_condition ) {
@@ -1137,10 +1137,10 @@ bool gun_actor::call( monster &z ) const
             }
             return false;
         }
-        aim_at = target->pos();
+        aim_at = target->pos_bub();
     } else {
         target = z.attack_target();
-        aim_at = target ? target->pos() : tripoint_zero;
+        aim_at = target ? target->pos_bub() : tripoint_bub_ms_zero;
         if( !target || !z.sees( *target ) || ( !target->is_monster() && !z.aggro_character ) ) {
             if( !target_moving_vehicles ) {
                 return false;
@@ -1151,11 +1151,11 @@ bool gun_actor::call( monster &z ) const
             if( moving_veh_parts.empty() ) {
                 return false;
             }
-            aim_at = random_entry( moving_veh_parts, tripoint_bub_ms() ).raw();
+            aim_at = random_entry( moving_veh_parts, tripoint_bub_ms() );
         }
     }
 
-    const int dist = rl_dist( z.pos(), aim_at );
+    const int dist = rl_dist( z.pos_bub(), aim_at );
     if( target ) {
         add_msg_debug( debugmode::DF_MATTACK, "Target %s at range %d", target->disp_name(), dist );
     } else {
@@ -1220,7 +1220,7 @@ bool gun_actor::try_target( monster &z, Creature &target ) const
     return true;
 }
 
-bool gun_actor::shoot( monster &z, const tripoint &target, const gun_mode_id &mode,
+bool gun_actor::shoot( monster &z, const tripoint_bub_ms &target, const gun_mode_id &mode,
                        int inital_recoil ) const
 {
     itype_id mig_gun_type = item_controller->migrate_id( gun_type );

--- a/src/mattack_actors.h
+++ b/src/mattack_actors.h
@@ -263,7 +263,7 @@ class gun_actor : public mattack_actor
         bool require_sunlight = false;
 
         bool try_target( monster &z, Creature &target ) const;
-        bool shoot( monster &z, const tripoint &target, const gun_mode_id &mode,
+        bool shoot( monster &z, const tripoint_bub_ms &target, const gun_mode_id &mode,
                     int inital_recoil = 0 ) const;
         int get_max_range() const;
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1005,7 +1005,7 @@ int Character::get_total_melee_stamina_cost( const item *weap ) const
     return std::min<int>( -50, proficiency_multiplier * ( mod_sta + melee - stance_malus ) );
 }
 
-void Character::reach_attack( const tripoint &p, int forced_movecost )
+void Character::reach_attack( const tripoint_bub_ms &p, int forced_movecost )
 {
     static const matec_id no_technique_id( "" );
     matec_id force_technique = no_technique_id;
@@ -1033,9 +1033,9 @@ void Character::reach_attack( const tripoint &p, int forced_movecost )
     float skill = std::min( 10.0f, get_skill_level( skill_melee ) );
     int t = 0;
     map &here = get_map();
-    std::vector<tripoint> path = line_to( pos(), p, t, 0 );
+    std::vector<tripoint_bub_ms> path = line_to( pos_bub(), p, t, 0 );
     path.pop_back(); // Last point is our critter
-    for( const tripoint &path_point : path ) {
+    for( const tripoint_bub_ms &path_point : path ) {
         // Possibly hit some unintended target instead
         Creature *inter = creatures.creature_at( path_point );
         /** @EFFECT_MELEE decreases chance of hitting intervening target on reach attack */

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -277,7 +277,7 @@ static bool sting_shoot( monster *z, Creature *target, damage_instance &dam, flo
     proj.impact.add( dam );
     proj.proj_effects.insert( ammo_effect_NO_OVERSHOOT );
 
-    dealt_projectile_attack atk = projectile_attack( proj, z->pos(), target->pos(),
+    dealt_projectile_attack atk = projectile_attack( proj, z->pos_bub(), target->pos_bub(),
                                   dispersion_sources{ 500 }, z );
     if( atk.dealt_dam.total_damage() > 0 ) {
         target->add_msg_if_player( m_bad, _( "The %s shoots a dart into you!" ), z->name() );
@@ -731,8 +731,8 @@ bool mattack::acid( monster *z )
     proj.impact.add_damage( damage_acid, 5 );
     proj.range = 10;
     proj.proj_effects.insert( ammo_effect_NO_OVERSHOOT );
-    dealt_projectile_attack dealt = projectile_attack( proj, z->pos(), target->pos(), dispersion_sources{ 5400 },
-                                    z );
+    dealt_projectile_attack dealt = projectile_attack( proj, z->pos_bub(), target->pos_bub(),
+                                    dispersion_sources{ 5400 }, z );
     const tripoint_bub_ms &hitp = tripoint_bub_ms( dealt.end_point );
     const Creature *hit_critter = dealt.hit_critter;
     if( hit_critter == nullptr && here.hit_with_acid( hitp ) ) {
@@ -956,8 +956,8 @@ bool mattack::pull_metal_weapon( monster *z )
                     proj.range = rl_dist( foe->pos(), z->pos() ) - 1;
                     proj.proj_effects = { { ammo_effect_NO_ITEM_DAMAGE, ammo_effect_DRAW_AS_LINE, ammo_effect_NO_DAMAGE_SCALING, ammo_effect_JET } };
 
-                    dealt_projectile_attack dealt = projectile_attack( proj, foe->pos(), z->pos(), dispersion_sources{ 0 },
-                                                    z );
+                    dealt_projectile_attack dealt = projectile_attack( proj, foe->pos_bub(), z->pos_bub(),
+                                                    dispersion_sources{ 0 }, z );
                     get_map().add_item( dealt.end_point, pulled_weapon );
                     target->add_msg_player_or_npc( m_type, _( "The %s is pulled away from your hands!" ),
                                                    _( "The %s is pulled away from <npcname>'s hands!" ), pulled_weapon.tname() );
@@ -1553,7 +1553,7 @@ bool mattack::spit_sap( monster *z )
     proj.range = 12;
     proj.proj_effects.insert( ammo_effect_APPLY_SAP );
     proj.impact.add_damage( damage_acid, rng( 5, 10 ) );
-    projectile_attack( proj, z->pos(), target->pos(), dispersion_sources{ 150 }, z );
+    projectile_attack( proj, z->pos_bub(), target->pos_bub(), dispersion_sources{ 150 }, z );
 
     return true;
 }

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -125,8 +125,8 @@ void mdefense::acidsplash( monster &m, Creature *const source,
     }
 
     // Don't splatter directly on the `m`, that doesn't work well
-    std::vector<tripoint> pts = closest_points_first( source->pos(), 1 );
-    pts.erase( std::remove( pts.begin(), pts.end(), m.pos() ), pts.end() );
+    std::vector<tripoint_bub_ms> pts = closest_points_first( source->pos_bub(), 1 );
+    pts.erase( std::remove( pts.begin(), pts.end(), m.pos_bub() ), pts.end() );
 
     projectile prj;
     prj.speed = 10;
@@ -135,8 +135,8 @@ void mdefense::acidsplash( monster &m, Creature *const source,
     prj.proj_effects.insert( ammo_effect_NO_DAMAGE_SCALING );
     prj.impact.add_damage( damage_acid, rng( 1, 3 ) );
     for( size_t i = 0; i < num_drops; i++ ) {
-        const tripoint &target = random_entry( pts );
-        projectile_attack( prj, m.pos(), target, dispersion_sources{ 1200 }, &m );
+        const tripoint_bub_ms &target = random_entry( pts );
+        projectile_attack( prj, m.pos_bub(), target, dispersion_sources{ 1200 }, &m );
     }
 
     if( get_player_view().sees( m.pos() ) ) {
@@ -166,7 +166,7 @@ void mdefense::return_fire( monster &m, Creature *source, const dealt_projectile
         return;
     }
 
-    const tripoint fire_point = source->pos();
+    const tripoint_bub_ms fire_point = source->pos_bub();
     // If target actually was not damaged by projectile - then do not bother
     // Also it covers potential exploit - peek throwing potentially can be used to exhaust turret ammo
     if( proj != nullptr && proj->dealt_dam.total_damage() == 0 ) {

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -36,14 +36,15 @@ static const int base_throw_now = 10'000;
 
 // TODO: make a better, more generic "check if this projectile is blocked" function
 // TODO: put this in a namespace for reuse
-static bool has_obstruction( const tripoint &from, const tripoint &to, bool check_ally = false )
+static bool has_obstruction( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
+                             bool check_ally = false )
 {
-    std::vector<tripoint> line = line_to( from, to );
+    std::vector<tripoint_bub_ms> line = line_to( from, to );
     // @to is what we want to hit. we don't need to check for obstruction there.
     line.pop_back();
     const map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &line_point : line ) {
+    for( const tripoint_bub_ms &line_point : line ) {
         if( here.impassable( line_point ) || ( check_ally && creatures.creature_at( line_point ) ) ) {
             return true;
         }
@@ -97,7 +98,7 @@ npc_attack_rating npc_attack_rating::operator-=( const int rhs )
     return *this;
 }
 
-void npc_attack_spell::use( npc &source, const tripoint &location ) const
+void npc_attack_spell::use( npc &source, const tripoint_bub_ms &location ) const
 {
     spell &sp = source.magic->get_spell( attack_spell_id );
     if( source.has_weapon() && !source.get_wielded_item()->has_flag( flag_MAGIC_FOCUS ) &&
@@ -105,7 +106,7 @@ void npc_attack_spell::use( npc &source, const tripoint &location ) const
         source.unwield();
     }
     add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is casting %s", source.disp_name(), sp.name() );
-    source.cast_spell( sp, false, location );
+    source.cast_spell( sp, false, location.raw() );
 }
 
 npc_attack_rating npc_attack_spell::evaluate( const npc &source,
@@ -117,10 +118,9 @@ npc_attack_rating npc_attack_spell::evaluate( const npc &source,
         return effectiveness;
     }
     const int time_penalty = base_time_penalty( source );
-    const std::vector<tripoint> targetable_points = attack_spell.targetable_locations( source );
-    for( const tripoint &targetable_point : targetable_points ) {
-        npc_attack_rating effectiveness_at_point = evaluate_tripoint(
-                    source, target, targetable_point );
+    const std::vector<tripoint_bub_ms> targetable_points = attack_spell.targetable_locations( source );
+    for( const tripoint_bub_ms &targetable_point : targetable_points ) {
+        npc_attack_rating effectiveness_at_point = evaluate_tripoint( source, target, targetable_point );
         effectiveness_at_point -= time_penalty;
         if( effectiveness_at_point > effectiveness ) {
             effectiveness = effectiveness_at_point;
@@ -138,10 +138,9 @@ std::vector<npc_attack_rating> npc_attack_spell::all_evaluations( const npc &sou
         return effectiveness;
     }
     int time_penalty = this->base_time_penalty( source );
-    const std::vector<tripoint> targetable_points = attack_spell.targetable_locations( source );
-    for( const tripoint &targetable_point : targetable_points ) {
-        npc_attack_rating effectiveness_at_point = evaluate_tripoint(
-                    source, target, targetable_point );
+    const std::vector<tripoint_bub_ms> targetable_points = attack_spell.targetable_locations( source );
+    for( const tripoint_bub_ms &targetable_point : targetable_points ) {
+        npc_attack_rating effectiveness_at_point = evaluate_tripoint( source, target, targetable_point );
         effectiveness_at_point -= time_penalty;
         effectiveness.push_back( effectiveness_at_point );
     }
@@ -171,15 +170,15 @@ int npc_attack_spell::base_time_penalty( const npc &source ) const
 }
 
 npc_attack_rating npc_attack_spell::evaluate_tripoint(
-    const npc &source, const Creature *target, const tripoint &location ) const
+    const npc &source, const Creature *target, const tripoint_bub_ms &location ) const
 {
     const spell &attack_spell = source.magic->get_spell( attack_spell_id );
 
     double total_potential = 0;
 
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &potential_target : calculate_spell_effect_area( attack_spell, location,
-            source ) ) {
+    for( const tripoint_bub_ms &potential_target : calculate_spell_effect_area( attack_spell,
+            location.raw(), source ) ) {
         Creature *critter = creatures.creature_at( potential_target );
 
         if( !critter ) {
@@ -197,7 +196,7 @@ npc_attack_rating npc_attack_spell::evaluate_tripoint(
         if( source.sees( *critter ) ) {
             damage = attack_spell.dps( source, *critter );
         }
-        const int distance_to_me = rl_dist( source.pos(), potential_target );
+        const int distance_to_me = rl_dist( source.pos_bub(), potential_target );
         const bool friendly_fire = att == Creature::Attitude::FRIENDLY &&
                                    !source.rules.has_flag( ally_rule::avoid_friendly_fire );
         int attitude_mult = 3;
@@ -229,7 +228,7 @@ npc_attack_rating npc_attack_spell::evaluate_tripoint(
     return npc_attack_rating( static_cast<int>( std::round( total_potential ) ), location );
 }
 
-void npc_attack_melee::use( npc &source, const tripoint &location ) const
+void npc_attack_melee::use( npc &source, const tripoint_bub_ms &location ) const
 {
     if( !source.is_wielding( weapon ) ) {
         if( !source.wield( weapon ) ) {
@@ -242,16 +241,16 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
         debugmsg( "ERROR: npc tried to attack null critter" );
         return;
     }
-    int target_distance = rl_dist( source.pos(), location );
+    int target_distance = rl_dist( source.pos_bub(), location );
     if( !source.is_adjacent( critter, true ) ) {
         if( target_distance <= weapon.reach_range( source ) ) {
             add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is attempting a reach attack",
                            source.disp_name() );
             // check for friendlies in the line of fire
-            std::vector<tripoint> path = line_to( source.pos(), location );
+            std::vector<tripoint_bub_ms> path = line_to( source.pos_bub(), location );
             path.pop_back(); // Last point is the target
             bool can_attack = true;
-            for( const tripoint &path_point : path ) {
+            for( const tripoint_bub_ms &path_point : path ) {
                 Creature *inter = get_creature_tracker().creature_at( path_point );
                 if( inter != nullptr && source.attitude_to( *inter ) == Creature::Attitude::FRIENDLY ) {
                     add_msg_debug( debugmode::debug_filter::DF_NPC, "%s aborted a reach attack; ally in the way",
@@ -324,21 +323,21 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
     }
 }
 
-tripoint_range<tripoint> npc_attack_melee::targetable_points( const npc &source ) const
+tripoint_range<tripoint_bub_ms> npc_attack_melee::targetable_points( const npc &source ) const
 {
-    return get_map().points_in_radius( source.pos(), 8 );
+    return get_map().points_in_radius( source.pos_bub(), 8 );
 }
 
 npc_attack_rating npc_attack_melee::evaluate( const npc &source,
         const Creature *target ) const
 {
-    npc_attack_rating effectiveness( std::nullopt, source.pos() );
+    npc_attack_rating effectiveness( std::nullopt, source.pos_bub() );
     if( !can_use( source ) ) {
         return effectiveness;
     }
     const int time_penalty = base_time_penalty( source );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &targetable_point : targetable_points( source ) ) {
+    for( const tripoint_bub_ms &targetable_point : targetable_points( source ) ) {
         if( Creature *critter = creatures.creature_at( targetable_point ) ) {
             if( source.attitude_to( *critter ) != Creature::Attitude::HOSTILE ) {
                 // no point in swinging a sword at a friendly!
@@ -363,7 +362,7 @@ std::vector<npc_attack_rating> npc_attack_melee::all_evaluations( const npc &sou
     }
     const int time_penalty = base_time_penalty( source );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &targetable_point : targetable_points( source ) ) {
+    for( const tripoint_bub_ms &targetable_point : targetable_points( source ) ) {
         if( Creature *critter = creatures.creature_at( targetable_point ) ) {
             if( source.attitude_to( *critter ) != Creature::Attitude::HOSTILE ) {
                 // no point in swinging a sword at a friendly!
@@ -412,10 +411,10 @@ npc_attack_rating npc_attack_melee::evaluate_critter( const npc &source,
         potential *= npc_attack_constants::target_modifier;
     }
 
-    return npc_attack_rating( static_cast<int>( std::round( potential ) ), critter->pos() );
+    return npc_attack_rating( static_cast<int>( std::round( potential ) ), critter->pos_bub() );
 }
 
-void npc_attack_gun::use( npc &source, const tripoint &location ) const
+void npc_attack_gun::use( npc &source, const tripoint_bub_ms &location ) const
 {
     if( !source.is_wielding( gun ) ) {
         if( !source.wield( gun ) ) {
@@ -433,7 +432,7 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
         return;
     }
 
-    if( has_obstruction( source.pos(), location, false ) ||
+    if( has_obstruction( source.pos_bub(), location, false ) ||
         ( source.rules.has_flag( ally_rule::avoid_friendly_fire ) &&
           !source.wont_hit_friend( tripoint_bub_ms( location ), gun, false ) ) ) {
         if( can_move( source ) ) {
@@ -444,14 +443,14 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
         return;
     }
 
-    const int dist = rl_dist( source.pos(), location );
+    const int dist = rl_dist( source.pos_bub(), location );
 
     // Only aim if we aren't in risk of being hit
     // TODO: Get distance to closest enemy
     if( dist > 1 && source.aim_per_move( gun, source.recoil ) > 0 &&
         source.confident_gun_mode_range( gunmode, source.recoil ) < dist ) {
         add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is aiming", source.disp_name() );
-        source.aim( Target_attributes( source.pos(), location ) );
+        source.aim( Target_attributes( source.pos_bub(), location ) );
     } else {
         if( source.is_hallucination() ) {
             gun_mode mode = source.get_wielded_item()->gun_current_mode();
@@ -491,22 +490,22 @@ int npc_attack_gun::base_time_penalty( const npc &source ) const
     return time_penalty + recoil_penalty;
 }
 
-tripoint_range<tripoint> npc_attack_gun::targetable_points( const npc &source ) const
+tripoint_range<tripoint_bub_ms> npc_attack_gun::targetable_points( const npc &source ) const
 {
     const item &weapon = *gunmode;
-    return get_map().points_in_radius( source.pos(), weapon.gun_range() );
+    return get_map().points_in_radius( source.pos_bub(), weapon.gun_range() );
 }
 
 npc_attack_rating npc_attack_gun::evaluate(
     const npc &source, const Creature *target ) const
 {
-    npc_attack_rating effectiveness( std::nullopt, source.pos() );
+    npc_attack_rating effectiveness( std::nullopt, source.pos_bub() );
     if( !can_use( source ) ) {
         return effectiveness;
     }
     const int time_penalty = base_time_penalty( source );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &targetable_point : targetable_points( source ) ) {
+    for( const tripoint_bub_ms &targetable_point : targetable_points( source ) ) {
         if( creatures.creature_at( targetable_point ) ) {
             npc_attack_rating effectiveness_at_point = evaluate_tripoint( source, target,
                     targetable_point );
@@ -528,7 +527,7 @@ std::vector<npc_attack_rating> npc_attack_gun::all_evaluations( const npc &sourc
     }
     const int time_penalty = base_time_penalty( source );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &targetable_point : targetable_points( source ) ) {
+    for( const tripoint_bub_ms &targetable_point : targetable_points( source ) ) {
         if( creatures.creature_at( targetable_point ) ) {
             npc_attack_rating effectiveness_at_point = evaluate_tripoint( source, target,
                     targetable_point );
@@ -540,7 +539,7 @@ std::vector<npc_attack_rating> npc_attack_gun::all_evaluations( const npc &sourc
 }
 
 npc_attack_rating npc_attack_gun::evaluate_tripoint(
-    const npc &source, const Creature *target, const tripoint &location ) const
+    const npc &source, const Creature *target, const tripoint_bub_ms &location ) const
 {
     const item &gun = *gunmode.target;
     const int damage = gun.gun_damage().total_damage() * gunmode.qty;
@@ -559,10 +558,10 @@ npc_attack_rating npc_attack_gun::evaluate_tripoint(
     }
 
     const bool avoids_friendly_fire = source.rules.has_flag( ally_rule::avoid_friendly_fire );
-    const int distance_to_me = rl_dist( location, source.pos() );
+    const int distance_to_me = rl_dist( location, source.pos_bub() );
 
     // Make attacks that involve moving to find clear LOS slightly less likely
-    if( has_obstruction( source.pos(), location, avoids_friendly_fire ) ) {
+    if( has_obstruction( source.pos_bub(), location, avoids_friendly_fire ) ) {
         potential *= 0.9f;
     } else if( avoids_friendly_fire &&
                !source.wont_hit_friend( tripoint_bub_ms( location ), gun, false ) ) {
@@ -581,7 +580,7 @@ npc_attack_rating npc_attack_gun::evaluate_tripoint(
     return npc_attack_rating( static_cast<int>( std::round( potential ) ), location );
 }
 
-void npc_attack_activate_item::use( npc &source, const tripoint &/*location*/ ) const
+void npc_attack_activate_item::use( npc &source, const tripoint_bub_ms &/*location*/ ) const
 {
     if( !source.wield( activatable_item ) ) {
         debugmsg( "%s can't wield %s it tried to activate", source.disp_name(),
@@ -607,11 +606,11 @@ npc_attack_rating npc_attack_activate_item::evaluate(
     const npc &source, const Creature * /*target*/ ) const
 {
     if( !can_use( source ) ) {
-        return npc_attack_rating( std::nullopt, source.pos() );
+        return npc_attack_rating( std::nullopt, source.pos_bub() );
     }
     // until we have better logic for grenades it's better to keep this as a last resort...
     const int emergency = source.emergency() ? 1 : 0;
-    return npc_attack_rating( emergency, source.pos() );
+    return npc_attack_rating( emergency, source.pos_bub() );
 }
 
 std::vector<npc_attack_rating> npc_attack_activate_item::all_evaluations( const npc &source,
@@ -623,11 +622,11 @@ std::vector<npc_attack_rating> npc_attack_activate_item::all_evaluations( const 
     }
     // until we have better logic for grenades it's better to keep this as a last resort...
     const int emergency = source.emergency() ? 1 : 0;
-    effectiveness.emplace_back( emergency, source.pos() );
+    effectiveness.emplace_back( emergency, source.pos_bub() );
     return effectiveness;
 }
 
-void npc_attack_throw::use( npc &source, const tripoint &location ) const
+void npc_attack_throw::use( npc &source, const tripoint_bub_ms &location ) const
 {
     if( !source.is_wielding( thrown_item ) ) {
         if( !source.wield( thrown_item ) ) {
@@ -636,9 +635,9 @@ void npc_attack_throw::use( npc &source, const tripoint &location ) const
         return;
     }
 
-    if( has_obstruction( source.pos(), location, false ) ||
+    if( has_obstruction( source.pos_bub(), location, false ) ||
         ( source.rules.has_flag( ally_rule::avoid_friendly_fire ) &&
-          !source.wont_hit_friend( tripoint_bub_ms( location ), thrown_item, true ) ) ) {
+          !source.wont_hit_friend( location, thrown_item, true ) ) ) {
         if( can_move( source ) ) {
             source.avoid_friendly_fire();
         } else {
@@ -712,20 +711,20 @@ int npc_attack_throw::base_penalty( const npc &source ) const
     return time_penalty;
 }
 
-tripoint_range<tripoint> npc_attack_throw::targetable_points( const npc &source ) const
+tripoint_range<tripoint_bub_ms> npc_attack_throw::targetable_points( const npc &source ) const
 {
     item single_item( thrown_item );
     if( single_item.count_by_charges() ) {
         single_item.charges = 1;
     }
     const int range = source.throw_range( single_item );
-    return get_map().points_in_radius( source.pos(), range );
+    return get_map().points_in_radius( source.pos_bub(), range );
 }
 
 npc_attack_rating npc_attack_throw::evaluate(
     const npc &source, const Creature *target ) const
 {
-    npc_attack_rating effectiveness( std::nullopt, source.pos() );
+    npc_attack_rating effectiveness( std::nullopt, source.pos_bub() );
     if( !can_use( source ) ) {
         // please don't throw your pants...
         return effectiveness;
@@ -742,15 +741,15 @@ npc_attack_rating npc_attack_throw::evaluate(
     // TODO: Should this be a field to cache the result?
     const bool avoids_friendly_fire = source.rules.has_flag( ally_rule::avoid_friendly_fire );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &potential : targetable_points( source ) ) {
+    for( const tripoint_bub_ms &potential : targetable_points( source ) ) {
 
         // hot potato! HOT POTATO!
         // Calculated for all targetable points, not just those with targets
         if( throw_now ) {
             // TODO: Take into account distance to allies too
-            const int distance_to_me = rl_dist( potential, source.pos() );
+            const int distance_to_me = rl_dist( potential, source.pos_bub() );
             int result = npc_attack_constants::base_throw_now + distance_to_me;
-            if( !has_obstruction( source.pos(), potential, avoids_friendly_fire ) ) {
+            if( !has_obstruction( source.pos_bub(), potential, avoids_friendly_fire ) ) {
                 // More likely to pick a target tile that isn't obstructed
                 result += 100;
             }
@@ -783,7 +782,7 @@ std::vector<npc_attack_rating> npc_attack_throw::all_evaluations( const npc &sou
     }
     const int penalty = base_penalty( source );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &potential : targetable_points( source ) ) {
+    for( const tripoint_bub_ms &potential : targetable_points( source ) ) {
         if( Creature *critter = creatures.creature_at( potential ) ) {
             if( source.attitude_to( *critter ) != Creature::Attitude::HOSTILE ) {
                 // no point in friendly fire!
@@ -799,9 +798,9 @@ std::vector<npc_attack_rating> npc_attack_throw::all_evaluations( const npc &sou
 }
 
 npc_attack_rating npc_attack_throw::evaluate_tripoint(
-    const npc &source, const Creature *target, const tripoint &location ) const
+    const npc &source, const Creature *target, const tripoint_bub_ms &location ) const
 {
-    if( has_obstruction( source.pos(), location ) ) {
+    if( has_obstruction( source.pos_bub(), location ) ) {
         return npc_attack_rating( std::nullopt, location );
     }
     item single_item( thrown_item );
@@ -829,7 +828,7 @@ npc_attack_rating npc_attack_throw::evaluate_tripoint(
     const float throw_mult = throw_cost( source, single_item ) * source.speed_rating() / 100.0f;
     const int damage = source.thrown_item_total_damage_raw( single_item );
     float dps = damage / throw_mult;
-    const int distance_to_me = rl_dist( location, source.pos() );
+    const int distance_to_me = rl_dist( location, source.pos_bub() );
     float suitable_item_mult = -0.15f;
     if( distance_to_me > 1 ) {
         if( thrown_item.has_flag( flag_NPC_THROWN ) ) {

--- a/src/npc_attack.h
+++ b/src/npc_attack.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <vector>
 
+#include "coordinates.h"
 #include "gun_mode.h"
 #include "map_iterator.h"
 #include "point.h"
@@ -19,15 +20,15 @@ class npc_attack_rating
         // the total calculated effectiveness of this attack. no value means this attack is not possible.
         std::optional<int> _value = std::nullopt;
         // the target tile of the attack
-        tripoint _target;
+        tripoint_bub_ms _target;
     public:
         npc_attack_rating() = default;
         npc_attack_rating( const std::optional<int> &_value,
-                           const tripoint &_target ) : _value( _value ), _target( _target ) {}
+                           const tripoint_bub_ms &_target ) : _value( _value ), _target( _target ) {}
         std::optional<int> value() const {
             return _value;
         }
-        tripoint target() const {
+        tripoint_bub_ms target() const {
             return _target;
         }
         bool operator>( const npc_attack_rating &rhs ) const;
@@ -45,7 +46,7 @@ class npc_attack
          *  target - the desired target of the npc. valued at 100%
          */
         virtual npc_attack_rating evaluate( const npc &source, const Creature *target ) const = 0;
-        virtual void use( npc &source, const tripoint &location ) const = 0;
+        virtual void use( npc &source, const tripoint_bub_ms &location ) const = 0;
         /**
          *  For debug information. returns all evaluated effectivenesses.
          *  This is abstracted out in evaluate() as it's faster to not use a container
@@ -68,12 +69,12 @@ class npc_attack_spell : public npc_attack
         npc_attack_rating evaluate( const npc &source, const Creature *target ) const override;
         std::vector<npc_attack_rating> all_evaluations( const npc &source,
                 const Creature *target ) const override;
-        void use( npc &source, const tripoint &location ) const override;
+        void use( npc &source, const tripoint_bub_ms &location ) const override;
     private:
         bool can_use( const npc &source ) const;
         int base_time_penalty( const npc &source ) const;
         npc_attack_rating evaluate_tripoint(
-            const npc &source, const Creature *target, const tripoint &location ) const;
+            const npc &source, const Creature *target, const tripoint_bub_ms &location ) const;
 };
 
 class npc_attack_melee : public npc_attack
@@ -84,9 +85,9 @@ class npc_attack_melee : public npc_attack
         npc_attack_rating evaluate( const npc &source, const Creature *target ) const override;
         std::vector<npc_attack_rating> all_evaluations( const npc &source,
                 const Creature *target ) const override;
-        void use( npc &source, const tripoint &location ) const override;
+        void use( npc &source, const tripoint_bub_ms &location ) const override;
     private:
-        tripoint_range<tripoint> targetable_points( const npc &source ) const;
+        tripoint_range<tripoint_bub_ms> targetable_points( const npc &source ) const;
         bool can_use( const npc &source ) const;
         int base_time_penalty( const npc &source ) const;
         npc_attack_rating evaluate_critter( const npc &source, const Creature *target,
@@ -102,13 +103,13 @@ class npc_attack_gun : public npc_attack
         npc_attack_rating evaluate( const npc &source, const Creature *target ) const override;
         std::vector<npc_attack_rating> all_evaluations( const npc &source,
                 const Creature *target ) const override;
-        void use( npc &source, const tripoint &location ) const override;
+        void use( npc &source, const tripoint_bub_ms &location ) const override;
     private:
-        tripoint_range<tripoint> targetable_points( const npc &source ) const;
+        tripoint_range<tripoint_bub_ms> targetable_points( const npc &source ) const;
         bool can_use( const npc &source ) const;
         int base_time_penalty( const npc &source ) const;
         npc_attack_rating evaluate_tripoint(
-            const npc &source, const Creature *target, const tripoint &location ) const;
+            const npc &source, const Creature *target, const tripoint_bub_ms &location ) const;
 };
 
 class npc_attack_throw : public npc_attack
@@ -119,13 +120,13 @@ class npc_attack_throw : public npc_attack
         npc_attack_rating evaluate( const npc &source, const Creature *target ) const override;
         std::vector<npc_attack_rating> all_evaluations( const npc &source,
                 const Creature *target ) const override;
-        void use( npc &source, const tripoint &location ) const override;
+        void use( npc &source, const tripoint_bub_ms &location ) const override;
     private:
-        tripoint_range<tripoint> targetable_points( const npc &source ) const;
+        tripoint_range<tripoint_bub_ms> targetable_points( const npc &source ) const;
         bool can_use( const npc &source ) const;
         int base_penalty( const npc &source ) const;
         npc_attack_rating evaluate_tripoint(
-            const npc &source, const Creature *target, const tripoint &location ) const;
+            const npc &source, const Creature *target, const tripoint_bub_ms &location ) const;
 };
 
 class npc_attack_activate_item : public npc_attack
@@ -137,7 +138,7 @@ class npc_attack_activate_item : public npc_attack
         npc_attack_rating evaluate( const npc &source, const Creature *target ) const override;
         std::vector<npc_attack_rating> all_evaluations( const npc &source,
                 const Creature *target ) const override;
-        void use( npc &source, const tripoint &location ) const override;
+        void use( npc &source, const tripoint_bub_ms &location ) const override;
     private:
         bool can_use( const npc &source ) const;
 };

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1688,7 +1688,7 @@ void npc::execute_action( npc_action action )
             if( can_use_offensive_cbm() ) {
                 activate_bionic_by_id( bio_hydraulics );
             }
-            reach_attack( tar.raw() );
+            reach_attack( tar );
             break;
         case npc_melee:
             update_path( tar );
@@ -1707,7 +1707,7 @@ void npc::execute_action( npc_action action )
             break;
 
         case npc_aim:
-            aim( Target_attributes( pos(), tar.raw() ) );
+            aim( Target_attributes( pos_bub(), tar ) );
             break;
 
         case npc_shoot: {
@@ -1719,11 +1719,11 @@ void npc::execute_action( npc_action action )
                 debugmsg( "NPC tried to shoot without valid mode" );
                 break;
             }
-            aim( Target_attributes( pos(), tar.raw() ) );
+            aim( Target_attributes( pos_bub(), tar ) );
             if( is_hallucination() ) {
                 pretend_fire( this, mode.qty, *mode );
             } else {
-                fire_gun( tar.raw(), mode.qty, *mode );
+                fire_gun( tar, mode.qty, *mode );
                 // "discard" the fake bio weapon after shooting it
                 if( is_using_bionic_weapon() ) {
                     discharge_cbm_weapon();
@@ -4154,7 +4154,7 @@ static void npc_throw( npc &np, item &it, const tripoint_bub_ms &pos )
         it.charges = 1;
     }
     if( !np.is_hallucination() ) { // hallucinations only pretend to throw
-        np.throw_item( pos.raw(), it );
+        np.throw_item( pos, it );
     }
     // Throw a single charge of a stacking object.
     if( stack_size == -1 || stack_size == 1 ) {

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1903,7 +1903,7 @@ static tripoint_abs_omt display()
     std::string action;
     data.show_explored = true;
     int fast_scroll_offset = get_option<int>( "FAST_SCROLL_OFFSET" );
-    std::optional<tripoint> mouse_pos;
+    std::optional<tripoint_bub_ms> mouse_pos;
     std::chrono::time_point<std::chrono::steady_clock> last_blink = std::chrono::steady_clock::now();
     std::chrono::time_point<std::chrono::steady_clock> last_advance = std::chrono::steady_clock::now();
     auto display_path_iter = display_path.rbegin();
@@ -1957,7 +1957,7 @@ static tripoint_abs_omt display()
             }
         } else if( action == "SELECT" &&
                    ( mouse_pos = ictxt.get_coordinates( g->w_overmap, point_zero, true ) ) ) {
-            curs += mouse_pos->xy();
+            curs += mouse_pos->xy().raw();
         } else if( action == "look" ) {
             tripoint_abs_ms pos = project_combine( curs, g->overmap_data.origin_remainder );
             tripoint pos_rel = get_map().getlocal( pos );

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -117,7 +117,7 @@ void projectile::unset_custom_explosion()
     custom_explosion.reset();
 }
 
-static void foamcrete_build( const tripoint &p )
+static void foamcrete_build( const tripoint_bub_ms &p )
 {
     map &here = get_map();
 
@@ -128,7 +128,7 @@ static void foamcrete_build( const tripoint &p )
     }
 
     if( here.has_flag_ter( ter_furn_flag::TFLAG_NO_FLOOR, p ) ) {
-        for( const tripoint &ep : here.points_in_radius( p, 1 ) ) {
+        for( const tripoint_bub_ms &ep : here.points_in_radius( p, 1 ) ) {
             if( here.has_flag_ter( ter_furn_flag::TFLAG_SUPPORTS_ROOF, ep ) ) {
                 here.ter_set( p, ter_t_foamcrete_floor );
                 here.add_field( p, field_fd_foamcrete, 1 );
@@ -144,7 +144,7 @@ static void foamcrete_build( const tripoint &p )
     }
 }
 
-void apply_ammo_effects( const Creature *source, const tripoint &p,
+void apply_ammo_effects( const Creature *source, const tripoint_bub_ms &p,
                          const std::set<ammo_effect_str_id> &effects, const int dealt_damage )
 {
     map &here = get_map();
@@ -155,10 +155,10 @@ void apply_ammo_effects( const Creature *source, const tripoint &p,
             continue;
         }
         if( effects.count( ae.id ) > 0 ) {
-            for( const tripoint_bub_ms &pt : here.points_in_radius( tripoint_bub_ms( p ), ae.aoe_radius,
+            for( const tripoint_bub_ms &pt : here.points_in_radius( p, ae.aoe_radius,
                     ae.aoe_radius_z ) ) {
                 if( x_in_y( ae.aoe_chance, 100 ) ) {
-                    const bool check_sees = !ae.aoe_check_sees || here.sees( p, pt.raw(), ae.aoe_check_sees_radius );
+                    const bool check_sees = !ae.aoe_check_sees || here.sees( p, pt, ae.aoe_check_sees_radius );
                     const bool check_passable = !ae.aoe_check_passable || here.passable( pt );
                     if( check_sees && check_passable ) {
                         here.add_field( pt, ae.aoe_field_type, rng( ae.aoe_intensity_min, ae.aoe_intensity_max ) );
@@ -179,13 +179,13 @@ void apply_ammo_effects( const Creature *source, const tripoint &p,
                 }
             }
             if( ae.aoe_explosion_data.power > 0 ) {
-                explosion_handler::explosion( source, p, ae.aoe_explosion_data );
+                explosion_handler::explosion( source, p.raw(), ae.aoe_explosion_data );
             }
             if( ae.do_flashbang ) {
-                explosion_handler::flashbang( p );
+                explosion_handler::flashbang( p.raw() );
             }
             if( ae.do_emp_blast ) {
-                explosion_handler::emp_blast( p );
+                explosion_handler::emp_blast( p.raw() );
             }
             if( ae.foamcrete_build ) {
                 foamcrete_build( p );
@@ -205,8 +205,8 @@ void apply_ammo_effects( const Creature *source, const tripoint &p,
             const spell ammo_spell = ae.spell_data.get_spell();
             if( ammo_spell.is_valid() ) {
                 if( ae.always_cast_spell || dealt_damage > 0 ) {
-                    ammo_spell.cast_all_effects( *const_cast<Creature *>( source ), p );
-                    ammo_spell.make_sound( p, *const_cast<Creature *>( source ) );
+                    ammo_spell.cast_all_effects( *const_cast<Creature *>( source ), p.raw() );
+                    ammo_spell.make_sound( p.raw(), *const_cast<Creature *>( source ) );
                 }
             }
         }

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -7,8 +7,8 @@
 #include <set>
 
 #include "compatibility.h"
+#include "coordinates.h"
 #include "damage.h"
-#include "point.h"
 
 class Creature;
 class item;
@@ -70,11 +70,11 @@ struct dealt_projectile_attack {
     projectile proj; // What we used to deal the attack
     Creature *hit_critter; // The critter that stopped the projectile or null
     dealt_damage_instance dealt_dam; // If hit_critter isn't null, hit data is written here
-    tripoint end_point; // Last hit tile (is hit_critter is null, drops should spawn here)
+    tripoint_bub_ms end_point; // Last hit tile (is hit_critter is null, drops should spawn here)
     double missed_by; // Accuracy of dealt attack
 };
 
-void apply_ammo_effects( const Creature *source, const tripoint &p,
+void apply_ammo_effects( const Creature *source, const tripoint_bub_ms &p,
                          const std::set<ammo_effect_str_id> &effects, int dealt_damage );
 int max_aoe_size( const std::set<ammo_effect_str_id> &tags );
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -263,12 +263,12 @@ class target_ui
         Status status = Status::Good;
 
         // Current trajectory
-        std::vector<tripoint> traj;
+        std::vector<tripoint_bub_ms> traj;
         // Aiming source (player's position)
-        tripoint src;
+        tripoint_bub_ms src;
         // Aiming destination (cursor position)
         // Use set_cursor_pos() to modify
-        tripoint dst;
+        tripoint_bub_ms dst;
         // Creature currently under cursor. nullptr if aiming at empty tile,
         // yourself or a creature you cannot see
         Creature *dst_critter = nullptr;
@@ -296,12 +296,12 @@ class target_ui
 
         // For AOE spells, list of tiles affected by the spell
         // relevant for TargetMode::Spell
-        std::set<tripoint> spell_aoe;
+        std::set<tripoint_bub_ms> spell_aoe;
 
         // Represents a turret and a straight line from that turret to target
         struct turret_with_lof {
             vehicle_part *turret;
-            std::vector<tripoint> line;
+            std::vector<tripoint_bub_ms> line;
         };
 
         // List of vehicle turrets in range (out of those listed in 'vturrets')
@@ -337,7 +337,7 @@ class target_ui
         // Set cursor position. If new position is out of range,
         // selects closest position in range.
         // Returns 'false' if cursor position did not change
-        bool set_cursor_pos( const tripoint &new_pos );
+        bool set_cursor_pos( const tripoint_bub_ms &new_pos );
 
         // Called when range/ammo changes (or may have changed)
         void on_range_ammo_changed();
@@ -346,7 +346,7 @@ class target_ui
         void update_target_list();
 
         // Choose where to position the cursor when opening the ui
-        tripoint choose_initial_target();
+        tripoint_bub_ms choose_initial_target();
 
         /**
          * Try to re-acquire target for aim-and-fire.
@@ -354,13 +354,13 @@ class target_ui
          * @param new_dst where to move aim cursor (if e.g. critter moved)
          * @returns true on success
          */
-        bool try_reacquire_target( bool critter, tripoint &new_dst );
+        bool try_reacquire_target( bool critter, tripoint_bub_ms &new_dst );
 
         // Update 'status' variable
         void update_status();
 
         // Calculates distance from 'src'. For consistency, prefer using this over rl_dist.
-        int dist_fn( const tripoint &p );
+        int dist_fn( const tripoint_bub_ms &p );
 
         // Set creature (or tile) under cursor as player's last target
         void set_last_target();
@@ -384,7 +384,7 @@ class target_ui
         void cycle_targets( int direction );
 
         // Set new view offset. Updates map cache if necessary
-        void set_view_offset( const tripoint &new_offset ) const;
+        void set_view_offset( const tripoint_rel_ms &new_offset ) const;
 
         // Updates 'turrets_in_range'
         void update_turrets_in_range();
@@ -455,7 +455,7 @@ target_handler::trajectory target_handler::mode_select_only( avatar &you, int ra
     ui.mode = target_ui::TargetMode::SelectOnly;
     ui.range = range;
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -482,7 +482,7 @@ target_handler::trajectory target_handler::mode_throw( avatar &you, item &releva
     ui.relevant = &relevant;
     ui.range = you.throw_range( relevant );
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -494,7 +494,7 @@ target_handler::trajectory target_handler::mode_reach( avatar &you, item_locatio
     ui.relevant = weapon.get_item();
     ui.range = weapon ? weapon->current_reach_range( you ) : 1;
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -508,7 +508,7 @@ target_handler::trajectory target_handler::mode_turret_manual( avatar &you, turr
     ui.range = turret.range();
     ui.ammo = turret.ammo_data();
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -538,7 +538,7 @@ target_handler::trajectory target_handler::mode_turrets( avatar &you, vehicle &v
     ui.vturrets = &turrets;
     ui.range = range_total;
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -553,7 +553,7 @@ target_handler::trajectory target_handler::mode_spell( avatar &you, spell &casti
     ui.no_fail = no_fail;
     ui.no_mana = no_mana;
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -949,7 +949,7 @@ void npc::pretend_fire( npc *source, int shots, item &gun )
     }
 }
 
-int Character::fire_gun( const tripoint &target, int shots )
+int Character::fire_gun( const tripoint_bub_ms &target, int shots )
 {
     item_location gun = get_wielded_item();
     if( !gun ) {
@@ -959,7 +959,7 @@ int Character::fire_gun( const tripoint &target, int shots )
     return fire_gun( target, shots, *gun, item_location() );
 }
 
-int Character::fire_gun( const tripoint &target, int shots, item &gun, item_location ammo )
+int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, item_location ammo )
 {
     if( !gun.is_gun() ) {
         debugmsg( "%s tried to fire non-gun (%s).", get_name(), gun.tname() );
@@ -1015,7 +1015,7 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun, item_loca
     skill_id gun_skill = gun.gun_skill();
     add_msg_debug( debugmode::DF_RANGED, "Gun skill (%s) %g", gun_skill.c_str(),
                    get_skill_level( gun_skill ) ) ;
-    tripoint aim = target;
+    tripoint_bub_ms aim = target;
     int curshot = 0;
     int hits = 0; // total shots on target
     int delay = 0; // delayed recoil that has yet to be applied
@@ -1062,7 +1062,7 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun, item_loca
             if( !first && !proj.multi_projectile_effects ) {
                 proj.proj_effects.erase( proj.proj_effects.begin(), proj.proj_effects.end() );
             }
-            dealt_projectile_attack shot = projectile_attack( proj, pos(), aim,
+            dealt_projectile_attack shot = projectile_attack( proj, pos_bub(), aim,
                                            dispersion, this, in_veh, wp_attack, first );
             first = false;
             if( shot.hit_critter ) {
@@ -1241,14 +1241,14 @@ int throw_cost( const Character &c, const item &to_throw )
 }
 
 // Handle capping aim level when the player cannot see the target tile or there is nothing to aim at.
-double calculate_aim_cap( const Character &you, const tripoint &target )
+double calculate_aim_cap( const Character &you, const tripoint_bub_ms &target )
 {
     double min_recoil = 0.0;
     const Creature *victim = get_creature_tracker().creature_at( target, true );
     // No p.sees_with_specials() here because special senses are not precise enough
     // to give creature's exact size & position, only which tile it occupies
     if( victim == nullptr || ( !you.sees( *victim ) && !you.sees_with_infrared( *victim ) ) ) {
-        const int range = rl_dist( you.pos(), target );
+        const int range = rl_dist( you.pos_bub(), target );
         // Get angle of triangle that spans the target square.
         const double angle = 2 * atan2( 0.5, range );
         // Convert from radians to arcmin.
@@ -1257,7 +1257,7 @@ double calculate_aim_cap( const Character &you, const tripoint &target )
     return min_recoil;
 }
 
-double calc_steadiness( const Character &you, const item &weapon, const tripoint &pos,
+double calc_steadiness( const Character &you, const item &weapon, const tripoint_bub_ms &pos,
                         double predicted_recoil )
 {
     const double min_recoil = calculate_aim_cap( you, pos );
@@ -1409,8 +1409,8 @@ int Character::thrown_item_total_damage_raw( const item &thrown ) const
     return total_damage;
 }
 
-dealt_projectile_attack Character::throw_item( const tripoint &target, const item &to_throw,
-        const std::optional<tripoint> &blind_throw_from_pos )
+dealt_projectile_attack Character::throw_item( const tripoint_bub_ms &target, const item &to_throw,
+        const std::optional<tripoint_bub_ms> &blind_throw_from_pos )
 {
     // Copy the item, we may alter it before throwing
     item thrown = to_throw;
@@ -1520,7 +1520,7 @@ dealt_projectile_attack Character::throw_item( const tripoint &target, const ite
 
     // Throw from the player's position, unless we're blind throwing, in which case
     // throw from the the blind throw position instead.
-    const tripoint throw_from = blind_throw_from_pos ? *blind_throw_from_pos : pos();
+    const tripoint_bub_ms throw_from = blind_throw_from_pos ? *blind_throw_from_pos : pos_bub();
 
     float range = rl_dist( throw_from, target );
     proj.range = range;
@@ -1706,7 +1706,7 @@ static double target_size_in_moa( int range, double size )
     return atan2( size, range ) * 60 * 180 / M_PI;
 }
 
-Target_attributes::Target_attributes( tripoint src, tripoint target )
+Target_attributes::Target_attributes( tripoint_bub_ms src, tripoint_bub_ms target )
 {
     Creature *target_critter = get_creature_tracker().creature_at( target );
     Creature *shooter = get_creature_tracker().creature_at( src );
@@ -1715,7 +1715,7 @@ Target_attributes::Target_attributes( tripoint src, tripoint target )
            target_critter->ranged_target_size() :
            get_map().ranged_target_size( target );
     size_in_moa = target_size_in_moa( range, size ) ;
-    light = get_map().ambient_light_at( tripoint_bub_ms( target ) );
+    light = get_map().ambient_light_at( target );
     visible = shooter->sees( target );
 
 }
@@ -1800,7 +1800,7 @@ static std::vector<aim_type_prediction> calculate_ranged_chances(
     const target_ui &ui, const Character &you,
     target_ui::TargetMode mode, const input_context &ctxt, const item &weapon,
     const dispersion_sources &dispersion, const std::vector<confidence_rating> &confidence_ratings,
-    const Target_attributes &target, const tripoint &pos, const item_location &load_loc )
+    const Target_attributes &target, const tripoint_bub_ms &pos, const item_location &load_loc )
 {
     std::vector<aim_type> aim_types { get_default_aim_type() };
     std::vector<aim_type_prediction> aim_outputs;
@@ -2049,7 +2049,7 @@ static bool pl_sees( const Creature &cr )
 }
 
 static int print_aim( const target_ui &ui, Character &you, const catacurses::window &w,
-                      int line_number, input_context &ctxt, const item &weapon, const tripoint &pos,
+                      int line_number, input_context &ctxt, const item &weapon, const tripoint_bub_ms &pos,
                       item_location &load_loc )
 {
     // This is absolute accuracy for the player.
@@ -2070,7 +2070,7 @@ static int print_aim( const target_ui &ui, Character &you, const catacurses::win
 
     const std::vector<aim_type_prediction> aim_chances = calculate_ranged_chances( ui, you,
             target_ui::TargetMode::Fire, ctxt, weapon, dispersion, confidence_config,
-            Target_attributes( you.pos(), pos ), pos, load_loc );
+            Target_attributes( you.pos_bub(), pos ), pos, load_loc );
 
     int time = RAS_time( you, load_loc );
 
@@ -2078,7 +2078,7 @@ static int print_aim( const target_ui &ui, Character &you, const catacurses::win
 }
 
 static void draw_throw_aim( const target_ui &ui, const Character &you, const catacurses::window &w,
-                            int &text_y, input_context &ctxt, const item &weapon, const tripoint &target_pos,
+                            int &text_y, input_context &ctxt, const item &weapon, const tripoint_bub_ms &target_pos,
                             bool is_blind_throw )
 {
     Creature *target = get_creature_tracker().creature_at( target_pos, true );
@@ -2087,7 +2087,7 @@ static void draw_throw_aim( const target_ui &ui, const Character &you, const cat
     }
 
     const dispersion_sources dispersion( you.throwing_dispersion( weapon, target, is_blind_throw ) );
-    const double range = rl_dist( you.pos(), target_pos );
+    const double range = rl_dist( you.pos_bub(), target_pos );
 
     const double target_size = target != nullptr ? target->ranged_target_size() : 1.0f;
 
@@ -2603,7 +2603,7 @@ target_handler::trajectory target_ui::run()
 
     avatar &player_character = get_avatar();
     on_out_of_scope cleanup( [&here, &player_character]() {
-        here.invalidate_map_cache( player_character.pos().z + player_character.view_offset.z );
+        here.invalidate_map_cache( player_character.pos().z + player_character.view_offset.z() );
     } );
 
     shared_ptr_fast<game::draw_callback_t> target_ui_cb = make_shared_fast<game::draw_callback_t>(
@@ -2648,7 +2648,7 @@ target_handler::trajectory target_ui::run()
     }
 
     // Initialize cursor position
-    src = you->pos();
+    src = you->pos_bub();
     update_target_list();
 
     if( activity && activity->abort_if_no_targets && targets.empty() ) {
@@ -2659,7 +2659,7 @@ target_handler::trajectory target_ui::run()
         traj.clear();
         return traj;
     }
-    tripoint initial_dst = src;
+    tripoint_bub_ms initial_dst = src;
     if( reentered ) {
         if( !try_reacquire_target( resume_critter, initial_dst ) ) {
             // Target lost
@@ -2937,7 +2937,7 @@ void target_ui::init_window_and_input()
 
 bool target_ui::handle_cursor_movement( const std::string &action, bool &skip_redraw )
 {
-    std::optional<tripoint> mouse_pos;
+    std::optional<tripoint_bub_ms> mouse_pos;
     const auto shift_view_or_cursor = [this]( const tripoint & delta ) {
         if( this->shifting_view ) {
             this->set_view_offset( this->you->view_offset + delta );
@@ -2967,8 +2967,8 @@ bool target_ui::handle_cursor_movement( const std::string &action, bool &skip_re
     } else if( action == "SELECT" &&
                ( mouse_pos = ctxt.get_coordinates( g->w_terrain, g->ter_view_p.xy() ) ) ) {
         // Set pos by clicking with mouse
-        mouse_pos->z = you->pos().z + you->view_offset.z;
-        set_cursor_pos( *mouse_pos );
+        mouse_pos->z() = you->pos().z + you->view_offset.z();
+        set_cursor_pos( tripoint_bub_ms( *mouse_pos ) );
     } else if( action == "LEVEL_UP" || action == "LEVEL_DOWN" ) {
         // Shift view/cursor up/down one z level
         tripoint delta = tripoint(
@@ -2983,7 +2983,7 @@ bool target_ui::handle_cursor_movement( const std::string &action, bool &skip_re
         cycle_targets( -1 );
     } else if( action == "CENTER" ) {
         if( shifting_view ) {
-            set_view_offset( tripoint_zero );
+            set_view_offset( tripoint_rel_ms_zero );
         } else {
             set_cursor_pos( src );
         }
@@ -2994,7 +2994,7 @@ bool target_ui::handle_cursor_movement( const std::string &action, bool &skip_re
     return true;
 }
 
-bool target_ui::set_cursor_pos( const tripoint &new_pos )
+bool target_ui::set_cursor_pos( const tripoint_bub_ms &new_pos )
 {
     if( dst == new_pos ) {
         return false;
@@ -3005,14 +3005,14 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
     }
 
     // Make sure new position is valid or find a closest valid position
-    std::vector<tripoint> new_traj;
-    tripoint valid_pos = new_pos;
+    std::vector<tripoint_bub_ms> new_traj;
+    tripoint_bub_ms valid_pos = new_pos;
     map &here = get_map();
     if( new_pos != src ) {
         // On Z axis, make sure we do not exceed map boundaries
-        valid_pos.z = clamp( valid_pos.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT );
+        valid_pos.z() = clamp( valid_pos.z(), -OVERMAP_DEPTH, OVERMAP_HEIGHT );
         // Or current view range
-        valid_pos.z = clamp( valid_pos.z - src.z, -fov_3d_z_range, fov_3d_z_range ) + src.z;
+        valid_pos.z() = clamp( valid_pos.z() - src.z(), -fov_3d_z_range, fov_3d_z_range ) + src.z();
 
         new_traj = here.find_clear_path( src, valid_pos );
         if( range == 1 ) {
@@ -3040,11 +3040,11 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
                 }
             }
         } else {
-            tripoint delta = valid_pos - src;
+            tripoint_rel_ms delta = valid_pos - src;
             valid_pos = src + tripoint(
-                            clamp( delta.x, -range, range ),
-                            clamp( delta.y, -range, range ),
-                            clamp( delta.z, -range, range )
+                            clamp( delta.x(), -range, range ),
+                            clamp( delta.y(), -range, range ),
+                            clamp( delta.z(), -range, range )
                         );
         }
     } else {
@@ -3068,18 +3068,18 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
     }
 
     // Make player's sprite flip to face the current target
-    point d( dst.xy() - src.xy() );
+    point_rel_ms d( dst.xy() - src.xy() );
     if( !g->is_tileset_isometric() ) {
-        if( d.x > 0 ) {
+        if( d.x() > 0 ) {
             you->facing = FacingDirection::RIGHT;
-        } else if( d.x < 0 ) {
+        } else if( d.x() < 0 ) {
             you->facing = FacingDirection::LEFT;
         }
     } else {
-        if( d.x >= 0 && d.y >= 0 ) {
+        if( d.x() >= 0 && d.y() >= 0 ) {
             you->facing = FacingDirection::RIGHT;
         }
-        if( d.y <= 0 && d.x <= 0 ) {
+        if( d.y() <= 0 && d.x() <= 0 ) {
             you->facing = FacingDirection::LEFT;
         }
     }
@@ -3103,15 +3103,15 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
         switch( casting->shape() ) {
             case spell_shape::blast:
                 spell_aoe = spell_effect::spell_effect_blast(
-                                spell_effect::override_parameters( *casting, get_player_character() ), src, dst );
+                                spell_effect::override_parameters( *casting, get_player_character() ), src.raw(), dst.raw() );
                 break;
             case spell_shape::cone:
                 spell_aoe = spell_effect::spell_effect_cone(
-                                spell_effect::override_parameters( *casting, get_player_character() ), src, dst );
+                                spell_effect::override_parameters( *casting, get_player_character() ), src.raw(), dst.raw() );
                 break;
             case spell_shape::line:
                 spell_aoe = spell_effect::spell_effect_line(
-                                spell_effect::override_parameters( *casting, get_player_character() ), src, dst );
+                                spell_effect::override_parameters( *casting, get_player_character() ), src.raw(), dst.raw() );
                 break;
             default:
                 spell_aoe.clear();
@@ -3148,24 +3148,24 @@ void target_ui::update_target_list()
     } );
 }
 
-tripoint target_ui::choose_initial_target()
+tripoint_bub_ms target_ui::choose_initial_target()
 {
     // Try previously targeted creature
     shared_ptr_fast<Creature> cr = you->last_target.lock();
-    if( cr && pl_sees( *cr ) && dist_fn( cr->pos() ) <= range ) {
-        return cr->pos();
+    if( cr && pl_sees( *cr ) && dist_fn( cr->pos_bub() ) <= range ) {
+        return cr->pos_bub();
     }
 
     // Try closest creature
     if( !targets.empty() ) {
-        return targets[0]->pos();
+        return targets[0]->pos_bub();
     }
 
     // Try closest practice target
     map &here = get_map();
-    const std::vector<tripoint> nearby = closest_points_first( src, range );
+    const std::vector<tripoint_bub_ms> nearby = closest_points_first( src, range );
     const auto target_spot = std::find_if( nearby.begin(), nearby.end(),
-    [this, &here]( const tripoint & pt ) {
+    [this, &here]( const tripoint_bub_ms & pt ) {
         return here.tr_at( pt ).id == tr_practice_target && this->you->sees( pt );
     } );
     if( target_spot != nearby.end() ) {
@@ -3176,13 +3176,13 @@ tripoint target_ui::choose_initial_target()
     return src;
 }
 
-bool target_ui::try_reacquire_target( bool critter, tripoint &new_dst )
+bool target_ui::try_reacquire_target( bool critter, tripoint_bub_ms &new_dst )
 {
     if( critter ) {
         // Try to re-acquire the creature
         shared_ptr_fast<Creature> cr = you->last_target.lock();
-        if( cr && pl_sees( *cr ) && dist_fn( cr->pos() ) <= range ) {
-            new_dst = cr->pos();
+        if( cr && pl_sees( *cr ) && dist_fn( cr->pos_bub() ) <= range ) {
+            new_dst = cr->pos_bub();
             return true;
         }
     }
@@ -3193,7 +3193,7 @@ bool target_ui::try_reacquire_target( bool critter, tripoint &new_dst )
     }
 
     // Try to re-acquire target tile or tile where the target creature used to be
-    tripoint local_lt = get_map().bub_from_abs( *you->last_target_pos ).raw();
+    tripoint_bub_ms local_lt = get_map().bub_from_abs( *you->last_target_pos );
     if( dist_fn( local_lt ) <= range ) {
         new_dst = local_lt;
         // Abort aiming if a creature moved in
@@ -3234,7 +3234,7 @@ void target_ui::update_status()
     }
 }
 
-int target_ui::dist_fn( const tripoint &p )
+int target_ui::dist_fn( const tripoint_bub_ms &p )
 {
     return static_cast<int>( std::round( rl_dist_exact( src, p ) ) );
 }
@@ -3311,7 +3311,7 @@ std::vector<weak_ptr_fast<Creature>> target_ui::list_friendlies_in_lof()
         return ret;
     }
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &p : traj ) {
+    for( const tripoint_bub_ms &p : traj ) {
         if( p != dst && p != src ) {
             Creature *cr = creatures.creature_at( p, true );
             if( cr && you->sees( *cr ) ) {
@@ -3352,7 +3352,7 @@ void target_ui::cycle_targets( int direction )
         if( t != targets.end() ) {
             size_t idx = std::distance( targets.begin(), t );
             new_target = ( idx + targets.size() + direction ) % targets.size();
-            set_cursor_pos( targets[new_target]->pos() );
+            set_cursor_pos( targets[new_target]->pos_bub() );
             return;
         }
     }
@@ -3360,23 +3360,23 @@ void target_ui::cycle_targets( int direction )
     // There is either no creature under the cursor or the player can't see it.
     // Use the closest/farthest target in this case
     if( direction == 1 ) {
-        set_cursor_pos( targets.front()->pos() );
+        set_cursor_pos( targets.front()->pos_bub() );
     } else {
-        set_cursor_pos( targets.back()->pos() );
+        set_cursor_pos( targets.back()->pos_bub() );
     }
 }
 
-void target_ui::set_view_offset( const tripoint &new_offset ) const
+void target_ui::set_view_offset( const tripoint_rel_ms &new_offset ) const
 {
-    tripoint new_( new_offset.xy(), clamp( new_offset.z, -fov_3d_z_range, fov_3d_z_range ) );
-    new_.z = clamp( new_.z + src.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT ) - src.z;
+    tripoint_rel_ms new_( new_offset.xy(), clamp( new_offset.z(), -fov_3d_z_range, fov_3d_z_range ) );
+    new_.z() = clamp( new_.z() + src.z(), -OVERMAP_DEPTH, OVERMAP_HEIGHT ) - src.z();
 
-    bool changed_z = you->view_offset.z != new_.z;
+    bool changed_z = you->view_offset.z() != new_.z();
     you->view_offset = new_;
     if( changed_z ) {
         // We need to do a bunch of cache updates since we're
         // looking at a different z-level.
-        get_map().invalidate_map_cache( new_.z );
+        get_map().invalidate_map_cache( new_.z() );
     }
 }
 
@@ -3386,7 +3386,7 @@ void target_ui::update_turrets_in_range()
     for( vehicle_part *t : *vturrets ) {
         turret_data td = veh->turret_query( *t );
         if( td.in_range( dst ) ) {
-            tripoint src = veh->global_part_pos3( *t );
+            tripoint_bub_ms src = veh->bub_part_pos( *t );
             turrets_in_range.push_back( {t, line_to( src, dst )} );
         }
     }
@@ -3404,12 +3404,12 @@ void target_ui::recalc_aim_turning_penalty()
     }
 
     double curr_recoil = you->recoil;
-    tripoint curr_recoil_pos;
+    tripoint_bub_ms curr_recoil_pos;
     const Creature *lt_ptr = you->last_target.lock().get();
     if( lt_ptr ) {
-        curr_recoil_pos = lt_ptr->pos();
+        curr_recoil_pos = lt_ptr->pos_bub();
     } else if( you->last_target_pos ) {
-        curr_recoil_pos = get_map().bub_from_abs( *you->last_target_pos ).raw();
+        curr_recoil_pos = get_map().bub_from_abs( *you->last_target_pos );
     } else {
         curr_recoil_pos = src;
     }
@@ -3660,11 +3660,11 @@ void target_ui::draw_terrain_overlay()
     tripoint_bub_ms center = you->pos_bub() + you->view_offset;
 
     // Removes parts that don't belong to currently visible Z level
-    const auto filter_this_z = [&center]( const std::vector<tripoint> &traj ) {
-        std::vector<tripoint> this_z = traj;
+    const auto filter_this_z = [&center]( const std::vector<tripoint_bub_ms> &traj ) {
+        std::vector<tripoint_bub_ms> this_z = traj;
         this_z.erase( std::remove_if( this_z.begin(), this_z.end(),
-        [&center]( const tripoint & p ) {
-            return p.z != center.z();
+        [&center]( const tripoint_bub_ms & p ) {
+            return p.z() != center.z();
         } ), this_z.end() );
         return this_z;
     };
@@ -3676,45 +3676,45 @@ void target_ui::draw_terrain_overlay()
     if( mode == TargetMode::Turrets && draw_turret_lines ) {
         // TODO: TILES version doesn't know how to draw more than 1 line at a time.
         //       We merge all lines together and draw them as a big malformed one
-        std::set<tripoint> points;
+        std::set<tripoint_bub_ms> points;
         for( const turret_with_lof &it : turrets_in_range ) {
-            std::vector<tripoint> this_z = filter_this_z( it.line );
-            for( const tripoint &p : this_z ) {
+            std::vector<tripoint_bub_ms> this_z = filter_this_z( it.line );
+            for( const tripoint_bub_ms &p : this_z ) {
                 points.insert( p );
             }
         }
         // Since "trajectory" for each turret is just a straight line,
         // we can draw it even if the player can't see some parts
         points.erase( dst ); // Workaround for fake cursor on TILES
-        std::vector<tripoint> l( points.begin(), points.end() );
-        if( dst.z == center.z() ) {
+        std::vector<tripoint_bub_ms> l( points.begin(), points.end() );
+        if( dst.z() == center.z() ) {
             // Workaround for fake cursor bug on TILES
             l.push_back( dst );
         }
-        g->draw_line( src, center.raw(), l, true );
+        g->draw_line( src, center, l, true );
     }
 
     // Draw trajectory
     if( mode != TargetMode::Turrets && dst != src ) {
-        std::vector<tripoint> this_z = filter_this_z( traj );
+        std::vector<tripoint_bub_ms> this_z = filter_this_z( traj );
 
         // Draw a highlighted trajectory only if we can see the endpoint.
         // Provides feedback to the player, but avoids leaking information
         // about tiles they can't see.
-        g->draw_line( dst, center.raw(), this_z );
+        g->draw_line( dst, center, this_z );
     }
 
     // Since draw_line does nothing if destination is not visible,
     // cursor also disappears. Draw it explicitly.
-    if( dst.z == center.z() ) {
+    if( dst.z() == center.z() ) {
         g->draw_cursor( dst );
     }
 
     // Draw spell AOE
     if( mode == TargetMode::Spell ) {
         drawsq_params params = drawsq_params().highlight( true ).center( center );
-        for( const tripoint &tile : spell_aoe ) {
-            if( tile.z != center.z() ) {
+        for( const tripoint_bub_ms &tile : spell_aoe ) {
+            if( tile.z() != center.z() ) {
                 continue;
             }
 #ifdef TILES
@@ -3981,7 +3981,7 @@ void target_ui::panel_cursor_info( int &text_y )
     std::vector<std::string> labels;
     labels.push_back( label_range );
     if( fov_3d_z_range > 0 ) {
-        labels.push_back( string_format( _( "Elevation: %d" ), dst.z - src.z ) );
+        labels.push_back( string_format( _( "Elevation: %d" ), dst.z() - src.z() ) );
     }
     labels.push_back( string_format( _( "Targets: %d" ), targets.size() ) );
 
@@ -4093,9 +4093,8 @@ void target_ui::panel_spell_info( int &text_y )
                                           _( "Line width: %s" ), aoes );
             } else {
                 text_y += fold_and_print( w_target, point( 1, text_y ), getmaxx( w_target ) - 2, color,
-                                          _( "Effective Spell Radius: %s%s" ), aoes,
-                                          casting->in_aoe( src, dst, get_player_character() ) ? colorize( _( " WARNING!  IN RANGE" ),
-                                                  c_red ) : "" );
+                                          _( "Effective Spell Radius: %s%s" ), aoes, casting->in_aoe( src.raw(), dst.raw(),
+                                                  get_player_character() ) ? colorize( _( " WARNING!  IN RANGE" ), c_red ) : "" );
             }
         }
     }

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -26,7 +26,7 @@ constexpr double MIN_RECOIL_IMPROVEMENT = 0.01;
 namespace target_handler
 {
 // Trajectory to target. Empty if selection was aborted or player ran out of moves
-using trajectory = std::vector<tripoint>;
+using trajectory = std::vector<tripoint_bub_ms>;
 
 /** Generic target select without fire something */
 trajectory mode_select_only( avatar &you, int range );
@@ -75,10 +75,10 @@ bool gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::string> 
 int throw_cost( const Character &c, const item &to_throw );
 
 // check for steadiness for a given pos
-double calc_steadiness( const Character &you, const item &weapon, const tripoint &pos,
+double calc_steadiness( const Character &you, const item &weapon, const tripoint_bub_ms &pos,
                         double predicted_recoil );
 
-double calculate_aim_cap( const Character &you, const tripoint &target );
+double calculate_aim_cap( const Character &you, const tripoint_bub_ms &target );
 
 double occupied_tile_fraction( creature_size target_size );
 
@@ -89,7 +89,7 @@ struct Target_attributes {
     float light = 0.0f;
     bool visible = true;
     explicit Target_attributes() = default;
-    explicit Target_attributes( tripoint src, tripoint target );
+    explicit Target_attributes( tripoint_bub_ms src, tripoint_bub_ms target );
     explicit Target_attributes( int rng, double size, float l, bool can_see );
 };
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -112,9 +112,9 @@ void game::serialize( std::ostream &fout )
     json.member( "om_x", pos_om.x() );
     json.member( "om_y", pos_om.y() );
     // view offset
-    json.member( "view_offset_x", u.view_offset.x );
-    json.member( "view_offset_y", u.view_offset.y );
-    json.member( "view_offset_z", u.view_offset.z );
+    json.member( "view_offset_x", u.view_offset.x() );
+    json.member( "view_offset_y", u.view_offset.y() );
+    json.member( "view_offset_z", u.view_offset.z() );
 
     json.member( "grscent", scent.serialize() );
     json.member( "typescent", scent.serialize( true ) );
@@ -229,9 +229,9 @@ void game::unserialize( std::istream &fin, const cata_path &path )
         data.read( "om_x", com.x() );
         data.read( "om_y", com.y() );
 
-        data.read( "view_offset_x", u.view_offset.x );
-        data.read( "view_offset_y", u.view_offset.y );
-        data.read( "view_offset_z", u.view_offset.z );
+        data.read( "view_offset_x", u.view_offset.x() );
+        data.read( "view_offset_y", u.view_offset.y() );
+        data.read( "view_offset_z", u.view_offset.z() );
 
         calendar::turn = time_point( tmpturn );
         calendar::start_of_cataclysm = time_point( tmpcalstart );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3992,8 +3992,8 @@ window_dimensions get_window_dimensions( const point &pos, const point &size )
     return get_window_dimensions( {}, pos, size );
 }
 
-std::optional<tripoint> input_context::get_coordinates( const catacurses::window &capture_win_,
-        const point &offset, const bool center_cursor ) const
+std::optional<tripoint_bub_ms> input_context::get_coordinates( const catacurses::window
+        &capture_win_, const point &offset, const bool center_cursor ) const
 {
     // This information is required by curses, but is not (currently) used in SDL
     ( void ) center_cursor;
@@ -4024,7 +4024,7 @@ std::optional<tripoint> input_context::get_coordinates( const catacurses::window
                                screen_pos, dim.scaled_font_size, win_size,
                                point_bub_ms( offset ), use_isometric );
 
-    return tripoint( p.raw(), get_map().get_abs_sub().z() );
+    return tripoint_bub_ms( p, get_map().get_abs_sub().z() );
 }
 
 int get_terminal_width()

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -201,13 +201,13 @@ int turret_data::range() const
     return res;
 }
 
-bool turret_data::in_range( const tripoint &target ) const
+bool turret_data::in_range( const tripoint_bub_ms &target ) const
 {
     if( !veh || !part ) {
         return false;
     }
     int range = veh->turret_query( *part ).range();
-    int dist = rl_dist( veh->global_part_pos3( *part ), target );
+    int dist = rl_dist( veh->bub_part_pos( *part ), target );
     return range >= dist;
 }
 
@@ -310,7 +310,7 @@ void turret_data::post_fire( Character &you, int shots )
     veh->drain( fuel_type_battery, units::to_kilojoule( mode->get_gun_energy_drain() * shots ) );
 }
 
-int turret_data::fire( Character &c, const tripoint &target )
+int turret_data::fire( Character &c, const tripoint_bub_ms &target )
 {
     if( !veh || !part ) {
         return 0;
@@ -392,7 +392,7 @@ int vehicle::turrets_aim_and_fire( std::vector<vehicle_part *> &turrets )
             if( has_target ) {
                 turret_data turret = turret_query( *t );
                 npc &cpu = t->get_targeting_npc( *this );
-                shots += turret.fire( cpu, t->target.second );
+                shots += turret.fire( cpu, tripoint_bub_ms( t->target.second ) );
                 t->reset_target( global_part_pos3( *t ) );
             }
         }
@@ -430,11 +430,11 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
 
     bool got_target = !trajectory.empty();
     if( got_target ) {
-        tripoint target = trajectory.back();
+        tripoint_bub_ms target = trajectory.back();
         // Set target for any turret in range
         for( vehicle_part *t : turrets ) {
             if( turret_query( *t ).in_range( target ) ) {
-                t->target.second = target;
+                t->target.second = target.raw();
             }
         }
 
@@ -662,7 +662,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
     }
 
     // Get the turret's target and reset it
-    tripoint targ = target.second;
+    tripoint_bub_ms targ( target.second );
     pt.reset_target( pos );
 
     shots = gun.fire( cpu, targ );

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1164,7 +1164,7 @@ int uimenu::query()
 struct pointmenu_cb::impl_t {
     const std::vector< tripoint > &points;
     int last; // to suppress redrawing
-    tripoint last_view; // to reposition the view after selecting
+    tripoint_rel_ms last_view; // to reposition the view after selecting
     shared_ptr_fast<game::draw_callback_t> terrain_draw_cb;
 
     explicit impl_t( const std::vector<tripoint> &pts );
@@ -1180,7 +1180,7 @@ pointmenu_cb::impl_t::impl_t( const std::vector<tripoint> &pts ) : points( pts )
     last_view = player_character.view_offset;
     terrain_draw_cb = make_shared_fast<game::draw_callback_t>( [this, &player_character]() {
         if( last >= 0 && static_cast<size_t>( last ) < points.size() ) {
-            g->draw_trail_to_square( player_character.view_offset, true );
+            g->draw_trail_to_square( player_character.view_offset.raw(), true );
         }
     } );
     g->add_draw_callback( terrain_draw_cb );
@@ -1199,12 +1199,12 @@ void pointmenu_cb::impl_t::select( uilist *const menu )
     last = menu->selected;
     avatar &player_character = get_avatar();
     if( menu->selected < 0 || menu->selected >= static_cast<int>( points.size() ) ) {
-        player_character.view_offset = tripoint_zero;
+        player_character.view_offset = tripoint_rel_ms_zero;
     } else {
         const tripoint &center = points[menu->selected];
-        player_character.view_offset = center - player_character.pos();
+        player_character.view_offset = tripoint_rel_ms( center - player_character.pos() );
         // TODO: Remove this line when it's safe
-        player_character.view_offset.z = 0;
+        player_character.view_offset.z() = 0;
     }
     g->invalidate_main_ui_adaptor();
 }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -201,14 +201,14 @@ void orient_part( vehicle *veh, const vpart_info &vpinfo, int partnum,
     avatar &player_character = get_avatar();
     // Stash offset and set it to the location of the part so look_around will
     // start there.
-    const tripoint old_view_offset = player_character.view_offset;
-    tripoint offset = veh->global_pos3();
+    const tripoint_rel_ms old_view_offset = player_character.view_offset;
+    tripoint_bub_ms offset = veh->pos_bub();
     // Appliances are one tile so the part placement there is always point_zero
     if( part_placement ) {
         point copied_placement = *part_placement ;
         offset += copied_placement ;
     }
-    player_character.view_offset = offset - player_character.pos();
+    player_character.view_offset = offset - player_character.pos_bub();
 
     point delta;
     do {
@@ -220,7 +220,7 @@ void orient_part( vehicle *veh, const vpart_info &vpinfo, int partnum,
         if( !chosen ) {
             continue;
         }
-        delta = ( *chosen - offset ).xy();
+        delta = ( *chosen - offset.raw() ).xy();
         // atan2 only gives reasonable values when delta is not all zero
     } while( delta == point_zero );
 

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -17,9 +17,9 @@ player_activity veh_shape::start( const tripoint_bub_ms &pos )
 {
     avatar &you = get_avatar();
     on_out_of_scope cleanup( []() {
-        get_map().invalidate_map_cache( get_avatar().view_offset.z );
+        get_map().invalidate_map_cache( get_avatar().view_offset.z() );
     } );
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
 
     cursor_allowed.clear();
     for( const vpart_reference &part : veh.get_all_parts() ) {
@@ -34,7 +34,7 @@ player_activity veh_shape::start( const tripoint_bub_ms &pos )
     const auto target_ui_cb = make_shared_fast<game::draw_callback_t>(
     [&]() {
         const avatar &you = get_avatar();
-        g->draw_cursor_unobscuring( tripoint_bub_ms( you.pos() + you.view_offset ) );
+        g->draw_cursor_unobscuring( you.pos_bub() + you.view_offset );
     } );
     g->add_draw_callback( target_ui_cb );
     ui_adaptor ui;
@@ -199,7 +199,7 @@ bool veh_shape::set_cursor_pos( const tripoint_bub_ms &new_pos )
         get_map().invalidate_map_cache( z );
     }
     cursor_pos = target_pos;
-    you.view_offset = cursor_pos.raw() - you.pos();
+    you.view_offset = cursor_pos - you.pos_bub();
     return true;
 }
 
@@ -215,13 +215,12 @@ bool veh_shape::handle_cursor_movement( const std::string &action )
     } else if( action == "zoom_out" ) {
         g->zoom_out();
     } else if( action == "SELECT" ) {
-        const std::optional<tripoint> mouse_pos = ctxt.get_coordinates( g->w_terrain );
+        const std::optional<tripoint_bub_ms> mouse_pos = ctxt.get_coordinates( g->w_terrain );
         if( !mouse_pos ) {
             return false;
         }
-        const tripoint_bub_ms mp( *mouse_pos );
-        if( get_cursor_pos() != mp ) {
-            set_cursor_pos( mp );
+        if( get_cursor_pos() != *mouse_pos ) {
+            set_cursor_pos( *mouse_pos );
         }
     } else if( action == "LEVEL_UP" ) {
         set_cursor_pos( get_cursor_pos() + tripoint_above );

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -373,7 +373,7 @@ class veh_menu_cb : public uilist_callback
             last_view = player_character.view_offset;
             terrain_draw_cb = make_shared_fast<game::draw_callback_t>( [this, &player_character]() {
                 if( draw_trail && last >= 0 && static_cast<size_t>( last ) < points.size() ) {
-                    g->draw_trail_to_square( player_character.view_offset, true );
+                    g->draw_trail_to_square( player_character.view_offset.raw(), true );
                 }
             } );
             g->add_draw_callback( terrain_draw_cb );
@@ -388,7 +388,7 @@ class veh_menu_cb : public uilist_callback
     private:
         const std::vector< tripoint > &points;
         int last; // to suppress redrawing
-        tripoint last_view; // to reposition the view after selecting
+        tripoint_rel_ms last_view; // to reposition the view after selecting
         shared_ptr_fast<game::draw_callback_t> terrain_draw_cb;
 
         void select( uilist *menu ) override {
@@ -398,12 +398,12 @@ class veh_menu_cb : public uilist_callback
             last = menu->selected;
             avatar &player_character = get_avatar();
             if( menu->selected < 0 || menu->selected >= static_cast<int>( points.size() ) ) {
-                player_character.view_offset = tripoint_zero;
+                player_character.view_offset = tripoint_rel_ms_zero;
             } else {
                 const tripoint &center = points[menu->selected];
-                player_character.view_offset = center - player_character.pos();
+                player_character.view_offset = tripoint_rel_ms( center - player_character.pos() );
                 // Remove next line if/when it's wanted/safe to shift view to other zlevels
-                player_character.view_offset.z = 0;
+                player_character.view_offset.z() = 0;
             }
             g->invalidate_main_ui_adaptor();
             if( on_select ) {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -637,7 +637,7 @@ class turret_data
          * Check if target is in range of this turret (considers current ammo)
          * Assumes this turret's status is 'ready'
          */
-        bool in_range( const tripoint &target ) const;
+        bool in_range( const tripoint_bub_ms &target ) const;
 
         /**
          * Prepare the turret for firing, called by firing function.
@@ -660,7 +660,7 @@ class turret_data
          * @param target coordinates that will be fired on.
          * @return the number of shots actually fired (may be zero).
          */
-        int fire( Character &c, const tripoint &target );
+        int fire( Character &c, const tripoint_bub_ms &target );
 
         bool can_reload() const;
         bool can_unload() const;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2218,7 +2218,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .skip_locked_check()
         .on_submit( [vppos] {
             add_msg( _( "You carefully peek through the curtains." ) );
-            g->peek( vppos );
+            g->peek( tripoint_bub_ms( vppos ) );
         } );
     }
 

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -751,8 +751,8 @@ bool gamepad_available()
     return false;
 }
 
-std::optional<tripoint> input_context::get_coordinates( const catacurses::window &, const point &,
-        bool center_cursor ) const
+std::optional<tripoint_bub_ms> input_context::get_coordinates( const catacurses::window &,
+        const point &, bool center_cursor ) const
 {
     // TODO: implement this properly
     return std::nullopt;

--- a/tests/archery_damage_test.cpp
+++ b/tests/archery_damage_test.cpp
@@ -17,6 +17,8 @@
 #include <string>
 
 #include "cata_catch.h"
+#include "coordinates.h"
+#include "coordinate_constants.h"
 #include "damage.h"
 #include "game_constants.h"
 #include "item.h"
@@ -81,7 +83,7 @@ static void test_archery_balance( const std::string &weapon_type, const std::str
     test_projectile.critical_multiplier = weapon.ammo_data()->ammo->critical_multiplier;
 
     dealt_projectile_attack attack {
-        test_projectile, nullptr, dealt_damage_instance(), tripoint_zero, accuracy_critical - 0.05
+        test_projectile, nullptr, dealt_damage_instance(), tripoint_bub_ms_zero, accuracy_critical - 0.05
     };
     if( !killable.empty() ) {
         test_projectile_attack( killable, true, attack, weapon_type );

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -23,9 +23,9 @@ static const flag_id json_flag_FILTHY( "FILTHY" );
 static const mtype_id mon_manhack( "mon_manhack" );
 
 static const int num_iters = 10000;
-static constexpr tripoint dude_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y, 0 );
-static constexpr tripoint mon_pos( HALF_MAPSIZE_X + 3, HALF_MAPSIZE_Y, 0 );
-static constexpr tripoint badguy_pos( HALF_MAPSIZE_X + 1, HALF_MAPSIZE_Y, 0 );
+static constexpr tripoint_bub_ms dude_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y, 0 );
+static constexpr tripoint_bub_ms mon_pos( HALF_MAPSIZE_X + 3, HALF_MAPSIZE_Y, 0 );
+static constexpr tripoint_bub_ms badguy_pos( HALF_MAPSIZE_X + 1, HALF_MAPSIZE_Y, 0 );
 
 static void check_near( const std::string &subject, float actual, const float expected,
                         const float tolerance )
@@ -47,8 +47,8 @@ static void check_not_near( const std::string &subject, float actual, const floa
 
 static float get_avg_melee_dmg( const std::string &clothing_id, bool infect_risk = false )
 {
-    monster zed( mon_manhack, mon_pos );
-    standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
+    monster zed( mon_manhack, mon_pos.raw() );
+    standard_npc dude( "TestCharacter", dude_pos.raw(), {}, 0, 8, 8, 8, 8 );
     item cloth( clothing_id );
     if( infect_risk ) {
         cloth.set_flag( json_flag_FILTHY );
@@ -83,8 +83,8 @@ static float get_avg_melee_dmg( const std::string &clothing_id, bool infect_risk
 
 static float get_avg_melee_dmg( item cloth, bool infect_risk = false )
 {
-    monster zed( mon_manhack, mon_pos );
-    standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
+    monster zed( mon_manhack, mon_pos.raw() );
+    standard_npc dude( "TestCharacter", dude_pos.raw(), {}, 0, 8, 8, 8, 8 );
     if( infect_risk ) {
         cloth.set_flag( json_flag_FILTHY );
     }
@@ -119,10 +119,10 @@ static float get_avg_melee_dmg( item cloth, bool infect_risk = false )
 static float get_avg_bullet_dmg( const std::string &clothing_id )
 {
     clear_map();
-    std::unique_ptr<standard_npc> badguy = std::make_unique<standard_npc>( "TestBaddie", badguy_pos,
-                                           std::vector<std::string>(), 0, 8, 8, 8, 8 );
-    std::unique_ptr<standard_npc> dude = std::make_unique<standard_npc>( "TestCharacter", dude_pos,
-                                         std::vector<std::string>(), 0, 8, 8, 8, 8 );
+    std::unique_ptr<standard_npc> badguy = std::make_unique<standard_npc>( "TestBaddie",
+                                           badguy_pos.raw(), std::vector<std::string>(), 0, 8, 8, 8, 8 );
+    std::unique_ptr<standard_npc> dude = std::make_unique<standard_npc>( "TestCharacter",
+                                         dude_pos.raw(), std::vector<std::string>(), 0, 8, 8, 8, 8 );
     item cloth( clothing_id );
     projectile proj;
     proj.speed = 1000;
@@ -243,7 +243,7 @@ TEST_CASE( "Off_Limb_Ghost_ablative_vest", "[coverage]" )
         item full = item( "test_ghost_vest" );
         full.force_insert_item( item( "test_plate_skirt_super" ), pocket_type::CONTAINER );
 
-        standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
+        standard_npc dude( "TestCharacter", dude_pos.raw(), {}, 0, 8, 8, 8, 8 );
         dude.wear_item( full, false );
         damage_instance du_full = damage_instance( damage_bullet, 100.0f );
         dude.absorb_hit( weakpoint_attack(), bodypart_id( "leg_l" ), du_full );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -2,6 +2,7 @@
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character_martial_arts.h"
+#include "coordinates.h"
 #include "effect_on_condition.h"
 #include "game.h"
 #include "make_static.h"
@@ -1209,9 +1210,9 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     CHECK( globvars.get_global_value( "npctalk_var_victim_type" ) == "mon_zombie" );
 
     // character_ranged_attacks_character
-    const tripoint target_pos = get_avatar().pos() + point_east;
+    const tripoint_bub_ms target_pos = get_avatar().pos_bub() + point_east;
     clear_map();
-    npc &npc_dst_ranged = spawn_npc( target_pos.xy(), "thug" );
+    npc &npc_dst_ranged = spawn_npc( target_pos.xy().raw(), "thug" );
     for( loop = 0; loop < 1000; loop++ ) {
         get_avatar().set_body();
         arm_shooter( get_avatar(), "shotgun_s" );
@@ -1231,12 +1232,12 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
 
     // character_ranged_attacks_monster
     clear_map();
-    monster &mon_dst_ranged = spawn_test_monster( "mon_zombie", target_pos );
+    monster &mon_dst_ranged = spawn_test_monster( "mon_zombie", target_pos.raw() );
     for( loop = 0; loop < 1000; loop++ ) {
         get_avatar().set_body();
         arm_shooter( get_avatar(), "shotgun_s" );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( mon_dst_ranged.pos(), 1, *get_avatar().get_wielded_item() );
+        get_avatar().fire_gun( mon_dst_ranged.pos_bub(), 1, *get_avatar().get_wielded_item() );
         if( !mon_dst_ranged.get_value( "npctalk_var_test_event_last_event" ).empty() ) {
             break;
         }
@@ -1251,7 +1252,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
 
     // character_kills_monster
     clear_map();
-    monster &victim = spawn_test_monster( "mon_zombie", target_pos );
+    monster &victim = spawn_test_monster( "mon_zombie", target_pos.raw() );
     victim.die( &get_avatar() );
 
     CHECK( get_avatar().get_value( "npctalk_var_test_event_last_event" ) == "character_kills_monster" );

--- a/tests/magic_spell_effect_test.cpp
+++ b/tests/magic_spell_effect_test.cpp
@@ -60,16 +60,22 @@ TEST_CASE( "line_attack", "[magic]" )
     // set up Character to test with, only need position
     npc &c = spawn_npc( point_zero, "test_talker" );
     clear_character( c );
-    c.setpos( tripoint_zero );
+    c.setpos( tripoint_bub_ms_zero );
 
     // target point 5 tiles east of zero
     tripoint target = tripoint_east * 5;
 
     // Ensure that AOE=0 spell covers the 5 tiles along vector towards target
     SECTION( "aoe=0" ) {
-        const std::set<tripoint> reference( { tripoint_east * 1, tripoint_east * 2, tripoint_east * 3, tripoint_east * 4, tripoint_east * 5 } );
+        const std::set<tripoint_bub_ms> reference( {
+            c.pos_bub() + tripoint_rel_ms_east * 1,
+            c.pos_bub() + tripoint_rel_ms_east * 2,
+            c.pos_bub() + tripoint_rel_ms_east * 3,
+            c.pos_bub() + tripoint_rel_ms_east * 4,
+            c.pos_bub() + tripoint_rel_ms_east * 5,
+        } );
 
-        std::set<tripoint> targets = calculate_spell_effect_area( sp, target, c );
+        std::set<tripoint_bub_ms> targets = calculate_spell_effect_area( sp, target, c );
 
         CHECK( reference == targets );
     }

--- a/tests/map_bash_test.cpp
+++ b/tests/map_bash_test.cpp
@@ -1,5 +1,6 @@
 #include "cata_catch.h"
 #include "character.h"
+#include "coordinate_constants.h"
 #include "map.h"
 #include "mapdata.h"
 #include "map_helpers.h"
@@ -174,13 +175,13 @@ TEST_CASE( "map_bash_ephemeral_persistence", "[map][bash]" )
     }
 }
 
-static void shoot_at_terrain( npc &shooter, const std::string &ter_str, tripoint wall_pos,
-                              bool expected_to_break, tripoint aim_pos = tripoint_zero )
+static void shoot_at_terrain( npc &shooter, const std::string &ter_str, tripoint_bub_ms wall_pos,
+                              bool expected_to_break, tripoint_bub_ms aim_pos = tripoint_bub_ms_zero )
 {
     map &here = get_map();
     // Place a terrain
     ter_str_id id{ ter_str };
-    if( aim_pos == tripoint_zero ) {
+    if( aim_pos == tripoint_bub_ms_zero ) {
         aim_pos = wall_pos;
     }
     here.ter_set( wall_pos, id );
@@ -210,55 +211,56 @@ TEST_CASE( "shooting_at_terrain", "[map][bash][ranged]" )
     shooter.worn.wear_item( shooter, item( "backpack" ), false, false );
     SECTION( "birdshot vs adobe wall point blank" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
-        shoot_at_terrain( shooter, "t_adobe_brick_wall", shooter.pos() + point_east, false );
+        shoot_at_terrain( shooter, "t_adobe_brick_wall", shooter.pos_bub() + point_east, false );
     }
     SECTION( "birdshot vs adobe wall near" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
-        shoot_at_terrain( shooter, "t_adobe_brick_wall", shooter.pos() + point_east * 2, false );
+        shoot_at_terrain( shooter, "t_adobe_brick_wall", shooter.pos_bub() + point_east * 2, false );
     }
     SECTION( "birdshot vs opaque glass door point blank" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
-        shoot_at_terrain( shooter, "test_t_door_glass_opaque_c", shooter.pos() + point_east, true );
+        shoot_at_terrain( shooter, "test_t_door_glass_opaque_c", shooter.pos_bub() + point_east, true );
     }
     SECTION( "birdshot vs opaque glass door near" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
-        shoot_at_terrain( shooter, "test_t_door_glass_opaque_c", shooter.pos() + point_east * 2, false );
+        shoot_at_terrain( shooter, "test_t_door_glass_opaque_c", shooter.pos_bub() + point_east * 2,
+                          false );
     }
     SECTION( "birdshot vs door near" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
-        shoot_at_terrain( shooter, "t_door_c", shooter.pos() + point_east * 2, false );
+        shoot_at_terrain( shooter, "t_door_c", shooter.pos_bub() + point_east * 2, false );
     }
     // I thought I saw some failures based on whether an unseen monster was present,
     // But I think it was just shooting at door wthout a 100% chance to break it and getting unlucky.
     SECTION( "birdshot through door at nothing" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
-        shoot_at_terrain( shooter, "t_door_c", shooter.pos() + point_east, true,
-                          shooter.pos() + point_east * 2 );
+        shoot_at_terrain( shooter, "t_door_c", shooter.pos_bub() + point_east, true,
+                          shooter.pos_bub() + point_east * 2 );
     }
     SECTION( "birdshot through door at monster" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
         spawn_test_monster( "mon_zombie", shooter.pos() + point_east * 2 );
-        shoot_at_terrain( shooter, "t_door_c", shooter.pos() + point_east, true,
-                          shooter.pos() + point_east * 2 );
+        shoot_at_terrain( shooter, "t_door_c", shooter.pos_bub() + point_east, true,
+                          shooter.pos_bub() + point_east * 2 );
     }
     // TODO: If we get a feature where damage accumulates a test for it would go here.
     // These are failing because you can't shoot transparent terrain.
     /*
     SECTION( "birdshot vs glass door point blank" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
-        shoot_at_terrain( shooter, "t_door_glass_c", shooter.pos() + point_east, true );
+        shoot_at_terrain( shooter, "t_door_glass_c", shooter.pos_bub() + point_east, true );
     }
     SECTION( "birdshot vs glass door near" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
-        shoot_at_terrain( shooter, "t_door_glass_c", shooter.pos() + point_east * 2, false );
+        shoot_at_terrain( shooter, "t_door_glass_c", shooter.pos_bub() + point_east * 2, false );
     }
     SECTION( "birdshot vs screen door point blank" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
-        shoot_at_terrain( shooter, "t_door_screen_c", shooter.pos() + point_east, true );
+        shoot_at_terrain( shooter, "t_door_screen_c", shooter.pos_bub() + point_east, true );
     }
     SECTION( "birdshot vs screen door near" ) {
         arm_shooter( shooter, "remington_870", {}, "shot_bird" );
-        shoot_at_terrain( shooter, "t_door_screen_c", shooter.pos() + point_east * 2, true );
+        shoot_at_terrain( shooter, "t_door_screen_c", shooter.pos_bub() + point_east * 2, true );
     }
     */
 }

--- a/tests/materials_test.cpp
+++ b/tests/materials_test.cpp
@@ -25,7 +25,7 @@ static const material_id material_wood( "wood" );
 
 static constexpr int num_iters = 1000;
 static constexpr tripoint dude_pos( HALF_MAPSIZE_X, HALF_MAPSIZE_Y, 0 );
-static constexpr tripoint target_pos( HALF_MAPSIZE_X - 10, HALF_MAPSIZE_Y, 0 );
+static constexpr tripoint_bub_ms target_pos( HALF_MAPSIZE_X - 10, HALF_MAPSIZE_Y, 0 );
 
 static void check_near( const std::string &subject, float prob, const float expected,
                         const float tolerance )

--- a/tests/npc_attack_test.cpp
+++ b/tests/npc_attack_test.cpp
@@ -89,7 +89,7 @@ TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
                 const npc_attack_rating &rating = main_npc.get_current_attack_evaluation();
                 CHECK( rating.value() );
                 CHECK( *rating.value() > 0 );
-                CHECK( rating.target() == zombie->pos() );
+                CHECK( rating.target() == zombie->pos_bub() );
             }
         }
         WHEN( "NPC only has an m16a4" ) {
@@ -109,7 +109,7 @@ TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
                     const npc_attack_rating &rating = main_npc.get_current_attack_evaluation();
                     CHECK( rating.value() );
                     CHECK( *rating.value() > 0 );
-                    CHECK( rating.target() == zombie->pos() );
+                    CHECK( rating.target() == zombie->pos_bub() );
                 }
             }
             WHEN( "NPC isn't allowed to use loud weapons" ) {
@@ -220,7 +220,7 @@ TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
                 const npc_attack_rating &rating = main_npc.get_current_attack_evaluation();
                 CHECK( rating.value() );
                 CHECK( *rating.value() > 0 );
-                CHECK( rating.target() == zombie->pos() );
+                CHECK( rating.target() == zombie->pos_bub() );
             }
         }
 
@@ -256,7 +256,7 @@ TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
                     const npc_attack_rating &rating = main_npc.get_current_attack_evaluation();
                     CHECK( rating.value() );
                     CHECK( *rating.value() > 0 );
-                    CHECK( rating.target() == zombie->pos() );
+                    CHECK( rating.target() == zombie->pos_bub() );
                 }
             }
             WHEN( "NPC is targetting farthest zombie" ) {
@@ -270,7 +270,7 @@ TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
                         const npc_attack_rating &rating = main_npc.get_current_attack_evaluation();
                         CHECK( rating.value() );
                         CHECK( *rating.value() > 0 );
-                        CHECK( rating.target() == zombie->pos() );
+                        CHECK( rating.target() == zombie->pos_bub() );
                     }
                 }
                 WHEN( "Furthest zombie is at low HP" ) {
@@ -284,7 +284,7 @@ TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
                         const npc_attack_rating &rating = main_npc.get_current_attack_evaluation();
                         CHECK( rating.value() );
                         CHECK( *rating.value() > 0 );
-                        CHECK( rating.target() == zombie_far->pos() );
+                        CHECK( rating.target() == zombie_far->pos_bub() );
                     }
                 }
             }

--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -7,6 +7,7 @@
 #include "ballistics.h"
 #include "cata_catch.h"
 #include "character.h"
+#include "coordinate_constants.h"
 #include "creature_tracker.h"
 #include "damage.h"
 #include "dispersion.h"
@@ -24,8 +25,8 @@
 static const itype_id itype_308( "308" );
 static const itype_id itype_m1a( "m1a" );
 
-static tripoint projectile_end_point( const std::vector<tripoint> &range, const item &gun,
-                                      int speed, int proj_range )
+static tripoint_bub_ms projectile_end_point( const std::vector<tripoint_bub_ms> &range,
+        const item &gun, int speed, int proj_range )
 {
     projectile test_proj;
     test_proj.speed = speed;
@@ -55,13 +56,17 @@ TEST_CASE( "projectiles_through_obstacles", "[projectile]" )
     // Ensure that a projectile fired from a gun can pass through a chain link fence
     // First, set up a test area - three tiles in a row
     // One on either side clear, with a chainlink fence in the middle
-    std::vector<tripoint> range = { tripoint_zero, tripoint_east, tripoint( 2, 0, 0 ) };
-    for( const tripoint &pt : range ) {
+    std::vector<tripoint_bub_ms> range = {
+        tripoint_bub_ms_zero,
+        tripoint_bub_ms_zero + tripoint_rel_ms_east,
+        tripoint_bub_ms_zero + tripoint_rel_ms_east * 2
+    };
+    for( const tripoint_bub_ms &pt : range ) {
         REQUIRE( here.inbounds( pt ) );
         here.ter_set( pt, ter_id( "t_dirt" ) );
         here.furn_set( pt, furn_id( "f_null" ) );
         REQUIRE_FALSE( creatures.creature_at( pt ) );
-        REQUIRE( here.is_transparent( pt ) );
+        REQUIRE( here.is_transparent( pt.raw() ) );
     }
 
     // Set an obstacle in the way, a chain fence

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -458,7 +458,7 @@ static void shoot_monster( const std::string &gun_type, const std::vector<std::s
         shooter->recoil = 0;
         monster &mon = spawn_test_monster( monster_type, monster_pos, false );
         const int prev_HP = mon.get_hp();
-        shooter->fire_gun( monster_pos, 1, *shooter->get_wielded_item() );
+        shooter->fire_gun( tripoint_bub_ms( monster_pos ), 1, *shooter->get_wielded_item() );
         damage.add( prev_HP - mon.get_hp() );
         if( damage.margin_of_error() < 0.05 && damage.n() > 100 ) {
             break;

--- a/tests/reload_time_test.cpp
+++ b/tests/reload_time_test.cpp
@@ -45,7 +45,7 @@ static void check_reload_time( const std::string &weapon, const std::string &amm
     CAPTURE( shooter.used_weapon()->get_reload_time() );
     aim_activity_actor act = aim_activity_actor::use_wielded();
     int moves_before = shooter.get_moves();
-    REQUIRE( shooter.fire_gun( spot.raw(), 1, *shooter.used_weapon(), shooter.ammo_location ) );
+    REQUIRE( shooter.fire_gun( spot, 1, *shooter.used_weapon(), shooter.ammo_location ) );
     int moves_after = shooter.get_moves();
     int spent_moves = moves_before - moves_after;
     int expected_upper = expected_moves * 1.05;

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -101,7 +101,7 @@ static void test_throwing_player_versus(
         monster &mon = spawn_test_monster( mon_id, monster_start, false );
         mon.set_moves( 0 );
 
-        dealt_projectile_attack atk = you.throw_item( mon.pos(), it );
+        dealt_projectile_attack atk = you.throw_item( mon.pos_bub(), it );
         data.hits.add( atk.hit_critter != nullptr );
         data.dmg.add( atk.dealt_dam.total_damage() );
 
@@ -270,7 +270,7 @@ static void test_player_kills_monster(
             you.mod_moves( you.get_speed() );
             while( you.get_moves() > 0 ) {
                 you.wield( it );
-                you.throw_item( mon.pos(), it );
+                you.throw_item( mon.pos_bub(), it );
                 you.remove_weapon();
                 ++num_items;
             }

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -8,6 +8,7 @@
 
 #include "ammo.h"
 #include "character.h"
+#include "coordinates.h"
 #include "item.h"
 #include "item_location.h"
 #include "itype.h"
@@ -99,7 +100,7 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             int shots_fired = 0;
             // 3 attempts to fire, to account for possible misfires
             for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {
-                shots_fired += qry.fire( player_character, player_character.pos() + point( qry.range(), 0 ) );
+                shots_fired += qry.fire( player_character, player_character.pos_bub() + point( qry.range(), 0 ) );
             }
             CHECK( shots_fired > 0 );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Typed tripoints.

#### Describe the solution

Convert tripoints mostly to tripoint_bub_ms.
This grew bigger than expected, because attack code is kinda intertwined with ui code.

#### Describe alternatives you've considered

Try to change less at once, but identifying good places to stop is hard.

#### Testing

Aimed and shot guns, aimed and threw items, checked line animations (emp bionic), drove cars at various speeds and in various directions to check view offset, also manually shifted and reset it, selected highlighted tiles when examining to check if mouse selection still works. Didn't notice any issues.
I think the only unchecked thing is curses, but I think issues with that should show during compilation, at least a few already did, since basic build is a curses build.

#### Additional context

