### PR TITLE
Closes #76534 Hair Growth After Haircutting is normal now.

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -127,7 +127,7 @@
     "id": "EOC_beard_growth_tracking",
     "//": "Use the same notes as hair growth.  However, facial hair grows faster than head hair, averaging 1.25 inches per month.",
     "//2": "Currently beard changes traits every 14 days",
-    "recurrence": { "math": [ "604800" ] },
+    "recurrence": { "math": [ "time('14 d')" ] },
     "global": false,
     "condition": { "u_has_trait": "natural_hair_growth" },
     "effect": [

--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -7,9 +7,10 @@
     "//3": "For ease of calculation, all math will be done with centimeters for hair growth.",
     "//4": "For reference starting point, a buzzcut is 0.32 centimeters long.",
     "//5": "1 inch is 2.54 centimeters.",
-    "recurrence": { "math": [ "(6480000 - ((u_val('health') * 180000) ) )" ] },
+    "//6": "Currently hair changes traits about every 20 days",
+    "recurrence": { "math": [ "150000" ] },
     "global": false,
-    "condition": { "u_has_trait": "natural_hair_growth" },
+    "condition": { "or": [ { "u_has_trait": "natural_hair_growth" } ] },
     "effect": [
       {
         "if": { "u_has_trait": "hair_buzzcut" },
@@ -125,7 +126,8 @@
     "type": "effect_on_condition",
     "id": "EOC_beard_growth_tracking",
     "//": "Use the same notes as hair growth.  However, facial hair grows faster than head hair, averaging 1.25 inches per month.",
-    "recurrence": { "math": [ "(43200000 - ((u_val('health') * 86400) ) )" ] },
+    "//2": "Currently beard changes traits every 14 days",
+    "recurrence": { "math": [ "604800" ] },
     "global": false,
     "condition": { "u_has_trait": "natural_hair_growth" },
     "effect": [

--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -10,7 +10,7 @@
     "//6": "Currently hair changes traits about every 20 days",
     "recurrence": { "math": [ "time('20 d')" ] },
     "global": false,
-    "condition": { "or": [ { "u_has_trait": "natural_hair_growth" } ] },
+    "condition": { "u_has_trait": "natural_hair_growth" },
     "effect": [
       {
         "if": { "u_has_trait": "hair_buzzcut" },

--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -8,7 +8,7 @@
     "//4": "For reference starting point, a buzzcut is 0.32 centimeters long.",
     "//5": "1 inch is 2.54 centimeters.",
     "//6": "Currently hair changes traits about every 20 days",
-    "recurrence": { "math": [ "150000" ] },
+    "recurrence": { "math": [ "time('20 d')" ] },
     "global": false,
     "condition": { "or": [ { "u_has_trait": "natural_hair_growth" } ] },
     "effect": [


### PR DESCRIPTION
I’ve addressed the issue related to hair growing instantly. Issue - #76534. The problem was indeed with the recurrence values in the appearance_eocs.json file. I’ve updated the recurrence math to use a fixed number, which should prevent hair growth from happening too quickly.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixed hair growth and balding issue in appearance_eocs.json"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

76534 Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The recurrence values were set to a fixed number instead of relying on faulty health-dependent calculations. This ensures that hair growth follows a more realistic timeline, fixing the rapid growth and inappropriate balding that was happening. I believe that there was no reason to use health within the calculations.

#### Describe alternatives you've considered

If using health dependent calculations is important to the developers then possibly lowering the number that multiplies the health significantly would be another approach to fixing the issue in a different way.

#### Testing

I tested the changes by creating a character with natural hair growth, cutting their hair, and using the debug menu to see how fast the hair and beard would grow. Along with this I also made sure to add my own logging which is not being committed. The logging would tell me which traits were being added and when.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
