### PR TITLE
Removed High Adrenaline as a background trait for Fire Performing hobby

### DIFF
--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -1318,7 +1318,7 @@
     "name": "Fire Performing",
     "description": "Whether you twirled, spun, juggled, or ate it, your manipulation of flaming objects was impressive and terrifying to behold.",
     "points": 1,
-    "traits": [ "PYROMANIA", "ADRENALINE", "DEFT" ],
+    "traits": [ "PYROMANIA", "DEFT" ],
     "skills": [ { "level": 1, "name": "survival" } ]
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "Removed High Adrenaline as a background trait for Fire Performing hobby"

#### Purpose of change
* Closes #70028.

#### Describe the solution
Removed High Adrenaline as a background trait for Fire Performing hobby.

#### Describe alternatives you've considered
None.

#### Testing
At character creation menu, checked that High Adrenaline isn't listed as background trait and in Traits section.

#### Additional context
None.