### PR TITLE
make turrets controlled by ID readers/consoles deactivate instead of despawn (revamped)

### DIFF
--- a/data/json/furniture_and_terrain/furniture_turret.json
+++ b/data/json/furniture_and_terrain/furniture_turret.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "furniture",
+    "id": "f_turret_bmg",
+    "name": { "str": "inactive M2HB autonomous CROWS II" },
+    "description": "A remote weapon system derived from the M153 CROWS II and enhanced with autonomous operation software.  This one is fitted with a .50 caliber M2HB machine gun.  Normally it would have no qualms about blowing your head clean (not really) off, but fortunately for you it's inactive.  On it a bright yellow label says \"AUTONOMOUS SECURITY UNIT DO NOT TAMPER\".",
+    "symbol": "2",
+    "color": "green",
+    "move_cost_mod": 2,
+    "coverage": 40,
+    "required_str": 8,
+    "flags": [ "TRANSPARENT", "PERMEABLE", "THIN_OBSTACLE" ]
+  },
+  {
+    "type": "furniture",
+    "id": "f_turret_rifle",
+    "name": { "str": "inactive M249 autonomous CROWS II" },
+    "description": "A remote weapon system derived from the M153 CROWS II and enhanced with autonomous operation software.  This one is fitted with a 5.56 caliber M249 machine gun.  Normally it would have no qualms about blowing your head clean (not really) off, but fortunately for you it's inactive.  On it a bright yellow label says \"AUTONOMOUS SECURITY UNIT DO NOT TAMPER\".",
+    "symbol": "2",
+    "color": "green",
+    "move_cost_mod": 2,
+    "coverage": 40,
+    "required_str": 8,
+    "flags": [ "TRANSPARENT", "PERMEABLE", "THIN_OBSTACLE" ]
+  }
+]

--- a/data/json/monsters/monster_flags.json
+++ b/data/json/monsters/monster_flags.json
@@ -230,9 +230,9 @@
     "//": "e.g.  a robot; affected by EMP blasts, and other stuff"
   },
   {
-    "id": "CONSOLE_DESPAWN",
+    "id": "CONSOLE_DEACTIVATE",
     "type": "monster_flag",
-    "//": "Despawns when a nearby console is properly hacked"
+    "//": "Deactivates and turns into a furniture when a nearby console is properly hacked"
   },
   {
     "id": "IMMOBILE",
@@ -240,9 +240,9 @@
     "//": "Doesn't move (e.g.  turrets)"
   },
   {
-    "id": "ID_CARD_DESPAWN",
+    "id": "ID_CARD_DEACTIVATE",
     "type": "monster_flag",
-    "//": "Despawns when a science ID card is used on a nearby console"
+    "//": "Deactivates and turns into a furniture when a science ID card is used on a nearby console"
   },
   {
     "id": "RIDEABLE_MECH",

--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -123,6 +123,7 @@
     "special_when_hit": [ "RETURN_FIRE", 100 ],
     "death_drops": {  },
     "death_function": { "corpse_type": "BROKEN" },
+    "deactivation": "f_turret_bmg",
     "flags": [
       "SEES",
       "NOHEAD",
@@ -132,8 +133,8 @@
       "IMMOBILE",
       "NO_BREATHE",
       "DROPS_AMMO",
-      "CONSOLE_DESPAWN",
-      "ID_CARD_DESPAWN"
+      "CONSOLE_DEACTIVATE",
+      "ID_CARD_DEACTIVATE"
     ],
     "armor": { "bash": 14, "cut": 16, "bullet": 13, "stab": 16 }
   },
@@ -183,6 +184,7 @@
     "special_when_hit": [ "RETURN_FIRE", 100 ],
     "death_drops": {  },
     "death_function": { "corpse_type": "BROKEN" },
+    "deactivation": "f_turret_rifle",
     "flags": [
       "SEES",
       "NOHEAD",
@@ -192,8 +194,8 @@
       "IMMOBILE",
       "NO_BREATHE",
       "DROPS_AMMO",
-      "ID_CARD_DESPAWN",
-      "CONSOLE_DESPAWN"
+      "ID_CARD_DEACTIVATE",
+      "CONSOLE_DEACTIVATE"
     ],
     "armor": { "bash": 14, "cut": 16, "bullet": 13, "stab": 16 }
   },
@@ -252,8 +254,8 @@
       "IMMOBILE",
       "NO_BREATHE",
       "DROPS_AMMO",
-      "ID_CARD_DESPAWN",
-      "CONSOLE_DESPAWN"
+      "ID_CARD_DEACTIVATE",
+      "CONSOLE_DEACTIVATE"
     ],
     "armor": { "bash": 14, "cut": 16, "bullet": 13, "stab": 16 }
   },
@@ -313,7 +315,7 @@
       "IMMOBILE",
       "NO_BREATHE",
       "DROPS_AMMO",
-      "ID_CARD_DESPAWN"
+      "ID_CARD_DEACTIVATE"
     ],
     "armor": { "bash": 14, "cut": 16, "bullet": 13, "stab": 16 }
   },

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -319,9 +319,10 @@ static void remove_submap_turrets()
         // Check 1) same overmap coords, 2) turret, 3) hostile
         if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs(
                     player_character.pos() ) ) &&
-            critter.has_flag( mon_flag_CONSOLE_DESPAWN ) &&
+            critter.has_flag( mon_flag_CONSOLE_DEACTIVATE ) &&
             critter.attitude_to( player_character ) == Creature::Attitude::HOSTILE ) {
             g->remove_zombie( critter );
+            here.furn_set( critter.pos(), critter.deactivate_mon() );
         }
     }
 }

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -162,7 +162,7 @@ bool cardreader_examine_actor::apply( const tripoint &examp ) const
 }
 
 /**
- * Use id/hack reader. Using an id despawns turrets.
+ * Use id/hack reader. Using an id deactivates turrets.
  */
 void cardreader_examine_actor::call( Character &you, const tripoint &examp ) const
 {
@@ -180,9 +180,10 @@ void cardreader_examine_actor::call( Character &you, const tripoint &examp ) con
             }
             // Check 1) same overmap coords, 2) turret, 3) hostile
             if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs( examp ) ) &&
-                critter.has_flag( mon_flag_ID_CARD_DESPAWN ) &&
+                critter.has_flag( mon_flag_ID_CARD_DEACTIVATE ) &&
                 critter.attitude_to( you ) == Creature::Attitude::HOSTILE ) {
                 g->remove_zombie( critter );
+                here.furn_set( critter.pos(), critter.deactivate_mon() );
             }
         }
         if( open ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3540,6 +3540,11 @@ void monster::add_item( const item &it )
     inv.push_back( it );
 }
 
+const furn_str_id monster::deactivate_mon()
+{
+    return type->deactivation;
+}
+
 bool monster::is_hallucination() const
 {
     return hallucination;

--- a/src/monster.h
+++ b/src/monster.h
@@ -476,6 +476,9 @@ class monster : public Creature
         // Add an item to inventory
         void add_item( const item &it );
 
+        // see mtype::deactivation
+        const furn_str_id deactivate_mon();
+
         /**
         * Consume UPS from mech battery.
         * @param amt amount of energy to consume. Is rounded down to kJ precision. Do not use negative values.

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1095,6 +1095,8 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "speed_description", speed_desc, speed_description_DEFAULT );
     optional( jo, was_loaded, "death_function", mdeath_effect );
 
+    optional( jo, was_loaded, "deactivation", deactivation );
+
     if( jo.has_array( "emit_fields" ) ) {
         JsonArray jar = jo.get_array( "emit_fields" );
         if( jar.has_string( 0 ) ) { // TEMPORARY until 0.F

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -61,7 +61,7 @@ mon_flag_id mon_flag_ACIDPROOF,
             mon_flag_CAN_OPEN_DOORS,
             mon_flag_CLIMBS,
             mon_flag_COMBAT_MOUNT,
-            mon_flag_CONSOLE_DESPAWN,
+            mon_flag_CONSOLE_DEACTIVATE,
             mon_flag_CONVERSATION,
             mon_flag_CORNERED_FIGHTER,
             mon_flag_DEADLY_VIRUS,
@@ -97,7 +97,7 @@ mon_flag_id mon_flag_ACIDPROOF,
             mon_flag_HEARS,
             mon_flag_HIT_AND_RUN,
             mon_flag_HUMAN,
-            mon_flag_ID_CARD_DESPAWN,
+            mon_flag_ID_CARD_DEACTIVATE,
             mon_flag_IMMOBILE,
             mon_flag_INSECTICIDEPROOF,
             mon_flag_INTERIOR_AMMO,
@@ -185,7 +185,7 @@ void set_mon_flag_ids()
     mon_flag_CAN_OPEN_DOORS = mon_flag_id( "CAN_OPEN_DOORS" );
     mon_flag_CLIMBS = mon_flag_id( "CLIMBS" );
     mon_flag_COMBAT_MOUNT = mon_flag_id( "COMBAT_MOUNT" );
-    mon_flag_CONSOLE_DESPAWN = mon_flag_id( "CONSOLE_DESPAWN" );
+    mon_flag_CONSOLE_DEACTIVATE = mon_flag_id( "CONSOLE_DEACTIVATE" );
     mon_flag_CONVERSATION = mon_flag_id( "CONVERSATION" );
     mon_flag_CORNERED_FIGHTER = mon_flag_id( "CORNERED_FIGHTER" );
     mon_flag_DEADLY_VIRUS = mon_flag_id( "DEADLY_VIRUS" );
@@ -221,7 +221,7 @@ void set_mon_flag_ids()
     mon_flag_HEARS = mon_flag_id( "HEARS" );
     mon_flag_HIT_AND_RUN = mon_flag_id( "HIT_AND_RUN" );
     mon_flag_HUMAN = mon_flag_id( "HUMAN" );
-    mon_flag_ID_CARD_DESPAWN = mon_flag_id( "ID_CARD_DESPAWN" );
+    mon_flag_ID_CARD_DEACTIVATE = mon_flag_id( "ID_CARD_DEACTIVATE" );
     mon_flag_IMMOBILE = mon_flag_id( "IMMOBILE" );
     mon_flag_INSECTICIDEPROOF = mon_flag_id( "INSECTICIDEPROOF" );
     mon_flag_INTERIOR_AMMO = mon_flag_id( "INTERIOR_AMMO" );
@@ -302,6 +302,7 @@ mtype::mtype()
     age_grow = -1;
     upgrade_into = mtype_id::NULL_ID();
     upgrade_group = mongroup_id::NULL_ID();
+    deactivation = furn_str_id::NULL_ID();
 
     reproduces = false;
     baby_count = -1;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -101,7 +101,7 @@ extern mon_flag_id mon_flag_ACIDPROOF,
        mon_flag_CAN_OPEN_DOORS,
        mon_flag_CLIMBS,
        mon_flag_COMBAT_MOUNT,
-       mon_flag_CONSOLE_DESPAWN,
+       mon_flag_CONSOLE_DEACTIVATE,
        mon_flag_CONVERSATION,
        mon_flag_CORNERED_FIGHTER,
        mon_flag_DEADLY_VIRUS,
@@ -137,7 +137,7 @@ extern mon_flag_id mon_flag_ACIDPROOF,
        mon_flag_HEARS,
        mon_flag_HIT_AND_RUN,
        mon_flag_HUMAN,
-       mon_flag_ID_CARD_DESPAWN,
+       mon_flag_ID_CARD_DEACTIVATE,
        mon_flag_IMMOBILE,
        mon_flag_INSECTICIDEPROOF,
        mon_flag_INTERIOR_AMMO,
@@ -318,6 +318,9 @@ struct mtype {
         mtype_id fungalize_into; // mtype_id this monster fungalize into
 
         reproduction_type baby_type;
+
+        // Funiture in case of deactivation (see remove_submap_turrets as an example)
+        furn_str_id deactivation;
 
         // Monster biosignature variables
         itype_id biosig_item;


### PR DESCRIPTION
#### Summary
Balance "make turrets controlled by ID readers/consoles deactivate instead of despawn"

#### Purpose of change
This is basically a revival of #71335. Turrets which can be disabled via consoles and id readers vanish into thin air when done so. This pr aims to make them deactivate instead of disappear. After which they can be collected through skill checks.
closes #71332 

#### Describe the solution
Turrets will now be replaced with a corresponding fixture upon hack/id-read. If a player wishes to claim the turret and its ammo they will need to engage in an action that requires computer and electronics skills. Failing this check will result in them being revived as a hostile entity. The higher their skill levels are, lesser will be the chance of the turrets jumping back to life. Trying to scavenge its parts trough brute force will also result in the turret reviving as well, unless the force is overwhelming for the furniture.

TODO:
- [ ] Find a way to keep some of turret's data (ammo etc.) with the furniture
- [ ] Add a skill-check action that gives the turret item / ammo upon success
- [ ] Make sure that te turret is reactivated when the skill check is failed or the furniture is smashed
- [ ] Create furnitures for all the turrets that can be deactivated

maybe:
- [ ] Create an eoc effect that oversees the same function

#### Describe alternatives you've considered
Turrets keep quantum tunneling themselves into Z level -11
idk i need some suggestions/feedback here

#### Testing
the mon -> furniture thing works fine
rest of the testing is pending along with the code

#### Additional context
I'M [BACK](https://youtu.be/YVkUvmDQ3HY?si=C87shW3blNa85GTv&t=32)
very WIP