### PR TITLE
Fixed crash on trying to unwield heavy items when trying to drive

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5577,8 +5577,7 @@ void game::control_vehicle()
                     } else {
                         return;
                     }
-                }
-                if( weapon->is_two_handed( u ) ) {
+                } else if( weapon->is_two_handed( u ) ) {
                     if( query_yn(
                             _( "You can't drive because you have to wield a %s with both hands.\n\nPut it away?" ),
                             weapon->tname() ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fixed crash on trying to unwield heavy items when trying to drive"

#### Purpose of change
* Closes #76791.

#### Describe the solution
The second check (for two-handedness) will be conducted only if the first check (for being too weak to hold a weapon with one arm) is failed, not unconditionally.

#### Describe alternatives you've considered
Combine two checks into one (`!u.has_two_arms_lifting() || weapon->is_two_handed( u )`) and reword error message to be more "generic".

#### Testing
Loaded save from #76791. Tried to start an engine. Answered to drop machete on game query. No crash.

#### Additional context
None.