### PR TITLE
Add barrel length to Beretta 90-two

### DIFF
--- a/data/json/items/gun/40.json
+++ b/data/json/items/gun/40.json
@@ -9,6 +9,7 @@
     "weight": "905 g",
     "volume": "554 ml",
     "longest_side": "250 mm",
+    "barrel_length": "125 mm",
     "price": "650 USD",
     "price_postapoc": "20 USD",
     "material": [ "steel", "plastic" ],


### PR DESCRIPTION
#### Summary
Bugfixes "Add barrel length to Beretta 90-two"

#### Purpose of change

Noticed the gun had no defined barrel length. Unsure why.

#### Describe the solution

Checked wikipedia and added a barrel length of 125mm to the definition

#### Describe alternatives you've considered

Leaving the gun without a barrel. Guess that could be interesting, just kind of use it as a slingshot to throw the bullets at the zombies.

#### Testing

#### Additional context
