### PR TITLE
Remove message.h/cpp includes from Cataclysm-lib-vcpkg-static project file

### DIFF
--- a/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
@@ -172,11 +172,9 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\src\*.h" Exclude="..\src\messages.h" />
-    <ClInclude Include="..\src\messages.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\*.cpp" Exclude="..\src\main.cpp;..\src\messages.cpp" />
-    <ClCompile Include="..\src\messages.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="flatbuffers.vcxproj">


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Since the test project has it's own versions of the message methods, this shouldn't be part of the `Cataclysm-lib-vcpkg-static` project.

#### Describe the solution

Remove the includes.

#### Describe alternatives you've considered



#### Testing

Messages still show during gameplay.

#### Additional context

