### PR TITLE
Dialogue: JSON fields for displaying hidden responses

### DIFF
--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -1363,6 +1363,20 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_TEST_SHOW_ALWAYS3",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      {
+        "condition": { "math": [ "1", ">", "0" ] },
+        "text": "You should always see this response and be able to select it.",
+        "show_always": true,
+        "topic": "TALK_DONE"
+      },
+      { "text": "All done", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_TEST_SHOW_ALWAYS2",
     "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
     "responses": [

--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -1346,5 +1346,64 @@
     "id": [ "TALK_TEST_GUARD" ],
     "type": "talk_topic",
     "responses": [ { "text": "I have a custom response to a common topic", "topic": "TALK_TEST_FACTION_TRUST" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_TEST_SHOW_ALWAYS",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      {
+        "condition": { "math": [ "0", ">", "1" ] },
+        "text": "You should see this response but not be able to select it (except in debug mode).",
+        "show_always": true,
+        "topic": "TALK_DONE"
+      },
+      { "text": "All done", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_TEST_SHOW_ALWAYS2",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      {
+        "condition": { "math": [ "0", ">", "1" ] },
+        "text": "You should see this response but not be able to select it (except in debug mode) because",
+        "show_always": true,
+        "show_reason": "zero isn't greater than one.",
+        "topic": "TALK_DONE"
+      },
+      { "text": "All done", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_TEST_SHOW_CONDITION",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      {
+        "condition": { "math": [ "0", ">", "1" ] },
+        "text": "You should see this response but not be able to select it (except in debug mode) because",
+        "topic": "TALK_DONE",
+        "show_condition": { "math": [ "1", ">", "0" ] },
+        "show_reason": "zero isn't greater than one."
+      },
+      { "text": "All done", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_TEST_SHOW_CONDITION2",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      {
+        "condition": { "math": [ "0", ">", "1" ] },
+        "text": "You should not see this response.",
+        "topic": "TALK_DONE",
+        "show_condition": { "math": [ "0", ">", "1" ] },
+        "show_reason": "zero isn't greater than one."
+      },
+      { "text": "All done", "topic": "TALK_DONE" }
+    ]
   }
 ]

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2899,6 +2899,15 @@
   },
   {
     "type": "keybinding",
+    "id": "DEBUG_DIALOGUE_SHOW_ALL_RESPONSE",
+    "name": "Toggle debug dialogue show hidden responses ",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "CTRL+R" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "r" }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "RESET",
     "category": "CALENDAR_UI",
     "name": "Reset time point to initial value",

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -775,14 +775,14 @@ This is an optional condition which can be used to prevent the response under ce
 #### `switch and default`
 The optional boolean keys "switch" and "default" are false by default.  Only the first response with `"switch": true`, `"default": false`, and a valid condition will be displayed, and no other responses with `"switch": true` will be displayed.  If no responses with `"switch": true` and `"default":  false` are displayed, then any and all responses with `"switch": true` and `"default": true` will be displayed.  In either case, all responses that have `"switch": false` (whether or not they have `"default": true` is set) will be displayed as long their conditions are satisfied.
 
-#### `show_always`
-An optional key that, if set to true, will allow the response to be displayed even if it has a condition evaluating false. The response will not be selectable unless debug mode is ON.
-
 #### `show_condition`
-An optional key that, if defined, will allow the response to be displayed even if it has a condition evaluating false. The response will not be selectable unless debug mode is ON. Cannot be defined if `show_always: true`. Note: do not confuse `show_condition` with `condition`.
+An optional key that, if defined and evaluates to true, will allow the response to be displayed even if it has a condition evaluating false. The response still will not be selectable if its condition is false, unless debug mode is ON. Cannot be defined if `show_always: true`. Note: do not confuse `show_condition` with `condition`. Empty by default.
+
+#### `show_always`
+Shorthand for "show_condition": takes a boolean instead of a condition. False by default.
 
 #### `show_reason`
-An optional key that, if defined, will append its contents to the end of a response displayed because of `show_always` or `show_condition`.
+An optional key that, if defined, will append its contents to the end of a response displayed because of `show_always` or `show_condition`. Empty by default.
 
 Example:
 ```json

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -769,11 +769,20 @@ Similar to `opinion`, but adjusts the NPC's opinion of your character according 
 
 ### Response Availability
 
-#### condition
+#### `condition`
 This is an optional condition which can be used to prevent the response under certain circumstances. If not defined, it defaults to always `true`. If the condition is not met, the response is not included in the list of possible responses. For possible content, [see Dialogue Conditions below](#dialogue-conditions) for details.
 
-#### switch and default
+#### `switch and default`
 The optional boolean keys "switch" and "default" are false by default.  Only the first response with `"switch": true`, `"default": false`, and a valid condition will be displayed, and no other responses with `"switch": true` will be displayed.  If no responses with `"switch": true` and `"default":  false` are displayed, then any and all responses with `"switch": true` and `"default": true` will be displayed.  In either case, all responses that have `"switch": false` (whether or not they have `"default": true` is set) will be displayed as long their conditions are satisfied.
+
+#### `show_always`
+An optional key that, if set to true, will allow the response to be displayed even if it has a condition evaluating false. The response will not be selectable unless debug mode is ON.
+
+#### `show_condition`
+An optional key that, if defined, will allow the response to be displayed even if it has a condition evaluating false. The response will not be selectable unless debug mode is ON. Cannot be defined if `show_always: true`. Note: do not confuse `show_condition` with `condition`.
+
+#### `show_reason`
+An optional key that, if defined, will append its contents to the end of a response displayed because of `show_always` or `show_condition`.
 
 Example:
 ```json

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -189,6 +189,16 @@ struct talk_response {
     //copy of json_talk_response::condition, optional
     std::function<bool( dialogue & )> condition;
 
+    //whether to display this response in normal gameplay even if condition is false
+    bool show_always = false;
+    //appended to response if condition fails or show_always/show_condition
+    std::string show_reason;
+    //show_always, but on show_condition being true
+    std::function<bool( dialogue & )> show_condition;
+
+    //flag to hold result of show_anyways (not read from JSON)
+    bool ignore_conditionals = false;
+
     mission *mission_selected = nullptr;
     skill_id skill = skill_id();
     matype_id style = matype_id();
@@ -256,6 +266,7 @@ struct dialogue {
 
         bool debug_conditionals = true;
         bool debug_effects = true;
+        bool debug_ignore_conditionals = false;
 
         // Methods for setting/getting misc key/value pairs.
         void set_value( const std::string &key, const std::string &value );
@@ -421,10 +432,11 @@ class json_talk_response
             return has_condition_;
         }
         bool test_condition( dialogue &d ) const;
+        bool show_anyways( dialogue &d ) const;
         /**
          * Callback from @ref json_talk_topic::gen_responses, see there.
          */
-        bool gen_responses( dialogue &d, bool switch_done ) const;
+        bool gen_responses( dialogue &d, bool switch_done );
         bool gen_repeat_response( dialogue &d, const itype_id &item_id, bool switch_done ) const;
 };
 
@@ -490,7 +502,7 @@ class json_talk_topic
          * @return true if built in response should excluded (not added). If false, built in
          * responses will be added (behind those added here).
          */
-        bool gen_responses( dialogue &d ) const;
+        bool gen_responses( dialogue &d );
 
         cata::flat_set<std::string> get_directly_reachable_topics( bool only_unconditional ) const;
 

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -174,9 +174,9 @@ void dialogue_window::print_header( const std::string &name ) const
     int x_debug = 15 + utf8_width( name );
     const int ymax = getmaxy( d_win );
     const int ybar = ymax - 1 - RESPONSES_LINES - 1;
-    const int flag_count = 4;
-    std::array<bool, flag_count> debug_flags = { show_dynamic_line_conditionals, show_response_conditionals, show_dynamic_line_effects, show_response_effects };
-    std::array<std::string, flag_count> debug_show_toggle = { "DL_COND", "RESP_COND", "DL_EFF", "RESP_EFF" };
+    const int flag_count = 5;
+    std::array<bool, flag_count> debug_flags = { show_dynamic_line_conditionals, show_response_conditionals, show_dynamic_line_effects, show_response_effects, show_all_responses };
+    std::array<std::string, flag_count> debug_show_toggle = { "DL_COND", "RESP_COND", "DL_EFF", "RESP_EFF", "ALL_RESP" };
     if( debug_mode ) {
         for( int i = 0; i < flag_count; i++ ) {
             mvwprintz( d_win, point( x_debug, 1 ), debug_flags[i] ? c_yellow : c_brown, debug_show_toggle[i] );

--- a/src/dialogue_win.h
+++ b/src/dialogue_win.h
@@ -56,6 +56,8 @@ class dialogue_window
         bool show_dynamic_line_effects = true;
         bool show_response_conditionals = true;
         bool show_response_effects = true;
+        //copy of dialogue::show_all_responses
+        bool show_all_responses = false;
         int sel_response = 0;
         std::string debug_topic_name;
     private:

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2496,6 +2496,14 @@ talk_data talk_response::create_option_line( dialogue &d, const input_event &hot
         ftext = string_format( pgettext( "talk option", "[%1$s %2$d%%] %3$s" ),
                                trial.name(), trial.calc_chance( d ), text );
     }
+
+    if( ignore_conditionals ) {
+        ftext = colorize( ftext, c_dark_gray );
+        if( !show_reason.empty() ) {
+            ftext += colorize( " -- [" + show_reason + "]", c_light_red );
+        }
+    }
+
     if( d.actor( true )->get_npc() ) {
         parse_tags( ftext, *d.actor( false )->get_character(), *d.actor( true )->get_npc(), d,
                     success.next_topic.item_type );
@@ -2533,6 +2541,12 @@ std::set<dialogue_consequence> talk_response::get_consequences( dialogue &d ) co
     }
 
     return {{ success.get_consequence( d ), failure.get_consequence( d ) }};
+}
+
+bool json_talk_response::show_anyways( dialogue &d ) const
+{
+    return actual_response.show_always || ( actual_response.show_condition &&
+                                            actual_response.show_condition( d ) );
 }
 
 dialogue_consequence talk_effect_t::get_consequence( dialogue const &d ) const
@@ -2629,6 +2643,7 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
     ctxt.register_action( "DEBUG_DIALOGUE_RESP_CONDITIONAL" );
     ctxt.register_action( "DEBUG_DIALOGUE_DL_EFFECT" );
     ctxt.register_action( "DEBUG_DIALOGUE_RESP_EFFECT" );
+    ctxt.register_action( "DEBUG_DIALOGUE_SHOW_ALL_RESPONSE" );
     ctxt.register_action( "QUIT" );
     std::vector<talk_data> response_lines;
     std::vector<input_event> response_hotkeys;
@@ -2680,6 +2695,11 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
                 generate_response_lines();
             } else if( action == "CONFIRM" ) {
                 response_ind = d_win.sel_response;
+                //response condition must be reverified since non-selectable responses can be displayed
+                talk_response &check_valid = responses[response_ind];
+                if( check_valid.condition && ( !check_valid.condition( *this ) && !debug_mode ) ) {
+                    action = "NONE";
+                }
             } else if( action == "DEBUG_DIALOGUE_DL_CONDITIONAL" ) {
                 d_win.show_dynamic_line_conditionals = !d_win.show_dynamic_line_conditionals;
             } else if( action == "DEBUG_DIALOGUE_RESP_CONDITIONAL" ) {
@@ -2688,6 +2708,13 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
                 d_win.show_dynamic_line_effects = !d_win.show_dynamic_line_effects;
             } else if( action == "DEBUG_DIALOGUE_RESP_EFFECT" ) {
                 d_win.show_response_effects = !d_win.show_response_effects;
+            } else if( action == "DEBUG_DIALOGUE_SHOW_ALL_RESPONSE" ) {
+                d_win.show_all_responses = !d_win.show_all_responses;
+                if( debug_mode ) {
+                    this->debug_ignore_conditionals = !this->debug_ignore_conditionals;
+                    gen_responses( topic );
+                    generate_response_lines();
+                }
             } else if( action == "ANY_INPUT" ) {
                 // Check real hotkeys
                 const auto hotkey_it = std::find( response_hotkeys.begin(),
@@ -2815,7 +2842,7 @@ std::vector<std::string> dialogue::build_debug_info( const dialogue_window &d_wi
         talk_response &actual_response = responses[do_response];
         std::map<std::string, std::string> &debug_info = actual_response.debug_info;
         if( d_win.show_response_conditionals ) {
-            if( debug_info.find( "condition" ) != debug_info.end() && actual_response.condition ) {
+            if( actual_response.condition && debug_info.find( "condition" ) != debug_info.end() ) {
                 debug_output.emplace_back( std::string( "Conditional: [" ) + ( actual_response.condition(
                                                *this ) ? colorize( "true", c_light_green ) : colorize( "false",
                                                        c_light_red ) ) + std::string( "] - " ) + debug_info["condition"] );
@@ -7229,7 +7256,18 @@ talk_response::talk_response( const JsonObject &jo, const std::string_view src )
         JsonObject failure_obj = jo.get_object( "failure" );
         failure = talk_effect_t( failure_obj, "effect", src );
     }
-
+    if( jo.has_member( "show_always" ) ) {
+        show_always = jo.get_bool( "show_always" );
+    }
+    if( jo.has_member( "show_reason" ) ) {
+        show_reason = jo.get_string( "show_reason" );
+    }
+    if( jo.has_member( "show_condition" ) ) {
+        if( show_always ) {
+            jo.throw_error( "show_always and show_condition cannot both be defined" );
+        }
+        read_condition( jo, "show_condition", show_condition, false );
+    }
     // TODO: mission_selected
     // TODO: skill
     // TODO: style
@@ -7302,10 +7340,12 @@ const talk_response &json_talk_response::get_actual_response() const
     return actual_response;
 }
 
-bool json_talk_response::gen_responses( dialogue &d, bool switch_done ) const
+bool json_talk_response::gen_responses( dialogue &d, bool switch_done )
 {
-    if( !is_switch || !switch_done ) {
-        if( test_condition( d ) ) {
+    if( !is_switch || !switch_done || d.debug_ignore_conditionals ) {
+        if( test_condition( d ) || show_anyways( d ) || d.debug_ignore_conditionals ) {
+            actual_response.ignore_conditionals = !test_condition( d ) && ( show_anyways( d ) ||
+                                                  d.debug_ignore_conditionals );
             d.responses.emplace_back( actual_response );
             return is_switch && !is_default;
         } else if( !failure_explanation.empty() || !failure_topic.empty() ) {
@@ -7623,12 +7663,12 @@ void json_talk_topic::load( const JsonObject &jo, const std::string_view src )
                                  replace_built_in_responses );
 }
 
-bool json_talk_topic::gen_responses( dialogue &d ) const
+bool json_talk_topic::gen_responses( dialogue &d )
 {
     d.responses.reserve( responses.size() ); // A wild guess, can actually be more or less
 
     bool switch_done = false;
-    for( const json_talk_response &r : responses ) {
+    for( json_talk_response &r : responses ) {
         switch_done |= r.gen_responses( d, switch_done );
     }
     for( const json_talk_repeat_response &repeat : repeat_responses ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "dialogue: JSON fields for displaying hidden responses"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Closes #56925

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Fully implemented as described. There are three new JSON fields for responses, and debug support for showing all hidden responses. Quoting the docs I updated for an easy summary:

#### `show_condition`
An optional key that, if defined and evaluates to true, will allow the response to be displayed even if it has a condition evaluating false. The response still will not be selectable if its condition is false, unless debug mode is ON. Cannot be defined if `show_always: true`. Note: do not confuse `show_condition` with `condition`. Empty by default.

#### `show_always`
Shorthand for "show_condition": takes a boolean instead of a condition. False by default.

#### `show_reason`
An optional key that, if defined, will append its contents to the end of a response displayed because of `show_always` or `show_condition`.

Also fixes an apparent segfault bug from #76681

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#76792 was my initial attempt and broke npc_talk_test.cpp, which was not ideal. This PR is smaller and less convoluted, and doesn't break any tests.

#### Testing

I wrote some new `talk_topic` test cases for `show_always`, `show_reason`, and `show_conditional`, made sure they work.
I also made sure that talking to NPCs, Rubik, and Hub01 was normal. Made sure my last debug PR was compatible with this one; as with that PR, this functionality is not exhaustively tested by any means.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Talking to Rubik, all responses shown
![all_resp1_1](https://github.com/user-attachments/assets/48d4fefa-899e-4110-93e6-1996cfa078c7)

toggling responses off
![all_resp2_1](https://github.com/user-attachments/assets/c1b985ce-14a2-4d4a-bad2-280e83135c08)

An example of show_condition/show_reason
![all_resp3_1](https://github.com/user-attachments/assets/971e8ed7-1a97-480f-a5bc-14db11663720)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
