### PR TITLE
Start of cataclysm day and start of game day now respect season length

### DIFF
--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -111,7 +111,7 @@ void scenario::load( const JsonObject &jo, const std::string_view )
     if( !was_loaded ) {
 
         int _start_of_cataclysm_hour = 0;
-        int _start_of_cataclysm_day = 61;
+        int _start_of_cataclysm_day = 1 + get_option<int>( "SEASON_LENGTH" ) / 3 * 2;
         season_type _start_of_cataclysm_season = SPRING;
         int _start_of_cataclysm_year = 1;
         if( jo.has_member( "start_of_cataclysm" ) ) {
@@ -129,7 +129,7 @@ void scenario::load( const JsonObject &jo, const std::string_view )
                                       ;
 
         int _start_of_game_hour = 8;
-        int _start_of_game_day = 61;
+        int _start_of_game_day = 1 + get_option<int>( "SEASON_LENGTH" ) / 3 * 2;
         season_type _start_of_game_season = SPRING;
         int _start_of_game_year = 1;
         if( jo.has_member( "start_of_game" ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Start of cataclysm day and start of game day now respect season length"

#### Purpose of change
* Closes #74535.

#### Describe the solution
Applied @ZhilkinSerg solution from https://github.com/CleverRaven/Cataclysm-DDA/issues/74535#issuecomment-2169221367.

#### Describe alternatives you've considered
None.

#### Testing
Made season length 14 days. Started creating custom character. Checked that default start of cataclysm day and start of game day are both year 1 day 9.

#### Additional context
None.