### PR TITLE
Fix CI for 0.H by not running tests with with wip limbs mod and Magiclysm together

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -10,10 +10,21 @@ import json
 
 mods_this_time = []
 
+exclusions = [
+    # Tuple of (mod_id, mod_id) - these two mods will be incompatible
+    # #76175 causes CI failure between limbified wings and Magiclysm ravenfolk
+    ('limb_wip', 'magiclysm')
+]
+
 
 def compatible_with(mod, existing_mods):
     if mod in total_conversions and total_conversions & set(existing_mods):
         return False
+    for entry in exclusions:
+        if entry[0] == mod and entry[1] in existing_mods:
+            return False
+        if entry[1] == mod and entry[0] in existing_mods:
+            return False
     return True
 
 
@@ -23,11 +34,14 @@ def add_mods(mods):
             # Either an invalid mod id, or blacklisted.
             return False
     for mod in mods:
-        if mod not in mods_this_time and compatible_with(mod, mods_this_time):
-            if add_mods(all_mod_dependencies[mod]):
-                mods_this_time.append(mod)
-            else:
-                return False
+        if mod in mods_this_time:
+            continue
+        if not compatible_with(mod, mods_this_time):
+            return False
+        if add_mods(all_mod_dependencies[mod]):
+            mods_this_time.append(mod)
+        else:
+            return False
     return True
 
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#76175 introduced a random CI failure between limbified wings and Magiclysm ravenfolk. This turns out to be really annoying to fix, so since WIP limb mod is indeed WIP, it's more straightforward to fix it  by stopoi g tests from running with wip limbs mod together with Magiclysm, instead of introducing 0.H-exclusive content tweaks to get past the erroring test.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Checkout https://github.com/CleverRaven/Cataclysm-DDA/blame/master/build-scripts/get_all_mods.py from master branch because it has a nice mod exclusion feature. Add anothersimulacrum as coauthor since they added that feature. Add the affected mods as an exclusion.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
* Spending more time trying to fix the affected content
* Spending more time trying to figure out why this doesn't break in master
* Suffering every time I see someone having trouble passing CI for 0.H backports
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run the affected test a handful of times in CI to see if it breaks. For some reason I could never trigger this failure locally even semi-reliably.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
