### PR TITLE
Make search data able to evaluate json variables

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2210,7 +2210,7 @@ Run EOCs on items in your or NPC's inventory
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
 | "u_run_inv_eocs" / "npc_run_inv_eocs" | **mandatory** | string or [variable object](#variable-object) | way the item would be picked; <br/>values can be:<br/>`all` - all items that match the conditions are picked;<br/> `random` - from all items that match the conditions, one picked;<br/>`manual` - menu is open with all items that can be picked, and you can choose one;<br/>`manual_mult` - same as `manual`, but multiple items can be picked |
-| "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; conditions can be:<br/>`id` - id of a specific item;<br/>`category` - category of an item (case sensitive, should always be in lower case);<br/>`flags`- flag or flags the item has<br/>`excluded_flags`- flag or flags the item doesn't have<br/>`material` - material of an item;<br/>`worn_only` - if true, return only items, that are worn;<br/>`wielded_only` - if true, return only wielded items;<br/>`calories` - minimum amount of kcal of an item | 
+| "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; see [search_data](#search_data) for syntax | 
 | "title" | optional | string or [variable object](#variable-object) | name of the menu, that would be shown, if `manual` or `manual_mult` is used | 
 | "true_eocs" / "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if item was picked successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run; picked item is returned as npc; for example, `n_hp()` return hp of an item | 
 
@@ -2244,7 +2244,7 @@ Pick a wooden item with `DURABLE_MELEE` and `ALWAYS_TWOHAND` flags, and run `EOC
     {
       "u_run_inv_eocs": "manual",
       "search_data": [ { "material": "wood", "flags": [ "DURABLE_MELEE", "ALWAYS_TWOHAND" ] } ],
-      "true_eocs": [ "EOC_DO_SOMETHING_WITH_ITEM" ]
+      "true_eocs": [ "EOC_DO_SOMETHING_WITH_ITEM" ],
       "false_eocs": [ { "id": "EOC_NO_SUCH_ITEM", "effect": [ { "u_message": "You don't have an item i need" } ] } ]
     }
   ]
@@ -2274,7 +2274,7 @@ Search items around you on the map, and run EoC on them
 | "loc" | optional | location variable | location, where items would be scanned; lack of it would scan only tile the talker stands on | 
 | "min_radius", "max_radius" | optional | int or [variable object](#variable-object) | radius around the location/talker that would be searched | 
 | "title" | optional | string or [variable object](#variable-object) | name of the menu that would be shown, if `manual` or `manual_mult` values are used | 
-| "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; conditions can be:<br/>`id` - id of a specific item;<br/>`category` - category of an item (case sensitive, should always be in lower case);<br/>`flags`- flag or flags the item has<br/>`excluded_flags`- flag or flags the item doesn't have<br/>`material` - material of an item;<br/>`worn_only` - if true, return only items, that are worn;<br/>`wielded_only` - if true, return only wielded items | 
+| "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; see [search_data](#search_data) for syntax | 
 | "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if item was picked successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run; picked item is returned as npc | 
 
 ##### Valid talkers:
@@ -4418,3 +4418,71 @@ Convert the beta talker (which must be an item) into a different item, optionall
 | Avatar | Character | NPC | Monster |  Furniture | Item |
 | ------ | --------- | --------- | ---- | ------- | --- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+
+
+## Mics
+
+### search_data
+search_data is an array, that allow to filter specific items from the list. At this moment it is used for `u_run_inv_eocs` (picks items from your inventory) and `u_map_run_item_eocs` (picks items from around the character)
+
+| Syntax | Value  | Info |
+| --- | --- | --- |
+| "id" | string, [variable object](#variable-object) or array of strings or variable objects | if used, filter the list of items by item id |
+| "id_blacklist" | string, [variable object](#variable-object) or array of strings or variable objects | if used, excludes items from the list by their id |
+| "category" | string, [variable object](#variable-object) or array of strings or variable objects | filter the list of items by their category |
+| "flags" | string, [variable object](#variable-object) or array of strings or variable objects | filter the list of items by flags they have |
+| "excluded_flags" | string, [variable object](#variable-object) or array of strings or variable objects | excludes items from the list by flags they have |
+| "material" | string, [variable object](#variable-object) or array of strings or variable objects | filter the list of items by their material |
+| "worn_only" | boolean | return only items you you wear (clothes) |
+| "wielded_only" | boolean | return only item you hold in your hands right now. if you hold nothing, and picking object is not manual, it return string `none` |
+| "held_only" | boolean | return both items you wear and item you hold in your hands |
+| "condition" | condition object | allows to use same conditions as EoC. Alpha talker in this case is whoever runs the effect, and beta is the item |
+
+Examples:
+
+```c++
+  {
+    "type": "effect_on_condition",
+    "id": "INV_EOCS_SHOWCASE",
+    "effect": [
+      { "set_string_var": "knife_large", "target_var": { "context_val": "val" } },
+      {
+        "u_run_inv_eocs": "manual_mult",
+        "search_data": [
+          { "id": "knife_large" },
+          { "id": { "context_val": "val" } },
+          { "id": [ "1l_aluminum", { "context_val": "val" } ] },
+          { "category": "weapons" },
+          { "category": { "context_val": "val" } },
+          { "category": [ "tools", { "context_val": "val" } ] },
+          { "material": "steel" },
+          { "material": { "context_val": "val" } },
+          { "material": [ "aluminum", { "context_val": "val" } ] },
+          { "flags": "SHEATH_KNIFE" },
+          { "flags": { "context_val": "val" } },
+          { "flags": [ "WATCH", { "context_val": "val" } ] },
+          { "excluded_flags": "SHEATH_KNIFE" },
+          { "excluded_flags": { "context_val": "val" } },
+          { "excluded_flags": [ "WATCH", { "context_val": "val" } ] },
+          { "worn_only": true },
+          { "wielded_only": true },
+          { "held_only": true },
+          { "condition": { "math": [ "rand(1)" ] } }, // since 0 for conditions is evaluated as "false", this would randomly discard ~half of items from picked
+          { "condition": { "math": [ "n_calories() >= 200" ] } }, // can check beta talker for it's specific properties via math
+          { "condition": { "and": [ { "math": [ "n_calories() >= 200" ] }, { "math": [ "n_calories() <= 500" ] } ] } }, // and even as range!
+          { "condition": { "math": [ "n_melee_damage('ALL') > 20" ] } }, // and more!
+          { "condition": { "compare_string": [ "yes", { "u_val": "general_examples_VIP" } ] } }
+        ],
+        "true_eocs": [ { "id": "EOC_WHATEVER", "effect": { "u_message": "alpha: <u_name>, beta: <npc_name>" } } ]
+      }
+    ]
+  }
+  ```
+
+Combination of values work as `and`, no matter how they are arranged. This two notation work exactly the same, and will return item you wield if it has `weapon` type:
+```json
+"search_data": [ { "category": "weapons" }, { "wielded_only": true } ]
+```
+```json
+"search_data": [ { "category": "weapons", "wielded_only": true } ]
+```

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -185,7 +185,7 @@ std::function<double( dialogue & )> damage_level_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return[params, beta = is_beta( scope )]( dialogue const & d ) {
-        item_location const *it = static_cast<talker const *>( d.actor( beta ) )->get_item();
+        item_location *it = d.actor( beta )->get_item();
         if( !it ) {
             debugmsg( "subject of damage_level() must be an item" );
             return 0;
@@ -1666,7 +1666,7 @@ std::function<double( dialogue & )> calories_eval( char scope,
             if( d.actor( beta )->get_character() ) {
                 return d.actor( beta )->get_stored_kcal();
             }
-            item_location *it = d.actor( beta )->get_item();
+            item_location const *it = static_cast<talker const *>( d.actor( beta ) )->get_item();
             if( it && *it ) {
                 npc dummy;
                 return dummy.compute_effective_nutrients( *it->get_item() ).kcal();

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -185,7 +185,7 @@ std::function<double( dialogue & )> damage_level_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return[params, beta = is_beta( scope )]( dialogue const & d ) {
-        item_location *it = d.actor( beta )->get_item();
+        item_location const *it = static_cast<talker const *>( d.actor( beta ) )->get_item();
         if( !it ) {
             debugmsg( "subject of damage_level() must be an item" );
             return 0;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -260,7 +260,7 @@ struct item_search_data {
         held_only = jo.get_bool( "held_only", false );
     }
 
-    bool check( const Character *guy, const item_location &loc, const dialogue &d ) { 
+    bool check( const Character *guy, const item_location &loc, const dialogue &d ) {
 
         bool match;
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -260,7 +260,7 @@ struct item_search_data {
         held_only = jo.get_bool( "held_only", false );
     }
 
-    bool check( const Character *guy, const item_location &loc, const dialogue d ) {
+    bool check( const Character *guy, const item_location &loc, const dialogue &d ) { 
 
         bool match;
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -178,55 +178,141 @@ struct sub_effect_parser {
 };
 
 struct item_search_data {
-    itype_id id;
-    item_category_id category;
-    material_id material;
-    int calories = 0;
-    std::vector<flag_id> flags;
-    std::vector<flag_id> excluded_flags;
+
+    std::vector<str_or_var> id;
+    str_or_var category;
+    std::vector<str_or_var> material;
+    dbl_or_var calories;
+    std::vector<str_or_var> flags;
+    std::vector<str_or_var> excluded_flags;
     bool worn_only;
     bool wielded_only;
+    bool helded_only;
+    // todo: add weight, volume
 
     explicit item_search_data( const JsonObject &jo ) {
-        id = itype_id( jo.get_string( "id", "" ) );
-        category = item_category_id( jo.get_string( "category", "" ) );
-        material = material_id( jo.get_string( "material", "" ) );
-        if( jo.has_int( "calories" ) ) {
-            calories = jo.get_int( "calories" );
+
+        if( jo.has_array( "id" ) ) {
+            for( JsonValue jv : jo.get_array( "id" ) ) {
+                id.emplace_back( get_str_or_var( jv, "id" ) );
+            }
         }
-        for( std::string flag : jo.get_string_array( "flags" ) ) {
-            flags.emplace_back( flag );
+        if( jo.has_object( "id" ) || jo.has_string( "id" ) ) {
+            id.emplace_back( get_str_or_var( jo.get_member( "id" ), "id" ) );
         }
-        for( std::string flag : jo.get_string_array( "excluded_flags" ) ) {
-            excluded_flags.emplace_back( flag );
+
+        if( jo.has_object( "category" ) || jo.has_string( "category" ) ) {
+            category = get_str_or_var( jo.get_member( "category" ), "category" );
         }
+
+        if( jo.has_array( "material" ) ) {
+            for( JsonValue jv : jo.get_array( "material" ) ) {
+                material.emplace_back( get_str_or_var( jv, "material" ) );
+            }
+        }
+        if( jo.has_object( "material" ) || jo.has_string( "material" ) ) {
+            material.emplace_back( get_str_or_var( jo.get_member( "material" ), "material" ) );
+        }
+
+        if( jo.has_array( "flags" ) ) {
+            for( JsonValue jv : jo.get_array( "flags" ) ) {
+                flags.emplace_back( get_str_or_var( jv, "flags" ) );
+            }
+        }
+        if( jo.has_object( "flags" ) || jo.has_string( "flags" ) ) {
+            flags.emplace_back( get_str_or_var( jo.get_member( "flags" ), "flags" ) );
+        }
+
+        if( jo.has_array( "excluded_flags" ) ) {
+            for( JsonValue jv : jo.get_array( "excluded_flags" ) ) {
+                excluded_flags.emplace_back( get_str_or_var( jv, "excluded_flags" ) );
+            }
+        }
+        if( jo.has_object( "excluded_flags" ) || jo.has_string( "excluded_flags" ) ) {
+            excluded_flags.emplace_back( get_str_or_var( jo.get_member( "excluded_flags" ),
+                                         "excluded_flags" ) );
+        }
+
         worn_only = jo.get_bool( "worn_only", false );
         wielded_only = jo.get_bool( "wielded_only", false );
+        helded_only = jo.get_bool( "helded_only", false );
     }
 
-    bool check( const Character *guy, const item_location &loc ) {
-        if( !id.is_empty() && id != loc->typeId() ) {
+    bool check( const Character *guy, const item_location &loc, dialogue d ) {
+
+        std::vector<itype_id> id_evaluated;
+        item_category_id category_evaluated;
+        std::vector<material_id> material_evaluated;
+        int calories_evaluated = 0;
+        std::vector<flag_id> flags_evaluated;
+        std::vector<flag_id> excluded_flags_evaluated;
+        bool match;
+
+        // todo: sort from the fastest methods to slowers, for theoretical performance wins
+        // todo: combine evaluation with actual check 
+
+        if( !id.empty() ) {
+
+            for( str_or_var id_eval : id ) {
+                id_evaluated.emplace_back( id_eval.evaluate( d ) );
+            }
+
+            match = false;
+            for( itype_id id : id_evaluated ) {
+                id == loc->typeId();
+                match = true;
+            }
+
+            if( !id_evaluated.empty() && !match ) {
+                return false;
+            }
+
+        }
+
+        category_evaluated = item_category_id( category.evaluate( d ) );
+
+        for( str_or_var material_eval : material ) {
+            material_evaluated.emplace_back( material_eval.evaluate( d ) );
+        }
+
+        calories_evaluated = calories.evaluate( d );
+
+        for( str_or_var flags_eval : flags ) {
+            flags_evaluated.emplace_back( flags_eval.evaluate( d ) );
+        }
+
+        for( str_or_var excluded_flags_eval : excluded_flags ) {
+            excluded_flags_evaluated.emplace_back( excluded_flags_eval.evaluate( d ) );
+        }
+
+        if( !category_evaluated.is_empty() && category_evaluated != loc->get_category_shallow().id ) {
             return false;
         }
-        if( !category.is_empty() && category != loc->get_category_shallow().id ) {
+
+        match = false;
+        for( material_id id : material_evaluated ) {
+            loc->made_of( id ) == 0;
+            match = true;
+        }
+
+        if( !material_evaluated.empty() && !match ) {
             return false;
         }
-        if( !material.is_empty() && loc->made_of( material ) == 0 ) {
-            return false;
-        }
-        if( calories > 0 ) {
+
+        if( calories_evaluated > 0 ) {
             // This is very stupid but we need a dummy to calculate nutrients
             npc dummy;
-            if( dummy.compute_effective_nutrients( *loc.get_item() ).kcal() < calories ) {
+            if( dummy.compute_effective_nutrients( *loc.get_item() ).kcal() < calories_evaluated ) {
                 return false;
             }
         }
-        for( flag_id flag : flags ) {
+
+        for( flag_id flag : flags_evaluated ) {
             if( !loc->has_flag( flag ) ) {
                 return false;
             }
         }
-        for( flag_id flag : excluded_flags ) {
+        for( flag_id flag : excluded_flags_evaluated ) {
             if( loc->has_flag( flag ) ) {
                 return false;
             }
@@ -237,6 +323,10 @@ struct item_search_data {
         if( wielded_only && !guy->is_wielding( *loc ) ) {
             return false;
         }
+        if( helded_only && !( guy->is_worn( *loc ) || guy->is_wielding( *loc ) ) ) {
+            return false;
+        }
+
         return true;
     }
 };
@@ -3021,7 +3111,7 @@ static void run_item_eocs( const dialogue &d, bool is_npc, const std::vector<ite
         // Check if item matches any search_data.
         bool true_tgt = data.empty();
         for( item_search_data datum : data ) {
-            if( datum.check( guy, loc ) ) {
+            if( datum.check( guy, loc, d ) ) {
                 true_tgt = true;
                 break;
             }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -189,6 +189,8 @@ struct item_search_data {
     bool wielded_only;
     bool held_only;
     // todo: add weight, volume
+    std::function<bool( dialogue & )> condition;
+    bool has_condition = false;
 
     explicit item_search_data( const JsonObject &jo ) {
 
@@ -240,6 +242,10 @@ struct item_search_data {
                                          false, "" ) );
         }
 
+        if( jo.has_member( "condition" ) ) {
+            read_condition( jo, "condition", condition, false );
+            has_condition = true;
+        }
         worn_only = jo.get_bool( "worn_only", false );
         wielded_only = jo.get_bool( "wielded_only", false );
         held_only = jo.get_bool( "held_only", false );
@@ -350,6 +356,13 @@ struct item_search_data {
         }
         if( held_only && !( guy->is_worn( *loc ) || guy->is_wielding( *loc ) ) ) {
             return false;
+        }
+
+        if( has_condition ) {
+            dialogue dial( d.actor( true )->clone(), get_talker_for( loc ), condition );
+            if( !condition( dial ) ) {
+                return false;
+            }
         }
 
         return true;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -214,6 +214,10 @@ struct item_search_data {
             material.emplace_back( get_str_or_var( jo.get_member( "material" ), "material" ) );
         }
 
+        if( jo.has_object( "calories" ) ) {
+            calories = get_dbl_or_var( jo.get_member( "calories" ), "calories", false, 0 );
+        }
+
         if( jo.has_array( "flags" ) ) {
             for( JsonValue jv : jo.get_array( "flags" ) ) {
                 flags.emplace_back( get_str_or_var( jv, "flags" ) );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -180,6 +180,7 @@ struct sub_effect_parser {
 struct item_search_data {
 
     std::vector<str_or_var> id;
+    std::vector<str_or_var> id_blacklist;
     std::vector<str_or_var> category;
     std::vector<str_or_var> material;
     std::vector<str_or_var> flags;
@@ -200,6 +201,16 @@ struct item_search_data {
         }
         if( jo.has_object( "id" ) || jo.has_string( "id" ) ) {
             id.emplace_back( get_str_or_var( jo.get_member( "id" ), "id", false, "" ) );
+        }
+
+        if( jo.has_array( "id_blacklist" ) ) {
+            for( JsonValue jv : jo.get_array( "id_blacklist" ) ) {
+                id_blacklist.emplace_back( get_str_or_var( jv, "id_blacklist" ) );
+            }
+        }
+        if( jo.has_object( "id_blacklist" ) || jo.has_string( "id_blacklist" ) ) {
+            id_blacklist.emplace_back( get_str_or_var( jo.get_member( "id_blacklist" ), "id_blacklist", false,
+                                       "" ) );
         }
 
         if( jo.has_array( "category" ) ) {
@@ -265,6 +276,22 @@ struct item_search_data {
                 }
             }
             if( !id_evaluated.empty() && !match ) {
+                return false;
+            }
+        }
+
+        if( !id_blacklist.empty() ) {
+            std::vector<itype_id> id_blacklist_evaluated;
+            for( str_or_var id_blacklist_eval : id_blacklist ) {
+                id_blacklist_evaluated.emplace_back( id_blacklist_eval.evaluate( d ) );
+            }
+            match = false;
+            for( itype_id id : id_blacklist_evaluated ) {
+                if( id == loc->typeId() ) {
+                    match = true;
+                }
+            }
+            if( !id_blacklist_evaluated.empty() && match ) {
                 return false;
             }
         }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -260,13 +260,14 @@ struct item_search_data {
         held_only = jo.get_bool( "held_only", false );
     }
 
-    bool check( const Character *guy, const item_location &loc, dialogue d ) {
+    bool check( const Character *guy, const item_location &loc, const dialogue d ) {
 
         bool match;
 
         if( !id.empty() ) {
             std::vector<itype_id> id_evaluated;
-            for( str_or_var id_eval : id ) {
+            id_evaluated.reserve( id.size() );
+            for( const str_or_var id_eval : id ) {
                 id_evaluated.emplace_back( id_eval.evaluate( d ) );
             }
             match = false;
@@ -282,7 +283,8 @@ struct item_search_data {
 
         if( !id_blacklist.empty() ) {
             std::vector<itype_id> id_blacklist_evaluated;
-            for( str_or_var id_blacklist_eval : id_blacklist ) {
+            id_blacklist_evaluated.reserve( id_blacklist.size() );
+            for( const str_or_var id_blacklist_eval : id_blacklist ) {
                 id_blacklist_evaluated.emplace_back( id_blacklist_eval.evaluate( d ) );
             }
             match = false;
@@ -298,7 +300,8 @@ struct item_search_data {
 
         if( !category.empty() ) {
             std::vector<item_category_id> category_evaluated;
-            for( str_or_var category_eval : category ) {
+            category_evaluated.reserve( category.size() );
+            for( const str_or_var category_eval : category ) {
                 category_evaluated.emplace_back( category_eval.evaluate( d ) );
             }
             match = false;
@@ -314,7 +317,8 @@ struct item_search_data {
 
         if( !material.empty() ) {
             std::vector<material_id> material_evaluated;
-            for( str_or_var material_eval : material ) {
+            material_evaluated.reserve( material.size() );
+            for( const str_or_var material_eval : material ) {
                 material_evaluated.emplace_back( material_eval.evaluate( d ) );
             }
             match = false;
@@ -330,7 +334,8 @@ struct item_search_data {
 
         if( !flags.empty() ) {
             std::vector<flag_id> flags_evaluated;
-            for( str_or_var flags_eval : flags ) {
+            flags_evaluated.reserve( flags.size() );
+            for( const str_or_var flags_eval : flags ) {
                 flags_evaluated.emplace_back( flags_eval.evaluate( d ) );
             }
             match = false;
@@ -346,7 +351,8 @@ struct item_search_data {
 
         if( !excluded_flags.empty() ) {
             std::vector<flag_id> excluded_flags_evaluated;
-            for( str_or_var excluded_flags_eval : excluded_flags ) {
+            excluded_flags_evaluated.reserve( excluded_flags.size() );
+            for( const str_or_var excluded_flags_eval : excluded_flags ) {
                 excluded_flags_evaluated.emplace_back( excluded_flags_eval.evaluate( d ) );
             }
             match = false;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -267,7 +267,7 @@ struct item_search_data {
         if( !id.empty() ) {
             std::vector<itype_id> id_evaluated;
             id_evaluated.reserve( id.size() );
-            for( const str_or_var id_eval : id ) {
+            for( const str_or_var &id_eval : id ) {
                 id_evaluated.emplace_back( id_eval.evaluate( d ) );
             }
             match = false;
@@ -284,7 +284,7 @@ struct item_search_data {
         if( !id_blacklist.empty() ) {
             std::vector<itype_id> id_blacklist_evaluated;
             id_blacklist_evaluated.reserve( id_blacklist.size() );
-            for( const str_or_var id_blacklist_eval : id_blacklist ) {
+            for( const str_or_var &id_blacklist_eval : id_blacklist ) {
                 id_blacklist_evaluated.emplace_back( id_blacklist_eval.evaluate( d ) );
             }
             match = false;
@@ -301,7 +301,7 @@ struct item_search_data {
         if( !category.empty() ) {
             std::vector<item_category_id> category_evaluated;
             category_evaluated.reserve( category.size() );
-            for( const str_or_var category_eval : category ) {
+            for( const str_or_var &category_eval : category ) {
                 category_evaluated.emplace_back( category_eval.evaluate( d ) );
             }
             match = false;
@@ -318,7 +318,7 @@ struct item_search_data {
         if( !material.empty() ) {
             std::vector<material_id> material_evaluated;
             material_evaluated.reserve( material.size() );
-            for( const str_or_var material_eval : material ) {
+            for( const str_or_var &material_eval : material ) {
                 material_evaluated.emplace_back( material_eval.evaluate( d ) );
             }
             match = false;
@@ -335,7 +335,7 @@ struct item_search_data {
         if( !flags.empty() ) {
             std::vector<flag_id> flags_evaluated;
             flags_evaluated.reserve( flags.size() );
-            for( const str_or_var flags_eval : flags ) {
+            for( const str_or_var &flags_eval : flags ) {
                 flags_evaluated.emplace_back( flags_eval.evaluate( d ) );
             }
             match = false;
@@ -352,7 +352,7 @@ struct item_search_data {
         if( !excluded_flags.empty() ) {
             std::vector<flag_id> excluded_flags_evaluated;
             excluded_flags_evaluated.reserve( excluded_flags.size() );
-            for( const str_or_var excluded_flags_eval : excluded_flags ) {
+            for( const str_or_var &excluded_flags_eval : excluded_flags ) {
                 excluded_flags_evaluated.emplace_back( excluded_flags_eval.evaluate( d ) );
             }
             match = false;

--- a/src/talker.h
+++ b/src/talker.h
@@ -55,7 +55,7 @@ class talker
         virtual item_location *get_item() {
             return nullptr;
         }
-        virtual item_location *get_item() const {
+        virtual item_location const *get_item() const {
             return nullptr;
         }
         virtual monster *get_monster() {

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -53,6 +53,14 @@ class talker_item_const: public talker_cloner<talker_item_const>
         int encumbrance_at( bodypart_id & ) const override;
         int get_volume() const override;
         int get_weight() const override;
+        item_location *get_item() override {
+            return nullptr;
+
+        }
+        item_location const *get_item() const override {
+            return me_it_const;
+
+        }
     protected:
         talker_item_const() = default;
         const item_location *me_it_const;
@@ -68,7 +76,7 @@ class talker_item: public talker_cloner<talker_item, talker_item_const>
         item_location *get_item() override {
             return me_it;
         }
-        item_location *get_item() const override {
+        item_location const *get_item() const override {
             return me_it;
         }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Apparently search data was limited to plain strings and ints. This PR tries to resolve it
Also add a few more things
#### Describe the solution
Replace ints and string with evaluation
Make id and material an array, not single item
Add id_blacklist array
add held_only
remove calorie evaluation completely 
add condition, that can be used to evaluate item (it is a beta talker in this case), which would allow us to just add math evaluations instead of adding both math evaluations AND expanding search data
#### Testing
I spend way too much time testing all the changes