### PR TITLE
Don't take integrated and no-takeoff items when mugging

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4680,7 +4680,7 @@ void npc::mug_player( Character &mark )
     std::vector<const item *> pseudo_items = mark.get_pseudo_items();
     const auto inv_valuables = mark.items_with( [this, pseudo_items]( const item & itm ) {
         return std::find( pseudo_items.begin(), pseudo_items.end(), &itm ) == pseudo_items.end() &&
-               value( itm ) > 0;
+               !itm.has_flag( flag_INTEGRATED ) && !itm.has_flag( flag_NO_TAKEOFF ) && value( itm ) > 0;
     } );
     for( item *it : inv_valuables ) {
         item &front_stack = *it; // is this safe?


### PR DESCRIPTION
#### Summary
Bugfixes "Don't take integrated and no-takeoff items when mugging"

#### Purpose of change
* Closes #73753.

#### Describe the solution
Exclude items with `INTEGRATED` and `NO_TAKEOFF` flags from the list of possible items to take when mugging.

#### Describe alternatives you've considered
None.

#### Testing
Got and wore Lifting Field from MoM. Spawned NPC and set its attitude to mugging. NPC took all my stuff except for Lifting Field.
Got and wore werewolf aura from Magiclysm. Spawned NPC and set its attitude to mugging. NPC took all my stuff except for werewolf aura.

#### Additional context
None.