### PR TITLE
No longer able to wear already worn items

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -262,7 +262,7 @@ Character::wear( int pos, bool interactive )
 std::optional<std::list<item>::iterator>
 Character::wear( item_location item_wear, bool interactive )
 {
-    item to_wear = *item_wear;
+    item &to_wear = *item_wear;
 
     // Need to account for case where we're trying to wear something that belongs to someone else
     if( !avatar_action::check_stealing( *this, to_wear ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "No longer able to wear already worn items"

#### Purpose of change
If you open examine menu of already worn item and select `Wear` (or press `W`), you will try to wear it again, spending time and seeing `You put on your <item>` despite nothing actually happens.

I think that #45290 made this stuff work wrong.

#### Describe the solution
Made declaration of `to_wear` reference in `Character::wear`.

#### Describe alternatives you've considered
None.

#### Testing
Opened examination menu of already worn T-shirt, tried to wear it again. Got `You are already wearing that.` message, and no time was spent.
Also just in case tried to wear someone else's items (with stealing check), tried to wear items not already worn, tried to wear wielded items, tried to wear items on the ground, tried to wear items with open `Pickup` menu. No errors, items were worn as they should.

#### Additional context
My understanding of all this reference and pointer stuff is very superficial, so I may be very wrong on proposed solution.