### PR TITLE
Un-popup the Beautiful Nether Lily Messages

### DIFF
--- a/data/json/furniture_and_terrain/furniture_nether_monster.json
+++ b/data/json/furniture_and_terrain/furniture_nether_monster.json
@@ -60,17 +60,11 @@
                   10
                 ],
                 [
-                  {
-                    "id": "admire_3",
-                    "effect": { "u_message": "You bow to the lily, and gain immense satisfaction in having done so." }
-                  },
+                  { "id": "admire_3", "effect": { "u_message": "You bow to the lily, and gain immense satisfaction in having done so." } },
                   5
                 ],
                 [
-                  {
-                    "id": "admire_4",
-                    "effect": { "u_message": "You focus on the lily and realize it truly is perfection *incarnate*." }
-                  },
+                  { "id": "admire_4", "effect": { "u_message": "You focus on the lily and realize it truly is perfection *incarnate*." } },
                   2
                 ]
               ]

--- a/data/json/furniture_and_terrain/furniture_nether_monster.json
+++ b/data/json/furniture_and_terrain/furniture_nether_monster.json
@@ -54,22 +54,22 @@
           "effect": [
             {
               "weighted_list_eocs": [
-                [ { "id": "admire", "effect": { "u_message": "You admire the lily.  Isn't it beautiful?", "popup": true } }, 15 ],
+                [ { "id": "admire", "effect": { "u_message": "You admire the lily.  Isn't it beautiful?" } }, 15 ],
                 [
-                  { "id": "admire_2", "effect": { "u_message": "You worship the lily, and feel truly fulfilled.", "popup": true } },
+                  { "id": "admire_2", "effect": { "u_message": "You worship the lily, and feel truly fulfilled." } },
                   10
                 ],
                 [
                   {
                     "id": "admire_3",
-                    "effect": { "u_message": "You bow to the lily, and gain immense satisfaction in having done so.", "popup": true }
+                    "effect": { "u_message": "You bow to the lily, and gain immense satisfaction in having done so." }
                   },
                   5
                 ],
                 [
                   {
                     "id": "admire_4",
-                    "effect": { "u_message": "You focus on the lily and realize it truly is perfection *incarnate*.", "popup": true }
+                    "effect": { "u_message": "You focus on the lily and realize it truly is perfection *incarnate*." }
                   },
                   2
                 ]


### PR DESCRIPTION

#### Summary
None


#### Purpose of change

While i was in the community discord, someone there asked about the significance regarding the popup messages on the beautiful nether lily. They thought the message being a pop-up one instead of the usual log message implied there's more to it than just a beautiful lily. Pop-up messages are usually used for something that is worth interrupting, like the incoming portal storm, shadow singularity, and so forth.

Despite the beauty of the nether lily, i feel it is not worth the pop-up messages it got.

#### Describe the solution

Delete `"popup": true` in the beautiful nether lily's furniture int(e)ract EOC.

#### Describe alternatives you've considered

Not doing so and let them fear the unknown implications that doesn't exist.

#### Testing


https://github.com/user-attachments/assets/5ff70c56-33c9-4c87-8b66-c31435b7b550



#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
