### PR TITLE
Only call loading_ui::done when actually done

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -776,7 +776,6 @@ void DynamicDataLoader::finalize_loaded_data()
         check_consistency();
     }
     finalized = true;
-    loading_ui::done();
 }
 
 void DynamicDataLoader::check_consistency()
@@ -876,5 +875,4 @@ void DynamicDataLoader::check_consistency()
         loading_ui::show( _( "Verifying" ), e.first );
         e.second();
     }
-    loading_ui::done();
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #76468

#### Describe the solution
DynamicDataLoader had some calls to loading_ui::done(), apparently in an effort to make sure the splash was cleaned up properly if it threw an error during loading. These appear to be redundant after #76361.

#### Describe alternatives you've considered
We could cache the chosen loading image even more securely so that excess calls to loading_ui::done() doesn't kill it and end up picking a new one, but that would be silly.

#### Testing
Repeatedly loaded the game with the mod from the linked issue without encountering more than one loading screen image per load

#### Additional context
I am not able to test this on curses. It is vaguely possible the behavior on curses is different and those calls end up being necessary, but I don't see any cause for concern.