### PR TITLE
Add PULL_WEAPON monattack and use in relevant areas

### DIFF
--- a/data/mods/Magiclysm/monsters/holiday_magiclysm.json
+++ b/data/mods/Magiclysm/monsters/holiday_magiclysm.json
@@ -111,7 +111,7 @@
     "path_settings": { "avoid_traps": true, "avoid_sharp": true },
     "fear_triggers": [ "HURT", "FIRE" ],
     "tracking_distance": 8,
-    "special_attacks": [ { "type": "spell", "spell_data": { "id": "prank", "min_level": 5 }, "cooldown": 80 }, [ "PULL_METAL_WEAPON", 25 ] ],
+    "special_attacks": [ { "type": "spell", "spell_data": { "id": "prank", "min_level": 5 }, "cooldown": 80 }, [ "PULL_WEAPON", 25 ] ],
     "flags": [ "SEES", "HEARS", "SMELLS", "FAE_CREATURE", "HAS_MIND", "PATH_AVOID_DANGER", "KEEP_DISTANCE", "WARM" ]
   }
 ]

--- a/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
@@ -108,7 +108,7 @@
         },
         "monster_message": "The air around %1$s distorts."
       },
-      [ "PULL_METAL_WEAPON", 8 ]
+      [ "PULL_WEAPON", 8 ]
     ],
     "flags": [
       "SEES",

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -1255,7 +1255,7 @@
         },
         "monster_message": "The air around %1$s wavers."
       },
-      [ "PULL_METAL_WEAPON", 15 ]
+      [ "PULL_WEAPON", 15 ]
     ],
     "flags": [
       "SEES",
@@ -1375,7 +1375,7 @@
         },
         "monster_message": "The air around %1$s distorts."
       },
-      [ "PULL_METAL_WEAPON", 10 ]
+      [ "PULL_WEAPON", 10 ]
     ],
     "flags": [
       "SEES",

--- a/doc/MONSTER_SPECIAL_ATTACKS.md
+++ b/doc/MONSTER_SPECIAL_ATTACKS.md
@@ -140,6 +140,7 @@ These special attacks are mostly hardcoded in C++ and are generally not configur
 - ```PHOTOGRAPH``` Photographs the player.  Causes a robot attack?
 - ```PLANT``` Fungal spores take seed and grow into a fungaloid.
 - ```PULL_METAL_WEAPON``` Pulls any weapon that's made of iron or steel from the player's hand.
+- ```PULL_WEAPON``` Pulls any object from the player's hand.
 - ```RATKING``` Inflicts disease `rat`.
 - ```RATTLE``` "a sibilant rattling sound!".
 - ```RESURRECT``` Revives the dead (again).

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -22,6 +22,7 @@ bool acid_barf( monster *z );
 bool shockstorm( monster *z );
 bool shocking_reveal( monster *z );
 bool pull_metal_weapon( monster *z );
+bool pull_weapon( monster *z );
 bool boomer( monster *z );
 bool boomer_glow( monster *z );
 bool resurrect( monster *z );

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -605,6 +605,7 @@ void MonsterGenerator::init_attack()
     add_hardcoded_attack( "SHOCKSTORM", mattack::shockstorm );
     add_hardcoded_attack( "SHOCKING_REVEAL", mattack::shocking_reveal );
     add_hardcoded_attack( "PULL_METAL_WEAPON", mattack::pull_metal_weapon );
+    add_hardcoded_attack( "PULL_WEAPON", mattack::pull_weapon );
     add_hardcoded_attack( "BOOMER", mattack::boomer );
     add_hardcoded_attack( "BOOMER_GLOW", mattack::boomer_glow );
     add_hardcoded_attack( "RESURRECT", mattack::resurrect );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Add PULL_WEAPON monattack and use in relevant mods"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Most cases of PULL_METAL_WEAPON are currently used in situations where they shouldn't actually care if the weapon is metal or not.  Add new monster attack that doesn't care about the item material and switch these cases over.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Basically reuse the pull_metal_weapon code but cut out all the segments related to material checking.
Switch old monattacks over if they shouldn't care about material.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![weapon pulling](https://github.com/user-attachments/assets/75b9707d-90ff-4f02-a988-3730740ca970)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
