### PR TITLE
Reset forced temperature on save and quit from tutorial world

### DIFF
--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -373,6 +373,10 @@ void tutorial_game::post_action( action_id act )
         }
         break;
 
+        case ACTION_SAVE:
+            get_weather().forced_temperature.reset();
+            break;
+
         default:
             // TODO: add more actions here
             break;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #75375.

#### Describe the solution
Reset forced temperature on save and quit from tutorial world.

#### Describe alternatives you've considered
Forbid saving in tutorial world.

#### Testing
Created tutorial world. Saved and quit from it. Created a new world, started a default scenario in it. Checked temperature in evac shelter (12C), in its basement (6C).

#### Additional context
None.