### PR TITLE
Spend time when taking off items via 'T' in item examine menu

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2310,7 +2310,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     u.change_side( locThisItem );
                     break;
                 case 'T':
-                    u.takeoff( locThisItem );
+                    u.takeoff( locThisItem.obtain( u ) );
                     break;
                 case 'd':
                     u.drop( locThisItem, u.pos() );


### PR DESCRIPTION
#### Summary
Bugfixes "Spend time when taking off items via 'T' in item examine menu"

#### Purpose of change
* Closes #70333.

#### Describe the solution
Use `locThisItem.obtain` instead of simple `locThisItem`.

#### Describe alternatives you've considered
None.

#### Testing
Wielded a stick. Examined my T-shirt. Pressed `T` to take the tee off. Noticed that time has passed.

#### Additional context
None.