### PR TITLE
Added check for stealing prior to inserting items into container

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -4,6 +4,7 @@
 #include <optional>
 
 #include "activity_actor_definitions.h"
+#include "avatar_action.h"
 #include "basecamp.h"
 #include "cata_assert.h"
 #include "cata_utility.h"
@@ -4014,6 +4015,12 @@ drop_locations inventory_drop_selector::execute()
 
         const inventory_input input = get_input();
         if( input.action == "CONFIRM" ) {
+            for( drop_location &stuff : to_use ) {
+                if( !avatar_action::check_stealing( get_player_character(), *stuff.first ) ) {
+                    return drop_locations();
+                }
+            }
+
             if( to_use.empty() ) {
                 popup_getkey( _( "No items were selected.  Use %s to select them." ),
                               ctxt.get_desc( "TOGGLE_ENTRY" ) );


### PR DESCRIPTION
#### Summary
Features "Added check for stealing prior to inserting items into container"

#### Purpose of change
* Closes #72611.

#### Describe the solution
Added `check_stealing` in `inventory_drop_selector::execute`

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned animal shelter with a veterinarian. Opened my runner pack and tried to insert veterinarian's medical gloves into it. Got a warning about stealing. Answered yes, answered no.

#### Additional context
None.