### PR TITLE
Small patch to ranged balance test flakiness

### DIFF
--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -461,15 +461,16 @@ static void shoot_monster( const std::string &gun_type, const std::vector<std::s
         const int prev_HP = mon.get_hp();
         shooter->fire_gun( monster_pos, 1, *shooter->get_wielded_item() );
         damage.add( prev_HP - mon.get_hp() );
-        if( damage.margin_of_error() < 0.05 && damage.n() > 100 ) {
-            break;
-        }
         if( other_checks ) {
             other_check_success += other_checks( *shooter, mon );
+        }
+        if( damage.margin_of_error() < 0.05 && damage.n() > 100 ) {
+            break;
         }
         mon.die( nullptr );
     } while( damage.n() < 200 ); // In fact, stable results can only be obtained when n reaches 10000
     const double avg = damage.avg();
+    CAPTURE( damage.n() );
     CAPTURE( gun_type );
     CAPTURE( mods );
     CAPTURE( ammo_type );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Notice the `shot_custom_damage_type` test randomly failing every now and then.

#### Describe the solution

Move the early break below processing the `other_checks`. This is the absolutely minimal solution.
Also added a capture for the number of times the test ran, could be relevant info sometimes, when the number can vary.

#### Describe alternatives you've considered

Removing the early break entirely. Not sure how much time that really saves.
Skipping the early break when there's other checks is another option.

#### Testing

Reproduced the failure with seed `1728104733`, didn't fail with the patch.

#### Additional context

