### PR TITLE
Remove dead code, move doc to `.h`

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1170,8 +1170,6 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
     you.invalidate_crafting_inventory();
 }
 
-// Opens up a menu to Unload a container, gun, or tool
-// If it's a gun, some gunmods can also be loaded
 void avatar_action::unload( avatar &you )
 {
     std::pair<item_location, bool> ret = game_menus::inv::unload( you );

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -39,9 +39,6 @@ inline bool move( avatar &you, map &m, const point &d )
     return move( you, m, tripoint( d, 0 ) );
 }
 
-// Handle moving from a ramp
-bool ramp_move( avatar &you, map &m, const tripoint &dest );
-
 /** Handles swimming by the player. Called by avatar_action::move(). */
 void swim( map &m, avatar &you, const tripoint &p );
 

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -73,7 +73,10 @@ bool fire_turret_manual( avatar &you, map &m, turret_data &turret );
 // Throw an item  't'
 void plthrow( avatar &you, item_location loc,
               const std::optional<tripoint_bub_ms> &blind_throw_from_pos = std::nullopt );
-
+/**
+ * Opens up a menu to Unload a container, gun, or tool
+ * If it's a gun, some gunmods can also be loaded
+ */
 void unload( avatar &you );
 
 // Use item; also tries E,R,W  'a'


### PR DESCRIPTION
#### Summary
Infrastructure "Remove dead code"

#### Purpose of change

Found dead code again.

#### Describe the solution

 - Used `git bisect run` as described in https://github.com/CleverRaven/Cataclysm-DDA/pull/76498#issuecomment-2363308411 again with `tst` code: 
   - ```bash
     lines=$( cat src/avatar_action.cpp | grep ramp_move | wc -l )
  
     if [ $lines -eq 2 ]; then
       exit 1
     fi
     ```

#### Describe alternatives you've considered

#### Testing

Compiles?

#### Additional context

Found dead code again. We should have a test to find the dead code.

 - Split off from #76617, which is postponed for now.