### PR TITLE
typified map.h + dependents, end of first pass

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3103,8 +3103,9 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
 
     map &here = get_map();
     if( autodoc && here.inbounds( you->pos_bub() ) ) {
-        const std::list<tripoint> autodocs = here.find_furnitures_with_flag_in_radius( you->pos(), 1,
-                                             ter_furn_flag::TFLAG_AUTODOC );
+        const std::list<tripoint_bub_ms> autodocs = here.find_furnitures_with_flag_in_radius(
+                    you->pos_bub(), 1,
+                    ter_furn_flag::TFLAG_AUTODOC );
 
         if( !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, you->pos_bub() ) ||
             autodocs.empty() ) {
@@ -3237,8 +3238,9 @@ void activity_handlers::operation_finish( player_activity *act, Character *you )
         if( act->values[1] > 0 ) {
             add_msg( m_good,
                      _( "The Autodoc returns to its resting position after successfully performing the operation." ) );
-            const std::list<tripoint> autodocs = here.find_furnitures_with_flag_in_radius( you->pos(), 1,
-                                                 ter_furn_flag::TFLAG_AUTODOC );
+            const std::list<tripoint_bub_ms> autodocs = here.find_furnitures_with_flag_in_radius(
+                        you->pos_bub(), 1,
+                        ter_furn_flag::TFLAG_AUTODOC );
             sounds::sound( autodocs.front(), 10, sounds::sound_t::music,
                            _( "a short upbeat jingle: \"Operation successful\"" ), true,
                            "Autodoc",
@@ -3246,8 +3248,9 @@ void activity_handlers::operation_finish( player_activity *act, Character *you )
         } else {
             add_msg( m_bad,
                      _( "The Autodoc jerks back to its resting position after failing the operation." ) );
-            const std::list<tripoint> autodocs = here.find_furnitures_with_flag_in_radius( you->pos(), 1,
-                                                 ter_furn_flag::TFLAG_AUTODOC );
+            const std::list<tripoint_bub_ms> autodocs = here.find_furnitures_with_flag_in_radius(
+                        you->pos_bub(), 1,
+                        ter_furn_flag::TFLAG_AUTODOC );
             sounds::sound( autodocs.front(), 10, sounds::sound_t::music,
                            _( "a sad beeping noise: \"Operation failed\"" ), true,
                            "Autodoc",

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -312,15 +312,15 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     if( you.has_effect( effect_amigara ) ) {
         int curdist = INT_MAX;
         int newdist = INT_MAX;
-        const tripoint minp = tripoint( 0, 0, you.posz() );
-        const tripoint maxp = tripoint( MAPSIZE_X, MAPSIZE_Y, you.posz() );
-        for( const tripoint &pt : m.points_in_rectangle( minp, maxp ) ) {
+        const tripoint_bub_ms minp{ 0, 0, you.posz() };
+        const tripoint_bub_ms maxp{ MAPSIZE_X, MAPSIZE_Y, you.posz() };
+        for( const tripoint_bub_ms &pt : m.points_in_rectangle( minp, maxp ) ) {
             if( m.ter( pt ) == ter_t_fault ) {
-                int dist = rl_dist( pt, you.pos_bub().raw() );
+                int dist = rl_dist( pt, you.pos_bub() );
                 if( dist < curdist ) {
                     curdist = dist;
                 }
-                dist = rl_dist( pt, dest_loc.raw() );
+                dist = rl_dist( pt, dest_loc );
                 if( dist < newdist ) {
                     newdist = dist;
                 }
@@ -601,8 +601,8 @@ bool avatar_action::ramp_move( avatar &you, map &m, const tripoint &dest_loc )
     // Try to find an aligned end of the ramp that will make our climb faster
     // Basically, finish walking on the stairs instead of pulling self up by hand
     bool aligned_ramps = false;
-    for( const tripoint &pt : m.points_in_radius( you.pos(), 1 ) ) {
-        if( rl_dist( pt, dest_loc ) < 2 && m.has_flag( ter_furn_flag::TFLAG_RAMP_END, pt ) ) {
+    for( const tripoint_bub_ms &pt : m.points_in_radius( you.pos_bub(), 1 ) ) {
+        if( rl_dist( pt.raw(), dest_loc ) < 2 && m.has_flag( ter_furn_flag::TFLAG_RAMP_END, pt ) ) {
             aligned_ramps = true;
             break;
         }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2414,7 +2414,7 @@ float Character::env_surgery_bonus( int radius ) const
 {
     float bonus = 1.0f;
     map &here = get_map();
-    for( const tripoint &cell : here.points_in_radius( pos(), radius ) ) {
+    for( const tripoint_bub_ms &cell : here.points_in_radius( pos_bub(), radius ) ) {
         if( here.furn( cell )->surgery_skill_multiplier ) {
             bonus = std::max( bonus, *here.furn( cell )->surgery_skill_multiplier );
         }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1366,8 +1366,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     }
 
     //invalidate draw_points_cache if viewport dimensions have changed
-    point top_left( min_col, min_row );
-    point bottom_right( max_col, max_row );
+    point_rel_ms top_left( min_col, min_row );
+    point_rel_ms bottom_right( max_col, max_row );
     if( top_left != here.prev_top_left || bottom_right != here.prev_bottom_right || o != here.prev_o ) {
         set_draw_cache_dirty();
     }
@@ -1660,7 +1660,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos.raw(), 0},
                             tile_render_info::sprite{ ll, invisible } );
                     // Stop building draw points below when floor reached
-                    if( here.dont_draw_lower_floor( pos.raw() ) ) {
+                    if( here.dont_draw_lower_floor( pos ) ) {
                         break;
                     }
                 }
@@ -1756,7 +1756,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                             } else if( f == &cata_tiles::draw_critter_at ) {
                                 // Draw
                                 if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) && do_draw_shadow &&
-                                    here.dont_draw_lower_floor( p.com.pos ) ) {
+                                    here.dont_draw_lower_floor( tripoint_bub_ms( p.com.pos ) ) ) {
                                     // Draw shadow of flying critters on bottom-most tile if no other critter drawn
                                     draw_critter_above( p.com.pos, ll, p.com.height_3d, invisible );
                                 }
@@ -2551,7 +2551,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
 
     if( !tt ) {
         // Use fog overlay as fallback for transparent terrain
-        if( category == TILE_CATEGORY::TERRAIN && !here.dont_draw_lower_floor( pos ) ) {
+        if( category == TILE_CATEGORY::TERRAIN && !here.dont_draw_lower_floor( tripoint_bub_ms( pos ) ) ) {
             draw_zlevel_overlay( pos, ll, height_3d );
 
             // t_open_air is plentiful at high z-levels
@@ -3235,7 +3235,7 @@ bool cata_tiles::draw_terrain_below( const tripoint &p, const lit_level, int &,
     const auto low_override = draw_below_override.find( tripoint_bub_ms( p ) );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second :
-        ( invisible[0] || here.dont_draw_lower_floor( p ) ) ) {
+        ( invisible[0] || here.dont_draw_lower_floor( tripoint_bub_ms( p ) ) ) ) {
         return false;
     }
 
@@ -3899,7 +3899,7 @@ bool cata_tiles::draw_vpart_below( const tripoint &p, const lit_level /*ll*/, in
     const auto low_override = draw_below_override.find( tripoint_bub_ms( p ) );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second : ( invisible[0] ||
-            get_map().dont_draw_lower_floor( p ) ) ) {
+            get_map().dont_draw_lower_floor( tripoint_bub_ms( p ) ) ) ) {
         return false;
     }
     tripoint pbelow( p.xy(), p.z - 1 );
@@ -4019,7 +4019,7 @@ bool cata_tiles::draw_critter_at_below( const tripoint &p, const lit_level, int 
     const auto low_override = draw_below_override.find( tripoint_bub_ms( p ) );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second : ( invisible[0] ||
-            get_map().dont_draw_lower_floor( p ) ) ) {
+            get_map().dont_draw_lower_floor( tripoint_bub_ms( p ) ) ) ) {
         return false;
     }
 
@@ -4178,15 +4178,16 @@ bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &heigh
         return false;
     }
 
-    tripoint scan_p( p.xy(), p.z + 1 );
+    tripoint_bub_ms scan_p( p + tripoint_above );
     map &here = get_map();
     Character &you = get_player_character();
     const Creature *pcritter = nullptr;
     // Search for a creature above
-    while( pcritter == nullptr && scan_p.z <= OVERMAP_HEIGHT && !here.dont_draw_lower_floor( scan_p ) &&
-           scan_p.z - you.pos().z <= fov_3d_z_range ) {
+    while( pcritter == nullptr && scan_p.z() <= OVERMAP_HEIGHT &&
+           !here.dont_draw_lower_floor( scan_p ) &&
+           scan_p.z() - you.pos_bub().z() <= fov_3d_z_range ) {
         pcritter = get_creature_tracker().creature_at( scan_p, true );
-        scan_p.z++;
+        scan_p.z()++;
     }
 
     // Abort if no creature found
@@ -4197,7 +4198,7 @@ bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &heigh
 
     // Draw shadow
     if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p,
-                             0, 0, ll, false, height_3d ) && scan_p.z - 1 > you.pos().z && you.sees( critter ) ) {
+                             0, 0, ll, false, height_3d ) && scan_p.z() - 1 > you.pos_bub().z() && you.sees( critter ) ) {
 
         bool is_player = false;
         bool sees_player = false;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1758,8 +1758,8 @@ void Character::forced_dismount()
         mounted_creature = nullptr;
         mon->mounted_player = nullptr;
     }
-    std::vector<tripoint> valid;
-    for( const tripoint &jk : get_map().points_in_radius( pos(), 1 ) ) {
+    std::vector<tripoint_bub_ms> valid;
+    for( const tripoint_bub_ms &jk : get_map().points_in_radius( pos_bub(), 1 ) ) {
         if( g->is_empty( jk ) ) {
             valid.push_back( jk );
         }
@@ -10323,10 +10323,10 @@ void Character::place_corpse( const tripoint_abs_omt &om_target )
     // Q: Why not grep a random point out of all the possible points (e.g. via random_entry)?
     // TODO: fix it, see above.
     if( bay.furn( fin ) != furn_str_id::NULL_ID() ) {
-        for( const tripoint &p : bay.points_on_zlevel() ) {
+        for( const tripoint_omt_ms &p : bay.points_on_zlevel() ) {
             if( bay.furn( p ) == furn_str_id::NULL_ID() ) {
-                fin.x() = p.x;
-                fin.y() = p.y;
+                fin.x() = p.x();
+                fin.y() = p.y();
             }
         }
     }

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -215,7 +215,7 @@ bool Character::try_remove_grab( bool attacking )
                                        std::max( std::max( static_cast<float>( get_skill_level( skill_melee ) ) / 10, 0.1f ),
                                                std::max( static_cast<float>( get_skill_level( skill_unarmed ) ) / 8, 0.1f ) ) );
         int grab_break_factor = has_grab_break_tec() ? 10 : 0;
-        const tripoint_range<tripoint> &surrounding = here.points_in_radius( pos(), 1, 0 );
+        const tripoint_range<tripoint_bub_ms> &surrounding = here.points_in_radius( pos_bub(), 1, 0 );
 
         // Iterate through all our grabs and attempt to break them one by one
         for( const effect &eff : get_effects_with_flag( json_flag_GRAB ) ) {
@@ -224,7 +224,7 @@ bool Character::try_remove_grab( bool attacking )
             // We need to figure out which monster is responsible for this grab early for good messaging
             // For now, one grabber per limb TODO: handle multiple grabbers and decrement intensity
             monster *grabber = nullptr;
-            for( const tripoint loc : surrounding ) {
+            for( const tripoint_bub_ms loc : surrounding ) {
                 monster *mon = creatures.creature_at<monster>( loc );
                 if( mon && mon->is_grabbing( eff.get_bp().id() ) ) {
                     add_msg_debug( debugmode::DF_MATTACK, "Grabber %s found", mon->name() );

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -398,7 +398,7 @@ bool computer_session::can_activate( computer_action action )
         case COMPACT_TERMINATE: {
             map &here = get_map();
             creature_tracker &creatures = get_creature_tracker();
-            for( const tripoint &p : here.points_on_zlevel() ) {
+            for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
                 monster *const mon = creatures.creature_at<monster>( p );
                 if( !mon ) {
                     continue;
@@ -510,7 +510,7 @@ void computer_session::action_sample()
 {
     get_player_character().mod_moves( -to_moves<int>( 1_seconds ) * 0.3 );
     map &here = get_map();
-    for( const tripoint_bub_ms &p : here.bub_points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
         if( here.ter( p ) != ter_t_sewage_pump ) {
             continue;
         }
@@ -576,7 +576,7 @@ void computer_session::action_terminate()
     Character &player_character = get_player_character();
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &p : here.points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
         monster *const mon = creatures.creature_at<monster>( p );
         if( !mon ) {
             continue;
@@ -595,7 +595,7 @@ void computer_session::action_portal()
 {
     get_event_bus().send<event_type::opens_portal>();
     map &here = get_map();
-    for( const tripoint_bub_ms &tmp : here.bub_points_on_zlevel() ) {
+    for( const tripoint_bub_ms &tmp : here.points_on_zlevel() ) {
         int numtowers = 0;
         for( const tripoint_bub_ms &tmp2 : here.points_in_radius( tmp, 2 ) ) {
             if( here.ter( tmp2 ) == ter_t_radio_tower ) {
@@ -793,7 +793,7 @@ void computer_session::action_list_bionics()
     std::vector<std::string> names;
     int more = 0;
     map &here = get_map();
-    for( const tripoint_bub_ms &p : here.bub_points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
         for( item &elem : here.i_at( p ) ) {
             if( elem.is_bionic() ) {
                 if( static_cast<int>( names.size() ) < TERMY - 8 ) {
@@ -881,7 +881,7 @@ void computer_session::action_list_mutations()
 void computer_session::action_elevator_on()
 {
     map &here = get_map();
-    for( const tripoint &p : here.points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
         if( here.ter( p ) == ter_t_elevator_control_off ) {
             here.ter_set( p, ter_t_elevator_control );
         }
@@ -1221,10 +1221,10 @@ void computer_session::action_srcf_seal()
     print_line( _( "Evacuate Immediately" ) );
     add_msg( m_warning, _( "Evacuate Immediately!" ) );
     map &here = get_map();
-    for( const tripoint &p : here.points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
         if( here.ter( p ) == ter_t_elevator || here.ter( p ) == ter_t_vat ) {
             here.make_rubble( p, furn_f_rubble_rock, true );
-            explosion_handler::explosion( &get_player_character(), p, 40, 0.7, true );
+            explosion_handler::explosion( &get_player_character(), p.raw(), 40, 0.7, true );
         }
         if( here.ter( p ) == ter_t_wall_glass ) {
             here.make_rubble( p, furn_f_rubble_rock, true );
@@ -1235,7 +1235,7 @@ void computer_session::action_srcf_seal()
         }
         if( here.ter( p ) == ter_t_sewage_pump ) {
             here.make_rubble( p, furn_f_rubble_rock, true );
-            explosion_handler::explosion( &get_player_character(), p, 50, 0.7, true );
+            explosion_handler::explosion( &get_player_character(), p.raw(), 50, 0.7, true );
         }
     }
     comp.options.clear(); // Disable the terminal.
@@ -1246,21 +1246,21 @@ void computer_session::action_srcf_elevator()
 {
     Character &player_character = get_player_character();
     map &here = get_map();
-    tripoint surface_elevator;
-    tripoint underground_elevator;
+    tripoint_bub_ms surface_elevator;
+    tripoint_bub_ms underground_elevator;
     bool is_surface_elevator_on = false;
     bool is_surface_elevator_exist = false;
     bool is_underground_elevator_on = false;
     bool is_underground_elevator_exist = false;
 
-    for( const tripoint &p : here.points_on_zlevel( 0 ) ) {
+    for( const tripoint_bub_ms &p : here.points_on_zlevel( 0 ) ) {
         if( here.ter( p ) == ter_t_elevator_control_off || here.ter( p ) == ter_t_elevator_control ) {
             surface_elevator = p;
             is_surface_elevator_on = here.ter( p ) == ter_t_elevator_control;
             is_surface_elevator_exist = true;
         }
     }
-    for( const tripoint &p : here.points_on_zlevel( -2 ) ) {
+    for( const tripoint_bub_ms &p : here.points_on_zlevel( -2 ) ) {
         if( here.ter( p ) == ter_t_elevator_control_off || here.ter( p ) == ter_t_elevator_control ) {
             underground_elevator = p;
             is_underground_elevator_on = here.ter( p ) == ter_t_elevator_control;
@@ -1586,7 +1586,7 @@ void computer_session::failure_shutdown()
 {
     bool found_tile = false;
     map &here = get_map();
-    for( const tripoint &p : here.points_in_radius( get_player_character().pos(), 1 ) ) {
+    for( const tripoint_bub_ms &p : here.points_in_radius( get_player_character().pos_bub(), 1 ) ) {
         if( here.has_flag( ter_furn_flag::TFLAG_CONSOLE, p ) ) {
             here.furn_set( p, furn_f_console_broken );
             add_msg( m_bad, _( "The console shuts down." ) );
@@ -1596,7 +1596,7 @@ void computer_session::failure_shutdown()
     if( found_tile ) {
         return;
     }
-    for( const tripoint &p : here.points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
         if( here.has_flag( ter_furn_flag::TFLAG_CONSOLE, p ) ) {
             here.furn_set( p, furn_f_console_broken );
             add_msg( m_bad, _( "The console shuts down." ) );
@@ -1653,10 +1653,10 @@ void computer_session::failure_pump_explode()
 {
     add_msg( m_warning, _( "The pump explodes!" ) );
     map &here = get_map();
-    for( const tripoint &p : here.points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
         if( here.ter( p ) == ter_t_sewage_pump ) {
             here.make_rubble( p );
-            explosion_handler::explosion( &get_player_character(), p, 10 );
+            explosion_handler::explosion( &get_player_character(), p.raw(), 10 );
         }
     }
 }
@@ -1665,13 +1665,13 @@ void computer_session::failure_pump_leak()
 {
     add_msg( m_warning, _( "Sewage leaks!" ) );
     map &here = get_map();
-    for( const tripoint &p : here.points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
         if( here.ter( p ) != ter_t_sewage_pump ) {
             continue;
         }
         const int leak_size = rng( 4, 10 );
         for( int i = 0; i < leak_size; i++ ) {
-            std::vector<tripoint> next_move;
+            std::vector<tripoint_bub_ms> next_move;
             if( here.passable( p + point_north ) ) {
                 next_move.push_back( p + point_north );
             }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3421,12 +3421,12 @@ static void kill_area()
         return;
     }
 
-    const tripoint_range<tripoint> points = get_map().points_in_rectangle(
-            first.position.value(), second.position.value() );
+    const tripoint_range<tripoint_bub_ms> points = get_map().points_in_rectangle(
+                tripoint_bub_ms( first.position.value() ), tripoint_bub_ms( second.position.value() ) );
 
     std::vector<Creature *> creatures = g->get_creatures_if(
     [&points]( const Creature & critter ) -> bool {
-        return !critter.is_avatar() && points.is_point_inside( critter.pos() );
+        return !critter.is_avatar() && points.is_point_inside( critter.pos_bub() );
     } );
 
     for( Creature *critter : creatures ) {

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -278,7 +278,7 @@ void monmove()
                            critter.name(),
                            critter.posx(), critter.posy(), critter.posz(), m.tername( critter.pos_bub() ) );
             bool okay = false;
-            for( const tripoint &dest : m.points_in_radius( critter.pos(), 3 ) ) {
+            for( const tripoint_bub_ms &dest : m.points_in_radius( critter.pos_bub(), 3 ) ) {
                 if( critter.can_move_to( dest ) && g->is_empty( dest ) ) {
                     critter.setpos( dest );
                     okay = true;

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -693,8 +693,8 @@ void editmap::draw_main_ui_overlay()
 #endif
             hilights["mapgentgt"].draw( *this, true );
             drawsq_params params = drawsq_params().center( tripoint_bub_ms( SEEX - 1, SEEY - 1, target.z() ) );
-            for( const tripoint &p : tmpmap.points_on_zlevel() ) {
-                tmpmap.drawsq( g->w_terrain, p, params );
+            for( const tripoint_omt_ms &p : tmpmap.points_on_zlevel() ) {
+                tmpmap.drawsq( g->w_terrain, p.raw(), params );
             }
             tmpmap.rebuild_vehicle_level_caches();
 #ifdef TILES

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -426,7 +426,7 @@ static std::vector<tripoint_bub_ms> shrapnel( map *m, const Creature *source,
     // TODO: Calculate range based on max effective range for projectiles.
     // Basically bisect between 0 and map diameter using shrapnel_calc().
     // Need to update shadowcasting to support limiting range without adjusting initial distance.
-    const tripoint_range<tripoint_bub_ms> area = m->bub_points_on_zlevel( src.z() );
+    const tripoint_range<tripoint_bub_ms> area = m->points_on_zlevel( src.z() );
 
     m->build_obstacle_cache( area.min(), area.max() + tripoint_south_east, obstacle_cache );
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2183,9 +2183,9 @@ void basecamp::scan_pseudo_items()
         tinymap expansion_map;
         expansion_map.load( tile, false );
 
-        tripoint mapmin = tripoint( 0, 0, omt_pos.z() );
-        tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_pos.z() );
-        for( const tripoint &pos : expansion_map.points_in_rectangle( mapmin, mapmax ) ) {
+        const tripoint_omt_ms mapmin{ 0, 0, omt_pos.z() };
+        const tripoint_omt_ms mapmax{ 2 * SEEX - 1, 2 * SEEY - 1, omt_pos.z() };
+        for( const tripoint_omt_ms &pos : expansion_map.points_in_rectangle( mapmin, mapmax ) ) {
             if( expansion_map.furn( pos ) != furn_str_id::NULL_ID() &&
                 expansion_map.furn( pos ).obj().crafting_pseudo_item.is_valid() &&
                 expansion_map.furn( pos ).obj().crafting_pseudo_item.obj().has_flag( flag_ALLOWS_REMOTE_USE ) ) {
@@ -3548,10 +3548,10 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
     const auto e_data = expansions.find( dir );
     const tripoint_abs_omt omt_tgt = e_data->second.pos;
 
-    const auto is_dirtmound = []( const tripoint & pos, tinymap & bay1, tinymap & bay2 ) {
+    const auto is_dirtmound = []( const tripoint_omt_ms & pos, tinymap & bay1, tinymap & bay2 ) {
         return ( bay1.ter( pos ) == ter_t_dirtmound ) && ( !bay2.has_furn( pos ) );
     };
-    const auto is_unplowed = []( const tripoint & pos, tinymap & farm_map ) {
+    const auto is_unplowed = []( const tripoint_omt_ms & pos, tinymap & farm_map ) {
         const ter_id &farm_ter = farm_map.ter( pos );
         return farm_ter->has_flag( ter_furn_flag::TFLAG_PLOWABLE );
     };
@@ -3620,7 +3620,7 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
                     }
                 }
                 // Needs to be plowed to match json
-                if( is_dirtmound( pos.raw(), *farm_json, farm_map ) && is_unplowed( pos.raw(), farm_map ) ) {
+                if( is_dirtmound( pos, *farm_json, farm_map ) && is_unplowed( pos, farm_map ) ) {
                     plots_cnt += 1;
                     if( comp ) {
                         farm_map.ter_set( pos, ter_t_dirtmound );
@@ -3629,7 +3629,7 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
                 break;
             }
             case farm_ops::plant:
-                if( is_dirtmound( pos.raw(), farm_map, farm_map ) ) {
+                if( is_dirtmound( pos, farm_map, farm_map ) ) {
                     plots_cnt += 1;
                     if( comp ) {
                         if( seed_inv.empty() ) {
@@ -4503,10 +4503,10 @@ bool basecamp::survey_field_return( const mission_id &miss_id )
     tinymap target;
     target.load( where, false );
     int mismatch_tiles = 0;
-    tripoint mapmin = tripoint( 0, 0, where.z() );
-    tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, where.z() );
+    const tripoint_omt_ms mapmin{ 0, 0, where.z() };
+    const tripoint_omt_ms mapmax = { 2 * SEEX - 1, 2 * SEEY - 1, where.z() };
     const std::unordered_set<ter_str_id> match_terrains = { ter_t_clay, ter_t_dirt, ter_t_dirtmound, ter_t_grass, ter_t_grass_dead, ter_t_grass_golf, ter_t_grass_long, ter_t_grass_tall, ter_t_moss, ter_t_sand };
-    for( const tripoint &p : target.points_in_rectangle( mapmin, mapmax ) ) {
+    for( const tripoint_omt_ms &p : target.points_in_rectangle( mapmin, mapmax ) ) {
         if( match_terrains.find( target.ter( p ).id() ) == match_terrains.end() ) {
             mismatch_tiles++;
         }
@@ -4822,9 +4822,9 @@ int om_harvest_ter( npc &comp, const tripoint_abs_omt &omt_tgt, const ter_id &t,
     target_bay.load( omt_tgt, false );
     int harvested = 0;
     int total = 0;
-    tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
-    tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
-    for( const tripoint &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
+    const tripoint_omt_ms mapmin{ 0, 0, omt_tgt.z() };
+    const tripoint_omt_ms mapmax{ 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() };
+    for( const tripoint_omt_ms &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
         if( target_bay.ter( p ) == t && x_in_y( chance, 100 ) ) {
             total++;
             if( estimate ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5601,12 +5601,12 @@ void game::control_vehicle()
         int num_valid_controls = 0;
         std::optional<tripoint> vehicle_position;
         std::optional<vpart_reference> vehicle_controls;
-        for( const tripoint &elem : m.points_in_radius( get_player_character().pos(), 1 ) ) {
+        for( const tripoint_bub_ms &elem : m.points_in_radius( get_player_character().pos_bub(), 1 ) ) {
             if( const optional_vpart_position vp = m.veh_at( elem ) ) {
                 const std::optional<vpart_reference> controls = vp.value().part_with_feature( "CONTROLS", true );
                 if( controls ) {
                     num_valid_controls++;
-                    vehicle_position = elem;
+                    vehicle_position = elem.raw();
                     vehicle_controls = controls;
                 }
             }
@@ -10836,9 +10836,9 @@ point game::place_player( const tripoint &dest_loc, bool quick )
         if( !critter.has_effect( effect_ridden ) ) {
             if( u.is_mounted() ) {
                 std::vector<tripoint> maybe_valid;
-                for( const tripoint &jk : m.points_in_radius( critter.pos(), 1 ) ) {
+                for( const tripoint_bub_ms &jk : m.points_in_radius( critter.pos_bub(), 1 ) ) {
                     if( is_empty( jk ) ) {
-                        maybe_valid.push_back( jk );
+                        maybe_valid.push_back( jk.raw() );
                     }
                 }
                 bool moved = false;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -792,7 +792,8 @@ static void haul()
     bool hauling = player_character.is_hauling();
     bool autohaul = player_character.is_autohauling();
     std::vector<item_location> &haul_list = player_character.haul_list;
-    std::vector<item_location> haulable_items = get_map().get_haulable_items( player_character.pos() );
+    std::vector<item_location> haulable_items = get_map().get_haulable_items(
+                player_character.pos_bub() );
     int haul_qty = haul_list.size();
     std::string &haul_filter = player_character.hauling_filter;
 

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -221,7 +221,7 @@ static bool get_liquid_target( item &liquid, const item *const source, const int
     } );
     // This handles liquids stored in vehicle parts directly (e.g. tanks).
     std::set<vehicle *> opts;
-    for( const tripoint &e : here.points_in_radius( player_character.pos(), 1 ) ) {
+    for( const tripoint_bub_ms &e : here.points_in_radius( player_character.pos_bub(), 1 ) ) {
         vehicle *veh = veh_pointer_or_null( here.veh_at( e ) );
         if( veh ) {
             vehicle_part_range vpr = veh->get_all_parts();

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2050,9 +2050,9 @@ void iexamine::pedestal_wyrm( Character &you, const tripoint_bub_ms &examp )
 
             // Send in a few wyrms to start things off.
             get_event_bus().send<event_type::awakes_dark_wyrms>();
-            for( const tripoint &p : here.points_on_zlevel() ) {
+            for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
                 if( here.ter( p ) == ter_t_orifice ) {
-                    g->place_critter_around( mon_dark_wyrm, p, 1 );
+                    g->place_critter_around( mon_dark_wyrm, p.raw(), 1 );
                 }
             }
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2180,7 +2180,7 @@ void inventory_selector::add_nearby_items( int radius )
 void inventory_selector::add_remote_map_items( tinymap *remote_map, const tripoint &target )
 {
     map_stack items = remote_map->i_at( target );
-    const std::string name = to_upper_case( remote_map->name( target ) );
+    const std::string name = to_upper_case( remote_map->name( tripoint_omt_ms( target ) ) );
     const item_category map_cat( name, no_translation( name ), translation(), 100 );
     _add_map_items( target, map_cat, items, [target]( item & it ) {
         return item_location( map_cursor( tripoint_bub_ms( target ) ), &it );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -719,18 +719,18 @@ std::optional<int> iuse::fungicide( Character *p, item *, const tripoint & )
         p->remove_effect( effect_spores );
         int spore_count = rng( 1, 6 );
         map &here = get_map();
-        for( const tripoint &dest : here.points_in_radius( p->pos(), 1 ) ) {
+        for( const tripoint_bub_ms &dest : here.points_in_radius( p->pos_bub(), 1 ) ) {
             if( spore_count == 0 ) {
                 break;
             }
-            if( dest == p->pos() ) {
+            if( dest == p->pos_bub() ) {
                 continue;
             }
             if( here.passable( dest ) && x_in_y( spore_count, 8 ) ) {
                 if( monster *const mon_ptr = creatures.creature_at<monster>( dest ) ) {
                     monster &critter = *mon_ptr;
                     if( !critter.type->in_species( species_FUNGUS ) ) {
-                        add_msg_if_player_sees( dest, m_warning, _( "The %s is covered in tiny spores!" ),
+                        add_msg_if_player_sees( dest.raw(), m_warning, _( "The %s is covered in tiny spores!" ),
                                                 critter.name() );
                     }
                     if( !critter.make_fungus() ) {
@@ -1775,9 +1775,9 @@ std::optional<int> iuse::fishing_rod( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
     map &here = get_map();
-    std::optional<tripoint> found;
-    for( const tripoint &pnt : here.points_in_radius( p->pos(), 1 ) ) {
-        if( here.has_flag( ter_furn_flag::TFLAG_FISHABLE, pnt ) && good_fishing_spot( pnt, p ) ) {
+    std::optional<tripoint_bub_ms> found;
+    for( const tripoint_bub_ms &pnt : here.points_in_radius( p->pos_bub(), 1 ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_FISHABLE, pnt ) && good_fishing_spot( pnt.raw(), p ) ) {
             found = pnt;
             break;
         }
@@ -1789,7 +1789,7 @@ std::optional<int> iuse::fishing_rod( Character *p, item *it, const tripoint & )
     p->add_msg_if_player( _( "You cast your line and wait to hook something…" ) );
     p->assign_activity( ACT_FISH, to_moves<int>( 5_hours ), 0, 0, it->tname() );
     p->activity.targets.emplace_back( *p, it );
-    p->activity.coord_set = g->get_fishable_locations( 60, *found );
+    p->activity.coord_set = g->get_fishable_locations( 60, found->raw() );
     return 0;
 }
 
@@ -2257,10 +2257,10 @@ class exosuit_interact
             for( item *i : c.items_with( filter ) ) {
                 candidates.emplace_back( c, i );
             }
-            for( const tripoint &p : here.points_in_radius( c.pos(), PICKUP_RANGE ) ) {
+            for( const tripoint_bub_ms &p : here.points_in_radius( c.pos_bub(), PICKUP_RANGE ) ) {
                 for( item &i : here.i_at( p ) ) {
                     if( filter( i ) ) {
-                        candidates.emplace_back( map_cursor( tripoint_bub_ms( p ) ), &i );
+                        candidates.emplace_back( map_cursor( p ), &i );
                     }
                 }
             }
@@ -3006,7 +3006,7 @@ std::optional<int> iuse::siphon( Character *p, item *, const tripoint & )
 
     vehicle *v = nullptr;
     bool found_more_than_one = false;
-    for( const tripoint &pos : here.points_in_radius( p->pos(), 1 ) ) {
+    for( const tripoint_bub_ms &pos : here.points_in_radius( p->pos_bub(), 1 ) ) {
         const optional_vpart_position vp = here.veh_at( pos );
         if( !vp ) {
             continue;
@@ -7145,7 +7145,7 @@ std::optional<int> iuse::radiocaron( Character *p, item *it, const tripoint & )
 static void sendRadioSignal( Character &p, const flag_id &signal )
 {
     map &here = get_map();
-    for( const tripoint &loc : here.points_in_radius( p.pos(), 60 ) ) {
+    for( const tripoint_bub_ms &loc : here.points_in_radius( p.pos_bub(), 60 ) ) {
         for( item &it : here.i_at( loc ) ) {
             if( it.has_flag( flag_RADIO_ACTIVATION ) && it.has_flag( signal ) ) {
                 sounds::sound( p.pos(), 6, sounds::sound_t::alarm, _( "beep" ), true, "misc", "beep" );
@@ -7172,7 +7172,7 @@ static void sendRadioSignal( Character &p, const flag_id &signal )
                     sounds::sound( p.pos(), 6, sounds::sound_t::alarm, _( "beep" ), true, "misc", "beep" );
                     // Invoke to transform a radio-modded explosive into its active form
                     if( itm->has_flag( flag_RADIO_INVOKE_PROC ) ) {
-                        itm->type->invoke( &p, *itm, loc );
+                        itm->type->invoke( &p, *itm, loc.raw() );
                         item_location itm_loc = item_location( map_cursor( tripoint_bub_ms( loc ) ), itm );
                         here.update_lum( itm_loc, true );
                     }
@@ -7505,7 +7505,7 @@ static bool multicooker_hallu( Character &p )
             } else {
                 p.add_msg_if_player( m_info, _( "You're surrounded by aggressive multi-cookers!" ) );
 
-                for( const tripoint &pn : get_map().points_in_radius( p.pos(), 1 ) ) {
+                for( const tripoint_bub_ms &pn : get_map().points_in_radius( p.pos_bub(), 1 ) ) {
                     if( monster *const m = g->place_critter_at( mon_hallu_multicooker, pn ) ) {
                         m->hallucination = true;
                     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5185,10 +5185,10 @@ std::optional<int> deploy_tent_actor::use( Character *p, item &it, const tripoin
     // We place the center of the structure (radius + 1)
     // spaces away from the player.
     // First check there's enough room.
-    const tripoint center = p->pos() + tripoint( ( radius + 1 ) * direction.x,
-                            ( radius + 1 ) * direction.y, 0 );
+    const tripoint_bub_ms center = p->pos_bub() + tripoint( ( radius + 1 ) * direction.x,
+                                   ( radius + 1 ) * direction.y, 0 );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &dest : here.points_in_radius( center, radius ) ) {
+    for( const tripoint_bub_ms &dest : here.points_in_radius( center, radius ) ) {
         if( const optional_vpart_position vp = here.veh_at( dest ) ) {
             add_msg( m_info, _( "The %s is in the way." ), vp->vehicle().name );
             return std::nullopt;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -201,9 +201,9 @@ bool map::build_vision_transparency_cache( const int zlev )
     memcpy( &vision_transparency_cache, &transparency_cache, sizeof( transparency_cache ) );
 
     Character &player_character = get_player_character();
-    const tripoint p = player_character.pos();
+    const tripoint_bub_ms p = player_character.pos_bub();
 
-    if( p.z != zlev ) {
+    if( p.z() != zlev ) {
         return false;
     }
 
@@ -217,28 +217,28 @@ bool map::build_vision_transparency_cache( const int zlev )
     bool is_prone = player_character.is_prone();
     static move_mode_id previous_move_mode = player_character.current_movement_mode();
 
-    for( const tripoint &loc : points_in_radius( p, 1 ) ) {
+    for( const tripoint_bub_ms &loc : points_in_radius( p, 1 ) ) {
         if( loc == p ) {
             // The tile player is standing on should always be visible
-            vision_transparency_cache[p.x][p.y] = LIGHT_TRANSPARENCY_OPEN_AIR;
+            vision_transparency_cache[p.x()][p.y()] = LIGHT_TRANSPARENCY_OPEN_AIR;
         } else if( ( is_crouching || is_prone || low_profile ) && coverage( loc ) >= 30 ) {
             // If we're crouching or prone behind an obstacle, we can't see past it.
-            if( vision_transparency_cache[loc.x][loc.y] != LIGHT_TRANSPARENCY_SOLID ||
+            if( vision_transparency_cache[loc.x()][loc.y()] != LIGHT_TRANSPARENCY_SOLID ||
                 previous_move_mode != player_character.current_movement_mode() ) {
                 previous_move_mode = player_character.current_movement_mode();
-                vision_transparency_cache[loc.x][loc.y] = LIGHT_TRANSPARENCY_SOLID;
+                vision_transparency_cache[loc.x()][loc.y()] = LIGHT_TRANSPARENCY_SOLID;
                 dirty = true;
             }
         }
     }
 
     // This segment handles blocking vision through TRANSLUCENT flagged terrain.
-    for( const tripoint &loc : points_in_radius( p, MAX_VIEW_DISTANCE ) ) {
+    for( const tripoint_bub_ms &loc : points_in_radius( p, MAX_VIEW_DISTANCE ) ) {
         if( loc == p ) {
             // The tile player is standing on should always be visible
-            vision_transparency_cache[p.x][p.y] = LIGHT_TRANSPARENCY_OPEN_AIR;
+            vision_transparency_cache[p.x()][p.y()] = LIGHT_TRANSPARENCY_OPEN_AIR;
         } else if( map::ter( loc ).obj().has_flag( ter_furn_flag::TFLAG_TRANSLUCENT ) ) {
-            vision_transparency_cache[loc.x][loc.y] = LIGHT_TRANSPARENCY_SOLID;
+            vision_transparency_cache[loc.x()][loc.y()] = LIGHT_TRANSPARENCY_SOLID;
             dirty = true;
         }
     }

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -70,8 +70,8 @@ static std::optional<tripoint> find_valid_teleporters_omt( const tripoint_abs_om
     // an OMT is (2 * SEEX) * (2 * SEEY) in size
     tinymap checker;
     checker.load( omt_pt, true );
-    for( const tripoint_omt_ms &p : checker.omt_points_on_zlevel() ) {
-        if( checker.has_flag_furn( ter_furn_flag::TFLAG_TRANSLOCATOR, p.raw() ) ) {
+    for( const tripoint_omt_ms &p : checker.points_on_zlevel() ) {
+        if( checker.has_flag_furn( ter_furn_flag::TFLAG_TRANSLOCATOR, p ) ) {
             return checker.getglobal( p ).raw();
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3845,8 +3845,8 @@ void map::decay_fields_and_scent( const time_duration &amount )
 point_bub_ms map::random_outdoor_tile() const
 {
     std::vector<point_bub_ms> options;
-    for( const tripoint &p : points_on_zlevel() ) {
-        if( is_outside( tripoint_bub_ms( p.x, p.y, abs_sub.z() ) ) ) {
+    for( const tripoint_bub_ms &p : points_on_zlevel() ) {
+        if( is_outside( { p.xy(), abs_sub.z() } ) ) {
             const point_bub_ms temp{ p.xy() };
             options.emplace_back( temp );
         }
@@ -5063,7 +5063,7 @@ void map::translate( const ter_id &from, const ter_id &to )
                   from.obj().name() );
         return;
     }
-    for( const tripoint &p : points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : points_on_zlevel() ) {
         if( ter( p ) == from ) {
             ter_set( p, to );
         }
@@ -5081,9 +5081,9 @@ void map::translate_radius( const ter_id &from, const ter_id &to, float radi,
     }
 
     const tripoint_abs_omt abs_omt_p = tripoint_abs_omt( ms_to_omt_copy( getglobal( p ).raw() ) );
-    for( const tripoint &t : points_on_zlevel() ) {
+    for( const tripoint_bub_ms &t : points_on_zlevel() ) {
         const tripoint_abs_omt abs_omt_t = tripoint_abs_omt( ms_to_omt_copy( getglobal( t ).raw() ) );
-        const float radiX = trig_dist( p.raw(), t );
+        const float radiX = trig_dist( p, t );
         if( ter( t ) == from ) {
             // within distance, and either no submap limitation or same overmap coords.
             if( radiX <= radi && ( !same_submap || abs_omt_t == abs_omt_p ) ) {
@@ -7495,14 +7495,14 @@ void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
 }
 
 // a check to see if the lower floor needs to be rendered in tiles
-bool map::dont_draw_lower_floor( const tripoint &p ) const
+bool map::dont_draw_lower_floor( const tripoint_bub_ms &p ) const
 {
-    if( !zlevels || p.z <= -OVERMAP_DEPTH ) {
+    if( !zlevels || p.z() <= -OVERMAP_DEPTH ) {
         return true;
     } else if( !inbounds( p ) ) {
         return false;
     } else {
-        return get_cache( p.z ).floor_cache[p.x][p.y];
+        return get_cache( p.z() ).floor_cache[p.x()][p.y()];
     }
 }
 
@@ -7994,7 +7994,7 @@ int map::ledge_coverage( const tripoint_bub_ms &viewer_p, const tripoint_bub_ms 
     tripoint ledge_p = high_p.raw();
     bresenham( tripoint( low_p.xy().raw(), high_p.z() ), high_p.raw(), 0, 0, [this,
     &ledge_p]( const tripoint & new_point ) {
-        if( dont_draw_lower_floor( new_point ) ) {
+        if( dont_draw_lower_floor( tripoint_bub_ms( new_point ) ) ) {
             ledge_p = new_point;
             return false;
         }
@@ -9626,51 +9626,37 @@ bool map::inbounds( const tripoint_abs_omt &p ) const
             p.y() <= map_origin.y() + my_HALF_MAPSIZE;
 }
 
-tripoint_range<tripoint> tinymap::points_on_zlevel() const
-{
-    return map::points_on_zlevel();
-}
-
-tripoint_range<tripoint_omt_ms> tinymap::omt_points_on_zlevel() const
+tripoint_range<tripoint_omt_ms> tinymap::points_on_zlevel() const
 {
 
-    const tripoint_range <tripoint_bub_ms> temp = map::bub_points_on_zlevel();
+    const tripoint_range <tripoint_bub_ms> temp = map::points_on_zlevel();
     return tripoint_range <tripoint_omt_ms>( rebase_omt( temp.min() ), rebase_omt( temp.max() ) );
 }
 
-tripoint_range<tripoint> tinymap::points_on_zlevel( int z ) const
+tripoint_range<tripoint_omt_ms> tinymap::points_on_zlevel( int z ) const
 {
-    return map::points_on_zlevel( z );
-}
-
-tripoint_range<tripoint> tinymap::points_in_rectangle(
-    const tripoint &from, const tripoint &to ) const
-{
-    return map::points_in_rectangle( from, to );
+    const tripoint_range<tripoint_bub_ms> temp = map::points_on_zlevel( z );
+    return tripoint_range <tripoint_omt_ms>( rebase_omt( temp.min() ), rebase_omt( temp.max() ) );
 }
 
 tripoint_range<tripoint_omt_ms> tinymap::points_in_rectangle(
     const tripoint_omt_ms &from, const tripoint_omt_ms &to ) const
 {
-    const tripoint_range<tripoint> preliminary_result = map::points_in_rectangle( from.raw(),
-            to.raw() );
-    return tripoint_range<tripoint_omt_ms>( tripoint_omt_ms( preliminary_result.min() ),
-                                            tripoint_omt_ms( preliminary_result.max() ) );
-}
-
-tripoint_range<tripoint> tinymap::points_in_radius(
-    const tripoint &center, size_t radius, size_t radiusz ) const
-{
-    return map::points_in_radius( center, radius, radiusz );
+    const tripoint_range<tripoint_bub_ms> preliminary_result = map::points_in_rectangle( rebase_bub(
+                from ),
+            rebase_bub( to ) );
+    return tripoint_range<tripoint_omt_ms>( rebase_omt( preliminary_result.min() ),
+                                            rebase_omt( preliminary_result.max() ) );
 }
 
 tripoint_range<tripoint_omt_ms> tinymap::points_in_radius(
     const tripoint_omt_ms &center, size_t radius, size_t radiusz ) const
 {
-    const tripoint_range<tripoint> preliminary_result = map::points_in_radius( center.raw(), radius,
+    const tripoint_range<tripoint_bub_ms> preliminary_result = map::points_in_radius( rebase_bub(
+                center ), radius,
             radiusz );
-    return tripoint_range<tripoint_omt_ms>( tripoint_omt_ms( preliminary_result.min() ),
-                                            tripoint_omt_ms( preliminary_result.max() ) );
+    return tripoint_range<tripoint_omt_ms>( rebase_omt( preliminary_result.min() ),
+                                            rebase_omt( preliminary_result.max() ) );
 }
 
 maptile tinymap::maptile_at( const tripoint_omt_ms &p )
@@ -10731,13 +10717,7 @@ tripoint_range<tripoint_bub_ms> map::points_in_radius(
     return tripoint_range<tripoint_bub_ms>( min, max );
 }
 
-tripoint_range<tripoint> map::points_on_zlevel( const int z ) const
-{
-    const tripoint_range<tripoint_bub_ms> temp = map::bub_points_on_zlevel( z );
-    return tripoint_range<tripoint>( temp.min().raw(), temp.max().raw() );
-}
-
-tripoint_range<tripoint_bub_ms> map::bub_points_on_zlevel( const int z ) const
+tripoint_range<tripoint_bub_ms> map::points_on_zlevel( const int z ) const
 {
     if( z < -OVERMAP_DEPTH || z > OVERMAP_HEIGHT ) {
         // TODO: need a default constructor that creates an empty range.
@@ -10748,43 +10728,38 @@ tripoint_range<tripoint_bub_ms> map::bub_points_on_zlevel( const int z ) const
     { 0, 0, z }, { SEEX * my_MAPSIZE - 1, SEEY * my_MAPSIZE - 1, z } );
 }
 
-tripoint_range<tripoint> map::points_on_zlevel() const
+tripoint_range<tripoint_bub_ms> map::points_on_zlevel() const
 {
     return points_on_zlevel( abs_sub.z() );
-}
-
-tripoint_range<tripoint_bub_ms> map::bub_points_on_zlevel() const
-{
-    return bub_points_on_zlevel( abs_sub.z() );
 
 }
 
 std::list<item_location> map::get_active_items_in_radius(
-    const tripoint &center, int radius )
+    const tripoint_bub_ms &center, int radius )
 {
     return get_active_items_in_radius( center, radius, special_item_type::none );
 }
 
-std::list<item_location> map::get_active_items_in_radius( const tripoint &center, int radius,
+std::list<item_location> map::get_active_items_in_radius( const tripoint_bub_ms &center, int radius,
         special_item_type type )
 {
     std::list<item_location> result;
 
-    const point minp( center.xy() + point( -radius, -radius ) );
-    const point maxp( center.xy() + point( radius, radius ) );
+    const point_bub_ms minp( center.xy() + point( -radius, -radius ) );
+    const point_bub_ms maxp( center.xy() + point( radius, radius ) );
 
-    const point ming( std::max( minp.x / SEEX, 0 ),
-                      std::max( minp.y / SEEY, 0 ) );
-    const point maxg( std::min( maxp.x / SEEX, my_MAPSIZE - 1 ),
-                      std::min( maxp.y / SEEY, my_MAPSIZE - 1 ) );
+    const point_sm_ms ming( std::max( minp.x() / SEEX, 0 ),
+                            std::max( minp.y() / SEEY, 0 ) );
+    const point_sm_ms maxg( std::min( maxp.x() / SEEX, my_MAPSIZE - 1 ),
+                            std::min( maxp.y() / SEEY, my_MAPSIZE - 1 ) );
 
     for( const tripoint_abs_sm &abs_submap_loc : submaps_with_active_items ) {
         const tripoint_rel_sm submap_loc = ( abs_submap_loc - abs_sub.xy() );
-        if( submap_loc.x() < ming.x || submap_loc.y() < ming.y ||
-            submap_loc.x() > maxg.x || submap_loc.y() > maxg.y ) {
+        if( submap_loc.x() < ming.x() || submap_loc.y() < ming.y() ||
+            submap_loc.x() > maxg.x() || submap_loc.y() > maxg.y() ) {
             continue;
         }
-        const point_rel_ms sm_offset( submap_loc.x() * SEEX, submap_loc.y() * SEEY );
+        const point_bub_ms sm_offset( submap_loc.x() * SEEX, submap_loc.y() * SEEY );
 
         submap *sm = get_submap_at_grid( submap_loc );
         if( sm == nullptr ) {
@@ -10795,14 +10770,14 @@ std::list<item_location> map::get_active_items_in_radius( const tripoint &center
         std::vector<item_reference> items = type == special_item_type::none ? sm->active_items.get() :
                                             sm->active_items.get_special( type );
         for( const item_reference &elem : items ) {
-            const tripoint_rel_ms pos( sm_offset + elem.location, submap_loc.z() );
+            const tripoint_bub_ms pos( sm_offset + elem.location, submap_loc.z() );
 
-            if( rl_dist( pos.raw(), center ) > radius ) {
+            if( rl_dist( pos, center ) > radius ) {
                 continue;
             }
 
             if( elem.item_ref ) {
-                result.emplace_back( map_cursor( rebase_bub( pos ) ), elem.item_ref.get() );
+                result.emplace_back( map_cursor( pos ), elem.item_ref.get() );
             }
         }
     }
@@ -10810,13 +10785,13 @@ std::list<item_location> map::get_active_items_in_radius( const tripoint &center
     return result;
 }
 
-std::list<tripoint> map::find_furnitures_with_flag_in_radius( const tripoint &center,
+std::list<tripoint_bub_ms> map::find_furnitures_with_flag_in_radius( const tripoint_bub_ms &center,
         size_t radius,
         const std::string &flag,
         size_t radiusz ) const
 {
-    std::list<tripoint> furn_locs;
-    for( const tripoint &furn_loc : points_in_radius( center, radius, radiusz ) ) {
+    std::list<tripoint_bub_ms> furn_locs;
+    for( const tripoint_bub_ms &furn_loc : points_in_radius( center, radius, radiusz ) ) {
         if( has_flag_furn( flag, furn_loc ) ) {
             furn_locs.push_back( furn_loc );
         }
@@ -10824,13 +10799,13 @@ std::list<tripoint> map::find_furnitures_with_flag_in_radius( const tripoint &ce
     return furn_locs;
 }
 
-std::list<tripoint> map::find_furnitures_with_flag_in_radius( const tripoint &center,
+std::list<tripoint_bub_ms> map::find_furnitures_with_flag_in_radius( const tripoint_bub_ms &center,
         size_t radius,
         const ter_furn_flag flag,
         size_t radiusz ) const
 {
-    std::list<tripoint> furn_locs;
-    for( const tripoint &furn_loc : points_in_radius( center, radius, radiusz ) ) {
+    std::list<tripoint_bub_ms> furn_locs;
+    for( const tripoint_bub_ms &furn_loc : points_in_radius( center, radius, radiusz ) ) {
         if( has_flag_furn( flag, furn_loc ) ) {
             furn_locs.push_back( furn_loc );
         }
@@ -10838,12 +10813,12 @@ std::list<tripoint> map::find_furnitures_with_flag_in_radius( const tripoint &ce
     return furn_locs;
 }
 
-std::list<Creature *> map::get_creatures_in_radius( const tripoint &center, size_t radius,
+std::list<Creature *> map::get_creatures_in_radius( const tripoint_bub_ms &center, size_t radius,
         size_t radiusz ) const
 {
     creature_tracker &creatures = get_creature_tracker();
     std::list<Creature *> creature_list;
-    for( const tripoint &loc : points_in_radius( center, radius, radiusz ) ) {
+    for( const tripoint_bub_ms &loc : points_in_radius( center, radius, radiusz ) ) {
         Creature *tmp_critter = creatures.creature_at( loc );
         if( tmp_critter != nullptr ) {
             creature_list.push_back( tmp_critter );
@@ -11163,20 +11138,20 @@ bool map::has_haulable_items( const tripoint_bub_ms &pos )
 
 std::vector<item_location> map::get_haulable_items( const tripoint &pos )
 {
+    return map::get_haulable_items( tripoint_bub_ms( pos ) );
+}
+
+std::vector<item_location> map::get_haulable_items( const tripoint_bub_ms &pos )
+{
     std::vector<item_location> target_items;
     map_stack items = i_at( pos );
     target_items.reserve( items.size() );
     for( item &it : items ) {
         if( is_haulable( it ) ) {
-            target_items.emplace_back( map_cursor( tripoint_bub_ms( pos ) ), &it );
+            target_items.emplace_back( map_cursor( pos ), &it );
         }
     }
     return target_items;
-}
-
-std::vector<item_location> map::get_haulable_items( const tripoint_bub_ms &pos )
-{
-    return map::get_haulable_items( pos.raw() );
 }
 
 tripoint_bub_ms drawsq_params::center() const

--- a/src/map.h
+++ b/src/map.h
@@ -2610,34 +2610,32 @@ class map
          * Yields a range of all points that are contained in the map and have the z-level of
          * this map (@ref abs_sub).
          */
-        // TODO: Get rid of untyped "overload"
-        tripoint_range<tripoint> points_on_zlevel() const;
-        tripoint_range<tripoint_bub_ms> bub_points_on_zlevel() const;
+        tripoint_range<tripoint_bub_ms> points_on_zlevel() const;
         /// Same as above, but uses the specific z-level. If the given z-level is invalid, it
         /// returns an empty range.
-        /// TODO: Get rid of untyped "overload".
-        tripoint_range<tripoint> points_on_zlevel( int z ) const;
-        tripoint_range<tripoint_bub_ms> bub_points_on_zlevel( int z ) const;
+        tripoint_range<tripoint_bub_ms> points_on_zlevel( int z ) const;
 
-        std::list<item_location> get_active_items_in_radius( const tripoint &center, int radius );
-        std::list<item_location> get_active_items_in_radius( const tripoint &center, int radius,
+        std::list<item_location> get_active_items_in_radius( const tripoint_bub_ms &center, int radius );
+        std::list<item_location> get_active_items_in_radius( const tripoint_bub_ms &center, int radius,
                 special_item_type type );
 
         /**returns positions of furnitures with matching flag in the specified radius*/
-        std::list<tripoint> find_furnitures_with_flag_in_radius( const tripoint &center, size_t radius,
+        std::list<tripoint_bub_ms> find_furnitures_with_flag_in_radius( const tripoint_bub_ms &center,
+                size_t radius,
                 const std::string &flag,
                 size_t radiusz = 0 ) const;
         /**returns positions of furnitures with matching flag in the specified radius*/
-        std::list<tripoint> find_furnitures_with_flag_in_radius( const tripoint &center, size_t radius,
+        std::list<tripoint_bub_ms> find_furnitures_with_flag_in_radius( const tripoint_bub_ms &center,
+                size_t radius,
                 ter_furn_flag flag,
                 size_t radiusz = 0 ) const;
         /**returns creatures in specified radius*/
-        std::list<Creature *> get_creatures_in_radius( const tripoint &center, size_t radius,
+        std::list<Creature *> get_creatures_in_radius( const tripoint_bub_ms &center, size_t radius,
                 size_t radiusz = 0 ) const;
 
         level_cache &access_cache( int zlev );
         const level_cache &access_cache( int zlev ) const;
-        bool dont_draw_lower_floor( const tripoint &p ) const;
+        bool dont_draw_lower_floor( const tripoint_bub_ms &p ) const;
 
         bool has_haulable_items( const tripoint_bub_ms &pos );
         // TODO: Get rid of untyped overload
@@ -2647,8 +2645,8 @@ class map
 #if defined(TILES)
         bool draw_points_cache_dirty = true;
         std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points_cache;
-        point prev_top_left;
-        point prev_bottom_right;
+        point_rel_ms prev_top_left;
+        point_rel_ms prev_bottom_right;
         point prev_o;
         std::multimap<point, formatted_text> overlay_strings_cache;
         color_block_overlay_container color_blocks_cache;
@@ -2669,7 +2667,7 @@ bool generate_uniform_omt( const tripoint_abs_sm &p, const oter_id &terrain_type
 /**
 * Tinymap is a small version of the map which covers a single overmap terrain (OMT) tile,
 * which corresponds to 2 * 2 submaps, or 24 * 24 map tiles. In addition to being smaller
-* than the map, it's also limited to a single Z level (defined the tripoint_abs_omt
+* than the map, it's also limited to a single Z level (defined by the tripoint_abs_omt
 * parameter to the 'load' operation, so it's not tied to the Z = 0 level).
 * The tinymap's natural relative reference system is the tripoint_omt_ms one.
 */
@@ -2681,14 +2679,11 @@ class tinymap : private map
 
         // This operation cannot be used with tinymap due to a lack of zlevel support, but are carried through for use by smallmap.
         void cut_down_tree( tripoint_omt_ms p, point dir ) {
-            map::cut_down_tree( tripoint_bub_ms( p.raw() ), dir );
+            map::cut_down_tree( rebase_bub( p ), dir );
         };
 
     public:
         tinymap() : map( 2, false ) {}
-        bool inbounds( const tripoint &p ) const {
-            return map::inbounds( p );
-        }
         bool inbounds( const tripoint_omt_ms &p ) const {
             return map::inbounds( rebase_bub( p ) );
         }
@@ -2723,30 +2718,22 @@ class tinymap : private map
         }
 
         using map::translate;
+        // TODO: Get rid of untyped overload.
         ter_id ter( const tripoint &p ) const {
-            return map::ter( p );    // TODO: Make it typed
+            return map::ter( tripoint_bub_ms( p ) );
         }
         ter_id ter( const tripoint_omt_ms &p ) const {
-            return map::ter( p.raw() );
+            return map::ter( rebase_bub( p ) );
         }
         // TODO: Get rid of untyped overload.
         bool ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
-            return map::ter_set( p, new_terrain, avoid_creatures );    // TODO: Make it typed
+            return map::ter_set( p, new_terrain, avoid_creatures );
         }
         bool ter_set( const tripoint_omt_ms &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
             return map::ter_set( rebase_bub( p ), new_terrain, avoid_creatures );
         }
-        bool has_flag_ter( ter_furn_flag flag,
-                           const tripoint &p ) const { // TODO: remove when usages converted
-            return map::has_flag_ter( flag, p );
-        }
         bool has_flag_ter( ter_furn_flag flag, const tripoint_omt_ms &p ) const {
-            return map::has_flag_ter( flag, p.raw() );
-        }
-        // TODO: Get rid of untyped overload.
-        void draw_line_ter( const ter_id &type, const point &p1, const point &p2,
-                            bool avoid_creature = false ) {
-            map::draw_line_ter( type, point_bub_ms( p1 ), point_bub_ms( p2 ), avoid_creature );
+            return map::has_flag_ter( flag, rebase_bub( p ) );
         }
         void draw_line_ter( const ter_id &type, const point_omt_ms &p1, const point_omt_ms &p2,
                             bool avoid_creature = false ) {
@@ -2756,18 +2743,15 @@ class tinymap : private map
                                const point_omt_ms &max, direction dir ) const {
             return map::is_last_ter_wall( no_furn, rebase_bub( p ), rebase_bub( max ), dir );
         }
-        // TODO: Get rid of untyped overload.
-        furn_id furn( const point &p ) const {
-            return map::furn( p );
-        }
         furn_id furn( const point_omt_ms &p ) const {
             return map::furn( rebase_bub( p ) );
         }
+        // TODO: Get rid of untyped overload.
         furn_id furn( const tripoint &p ) const {
-            return map::furn( p );    // TODO: Make it typed
+            return map::furn( tripoint_bub_ms( p ) );
         }
         furn_id furn( const tripoint_omt_ms &p ) const {
-            return map::furn( p.raw() );
+            return map::furn( rebase_bub( p ) );
         }
         // TODO: Get rid of untyped overload.
         bool has_furn( const tripoint &p ) const {
@@ -2779,30 +2763,17 @@ class tinymap : private map
         bool has_furn( const point_omt_ms &p ) const {
             return map::has_furn( rebase_bub( p ) );
         }
-        // TODO: Get rid of untyped overload.
-        void set( const tripoint &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
-            map::set( p, new_terrain, new_furniture );
-        }
         void set( const tripoint_omt_ms &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
             map::set( rebase_bub( p ), new_terrain, new_furniture );
-        }
-        bool furn_set( const point &p, const furn_id &new_furniture,
-                       bool avoid_creatures = false ) { // TODO: Make it typed
-            return furn_set( tripoint( p, abs_sub.z() ), new_furniture, false, avoid_creatures );
         }
         // TODO: Get rid of untyped overload.
         bool furn_set( const tripoint &p, const furn_id &new_furniture, bool furn_reset = false,
                        bool avoid_creatures = false ) {
-            return map::furn_set( p, new_furniture, furn_reset, avoid_creatures );
+            return map::furn_set( tripoint_bub_ms( p ), new_furniture, furn_reset, avoid_creatures );
         }
         bool furn_set( const tripoint_omt_ms &p, const furn_id &new_furniture, bool furn_reset = false,
                        bool avoid_creatures = false ) {
             return map::furn_set( rebase_bub( p ), new_furniture, furn_reset, avoid_creatures );
-        }
-        // TODO: Get rid of untyped overload.
-        void draw_line_furn( const furn_id &type, const point &p1, const point &p2,
-                             bool avoid_creatures = false ) {
-            map::draw_line_furn( type, point_bub_ms( p1 ), point_bub_ms( p2 ), avoid_creatures );
         }
         void draw_line_furn( const furn_id &type, const point_omt_ms &p1, const point_omt_ms &p2,
                              bool avoid_creatures = false ) {
@@ -2812,29 +2783,22 @@ class tinymap : private map
                                bool avoid_creatures = false ) {
             map::draw_square_furn( type, rebase_bub( p1 ), rebase_bub( p2 ), avoid_creatures );
         }
-        bool has_flag_furn( ter_furn_flag flag, const tripoint &p ) const {
-            return map::has_flag_furn( flag, p );    // TODO: Make it typed
+        bool has_flag_furn( ter_furn_flag flag, const tripoint_omt_ms &p ) const {
+            return map::has_flag_furn( flag, rebase_bub( p ) );
         }
         computer *add_computer( const tripoint_omt_ms &p, const std::string &name, int security ) {
             return map::add_computer( rebase_bub( p ), name, security );
         }
-        std::string name( const tripoint &p ) {
-            return map::name( p );    // TODO: Make it typed
+        std::string name( const tripoint_omt_ms &p ) {
+            return map::name( rebase_bub( p ) );
         }
-        bool impassable( const tripoint &p ) const {
-            return map::impassable( p );    // TODO: Make it typed
+        bool impassable( const tripoint_omt_ms &p ) const {
+            return map::impassable( rebase_bub( p ) );
         }
-        // TODO: Get rid of untyped overload.
-        tripoint_range<tripoint> points_on_zlevel() const;
-        tripoint_range<tripoint_omt_ms> omt_points_on_zlevel() const;
-        tripoint_range<tripoint> points_on_zlevel( int z ) const; // TODO: Make it typed
-        tripoint_range<tripoint> points_in_rectangle(
-            const tripoint &from, const tripoint &to ) const; // TODO: Make it typed
+        tripoint_range<tripoint_omt_ms> points_on_zlevel() const;
+        tripoint_range<tripoint_omt_ms> points_on_zlevel( int z ) const;
         tripoint_range<tripoint_omt_ms> points_in_rectangle(
             const tripoint_omt_ms &from, const tripoint_omt_ms &to ) const;
-        tripoint_range<tripoint> points_in_radius(
-            const tripoint &center, size_t radius,
-            size_t radiusz = 0 ) const; // TODO: remove when usages converted.
         tripoint_range<tripoint_omt_ms> points_in_radius(
             const tripoint_omt_ms &center, size_t radius, size_t radiusz = 0 ) const;
         // TODO: Get rid of untyped overload.
@@ -2862,12 +2826,13 @@ class tinymap : private map
             map::spawn_item( rebase_bub( p ), type_id, quantity, charges, birthday, damlevel, flags, variant,
                              faction );
         }
-        void spawn_item( const tripoint &p, const std::string &type_id, // TODO: Make it typed
+        void spawn_item( const tripoint_omt_ms &p, const std::string &type_id, // TODO: Make it typed
                          unsigned quantity = 1, int charges = 0,
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
                          const std::set<flag_id> &flags = {}, const std::string &variant = "",
                          const std::string &faction = "" ) {
-            map::spawn_item( p, type_id, quantity, charges, birthday, damlevel, flags, variant, faction );
+            map::spawn_item( rebase_bub( p ), type_id, quantity, charges, birthday, damlevel, flags, variant,
+                             faction );
         }
         std::vector<item *> spawn_items( const tripoint_omt_ms &p, const std::vector<item> &new_items ) {
             return map::spawn_items( rebase_bub( p ), new_items );
@@ -2907,30 +2872,15 @@ class tinymap : private map
         void i_clear( const tripoint_omt_ms &p ) {
             return map::i_clear( rebase_bub( p ) );
         }
-        bool add_field( const tripoint &p, const field_type_id &type_id, int intensity = INT_MAX,
-                        const time_duration &age = 0_turns, bool hit_player = true ) {
-            return map::add_field( tripoint_bub_ms( p ), type_id, intensity, age,
-                                   hit_player ); // TODO: Make it typed
-        }
         bool add_field( const tripoint_omt_ms &p, const field_type_id &type_id, int intensity = INT_MAX,
                         const time_duration &age = 0_turns, bool hit_player = true ) {
             return map::add_field( rebase_bub( p ), type_id, intensity, age, hit_player );
         }
-        void delete_field( const tripoint &p, const field_type_id &field_to_remove ) {
-            return map::delete_field( tripoint_bub_ms( p ), field_to_remove );  // TODO: Make it typed
-        }
         void delete_field( const tripoint_omt_ms &p, const field_type_id &field_to_remove ) {
             return map::delete_field( rebase_bub( p ), field_to_remove );
         }
-        // TODO: Get rid of untyped overload.
-        bool has_flag( ter_furn_flag flag, const tripoint &p ) const {
-            return map::has_flag( flag, p );
-        }
         bool has_flag( ter_furn_flag flag, const tripoint_omt_ms &p ) const {
             return map::has_flag( flag, rebase_bub( p ) );
-        }
-        bool has_flag( ter_furn_flag flag, const point &p ) const { // TODO: Make it typed
-            return map::has_flag( flag, p );
         }
         void destroy( const tripoint_omt_ms &p, bool silent = false ) {
             return map::destroy( rebase_bub( p ), silent );
@@ -2938,15 +2888,11 @@ class tinymap : private map
         const trap &tr_at( const tripoint_omt_ms &p ) const {
             return map::tr_at( rebase_bub( p ) );
         }
-        // TODO: Get rid of untyped overload.
-        void trap_set( const tripoint &p, const trap_id &type ) {
-            map::trap_set( tripoint_bub_ms( p ), type );
-        }
         void trap_set( const tripoint_omt_ms &p, const trap_id &type ) {
             map::trap_set( rebase_bub( p ), type );
         }
         void set_signage( const tripoint_omt_ms &p, const std::string &message ) {
-            map::set_signage( rebase_bub( p ), message );  // TODO: Make it typed
+            map::set_signage( rebase_bub( p ), message );
         }
         void delete_signage( const tripoint_omt_ms &p ) {
             map::delete_signage( rebase_bub( p ) );
@@ -2954,11 +2900,8 @@ class tinymap : private map
         VehicleList get_vehicles() {
             return map::get_vehicles();
         }
-        optional_vpart_position veh_at( const tripoint &p ) const {
-            return map::veh_at( p );    // TODO: Make it typed
-        }
         optional_vpart_position veh_at( const tripoint_omt_ms &p ) const {
-            return map::veh_at( p.raw() );
+            return map::veh_at( rebase_bub( p ) );
         }
         vehicle *add_vehicle( const vproto_id &type, const tripoint_omt_ms &p, const units::angle &dir,
                               int init_veh_fuel = -1, int init_veh_status = -1, bool merge_wrecks = true ) {
@@ -2969,19 +2912,13 @@ class tinymap : private map
                                  const tripoint_omt_ms &to ) {
             return map::add_splatter_trail( type, rebase_bub( from ), rebase_bub( to ) );
         }
-        // TODO: Get rid of untyped overload.
-        void collapse_at( const tripoint &p, bool silent,
-                          bool was_supporting = false,
-                          bool destroy_pos = true ) {
-            map::collapse_at( tripoint_bub_ms( p ), silent, was_supporting, destroy_pos );
-        }
         void collapse_at( const tripoint_omt_ms &p, bool silent,
                           bool was_supporting = false,
                           bool destroy_pos = true ) {
             map::collapse_at( rebase_bub( p ), silent, was_supporting, destroy_pos );
         }
         tripoint_abs_sm get_abs_sub() const {
-            return map::get_abs_sub();    // TODO: Convert to tripoint_abs_omt
+            return map::get_abs_sub();
         }
         tripoint_abs_ms getglobal( const tripoint_omt_ms &p ) const {
             return map::getglobal( rebase_bub( p ) );
@@ -2989,6 +2926,7 @@ class tinymap : private map
         tripoint_omt_ms omt_from_abs( const tripoint_abs_ms &p ) const {
             return rebase_omt( map::bub_from_abs( p ) );
         };
+        // TODO: Get rid of untyped overload.
         bool is_outside( const tripoint &p ) const {
             return map::is_outside( p );
         }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -458,7 +458,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
 
 static void place_trap_if_clear( tinymap &m, const point &target, trap_id trap_type )
 {
-    tripoint tri_target( target, m.get_abs_sub().z() );
+    tripoint_omt_ms tri_target( target.x, target.y, m.get_abs_sub().z() );
     if( m.ter( tri_target ).obj().trap == tr_null ) {
         mtrap_set( &m, target, trap_type );
     }
@@ -504,7 +504,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         line_furn( &m, furn_f_sandbag_half, point( 9, 4 ), point( 9, 7 ) );
 
         //7.62x51mm casings left from m60 of the humvee
-        for( const tripoint &loc : m.points_in_radius( tripoint{ 6, 4, abs_sub.z }, 3, 0 ) ) {
+        for( const tripoint_omt_ms &loc : m.points_in_radius( tripoint_omt_ms{ 6, 4, abs_sub.z }, 3, 0 ) ) {
             if( one_in( 4 ) ) {
                 m.spawn_item( loc, itype_762_51_casing );
             }
@@ -521,7 +521,8 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         line_furn( &m, furn_f_sandbag_half, point( 20, 3 ), point( 20, 6 ) );
 
         //5.56x45mm casings left from a soldier
-        for( const tripoint &loc : m.points_in_radius( tripoint{ 17, 4, abs_sub.z }, 2, 0 ) ) {
+        for( const tripoint_omt_ms &loc : m.points_in_radius( tripoint_omt_ms{ 17, 4, abs_sub.z }, 2,
+                0 ) ) {
             if( one_in( 4 ) ) {
                 m.spawn_item( loc, itype_223_casing );
             }
@@ -537,46 +538,48 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         }
 
         //33% chance to spawn empty magazines used by soldiers
-        std::vector<point> empty_magazines_locations = line_to( point( 15, 5 ), point( 20, 5 ) );
-        for( point &i : empty_magazines_locations ) {
+        std::vector<tripoint_omt_ms> empty_magazines_locations = line_to( tripoint_omt_ms( 15, 5,
+                abs_sub.z ), tripoint_omt_ms( 20, 5, abs_sub.z ) );
+        for( tripoint_omt_ms &i : empty_magazines_locations ) {
             if( one_in( 3 ) ) {
-                m.spawn_item( { i, abs_sub.z }, itype_stanag30 );
+                m.spawn_item( i, itype_stanag30 );
             }
         }
 
         //Horizontal line of barbed wire fence
         line( &m, ter_t_fence_barbed, point( 3, 9 ), point( SEEX * 2 - 4, 9 ) );
 
-        std::vector<point_omt_ms> barbed_wire = line_to( point_omt_ms( 3, 9 ), point_omt_ms( SEEX * 2 - 4,
-                                                9 ) );
-        for( point_omt_ms &i : barbed_wire ) {
+        std::vector<tripoint_omt_ms> barbed_wire = line_to( tripoint_omt_ms( 3, 9, abs_sub.z ),
+                tripoint_omt_ms( SEEX * 2 - 4,
+                                 9, abs_sub.z ) );
+        for( tripoint_omt_ms &i : barbed_wire ) {
             //10% chance to spawn corpses of bloody people/zombies on every tile of barbed wire fence
             if( one_in( 10 ) ) {
-                m.add_corpse( { i, abs_sub.z } );
-                m.add_field( { i, abs_sub.z }, fd_blood, rng( 1, 3 ) );
+                m.add_corpse( i );
+                m.add_field( i, fd_blood, rng( 1, 3 ) );
             }
         }
 
         //Spawn 6-20 mines in the lower submap.
         //Spawn ordinary mine on asphalt, otherwise spawn buried mine
         for( int i = 0; i < num_mines; i++ ) {
-            const point p( rng( 3, SEEX * 2 - 4 ), rng( SEEY, SEEY * 2 - 2 ) );
+            const tripoint_omt_ms p( rng( 3, SEEX * 2 - 4 ), rng( SEEY, SEEY * 2 - 2 ), abs_sub.z );
             if( m.has_flag( ter_furn_flag::TFLAG_DIGGABLE, p ) ) {
-                place_trap_if_clear( m, p, tr_landmine_buried );
+                place_trap_if_clear( m, p.xy().raw(), tr_landmine_buried );
             } else {
-                place_trap_if_clear( m, p, tr_landmine );
+                place_trap_if_clear( m, p.xy().raw(), tr_landmine );
             }
         }
 
         //Spawn 6-20 puddles of blood on tiles without mines
         for( int i = 0; i < num_mines; i++ ) {
-            const point_omt_ms p2( rng( 3, SEEX * 2 - 4 ), rng( SEEY, SEEY * 2 - 2 ) );
-            if( m.tr_at( { p2, abs_sub.z } ).is_null() ) {
-                m.add_field( { p2, abs_sub.z }, fd_blood, rng( 1, 3 ) );
+            const tripoint_omt_ms p2( rng( 3, SEEX * 2 - 4 ), rng( SEEY, SEEY * 2 - 2 ), abs_sub.z );
+            if( m.tr_at( p2 ).is_null() ) {
+                m.add_field( p2, fd_blood, rng( 1, 3 ) );
                 //10% chance to spawn a corpse of dead people/zombie on a tile with blood
                 if( one_in( 10 ) ) {
-                    m.add_corpse( { p2, abs_sub.z } );
-                    for( const tripoint_omt_ms &loc : m.points_in_radius( { p2, abs_sub.z }, 1 ) ) {
+                    m.add_corpse( p2 );
+                    for( const tripoint_omt_ms &loc : m.points_in_radius( p2, 1 ) ) {
                         //50% chance to spawn gibs in every tile around corpse in 1-tile radius
                         if( one_in( 2 ) ) {
                             m.add_field( { loc.xy(), abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
@@ -589,9 +592,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         //Set two warning signs on the last horizontal line of the submap
         const int x = rng( 3, SEEX );
         const int x1 = rng( SEEX + 1, SEEX * 2 - 4 );
-        m.furn_set( point( x, SEEY * 2 - 1 ), furn_f_sign_warning );
+        m.furn_set( tripoint_omt_ms( x, SEEY * 2 - 1, abs_sub.z ), furn_f_sign_warning );
         m.set_signage( { x, SEEY * 2 - 1, abs_sub.z }, text );
-        m.furn_set( point( x1, SEEY * 2 - 1 ), furn_f_sign_warning );
+        m.furn_set( tripoint_omt_ms( x1, SEEY * 2 - 1, abs_sub.z ), furn_f_sign_warning );
         m.set_signage( { x1, SEEY * 2 - 1, abs_sub.z }, text );
 
         did_something = true;
@@ -606,13 +609,14 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         //Section of barbed wire fence
         line( &m, ter_t_fence_barbed, point( 3, 13 ), point( SEEX * 2 - 4, 13 ) );
 
-        std::vector<point_omt_ms> barbed_wire = line_to( point_omt_ms( 3, 13 ), point_omt_ms( SEEX * 2 - 4,
-                                                13 ) );
-        for( point_omt_ms &i : barbed_wire ) {
+        std::vector<tripoint_omt_ms> barbed_wire = line_to( tripoint_omt_ms( 3, 13, abs_sub.z ),
+                tripoint_omt_ms( SEEX * 2 - 4,
+                                 13, abs_sub.z ) );
+        for( tripoint_omt_ms &i : barbed_wire ) {
             //10% chance to spawn corpses of bloody people/zombies on every tile of barbed wire fence
             if( one_in( 10 ) ) {
-                m.add_corpse( { i, abs_sub.z } );
-                m.add_field( { i, abs_sub.z }, fd_blood, rng( 1, 3 ) );
+                m.add_corpse( i );
+                m.add_field( i, fd_blood, rng( 1, 3 ) );
             }
         }
 
@@ -621,7 +625,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         if( one_in( 2 ) ) {
             m.add_splatter_trail( fd_blood, { 9, 15, abs_sub.z }, { 11, 18, abs_sub.z } );
             m.add_splatter_trail( fd_blood, { 11, 18, abs_sub.z }, { 11, 21, abs_sub.z } );
-            for( const tripoint &loc : m.points_in_radius( tripoint{ 11, 21, abs_sub.z }, 1 ) ) {
+            for( const tripoint_omt_ms &loc : m.points_in_radius( tripoint_omt_ms{ 11, 21, abs_sub.z }, 1 ) ) {
                 //50% chance to spawn gibs in every tile around corpse in 1-tile radius
                 if( one_in( 2 ) ) {
                     m.add_field( { loc.xy(), abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
@@ -634,24 +638,27 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         }
 
         //5.56x45mm casings left from a soldier
-        for( const tripoint &loc : m.points_in_radius( tripoint{ 9, 15, abs_sub.z }, 2, 0 ) ) {
+        for( const tripoint_omt_ms &loc : m.points_in_radius( tripoint_omt_ms{ 9, 15, abs_sub.z }, 2,
+                0 ) ) {
             if( one_in( 4 ) ) {
                 m.spawn_item( loc, itype_223_casing );
             }
         }
 
         //5.56x45mm casings left from another soldier
-        for( const tripoint &loc : m.points_in_radius( tripoint{ 15, 15, abs_sub.z }, 2, 0 ) ) {
+        for( const tripoint_omt_ms &loc : m.points_in_radius( tripoint_omt_ms{ 15, 15, abs_sub.z }, 2,
+                0 ) ) {
             if( one_in( 4 ) ) {
                 m.spawn_item( loc, itype_223_casing );
             }
         }
 
         //33% chance to spawn empty magazines used by soldiers
-        std::vector<point> empty_magazines_locations = line_to( point( 5, 16 ), point( 18, 16 ) );
-        for( point &i : empty_magazines_locations ) {
+        std::vector<tripoint_omt_ms> empty_magazines_locations = line_to( tripoint_omt_ms( 5, 16,
+                abs_sub.z ), tripoint_omt_ms( 18, 16, abs_sub.z ) );
+        for( tripoint_omt_ms &i : empty_magazines_locations ) {
             if( one_in( 3 ) ) {
-                m.spawn_item( { i, abs_sub.z }, itype_stanag30 );
+                m.spawn_item( i, itype_stanag30 );
             }
         }
 
@@ -665,26 +672,26 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         //Spawn 6-20 mines in the upper submap.
         //Spawn ordinary mine on asphalt, otherwise spawn buried mine
         for( int i = 0; i < num_mines; i++ ) {
-            const point p3( rng( 3, SEEX * 2 - 4 ), rng( 1, SEEY ) );
+            const tripoint_omt_ms p3( rng( 3, SEEX * 2 - 4 ), rng( 1, SEEY ), abs_sub.z );
             if( m.has_flag( ter_furn_flag::TFLAG_DIGGABLE, p3 ) ) {
-                place_trap_if_clear( m, p3, tr_landmine_buried );
+                place_trap_if_clear( m, p3.xy().raw(), tr_landmine_buried );
             } else {
-                place_trap_if_clear( m, p3, tr_landmine );
+                place_trap_if_clear( m, p3.xy().raw(), tr_landmine );
             }
         }
 
         //Spawn 6-20 puddles of blood on tiles without mines
         for( int i = 0; i < num_mines; i++ ) {
-            const point_omt_ms p4( rng( 3, SEEX * 2 - 4 ), rng( 1, SEEY ) );
-            if( m.tr_at( { p4, abs_sub.z } ).is_null() ) {
-                m.add_field( { p4, abs_sub.z }, fd_blood, rng( 1, 3 ) );
+            const tripoint_omt_ms p4( rng( 3, SEEX * 2 - 4 ), rng( 1, SEEY ), abs_sub.z );
+            if( m.tr_at( p4 ).is_null() ) {
+                m.add_field( p4, fd_blood, rng( 1, 3 ) );
                 //10% chance to spawn a corpse of dead people/zombie on a tile with blood
                 if( one_in( 10 ) ) {
-                    m.add_corpse( { p4, abs_sub.z } );
-                    for( const tripoint_omt_ms &loc : m.points_in_radius( { p4, abs_sub.z }, 1 ) ) {
+                    m.add_corpse( p4 );
+                    for( const tripoint_omt_ms &loc : m.points_in_radius( p4, 1 ) ) {
                         //50% chance to spawn gibs in every tile around corpse in 1-tile radius
                         if( one_in( 2 ) ) {
-                            m.add_field( { loc.xy(), abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
+                            m.add_field( loc, fd_gibs_flesh, rng( 1, 3 ) );
                         }
                     }
                 }
@@ -694,9 +701,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         //Set two warning signs on the first horizontal line of the submap
         const int x = rng( 3, SEEX );
         const int x1 = rng( SEEX + 1, SEEX * 2 - 4 );
-        m.furn_set( point( x, 0 ), furn_f_sign_warning );
+        m.furn_set( tripoint_omt_ms( x, 0, abs_sub.z ), furn_f_sign_warning );
         m.set_signage( { x, 0, abs_sub.z }, text );
-        m.furn_set( point( x1, 0 ), furn_f_sign_warning );
+        m.furn_set( tripoint_omt_ms( x1, 0, abs_sub.z ), furn_f_sign_warning );
         m.set_signage( { x1, 0, abs_sub.z }, text );
 
         did_something = true;
@@ -708,30 +715,31 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         square_furn( &m, furn_f_canvas_wall, point_omt_ms( 0, 3 ), point_omt_ms( 4, 13 ) );
 
         //Add first tent doors
-        m.furn_set( tripoint{ 4, 5, abs_sub.z }, furn_f_canvas_door );
-        m.furn_set( tripoint{ 4, 11, abs_sub.z }, furn_f_canvas_door );
+        m.furn_set( tripoint_omt_ms{ 4, 5, abs_sub.z }, furn_f_canvas_door );
+        m.furn_set( tripoint_omt_ms{ 4, 11, abs_sub.z }, furn_f_canvas_door );
 
         //Fill empty space with groundsheets
         square_furn( &m, furn_f_fema_groundsheet, point_omt_ms( 1, 4 ), point_omt_ms( 3, 12 ) );
 
         //Place makeshift beds in the first tent and place loot
-        m.furn_set( tripoint{ 1, 4, abs_sub.z }, furn_f_makeshift_bed );
+        m.furn_set( tripoint_omt_ms{ 1, 4, abs_sub.z }, furn_f_makeshift_bed );
         m.put_items_from_loc( Item_spawn_data_army_bed, { 1, 4, abs_sub.z } );
-        m.furn_set( tripoint{ 1, 6, abs_sub.z }, furn_f_makeshift_bed );
-        m.furn_set( tripoint{ 1, 8, abs_sub.z }, furn_f_makeshift_bed );
-        m.furn_set( tripoint{ 1, 10, abs_sub.z }, furn_f_makeshift_bed );
+        m.furn_set( tripoint_omt_ms{ 1, 6, abs_sub.z }, furn_f_makeshift_bed );
+        m.furn_set( tripoint_omt_ms{ 1, 8, abs_sub.z }, furn_f_makeshift_bed );
+        m.furn_set( tripoint_omt_ms{ 1, 10, abs_sub.z }, furn_f_makeshift_bed );
         m.put_items_from_loc( Item_spawn_data_army_bed, { 1, 10, abs_sub.z } );
-        m.furn_set( tripoint{ 1, 12, abs_sub.z }, furn_f_makeshift_bed );
+        m.furn_set( tripoint_omt_ms{ 1, 12, abs_sub.z }, furn_f_makeshift_bed );
         m.put_items_from_loc( Item_spawn_data_army_bed, { 1, 12, abs_sub.z } );
 
         //33% chance for a crazy maniac ramming the tent with some unfortunate inside
         if( one_in( 3 ) ) {
             //Blood and gore
-            std::vector<point> blood_track = line_to( point( 1, 6 ), point( 8, 6 ) );
-            for( point &i : blood_track ) {
-                m.add_field( { i, abs_sub.z }, fd_blood, 1 );
+            std::vector<tripoint_omt_ms> blood_track = line_to( tripoint_omt_ms( 1, 6, abs_sub.z ),
+                    tripoint_omt_ms( 8, 6, abs_sub.z ) );
+            for( tripoint_omt_ms &i : blood_track ) {
+                m.add_field( i, fd_blood, 1 );
             }
-            m.add_field( tripoint { 1, 6, abs_sub.z }, fd_gibs_flesh, 1 );
+            m.add_field( tripoint_omt_ms { 1, 6, abs_sub.z }, fd_gibs_flesh, 1 );
 
             //Add the culprit
             m.add_vehicle( vehicle_prototype_car_fbi, tripoint_omt_ms( 7, 7, abs_sub.z ), 0_degrees, 70, 1 );
@@ -754,17 +762,18 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             m.put_items_from_loc( Item_spawn_data_army_bed, { 1, 8, abs_sub.z } );
 
             //5.56x45mm casings left from a soldier
-            for( const tripoint &loc : m.points_in_radius( tripoint{ 9, 8, abs_sub.z }, 2, 0 ) ) {
+            for( const tripoint_omt_ms &loc : m.points_in_radius( tripoint_omt_ms{ 9, 8, abs_sub.z }, 2, 0 ) ) {
                 if( one_in( 4 ) ) {
                     m.spawn_item( loc, itype_223_casing );
                 }
             }
 
             //33% chance to spawn empty magazines used by soldiers
-            std::vector<point> empty_magazines_locations = line_to( point( 9, 3 ), point( 9, 13 ) );
-            for( point &i : empty_magazines_locations ) {
+            std::vector<tripoint_omt_ms> empty_magazines_locations = line_to( tripoint_omt_ms( 9, 3,
+                    abs_sub.z ), tripoint_omt_ms( 9, 13, abs_sub.z ) );
+            for( tripoint_omt_ms &i : empty_magazines_locations ) {
                 if( one_in( 3 ) ) {
-                    m.spawn_item( { i, abs_sub.z }, itype_stanag30 );
+                    m.spawn_item( i, itype_stanag30 );
                 }
             }
             //Intact sandbag barricade
@@ -779,59 +788,62 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         //Place second tent
         square_furn( &m, furn_f_canvas_wall, point_omt_ms( 0, 16 ), point_omt_ms( 4, 20 ) );
         square_furn( &m, furn_f_fema_groundsheet, point_omt_ms( 1, 17 ), point_omt_ms( 3, 19 ) );
-        m.furn_set( tripoint{ 4, 18, abs_sub.z }, furn_f_canvas_door );
+        m.furn_set( tripoint_omt_ms{ 4, 18, abs_sub.z }, furn_f_canvas_door );
 
         //Place desk and chair in the second tent
         line_furn( &m, furn_f_desk, point( 1, 17 ), point( 2, 17 ) );
-        m.furn_set( tripoint{ 1, 18, abs_sub.z }, furn_f_chair );
+        m.furn_set( tripoint_omt_ms{ 1, 18, abs_sub.z }, furn_f_chair );
 
         //5.56x45mm casings left from another soldier
-        for( const tripoint &loc : m.points_in_radius( tripoint{ 9, 18, abs_sub.z }, 2, 0 ) ) {
+        for( const tripoint_omt_ms &loc : m.points_in_radius( tripoint_omt_ms{ 9, 18, abs_sub.z }, 2,
+                0 ) ) {
             if( one_in( 4 ) ) {
                 m.spawn_item( loc, itype_223_casing );
             }
         }
 
         //33% chance to spawn empty magazines used by soldiers
-        std::vector<point> empty_magazines_locations = line_to( point( 9, 16 ), point( 9, 20 ) );
-        for( point &i : empty_magazines_locations ) {
+        std::vector<tripoint_omt_ms> empty_magazines_locations = line_to( tripoint_omt_ms( 9, 16,
+                abs_sub.z ), tripoint_omt_ms( 9, 20, abs_sub.z ) );
+        for( tripoint_omt_ms &i : empty_magazines_locations ) {
             if( one_in( 3 ) ) {
-                m.spawn_item( { i, abs_sub.z }, itype_stanag30 );
+                m.spawn_item( i, itype_stanag30 );
             }
         }
 
-        std::vector<point_omt_ms> barbed_wire = line_to( point_omt_ms( 12, 3 ), point_omt_ms( 12, 20 ) );
-        for( point_omt_ms &i : barbed_wire ) {
+        std::vector<tripoint_omt_ms> barbed_wire = line_to( tripoint_omt_ms( 12, 3, abs_sub.z ),
+                tripoint_omt_ms( 12, 20, abs_sub.z ) );
+        for( tripoint_omt_ms &i : barbed_wire ) {
             //10% chance to spawn corpses of bloody people/zombies on every tile of barbed wire fence
             if( one_in( 10 ) ) {
-                m.add_corpse( { i, abs_sub.z } );
-                m.add_field( { i, abs_sub.z }, fd_blood, rng( 1, 3 ) );
+                m.add_corpse( i );
+                m.add_field( i, fd_blood, rng( 1, 3 ) );
             }
         }
 
         //Spawn 6-20 mines in the rightmost submap.
         //Spawn ordinary mine on asphalt, otherwise spawn buried mine
         for( int i = 0; i < num_mines; i++ ) {
-            const point p5( rng( SEEX + 1, SEEX * 2 - 2 ), rng( 3, SEEY * 2 - 4 ) );
+            const tripoint_omt_ms p5( rng( SEEX + 1, SEEX * 2 - 2 ), rng( 3, SEEY * 2 - 4 ), abs_sub.z );
             if( m.has_flag( ter_furn_flag::TFLAG_DIGGABLE, p5 ) ) {
-                place_trap_if_clear( m, p5, tr_landmine_buried );
+                place_trap_if_clear( m, p5.xy().raw(), tr_landmine_buried );
             } else {
-                place_trap_if_clear( m, p5, tr_landmine );
+                place_trap_if_clear( m, p5.xy().raw(), tr_landmine );
             }
         }
 
         //Spawn 6-20 puddles of blood on tiles without mines
         for( int i = 0; i < num_mines; i++ ) {
-            const point_omt_ms p6( rng( SEEX + 1, SEEX * 2 - 2 ), rng( 3, SEEY * 2 - 4 ) );
-            if( m.tr_at( { p6, abs_sub.z } ).is_null() ) {
-                m.add_field( { p6, abs_sub.z }, fd_blood, rng( 1, 3 ) );
+            const tripoint_omt_ms p6( rng( SEEX + 1, SEEX * 2 - 2 ), rng( 3, SEEY * 2 - 4 ), abs_sub.z );
+            if( m.tr_at( p6 ).is_null() ) {
+                m.add_field( p6, fd_blood, rng( 1, 3 ) );
                 //10% chance to spawn a corpse of dead people/zombie on a tile with blood
                 if( one_in( 10 ) ) {
-                    m.add_corpse( { p6, abs_sub.z } );
-                    for( const tripoint_omt_ms &loc : m.points_in_radius( { p6, abs_sub.z }, 1 ) ) {
+                    m.add_corpse( p6 );
+                    for( const tripoint_omt_ms &loc : m.points_in_radius( p6, 1 ) ) {
                         //50% chance to spawn gibs in every tile around corpse in 1-tile radius
                         if( one_in( 2 ) ) {
-                            m.add_field( { loc.xy(), abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
+                            m.add_field( loc, fd_gibs_flesh, rng( 1, 3 ) );
                         }
                     }
                 }
@@ -841,9 +853,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         //Set two warning signs on the last vertical line of the submap
         const int y = rng( 3, SEEY );
         const int y1 = rng( SEEY + 1, SEEY * 2 - 4 );
-        m.furn_set( point( SEEX * 2 - 1, y ), furn_f_sign_warning );
+        m.furn_set( tripoint_omt_ms( SEEX * 2 - 1, y, abs_sub.z ), furn_f_sign_warning );
         m.set_signage( { SEEX * 2 - 1, y, abs_sub.z }, text );
-        m.furn_set( point( SEEX * 2 - 1, y1 ), furn_f_sign_warning );
+        m.furn_set( tripoint_omt_ms( SEEX * 2 - 1, y1, abs_sub.z ), furn_f_sign_warning );
         m.set_signage( { SEEX * 2 - 1, y1, abs_sub.z }, text );
 
         did_something = true;
@@ -869,33 +881,35 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         }
 
         //5.56x45mm casings left from soldiers
-        for( const tripoint &loc : m.points_in_radius( tripoint{ 15, 5, abs_sub.z }, 2, 0 ) ) {
+        for( const tripoint_omt_ms &loc : m.points_in_radius( tripoint_omt_ms{ 15, 5, abs_sub.z }, 2,
+                0 ) ) {
             if( one_in( 4 ) ) {
                 m.spawn_item( loc, itype_223_casing );
             }
         }
 
         //33% chance to spawn empty magazines used by soldiers
-        std::vector<point> empty_magazines_locations = line_to( point( 15, 2 ), point( 15, 8 ) );
-        for( point &i : empty_magazines_locations ) {
+        std::vector<tripoint_omt_ms> empty_magazines_locations = line_to( tripoint_omt_ms( 15, 2,
+                abs_sub.z ), tripoint_omt_ms( 15, 8, abs_sub.z ) );
+        for( tripoint_omt_ms &i : empty_magazines_locations ) {
             if( one_in( 3 ) ) {
-                m.spawn_item( { i, abs_sub.z }, itype_stanag30 );
+                m.spawn_item( i, itype_stanag30 );
             }
         }
 
         //Add some crates near the truck...
-        m.furn_set( tripoint{ 16, 18, abs_sub.z }, furn_f_crate_c );
-        m.furn_set( tripoint{ 16, 19, abs_sub.z }, furn_f_crate_c );
-        m.furn_set( tripoint{ 17, 18, abs_sub.z }, furn_f_crate_o );
+        m.furn_set( tripoint_omt_ms{ 16, 18, abs_sub.z }, furn_f_crate_c );
+        m.furn_set( tripoint_omt_ms{ 16, 19, abs_sub.z }, furn_f_crate_c );
+        m.furn_set( tripoint_omt_ms{ 17, 18, abs_sub.z }, furn_f_crate_o );
 
         //...and fill them with mines
         m.spawn_item( tripoint_omt_ms{ 16, 18, abs_sub.z }, itype_landmine, rng( 0, 5 ) );
         m.spawn_item( tripoint_omt_ms{ 16, 19, abs_sub.z }, itype_landmine, rng( 0, 5 ) );
 
         // Set some resting place with fire ring, camp chairs, folding table, and benches.
-        m.furn_set( tripoint{ 20, 12, abs_sub.z }, furn_f_crate_o );
-        m.furn_set( tripoint{ 21, 12, abs_sub.z }, furn_f_firering );
-        m.furn_set( tripoint{ 22, 12, abs_sub.z }, furn_f_tourist_table );
+        m.furn_set( tripoint_omt_ms{ 20, 12, abs_sub.z }, furn_f_crate_o );
+        m.furn_set( tripoint_omt_ms{ 21, 12, abs_sub.z }, furn_f_firering );
+        m.furn_set( tripoint_omt_ms{ 22, 12, abs_sub.z }, furn_f_tourist_table );
         line_furn( &m, furn_f_bench, point( 23, 11 ), point( 23, 13 ) );
         line_furn( &m, furn_f_camp_chair, point( 20, 14 ), point( 21, 14 ) );
 
@@ -911,10 +925,10 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             m.put_items_from_loc( Item_spawn_data_mon_zombie_soldier_death_drops,
             { 23, 12, abs_sub.z } );
             m.add_item_or_charges( tripoint_omt_ms{ 23, 12, abs_sub.z }, body );
-            m.add_field( tripoint{ 23, 12, abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
+            m.add_field( tripoint_omt_ms{ 23, 12, abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
 
             //Spawn broken bench and splintered wood
-            m.furn_set( tripoint{ 23, 13, abs_sub.z }, furn_str_id::NULL_ID() );
+            m.furn_set( tripoint_omt_ms{ 23, 13, abs_sub.z }, furn_str_id::NULL_ID() );
             m.spawn_item( tripoint_omt_ms{ 23, 13, abs_sub.z }, itype_splinter, rng( 5, 10 ) );
 
             //Spawn blood
@@ -940,39 +954,39 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         //Place a tent
         square_furn( &m, furn_f_canvas_wall, point_omt_ms( 20, 4 ), point_omt_ms( 23, 7 ) );
         square_furn( &m, furn_f_fema_groundsheet, point_omt_ms( 21, 5 ), point_omt_ms( 22, 6 ) );
-        m.furn_set( tripoint{ 21, 7, abs_sub.z }, furn_f_canvas_door );
+        m.furn_set( tripoint_omt_ms{ 21, 7, abs_sub.z }, furn_f_canvas_door );
 
         //Place beds in a tent
-        m.furn_set( tripoint{ 21, 5, abs_sub.z }, furn_f_makeshift_bed );
+        m.furn_set( tripoint_omt_ms{ 21, 5, abs_sub.z }, furn_f_makeshift_bed );
         m.put_items_from_loc( Item_spawn_data_army_bed, { 21, 5, abs_sub.z },
                               calendar::turn_zero );
-        m.furn_set( tripoint{ 22, 6, abs_sub.z }, furn_f_makeshift_bed );
+        m.furn_set( tripoint_omt_ms{ 22, 6, abs_sub.z }, furn_f_makeshift_bed );
         m.put_items_from_loc( Item_spawn_data_army_bed, { 22, 6, abs_sub.z },
                               calendar::turn_zero );
 
         //Spawn 6-20 mines in the leftmost submap.
         //Spawn ordinary mine on asphalt, otherwise spawn buried mine
         for( int i = 0; i < num_mines; i++ ) {
-            const point p7( rng( 1, SEEX ), rng( 3, SEEY * 2 - 4 ) );
+            const tripoint_omt_ms p7( rng( 1, SEEX ), rng( 3, SEEY * 2 - 4 ), abs_sub.z );
             if( m.has_flag( ter_furn_flag::TFLAG_DIGGABLE, p7 ) ) {
-                place_trap_if_clear( m, p7, tr_landmine_buried );
+                place_trap_if_clear( m, p7.xy().raw(), tr_landmine_buried );
             } else {
-                place_trap_if_clear( m, p7, tr_landmine );
+                place_trap_if_clear( m, p7.xy().raw(), tr_landmine );
             }
         }
 
         //Spawn 6-20 puddles of blood on tiles without mines
         for( int i = 0; i < num_mines; i++ ) {
-            const point_omt_ms p8( rng( 1, SEEX ), rng( 3, SEEY * 2 - 4 ) );
-            if( m.tr_at( { p8, abs_sub.z } ).is_null() ) {
-                m.add_field( { p8, abs_sub.z }, fd_blood, rng( 1, 3 ) );
+            const tripoint_omt_ms p8( rng( 1, SEEX ), rng( 3, SEEY * 2 - 4 ), abs_sub.z );
+            if( m.tr_at( p8 ).is_null() ) {
+                m.add_field( p8, fd_blood, rng( 1, 3 ) );
                 //10% chance to spawn a corpse of dead people/zombie on a tile with blood
                 if( one_in( 10 ) ) {
-                    m.add_corpse( { p8, abs_sub.z } );
-                    for( const tripoint_omt_ms &loc : m.points_in_radius( { p8, abs_sub.z }, 1 ) ) {
+                    m.add_corpse( p8 );
+                    for( const tripoint_omt_ms &loc : m.points_in_radius( p8, 1 ) ) {
                         //50% chance to spawn gibs in every tile around corpse in 1-tile radius
                         if( one_in( 2 ) ) {
-                            m.add_field( { loc.xy(), abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
+                            m.add_field( loc, fd_gibs_flesh, rng( 1, 3 ) );
                         }
                     }
                 }
@@ -982,9 +996,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         //Set two warning signs on the first vertical line of the submap
         const int y = rng( 3, SEEY );
         const int y1 = rng( SEEY + 1, SEEY * 2 - 4 );
-        m.furn_set( point( 0, y ), furn_f_sign_warning );
+        m.furn_set( tripoint_omt_ms( 0, y, abs_sub.z ), furn_f_sign_warning );
         m.set_signage( { 0, y, abs_sub.z }, text );
-        m.furn_set( point( 0, y1 ), furn_f_sign_warning );
+        m.furn_set( tripoint_omt_ms( 0, y1, abs_sub.z ), furn_f_sign_warning );
         m.set_signage( { 0, y1, abs_sub.z }, text );
 
         did_something = true;
@@ -1519,9 +1533,9 @@ static bool mx_reed( map &m, const tripoint &abs_sub )
     // to one_in(4) = 1/4 of terrain;
     int intensity = rng( 1, 4 );
 
-    const auto near_water = [ &m ]( tripoint loc ) {
+    const auto near_water = [ &m ]( tripoint_bub_ms loc ) {
 
-        for( const tripoint &p : m.points_in_radius( loc, 1 ) ) {
+        for( const tripoint_bub_ms &p : m.points_in_radius( loc, 1 ) ) {
             if( p == loc ) {
                 continue;
             }
@@ -1540,7 +1554,7 @@ static bool mx_reed( map &m, const tripoint &abs_sub )
     vegetation.add( furn_f_lilypad, 1 );
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
-            const tripoint loc( i, j, abs_sub.z );
+            const tripoint_bub_ms loc( i, j, abs_sub.z );
             const ter_id &ter_loc = m.ter( loc );
             if( ( ter_loc == ter_t_water_sh || ter_loc == ter_t_water_moving_sh ) &&
                 one_in( intensity ) ) {

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -2263,7 +2263,7 @@ void mremove_fields( map *m, const tripoint_bub_ms &p )
 
 void resolve_regional_terrain_and_furniture( const mapgendata &dat )
 {
-    for( const tripoint &p : dat.m.points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : dat.m.points_on_zlevel() ) {
         const ter_id tid_before = dat.m.ter( p );
         const ter_id tid_after = dat.region.region_terrain_and_furniture.resolve( tid_before );
         if( tid_after != tid_before ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1671,8 +1671,8 @@ bool Character::valid_aoe_technique( Creature &t, const ma_technique &technique,
     }
 
     if( targets.empty() && technique.aoe == "spin" ) {
-        for( const tripoint &tmp : get_map().points_in_radius( pos(), 1 ) ) {
-            if( tmp == t.pos() ) {
+        for( const tripoint_bub_ms &tmp : get_map().points_in_radius( pos_bub(), 1 ) ) {
+            if( tmp == t.pos_bub() ) {
                 continue;
             }
             monster *const mon = creatures.creature_at<monster>( tmp );

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1581,7 +1581,7 @@ void talk_function::field_plant( npc &p, const std::string &place )
                                       player_character.global_omt_location(), place, 20, false );
     tinymap bay;
     bay.load( site, false );
-    for( const tripoint &plot : bay.points_on_zlevel() ) {
+    for( const tripoint_omt_ms &plot : bay.points_on_zlevel() ) {
         if( bay.ter( plot ) == ter_t_dirtmound ) {
             empty_plots++;
         }
@@ -1621,7 +1621,7 @@ void talk_function::field_plant( npc &p, const std::string &place )
     player_character.use_amount( itype_FMCNote, limiting_number );
 
     //Plant the actual seeds
-    for( const tripoint_omt_ms &plot : bay.omt_points_on_zlevel() ) {
+    for( const tripoint_omt_ms &plot : bay.points_on_zlevel() ) {
         if( bay.ter( plot ) == ter_t_dirtmound && limiting_number > 0 ) {
             std::list<item> used_seed;
             if( item::count_by_charges( seed_id ) ) {
@@ -1653,7 +1653,7 @@ void talk_function::field_harvest( npc &p, const std::string &place )
     std::vector<itype_id> plant_types;
     std::vector<std::string> plant_names;
     bay.load( site, false );
-    for( const tripoint &plot : bay.points_on_zlevel() ) {
+    for( const tripoint_omt_ms &plot : bay.points_on_zlevel() ) {
         map_stack items = bay.i_at( plot );
         if( bay.furn( plot ) == furn_f_plant_harvest && !items.empty() ) {
             // Can't use item_stack::only_item() since there might be fertilizer
@@ -1700,7 +1700,7 @@ void talk_function::field_harvest( npc &p, const std::string &place )
         skillLevel += 2;
     }
 
-    for( const tripoint &plot : bay.points_on_zlevel() ) {
+    for( const tripoint_omt_ms &plot : bay.points_on_zlevel() ) {
         if( bay.furn( plot ) == furn_f_plant_harvest ) {
             // Can't use item_stack::only_item() since there might be fertilizer
             map_stack items = bay.i_at( plot );
@@ -2798,7 +2798,7 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
     bay.load( site, false );
     creature_tracker &creatures = get_creature_tracker();
     std::set<item> return_items;
-    for( const tripoint_omt_ms &p : bay.omt_points_on_zlevel() ) {
+    for( const tripoint_omt_ms &p : bay.points_on_zlevel() ) {
         const ter_id t = bay.ter( p );
         //Open all the doors, doesn't need to be exhaustive
         const std::unordered_set<ter_str_id> openable_doors = {ter_t_door_c, ter_t_door_c_peep, ter_t_door_b, ter_t_door_boarded, ter_t_door_boarded_damaged, ter_t_rdoor_boarded, ter_t_rdoor_boarded_damaged, ter_t_door_boarded_peep, ter_t_door_boarded_damaged_peep };

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -97,7 +97,7 @@ static tripoint_omt_ms find_potential_computer_point( const tinymap &compmap )
     std::vector<tripoint_omt_ms> broken;
     std::vector<tripoint_omt_ms> potential;
     std::vector<tripoint_omt_ms> last_resort;
-    for( const tripoint_omt_ms &p : compmap.omt_points_on_zlevel() ) {
+    for( const tripoint_omt_ms &p : compmap.points_on_zlevel() ) {
         if( compmap.furn( p ) == furn_f_console_broken ) {
             broken.emplace_back( p );
         } else if( broken.empty() && compmap.ter( p ) == ter_t_floor &&
@@ -221,10 +221,10 @@ void mission_start::place_deposit_box( mission *miss )
 
     tinymap compmap;
     compmap.load( site, false );
-    std::vector<tripoint> valid;
-    for( const tripoint &p : compmap.points_on_zlevel() ) {
+    std::vector<tripoint_omt_ms> valid;
+    for( const tripoint_omt_ms &p : compmap.points_on_zlevel() ) {
         if( compmap.ter( p ) == ter_t_floor ) {
-            for( const tripoint &p2 : compmap.points_in_radius( p, 1 ) ) {
+            for( const tripoint_omt_ms &p2 : compmap.points_in_radius( p, 1 ) ) {
                 if( compmap.ter( p2 ) == ter_t_wall_metal ) {
                     valid.push_back( p );
                     break;
@@ -232,8 +232,8 @@ void mission_start::place_deposit_box( mission *miss )
             }
         }
     }
-    const tripoint fallback( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), site.z() );
-    const tripoint comppoint = random_entry( valid, fallback );
+    const tripoint_omt_ms fallback( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), site.z() );
+    const tripoint_omt_ms comppoint = random_entry( valid, fallback );
     compmap.spawn_item( comppoint, "safe_box" );
     compmap.save();
 }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -515,9 +515,9 @@ bool mattack::eat_food( monster *z )
 bool mattack::eat_carrion( monster *z )
 {
     map &here = get_map();
-    for( const tripoint &p : here.points_in_radius( z->pos(), 1 ) ) {
+    for( const tripoint_bub_ms &p : here.points_in_radius( z->pos_bub(), 1 ) ) {
         // Don't snap up food RIGHT under the player's nose.
-        if( rl_dist( get_player_character().pos(), p ) <= 2 ) {
+        if( rl_dist( get_player_character().pos_bub(), p ) <= 2 ) {
             continue;
         }
         map_stack items = here.i_at( p );
@@ -544,9 +544,9 @@ bool mattack::graze( monster *z )
 {
     map &here = get_map();
     //Grazers eat grass and entire plants or bushes. Toxic/inedible plants can be blacklisted with GRAZER_INEDIBLE.
-    for( const tripoint &p : here.points_in_radius( z->pos(), 1 ) ) {
+    for( const tripoint_bub_ms &p : here.points_in_radius( z->pos_bub(), 1 ) ) {
         //Don't eat grass right next to the player.
-        if( z->friendly && rl_dist( get_player_character().pos(), p ) <= 2 ) {
+        if( z->friendly && rl_dist( get_player_character().pos_bub(), p ) <= 2 ) {
             continue;
         }
         if( here.has_flag( ter_furn_flag::TFLAG_FLOWER, p ) &&
@@ -580,9 +580,9 @@ bool mattack::browse( monster *z )
 {
     map &here = get_map();
     //Browsers eat fruit/nuts/etc off of seasonally harvestable plants and trees.
-    for( const tripoint &p : here.points_in_radius( z->pos(), 1 ) ) {
+    for( const tripoint_bub_ms &p : here.points_in_radius( z->pos_bub(), 1 ) ) {
         // Don't forage for food if the player is right there.
-        if( z->friendly && rl_dist( get_player_character().pos(), p ) <= 2 ) {
+        if( z->friendly && rl_dist( get_player_character().pos_bub(), p ) <= 2 ) {
             continue;
         }
         if( here.has_flag( ter_furn_flag::TFLAG_BROWSABLE, p ) && ( z->amount_eaten <= z->stomach_size ) ) {
@@ -1102,7 +1102,7 @@ bool mattack::resurrect( monster *z )
         sees_and_is_empty_cache[T] = here.sees( z->pos(), T, -1 ) && g->is_empty( T );
         return sees_and_is_empty_cache[T];
     };
-    for( item_location &location : here.get_active_items_in_radius( z->pos(), range,
+    for( item_location &location : here.get_active_items_in_radius( z->pos_bub(), range,
             special_item_type::corpse ) ) {
         const tripoint_bub_ms &p = location.pos_bub();
         item &i = *location;
@@ -1356,7 +1356,7 @@ bool mattack::growplants( monster *z )
 {
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &p : here.points_in_radius( z->pos(), 3 ) ) {
+    for( const tripoint_bub_ms &p : here.points_in_radius( z->pos_bub(), 3 ) ) {
 
         // Only affect natural, dirtlike terrain or trees.
         if( !( here.has_flag_ter( ter_furn_flag::TFLAG_DIGGABLE, p ) ||
@@ -1410,7 +1410,7 @@ bool mattack::growplants( monster *z )
     if( !one_in( 5 ) ) {
         return true;
     }
-    for( const tripoint &p : here.points_in_radius( z->pos(), 5 ) ) {
+    for( const tripoint_bub_ms &p : here.points_in_radius( z->pos_bub(), 5 ) ) {
         const ter_id ter = here.ter( p );
         if( ter != ter_t_tree_young && ter != ter_t_underbrush ) {
             // Skip as soon as possible to avoid all the checks
@@ -1488,7 +1488,7 @@ bool mattack::vine( monster *z )
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
     z->mod_moves( -to_moves<int>( 1_seconds ) );
-    for( const tripoint &dest : here.points_in_radius( z->pos(), 1 ) ) {
+    for( const tripoint_bub_ms &dest : here.points_in_radius( z->pos_bub(), 1 ) ) {
         Creature *critter = creatures.creature_at( dest );
         if( critter != nullptr && z->attitude_to( *critter ) == Creature::Attitude::HOSTILE ) {
             if( critter->uncanny_dodge() ) {
@@ -1580,7 +1580,7 @@ bool mattack::triffid_heartbeat( monster *z )
     if( rl_dist( z->pos_bub(), player_character.pos_bub() ) > 5 &&
         !here.route( player_character.pos_bub(), z->pos_bub(), root_pathfind ).empty() ) {
         add_msg( m_warning, _( "The root walls creak around you." ) );
-        for( const tripoint &dest : here.points_in_radius( z->pos(), 3 ) ) {
+        for( const tripoint_bub_ms &dest : here.points_in_radius( z->pos_bub(), 3 ) ) {
             if( g->is_empty( dest ) && one_in( 4 ) ) {
                 here.ter_set( dest, ter_t_root_wall );
             } else if( here.ter( dest ) == ter_t_root_wall && one_in( 10 ) ) {
@@ -1884,8 +1884,8 @@ bool mattack::fungus_sprout( monster *z )
     // To avoid map shift weirdness
     bool push_player = false;
     Character &player_character = get_player_character();
-    for( const tripoint &dest : get_map().points_in_radius( z->pos(), 1 ) ) {
-        if( player_character.pos() == dest ) {
+    for( const tripoint_bub_ms &dest : get_map().points_in_radius( z->pos_bub(), 1 ) ) {
+        if( player_character.pos_bub() == dest ) {
             push_player = true;
         }
         if( monster *const wall = g->place_critter_at( mon_fungal_wall, dest ) ) {
@@ -1956,8 +1956,8 @@ bool mattack::fungus_fortify( monster *z )
 
     bool fortified = false;
     bool push_player = false; // To avoid map shift weirdness
-    for( const tripoint &dest : here.points_in_radius( z->pos(), 1 ) ) {
-        if( player_character.pos() == dest ) {
+    for( const tripoint_bub_ms &dest : here.points_in_radius( z->pos_bub(), 1 ) ) {
+        if( player_character.pos_bub() == dest ) {
             push_player = true;
         }
         if( monster *const wall = g->place_critter_at( mon_fungal_hedgerow, dest ) ) {
@@ -2418,7 +2418,7 @@ bool mattack::nurse_check_up( monster *z )
     Character *target = nullptr;
     tripoint tmp_pos( z->pos() + point( 12, 12 ) );
     map &here = get_map();
-    for( Creature *critter : here.get_creatures_in_radius( z->pos(), 6 ) ) {
+    for( Creature *critter : here.get_creatures_in_radius( z->pos_bub(), 6 ) ) {
         Character *tmp_player = dynamic_cast<Character *>( critter );
         if( tmp_player != nullptr && z->sees( *tmp_player ) &&
             here.clear_path( z->pos(), tmp_player->pos(), 10, 0,
@@ -2470,7 +2470,7 @@ bool mattack::nurse_assist( monster *z )
     Character *target = nullptr;
     map &here = get_map();
     tripoint tmp_pos( z->pos() + point( 12, 12 ) );
-    for( Creature *critter : here.get_creatures_in_radius( z->pos(), 6 ) ) {
+    for( Creature *critter : here.get_creatures_in_radius( z->pos_bub(), 6 ) ) {
         Character *tmp_player = dynamic_cast<Character *>( critter );
         // No need to scan players we can't reach
         if( tmp_player != nullptr && z->sees( *tmp_player ) &&
@@ -2525,7 +2525,7 @@ bool mattack::nurse_operate( monster *z )
     Character *target = nullptr;
     map &here = get_map();
     tripoint tmp_pos( z->pos() + point( 12, 12 ) );
-    for( Creature *critter : here.get_creatures_in_radius( z->pos(), 6 ) ) {
+    for( Creature *critter : here.get_creatures_in_radius( z->pos_bub(), 6 ) ) {
         Character *tmp_player = dynamic_cast< Character *>( critter );
         // No need to scan players we can't reach
         if( tmp_player != nullptr && z->sees( *tmp_player ) &&
@@ -2554,8 +2554,8 @@ bool mattack::nurse_operate( monster *z )
 
         z->friendly = 0;
         z->anger = 100;
-        std::list<tripoint> couch_pos = here.find_furnitures_with_flag_in_radius( z->pos(), 10,
-                                        ter_furn_flag::TFLAG_AUTODOC_COUCH );
+        std::list<tripoint_bub_ms> couch_pos = here.find_furnitures_with_flag_in_radius( z->pos_bub(), 10,
+                                               ter_furn_flag::TFLAG_AUTODOC_COUCH );
 
         if( couch_pos.empty() ) {
             add_msg( m_info, _( "The %s looks for something but doesn't seem to find it." ), z->name() );
@@ -2567,7 +2567,7 @@ bool mattack::nurse_operate( monster *z )
 
         // Check if target is already grabbed by something else
         if( target->has_effect( effect_grabbed ) ) {
-            for( Creature *critter : here.get_creatures_in_radius( target->pos(), 1 ) ) {
+            for( Creature *critter : here.get_creatures_in_radius( target->pos_bub(), 1 ) ) {
                 monster *mon = dynamic_cast<monster *>( critter );
                 if( mon != nullptr && mon != z ) {
                     if( mon->type->id != mon_nursebot_defective ) {
@@ -2858,19 +2858,19 @@ bool mattack::searchlight( monster *z )
             settings.set_var( "SL_PREFER_RIGHT", "TRUE" );
             settings.set_var( "SL_PREFER_LEFT", "TRUE" );
 
-            for( const tripoint &dest : here.points_in_radius( z->pos(), 24 ) ) {
+            for( const tripoint_bub_ms &dest : here.points_in_radius( z->pos_bub(), 24 ) ) {
                 const monster *const mon = creatures.creature_at<monster>( dest );
                 if( mon && mon->type->id == mon_turret_searchlight ) {
-                    if( dest.x < zpos.x() ) {
+                    if( dest.x() < zpos.x() ) {
                         settings.set_var( "SL_PREFER_LEFT", "FALSE" );
                     }
-                    if( dest.x > zpos.x() ) {
+                    if( dest.x() > zpos.x() ) {
                         settings.set_var( "SL_PREFER_RIGHT", "FALSE" );
                     }
-                    if( dest.y < zpos.y() ) {
+                    if( dest.y() < zpos.y() ) {
                         settings.set_var( "SL_PREFER_UP", "FALSE" );
                     }
-                    if( dest.y > zpos.y() ) {
+                    if( dest.y() > zpos.y() ) {
                         settings.set_var( "SL_PREFER_DOWN", "FALSE" );
                     }
                 }
@@ -3199,7 +3199,7 @@ bool mattack::breathe( monster *z )
     bool able = z->type->id == hub_type;
     creature_tracker &creatures = get_creature_tracker();
     if( !able ) {
-        for( const tripoint &dest : get_map().points_in_radius( z->pos(), spawn_radius ) ) {
+        for( const tripoint_bub_ms &dest : get_map().points_in_radius( z->pos_bub(), spawn_radius ) ) {
             monster *const mon = creatures.creature_at<monster>( dest );
             if( mon && mon->type->id == hub_type ) {
                 able = true;
@@ -4606,7 +4606,7 @@ bool mattack::zombie_fuse( monster *z )
 {
     monster *critter = nullptr;
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &p : get_map().points_in_radius( z->pos(), 1 ) ) {
+    for( const tripoint_bub_ms &p : get_map().points_in_radius( z->pos_bub(), 1 ) ) {
         critter = creatures.creature_at<monster>( p );
         if( critter != nullptr && critter->faction == z->faction
             && critter != z && critter->get_size() <= z->get_size() ) {
@@ -4649,11 +4649,11 @@ bool mattack::doot( monster *z )
     z->mod_moves( -to_moves<int>( 3_seconds ) );
     add_msg_if_player_sees( *z, _( "The %s doots its trumpet!" ), z->name() );
     int spooks = 0;
-    for( const tripoint &spookyscary : get_map().points_in_radius( z->pos(), 2 ) ) {
+    for( const tripoint_bub_ms &spookyscary : get_map().points_in_radius( z->pos_bub(), 2 ) ) {
         if( !g->is_empty( spookyscary ) ) {
             continue;
         }
-        const int dist = rl_dist( z->pos(), spookyscary );
+        const int dist = rl_dist( z->pos_bub(), spookyscary );
         if( ( one_in( dist + 3 ) || spooks == 0 ) && spooks < 5 ) {
             add_msg_if_player_sees( spookyscary, _( "A spooky skeleton rises from the ground!" ) );
             g->place_critter_at( mon_zombie_skeltal_minion, spookyscary );

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -149,12 +149,12 @@ item_location mdeath::splatter( monster &z )
 
     map &here = get_map();
     if( gibbable ) {
-        const auto area = here.points_in_radius( z.pos(), 1 );
+        const tripoint_range<tripoint_bub_ms> area = here.points_in_radius( z.pos_bub(), 1 );
         int number_of_gibs = std::min( std::floor( corpse_damage ) - 1, 1 + max_hp / 5.0f );
 
         if( z.type->size >= creature_size::medium ) {
             number_of_gibs += rng( 1, 6 );
-            sfx::play_variant_sound( "mon_death", "zombie_gibbed", sfx::get_heard_volume( z.pos() ) );
+            sfx::play_variant_sound( "mon_death", "zombie_gibbed", sfx::get_heard_volume( z.pos_bub() ) );
         }
 
         for( int i = 0; i < number_of_gibs; ++i ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2456,11 +2456,11 @@ bool monster::move_effects( bool )
         // Pretty hacky, but monsters have no stats
         map &here = get_map();
         creature_tracker &creatures = get_creature_tracker();
-        const tripoint_range<tripoint> &surrounding = here.points_in_radius( pos(), 1, 0 );
+        const tripoint_range<tripoint_bub_ms> &surrounding = here.points_in_radius( pos_bub(), 1, 0 );
         for( const effect &grab : get_effects_with_flag( json_flag_GRAB ) ) {
             // Is our grabber around?
             monster *grabber = nullptr;
-            for( const tripoint loc : surrounding ) {
+            for( const tripoint_bub_ms loc : surrounding ) {
                 monster *mon = creatures.creature_at<monster>( loc );
                 if( mon && mon->has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
                     add_msg_debug( debugmode::DF_MATTACK, "Grabber %s found", mon->name() );
@@ -2786,7 +2786,7 @@ void monster::process_turn()
     // Persist grabs as long as there's an adjacent target.
     if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
         bool remove = true;
-        for( const tripoint &dest : here.points_in_radius( pos(), 1, 0 ) ) {
+        for( const tripoint_bub_ms &dest : here.points_in_radius( pos_bub(), 1, 0 ) ) {
             const Creature *const you = creatures.creature_at<Creature>( dest );
             if( you && you->has_effect_with_flag( json_flag_GRAB ) ) {
                 add_msg_debug( debugmode::DF_MATTACK, "Grabbed creature %s found, persisting grab.",
@@ -2896,14 +2896,14 @@ void monster::die( Creature *nkiller )
     creature_tracker &creatures = get_creature_tracker();
     if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
         // Need to filter out which limb we were grabbing before death
-        for( const tripoint &player_pos : here.points_in_radius( pos(), 1, 0 ) ) {
+        for( const tripoint_bub_ms &player_pos : here.points_in_radius( pos_bub(), 1, 0 ) ) {
             Creature *you = creatures.creature_at( player_pos );
             if( !you || !you->has_effect_with_flag( json_flag_GRAB ) ) {
                 continue;
             }
             // ...but if there are no grabbers around we can just skip to the end
             bool grabbed = false;
-            for( const tripoint &mon_pos : here.points_in_radius( player_pos, 1, 0 ) ) {
+            for( const tripoint_bub_ms &mon_pos : here.points_in_radius( player_pos, 1, 0 ) ) {
                 const monster *const mon = creatures.creature_at<monster>( mon_pos );
                 // No persisting our grabs from beyond the grave, but we also don't get to remove the effect early
                 if( mon && mon->has_effect_with_flag( json_flag_GRAB_FILTER ) && mon != this ) {
@@ -3429,7 +3429,7 @@ void monster::process_effects()
     if( has_flag( mon_flag_CORNERED_FIGHTER ) ) {
         map &here = get_map();
         creature_tracker &creatures = get_creature_tracker();
-        for( const tripoint &p : here.points_in_radius( pos(), 2 ) ) {
+        for( const tripoint_bub_ms &p : here.points_in_radius( pos_bub(), 2 ) ) {
             const monster *const mon = creatures.creature_at<monster>( p );
             const Character *const guy = creatures.creature_at<Character>( p );
             if( mon && mon != this && mon->faction->attitude( faction ) != MFA_FRIENDLY &&

--- a/src/monster_oracle.cpp
+++ b/src/monster_oracle.cpp
@@ -66,7 +66,7 @@ status_t monster_oracle_t::items_available( const std::string_view ) const
         }
         // case 4: no whitelist specified (it is approved for everything) but a blacklist specified
         if( !absorb_material.empty() && !no_absorb_material.empty() ) {
-            for( item &it : get_map().i_at( subject->pos() ) ) {
+            for( item &it : get_map().i_at( subject->pos_bub() ) ) {
                 for( const material_type *mat_type : it.made_of_types() ) {
                     if( !( std::find( no_absorb_material.begin(), no_absorb_material.end(),
                                       mat_type->id ) != no_absorb_material.end() ) ) {
@@ -86,7 +86,7 @@ status_t monster_oracle_t::items_available( const std::string_view ) const
 // TODO: Have it select a target and stash it somewhere.
 status_t monster_oracle_t::adjacent_plants( const std::string_view ) const
 {
-    for( const tripoint &p : get_map().points_in_radius( subject->pos(), 1 ) ) {
+    for( const tripoint_bub_ms &p : get_map().points_in_radius( subject->pos_bub(), 1 ) ) {
         if( get_map().has_flag( ter_furn_flag::TFLAG_PLANT, p ) ) {
             return status_t::running;
         }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -915,7 +915,7 @@ void Character::activate_mutation( const trait_id &mut )
         }        // Check for adjacent trees.
         bool adjacent_tree = false;
         map &here = get_map();
-        for( const tripoint &p2 : here.points_in_radius( pos(), 1 ) ) {
+        for( const tripoint_bub_ms &p2 : here.points_in_radius( pos_bub(), 1 ) ) {
             if( here.has_flag( ter_furn_flag::TFLAG_TREE, p2 ) ) {
                 adjacent_tree = true;
             }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2474,8 +2474,8 @@ void npc::npc_dismount()
                        disp_name() );
         return;
     }
-    std::optional<tripoint> pnt;
-    for( const tripoint &elem : get_map().points_in_radius( pos(), 1 ) ) {
+    std::optional<tripoint_bub_ms> pnt;
+    for( const tripoint_bub_ms &elem : get_map().points_in_radius( pos_bub(), 1 ) ) {
         if( g->is_empty( elem ) ) {
             pnt = elem;
             break;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -428,7 +428,7 @@ std::vector<sphere> npc::find_dangerous_explosives() const
 {
     std::vector<sphere> result;
 
-    const auto active_items = get_map().get_active_items_in_radius( pos(), MAX_VIEW_DISTANCE,
+    const auto active_items = get_map().get_active_items_in_radius( pos_bub(), MAX_VIEW_DISTANCE,
                               special_item_type::explosive );
 
     for( const item_location &elem : active_items ) {
@@ -3938,7 +3938,7 @@ bool npc::find_corpse_to_pulp()
 
     if( corpse == nullptr ) {
         // If we're following the player, don't wander off to pulp corpses
-        const tripoint around = is_walking_with() ? player_character.pos() : pos();
+        const tripoint_bub_ms around = is_walking_with() ? player_character.pos_bub() : pos_bub();
         for( const item_location &location : here.get_active_items_in_radius( around, range,
                 special_item_type::corpse ) ) {
             corpse = check_tile( location.pos_bub() );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -810,7 +810,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     std::unordered_set<tripoint_abs_omt> &revealed_highlights = get_avatar().map_revealed_omts;
     const bool viewing_weather = uistate.overmap_debug_weather || uistate.overmap_visible_weather;
     const bool draw_overlays = blink || fast_traveling;
-    o = origin.raw().xy();
+    o = origin.xy().raw();
 
     const auto global_omt_to_draw_position = []( const tripoint_abs_omt & omp ) {
         // z position is hardcoded to 0 because the things this will be used to draw should not be skipped

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -248,7 +248,8 @@ void start_location::prepare_map( tinymap &m ) const
     const int z = m.get_abs_sub().z();
     if( flags().count( "BOARDED" ) > 0 ) {
         m.build_outside_cache( z );
-        board_up( m, m.points_on_zlevel( z ) );
+        const tripoint_range <tripoint_omt_ms> temp = m.points_on_zlevel( z );
+        board_up( m, { temp.min().raw(), temp.max().raw() } );
     } else {
         m.translate( ter_t_window_domestic, ter_t_curtains );
     }
@@ -527,12 +528,12 @@ void start_location::burn( const tripoint_abs_omt &omtstart, const size_t count,
     m.build_outside_cache( m.get_abs_sub().z() );
     point player_pos = get_player_character().pos().xy();
     const point u( player_pos.x % HALF_MAPSIZE_X, player_pos.y % HALF_MAPSIZE_Y );
-    std::vector<tripoint> valid;
-    for( const tripoint &p : m.points_on_zlevel() ) {
+    std::vector<tripoint_omt_ms> valid;
+    for( const tripoint_omt_ms &p : m.points_on_zlevel() ) {
         if( !( m.has_flag_ter( ter_furn_flag::TFLAG_DOOR, p ) ||
                m.has_flag_ter( ter_furn_flag::TFLAG_OPENCLOSE_INSIDE, p ) ||
                m.is_outside( p ) ||
-               ( p.x >= u.x - rad && p.x <= u.x + rad && p.y >= u.y - rad && p.y <= u.y + rad ) ) ) {
+               ( p.x() >= u.x - rad && p.x() <= u.x + rad && p.y() >= u.y - rad && p.y() <= u.y + rad ) ) ) {
             if( m.has_flag( ter_furn_flag::TFLAG_FLAMMABLE, p ) ||
                 m.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH, p ) ) {
                 valid.push_back( p );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -333,7 +333,7 @@ void suffer::while_grabbed( Character &you )
     creature_tracker &creatures = get_creature_tracker();
     int crowd = 0;
     int impassable_ter = 0;
-    for( auto&& dest : here.points_in_radius( you.pos(), 1, 0 ) ) { // *NOPAD*
+    for( auto&& dest : here.points_in_radius( you.pos_bub(), 1, 0 ) ) { // *NOPAD*
         const monster *const mon = creatures.creature_at<monster>( dest );
         if( mon && mon->has_flag( mon_flag_GROUP_BASH ) ) {
             crowd++;

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -118,9 +118,9 @@ void timed_event::actualize()
                 pgettext( "memorial_female", "Drew the attention of more dark wyrms!" ) );
 
             // 50% chance to spawn a dark wyrm near every orifice on the level.
-            for( const tripoint &p : here.points_on_zlevel() ) {
+            for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
                 if( here.ter( p ) == ter_id( "t_orifice" ) ) {
-                    g->place_critter_around( mon_dark_wyrm, p, 1 );
+                    g->place_critter_around( mon_dark_wyrm, p.raw(), 1 );
                 }
             }
 
@@ -141,9 +141,9 @@ void timed_event::actualize()
         case timed_event_type::AMIGARA: {
             get_event_bus().send<event_type::angers_amigara_horrors>();
             int num_horrors = rng( 3, 5 );
-            std::optional<tripoint> fault_point;
+            std::optional<tripoint_bub_ms> fault_point;
             bool horizontal = false;
-            for( const tripoint &p : here.points_on_zlevel() ) {
+            for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
                 if( here.ter( p ) == ter_t_fault ) {
                     fault_point = p;
                     horizontal = here.ter( p + tripoint_east ) == ter_t_fault ||
@@ -153,20 +153,20 @@ void timed_event::actualize()
             }
             for( int i = 0; fault_point && i < num_horrors; i++ ) {
                 for( int tries = 0; tries < 10; ++tries ) {
-                    tripoint monp = player_character.pos();
+                    tripoint_bub_ms monp = player_character.pos_bub();
                     if( horizontal ) {
-                        monp.x = rng( fault_point->x, fault_point->x + 2 * SEEX - 8 );
+                        monp.x() = rng( fault_point->x(), fault_point->x() + 2 * SEEX - 8 );
                         for( int n = -1; n <= 1; n++ ) {
-                            if( here.ter( point( monp.x, fault_point->y + n ) ) == ter_t_rock_floor ) {
-                                monp.y = fault_point->y + n;
+                            if( here.ter( point_bub_ms( monp.x(), fault_point->y() + n ) ) == ter_t_rock_floor ) {
+                                monp.y() = fault_point->y() + n;
                             }
                         }
                     } else {
                         // Vertical fault
-                        monp.y = rng( fault_point->y, fault_point->y + 2 * SEEY - 8 );
+                        monp.y() = rng( fault_point->y(), fault_point->y() + 2 * SEEY - 8 );
                         for( int n = -1; n <= 1; n++ ) {
-                            if( here.ter( point( fault_point->x + n, monp.y ) ) == ter_t_rock_floor ) {
-                                monp.x = fault_point->x + n;
+                            if( here.ter( point_bub_ms( fault_point->x() + n, monp.y() ) ) == ter_t_rock_floor ) {
+                                monp.x() = fault_point->x() + n;
                             }
                         }
                     }
@@ -180,7 +180,7 @@ void timed_event::actualize()
 
         case timed_event_type::ROOTS_DIE:
             get_event_bus().send<event_type::destroys_triffid_grove>();
-            for( const tripoint_bub_ms &p : here.bub_points_on_zlevel() ) {
+            for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
                 if( here.ter( p ) == ter_t_root_wall && one_in( 3 ) ) {
                     here.ter_set( p, ter_t_underbrush );
                 }
@@ -190,7 +190,7 @@ void timed_event::actualize()
         case timed_event_type::TEMPLE_OPEN: {
             get_event_bus().send<event_type::opens_temple>();
             bool saw_grate = false;
-            for( const tripoint_bub_ms &p : here.bub_points_on_zlevel() ) {
+            for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
                 if( here.ter( p ) == ter_t_grate ) {
                     here.ter_set( p, ter_t_stairs_down );
                     if( !saw_grate && player_character.sees( p ) ) {
@@ -208,10 +208,10 @@ void timed_event::actualize()
             bool flooded = false;
 
             cata::mdarray<ter_id, point_bub_ms> flood_buf;
-            for( const tripoint_bub_ms &p : here.bub_points_on_zlevel() ) {
+            for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
                 flood_buf[p.x()][p.y()] = here.ter( p );
             }
-            for( const tripoint_bub_ms &p : here.bub_points_on_zlevel() ) {
+            for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
                 if( here.ter( p ) == ter_t_water_sh ) {
                     bool deepen = false;
                     for( const tripoint_bub_ms &w : points_in_radius( p, 1 ) ) {
@@ -260,8 +260,8 @@ void timed_event::actualize()
                 }
             }
             // flood_buf is filled with correct tiles; now copy them back to here
-            for( const tripoint &p : here.points_on_zlevel() ) {
-                here.ter_set( p, flood_buf[p.x][p.y] );
+            for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
+                here.ter_set( p, flood_buf[p.x()][p.y()] );
             }
             get_timed_events().add( timed_event_type::TEMPLE_FLOOD,
                                     calendar::turn + rng( 2_turns, 3_turns ) );
@@ -347,7 +347,7 @@ void timed_event::per_turn()
 
         case timed_event_type::AMIGARA_WHISPERS: {
             bool faults = false;
-            for( const tripoint &p : here.points_on_zlevel() ) {
+            for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
                 if( here.ter( p ) == ter_t_fault ) {
                     faults = true;
                     break;

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1208,8 +1208,8 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
         return false;
     }
 
-    std::vector<tripoint> safe;
-    for( const tripoint &tmp : here.points_in_radius( you.pos(), 1 ) ) {
+    std::vector<tripoint_bub_ms> safe;
+    for( const tripoint_bub_ms &tmp : here.points_in_radius( you.pos_bub(), 1 ) ) {
         if( here.passable( tmp ) && here.tr_at( tmp ) != tr_pit ) {
             safe.push_back( tmp );
         }
@@ -1294,18 +1294,17 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
     map &here = get_map();
 
     int height = 0;
-    tripoint where = p;
-    tripoint below = where;
-    below.z--;
+    tripoint_bub_ms where( p );
+    tripoint_bub_ms below( where + tripoint_below );
     creature_tracker &creatures = get_creature_tracker();
     while( here.valid_move( where, below, false, true ) ) {
-        where.z--;
+        where.z()--;
         if( get_creature_tracker().creature_at( where ) != nullptr ) {
-            where.z++;
+            where.z()++;
             break;
         }
 
-        below.z--;
+        below.z()--;
         height++;
     }
 
@@ -1316,8 +1315,8 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
             return false;
         }
 
-        std::vector<tripoint> valid;
-        for( const tripoint &pt : here.points_in_radius( below, 1 ) ) {
+        std::vector<tripoint_bub_ms> valid;
+        for( const tripoint_bub_ms &pt : here.points_in_radius( below, 1 ) ) {
             if( g->is_empty( pt ) ) {
                 valid.push_back( pt );
             }
@@ -1331,7 +1330,7 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
         }
 
         height++;
-        where.z--;
+        where.z()--;
     } else if( height == 0 ) {
         return false;
     }
@@ -1349,7 +1348,7 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
         if( c->has_effect( effect_strengthened_gravity ) ) {
             height += 1;
         }
-        c->impact( height * 10, where );
+        c->impact( height * 10, where.raw() );
         return true;
     }
 
@@ -1393,11 +1392,11 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
         } else {
             you->add_msg_if_player( m_bad,
                                     _( "You attempt to break the fall with your %s but it is out of fuel!" ), jetpack.tname() );
-            you->impact( height * 30, where );
+            you->impact( height * 30, where.raw() );
 
         }
     } else {
-        you->impact( height * 30, where );
+        you->impact( height * 30, where.raw() );
     }
 
     if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, where ) ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -751,12 +751,12 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
         empty = false;
         // Coordinates of where part will go due to movement (dx/dy/dz)
         //  and turning (precalc[1])
-        const tripoint dsp = vp.next_pos.raw();
-        veh_collision coll = part_collision( p, dsp, just_detect, bash_floor );
+        const tripoint_bub_ms dsp = vp.next_pos;
+        veh_collision coll = part_collision( p, dsp.raw(), just_detect, bash_floor );
         if( coll.type == veh_coll_nothing && info.has_flag( VPFLAG_ROTOR ) ) {
             size_t radius = static_cast<size_t>( std::round( info.rotor_info->rotor_diameter / 2.0f ) );
-            for( const tripoint &rotor_point : here.points_in_radius( dsp, radius ) ) {
-                veh_collision rotor_coll = part_collision( p, rotor_point, just_detect, false );
+            for( const tripoint_bub_ms &rotor_point : here.points_in_radius( dsp, radius ) ) {
+                veh_collision rotor_coll = part_collision( p, rotor_point.raw(), just_detect, false );
                 if( rotor_coll.type != veh_coll_nothing ) {
                     coll = rotor_coll;
                     if( just_detect ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1117,16 +1117,15 @@ void vehicle::operate_scoop()
                 _( "Whirrrr" ), _( "Ker-chunk" ), _( "Swish" ), _( "Cugugugugug" )
             }
         };
-        sounds::sound( global_part_pos3( scoop ), rng( 20, 35 ), sounds::sound_t::combat,
+        sounds::sound( bub_part_pos( scoop ), rng( 20, 35 ), sounds::sound_t::combat,
                        random_entry_ref( sound_msgs ), false, "vehicle", "scoop" );
-        std::vector<tripoint> parts_points;
-        for( const tripoint &current :
-             here.points_in_radius( global_part_pos3( scoop ), 1 ) ) {
+        std::vector<tripoint_bub_ms> parts_points;
+        for( const tripoint_bub_ms &current :
+             here.points_in_radius( bub_part_pos( scoop ), 1 ) ) {
             parts_points.push_back( current );
         }
-        for( const tripoint &position : parts_points ) {
-            // TODO: fix point types
-            here.mop_spills( tripoint_bub_ms( position ) );
+        for( const tripoint_bub_ms &position : parts_points ) {
+            here.mop_spills( position );
             if( !here.has_items( position ) ) {
                 continue;
             }

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -30,7 +30,7 @@ static int count_fields( const field_type_str_id &field_type )
 {
     map &m = get_map();
     int live_fields = 0;
-    for( const tripoint_bub_ms &cursor : m.bub_points_on_zlevel() ) {
+    for( const tripoint_bub_ms &cursor : m.points_on_zlevel() ) {
         field_entry *entry = m.get_field( cursor, field_type );
         if( entry && entry->is_field_alive() ) {
             live_fields++;
@@ -47,7 +47,7 @@ TEST_CASE( "acid_field_expiry_on_map", "[field]" )
     clear_map();
     map &m = get_map();
     // place a smoke field
-    for( const tripoint_bub_ms &cursor : m.bub_points_on_zlevel() ) {
+    for( const tripoint_bub_ms &cursor : m.points_on_zlevel() ) {
         m.add_field( cursor, field_fd_acid, 1 );
     }
     REQUIRE( count_fields( field_fd_acid ) == 17424 );

--- a/tests/ground_destroy_test.cpp
+++ b/tests/ground_destroy_test.cpp
@@ -23,11 +23,11 @@ TEST_CASE( "pavement_destroy", "[.]" )
     clear_map_and_put_player_underground();
     map &here = get_map();
     // Populate the map with pavement.
-    here.ter_set( tripoint_zero, ter_id( "t_pavement" ) );
+    here.ter_set( tripoint_bub_ms_zero, ter_id( "t_pavement" ) );
 
     // Destroy it
-    here.destroy( tripoint_zero, true );
-    ter_id after_destroy = here.ter( tripoint_zero );
+    here.destroy( tripoint_bub_ms_zero, true );
+    ter_id after_destroy = here.ter( tripoint_bub_ms_zero );
     if( after_destroy == flat_roof_id ) {
         FAIL( flat_roof_id.obj().name() << " found after destroying pavement" );
     } else {
@@ -53,7 +53,7 @@ TEST_CASE( "explosion_on_ground", "[.]" )
     // Populate map with various test terrain.
     for( int x = 0; x < area_dim; x++ ) {
         for( int y = 0; y < area_dim; y++ ) {
-            here.ter_set( tripoint( x, y, 0 ), test_terrain_id[idx] );
+            here.ter_set( tripoint_bub_ms( x, y, 0 ), test_terrain_id[idx] );
             idx = ( idx + 1 ) % test_terrain_id.size();
         }
     }
@@ -61,15 +61,15 @@ TEST_CASE( "explosion_on_ground", "[.]" )
     itype_id rdx_keg_typeid( "tool_rdx_charge_act" );
     REQUIRE( item::type_is_defined( rdx_keg_typeid ) );
 
-    const tripoint area_center( area_dim / 2, area_dim / 2, 0 );
+    const tripoint_bub_ms area_center( area_dim / 2, area_dim / 2, 0 );
     item rdx_keg( rdx_keg_typeid );
     rdx_keg.charges = 0;
-    rdx_keg.type->invoke( &get_avatar(), rdx_keg, area_center );
+    rdx_keg.type->invoke( &get_avatar(), rdx_keg, area_center.raw() );
 
     // Check area to see if any t_flat_roof is present.
     for( int x = 0; x < area_dim; x++ ) {
         for( int y = 0; y < area_dim; y++ ) {
-            tripoint pt( x, y, 0 );
+            tripoint_bub_ms pt( x, y, 0 );
             ter_id t_id = here.ter( pt );
             if( t_id == flat_roof_id ) {
                 FAIL( "After explosion, " << t_id.obj().name() << " found at " << x << "," << y );
@@ -99,24 +99,24 @@ TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
     const int area_dim = 24;
     for( int x = 0; x < area_dim; x++ ) {
         for( int y = 0; y < area_dim; y++ ) {
-            here.ter_set( tripoint( x, y, 0 ), floor_id );
-            here.ter_set( tripoint( x, y, -1 ), rock_floor_id );
+            here.ter_set( tripoint_bub_ms( x, y, 0 ), floor_id );
+            here.ter_set( tripoint_bub_ms( x, y, -1 ), rock_floor_id );
         }
     }
     // Detonate an RDX keg item in the middle of the populated map space
     itype_id rdx_keg_typeid( "tool_rdx_charge_act" );
     REQUIRE( item::type_is_defined( rdx_keg_typeid ) );
 
-    const tripoint area_center( area_dim / 2, area_dim / 2, 0 );
+    const tripoint_bub_ms area_center( area_dim / 2, area_dim / 2, 0 );
     item rdx_keg( rdx_keg_typeid );
     rdx_keg.charges = 0;
-    rdx_keg.type->invoke( &get_avatar(), rdx_keg, area_center );
+    rdx_keg.type->invoke( &get_avatar(), rdx_keg, area_center.raw() );
 
     // Check z0 for open air
     bool found_open_air = false;
     for( int x = 0; x < area_dim; x++ ) {
         for( int y = 0; y < area_dim; y++ ) {
-            tripoint pt( x, y, 0 );
+            tripoint_bub_ms pt( x, y, 0 );
             ter_id t_id = here.ter( pt );
             INFO( "t " << t_id.obj().name() << " at " << x << "," << y );
             if( t_id == open_air_id ) {
@@ -154,15 +154,15 @@ TEST_CASE( "collapse_checks", "[.]" )
 
     map &here = get_map();
     // build a structure
-    const tripoint &midair = tripoint( tripoint_zero.xy(), tripoint_zero.z + 1 );
-    for( const tripoint &pt : here.points_in_radius( midair, wall_size, 1 ) ) {
+    const tripoint_bub_ms &midair{ tripoint_bub_ms_zero + tripoint_above };
+    for( const tripoint_bub_ms &pt : here.points_in_radius( midair, wall_size, 1 ) ) {
         here.ter_set( pt, floor_id );
     }
-    std::set<tripoint> corners;
+    std::set<tripoint_bub_ms> corners;
     for( int delta_z = 0; delta_z < 3; delta_z++ ) {
         for( int delta_x = 0; delta_x <= 1; delta_x++ ) {
             for( int delta_y = 0; delta_y <= 1; delta_y++ ) {
-                const tripoint pt( delta_x * wall_size, delta_y * wall_size, delta_z );
+                const tripoint_bub_ms pt( delta_x * wall_size, delta_y * wall_size, delta_z );
                 corners.insert( pt );
                 here.ter_set( pt, wall_id );
             }
@@ -170,7 +170,7 @@ TEST_CASE( "collapse_checks", "[.]" )
     }
 
     // make sure it's a valid structure
-    for( const tripoint &pt : here.points_in_radius( midair, wall_size, 1 ) ) {
+    for( const tripoint_bub_ms &pt : here.points_in_radius( midair, wall_size, 1 ) ) {
         if( corners.find( pt ) != corners.end() ) {
             REQUIRE( here.ter( pt ) == wall_id );
         } else {
@@ -179,12 +179,12 @@ TEST_CASE( "collapse_checks", "[.]" )
     }
 
     // destroy the floor on the first floor; floor above should not collapse
-    for( const tripoint &pt : here.points_in_radius( tripoint_zero, wall_size ) ) {
+    for( const tripoint_bub_ms &pt : here.points_in_radius( tripoint_bub_ms_zero, wall_size ) ) {
         if( corners.find( pt ) == corners.end() ) {
             here.destroy( pt, true );
         }
     }
-    for( const tripoint &pt : here.points_in_radius( midair, wall_size ) ) {
+    for( const tripoint_bub_ms &pt : here.points_in_radius( midair, wall_size ) ) {
         if( corners.find( pt ) != corners.end() ) {
             CHECK( here.ter( pt ) == wall_id );
         } else {
@@ -195,15 +195,15 @@ TEST_CASE( "collapse_checks", "[.]" )
     // destroy the walls on the first floor; upper floors should mostly collapse
     for( int delta_x = 0; delta_x <= 1; delta_x++ ) {
         for( int delta_y = 0; delta_y <= 1; delta_y++ ) {
-            const tripoint pt( delta_x * wall_size, delta_y * wall_size, 0 );
+            const tripoint_bub_ms pt( delta_x * wall_size, delta_y * wall_size, 0 );
             here.destroy( pt, true );
         }
     }
     int open_air_count = 0;
     int tile_count = 0;
     int no_wall_count = 0;
-    for( const tripoint &pt : here.points_in_radius( midair, wall_size, 1 ) ) {
-        if( pt.z == 0 ) {
+    for( const tripoint_bub_ms &pt : here.points_in_radius( midair, wall_size, 1 ) ) {
+        if( pt.z() == 0 ) {
             continue;
         }
         const ter_id t_id = here.ter( pt );

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -183,19 +183,19 @@ void build_water_test_map( const ter_id &surface, const ter_id &mid, const ter_i
     clear_map( z_bottom - 1, z_surface + 1 );
 
     map &here = get_map();
-    const tripoint p1( 0, 0, z_bottom - 1 );
-    const tripoint p2( MAPSIZE * SEEX, MAPSIZE * SEEY, z_surface + 1 );
-    for( const tripoint &p : here.points_in_rectangle( p1, p2 ) ) {
+    const tripoint_bub_ms p1( 0, 0, z_bottom - 1 );
+    const tripoint_bub_ms p2( MAPSIZE * SEEX, MAPSIZE * SEEY, z_surface + 1 );
+    for( const tripoint_bub_ms &p : here.points_in_rectangle( p1, p2 ) ) {
 
-        if( p.z == z_surface ) {
+        if( p.z() == z_surface ) {
             here.ter_set( p, surface );
-        } else if( p.z < z_surface && p.z > z_bottom ) {
+        } else if( p.z() < z_surface && p.z() > z_bottom ) {
             here.ter_set( p, mid );
-        } else if( p.z == z_bottom ) {
+        } else if( p.z() == z_bottom ) {
             here.ter_set( p, bottom );
-        } else if( p.z < z_bottom ) {
+        } else if( p.z() < z_bottom ) {
             here.ter_set( p, ter_t_rock );
-        } else if( p.z > z_surface ) {
+        } else if( p.z() > z_surface ) {
             here.ter_set( p, ter_t_open_air );
         }
     }

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -126,9 +126,9 @@ TEST_CASE( "tinymap_bounds_checking" )
                 if( x < 0 || x >= SEEX * 2 ||
                     y < 0 || y >= SEEY * 2 ||
                     z < -OVERMAP_DEPTH || z > OVERMAP_HEIGHT ) {
-                    CHECK( !m.ter( tripoint{ x, y, z } ) );
+                    CHECK( !m.ter( tripoint_omt_ms{ x, y, z } ) );
                 } else {
-                    CHECK( m.ter( tripoint{ x, y, z } ) );
+                    CHECK( m.ter( tripoint_omt_ms{ x, y, z } ) );
                 }
             }
         }

--- a/tests/mongroup_test.cpp
+++ b/tests/mongroup_test.cpp
@@ -284,12 +284,12 @@ static void test_multi_spawn( const mtype_id &old_mon, int range, int min, int m
         clear_map();
         map &m = get_map();
         calendar::turn = start;
-        const tripoint ground_zero = get_player_character().pos() - tripoint( 5, 5, 0 );
+        const tripoint_bub_ms ground_zero = get_player_character().pos_bub() - tripoint( 5, 5, 0 );
 
         monster *orig = g->place_critter_at( old_mon, ground_zero );
         REQUIRE( orig );
         REQUIRE( orig->type->id == old_mon );
-        REQUIRE( orig->pos() == ground_zero );
+        REQUIRE( orig->pos_bub() == ground_zero );
         REQUIRE( orig->can_upgrade() );
 
         // monster::next_upgrade_time has a ~3% chance to outright fail
@@ -306,8 +306,8 @@ static void test_multi_spawn( const mtype_id &old_mon, int range, int min, int m
                 continue;
             }
             total_spawns++;
-            CHECK( std::abs( c->pos().x - ground_zero.x ) <= range );
-            CHECK( std::abs( c->pos().y - ground_zero.y ) <= range );
+            CHECK( std::abs( c->pos_bub().x() - ground_zero.x() ) <= range );
+            CHECK( std::abs( c->pos_bub().y() - ground_zero.y() ) <= range );
             if( new_count.count( c->as_monster()->type->id ) == 0 ) {
                 new_count[c->as_monster()->type->id] = 0;
             }

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -257,7 +257,7 @@ static bool tally_items( std::unordered_map<itype_id, float> &global_item_count,
                          std::unordered_map<itype_id, int> &item_count, tinymap &tm )
 {
     bool found = false;
-    for( const tripoint &p : tm.points_on_zlevel() ) {
+    for( const tripoint_omt_ms &p : tm.points_on_zlevel() ) {
         for( item &i : tm.i_at( p ) ) {
             std::unordered_map<itype_id, float>::iterator iter = global_item_count.find( i.typeId() );
             if( iter != global_item_count.end() ) {

--- a/tests/visitable_zone_test.cpp
+++ b/tests/visitable_zone_test.cpp
@@ -10,26 +10,27 @@
 #include <vector>
 
 // The area of the whole map from two below to one above ground level.
-static const tripoint p1( 0, 0, -2 );
-static const tripoint p2( ( MAPSIZE *SEEX ) - 1, ( MAPSIZE *SEEY ) - 1, 1 );
+static const tripoint_bub_ms p1( 0, 0, -2 );
+static const tripoint_bub_ms p2( ( MAPSIZE *SEEX ) - 1, ( MAPSIZE *SEEY ) - 1, 1 );
 
 struct structure {
-    structure( const tripoint &origin, const tripoint &dimensions, const std::string &name ) :
+    structure( const tripoint_bub_ms &origin, const tripoint_rel_ms &dimensions,
+               const std::string &name ) :
         area( origin, origin + dimensions ), name_( name ) {};
-    bool contains( const tripoint &p ) const {
+    bool contains( const tripoint_bub_ms &p ) const {
         return area.contains( p );
     }
-    inclusive_cuboid<tripoint> area;
+    inclusive_cuboid<tripoint_bub_ms> area;
     std::string name_;
 };
 
 static void place_structures( const std::vector<structure> &spawn_areas,
-                              std::vector<std::vector<tripoint>> &interior_areas,
-                              std::vector<tripoint> &outside_area,
-                              std::vector<tripoint> &rooftop_area )
+                              std::vector<std::vector<tripoint_bub_ms>> &interior_areas,
+                              std::vector<tripoint_bub_ms> &outside_area,
+                              std::vector<tripoint_bub_ms> &rooftop_area )
 {
     map &here = get_map();
-    for( const tripoint &p : here.points_in_rectangle( p1, p2 ) ) {
+    for( const tripoint_bub_ms &p : here.points_in_rectangle( p1, p2 ) ) {
         bool found = false;
         for( unsigned int i = 0; i < spawn_areas.size(); ++i ) {
             // Indexing so these can pair up with interior_areas.
@@ -37,17 +38,17 @@ static void place_structures( const std::vector<structure> &spawn_areas,
             if( spawn_area.contains( p ) ) {
                 found = true;
                 // Uppermost level (if any) gets a roof covering the whole footprint.
-                if( spawn_area.area.p_max.z != spawn_area.area.p_min.z && p.z == spawn_area.area.p_max.z ) {
+                if( spawn_area.area.p_max.z() != spawn_area.area.p_min.z() && p.z() == spawn_area.area.p_max.z() ) {
                     rooftop_area.emplace_back( p );
                     here.ter_set( p, ter_id( "t_flat_roof" ) );
                     break;
                 }
-                inclusive_cuboid<tripoint> interior{
-                    rectangle<point>{
+                inclusive_cuboid<tripoint_bub_ms> interior{
+                    rectangle<point_bub_ms>{
                         spawn_area.area.p_min.xy() + point_south_east,
                         spawn_area.area.p_max.xy() - point_south_east
                     },
-                    spawn_area.area.p_min.z, spawn_area.area.p_min.z
+                    spawn_area.area.p_min.z(), spawn_area.area.p_min.z()
                 };
                 if( interior.contains( p ) ) {
                     here.ter_set( p, ter_id( "t_floor" ) );
@@ -58,7 +59,7 @@ static void place_structures( const std::vector<structure> &spawn_areas,
                 break;
             }
         }
-        if( !found && p.z == 0 ) {
+        if( !found && p.z() == 0 ) {
             outside_area.push_back( p );
         }
     }
@@ -67,8 +68,8 @@ static void place_structures( const std::vector<structure> &spawn_areas,
 // Just make all the buildings the same size.
 static constexpr int building_width = 7;
 static constexpr int building_height = 1;
-static constexpr tripoint building_offset{ building_width, building_width, building_height };
-static constexpr tripoint cave_offset{ building_width, building_width, 0 };
+static constexpr tripoint_rel_ms building_offset{ building_width, building_width, building_height };
+static constexpr tripoint_rel_ms cave_offset{ building_width, building_width, 0 };
 
 TEST_CASE( "visitable_zone_surface_test" )
 {
@@ -79,24 +80,24 @@ TEST_CASE( "visitable_zone_surface_test" )
     std::vector<monster *> monsters;
     // All of these origins must be building_width + 3 away from each other.
     // Surface building locations.
-    const tripoint enclosed_building{ 30, 30, 0 };
-    const tripoint closed_door = enclosed_building + tripoint_east * 2;
+    const tripoint_bub_ms enclosed_building{ 30, 30, 0 };
+    const tripoint_bub_ms closed_door = enclosed_building + tripoint_east * 2;
     // Surface building with a door.
-    const tripoint door_building{ 40, 30, 0 };
-    const tripoint open_door = door_building + tripoint_east * 2;
+    const tripoint_bub_ms door_building{ 40, 30, 0 };
+    const tripoint_bub_ms open_door = door_building + tripoint_east * 2;
     // Surface building with a window.
-    const tripoint window_building{ 50, 30, 0 };
-    const tripoint window = window_building + tripoint_south * 2;
+    const tripoint_bub_ms window_building{ 50, 30, 0 };
+    const tripoint_bub_ms window = window_building + tripoint_south * 2;
     // Underground room.
-    const tripoint underground_room{ 60, 30, -1 };
+    const tripoint_bub_ms underground_room{ 60, 30, -1 };
     // Underground room.
-    const tripoint underground_stairs_room{ 70, 30, -1 };
-    const tripoint underground_stairs_up = underground_stairs_room + tripoint_south_east * 3;
-    const tripoint underground_stairs_down = underground_stairs_up + tripoint_above;
+    const tripoint_bub_ms underground_stairs_room{ 70, 30, -1 };
+    const tripoint_bub_ms underground_stairs_up = underground_stairs_room + tripoint_south_east * 3;
+    const tripoint_bub_ms underground_stairs_down = underground_stairs_up + tripoint_above;
     // Elevated building with stairs to the surface.
-    const tripoint stilts_building{ 80, 30, 1 };
-    const tripoint stilts_stairs_down = stilts_building + tripoint_south_east * 3;
-    const tripoint stilts_stairs_up = stilts_stairs_down + tripoint_below;
+    const tripoint_bub_ms stilts_building{ 80, 30, 1 };
+    const tripoint_bub_ms stilts_stairs_down = stilts_building + tripoint_south_east * 3;
+    const tripoint_bub_ms stilts_stairs_up = stilts_stairs_down + tripoint_below;
 
     std::vector<structure> spawn_locations = {{
             { enclosed_building, building_offset, "closed door building" },
@@ -107,9 +108,9 @@ TEST_CASE( "visitable_zone_surface_test" )
             { stilts_building, building_offset, "building on stilts" }
         }
     };
-    std::vector<std::vector<tripoint>> interior_areas( spawn_locations.size() );
-    std::vector<tripoint> outside_area;
-    std::vector<tripoint> rooftop_area;
+    std::vector<std::vector<tripoint_bub_ms>> interior_areas( spawn_locations.size() );
+    std::vector<tripoint_bub_ms> outside_area;
+    std::vector<tripoint_bub_ms> rooftop_area;
     place_structures( spawn_locations, interior_areas, outside_area, rooftop_area );
     here.ter_set( closed_door, ter_id( "t_door_c" ) );
     here.ter_set( open_door, ter_id( "t_door_o" ) );
@@ -140,7 +141,7 @@ TEST_CASE( "visitable_zone_surface_test" )
     REQUIRE( !here.passable( window ) );
     REQUIRE( here.is_transparent_wo_fields( tripoint_bub_ms( window ) ) );
 
-    for( std::vector<tripoint> &area : interior_areas ) {
+    for( std::vector<tripoint_bub_ms> &area : interior_areas ) {
         for( const int &choice : rng_sequence( 2, 0, area.size() - 1 ) ) {
             monster &mon = spawn_test_monster( mon_type, tripoint_bub_ms( area[choice] ) );
             monsters.push_back( &mon );
@@ -163,14 +164,14 @@ TEST_CASE( "visitable_zone_surface_test" )
     CHECK( count_by_zone.size() == 3 );
 
     for( monster *mon : monsters ) {
-        tripoint mpos = mon->pos();
+        tripoint_bub_ms mpos = mon->pos_bub();
         std::vector<structure>::iterator it =
             find_if( spawn_locations.begin(), spawn_locations.end(),
         [mon]( structure & a_structure ) {
-            return a_structure.contains( mon->pos() );
+            return a_structure.contains( mon->pos_bub() );
         } );
         std::string spawn_site = "outside";
-        if( mpos.z >= 1 ) {
+        if( mpos.z() >= 1 ) {
             spawn_site = "rooftop";
         } else if( it != spawn_locations.end() ) {
             spawn_site = it->name_;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Another small step towards using typed coordinates.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Convert dependents on map.h utyped operations to use the corresponding typed one when reasonably convenient, and then delete the untyped operation if no users remain.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
This PR should result in no functional changes, so no particular things to test.

Loaded a save, walked up a ramp, entered a car and drove it through some hay bales, then over a zombie corpse with stuff in its inventory, rammed a turkey or two, and smashed into a stationary vehicle. Nothing strange seen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Encountered a case or two where types weren't as they should be. Those were adjusted (note that it doesn't change any functionality).

I'm sure map::prev_top_left and map::prev_bottom_left are relative map square coordinates, so that's the type I gave them, but they may be bubble coordinates (i.e. a specific subtype of relative ones). I'm still confused over the whole UI coordinate usage thing, as it doesn't seem to be consistent: is the UI (cata_tiles, sdl_tiles, etc.) using bubble coordinates, its own thing, or just a random mess of whatever untyped stuff it's fed with?
map::prev_o is a mystery. It's fed into a bub_ms operation, but set at one place by an abs_ms parameter, while being describes as an offset by its comment. Thus, I've left it unchanged for this time.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
