### PR TITLE
explicitly naming the wasp towers

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -499,7 +499,7 @@
       "wasp_tower_top"
     ],
     "vision_levels": "isolated_tower",
-    "name": "radio tower",
+    "name": "wasp tower",
     "sym": "X",
     "color": "light_gray",
     "see_cost": "high",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
As the OM granularity is here, I don't think the survivor should be obscured the actual name.

#### Describe the solution
Changed the name

#### Describe alternatives you've considered
NONE

#### Testing
Should work

#### Additional context
Well, do you think not being able to notice a HUGE wasp nest from a good distance make sense?