### PR TITLE
NPCs get mad if you mess with their property

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_missions.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_missions.json
@@ -34,6 +34,21 @@
     }
   },
   {
+    "type": "mapgen",
+    "update_mapgen_id": "smokes_take_down_back_bay_barricade",
+    "method": "json",
+    "object": {
+      "set": [
+        { "square": "furniture", "id": "f_clear", "x": 6, "y": 3, "x2": 17, "y2": 3 },
+        { "square": "furniture", "id": "f_clear", "x": 3, "y": 4, "x2": 20, "y2": 14 },
+        { "square": "furniture", "id": "f_clear", "x": 4, "y": 15, "x2": 20, "y2": 15 },
+        { "square": "furniture", "id": "f_clear", "x": 5, "y": 16, "x2": 18, "y2": 16 },
+        { "square": "item_remove", "x": 3, "y": 3, "x2": 20, "y2": 16 },
+        { "square": "item_remove", "x": 21, "y": 12, "x2": 23, "y2": 15 }
+      ]
+    }
+  },
+  {
     "id": "MISSION_FREE_MERCHANTS_EVAC_1",
     "type": "mission_definition",
     "name": { "str": "Clear Back Bay" },
@@ -48,6 +63,7 @@
         "om_terrain": "evac_center_9",
         "reveal_radius": 1
       },
+      "effect": [ { "mapgen_update": "smokes_take_down_back_bay_barricade", "om_terrain": "evac_center_8" } ],
       "update_mapgen": {
         "om_terrain": "evac_center_9",
         "place_monster": [ { "group": "GROUP_REFUGEE_BOSS_ZOMBIE", "name": "Sean McLaughlin", "x": 10, "y": 10, "target": true } ]
@@ -68,7 +84,7 @@
     "followup": "MISSION_FREE_MERCHANTS_EVAC_2",
     "dialogue": {
       "describe": "We need help…",
-      "offer": "If you really want to lend a hand we could use your help clearing out the dead in the back bay.  Fearful of going outside during the first days of the Cataclysm we ended up throwing our dead and the zombies we managed to kill in the sealed back bay.  Our promising leader at the time even fell… he turned into something different.  Kill all of them and make sure they won't bother us again.  We can't pay much, besides some of our own internal money which isn't good for that much yet, but it would help us to reclaim the bay.",
+      "offer": "If you really want to lend a hand we could use your help clearing out the dead in the back bay.  Fearful of going outside during the first days of the Cataclysm we ended up throwing our dead and the zombies we managed to kill in the sealed back bay.  Our promising leader at the time even fell… he turned into something different.  Kill all of them and make sure they won't bother us again.  We can't pay much, besides some of our own internal money which isn't good for that much yet, but it would help us to reclaim the bay.  <color_red>If you accept, I'll tell the guards to immediately take down the barricade in the back.  You should only accept if you're ready to do this now.</color>",
       "accepted": "Please be careful, we don't need any more deaths.",
       "rejected": "Come back when you get a chance, we really need to start reclaiming the region.",
       "advice": "If you can, get a friend or two to help you.",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5990,10 +5990,16 @@ void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
 
     if( m.has_furn( examp ) ) {
         if( !u.cant_do_mounted() ) {
+            if( !warn_player_maybe_anger_local_faction( false, true ) ) {
+                return; // player declined to mess with faction's stuff
+            }
             xfurn_t.examine( u, examp );
         }
     } else {
         if( xter_t.can_examine( examp ) && !u.is_mounted() ) {
+            if( !warn_player_maybe_anger_local_faction( false, true ) ) {
+                return; // player declined to mess with faction's stuff
+            }
             xter_t.examine( u, examp );
         }
     }
@@ -6046,6 +6052,41 @@ void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
                 pickup( examp );
             }
         }
+    }
+}
+
+bool game::warn_player_maybe_anger_local_faction( bool really_bad_offense,
+        bool asking_for_public_goods )
+{
+    Character &player_character = get_player_character();
+    std::optional<basecamp *> bcp = overmap_buffer.find_camp(
+                                        player_character.global_omt_location().xy() );
+    if( !bcp ) {
+        return true; // Nobody to piss off
+    }
+    basecamp *actual_camp = *bcp;
+    if( actual_camp->allowed_access_by( player_character, asking_for_public_goods ) ) {
+        return true; // You're allowed to do this anyway
+    }
+
+    // The threshold for guaranteed hostility. Don't bother query/modifying relationship if they already hate us
+    // TODO: Make this magic number into a constant
+    if( actual_camp->get_owner()->likes_u < -10 ) {
+        return true;
+    }
+
+    // Else there's a camp, and we're doing something we're not supposed to! Time to warn the player.
+    if( !query_yn(
+            _( "You're in the territory of %s, they probably won't appreciate your actions.  Continue anyway?" ),
+            actual_camp->get_owner()->name ) ) {
+        return false;
+    } else {
+        faction *owner_fac_pointer = g->faction_manager_ptr->get( actual_camp->get_owner() );
+        // really_bad_offense loses 20 points of fac rep, otherwise 5
+        owner_fac_pointer->likes_u -= really_bad_offense ? 20 : 5;
+        owner_fac_pointer->trusts_u -= really_bad_offense ? 20 : 5;
+        owner_fac_pointer->respects_u -= really_bad_offense ? 20 : 5;
+        return true;
     }
 }
 

--- a/src/game.h
+++ b/src/game.h
@@ -928,6 +928,14 @@ class game
 
         void reload( item_location &loc, bool prompt = false, bool empty = true );
     public:
+        /* Returns true if there's nobody to anger, player is already allowed to do this, or player answered yes to warning query
+        * This function also handles changing the faction opinion if player proceeds despite warning
+        * Returns false only if player declined query
+        * Second boolean asking_for_public_goods should be used for cases where the action isn't necessarily detrimental
+        * to the faction, like merely using the examine_action of furniture.
+        */
+        bool warn_player_maybe_anger_local_faction( bool really_bad_offense = false,
+                bool asking_for_public_goods = false );
         int grabbed_furn_move_time( const tripoint &dp );
         bool grabbed_furn_move( const tripoint &dp );
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -772,6 +772,9 @@ static void grab()
             add_msg( _( "You can not grab the %s." ), here.furnname( grabp ) );
             return;
         }
+        if( !g->warn_player_maybe_anger_local_faction( true ) ) {
+            return; // player declined to mess with faction's stuff
+        }
         you.grab( object_type::FURNITURE, grabp - you.pos_bub() );
         if( !here.can_move_furniture( grabp, &you ) ) {
             add_msg( _( "You grab the %s. It feels really heavy." ), here.furnname( grabp ) );
@@ -927,6 +930,10 @@ static void smash()
         return;
     }
     tripoint_bub_ms smashp = tripoint_bub_ms( *smashp_ );
+
+    if( !g->warn_player_maybe_anger_local_faction( true ) ) {
+        return; // player declined to smash faction's stuff
+    }
 
     bool smash_floor = false;
     if( smashp.z() != player_character.posz() ) {
@@ -1355,6 +1362,10 @@ static void sleep()
         g->quicksave();
     } else if( as_m.ret == 2 || as_m.ret < 0 ) {
         return;
+    }
+
+    if( !g->warn_player_maybe_anger_local_faction( false, true ) ) {
+        return; // player declined to annoy locals by illegally sleeping in their territory
     }
 
     time_duration try_sleep_dur = 24_hours;
@@ -2654,6 +2665,9 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             if( player_character.in_vehicle ) {
                 add_msg( m_info, _( "You can't construct while in a vehicle." ) );
             } else {
+                if( !g->warn_player_maybe_anger_local_faction( true ) ) {
+                    break; // player declined to mess with faction's stuff
+                }
                 construction_menu( false );
             }
             break;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4665,6 +4665,9 @@ std::optional<int> iuse::chop_tree( Character *p, item *it, const tripoint & )
         }
         return std::nullopt;
     }
+    if( p->is_avatar() && !g->warn_player_maybe_anger_local_faction( true ) ) {
+        return std::nullopt; // player declined to anger locals
+    }
     int moves = chop_moves( p, it );
     const std::vector<Character *> helpers = p->get_crafting_helpers();
     for( std::size_t i = 0; i < helpers.size() && i < 3; i++ ) {


### PR DESCRIPTION
#### Summary
Features "NPC factions get mad if you mess with their property by smashing or deconstructing it etc"

#### Purpose of change
RUIN THE GAME

Currently the NPC factions don't consider ownership of anything besides items. You can break down their walls right in front of them without them even raising their voice.

#### Describe the solution
Make them ANGRY! Anytime you're at a NPC camp (oh right I added those) we can simply assume the NPCs should own that stuff. No need to make custom zones, or rely on mapgen. Just if you're nearby, they own it. There's lots of other places you can go.

Currently this does not check if anyone is nearby to actually see you, or assess whether they should 'know' of your offense. It is simply telepathically communicated to them.

Currently this draft only handles the following:
examining furniture/terrain (not serious offense, is public goods)

smashing (is serious offense, not public goods)

grabbing furniture (not serious offense, not public goods)
(Note this only triggers with *new* grabs, dragging stuff doesn't spam you every turn.)

construction (is serious offense, not public goods)

sleeping (not serious offense, is public goods)

tree cutting (is serious offense, not public goods)

I am open to ideas for where else this needs to be checked.

Currently there is very little nuance to their reaction. You simply get warned and if you ignore the warning you take a relationship hit. The more serious offenses (smashing down their walls or trying to) cause a very big relationship hit, otherwise it's moderate. They don't try to talk to you and warn you, like if you steal items.

#### Describe alternatives you've considered
Mapgen-based ownership zones

#### Testing
Not nearly enough yet, hence in draft. I am sure that even after I have tested this will cause many issues and require lots of followup work. I would like to thank our experimental players in advance for their thorough playtesting :)


https://github.com/user-attachments/assets/0f77bb18-e229-4411-b3af-4604341059f4



#### Additional context
~~So far I know of exactly one issue this will cause: The refugee center's boarded up back bay. If you're not allowed to smash, grab, or interact with the furniture in the way there's no way to get in. I don't have a solution for that yet.~~

Shouldn't be an issue https://github.com/CleverRaven/Cataclysm-DDA/pull/76810#issuecomment-2395315378