### PR TITLE
Add character ID to solo faction IDs to ensure uniqueness

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3487,6 +3487,7 @@ static void spawn_npc()
                            temp->getID() ) );
     std::string new_fac_id = "solo_";
     new_fac_id += temp->name;
+    new_fac_id += std::to_string( temp->getID().get_value() );
     // create a new "lone wolf" faction for this one NPC
     faction *new_solo_fac = g->faction_manager_ptr->add_new_faction( temp->name,
                             faction_id( new_fac_id ), faction_no_faction );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12805,6 +12805,7 @@ void game::perhaps_add_random_npc( bool ignore_spawn_timers_and_rates )
 
     std::string new_fac_id = "solo_";
     new_fac_id += tmp->name;
+    new_fac_id += std::to_string( tmp->getID().get_value() );
     // create a new "lone wolf" faction for this one NPC
     faction *new_solo_fac = faction_manager_ptr->add_new_faction( tmp->name, faction_id( new_fac_id ),
                             faction_no_faction );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -944,6 +944,7 @@ void talk_function::leave( npc &p )
     g->remove_npc_follower( p.getID() );
     std::string new_fac_id = "solo_";
     new_fac_id += p.name;
+    new_fac_id += std::to_string( p.getID().get_value() );
     p.job.clear_all_priorities();
     // create a new "lone wolf" faction for this one NPC
     faction *new_solo_fac = g->faction_manager_ptr->add_new_faction( p.name,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
When doing some NPC related things, I noticed that our solo factions are named, by `solo_` plus the NPC's name.

Thus, two solo factions for NPCs with the same name would end up with both characters in the same 'solo' faction, even though they are different people.

#### Describe the solution
Also add the character ID to the faction's ID, which should ensure uniqueness.

#### Describe alternatives you've considered
I originally thought of using just the ID, so `solo_57` as an example, but I realized we could keep the name as well. There's no downside to it, and it's an additional level of safety.

#### Testing
Applied changes, debug spawned some NPCs. No errors.

Loaded game with existing solo NPCs, no errors.

#### Additional context

