### PR TITLE
Dialogue: display hidden responses, with debug toggle support 

### DIFF
--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -1346,5 +1346,76 @@
     "id": [ "TALK_TEST_GUARD" ],
     "type": "talk_topic",
     "responses": [ { "text": "I have a custom response to a common topic", "topic": "TALK_TEST_FACTION_TRUST" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_TEST_SHOW_ALWAYS",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      {
+        "condition": { "math": [ "0", ">", "1" ] },
+        "text": "You should see this response but not be able to select it (except in debug mode).",
+		"show_always": true,
+        "topic": "TALK_DONE"
+      },
+	  {
+		  "text": "All done",
+		  "topic": "TALK_DONE"
+	  }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_TEST_SHOW_ALWAYS2",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      {
+        "condition": { "math": [ "0", ">", "1" ] },
+        "text": "You should see this response but not be able to select it (except in debug mode) because",
+		"show_always": true,
+        "show_reason": "zero isn't greater than one.",
+        "topic": "TALK_DONE"
+      },
+	  {
+		  "text": "All done",
+		  "topic": "TALK_DONE"
+	  }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_TEST_SHOW_CONDITION",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      {
+        "condition": { "math": [ "0", ">", "1" ] },
+        "text": "You should see this response but not be able to select it (except in debug mode) because",
+        "topic": "TALK_DONE",
+		"show_condition": { "math": [ "1", ">", "0" ] },
+		"show_reason": "zero isn't greater than one."
+      },
+	  {
+		  "text": "All done",
+		  "topic": "TALK_DONE"
+	  }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_TEST_SHOW_CONDITION2",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      {
+		"condition": { "math": [ "0", ">", "1" ] },
+        "text": "You should not see this response.",
+        "topic": "TALK_DONE",
+		"show_condition": { "math": [ "0", ">", "1" ] },
+		"show_reason": "zero isn't greater than one."
+      },
+	  {
+		  "text": "All done",
+		  "topic": "TALK_DONE"
+	  }
+    ]
   }
 ]

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2899,6 +2899,15 @@
   },
   {
     "type": "keybinding",
+    "id": "DEBUG_DIALOGUE_SHOW_ALL_RESPONSE",
+    "name": "Toggle debug dialogue show hidden responses ",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "CTRL+R" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "r" }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "RESET",
     "category": "CALENDAR_UI",
     "name": "Reset time point to initial value",

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -769,11 +769,20 @@ Similar to `opinion`, but adjusts the NPC's opinion of your character according 
 
 ### Response Availability
 
-#### condition
+#### `condition`
 This is an optional condition which can be used to prevent the response under certain circumstances. If not defined, it defaults to always `true`. If the condition is not met, the response is not included in the list of possible responses. For possible content, [see Dialogue Conditions below](#dialogue-conditions) for details.
 
-#### switch and default
+#### `switch and default`
 The optional boolean keys "switch" and "default" are false by default.  Only the first response with `"switch": true`, `"default": false`, and a valid condition will be displayed, and no other responses with `"switch": true` will be displayed.  If no responses with `"switch": true` and `"default":  false` are displayed, then any and all responses with `"switch": true` and `"default": true` will be displayed.  In either case, all responses that have `"switch": false` (whether or not they have `"default": true` is set) will be displayed as long their conditions are satisfied.
+
+#### `show_always`
+An optional key that, if set to true, will display a response even if it has a condition evaluating false. The response will not be selectable unless debug mode is ON.
+
+#### `show_condition`
+An optional key that, if defined, will display a response even if it has a condition evaluating false. The response will not be selectable unless debug mode is ON. Cannot be defined if `show_always: true`. Note: do not confuse `show_condition` with `condition`.
+
+#### `show_reason`
+An optional key that, if defined, will append its contents to the end of a response displayed if `show_always` or `show_condition` are provided.
 
 Example:
 ```json

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -189,6 +189,13 @@ struct talk_response {
     //copy of json_talk_response::condition, optional
     std::function<bool( dialogue & )> condition;
 
+    //whether to display this response in normal gameplay even if condition is false
+    bool show_always = false;
+    //appended to response if condition fails or show_always/show_condition
+    std::string show_reason;
+    //show_always, but on given condition
+    std::function<bool( dialogue & )> show_condition;
+
     mission *mission_selected = nullptr;
     skill_id skill = skill_id();
     matype_id style = matype_id();
@@ -198,12 +205,12 @@ struct talk_response {
     talk_effect_t success;
     talk_effect_t failure;
 
-    talk_data create_option_line( dialogue &d, const input_event &hotkey,
+    talk_data create_option_line( dialogue &d, const dialogue_window &d_win, const input_event &hotkey,
                                   bool is_computer = false );
     std::set<dialogue_consequence> get_consequences( dialogue &d ) const;
     // debug: conditional / effect
     std::map<std::string, std::string> debug_info;
-
+    bool show_anyways( dialogue &d ) const;
     talk_response();
     explicit talk_response( const JsonObject &, std::string_view );
 };
@@ -245,8 +252,13 @@ struct dialogue {
         bool by_radio = false;
         /**
          * Possible responses from the player character, filled in @ref gen_responses.
+         * Note: this can include responses with false conditionals.
          */
         std::vector<talk_response> responses;
+        /**
+        * Contains only responses selected to draw on-screen. Safe to select from and draw.
+        */
+        std::vector<talk_response> selected_responses;
         void gen_responses( const talk_topic &topic );
 
         void add_topic( const std::string &topic );

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -174,9 +174,9 @@ void dialogue_window::print_header( const std::string &name ) const
     int x_debug = 15 + utf8_width( name );
     const int ymax = getmaxy( d_win );
     const int ybar = ymax - 1 - RESPONSES_LINES - 1;
-    const int flag_count = 4;
-    std::array<bool, flag_count> debug_flags = { show_dynamic_line_conditionals, show_response_conditionals, show_dynamic_line_effects, show_response_effects };
-    std::array<std::string, flag_count> debug_show_toggle = { "DL_COND", "RESP_COND", "DL_EFF", "RESP_EFF" };
+    const int flag_count = 5;
+    std::array<bool, flag_count> debug_flags = { show_dynamic_line_conditionals, show_response_conditionals, show_dynamic_line_effects, show_response_effects, show_all_responses };
+    std::array<std::string, flag_count> debug_show_toggle = { "DL_COND", "RESP_COND", "DL_EFF", "RESP_EFF", "ALL_RESP"};
     if( debug_mode ) {
         for( int i = 0; i < flag_count; i++ ) {
             mvwprintz( d_win, point( x_debug, 1 ), debug_flags[i] ? c_yellow : c_brown, debug_show_toggle[i] );

--- a/src/dialogue_win.h
+++ b/src/dialogue_win.h
@@ -56,6 +56,7 @@ class dialogue_window
         bool show_dynamic_line_effects = true;
         bool show_response_conditionals = true;
         bool show_response_effects = true;
+        bool show_all_responses = true;
         int sel_response = 0;
         std::string debug_topic_name;
     private:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "dialogue: display hidden responses, with debug toggle support"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Closes #56925

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Fully implemented as described. There are three new JSON keys for responses, quoting the docs I updated:
#### `show_always`
An optional key that, if set to true, will display a response even if it has a condition evaluating false. The response will not be selectable unless debug mode is ON.

#### `show_condition`
An optional key that, if defined, will display a response even if it has a condition evaluating false. The response will not be selectable unless debug mode is ON. Cannot be defined if `show_always: true`. Note: do not confuse `show_condition` with `condition`.

#### `show_reason`
An optional key that, if defined, will append its contents to the end of a response displayed if `show_always` or `show_condition` are provided.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I wrote some new `talk_topic` test cases for `show_always`, `show_reason`, and `show_conditional`, made sure they work.
I also made sure that talking to NPCs and Rubik was normal. Made sure my last debug PRs were compatible with this one; as with those PRs, this functionality is not exhaustively tested by any means.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Rubik, with responses not hidden (default for debug mode)
![all_resp1](https://github.com/user-attachments/assets/ec313339-ac92-49c2-81d1-25cee62c9c39)

Rubik, with responses hidden
![all_resp2](https://github.com/user-attachments/assets/2dd83fab-fc44-40af-9b7c-09bb998f74e1)

an example of show_condition/show_reason
![all_resp3](https://github.com/user-attachments/assets/8f332a9a-26a2-4b66-bc87-f188428ddd18)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
