### PR TITLE
Increase the batch size of the calcium carbide producing reaction

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -95,6 +95,28 @@
   },
   {
     "type": "vehicle_part",
+    "id": "ap_arc_furnace",
+    "name": { "str": "arc furnace" },
+    "looks_like": "f_arc_furnace",
+    "color": "blue",
+    "categories": [ "utility" ],
+    "description": "An arc furnace designed to burn a powdery mix of coke and limestone to create calcium carbide.  Plugged in and ready to go.",
+    "broken_color": "yellow_red",
+    "damage_modifier": 10,
+    "damage_reduction": { "all": 30 },
+    "durability": 80,
+    "flags": [ "OBSTACLE", "APPLIANCE" ],
+    "pseudo_tools": [ { "id": "fake_arc_furnace" } ],
+    "item": "arc_furnace",
+    "breaks_into": [
+      { "item": "scrap", "count": [ 2, 4 ] },
+      { "item": "steel_chunk", "count": [ 0, 3 ] },
+      { "item": "pipe", "count": [ 0, 4 ] }
+    ],
+    "variants": [ { "symbols": "U", "symbols_broken": "x" } ]
+  },
+  {
+    "type": "vehicle_part",
     "id": "ap_forge",
     "copy-from": "veh_forge",
     "name": { "str": "electric forge" },

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -454,6 +454,7 @@
     "required_str": -1,
     "max_volume": "200 L",
     "flags": [ "CONTAINER", "FIRE_CONTAINER", "PLACE_ITEM" ],
+    "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "arc_furnace" },
     "deconstruct": { "items": [ { "item": "metal_tank", "count": [ 1, 4 ] }, { "item": "pipe", "count": [ 2, 4 ] } ] },
     "bash": {
       "str_min": 18,

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -43,6 +43,19 @@
   },
   {
     "type": "GENERIC",
+    "id": "arc_furnace",
+    "looks_like": "f_arc_furnace",
+    "symbol": "U",
+    "description": "An arc furnace designed to burn a powdery mix of coke and limestone to create calcium carbide.  Needs to be placed and plugged into a power source.",
+    "color": "blue",
+    "name": { "str": "disconnected arc furnace", "str_pl": "disconnected arc furnaces" },
+    "material": [ "budget_steel" ],
+    "longest_side": "200 cm",
+    "volume": "400 L",
+    "weight": "1024 kg"
+  },
+  {
+    "type": "GENERIC",
     "id": "drill_press",
     "looks_like": "f_machinery_light",
     "symbol": "7",

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -48,7 +48,7 @@
     "symbol": "U",
     "description": "An arc furnace designed to burn a powdery mix of coke and limestone to create calcium carbide.  Needs to be placed and plugged into a power source.",
     "color": "blue",
-    "name": { "str": "disconnected arc furnace", "str_pl": "disconnected arc furnaces" },
+    "name": { "str": "disconnected arc furnace" },
     "material": [ "budget_steel" ],
     "longest_side": "200 cm",
     "volume": "400 L",

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -2645,14 +2645,15 @@
     "//1": "multiple batches worth can be smelted and cooled at once, but grinding time dominates",
     "batch_time_factors": [ 25, 2 ],
     "//2": "some loss/waste, e.g. imperfect smelting; powder escaping",
-    "charges": 95,
+    "//2a": "Lower limit is based on a guesstimate about how much charge you need in the furnace for it to operate",
+    "charges": 95000,
     "book_learn": [ [ "textbook_chemistry", 4 ], [ "textbook_gaswarfare", 4 ], [ "atomic_survival", 3 ] ],
     "//3": "At least some knowledge on chemicals handling is required.",
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],
     "qualities": [ { "id": "FINE_GRIND", "level": 1 } ],
     "//4": "460kJ per mole @ 70% energy efficiency",
-    "tools": [ [ [ "fake_arc_furnace", 650 ] ] ],
-    "components": [ [ [ "cac2powder", 100 ] ] ]
+    "tools": [ [ [ "fake_arc_furnace", 650000 ] ] ],
+    "components": [ [ [ "cac2powder", 100000 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I noticed the calcium carbide producing recipe doesn't line up with reality.  Stoichiometically it's fine, the problem is in a "working" arc furnace (as opposed to a small one for labs) you're going to encounter a minimum amount of inputs it will handle, and the existing recipe sets this amount at one gram, which is... quite a bit too low.

#### Describe the solution
Bumped up the amount of material the recipe processes to 1kg instead of 1g, which seems like a reasonable-ish amount of material you'd expect to process in a workshop.  I'm not clear what kind of workshop actually has arc furnaces in it, but I'm already shaving quite a lot of yak here.
This also makes arc furnace into an appliance, which mitigates issues with attempting such a power-intensive recipe without a power grid.  It was already the case that operating the arc furnace from a UPS (WAT?) didn't work because processing one gram of material consumed more power than the UPS could hold.  Now you can build a battery bank to supply that much power.

#### Describe alternatives you've considered
An alternate "lab sized" arc furnace like this thing https://mrf-furnaces.com/products/arc-melting-furnaces/arc-melt-furnace-sa-200/#tab-id-1 would be fine for a scaled down version of the recipe.  A survivor crafted arc furnace is also not out of the question either.
The amount of powder to process could vary, it's not at all clear what this thing is supposed to represent, so it's hard to say.  At a minimum it could probably be around 100g instead of 1kg, though I'm still not clear why a workshop needs a specialized tool for processing such a small amount of material at a time.
I looked into dental arc furnaces, but it looks like those don't tend to reach high enough temperatures for calcium carbide production.

#### Testing
Visited a light industry, built a powerwall with 10+ large storage batteries, converted an arc furnace to an appliance and attached it to the batteries, spawned in grinding tools and some calcium carbide premix, and made a batch of it via the crafting interface.