### PR TITLE
Ravenfolk updates

### DIFF
--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -780,7 +780,6 @@
     "purifiable": false,
     "types": [ "TEETH", "MUZZLE" ],
     "cancels": [ "MOUTH_TENTACLES" ],
-    "prereqs": [ "BEAK" ],
     "threshreq": [ "THRESH_SPECIES_RAVENFOLK" ],
     "category": [ "SPECIES_RAVENFOLK" ],
     "wet_protection": [ { "part": "mouth", "ignored": 2 } ],
@@ -802,12 +801,6 @@
     "copy-from": "HOLLOW_BONES",
     "description": "Your bones are nearly hollow, a remnant of your people's past as creatures of the air.  Your body is very light as a result, enabling you to move and attack 20% faster, but also frail; you can carry 40% less, and bashing attacks injure you more.",
     "category": [ "SPECIES_RAVENFOLK" ]
-  },
-  {
-    "type": "mutation",
-    "id": "BEAK",
-    "copy-from": "BEAK",
-    "extend": { "category": [ "SPECIES_RAVENFOLK" ] }
   },
   {
     "type": "mutation",

--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -752,6 +752,24 @@
   },
   {
     "type": "mutation",
+    "id": "RAVENFOLK_WINGS",
+    "name": { "str": "Ravenfolk Wings" },
+    "points": 0,
+    "visibility": 6,
+    "ugliness": 2,
+    "purifiable": false,
+    "mixed_effect": true,
+    "description": "You have a pair of large raven wings projecting from your shoulderblades.  Your body is too heavy to be able to fly, but if you're not too weighed down, you might be able to glide from a ledge or lessen the impact of a fall.",
+    "category": [ "SPECIES_RAVENFOLK" ],
+    "threshreq": [ "THRESH_SPECIES_RAVENFOLK" ],
+    "types": [ "WINGS" ],
+    "strict_threshreq": true,
+    "restricts_gear": [ "torso" ],
+    "allow_soft_gear": true,
+    "flags": [ "WINGS_2", "WING_GLIDE" ]
+  },
+  {
+    "type": "mutation",
     "id": "BEAK_RAVEN",
     "name": { "str": "Raven Beak" },
     "points": 0,
@@ -819,12 +837,6 @@
     "id": "EAGLEEYED",
     "copy-from": "EAGLEEYED",
     "extend": { "category": [ "SPECIES_RAVENFOLK" ] }
-  },
-  {
-    "type": "mutation",
-    "id": "WINGS_BIRD",
-    "copy-from": "WINGS_BIRD",
-    "extend": { "category": [ "SPECIES_RAVENFOLK" ], "threshreq": [ "THRESH_SPECIES_RAVENFOLK" ] }
   },
   {
     "type": "mutation",

--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -746,6 +746,7 @@
     "name": { "str": "Ravenfolk Legs" },
     "description": "Your legs and feet are those of a raven, with three long talons at the front and one at the back, ending in wicked claws and preventing you from wearing shoes.  Fortunately they don't impede your movement.",
     "category": [ "SPECIES_RAVENFOLK" ],
+    "purifiable": false,
     "extend": { "prereqs": [ "RAVEN_BONES" ] },
     "threshreq": [ "THRESH_SPECIES_RAVENFOLK" ],
     "flags": [ "TOUGH_FEET" ]

--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -767,7 +767,10 @@
     "strict_threshreq": true,
     "restricts_gear": [ "torso" ],
     "allow_soft_gear": true,
-    "flags": [ "WINGS_2", "WING_GLIDE" ]
+    "flags": [ "WINGS_2", "WING_GLIDE" ],
+    "active": true,
+    "activated_is_setup": false,
+    "activated_eocs": [ "EOC_RAVENFOLK_LEAP" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Magiclysm/mutations/mutation_eocs.json
+++ b/data/mods/Magiclysm/mutations/mutation_eocs.json
@@ -80,5 +80,21 @@
         }
       ]
     }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RAVENFOLK_LEAP",
+    "effect": [
+      {
+        "run_eoc_with": "EOC_GENERIC_SPELL_MUTATION",
+        "variables": {
+          "energy_amount": "2500",
+          "prep_time": "1",
+          "spell_to_cast": "spell_ravenfolk_leap",
+          "message_success": { "i18n": true, "str": "You launch yourself into a powerful wing-assisted leap." },
+          "message_fail": { "i18n": true, "str": "You're too tired to leap." }
+        }
+      }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/mutations/mutation_spells.json
+++ b/data/mods/Magiclysm/mutations/mutation_spells.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "SPELL",
+    "id": "spell_ravenfolk_leap",
+    "name": "Wing Leap",
+    "description": "You launch yourself into a powerful wing-assisted leap.",
+    "valid_targets": [ "ground" ],
+    "flags": [ "SILENT", "NO_LEGS", "NO_HANDS", "NO_EXPLOSION_SFX" ],
+    "effect": "dash",
+    "shape": "cone",
+    "min_damage": 0,
+    "max_damage": 0,
+    "damage_type": "bash",
+    "min_range": 6,
+    "max_range": 6
+  }
+]

--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -468,7 +468,7 @@
     "type": "mutation",
     "id": "WINGS_STUB",
     "copy-from": "WINGS_STUB",
-    "extend": { "category": [ "DRAGON_BLACK", "SPECIES_RAVENFOLK" ], "changes_to": [ "DRAGON_WINGS_BLACK" ] }
+    "extend": { "category": [ "DRAGON_BLACK" ], "changes_to": [ "DRAGON_WINGS_BLACK" ] }
   },
   {
     "type": "mutation",

--- a/data/mods/Magiclysm/npc/trait_groups.json
+++ b/data/mods/Magiclysm/npc/trait_groups.json
@@ -266,7 +266,7 @@
     "traits": [
       { "trait": "THRESH_SPECIES_RAVENFOLK" },
       { "trait": "RAVENFOLK_BUILD" },
-      { "trait": "WINGS_BIRD" },
+      { "trait": "RAVENFOLK_WINGS" },
       { "trait": "DOWN" },
       { "trait": "BEAK_RAVEN" },
       { "trait": "RAVENFOLK_LEGS" },

--- a/data/mods/Magiclysm/traits/fantasy_species.json
+++ b/data/mods/Magiclysm/traits/fantasy_species.json
@@ -119,7 +119,7 @@
     "traits": [
       "THRESH_SPECIES_RAVENFOLK",
       "RAVENFOLK_BUILD",
-      "WINGS_BIRD",
+      "RAVENFOLK_WINGS",
       "DOWN",
       "BEAK_RAVEN",
       "RAVENFOLK_LEGS",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add Ravenfolk specific wings mutation with long leap ability, remove duplicate beak and wing stubs from Ravenfolk"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
* Adds a Ravenfolk specific wings mutation so that they don't have both wings and wing stubs
* Remove BEAK prereq from Ravenfolk beak so that they don't have both a beak and Ravenfolk beak
* Add a wing boosted six tile leap that Ravenfolk ferals have based on suggestion from @Standing-Storm. Feel free to give me better strings and stamina cost for this.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
~~I've considered adding a leap ability to the wings as per Standing-Storm's suggestion, not sure if I have the time to add and test it here.~~
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There's an associated bug with stamina use, you can keep activating the leap ability despite being out of stamina due to #76839.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
