### PR TITLE
Partly refactor and nerf some traps (caltrops, nailboards, glass)

### DIFF
--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -219,6 +219,44 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
     return true;
 }
 
+static void mount_step_on_trap_make_slow_give_msg( monster *z, const tripoint &p )
+{
+    if( !z ) { // should never happen
+        debugmsg( "non-monster creature passed to mount_step_on_trap_make_slow_give_msg" );
+        return;
+    }
+    map &here = get_map();
+    Character *rider = nullptr;
+    for( npc &guy : g->all_npcs() ) {
+        if( guy.pos() == p && guy.pos() == z->pos() ) {
+            rider = &guy;
+            break;
+        }
+    }
+    if( !rider ) {
+        rider = &get_player_character();
+    }
+    if( rider->is_avatar() ) {
+        //~Player with an animal mount. e.g. "Your horse stepped on a spiked board!"
+        add_msg( m_warning, _( "Your %s stepped on a %s!" ), z->get_name(), here.tr_at( p ).name() );
+    } else {
+        //~NPC with an animal mount. e.g. "Jane's horse stepped on a spiked board!"
+        add_msg_if_player_sees( p, _( "%s %s stepped on a %s!" ), rider->disp_name( true ),
+                                z->get_name(), here.tr_at( p ).name() );
+    }
+    rider->mod_moves( -z->get_speed() * 0.8 );
+}
+
+static void try_apply_tetanus( Character *you, int total_cut_dmg )
+{
+    if( you != nullptr && !you->has_flag( json_flag_INFECTION_IMMUNE ) && total_cut_dmg > 0 ) {
+        const int chance_in = you->has_trait( trait_INFRESIST ) ? 256 : 35;
+        if( one_in( chance_in ) ) {
+            you->add_effect( effect_tetanus, 1_turns, true );
+        }
+    }
+}
+
 bool trapfunc::board( const tripoint &p, Creature *c, item * )
 {
     if( c == nullptr ) {
@@ -229,48 +267,28 @@ bool trapfunc::board( const tripoint &p, Creature *c, item * )
     if( !x_in_y( occupied_tile_fraction( c->get_size() ), 1.0f ) ) {
         return false;
     }
-    c->add_msg_player_or_npc( m_bad, _( "You step on a spiked board!" ),
-                              _( "<npcname> steps on a spiked board!" ) );
-    monster *z = dynamic_cast<monster *>( c );
-    if( z != nullptr ) {
-        if( z->has_effect( effect_ridden ) ) {
-            add_msg( m_warning, _( "Your %s stepped on a spiked board!" ), c->get_name() );
-            get_player_character().mod_moves( -z->get_speed() * 0.8 );
-        } else {
-            z->mod_moves( -z->get_speed() * 0.8 );
-        }
-        z->deal_damage( nullptr,
-                        random_entry( c->get_ground_contact_bodyparts() ),
-                        damage_instance( damage_cut, rng( 3, 5 ) ) );
+    c->add_msg_if_player( m_bad, _( "You step on a %s!" ), here.tr_at( p ).name() );
+    c->add_msg_if_npc( _( "%s steps on a %s!" ), c->disp_name( false, true ), here.tr_at( p ).name() );
+    if( c->has_effect( effect_ridden ) ) {
+        monster *z = c->as_monster();
+        mount_step_on_trap_make_slow_give_msg( z, p );
     } else {
-        dealt_damage_instance dd = c->deal_damage( nullptr,
-                                   random_entry( c->get_ground_contact_bodyparts() ),
-                                   damage_instance( damage_cut, rng( 3, 5 ) ) );
-        int total_cut_dmg = dd.type_damage( damage_cut );
-        Character *you = c->as_character();
-        if( you != nullptr && !you->has_flag( json_flag_INFECTION_IMMUNE ) && total_cut_dmg > 0 ) {
-            const int chance_in = you->has_trait( trait_INFRESIST ) ? 256 : 35;
-            if( one_in( chance_in ) ) {
-                you->add_effect( effect_tetanus, 1_turns, true );
-            }
-        }
+        c->mod_moves( -c->get_speed() * 0.8 );
     }
+    dealt_damage_instance dd = c->deal_damage( nullptr,
+                               random_entry( c->get_ground_contact_bodyparts() ),
+                               damage_instance( damage_cut, rng( 3, 5 ) ) );
+    try_apply_tetanus( c->as_character(), dd.type_damage( damage_cut ) );
     c->check_dead_state();
     // Weight of 100kg+ is guaranteed to break the trap, linear chance as weight increases
     if( x_in_y( c->get_weight() / 1_kilogram, 100 ) ) {
         // destroy trap
         here.remove_trap( p );
         if( !c->is_avatar() ) {
-            // stupid branch to properly capitalize the start of the sentence
-            if( c->is_monster() ) {
-                add_msg_if_player_sees( p, _( "The %s destroys a spiked board as they move over it!" ),
-                                        c->get_name() );
-            } else if( c->is_npc() ) {
-                add_msg_if_player_sees( p, _( "%s destroys a spiked board as they move over it!" ),
-                                        c->disp_name() );
-            }
+            add_msg_if_player_sees( p, _( "%s destroys a %s as they move over it!" ),
+                                    c->disp_name( false, true ), here.tr_at( p ).name() );
         } else {
-            add_msg( _( "You destroy the spiked board as you step on it!" ) );
+            add_msg( _( "You destroy the %s as you step on it!" ), here.tr_at( p ).name() );
         }
     } else if( x_in_y( 40, 100 ) ) {
         // 40% chance disarm trap
@@ -289,47 +307,29 @@ bool trapfunc::caltrops( const tripoint &p, Creature *c, item * )
     if( !x_in_y( occupied_tile_fraction( c->get_size() ), 1.0f ) ) {
         return false;
     }
-    c->add_msg_player_or_npc( m_bad, _( "You step on a sharp metal caltrop!" ),
-                              _( "<npcname> steps on a sharp metal caltrop!" ) );
-    monster *z = dynamic_cast<monster *>( c );
-    if( z != nullptr ) {
-        if( z->has_effect( effect_ridden ) ) {
-            add_msg( m_warning, _( "Your %s steps on a sharp metal caltrop!" ), c->get_name() );
-            get_player_character().mod_moves( -z->get_speed() * 0.8 );
-        } else {
-            z->mod_moves( -z->get_speed() * 0.8 );
-        }
-        z->deal_damage( nullptr, random_entry( c->get_ground_contact_bodyparts() ),
-                        damage_instance( damage_cut, rng( 9, 15 ) ) );
+    c->add_msg_if_player( m_bad, _( "You step on a sharp %s!" ), here.tr_at( p ).name() );
+    c->add_msg_if_npc( _( "%s steps on a sharp %s!" ), c->disp_name( false, true ),
+                       here.tr_at( p ).name() );
+    if( c->has_effect( effect_ridden ) ) {
+        monster *z = c->as_monster();
+        mount_step_on_trap_make_slow_give_msg( z, p );
     } else {
-        dealt_damage_instance dd = c->deal_damage( nullptr,
-                                   random_entry( c->get_ground_contact_bodyparts() ),
-                                   damage_instance( damage_cut, rng( 9, 15 ) ) );
-        int total_cut_dmg = dd.type_damage( damage_cut );
-        Character *you = dynamic_cast<Character *>( c );
-        if( you != nullptr && !you->has_flag( json_flag_INFECTION_IMMUNE ) && total_cut_dmg > 0 ) {
-            const int chance_in = you->has_trait( trait_INFRESIST ) ? 256 : 35;
-            if( one_in( chance_in ) ) {
-                you->add_effect( effect_tetanus, 1_turns, true );
-            }
-        }
+        c->mod_moves( -c->get_speed() * 0.8 );
     }
+    dealt_damage_instance dd = c->deal_damage( nullptr,
+                               random_entry( c->get_ground_contact_bodyparts() ),
+                               damage_instance( damage_cut, rng( 9, 15 ) ) );
+    try_apply_tetanus( c->as_character(), dd.type_damage( damage_cut ) );
     // Weight of 200kg+ is guaranteed to break the trap, linear chance as weight increases
     // Arbitrary value, picked from hulk's weight value.
     if( x_in_y( c->get_weight() / 1_kilogram, 200 ) ) {
         // destroy trap
         here.remove_trap( p );
         if( !c->is_avatar() ) {
-            // stupid branch to properly capitalize the start of the sentence
-            if( c->is_monster() ) {
-                add_msg_if_player_sees( p, _( "The %s destroys a caltrop as they move over it!" ),
-                                        c->get_name() );
-            } else if( c->is_npc() ) {
-                add_msg_if_player_sees( p, _( "%s destroys a caltrop as they move over it!" ),
-                                        c->disp_name() );
-            }
+            add_msg_if_player_sees( p, _( "%s destroys a %s as they move over it!" ),
+                                    c->disp_name( false, true ), here.tr_at( p ).name() );
         } else {
-            add_msg( _( "You destroy the caltrop as you step on it!" ) );
+            add_msg( _( "You destroy the %s as you step on it!" ), here.tr_at( p ).name() );
         }
     } else if( x_in_y( 20, 100 ) ) {
         // 20% chance disarm trap
@@ -344,23 +344,27 @@ bool trapfunc::caltrops_glass( const tripoint &p, Creature *c, item * )
     if( c == nullptr ) {
         return false;
     }
+    map &here = get_map();
     // Only a chance to step on the caltrop, dependent on size
     if( !x_in_y( occupied_tile_fraction( c->get_size() ), 1.0f ) ) {
         return false;
     }
-    c->add_msg_player_or_npc( m_bad, _( "You step on a sharp glass caltrop!" ),
-                              _( "<npcname> steps on a sharp glass caltrop!" ) );
-    if( c->is_monster() ) {
-        add_msg_if_player_sees( p, _( "The %s steps on a sharp glass caltrop!" ), c->get_name() );
+    c->add_msg_if_player( m_bad, _( "You step on a sharp %s!" ), here.tr_at( p ).name() );
+    c->add_msg_if_npc( _( "%s steps on a sharp %s!" ), c->disp_name( false, true ),
+                       here.tr_at( p ).name() );
+    if( c->has_effect( effect_ridden ) ) {
+        monster *z = c->as_monster();
+        mount_step_on_trap_make_slow_give_msg( z, p );
+    } else {
+        c->mod_moves( -c->get_speed() * 0.8 );
     }
-    c->mod_moves( -c->get_speed() * 0.8 );
     c->deal_damage( nullptr, random_entry( c->get_ground_contact_bodyparts() ),
                     damage_instance( damage_cut, rng( 3, 10 ) ) );
     c->check_dead_state();
     add_msg_if_player_sees( p, _( "The shards shatter!" ) );
     sounds::sound( p, 8, sounds::sound_t::combat, _( "glass cracking!" ), false, "trap",
                    "glass_caltrops" );
-    get_map().remove_trap( p );
+    here.remove_trap( p );
     return true;
 }
 


### PR DESCRIPTION
#### Summary
Balance "Nerf some traps(caltrops, nailboards, glass). Larger creatures can destroy them with their weight, or otherwise render them ineffective and need to be setup again"

#### Purpose of change
I've read some stories of people cheesing hulks or other mindless enemies (without trapavoid) by luring them back and forth over a single caltrop or nailboard. 

As you all know: No fun allowed.

#### Describe the solution
Rewrite most of the old dusty code to make rational assumptions. For example a quadruped player that steps on a caltrop will no longer stop, pause, and then roll around to make sure all their legs and arms properly fall victim to the same caltrop. Only one limb used for movement will be affected, picked at random. (Also removed the hardcoded checks for left/right leg)

Since a tile is approximately 1x1 meters across, scaled the chance to actually run into the caltrops/board/glass trap by the creature's size, instead of being guaranteed when moving into that tile. The caltrop trap is a single caltrop, the nailboard trap is three boards and 20 nails or so. There's just not enough surface area to get anything close to 100% coverage unless the creature is freakishly huge.

Made metal caltrops and nailboards sometimes get destroyed by the triggering creature, scaling chance based on the creature's weight. A zombie behemoth the size of a truck should just roll over the damn thing

Even if the trap isn't destroyed, any triggering can sometimes "disarm" those two traps, rendering them back into item form. This would be the equivalent of e.g. the nailboard getting turned over. Caltrops are typically designed so that they always rest with a point upwards, but they could be bent out of shape or partly embedded into the ground at an angle that makes them ineffective.

Equalized the damage for these traps when triggering vs monsters as opposed to triggering vs characters. No reason for it to do more or less damage depending on the target.

Fix a call to make sound in the glass caltrops function which only fired if the player was able to see it when it triggered
![image](https://github.com/user-attachments/assets/8e53a8d7-0a22-4a70-aabb-d2f0ad163e7c)

Simplified and replaced some old no-longer-necessary dynamic casts to monster pointers with is_monster() and the like

Safety-checked a cast to character by making sure the cast doesn't result in nullptr before calling it

Changed a numeric value from being stored as `char`(????????????) to int

https://github.com/CleverRaven/Cataclysm-DDA/blob/master/src/trapfunc.cpp#L155

#### Describe alternatives you've considered
JSONizing traps??

#### Testing
Spawned some lines of caltrops, glass, and nailboards. Lead a bunch of fat zombies back and forth over them. Lines of traps weren't guaranteed to kill zombies at any depth, and the horde left the field of traps pretty sparse after a few passes. Still a lot of zombies died and there was blood everywhere, which is about what I'd expect for a deep line of traps.

#### Additional context

