### PR TITLE
[Xedra Evolved] Little cleanups

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/scenario_specific.json
+++ b/data/mods/Xedra_Evolved/eocs/scenario_specific.json
@@ -9,52 +9,14 @@
     "type": "effect_on_condition",
     "id": "scenario_paraclesian_birth",
     "eoc_type": "SCENARIO_SPECIFIC",
-    "condition": { "u_has_trait": "IERDE" },
-    "effect": [ { "math": [ "u_vitamin('mutagen_earthkin')", "+=", "550 " ] }, { "math": [ "u_vitamin('mutagen')", "+=", "550" ] } ],
-    "false_effect": {
-      "run_eocs": [
-        {
-          "id": "scenario_paraclesian_birth2",
-          "condition": { "u_has_trait": "UNDINE" },
-          "effect": [ { "math": [ "u_vitamin('mutagen_waterkin')", "+=", "550 " ] }, { "math": [ "u_vitamin('mutagen')", "+=", "550" ] } ],
-          "false_effect": {
-            "run_eocs": [
-              {
-                "id": "scenario_paraclesian_birth3",
-                "condition": { "u_has_trait": "SALAMANDER" },
-                "effect": [ { "math": [ "u_vitamin('mutagen_flamekin')", "+=", "550 " ] }, { "math": [ "u_vitamin('mutagen')", "+=", "550" ] } ],
-                "false_effect": {
-                  "run_eocs": [
-                    {
-                      "id": "scenario_paraclesian_birth4",
-                      "condition": { "u_has_trait": "SYLPH" },
-                      "effect": [ { "math": [ "u_vitamin('mutagen_airkin')", "+=", "550 " ] }, { "math": [ "u_vitamin('mutagen')", "+=", "550" ] } ],
-                      "false_effect": {
-                        "run_eocs": [
-                          {
-                            "id": "scenario_paraclesian_birth5",
-                            "condition": { "u_has_trait": "HOMULLUS" },
-                            "effect": [ { "math": [ "u_vitamin('mutagen_dollkin')", "+=", "550 " ] }, { "math": [ "u_vitamin('mutagen')", "+=", "550" ] } ],
-                            "false_effect": {
-                              "run_eocs": [
-                                {
-                                  "id": "scenario_paraclesian_birth6",
-                                  "condition": { "u_has_trait": "ARVORE" },
-                                  "effect": [ { "math": [ "u_vitamin('mutagen_plantkin')", "+=", "550 " ] }, { "math": [ "u_vitamin('mutagen')", "+=", "550" ] } ]
-                                }
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      ]
-    }
+    "effect": [
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "if": { "u_has_trait": "IERDE" }, "then": { "math": [ "u_vitamin('mutagen_earthkin')", "+=", "550 " ] } },
+      { "if": { "u_has_trait": "UNDINE" }, "then": { "math": [ "u_vitamin('mutagen_waterkin')", "+=", "550 " ] } },
+      { "if": { "u_has_trait": "SALAMANDER" }, "then": { "math": [ "u_vitamin('mutagen_flamekin')", "+=", "550 " ] } },
+      { "if": { "u_has_trait": "SYLPH" }, "then": { "math": [ "u_vitamin('mutagen_airkin')", "+=", "550 " ] } },
+      { "if": { "u_has_trait": "HOMULLUS" }, "then": { "math": [ "u_vitamin('mutagen_dollkin')", "+=", "550 " ] } },
+      { "if": { "u_has_trait": "ARVORE" }, "then": { "math": [ "u_vitamin('mutagen_plantkin')", "+=", "550 " ] } }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/eocs/spell_learning_eoc.json
+++ b/data/mods/Xedra_Evolved/eocs/spell_learning_eoc.json
@@ -55,11 +55,17 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_XE_QUEUE_LEVELING",
-    "recurrence": [ "1 h", "3 h" ],
-    "condition": { "u_has_effect": "sleep" },
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
     "effect": [
-      { "if": { "math": [ "xe_eater_leveling", ">", "0" ] }, "then": [ { "run_eocs": "EOC_PICK_SPELL_EATER" } ] },
-      { "if": { "math": [ "xe_dreamer_leveling", ">", "0" ] }, "then": [ { "run_eocs": "EOC_PICK_SPELL_DREAMER" } ] }
+      {
+        "if": { "math": [ "xe_eater_leveling", ">", "0" ] },
+        "then": [ { "run_eocs": "EOC_PICK_SPELL_EATER", "repeat": { "global_val": "xe_eater_leveling" } } ]
+      },
+      {
+        "if": { "math": [ "xe_dreamer_leveling", ">", "0" ] },
+        "then": [ { "run_eocs": "EOC_PICK_SPELL_DREAMER", "repeat": { "global_val": "xe_dreamer_leveling" } } ]
+      }
     ]
   },
   {

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1633,6 +1633,8 @@ Runs another EoC. It can be a separate EoC, or an inline EoC inside `run_eocs` e
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
 | "run_eocs" | **mandatory** | string (eoc id or inline eoc) or [variable object](#variable-object)) or array of eocs | EoC or EoCS that would be run |
+| "repeat" | optional | int or [variable object](#variable-object)) | if used, all eocs in run_eocs would be repeated this amount of times. Default 1 |
+
 
 ##### Valid talkers:
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5184,17 +5184,18 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
     if( eocs_entries.empty() ) {
         jo.throw_error( "Invalid input for run_eocs" );
     }
-    return [eocs_entries, repeat]( dialogue const & d ) {
+    return [eocs_entries, repeat]( dialogue & d ) {
         int i = 0;
+        int repeat_amount = repeat.evaluate( d );
 
-        while ( i < repeat.evaluate( d ) ) {
-            for( const eoc_entry &entry : eocs_entries ) {
-                effect_on_condition_id eoc_id =
-                    entry.var ? effect_on_condition_id( entry.var->evaluate( d ) ) : entry.id;
-                dialogue newDialog( d );
+        for( const eoc_entry &entry : eocs_entries ) {
+            effect_on_condition_id eoc_id =
+                entry.var ? effect_on_condition_id( entry.var->evaluate( d ) ) : entry.id;
+            dialogue newDialog( d );
+            while( i < repeat_amount ) {
                 eoc_id->activate( newDialog );
+                ++i;
             };
-            ++i;
         }
     };
 }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5179,17 +5179,23 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
                                     const std::string_view src )
 {
     std::vector<eoc_entry> eocs_entries = load_eoc_vector_id_and_var( jo, member, src );
+    dbl_or_var repeat = get_dbl_or_var( jo, "repeat", false, 1 );
 
     if( eocs_entries.empty() ) {
         jo.throw_error( "Invalid input for run_eocs" );
     }
-    return [eocs_entries]( dialogue const & d ) {
-        for( const eoc_entry &entry : eocs_entries ) {
-            effect_on_condition_id eoc_id =
-                entry.var ? effect_on_condition_id( entry.var->evaluate( d ) ) : entry.id;
-            dialogue newDialog( d );
-            eoc_id->activate( newDialog );
-        };
+    return [eocs_entries, repeat]( dialogue const & d ) {
+        int i = 0;
+
+        while ( i < repeat.evaluate( d ) ) {
+            for( const eoc_entry &entry : eocs_entries ) {
+                effect_on_condition_id eoc_id =
+                    entry.var ? effect_on_condition_id( entry.var->evaluate( d ) ) : entry.id;
+                dialogue newDialog( d );
+                eoc_id->activate( newDialog );
+            };
+            ++i;
+        }
     };
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Just few stuff that amused me in how wonky they are
#### Describe the solution
Replace giant chain of if-else-then eocs in scenario_paraclesian_birth with a neat if-else set
Make EOC_XE_QUEUE_LEVELING use character_wakes_up event instead of running recurring eoc all the time, checking do you sleep or not
Make EOC_XE_QUEUE_LEVELING dump off all levels, instead of doing it one by one; Added `repeat` field to avoid making eoc loop to handle it
#### Testing
  {
    "type": "effect_on_condition",
    "id": "AAAAAAAAAAAA",
    "effect": [ { "run_eocs": [ "BBBBBBBBBB" ], "repeat": 11 } ]
  },
  {
    "type": "effect_on_condition",
    "id": "BBBBBBBBBB",
    "effect": [ { "u_message": "Fuck yeah" } ]
  },
  
![image](https://github.com/user-attachments/assets/0e3c643c-3000-4301-bf88-f0aea33db4ff)
