### PR TITLE
Dialogue debug: toggle display of conditionals/effects

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2863,6 +2863,42 @@
   },
   {
     "type": "keybinding",
+    "id": "DEBUG_DIALOGUE_DL_CONDITIONAL",
+    "name": "Toggle debug dialogue dynamic_line conditionals",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "CTRL+C" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "c" }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "DEBUG_DIALOGUE_RESP_CONDITIONAL",
+    "name": "Toggle debug dialogue response conditionals",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "CTRL+D" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "d" }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "DEBUG_DIALOGUE_DL_EFFECT",
+    "name": "Toggle debug dialogue dynamic_line effects",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "CTRL+T" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "t" }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "DEBUG_DIALOGUE_RESP_EFFECT",
+    "name": "Toggle debug dialogue response effects",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "CTRL+Y" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "y" }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "RESET",
     "category": "CALENDAR_UI",
     "name": "Reset time point to initial value",

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -611,7 +611,7 @@ Speaker effects are useful for setting status variables to indicate that player 
 ---
 
 ## Responses
-A response contains at least a text, which is display to the user and "spoken" by the player character (its content has no meaning for the game) and a topic to which the dialogue will switch to. It can also have a trial object which can be used to either lie, persuade or intimidate the NPC, [see below](#trials) for details. There can be different results, used either when the trial succeeds and when it fails.
+A response contains at least a text, which is display to the user and "spoken" by the player character (its content has no meaning for the game) and a topic to which the dialogue will switch to. The "condition" field dictates whether the response will be shown. It can also have a trial object which can be used to either lie, persuade, or intimidate the NPC, or even test another conditional [see below](#trials) for details; different "effect"s can be applied for trial success/failure.
 
 Format:
 ```json

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -20,6 +20,18 @@
 #include "translations.h"
 #include "type_id.h"
 
+/**
+* A brief overview of how dialogues work:
+* json_talk_topic loads talk_topic JSON fields (e.g. from data/json/npcs) into:
+* 1) field-specific containers in json_talk_topic, such as json_talk_response or dynamic_line_t
+* 2) the static map json_talk_topics, keyed by the "id" field
+*
+* dialogue::gen_responses() will call down to json_talk_response::gen_responses to fill dialogue::responses
+* dialogue::dynamic_line() will construct the current talk_topic dynamic line
+* dialogue::responses and dialogue::dynamic_line together are drawn in the dialogue window
+* dialogue::opt will load the data into a dialogue_window UI
+*/
+
 class JsonArray;
 class JsonObject;
 class martialart;
@@ -81,7 +93,10 @@ struct talk_trial {
     talk_trial() = default;
     explicit talk_trial( const JsonObject & );
 };
-
+/**
+* Holds talk_topic id, with optional item data.
+* See json_talk_topic for JSON parsing.
+*/
 struct talk_topic {
     explicit talk_topic( std::string i, itype_id const &it = itype_id::NULL_ID(),
                          std::string r = {} )
@@ -149,7 +164,9 @@ struct talk_effect_t {
 };
 
 /**
- * This defines possible responses from the player character.
+ * Represents a response for a talk_topic.
+ * The parametered constructor is not called directly, but rather from
+ * json_talk_response to read response JSON
  */
 struct talk_response {
     /**
@@ -168,6 +185,10 @@ struct talk_response {
     /**
      * The following values are forwarded to the chatbin of the NPC (see @ref npc_chatbin).
      */
+
+    //copy of json_talk_response::condition, optional
+    std::function<bool( dialogue & )> condition;
+
     mission *mission_selected = nullptr;
     skill_id skill = skill_id();
     matype_id style = matype_id();
@@ -180,11 +201,16 @@ struct talk_response {
     talk_data create_option_line( dialogue &d, const input_event &hotkey,
                                   bool is_computer = false );
     std::set<dialogue_consequence> get_consequences( dialogue &d ) const;
+    // debug: conditional / effect
+    std::map<std::string, std::string> debug_info;
 
     talk_response();
     explicit talk_response( const JsonObject &, std::string_view );
 };
 
+/**
+* A collection of talk_topics and talk_responses that make up a conversation.
+*/
 struct dialogue {
         /**
          * If true, we are done talking and the dialog ends.
@@ -227,6 +253,9 @@ struct dialogue {
         void add_topic( const talk_topic &topic );
         bool has_beta;
         bool has_alpha;
+
+        bool debug_conditionals = true;
+        bool debug_effects = true;
 
         // Methods for setting/getting misc key/value pairs.
         void set_value( const std::string &key, const std::string &value );
@@ -326,6 +355,15 @@ struct dialogue {
                                      const itype_id &item_type, bool first = false );
 
         int get_best_quit_response();
+
+        /**
+        * Outputs mildly formatted JSON data for either "dynamic_line" or "responses"
+        * @param topic: the current talk_topic
+        * @param responses: true = responses, false = dynamic line
+        * @param do_response: if > -1, which response to get data for
+        */
+        std::vector<std::string> build_debug_info( const dialogue_window &d_win, const talk_topic &topic,
+                int do_response = -1 );
 };
 
 /**
@@ -373,7 +411,6 @@ class json_talk_response
         std::string failure_topic;
 
         void load_condition( const JsonObject &jo, std::string_view src );
-        bool test_condition( dialogue &d ) const;
 
     public:
         json_talk_response() = default;
@@ -383,7 +420,7 @@ class json_talk_response
         bool has_condition() const {
             return has_condition_;
         }
-
+        bool test_condition( dialogue &d ) const;
         /**
          * Callback from @ref json_talk_topic::gen_responses, see there.
          */
@@ -415,10 +452,13 @@ class json_dynamic_line_effect
         json_dynamic_line_effect( const JsonObject &jo, const std::string &id, std::string_view src );
         bool test_condition( dialogue &d ) const;
         void apply( dialogue &d ) const;
+        // debug: conditional / effect
+        std::map<std::string, std::string> debug_info;
+
 };
 
 /**
- * Talk topic definitions load from json.
+ * Loads talk_topic JSON objects and their contents; see json_talk_topic::load
  */
 class json_talk_topic
 {
@@ -453,9 +493,12 @@ class json_talk_topic
         bool gen_responses( dialogue &d ) const;
 
         cata::flat_set<std::string> get_directly_reachable_topics( bool only_unconditional ) const;
+
+        std::vector<json_talk_response> get_responses();
 };
 
 void unload_talk_topics();
 void load_talk_topic( const JsonObject &jo, std::string_view src );
+void get_raw_debug_fields( const JsonObject &jo, std::map<std::string, std::string> &debug_info );
 
 #endif // CATA_SRC_DIALOGUE_H

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -52,34 +52,42 @@ void dialogue_window::draw( const std::string &npc_name )
     int ycurrent = getmaxy( d_win ) - 1 - RESPONSES_LINES + 1;
     const int xmid = getmaxx( d_win ) / 2;
     // Actions go on the right column; they're unaffected by scrolling.
+    const int actions_xoffset = xmid + 2;
+    nc_color cur_color = c_magenta;
     input_context ctxt( "DIALOGUE_CHOOSE_RESPONSE" );
-    if( !is_computer && !is_not_conversation ) {
-        const int actions_xoffset = xmid + 2;
-        nc_color cur_color = c_magenta;
-        std::string formatted_text = formatted_hotkey( ctxt.get_desc( "LOOK_AT", 1 ),
-                                     cur_color ).append( _( "Look at" ) );
-        print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
-                            formatted_text );
-        ++ycurrent;
-        formatted_text = formatted_hotkey( ctxt.get_desc( "SIZE_UP_STATS", 1 ),
-                                           cur_color ).append( _( "Size up stats" ) );
-        print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
-                            formatted_text );
-        ++ycurrent;
-        formatted_text = formatted_hotkey( ctxt.get_desc( "ASSESS_PERSONALITY", 1 ),
-                                           cur_color ).append( _( "Assess personality" ) );
-        print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
-                            formatted_text );
-        ++ycurrent;
-        formatted_text = formatted_hotkey( ctxt.get_desc( "YELL", 1 ), cur_color ).append( _( "Yell" ) );
-        print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
-                            formatted_text );
-        ++ycurrent;
-        formatted_text = formatted_hotkey( ctxt.get_desc( "CHECK_OPINION", 1 ),
-                                           cur_color ).append( _( "Check opinion" ) );
-        print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
-                            formatted_text );
+    if( debug_mode ) {
+        for( const std::string &line : responses_debug ) {
+            ycurrent += fold_and_print( d_win, point( actions_xoffset, ycurrent - 1 ), xmid - 4, c_yellow,
+                                        line );
+        }
+    } else {
+        if( !is_computer && !is_not_conversation ) {
+            std::string formatted_text = formatted_hotkey( ctxt.get_desc( "LOOK_AT", 1 ),
+                                         cur_color ).append( _( "Look at" ) );
+            print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
+                                formatted_text );
+            ++ycurrent;
+            formatted_text = formatted_hotkey( ctxt.get_desc( "SIZE_UP_STATS", 1 ),
+                                               cur_color ).append( _( "Size up stats" ) );
+            print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
+                                formatted_text );
+            ++ycurrent;
+            formatted_text = formatted_hotkey( ctxt.get_desc( "ASSESS_PERSONALITY", 1 ),
+                                               cur_color ).append( _( "Assess personality" ) );
+            print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
+                                formatted_text );
+            ++ycurrent;
+            formatted_text = formatted_hotkey( ctxt.get_desc( "YELL", 1 ), cur_color ).append( _( "Yell" ) );
+            print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
+                                formatted_text );
+            ++ycurrent;
+            formatted_text = formatted_hotkey( ctxt.get_desc( "CHECK_OPINION", 1 ),
+                                               cur_color ).append( _( "Check opinion" ) );
+            print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
+                                formatted_text );
+        }
     }
+
     wnoutrefresh( d_win );
 
     responses_list->print_entries();
@@ -163,8 +171,21 @@ void dialogue_window::print_header( const std::string &name ) const
         mvwprintz( d_win, point( 2, 1 ), default_color(), _( "Dialogue: %s" ), name );
     }
     const int xmax = getmaxx( d_win );
+    int x_debug = 15 + utf8_width( name );
     const int ymax = getmaxy( d_win );
     const int ybar = ymax - 1 - RESPONSES_LINES - 1;
+    const int flag_count = 4;
+    std::array<bool, flag_count> debug_flags = { show_dynamic_line_conditionals, show_response_conditionals, show_dynamic_line_effects, show_response_effects };
+    std::array<std::string, flag_count> debug_show_toggle = { "DL_COND", "RESP_COND", "DL_EFF", "RESP_EFF" };
+    if( debug_mode ) {
+        for( int i = 0; i < flag_count; i++ ) {
+            mvwprintz( d_win, point( x_debug, 1 ), debug_flags[i] ? c_yellow : c_brown, debug_show_toggle[i] );
+            x_debug += utf8_width( debug_show_toggle[i] ) + 1;
+        }
+        x_debug += 2;
+        mvwprintz( d_win, point( x_debug, 1 ), default_color(), "talk_topic: " + debug_topic_name );
+    }
+
     // Horizontal bar dividing history and responses
     mvwputch( d_win, point( 0, ybar ), BORDER_COLOR, LINE_XXXO );
     mvwhline( d_win, point( 1, ybar ), LINE_OXOX, xmax - 1 );
@@ -183,4 +204,9 @@ void dialogue_window::print_header( const std::string &name ) const
 void dialogue_window::set_responses( const std::vector<talk_data> &responses )
 {
     responses_list->create_entries( responses );
+}
+
+void dialogue_window::set_responses_debug( const std::vector<std::string> &responses )
+{
+    responses_debug = responses;
 }

--- a/src/dialogue_win.h
+++ b/src/dialogue_win.h
@@ -45,11 +45,19 @@ class dialogue_window
 
         void set_up_scrolling( input_context &ctxt ) const;
 
+        /** sets debug info to draw for a response */
+        void set_responses_debug( const std::vector<std::string> &responses );
+
         /** Unhighlights all messages. */
         void clear_history_highlights();
         bool is_computer = false;
         bool is_not_conversation = false;
+        bool show_dynamic_line_conditionals = true;
+        bool show_dynamic_line_effects = true;
+        bool show_response_conditionals = true;
+        bool show_response_effects = true;
         int sel_response = 0;
+        std::string debug_topic_name;
     private:
         catacurses::window d_win;
         catacurses::window history_win;
@@ -80,6 +88,7 @@ class dialogue_window
         std::vector<std::tuple<std::string, std::vector<std::string>>> folded_txt;
         std::vector<int> folded_heights;
         std::unique_ptr<multiline_list> responses_list;
+        std::vector<std::string> responses_debug;
 
         nc_color default_color() const;
         void print_header( const std::string &name ) const;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1,4 +1,3 @@
-#include "dialogue.h" // IWYU pragma: associated
 
 #include <algorithm>
 #include <array>
@@ -1941,7 +1940,11 @@ int talk_trial::calc_chance( dialogue &d ) const
             chance = d.actor( false )->get_skill_level( skill_id( skill_required ) ) >= difficulty ? 100 : 0;
             break;
         case TALK_TRIAL_CONDITION:
-            chance = condition( d ) ? 100 : 0;
+            if( condition ) {
+                chance = condition( d ) ? 100 : 0;
+            } else {
+                chance = 0;
+            }
             break;
         case TALK_TRIAL_LIE:
             chance += d.actor( false )->trial_chance_mod( "lie" ) + d.actor( true )->trial_chance_mod( "lie" );
@@ -2598,7 +2601,12 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
         d_win.add_to_history( challenge, d_win.is_not_conversation ? "" : actor( true )->disp_name(),
                               npc_actor ? npc_actor->basic_symbol_color() : c_red );
     }
-
+    if( debug_mode ) {
+        std::vector<std::string> dynamic_line_debug = build_debug_info( d_win, topic );
+        for( auto &line : dynamic_line_debug ) {
+            d_win.add_to_history( line );
+        }
+    }
     apply_speaker_effects( topic );
 
     if( responses.empty() ) {
@@ -2611,6 +2619,10 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "ANY_INPUT" );
+    ctxt.register_action( "DEBUG_DIALOGUE_DL_CONDITIONAL" );
+    ctxt.register_action( "DEBUG_DIALOGUE_RESP_CONDITIONAL" );
+    ctxt.register_action( "DEBUG_DIALOGUE_DL_EFFECT" );
+    ctxt.register_action( "DEBUG_DIALOGUE_RESP_EFFECT" );
     ctxt.register_action( "QUIT" );
     std::vector<talk_data> response_lines;
     std::vector<input_event> response_hotkeys;
@@ -2644,6 +2656,10 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
     do {
         std::string action;
         do {
+            if( debug_mode ) {
+                d_win.set_responses_debug( build_debug_info( d_win, topic, d_win.sel_response ) );
+                d_win.debug_topic_name = topic.id;
+            }
             ui_manager::redraw();
             input_event evt;
             action = ctxt.handle_input();
@@ -2658,6 +2674,14 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
                 generate_response_lines();
             } else if( action == "CONFIRM" ) {
                 response_ind = d_win.sel_response;
+            } else if( action == "DEBUG_DIALOGUE_DL_CONDITIONAL" ) {
+                d_win.show_dynamic_line_conditionals = !d_win.show_dynamic_line_conditionals;
+            } else if( action == "DEBUG_DIALOGUE_RESP_CONDITIONAL" ) {
+                d_win.show_response_conditionals = !d_win.show_response_conditionals;
+            } else if( action == "DEBUG_DIALOGUE_DL_EFFECT" ) {
+                d_win.show_dynamic_line_effects = !d_win.show_dynamic_line_effects;
+            } else if( action == "DEBUG_DIALOGUE_RESP_EFFECT" ) {
+                d_win.show_response_effects = !d_win.show_response_effects;
             } else if( action == "ANY_INPUT" ) {
                 // Check real hotkeys
                 const auto hotkey_it = std::find( response_hotkeys.begin(),
@@ -2735,6 +2759,119 @@ int dialogue::get_best_quit_response()
     return responses.size(); // Didn't find a good option
 }
 
+void get_raw_debug_fields( const JsonObject &jo, std::map<std::string, std::string> &debug_info )
+{
+    //check for object, add raw JSON text to map if exists
+    auto add_to_debug = [&]( const JsonObject & jo, const char *key ) {
+        std::string key_str( key );
+        if( jo.has_string( key_str ) ) {
+            debug_info.emplace( key_str, jo.get_string( key_str ) );
+        } else if( jo.has_object( key_str ) ) {
+            JsonObject json_cond = jo.get_object( key_str );
+            json_cond.allow_omitted_members();
+            debug_info.emplace( key_str, json_cond.str() );
+        } else if( jo.has_array( key_str ) ) {
+            JsonArray json_cond = jo.get_array( key_str );
+            std::string concat;
+            for( JsonValue elem : json_cond ) {
+                if( elem.test_string() ) {
+                    concat += elem.get_string();
+                } else if( elem.test_object() ) {
+                    JsonObject json_obj = elem.get_object();
+                    json_obj.allow_omitted_members();
+                    concat += json_obj.str();
+                }
+            }
+            debug_info.emplace( key_str, concat );
+        }
+    };
+
+    add_to_debug( jo, "condition" );
+    add_to_debug( jo, "effect" );
+    add_to_debug( jo, "trial" );
+    add_to_debug( jo, "success" );
+    add_to_debug( jo, "failure" );
+}
+
+
+std::vector<std::string> dialogue::build_debug_info( const dialogue_window &d_win,
+        const talk_topic &topic, int do_response )
+{
+    std::vector<std::string> debug_output;
+    json_talk_topic json_topic = json_talk_topics[topic.id];
+    if( do_response > -1 ) {
+        std::string write_str;
+        std::vector<json_talk_response> json_responses = json_topic.get_responses();
+        if( json_responses.empty() ) {
+            return debug_output;
+        }
+
+        talk_response &actual_response = responses[do_response];
+        std::map<std::string, std::string> &debug_info = actual_response.debug_info;
+        if( d_win.show_response_conditionals ) {
+            if( debug_info.find( "condition" ) != debug_info.end() && actual_response.condition ) {
+                debug_output.emplace_back( std::string( "Conditional: [" ) + ( actual_response.condition(
+                                               *this ) ? colorize( "true", c_light_green ) : colorize( "false",
+                                                       c_light_red ) ) + std::string( "] - " ) + debug_info["condition"] );
+            } else {
+                debug_output.emplace_back( "No conditionals" );
+            }
+        }
+        if( debug_info.find( "trial" ) != debug_info.end() ) {
+            if( d_win.show_response_conditionals ) {
+                if( actual_response.trial.condition ) {
+                    debug_output.emplace_back( std::string( "Trial: [" ) + ( actual_response.trial.condition(
+                                                   *this ) ? colorize( "true", c_light_green ) : colorize( "false",
+                                                           c_light_red ) ) + std::string( "] - " ) + debug_info["trial"] );
+                } else {
+                    debug_output.emplace_back( "Trial: " + debug_info["trial"] );
+                }
+            }
+            if( d_win.show_response_effects ) {
+                debug_output.emplace_back( colorize( "Success: ", c_green ) + debug_info["success"] );
+                debug_output.emplace_back( colorize( "Failure: ", c_red ) + debug_info["failure"] );
+            }
+        }
+        if( d_win.show_response_effects ) {
+            if( debug_info.find( "effect" ) != debug_info.end() ) {
+                debug_output.emplace_back( "Effect: " + debug_info["effect"] );
+            } else {
+                debug_output.emplace_back( "No effects" );
+            }
+        }
+    } else {
+        std::vector<json_dynamic_line_effect> speaker_effects = json_topic.get_speaker_effects();
+        int eff_count = 1;
+        bool added_cond = false;
+        bool added_eff = false;
+        for( json_dynamic_line_effect eff : speaker_effects ) {
+            std::map<std::string, std::string> &debug_info = eff.debug_info;
+            std::string eff_count_str = std::to_string( eff_count );
+            if( debug_info.find( "condition" ) != debug_info.end() && d_win.show_dynamic_line_conditionals ) {
+                debug_output.emplace_back( colorize( "CND" + eff_count_str + std::string( ": [" ),
+                                                     c_yellow ) + ( eff.test_condition(
+                                                             *this ) ? colorize( "true", c_light_green ) : colorize( "false",
+                                                                     c_light_red ) ) + std::string( "] - " ) + colorize( debug_info["condition"], c_yellow ) );
+                added_cond = true;
+            }
+            if( debug_info.find( "effect" ) != debug_info.end() && d_win.show_dynamic_line_effects ) {
+                debug_output.emplace_back( colorize( "EFF" + eff_count_str + ": " + debug_info["effect"],
+                                                     c_yellow ) );
+                added_eff = true;
+            }
+            eff_count++;
+        }
+        if( !added_cond && d_win.show_dynamic_line_conditionals ) {
+            debug_output.emplace_back( colorize( "No conditionals", c_yellow ) );
+        }
+        if( !added_eff && d_win.show_dynamic_line_effects ) {
+            debug_output.emplace_back( colorize( "No effects", c_yellow ) );
+        }
+    }
+
+    return debug_output;
+}
+
 talk_trial::talk_trial( const JsonObject &jo )
 {
     static const std::unordered_map<std::string, talk_trial_type> types_map = { {
@@ -2759,9 +2896,10 @@ talk_trial::talk_trial( const JsonObject &jo )
     if( type == TALK_TRIAL_SKILL_CHECK ) {
         skill_required = jo.get_string( "skill_required" );
     }
-
-    read_condition( jo, "condition", condition, false );
-
+    //condition remains empty instead of adding a default
+    if( jo.has_member( "condition" ) ) {
+        read_condition( jo, "condition", condition, false );
+    }
     if( jo.has_member( "mod" ) ) {
         for( JsonArray jmod : jo.get_array( "mod" ) ) {
             trial_mod this_modifier;
@@ -7128,6 +7266,8 @@ json_talk_response::json_talk_response( const JsonObject &jo, const std::string_
     : actual_response( jo, src )
 {
     load_condition( jo, src );
+    get_raw_debug_fields( jo, actual_response.debug_info );
+    actual_response.condition = condition;
 }
 
 void json_talk_response::load_condition( const JsonObject &jo, const std::string_view )
@@ -7388,6 +7528,7 @@ json_dynamic_line_effect::json_dynamic_line_effect( const JsonObject &jo,
     std::function<bool( dialogue & )> tmp_condition;
     read_condition( jo, "condition", tmp_condition, true );
     talk_effect_t tmp_effect = talk_effect_t( jo, "effect", src );
+    get_raw_debug_fields( jo, debug_info );
     // if the topic has a sentinel, it means implicitly add a check for the sentinel value
     // and do not run the effects if it is set.  if it is not set, run the effects and
     // set the sentinel
@@ -7529,6 +7670,11 @@ cata::flat_set<std::string> json_talk_topic::get_directly_reachable_topics(
     }
 
     return cata::flat_set<std::string>( result.begin(), result.end() );
+}
+
+std::vector<json_talk_response> json_talk_topic::get_responses()
+{
+    return responses;
 }
 
 std::string json_talk_topic::get_dynamic_line( dialogue &d ) const


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "dialogue debug: toggle display of conditionals/effects"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Closes #56927
Closes #56928

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- See linked issues above for the design, which was implemented as written.
- I also added a display for the current talk_topic and for the draw toggles, and color-coded conditional outcomes.
- Very helpful to anyone working on dialogues.

Notes:
- All dialogue draw toggles default to on, mostly because it's tough to selectively remove text from the dialogue history. Toggling dynamic line condition/effects off will not remove them from the dialogue history, but will prevent them from being added.
- Response debug info draws over the usual text that's there out of necessity for space.
- Added more documentation for npctalk.cpp, NPC.md because dialogue code is confusing.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I could take or leave the yellow text, but it helps distinguish it from the dialogue

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Talked to Rubik and some NPCs, made sure that relevant info was displayed. By no means is this exhaustively tested; it's a debug feature.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

#56925 would have been implemented with this PR, but I wanted to keep the line count reasonable, expect it soon.

Screenshots:
Rubik
![image](https://github.com/user-attachments/assets/8776f411-d45a-403f-837f-1f56dc680efd)
meeting NPC
![image](https://github.com/user-attachments/assets/7d0dbdfe-f841-4206-8f8e-408ff26a5c5c)
toggle response condition/effect off
![image](https://github.com/user-attachments/assets/eee09881-84a6-42d5-9efc-d3c1ffdf58d3)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
