### PR TITLE
Replaced 'motel' and '2-floor motel' with twd motel as possible start location for Low Profile scenario

### DIFF
--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -771,7 +771,7 @@
     "type": "start_location",
     "id": "sloc_motel",
     "name": "Motel",
-    "terrain": [ "motel_1", "2fmotel_1", "2fmotel_1_f2" ]
+    "terrain": [ "motel_twd_1_f1" ]
   },
   {
     "type": "start_location",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #73733.

#### Describe the solution
Since currently there's no way to made game select overmap terrain from a `overmap_special` rather than `city_building`, and both `motel_1` and `2fmotel_1` OMTs can spawn in cities and in wilderness, I replaced both of these motels with a second floor of `motel_twd` as a start location, which can only spawn in wilderness.

#### Describe alternatives you've considered
- Remove motels as start locations altogether, since scenario description states that player character "jumped from low-rent motel to cheap trailer";
- Change name of scenario's start location from `Outside Town` to something else, like `Cheap trailer/motel`.

#### Testing
Chose Low Profile scenario, selected `Motel` as start location, got spawned in a motel.

#### Additional context
None.