### PR TITLE
Rotten blood can't be analyzed on centrifuge

### DIFF
--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1051,7 +1051,9 @@ void computer_session::action_blood_anal()
             } else if( items.only_item().legacy_front().typeId() != itype_blood &&
                        items.only_item().legacy_front().typeId() != itype_blood_tainted ) {
                 print_error( _( "ERROR: Please only use blood samples." ) );
-            } else { // Success!
+            } else if( items.only_item().legacy_front().rotten() ) {
+                print_error( _( "ERROR: Please only use fresh blood samples." ) );
+            }  else { // Success!
                 const item &blood = items.only_item().legacy_front();
                 const mtype *mt = blood.get_mtype();
                 if( mt == nullptr || mt->id == mtype_id::NULL_ID() ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Rotten blood can't be analyzed on centrifuge"

#### Purpose of change
* Closes #69727. Well, _closes_ might the strong word since my tests show that quest can be completed even without my changes.

#### Describe the solution
Added check for rotten blood on the centrifuge. Rotten blood can't be analyzed.

#### Describe alternatives you've considered
None.

#### Testing
Drew blood from a zombie. Waited for blood to rot. Tried to analyze it on the centrifuge. Got error from computer.
Also, while investigating #69727, I checked that blood from rotten zombie corpses is still considered fresh and can be analyzed for the quest.

#### Additional context
None.