### PR TITLE
[MoM] Add Attunement meter to Spacebar UI

### DIFF
--- a/data/mods/MindOverMatter/ui/spacebar.json
+++ b/data/mods/MindOverMatter/ui/spacebar.json
@@ -1,0 +1,148 @@
+[
+  {
+    "copy-from": "spacebar",
+    "type": "widget",
+    "id": "spacebar",
+    "extend": { "widgets": [ "spacebar_nether_attunement_block" ] }
+  },
+  {
+    "id": "spacebar_nether_attunement_block",
+    "type": "widget",
+    "style": "layout",
+    "label": "Attunement",
+    "arrange": "minimum_columns",
+    "width": 58,
+    "widgets": [ "spacebar_separator_2", "spacebar_nether_attunement_meter" ]
+  },
+  {
+    "id": "spacebar_nether_attunement_meter",
+    "type": "widget",
+    "style": "text",
+    "label": "Attune",
+    "width": 56,
+    "clauses": [
+      {
+        "id": "invisible",
+        "text": "",
+        "color": "c_black",
+        "condition": { "not": { "u_has_effect": "effect_disease_psionic_drain" } }
+      },
+      {
+        "id": "visible_1",
+        "text": "<color_green>Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "15" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "35" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_2",
+        "text": "<color_green>Ψ≔≕Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "35" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "55" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_3",
+        "text": "<color_light_green>Ψ≔≕Ψ≔≕Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "55" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "75" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_4",
+        "text": "<color_light_green>Ψ≔≕Ψ≔≕Ψ≔≕Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "75" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "95" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_5",
+        "text": "<color_yellow>Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "95" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "115" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_6",
+        "text": "<color_yellow>Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "115" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "135" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_7",
+        "text": "<color_light_red>Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "135" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "155" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_8",
+        "text": "<color_light_red>Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "155" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "175" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_9",
+        "text": "<color_red>Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "175" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "195" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_10",
+        "text": "<color_red>Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "195" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "215" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_11",
+        "text": "<color_pink>Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ</color>",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "215" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "235" ] }
+          ]
+        }
+      },
+      {
+        "id": "visible_12",
+        "text": "<color_pink>Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ≔≕Ψ</color>",
+        "condition": { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "235" ] }
+      }
+    ],
+    "padding": 0
+  }
+]

--- a/data/mods/MindOverMatter/ui/spacebar.json
+++ b/data/mods/MindOverMatter/ui/spacebar.json
@@ -9,7 +9,7 @@
     "id": "spacebar_nether_attunement_block",
     "type": "widget",
     "style": "layout",
-    "label": "Attunement",
+    "label": "Nether Attunement",
     "arrange": "minimum_columns",
     "width": 58,
     "widgets": [ "spacebar_separator_2", "spacebar_nether_attunement_meter" ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add Attunement meter to Spacebar UI"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Been using this a bit in my personal game and it's worth opening up for wider use. You can open your @ screen and see how much Nether Attunement you have anyway.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the widget. It's color-coded and grows based on your levels of Nether Attunement. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Gave myself three ascended backgrounds and Debug Concentration and concentrated on 10 powers at once and watched the bar grow. It works. 

Image at no, low, medium, high, and max Nether Attunement: 

![Untitled2](https://github.com/user-attachments/assets/0d6c9239-f4c2-43be-9757-fa7727b4dd42)

The color changes every 2 levels of attunement.  Green (1-2), light green (3-4), yellow (5-6), light red (7-8), red (9-10), pink (11-12).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
