### PR TITLE
Added check for stealing prior to wearing

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -9,6 +9,7 @@
 #include <numeric>
 #include <ostream>
 
+#include "avatar_action.h"
 #include "bodygraph.h"
 #include "calendar.h"
 #include "cata_utility.h"
@@ -262,6 +263,12 @@ std::optional<std::list<item>::iterator>
 Character::wear( item_location item_wear, bool interactive )
 {
     item to_wear = *item_wear;
+
+    // Need to account for case where we're trying to wear something that belongs to someone else
+    if( !avatar_action::check_stealing( *this, to_wear ) ) {
+        return std::nullopt;
+    }
+
     if( is_worn( to_wear ) ) {
         if( interactive ) {
             add_msg_player_or_npc( m_info,


### PR DESCRIPTION
#### Summary
Features "Added check for stealing prior to wearing"

#### Purpose of change
* Closes #75183.

#### Describe the solution
Added `check_stealing` in `Character::wear`.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned animal shelter with a veterinarian. Tried to wear canine bite suit. Got a warning about stealing. Answered yes, answered no.

#### Additional context
None.