### PR TITLE
Fix consume activity creation from liquid handler

### DIFF
--- a/src/handle_liquid.h
+++ b/src/handle_liquid.h
@@ -57,35 +57,14 @@ void handle_all_liquid( item liquid, int radius, const item *avoid = nullptr );
 bool consume_liquid( item &liquid, int radius = 0, const item *avoid = nullptr );
 
 /**
- * Handle finite liquid from ground. The function also handles consuming move points.
- * This may start a player activity.
- * @param on_ground Iterator to the item on the ground. Must be valid and point to an
- * item in the stack at `m.i_at(pos)`
- * @param pos The position of the item on the map.
+ * Handle liquids from inside a container item. The function also handles consuming move points.
+  * @param container Container of the liquid
  * @param radius around position to handle liquid for
  * @return Whether the item has been removed (which implies it was handled completely).
  * The iterator is invalidated in that case. Otherwise the item remains but may have
  * fewer charges.
  */
-bool handle_liquid_from_ground( const map_stack::iterator &on_ground, const tripoint &pos,
-                                int radius = 0 );
-
-/**
- * Handle liquid from inside a container item. The function also handles consuming move points.
- * @param in_container Iterator to the liquid. Must be valid and point to an
- * item in the @ref item::contents of the container.
- * @param container Container of the liquid
- * @param radius around position to handle liquid for
- * @return Whether the item has been removed (which implies it was handled completely).
- * The iterator is invalidated in that case. Otherwise the item remains but may have
- * fewer charges.
- */
-bool handle_liquid_from_container( item *in_container, item &container,
-                                   int radius = 0 );
-/**
- * Shortcut to the above: handles the first item in the container.
- */
-bool handle_liquid_from_container( item &container, int radius = 0 );
+bool handle_all_liquids_from_container( item_location &container, int radius = 0 );
 
 bool can_handle_liquid( const item &liquid );
 
@@ -110,13 +89,15 @@ bool can_handle_liquid( const item &liquid );
  */
 bool handle_liquid( item &liquid, const item *source = nullptr, int radius = 0,
                     const tripoint *source_pos = nullptr,
-                    vehicle *source_veh = nullptr, int part_num = -1,
+                    const vehicle *source_veh = nullptr, int part_num = -1,
                     const monster *source_mon = nullptr );
+bool handle_liquid( item_location &liquid, const item *source = nullptr, int radius = 0 );
 
 /* Not to be used directly. Use liquid_handler::handle_liquid instead. */
 bool perform_liquid_transfer( item &liquid, const tripoint *source_pos,
-                              vehicle *source_veh, int part_num,
+                              const vehicle *source_veh, int part_num,
                               const monster * /*source_mon*/, liquid_dest_opt &target );
+bool perform_liquid_transfer( item_location &liquid, liquid_dest_opt &target );
 } // namespace liquid_handler
 
 #endif // CATA_SRC_HANDLE_LIQUID_H

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -556,7 +556,8 @@ void iexamine::gaspump( Character &you, const tripoint_bub_ms &examp )
                 }
 
             } else {
-                liquid_handler::handle_liquid_from_ground( item_it, examp.raw(), 1 );
+                item_location loc( map_cursor( examp ), &*item_it );
+                liquid_handler::handle_liquid( loc, nullptr, 1 );
             }
             return;
         }
@@ -3642,7 +3643,8 @@ void iexamine::fvat_empty( Character &you, const tripoint_bub_ms &examp )
                 break;
             }
             case REMOVE_BREW: {
-                liquid_handler::handle_liquid_from_ground( here.i_at( examp ).begin(), examp.raw() );
+                item_location loc( map_cursor( examp ), &*here.i_at( examp ).begin() );
+                liquid_handler::handle_liquid( loc );
                 return;
             }
             case START_FERMENT: {
@@ -3765,7 +3767,8 @@ void iexamine::fvat_full( Character &you, const tripoint_bub_ms &examp )
     }
 
     const std::string booze_name = brew_i.tname();
-    if( liquid_handler::handle_liquid_from_ground( items_here.begin(), examp.raw() ) ) {
+    item_location loc( map_cursor( examp ), &*items_here.begin() );
+    if( liquid_handler::handle_liquid( loc ) ) {
         fvat_set_empty( examp );
         add_msg( _( "You squeeze the last drops of %s from the vat." ), booze_name );
     }
@@ -3869,7 +3872,8 @@ void iexamine::compost_empty( Character &you, const tripoint_bub_ms &examp )
                 break;
             }
             case REMOVE_COMPOST: {
-                liquid_handler::handle_liquid_from_ground( here.i_at( examp ).begin(), examp.raw() );
+                item_location loc( map_cursor( examp ), &*here.i_at( examp ).begin() );
+                liquid_handler::handle_liquid( loc );
                 return;
             }
             case START_FERMENT: {
@@ -4046,7 +4050,8 @@ void iexamine::compost_full( Character &you, const tripoint_bub_ms &examp )
     }
 
     const std::string compost_name = compost_i.tname();
-    if( liquid_handler::handle_liquid_from_ground( items_here.begin(), examp.raw() ) ) {
+    item_location loc( map_cursor( examp ), &*items_here.begin() );
+    if( liquid_handler::handle_liquid( loc ) ) {
         compost_set_empty( examp );
         add_msg( _( "You squeeze the last drops of %s from the tank." ), compost_name );
     }
@@ -4207,13 +4212,14 @@ void iexamine::keg( Character &you, const tripoint_bub_ms &examp )
         selectmenu.query();
 
         switch( selectmenu.ret ) {
-            case DISPENSE:
-                if( liquid_handler::handle_liquid_from_ground( items.begin(), examp.raw() ) ) {
+            case DISPENSE: {
+                item_location loc( map_cursor( examp ), &*items.begin() );
+                if( liquid_handler::handle_liquid( loc ) ) {
                     add_msg( _( "You squeeze the last drops of %1$s from the %2$s." ),
                              drink_tname, keg_name );
                 }
                 return;
-
+            }
             case HAVE_A_DRINK:
                 if( !you.can_consume_as_is( drink ) ) {
                     return; // They didn't actually drink
@@ -4498,7 +4504,8 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint_bub_ms &examp )
         }
 
         case HARVEST_SAP: {
-            liquid_handler::handle_liquid_from_container( *container, PICKUP_RANGE );
+            item_location loc( map_cursor( examp ), container );
+            liquid_handler::handle_all_liquids_from_container( loc, PICKUP_RANGE );
             return;
         }
 
@@ -4713,9 +4720,10 @@ void iexamine::water_source( Character &, const tripoint_bub_ms &examp )
 void iexamine::finite_water_source( Character &, const tripoint_bub_ms &examp )
 {
     map_stack items = get_map().i_at( examp );
-    for( auto item_it = items.begin(); item_it != items.end(); ++item_it ) {
-        if( item_it->made_of( phase_id::LIQUID ) ) {
-            liquid_handler::handle_liquid_from_ground( item_it, examp.raw() );
+    for( item &it : items ) {
+        if( it.made_of( phase_id::LIQUID ) ) {
+            item_location loc( map_cursor( examp ), &it );
+            liquid_handler::handle_liquid( loc );
             break;
         }
     }

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -90,6 +90,9 @@ class item_location::impl
         }
         virtual tripoint position() const = 0;
         virtual Character *carrier() const = 0;
+        virtual const vehicle_cursor *veh_cursor() const {
+            return nullptr;
+        };
         virtual std::string describe( const Character * ) const = 0;
         virtual item_location obtain( Character &, int ) = 0;
         virtual units::volume volume_capacity() const = 0;
@@ -487,6 +490,10 @@ class item_location::impl::item_on_vehicle : public item_location::impl
 
         Character *carrier() const override {
             return nullptr;
+        }
+
+        const vehicle_cursor *veh_cursor() const override {
+            return &cur;
         }
 
         std::string describe( const Character *ch ) const override {
@@ -1107,6 +1114,11 @@ void item_location::set_should_stack( bool should_stack ) const
 Character *item_location::carrier() const
 {
     return ptr->carrier();
+}
+
+const vehicle_cursor *item_location::veh_cursor() const
+{
+    return ptr->veh_cursor();
 }
 
 bool item_location::held_by( Character const &who ) const

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -111,6 +111,9 @@ class item_location
         /** returns the character whose inventory contains this item, nullptr if none **/
         Character *carrier() const;
 
+        /** returns the character whose inventory contains this item, nullptr if none **/
+        const vehicle_cursor *veh_cursor() const;
+
         /** returns true if the item is in the inventory of the given character **/
         bool held_by( Character const &who ) const;
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix consume activity creation from liquid handler"

#### Purpose of change

Fixes #76425
Essentially reverts the changes from 717630e2cfc00dd58d1ef3dd3de40e4f63cf2618 and implements a separate path to take for `item_location`s.

#### Describe the solution

Add overloads to `handle_liquid`, `perform_liquid_transfer` and `get_liquid_target` that handle `item_location`s.
Remove now unnecessary methods `handle_liquid_from_ground` and `handle_liquid_from_container` because they can be directly handled with `item_location`s.
Adjusted `handle_liquid_from_container` to use `item_location` and renamed it to `handle_all_liquids_from_container` to better reflect what it actually does.
Shuffled some code around and into separate methods to avoid code duplication.

#### Describe alternatives you've considered

Instead of renaming `handle_liquid_from_container` make it do what the comment said it does instead, but I think it makes more sense to handle everything instead of just the first liquid found. But I'm not even sure if there even are containers with multiple watertight pockets.

#### Testing

Drank from recesses, toilets, ponds, bottles, tapped a maple tree, drank from vehicle tanks.

#### Additional context

As long as there is the option of making `consume_activity_actor`s from item references instead of `item_location`s, there will be the issue that #71971 claimed to have solved:
> 1. If you `e`xamine a water source, select the "consume" option, then back out (e.g. because you decide the toilet tank water is too gross, or because you're full), a unit of water is still consumed from the source

Although "consumed" here doesn't mean you actually do something with it, it just vanishes, as far as I'm aware.