### PR TITLE
HUB01 templates' spawn is more predictable

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2074,7 +2074,7 @@
     "price": "2000 kUSD",
     "price_postapoc": "30 USD",
     "//": "actually worth millions",
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID", "MISSION_ITEM" ]
   },
   {
     "type": "GENERIC",
@@ -2086,7 +2086,7 @@
     "price": "1000 kUSD",
     "price_postapoc": "30 USD",
     "//": "given to HUB 01 for even better armor",
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID", "MISSION_ITEM" ]
   },
   {
     "type": "GENERIC",


### PR DESCRIPTION
#### Summary
Bugfixes "HUB01 templates' spawn is more predictable"

#### Purpose of change
* Closes #74573.

#### Describe the solution
Added `MISSION_ITEM` flag to HUB01 templates so they spawn 100% of time.

#### Describe alternatives you've considered
None.

#### Testing
Set item scaling factor to 0.01. Debug-spawned `robofac_mi3_photonics_chunk` about a dozen times. Checked that templates are spawned 100% of time.

#### Additional context
None.