### PR TITLE
Make chilis smokable

### DIFF
--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -339,7 +339,8 @@
     "price_postapoc": "16 cent",
     "material": [ "veggy" ],
     "volume": "70 ml",
-    "flags": [ "FREEZERBURN", "RAW" ],
+    "smoking_result": "dry_chili",
+    "flags": [ "FREEZERBURN", "RAW", "SMOKABLE" ],
     "vitamins": [ [ "vitC", "64700 μg" ], [ "iron", "500 μg" ], [ "calcium", "6300 μg" ], [ "veggy_allergen", 1 ] ],
     "fun": -2
   },


### PR DESCRIPTION
#### Summary

Features "Make chilis smokable"

#### Purpose of change

To allow chilis to be dehydrated in the smoking rack

#### Describe the solution

Added the "smokable" flag, and "dry_chili" as the smoking result to the chili_pepper json definition

#### Describe alternatives you've considered

I don't have 1128 of these, so it would've been feasible to do it by hand with the crafting recipe, but I figured I'd fix it while I was fixing the garlic one just in case someone does have 1128 chilis they want to dehydrate

#### Testing

![image](https://github.com/user-attachments/assets/28e9e91f-7b43-430f-b1e3-e436f1e8c855)
![image](https://github.com/user-attachments/assets/ab16e8b0-d8ea-402e-9bdb-c5b57a403440)

#### Additional context
