### PR TITLE
Make garlic smokable

### DIFF
--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -550,8 +550,10 @@
     "price_postapoc": "8 cent",
     "material": [ "garlic" ],
     "volume": "6 ml",
+    "smoking_result": "dry_garlic",
     "fun": -3,
     "vitamins": [ [ "vitC", "900 μg" ], [ "iron", "100 μg" ], [ "calcium", "5400 μg" ], [ "veggy_allergen", 1 ] ],
+    "flags": [ "SMOKABLE" ],
     "seed_data": { "plant_name": "garlic", "fruit": "garlic", "byproducts": [ "withered" ], "grow": "65 days" }
   },
   {


### PR DESCRIPTION
#### Summary
Features "Make garlic smokable"


#### Purpose of change
To allow garlic to be dehydrated in the smoking rack


#### Describe the solution
Added the "smokable" flag, and "dry_garlic" as the smoking result to the garlic_clove json definition


#### Describe alternatives you've considered
Dehydrating my 1128 garlic cloves using the crafting recipe, which would have taken around 40 in game hours. No thank you.

#### Testing
![image](https://github.com/user-attachments/assets/e631dc8c-9767-4580-b310-07f4b2593a21)
Forgot to take a pic of the garlic cloves appearing in the "add food to smoking rack" menu, but I promise it was there

#### Additional context
