### PR TITLE
Character randomization sometimes produces 'crossdressing' characters

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4547,7 +4547,11 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         } else if( action == "RANDOMIZE_CHAR_DESCRIPTION" ) {
             bool gender_selection = one_in( 2 );
             you.male = gender_selection;
-            outfit = gender_selection;
+            if( one_in( 10 ) ) {
+                outfit = !gender_selection;
+            } else {
+                outfit = gender_selection;
+            }
             if( !MAP_SHARING::isSharing() ) { // Don't allow random names when sharing maps. We don't need to check at the top as you won't be able to edit the name
                 you.pick_name();
                 no_name_entered = you.name.empty();
@@ -4907,6 +4911,7 @@ void avatar::save_template( const std::string &name, pool_type pool )
         if( !random_start_location ) {
             jsout.member( "start_location", start_location );
         }
+        jsout.member( "outfit_gender", outfit );
         jsout.end_object();
 
         serialize( jsout );
@@ -4938,6 +4943,8 @@ bool avatar::load_template( const std::string &template_name, pool_type &pool )
 
             random_start_location = jobj.get_bool( "random_start_location", true );
             const std::string jobj_start_location = jobj.get_string( "start_location", "" );
+
+            outfit = jobj.get_bool( "outfit_gender", true );
 
             // get_scenario()->allowed_start( loc.ident() ) is checked once scenario loads in avatar::load()
             for( const class start_location &loc : start_locations::get_all() ) {


### PR DESCRIPTION
#### Summary
Features "Character randomization sometimes produces 'crossdressing' characters"

#### Purpose of change
While examining the new character code I noticed that character randomization *always* locked the outfit gender to actual gender. Not all people wear clothes considered typical for their gender, so this is a strange omission.

* Fix #76808 (by accident even)

#### Describe the solution
Give it a 10% chance to give the randomized character a different gender's outfit.

Character templates will properly save the outfit gender and re-apply it when that template is used again

#### Describe alternatives you've considered
I was just going to make it 50/50 on the outfit but that was TOO GAY. This is only moderately gay.

#### Testing
Randomizing sometimes gives other gender outfits:


https://github.com/user-attachments/assets/d6df94d0-0dfd-4e69-9c43-a091009bc03c



Outfit gender is properly saved with character template:


https://github.com/user-attachments/assets/21ad53c5-9086-42bd-af97-75d4d7f6fb64


#### Additional context
