### PR TITLE
Backport #75642 Prevent div by zero crash in mana widget

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1300,7 +1300,7 @@ nc_color widget::value_color( int value )
     // Get range of values from min to max
     const int var_range = _var_max - _var_min;
 
-    if( ! _breaks.empty() ) {
+    if( var_range > 0 && ! _breaks.empty() ) {
         const int value_offset = ( 100 * ( value - _var_min ) ) / var_range;
         for( int i = 0; i < color_max; i++ ) {
             if( value_offset < _breaks[i] ) {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1300,7 +1300,7 @@ nc_color widget::value_color( int value )
     // Get range of values from min to max
     const int var_range = _var_max - _var_min;
 
-    if( var_range > 0 && ! _breaks.empty() ) {
+    if( var_range != 0 && ! _breaks.empty() ) {
         const int value_offset = ( 100 * ( value - _var_min ) ) / var_range;
         for( int i = 0; i < color_max; i++ ) {
             if( value_offset < _breaks[i] ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Prevent sidebar crash when trying to divide by zero"

#### Purpose of change
* Backporting bug fix crash #75642  by @inogenous 

#### Describe the solution
Backport the crash bugfix
Just to be super duper extra safe, we still allow execution even if the value of var_range is negative. This might produce erroneous results, but it won't crash like div by zero.

Reason for the extra safety is that I thought it would prevent #76772, but @harakka was unable to reproduce. Still it appears that div-by-zero *could* happen on 0.H, so this is the narrowest possible backport.

#### Describe alternatives you've considered
Backporting the PR without any modification

More investigation into what caused/causes #76772

#### Testing
None personally

#### Additional context

