### PR TITLE
Add some NPC pilots to the world

### DIFF
--- a/data/json/npcs/BG_traits.json
+++ b/data/json/npcs/BG_traits.json
@@ -644,6 +644,18 @@
   },
   {
     "type": "mutation",
+    "id": "BGSS_Lost_Pilot_1",
+    "name": { "str": "Survivor: Ex-Pilot 1" },
+    "points": 0,
+    "description": "This NPC could tell you about how they survived the Cataclysm.",
+    "player_display": false,
+    "valid": false,
+    "purifiable": false,
+    "types": [ "BACKGROUND_SURVIVAL_STORY" ],
+    "flags": [ "BG_SURVIVAL_STORY" ]
+  },
+  {
+    "type": "mutation",
     "//": "This is a unique background story trait that should not be given out randomly.",
     "id": "BGSS_Scavenger_Merc_1",
     "name": { "str": "Survivor Story" },

--- a/data/json/npcs/Backgrounds/backgrounds_table_of_contents.json
+++ b/data/json/npcs/Backgrounds/backgrounds_table_of_contents.json
@@ -531,6 +531,12 @@
         "topic": "CWH_GUNG_HO_3_IDEAS1",
         "condition": { "npc_has_trait": "BGSS_Gung_Ho_3" },
         "switch": true
+      },
+      {
+        "text": "<BGSS_intro_question>",
+        "topic": "BGSS_Lost_Pilot_1_STORY1",
+        "condition": { "npc_has_trait": "BGSS_Lost_Pilot_1" },
+        "switch": true
       }
     ]
   },

--- a/data/json/npcs/Backgrounds/ex_pilot_1.json
+++ b/data/json/npcs/Backgrounds/ex_pilot_1.json
@@ -7,6 +7,18 @@
       "relevant_genders": [ "npc" ]
     },
     "responses": [
+      { "text": "You were a pilot?  Can you fly a helicopter?", "topic": "BGSS_Lost_Pilot_1_STORY2" },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "BGSS_Lost_Pilot_1_STORY2",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "'pot' and 'mary jane' are both slang terms for marijuana, a recreational drug that's federally illegal in the US.  In several states, possessing more than a certain quantity of marijuana is considered 'possession with intent to distribute' and can incur a felony conviction. Some states also allow conviction records of non-violent drug offenses to be 'sealed' (restricted from being publicly published or considered by the court) if the convicted person does not commit further crimes.",
+      "str": "Uh, well probably?  I flew fixed-wing for work, but my interest in flying was for helitack - uh, that's helicopter transport for firefighting teams.  Anyway, I got a stupid pot conviction and that disqualified me.  Took a job with the airline to keep fresh until I could finish probation and get the records sealed.  Funny, you smoke some mary jane and they say you can't save lives with firefighting.  But they'll let you fly a plane with hundreds of people in it, not like anyone's ever crashed one of those on purpose before.  So yeah, get me a helicopter and I'd be happy to fly."
+    },
+    "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/Backgrounds/ex_pilot_1.json
+++ b/data/json/npcs/Backgrounds/ex_pilot_1.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "BGSS_Lost_Pilot_1_STORY1",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "gendered_line": "Where was I?  I don't even know, what day do you think it all ended?  When I thought shit was hitting the fan I took some vacation time at the airline.  Next day, somebody bombed them.  No shit, just like Oklahoma city in '95.  Thought that was a good sign to get out so I emailed some family out in the country that I was coming over and got on the road.  Didn't even make it to the interstate before I ran into the cops setting up a roadblock.  I drove off the road and it all gets fuzzy from there.  Next town I got to was already lynching people from the streetlights… I didn't stop for gas.  Lost the car at some point, lost track of the days too.  Not sure I ever got a reply to my email.",
+      "relevant_genders": [ "npc" ]
+    },
+    "responses": [
+      { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  }
+]

--- a/data/json/npcs/classes.json
+++ b/data/json/npcs/classes.json
@@ -397,6 +397,17 @@
   },
   {
     "type": "npc_class",
+    "id": "NC_SCAVENGER_EX_PILOT",
+    "name": { "str": "Former Pilot" },
+    "job_description": "I just want to fly away to somewhere better.",
+    "common_spawn_weight": 0.3,
+    "traits": [ { "trait": "BGSS_Lost_Pilot_1" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_per": { "rng": [ 2, 4 ] },
+    "proficiencies": [ "prof_helicopter_pilot" ],
+    "skills": [ { "skill": "driving", "bonus": { "rng": [ 3, 5 ] } } ]
+  },
+  {
+    "type": "npc_class",
     "id": "NC_HUNTER",
     "name": { "str": "Hunter" },
     "job_description": "I'm tracking game.",

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -4390,6 +4390,7 @@ Ojibwe
 ok
 okie
 Okinawan
+Oklahoma
 Olaf
 Olam
 o'lantern


### PR DESCRIPTION
#### Summary
Content "Add a random NPC class that knows how to fly. Yes you CAN recruit them, switch to them, and then fly a helicopter with their skills."

#### Purpose of change
The obvious 15-minute JSON solution, brought to you by big bad dev

#### Describe the solution
In between adding all the infrastructure I guess I can just add the thing myself, too.

Adds a randomly spawned NPC class whose sole gimmick is that they know how to fly helicopters. Gave them a little backstory of their own.

Used the [NPC class weighting](https://github.com/CleverRaven/Cataclysm-DDA/pull/75384) to make it 30% as likely to appear as a normal NPC class. We seem to have at least 70 classes in classes.json, so with a weight of 0.3 it has a **roughly** 0.3/70.3 = ~0.4% chance of being the chosen random NPC class, assuming all of those classes are 'common'.

The weight of 0.3 was chosen arbitrarily as I assume not many people fly helicopters. It can easily be tweaked upwards/downwards as desired or needed. And yes, you can just json mod it up/down to whatever value you want.

#### Describe alternatives you've considered
weighted proficiency groups so we could just fold this into other classes instead of making a new class

make NPCs drive so switching to them is optional instead of mandatory

#### Testing
Spawned some NPCs, got a pilot. Talked to them, got their unique background.

![image](https://github.com/user-attachments/assets/0c10de33-52a6-4732-b8b1-4baf334c516d)

#### Additional context

