### PR TITLE
Fix display of loudness multiplier of gunmods

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3624,7 +3624,7 @@ void item::gunmod_info( std::vector<iteminfo> &info, const iteminfo_query *parts
                            iteminfo::lower_is_better | iteminfo::show_plus,
                            mod.loudness );
     }
-    if( mod.loudness_multiplier != 0 && parts->test( iteminfo_parts::GUNMOD_LOUDNESS_MULTIPLIER ) ) {
+    if( mod.loudness_multiplier != 1.0 && parts->test( iteminfo_parts::GUNMOD_LOUDNESS_MULTIPLIER ) ) {
         info.emplace_back( "GUNMOD", _( "Loudness multiplier: " ), "",
                            iteminfo::lower_is_better | iteminfo::show_plus,
                            mod.loudness );


### PR DESCRIPTION
Issue #76604

#### Summary
Bugfixes "Fixing display of loudness multiplier of gunmods"