### PR TITLE
Backport #76175 (grass regrows for grazing) to 0.H

### DIFF
--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -2607,12 +2607,15 @@
   {
     "type": "terrain",
     "id": "t_grass_grazed",
-    "copy-from": "t_grass_dead",
     "name": "grazed grass",
     "description": "An area of extremely short green stubble protruding from the dirt.  Something has been clearly grazing here.",
     "looks_like": "t_grass_dead",
+    "symbol": ".",
+    "color": "brown",
+    "move_cost": 2,
     "transforms_into": "t_grass",
-    "extend": { "flags": [ "HARVESTED" ] }
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "HARVESTED" ],
+    "bash": { "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -2549,7 +2549,8 @@
     "symbol": ".",
     "color": "green",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
+    "transforms_into": "t_grass_grazed",
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "GRAZABLE" ],
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
@@ -2602,6 +2603,16 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
     "bash": { "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+  },
+  {
+    "type": "terrain",
+    "id": "t_grass_grazed",
+    "copy-from": "t_grass_dead",
+    "name": "grazed grass",
+    "description": "An area of extremely short green stubble protruding from the dirt.  Something has been clearly grazing here.",
+    "looks_like": "t_grass_dead",
+    "transforms_into": "t_grass",
+    "extend": { "flags": [ "HARVESTED" ] }
   },
   {
     "type": "terrain",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Grazing animals actually eat grass, and it regrows every season"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#69249, which is in 0.H, added the requirement for animals to eat in order to have offspring and produce goods. Problem with this is, animals don't actively search for food, and grass doesn't regrow so pasturing them does absolutely nothing. While this PR is a feature backport, I think it's 
1. worthwhile to have in order to have keeping animals be slightly less useless. Grazed grass regrowing once per season is still pretty rare, but it's something at least.
2. relatively low risk because it's a json change and the underlying json system is commonly used and therefore battle tested

If powers that be decide feature backports are not ok at this stage, even though they mitigate unfinished features in 0.H, just close this. I won't feel bad :P

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Cherry-pick #76422
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. Make an enclosure with some cows
3. Wait in the area for a few hours until they turn the enclosure into grazed grass
4. Teleport away
5. Advance time into next season
6. Teleport back
7. Observe that grazed grass has returned to normal grass

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
