### PR TITLE
Cabin in Safe Place scenario is now actually safe

### DIFF
--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -346,7 +346,7 @@
     "type": "start_location",
     "id": "sloc_cabin",
     "name": "Cabin",
-    "terrain": [ "cabin" ]
+    "terrain": [ "cabin_3", "cabin_4", "cabin_5", "cabin_6", "cabin_7" ]
   },
   {
     "type": "start_location",


### PR DESCRIPTION
#### Summary
Bugfixes "Cabin in Safe Place scenario is now actually safe"

#### Purpose of change
* Closes #70269.

#### Describe the solution
Instead of single and potentially unsafe `cabin` location, allow 5 different and guaranteed safe cabins to choose from.

#### Describe alternatives you've considered
None.

#### Testing
Chose Safe Place scenario, selected `Cabin` starting location, checked that cabin is actually safe.

#### Additional context
None.