### PR TITLE
limit stomach_contents::capacity to be no less than 250 ml

### DIFF
--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -320,9 +320,9 @@ void stomach_contents::deserialize( const JsonObject &jo )
 }
 
 units::volume stomach_contents::capacity( const Character &owner ) const
-{
-    return owner.enchantment_cache->modify_value( enchant_vals::mod::STOMACH_SIZE_MULTIPLIER,
-            max_volume );
+{ 
+    return std::max( 250_ml, owner.enchantment_cache->modify_value( 
+        enchant_vals::mod::STOMACH_SIZE_MULTIPLIER, max_volume ) );
 }
 
 units::volume stomach_contents::stomach_remaining( const Character &owner ) const

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -320,9 +320,9 @@ void stomach_contents::deserialize( const JsonObject &jo )
 }
 
 units::volume stomach_contents::capacity( const Character &owner ) const
-{ 
-    return std::max( 250_ml, owner.enchantment_cache->modify_value( 
-        enchant_vals::mod::STOMACH_SIZE_MULTIPLIER, max_volume ) );
+{
+    return std::max( 250_ml, owner.enchantment_cache->modify_value(
+                         enchant_vals::mod::STOMACH_SIZE_MULTIPLIER, max_volume ) );
 }
 
 units::volume stomach_contents::stomach_remaining( const Character &owner ) const


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #76882
#### Describe the solution
Limit stomach size to 250 ml, single unit of water; can't be smaller otherwise player gonna die from thirst, unable to drink water, vomiting it after each consumption
#### Describe alternatives you've considered
300 ml
#### Additional context
gastrectomy is no joke