### PR TITLE
[MoM] Allow Intuitive Artisan to craft in complete darkness (because you close your eyes and let the visions take over)

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -238,7 +238,7 @@ This is natural painkiller and so has natural effects (reduces speed slightly)<b
 *Duration*: 20 minutes and 15 seconds to 45 minutes, plus 4 minutes and 10 seconds to 10 minutes per level<br />
 *Stamina Cost*: 6500, minus 145 per level to a minimum of 3250<br />
 *Channeling Time*: 500 moves, minus 3 moves per level to a minimum of 300<br />
-*Effects*: Enter a trance and improve the psion's ability to craft, increasing crafting speed by 4% and skill level by 0.25 per 4 power levels. However, the psion's vision will be limited and their movement speed will be slowed while in the trance.<br />
+*Effects*: Enter a trance and improve the psion's ability to craft, increasing crafting speed by 4% and skill level by 0.25 per 4 power levels and allowing them to craft regardless of light levels. However, the psion's vision will be limited and their movement speed will be slowed while in the trance, and they will be blind while actually crafting anything.<br />
 *Prerequisites*: Speed Reader 8, Discern Weakness 4, Premonition 6<br />
 
 ## One Perfect Shot

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -787,7 +787,7 @@
     "id": "effect_clair_craft_bonus",
     "name": [ "Intuitive Artistry" ],
     "desc": [
-      "You just know what you need to do next.  It's harder for you to pay attention to anything else due to the shifting futures, however."
+      "You just know what you need to do next.  It's harder for you to pay attention to anything else due to the shifting futures, however, and you will lose awareness of the outside world entirely when making something."
     ],
     "rating": "good",
     "max_duration": "7 days",
@@ -806,7 +806,16 @@
         ]
       }
     ],
-    "flags": [ "MYOPIC" ]
+    "flags": [ "MYOPIC", "CRAFT_IN_DARKNESS" ]
+  },
+  {
+     
+    "type": "effect_type",
+    "id": "effect_clair_craft_bonus_blindness",
+    "//": "Hidden effect, blinds you while crafting.",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "BLIND" ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -809,7 +809,6 @@
     "flags": [ "MYOPIC", "CRAFT_IN_DARKNESS" ]
   },
   {
-     
     "type": "effect_type",
     "id": "effect_clair_craft_bonus_blindness",
     "//": "Hidden effect, blinds you while crafting.",

--- a/data/mods/MindOverMatter/powers/clairsentience.json
+++ b/data/mods/MindOverMatter/powers/clairsentience.json
@@ -390,7 +390,7 @@
     "id": "clair_craft_bonus",
     "type": "SPELL",
     "name": "[Ψ]Intuitive Artisan (C)",
-    "description": "Opening yourself up to the immediate future, you can see the best option to take when crafting or working on a task.  However, due ot the intensity of the visions you will be <color_red>blind</color> to the outside world while crafting anything.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.  It is <color_red>canceled by engaging in combat</color>.",
+    "description": "Opening yourself up to the immediate future, you can see the best option to take when crafting or working on a task.  However, due to the intensity of the visions you will be <color_red>blind</color> to the outside world while crafting anything.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.  It is <color_red>canceled by engaging in combat</color>.",
     "message": "",
     "teachable": false,
     "valid_targets": [ "self" ],

--- a/data/mods/MindOverMatter/powers/clairsentience.json
+++ b/data/mods/MindOverMatter/powers/clairsentience.json
@@ -390,7 +390,7 @@
     "id": "clair_craft_bonus",
     "type": "SPELL",
     "name": "[Ψ]Intuitive Artisan (C)",
-    "description": "Opening yourself up to the immediate future, you can see the best option to take when crafting or working on a task.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.  It is <color_red>canceled by engaging in combat</color>.",
+    "description": "Opening yourself up to the immediate future, you can see the best option to take when crafting or working on a task.  However, due ot the intensity of the visions you will be <color_red>blind</color> to the outside world while crafting anything.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.  It is <color_red>canceled by engaging in combat</color>.",
     "message": "",
     "teachable": false,
     "valid_targets": [ "self" ],

--- a/data/mods/MindOverMatter/powers/clairsentience_eoc.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_eoc.json
@@ -140,6 +140,43 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_CLAIR_CRAFTING_ADD_BLINDNESS_WHEN_CRAFTING",
+    "eoc_type": "EVENT",
+    "required_event": "character_starts_activity",
+    "condition": {
+      "and": [
+        { "u_has_effect": "effect_clair_craft_bonus" },
+        {
+          "or": [
+            { "compare_string": [ "ACT_MULTIPLE_CRAFT", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_CRAFT", { "context_val": "activity" } ] }
+          ]
+        }
+      ]
+    },
+    "effect": [ { "u_add_effect": "effect_clair_craft_bonus_blindness", "duration": "12 hours" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLAIR_CRAFTING_REMOVE_BLINDNESS_WHEN_DONE_CRAFTING",
+    "eoc_type": "EVENT",
+    "required_event": "character_finished_activity",
+    "condition": {
+      "and": [
+        { "u_has_effect": "effect_clair_craft_bonus" },
+        { "u_has_effect": "effect_clair_craft_bonus_blindness" },
+        {
+          "or": [
+            { "compare_string": [ "ACT_MULTIPLE_CRAFT", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_CRAFT", { "context_val": "activity" } ] }
+          ]
+        }
+      ]
+    },
+    "effect": [ { "u_lose_effect": "effect_clair_craft_bonus_blindness" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_CLAIR_ASTRAL_PROJECTION_INITIATE",
     "effect": [
       { "u_location_variable": { "u_val": "clair_astral_projection_original_location" }, "min_radius": 0, "max_radius": 0 },

--- a/data/mods/MindOverMatter/powers/clairsentience_eoc.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_eoc.json
@@ -154,7 +154,10 @@
         }
       ]
     },
-    "effect": [ { "u_add_effect": "effect_clair_craft_bonus_blindness", "duration": "12 hours" } ]
+    "effect": [
+      { "u_add_effect": "effect_clair_craft_bonus_blindness", "duration": "12 hours" },
+      { "u_message": "You close your eyes as the visions overtake you.", "type": "mixed" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -173,7 +176,10 @@
         }
       ]
     },
-    "effect": [ { "u_lose_effect": "effect_clair_craft_bonus_blindness" } ]
+    "effect": [
+      { "u_lose_effect": "effect_clair_craft_bonus_blindness" },
+      { "u_message": "You open your eyes as the visions fade.", "type": "neutral" }
+    ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Allow Intuitive Artisan to craft in complete darkness (because you close your eyes and let the visions take over)"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Follow up to #76697 for MoM, letting Clairsentients craft in complete darkness in a logical way.  The power Intuitive Artisan makes you better at crafting because you're sorting through possible futures to find the best one where you make whatever you're making in perfect time. So if you're just sorting through the visions and letting them guide you, maybe you don't need to use your physical vision to craft. But if you don't use your physical vision, you're blind.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Use two EoCs so that the psion closes their eyes when crafting using Intuitive Artistry, blinding them, and have the effect removed when crafting ends. Crafting is thus faster and you can do it in complete darkness, but you'd better be in a safe place when you're overwhelmed with psychic visions (or also be running Premonition so you have other visions if monsters approach). 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Power allows you to craft in the dark. The psion is blind while crafting and the blindness ends when crafting is canceled or completed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
