### PR TITLE
typified a bit of map.cpp and dependents

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -908,7 +908,7 @@ bool avatar_action::eat_here( avatar &you )
             add_msg( _( "You're too full to eat the leaves from the %s." ), here.ter( you.pos_bub() )->name() );
             return true;
         } else {
-            here.ter_set( you.pos(), ter_t_grass );
+            here.ter_set( you.pos_bub(), ter_t_grass );
             item food( "underbrush", calendar::turn, 1 );
             you.assign_activity( consume_activity_actor( food ) );
             return true;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3239,7 +3239,7 @@ bool cata_tiles::draw_terrain_below( const tripoint &p, const lit_level, int &,
         return false;
     }
 
-    tripoint pbelow = tripoint( p.xy(), p.z - 1 );
+    tripoint_bub_ms pbelow = tripoint_bub_ms( p + tripoint_below );
     nc_color col = c_dark_gray;
 
     const ter_t &curr_ter = here.ter( pbelow ).obj();
@@ -3264,7 +3264,7 @@ bool cata_tiles::draw_terrain_below( const tripoint &p, const lit_level, int &,
         col = curr_ter.color();
     }
 
-    draw_square_below( pbelow.xy(), col, sizefactor );
+    draw_square_below( pbelow.xy().raw(), col, sizefactor );
     return true;
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1384,7 +1384,7 @@ bool Character::has_watch() const
 {
     map &here = get_map();
     return cache_has_item_with_flag( flag_WATCH, true ) ||
-           ( here.veh_at( pos() ) &&
+           ( here.veh_at( pos_bub() ) &&
              !empty( here.veh_at( pos_bub() )->vehicle().get_avail_parts( "WATCH" ) ) ) ||
            has_flag( json_flag_WATCH );
 }
@@ -10381,8 +10381,8 @@ std::vector<Creature *> Character::get_targetable_creatures( const int range, bo
         bool can_see = ( ( sees( critter ) || sees_with_infrared( critter ) ) && here.sees( pos_bub(), critter.pos_bub(), 100 ) );
         if( can_see && melee )  //handles the case where we can see something with glass in the way for melee attacks
         {
-            std::vector<tripoint> path = here.find_clear_path( pos(), critter.pos() );
-            for( const tripoint &point : path ) {
+            std::vector<tripoint_bub_ms> path = here.find_clear_path( pos_bub(), critter.pos_bub() );
+            for( const tripoint_bub_ms &point : path ) {
                 if( here.impassable( point ) &&
                     !( weapon.has_flag( flag_SPEAR ) && // Fences etc. Spears can stab through those
                        here.has_flag( ter_furn_flag::TFLAG_THIN_OBSTACLE,
@@ -11020,31 +11020,31 @@ void Character::gravity_check()
 void Character::stagger()
 {
     map &here = get_map();
-    std::vector<tripoint> valid_stumbles;
+    std::vector<tripoint_bub_ms> valid_stumbles;
     valid_stumbles.reserve( 11 );
     for( const tripoint_bub_ms &dest : here.points_in_radius( pos_bub(), 1 ) ) {
         if( dest != pos_bub() ) {
             if( here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest ) ) {
-                valid_stumbles.emplace_back( dest.xy().raw(), dest.z() - 1 );
+                valid_stumbles.emplace_back( dest + tripoint_below );
             } else if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest ) ) {
-                valid_stumbles.emplace_back( dest.xy().raw(), dest.z() + 1 );
+                valid_stumbles.emplace_back( dest + tripoint_above );
             } else {
-                valid_stumbles.push_back( dest.raw() );
+                valid_stumbles.push_back( dest );
             }
         }
     }
     const tripoint_bub_ms below( posx(), posy(), posz() - 1 );
     if( here.valid_move( pos_bub(), below, false, true ) ) {
-        valid_stumbles.push_back( below.raw() );
+        valid_stumbles.push_back( below );
     }
     creature_tracker &creatures = get_creature_tracker();
     while( !valid_stumbles.empty() ) {
         bool blocked = false;
-        const tripoint dest = random_entry_removed( valid_stumbles );
+        const tripoint_bub_ms dest = random_entry_removed( valid_stumbles );
         const optional_vpart_position vp_there = here.veh_at( dest );
         if( vp_there ) {
             vehicle &veh = vp_there->vehicle();
-            if( veh.enclosed_at( dest ) ) {
+            if( veh.enclosed_at( dest.raw() ) ) {
                 blocked = true;
             }
         }

--- a/src/climbing.cpp
+++ b/src/climbing.cpp
@@ -378,15 +378,14 @@ climbing_aid::fall_scan::fall_scan( const tripoint &examp )
 
     // Get coordinates just below and at ground level.
     // Also detect if furniture would block our tools/abilities.
-    tripoint bottom = examp;
-    tripoint just_below = examp;
-    just_below.z--;
+    tripoint_bub_ms bottom( examp );
+    tripoint_bub_ms just_below( bottom + tripoint_below );
 
     int hit_furn = false;
     int hit_crea = false;
     int hit_veh = false;
 
-    for( tripoint lower = just_below; here.valid_move( bottom, lower, false, true ); ) {
+    for( tripoint_bub_ms lower = just_below; here.valid_move( bottom, lower, false, true ); ) {
         if( !hit_furn ) {
             if( here.has_furn( lower ) ) {
                 hit_furn = true;
@@ -410,7 +409,7 @@ climbing_aid::fall_scan::fall_scan( const tripoint &examp )
             }
         }
         ++height;
-        bottom.z--;
-        lower.z--;
+        bottom.z()--;
+        lower.z()--;
     }
 }

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -618,15 +618,15 @@ void computer_session::action_cascade()
         return;
     }
     get_event_bus().send<event_type::causes_resonance_cascade>();
-    tripoint player_pos = get_player_character().pos();
+    tripoint_bub_ms player_pos = get_player_character().pos_bub();
     map &here = get_map();
     std::vector<tripoint> cascade_points;
-    for( const tripoint &dest : here.points_in_radius( player_pos, 10 ) ) {
+    for( const tripoint_bub_ms &dest : here.points_in_radius( player_pos, 10 ) ) {
         if( here.ter( dest ) == ter_t_radio_tower ) {
-            cascade_points.push_back( dest );
+            cascade_points.push_back( dest.raw() );
         }
     }
-    explosion_handler::resonance_cascade( random_entry( cascade_points, player_pos ) );
+    explosion_handler::resonance_cascade( random_entry( cascade_points, player_pos.raw() ) );
 }
 
 void computer_session::action_research()

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1717,7 +1717,7 @@ void construct::done_wiring( const tripoint_bub_ms &p, Character &/*who*/ )
 {
     get_map().partial_con_remove( p );
 
-    place_appliance( p.raw(), vpart_from_item( itype_wall_wiring ) );
+    place_appliance( p, vpart_from_item( itype_wall_wiring ) );
 }
 
 void construct::done_appliance( const tripoint_bub_ms &p, Character & )
@@ -1741,8 +1741,7 @@ void construct::done_appliance( const tripoint_bub_ms &p, Character & )
     const item &base = components.front();
     const vpart_id &vpart = vpart_appliance_from_item( base.typeId() );
 
-    // TODO: fix point types
-    place_appliance( p.raw(), vpart, base );
+    place_appliance( p, vpart, base );
 }
 
 void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_character )

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -699,8 +699,8 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
                 // Hack: trying yo avoid turret LOS blocking by frames bug by trying to see target from vehicle boundary
                 // Or turret wallhack for turret's car
                 // TODO: to visibility checking another way, probably using 3D FOV
-                std::vector<tripoint> path_to_target = line_to( pos(), m->pos() );
-                path_to_target.insert( path_to_target.begin(), pos() );
+                std::vector<tripoint_bub_ms> path_to_target = line_to( pos_bub(), m->pos_bub() );
+                path_to_target.insert( path_to_target.begin(), pos_bub() );
 
                 // Getting point on vehicle boundaries and on line between target and turret
                 bool continueFlag = true;

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -37,7 +37,7 @@ void appliance_convert_examine_actor::call( Character &, const tripoint_bub_ms &
         here.ter_set( examp, *ter_set );
     }
 
-    place_appliance( examp.raw(), vpart_appliance_from_item( appliance_item ) );
+    place_appliance( examp, vpart_appliance_from_item( appliance_item ) );
 }
 
 void appliance_convert_examine_actor::finalize() const

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -819,7 +819,7 @@ void item_location::deserialize( const JsonObject &obj )
     std::string type = obj.get_string( "type" );
 
     int idx = -1;
-    tripoint pos = tripoint_min;
+    tripoint_bub_ms pos = tripoint_bub_ms_min;
 
     obj.read( "idx", idx );
     obj.read( "pos", pos );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1371,7 +1371,7 @@ static void marloss_common( Character &p, item &it, const trait_id &current_colo
         }
 
         p.set_mutation( trait_THRESH_MARLOSS );
-        get_map().ter_set( p.pos(), ter_t_marloss );
+        get_map().ter_set( p.pos_bub(), ter_t_marloss );
         get_event_bus().send<event_type::crosses_marloss_threshold>( p.getID() );
         p.add_msg_if_player( m_good,
                              _( "You wake up in a Marloss bush.  Almost *cradled* in it, actually, as though it grew there for you." ) );
@@ -3076,13 +3076,13 @@ static std::optional<int> dig_tool( Character *p, item *it, const tripoint &pos,
         return std::nullopt;
     }
 
-    tripoint pnt = pos;
-    if( pos == p->pos() ) {
+    tripoint_bub_ms pnt( pos );
+    if( pos == p->pos_bub().raw() ) {
         const std::optional<tripoint> pnt_ = choose_adjacent( prompt );
         if( !pnt_ ) {
             return std::nullopt;
         }
-        pnt = *pnt_;
+        pnt = tripoint_bub_ms( *pnt_ );
     }
 
     map &here = get_map();

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1081,16 +1081,16 @@ static ret_val<tripoint> check_deploy_square( Character *p, item &it, const trip
     if( p->cant_do_mounted() ) {
         return ret_val<tripoint>::make_failure( pos );
     }
-    tripoint pnt = pos;
-    if( pos == p->pos() ) {
+    tripoint_bub_ms pnt( pos );
+    if( pos == p->pos_bub().raw() ) {
         if( const std::optional<tripoint> pnt_ = choose_adjacent( _( "Deploy where?" ) ) ) {
-            pnt = *pnt_;
+            pnt = tripoint_bub_ms( *pnt_ );
         } else {
             return ret_val<tripoint>::make_failure( pos );
         }
     }
 
-    if( pnt == p->pos() ) {
+    if( pnt == p->pos_bub() ) {
         return ret_val<tripoint>::make_failure( pos,
                                                 _( "You attempt to become one with the %s.  It doesn't work." ), it.tname() );
     }
@@ -1141,7 +1141,7 @@ static ret_val<tripoint> check_deploy_square( Character *p, item &it, const trip
         }
     }
 
-    return ret_val<tripoint>::make_success( pnt );
+    return ret_val<tripoint>::make_success( pnt.raw() );
 }
 
 std::optional<int> deploy_furn_actor::use( Character *p, item &it,
@@ -1185,7 +1185,7 @@ std::optional<int> deploy_appliance_actor::use( Character *p, item &it, const tr
     }
 
     it.spill_contents( suitable.value() );
-    place_appliance( suitable.value(), vpart_appliance_from_item( appliance_base ) );
+    place_appliance( tripoint_bub_ms( suitable.value() ), vpart_appliance_from_item( appliance_base ) );
     p->mod_moves( -to_moves<int>( 2_seconds ) );
     return 1;
 }
@@ -3798,8 +3798,8 @@ std::unique_ptr<iuse_actor> place_trap_actor::clone() const
 static bool is_solid_neighbor( const tripoint &pos, const point &offset )
 {
     map &here = get_map();
-    const tripoint a = pos + tripoint( offset, 0 );
-    const tripoint b = pos - tripoint( offset, 0 );
+    const tripoint_bub_ms a = tripoint_bub_ms( pos ) + tripoint( offset, 0 );
+    const tripoint_bub_ms b = tripoint_bub_ms( pos ) - tripoint( offset, 0 );
     return here.move_cost( a ) != 2 && here.move_cost( b ) != 2;
 }
 

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -22,45 +22,45 @@ double iso_tangent( double distance, const units::angle &vertex )
     return tan( vertex / 2 )  * distance * 2;
 }
 
-void bresenham( const point &p1, const point &p2, int t,
-                const std::function<bool( const point & )> &interact )
+void bresenham( const point_bub_ms &p1, const point_bub_ms &p2, int t,
+                const std::function<bool( const point_bub_ms & )> &interact )
 {
     // The slope components.
-    const point d = p2 - p1;
+    const point_rel_ms d = p2 - p1;
     // Signs of slope values.
-    const point s( ( d.x == 0 ) ? 0 : sgn( d.x ), ( d.y == 0 ) ? 0 : sgn( d.y ) );
+    const point s( ( d.x() == 0 ) ? 0 : sgn( d.x() ), ( d.y() == 0 ) ? 0 : sgn( d.y() ) );
     // Absolute values of slopes x2 to avoid rounding errors.
-    const point a = d.abs() * 2;
+    const point a = d.raw().abs() * 2;
 
-    point cur = p1;
+    point_bub_ms cur = p1;
 
     if( a.x == a.y ) {
-        while( cur.x != p2.x ) {
-            cur.y += s.y;
-            cur.x += s.x;
+        while( cur.x() != p2.x() ) {
+            cur.y() += s.y;
+            cur.x() += s.x;
             if( !interact( cur ) ) {
                 break;
             }
         }
     } else if( a.x > a.y ) {
-        while( cur.x != p2.x ) {
+        while( cur.x() != p2.x() ) {
             if( t > 0 ) {
-                cur.y += s.y;
+                cur.y() += s.y;
                 t -= a.x;
             }
-            cur.x += s.x;
+            cur.x() += s.x;
             t += a.y;
             if( !interact( cur ) ) {
                 break;
             }
         }
     } else {
-        while( cur.y != p2.y ) {
+        while( cur.y() != p2.y() ) {
             if( t > 0 ) {
-                cur.x += s.x;
+                cur.x() += s.x;
                 t -= a.y;
             }
-            cur.y += s.y;
+            cur.y() += s.y;
             t += a.x;
             if( !interact( cur ) ) {
                 break;
@@ -69,47 +69,47 @@ void bresenham( const point &p1, const point &p2, int t,
     }
 }
 
-void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
-                const std::function<bool( const tripoint & )> &interact )
+void bresenham( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2, int t, int t2,
+                const std::function<bool( const tripoint_bub_ms & )> &interact )
 {
     // The slope components.
-    const tripoint d( -loc1 + loc2 );
+    const tripoint_rel_ms d( loc2 - loc1 );
     // The signs of the slopes.
-    const tripoint s( ( d.x == 0 ? 0 : sgn( d.x ) ), ( d.y == 0 ? 0 : sgn( d.y ) ),
-                      ( d.z == 0 ? 0 : sgn( d.z ) ) );
+    const tripoint s( ( d.x() == 0 ? 0 : sgn( d.x() ) ), ( d.y() == 0 ? 0 : sgn( d.y() ) ),
+                      ( d.z() == 0 ? 0 : sgn( d.z() ) ) );
     // Absolute values of slope components, x2 to avoid rounding errors.
-    const tripoint a( std::abs( d.x ) * 2, std::abs( d.y ) * 2, std::abs( d.z ) * 2 );
+    const tripoint a( std::abs( d.x() ) * 2, std::abs( d.y() ) * 2, std::abs( d.z() ) * 2 );
 
-    tripoint cur( loc1 );
+    tripoint_bub_ms cur( loc1 );
 
     if( a.z == 0 ) {
         if( a.x == a.y ) {
-            while( cur.x != loc2.x ) {
-                cur.y += s.y;
-                cur.x += s.x;
+            while( cur.x() != loc2.x() ) {
+                cur.y() += s.y;
+                cur.x() += s.x;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
         } else if( a.x > a.y ) {
-            while( cur.x != loc2.x ) {
+            while( cur.x() != loc2.x() ) {
                 if( t > 0 ) {
-                    cur.y += s.y;
+                    cur.y() += s.y;
                     t -= a.x;
                 }
-                cur.x += s.x;
+                cur.x() += s.x;
                 t += a.y;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
         } else {
-            while( cur.y != loc2.y ) {
+            while( cur.y() != loc2.y() ) {
                 if( t > 0 ) {
-                    cur.x += s.x;
+                    cur.x() += s.x;
                     t -= a.y;
                 }
-                cur.y += s.y;
+                cur.y() += s.y;
                 t += a.x;
                 if( !interact( cur ) ) {
                     break;
@@ -118,25 +118,23 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
         }
     } else {
         if( a.x == a.y && a.y == a.z ) {
-            while( cur.x != loc2.x ) {
-                cur.z += s.z;
-                cur.y += s.y;
-                cur.x += s.x;
+            while( cur.x() != loc2.x() ) {
+                cur += s;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
         } else if( ( a.z > a.x ) && ( a.z > a.y ) ) {
-            while( cur.z != loc2.z ) {
+            while( cur.z() != loc2.z() ) {
                 if( t > 0 ) {
-                    cur.x += s.x;
+                    cur.x() += s.x;
                     t -= a.z;
                 }
                 if( t2 > 0 ) {
-                    cur.y += s.y;
+                    cur.y() += s.y;
                     t2 -= a.z;
                 }
-                cur.z += s.z;
+                cur.z() += s.z;
                 t += a.x;
                 t2 += a.y;
                 if( !interact( cur ) ) {
@@ -144,55 +142,55 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
                 }
             }
         } else if( a.x == a.y ) {
-            while( cur.x != loc2.x ) {
+            while( cur.x() != loc2.x() ) {
                 if( t > 0 ) {
-                    cur.z += s.z;
+                    cur.z() += s.z;
                     t -= a.x;
                 }
-                cur.y += s.y;
-                cur.x += s.x;
+                cur.y() += s.y;
+                cur.x() += s.x;
                 t += a.z;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
         } else if( a.x == a.z ) {
-            while( cur.x != loc2.x ) {
+            while( cur.x() != loc2.x() ) {
                 if( t > 0 ) {
-                    cur.y += s.y;
+                    cur.y() += s.y;
                     t -= a.x;
                 }
-                cur.z += s.z;
-                cur.x += s.x;
+                cur.z() += s.z;
+                cur.x() += s.x;
                 t += a.y;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
         } else if( a.y == a.z ) {
-            while( cur.y != loc2.y ) {
+            while( cur.y() != loc2.y() ) {
                 if( t > 0 ) {
-                    cur.x += s.x;
+                    cur.x() += s.x;
                     t -= a.z;
                 }
-                cur.y += s.y;
-                cur.z += s.z;
+                cur.y() += s.y;
+                cur.z() += s.z;
                 t += a.x;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
         } else if( a.x > a.y ) {
-            while( cur.x != loc2.x ) {
+            while( cur.x() != loc2.x() ) {
                 if( t > 0 ) {
-                    cur.y += s.y;
+                    cur.y() += s.y;
                     t -= a.x;
                 }
                 if( t2 > 0 ) {
-                    cur.z += s.z;
+                    cur.z() += s.z;
                     t2 -= a.x;
                 }
-                cur.x += s.x;
+                cur.x() += s.x;
                 t += a.y;
                 t2 += a.z;
                 if( !interact( cur ) ) {
@@ -200,16 +198,16 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
                 }
             }
         } else { //dy > dx >= dz
-            while( cur.y != loc2.y ) {
+            while( cur.y() != loc2.y() ) {
                 if( t > 0 ) {
-                    cur.x += s.x;
+                    cur.x() += s.x;
                     t -= a.y;
                 }
                 if( t2 > 0 ) {
-                    cur.z += s.z;
+                    cur.z() += s.z;
                     t2 -= a.y;
                 }
-                cur.y += s.y;
+                cur.y() += s.y;
                 t += a.x;
                 t2 += a.z;
                 if( !interact( cur ) ) {
@@ -231,8 +229,8 @@ std::vector<point> line_to( const point &p1, const point &p2, int t )
         line.push_back( p1 );
     } else {
         line.reserve( numCells );
-        bresenham( p1, p2, t, [&line]( const point & new_point ) {
-            line.push_back( new_point );
+        bresenham( point_bub_ms( p1 ), point_bub_ms( p2 ), t, [&line]( const point_bub_ms & new_point ) {
+            line.push_back( new_point.raw() );
             return true;
         } );
     }
@@ -248,8 +246,9 @@ std::vector <tripoint> line_to( const tripoint &loc1, const tripoint &loc2, int 
         line.push_back( loc1 );
     } else {
         line.reserve( numCells );
-        bresenham( loc1, loc2, t, t2, [&line]( const tripoint & new_point ) {
-            line.push_back( new_point );
+        bresenham( tripoint_bub_ms( loc1 ), tripoint_bub_ms( loc2 ), t,
+        t2, [&line]( const tripoint_bub_ms & new_point ) {
+            line.push_back( new_point.raw() );
             return true;
         } );
     }

--- a/src/line.h
+++ b/src/line.h
@@ -142,10 +142,10 @@ std::string direction_suffix( const tripoint &p, const tripoint &q );
  * The actual Bresenham algorithm in 2D and 3D, everything else should call these
  * and pass in an interact functor to iterate across a line between two points.
  */
-void bresenham( const point &p1, const point &p2, int t,
-                const std::function<bool( const point & )> &interact );
-void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
-                const std::function<bool( const tripoint & )> &interact );
+void bresenham( const point_bub_ms &p1, const point_bub_ms &p2, int t,
+                const std::function<bool( const point_bub_ms & )> &interact );
+void bresenham( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2, int t, int t2,
+                const std::function<bool( const tripoint_bub_ms & )> &interact );
 
 tripoint move_along_line( const tripoint &loc, const std::vector<tripoint> &line,
                           int distance );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -410,7 +410,7 @@ void map::invalidate_map_cache( const int zlev )
     }
 }
 
-const_maptile map::maptile_at( const tripoint &p ) const
+const_maptile map::maptile_at( const tripoint_bub_ms &p ) const
 {
     if( !inbounds( p ) ) {
         return const_maptile( &null_submap, point_sm_ms_zero );
@@ -419,28 +419,18 @@ const_maptile map::maptile_at( const tripoint &p ) const
     return maptile_at_internal( p );
 }
 
-const_maptile map::maptile_at( const tripoint_bub_ms &p ) const
+maptile map::maptile_at( const tripoint &p )
 {
-    return maptile_at( p.raw() );
+    return maptile_at( tripoint_bub_ms( p ) );
 }
 
-maptile map::maptile_at( const tripoint &p )
+maptile map::maptile_at( const tripoint_bub_ms &p )
 {
     if( !inbounds( p ) ) {
         return maptile( &null_submap, point_sm_ms_zero );
     }
 
     return maptile_at_internal( p );
-}
-
-maptile map::maptile_at( const tripoint_bub_ms &p )
-{
-    return maptile_at( p.raw() );
-}
-
-const_maptile map::maptile_at_internal( const tripoint &p ) const
-{
-    return map::maptile_at_internal( tripoint_bub_ms( p ) );
 }
 
 const_maptile map::maptile_at_internal( const tripoint_bub_ms &p ) const
@@ -680,7 +670,7 @@ void map::vehmove()
     VehicleList vehicle_list;
     int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z();
     int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z();
-    const tripoint player_pos = get_player_character().pos();
+    const tripoint_bub_ms player_pos = get_player_character().pos_bub();
     for( int zlev = minz; zlev <= maxz; ++zlev ) {
         level_cache *cache_lazy = get_cache_lazy( zlev );
         if( !cache_lazy ) {
@@ -784,11 +774,6 @@ static bool sees_veh( const Creature &c, vehicle &veh, bool force_recalc )
     return std::any_of( veh_points.begin(), veh_points.end(), [&c]( const tripoint & pt ) {
         return c.sees( pt );
     } );
-}
-
-vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &facing )
-{
-    return map::move_vehicle( veh, tripoint_rel_ms( dp ), facing );
 }
 
 vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tileray &facing )
@@ -1317,11 +1302,6 @@ std::set<tripoint_bub_ms> map::get_moving_vehicle_targets( const Creature &z, in
 
 // 3D vehicle functions
 
-VehicleList map::get_vehicles( const tripoint &start, const tripoint &end )
-{
-    return map::get_vehicles( tripoint_bub_ms( start ), tripoint_bub_ms( end ) );
-}
-
 VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_ms &end )
 {
     const int chunk_sx = std::max( 0, ( start.x() / SEEX ) - 1 );
@@ -1379,11 +1359,6 @@ optional_vpart_position map::veh_at( const tripoint_bub_ms &p ) const
     return optional_vpart_position( vpart_position( *veh, part_num ) );
 }
 
-const vehicle *map::veh_at_internal( const tripoint &p, int &part_num ) const
-{
-    return map::veh_at_internal( tripoint_bub_ms( p ), part_num );
-}
-
 const vehicle *map::veh_at_internal( const tripoint_bub_ms &p, int &part_num ) const
 {
     // This function is called A LOT. Move as much out of here as possible.
@@ -1410,7 +1385,7 @@ vehicle *map::veh_at_internal( const tripoint_bub_ms &p, int &part_num )
     return const_cast<vehicle *>( const_cast<const map *>( this )->veh_at_internal( p, part_num ) );
 }
 
-void map::board_vehicle( const tripoint &pos, Character *p )
+void map::board_vehicle( const tripoint_bub_ms &pos, Character *p )
 {
     if( p == nullptr ) {
         debugmsg( "map::board_vehicle: null player" );
@@ -1444,11 +1419,6 @@ void map::board_vehicle( const tripoint &pos, Character *p )
     }
 }
 
-void map::board_vehicle( const tripoint_bub_ms &pos, Character *p )
-{
-    map::board_vehicle( pos.raw(), p );
-}
-
 void map::unboard_vehicle( const vpart_reference &vp, Character *passenger, bool dead_passenger )
 {
     // Mark the part as un-occupied regardless of whether there's a live passenger here.
@@ -1471,11 +1441,6 @@ void map::unboard_vehicle( const vpart_reference &vp, Character *passenger, bool
     passenger->controlling_vehicle = false;
 }
 
-void map::unboard_vehicle( const tripoint &p, bool dead_passenger )
-{
-    map::unboard_vehicle( tripoint_bub_ms( p ), dead_passenger );
-}
-
 void map::unboard_vehicle( const tripoint_bub_ms &p, bool dead_passenger )
 {
     const std::optional<vpart_reference> vp = veh_at( p ).part_with_feature( VPFLAG_BOARDABLE, false );
@@ -1492,12 +1457,6 @@ void map::unboard_vehicle( const tripoint_bub_ms &p, bool dead_passenger )
     }
     passenger = vp->get_passenger();
     unboard_vehicle( *vp, passenger, dead_passenger );
-}
-
-bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_pos,
-                            const std::set<int> &parts_to_move )
-{
-    return map::displace_vehicle( veh, tripoint_rel_ms( dp ), adjust_pos, parts_to_move );
 }
 
 bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const bool adjust_pos,
@@ -1743,11 +1702,6 @@ bool map::displace_water( const tripoint_bub_ms &p )
 
 // End of 3D vehicle
 
-void map::set( const tripoint &p, const ter_id &new_terrain, const furn_id &new_furniture )
-{
-    map::set( tripoint_bub_ms( p ), new_terrain, new_furniture );
-}
-
 void map::set( const tripoint_bub_ms &p, const ter_id &new_terrain, const furn_id &new_furniture )
 {
     furn_set( p, new_furniture );
@@ -1776,15 +1730,15 @@ std::string map::disp_name( const tripoint_bub_ms &p )
 
 std::string map::obstacle_name( const tripoint &p )
 {
-    if( const std::optional<vpart_reference> vp = veh_at( p ).obstacle_at_part() ) {
-        return vp->info().name();
-    }
-    return name( p );
+    return obstacle_name( tripoint_bub_ms( p ) );
 }
 
 std::string map::obstacle_name( const tripoint_bub_ms &p )
 {
-    return obstacle_name( p.raw() );
+    if( const std::optional<vpart_reference> vp = veh_at( p ).obstacle_at_part() ) {
+        return vp->info().name();
+    }
+    return name( p );
 }
 
 bool map::has_furn( const tripoint &p ) const
@@ -1965,6 +1919,11 @@ bool map::can_move_furniture( const tripoint_bub_ms &pos, Character *you ) const
 
 std::string map::furnname( const tripoint &p )
 {
+    return furnname( tripoint_bub_ms( p ) );
+}
+
+std::string map::furnname( const tripoint_bub_ms &p )
+{
     const furn_t &f = furn( p ).obj();
     if( f.has_flag( ter_furn_flag::TFLAG_PLANT ) ) {
         // Can't use item_stack::only_item() since there might be fertilizer
@@ -1973,7 +1932,7 @@ std::string map::furnname( const tripoint &p )
             return it.is_seed();
         } );
         if( seed == items.end() ) {
-            debugmsg( "Missing seed for plant at (%d, %d, %d)", p.x, p.y, p.z );
+            debugmsg( "Missing seed for plant at (%d, %d, %d)", p.x(), p.y(), p.z() );
             return "null";
         }
         const std::string &plant = seed->get_plant_name();
@@ -1981,11 +1940,6 @@ std::string map::furnname( const tripoint &p )
     } else {
         return f.name();
     }
-}
-
-std::string map::furnname( const tripoint_bub_ms &p )
-{
-    return furnname( p.raw() );
 }
 
 /*
@@ -2058,18 +2012,18 @@ uint8_t map::get_known_connections( const tripoint_bub_ms &p,
 
     const level_cache &ch = access_cache( p.z() );
     uint8_t val = 0;
-    std::function<bool( const tripoint & )> is_memorized;
+    std::function<bool( const tripoint_bub_ms & )> is_memorized;
     avatar &player_character = get_avatar();
 #ifdef TILES
     if( use_tiles ) {
         is_memorized =
-        [&]( const tripoint & q ) {
+        [&]( const tripoint_bub_ms & q ) {
             return !player_character.get_memorized_tile( getglobal( q ) ).get_ter_id().empty();
         };
     } else {
 #endif
         is_memorized =
-        [&]( const tripoint & q ) {
+        [&]( const tripoint_bub_ms & q ) {
             return player_character.get_memorized_tile( getglobal( q ) ).symbol != 0;
         };
 #ifdef TILES
@@ -2092,7 +2046,7 @@ uint8_t map::get_known_connections( const tripoint_bub_ms &p,
                                  get_visibility( ch.visibility_cache[neighbour.x()][neighbour.y()],
                                          get_visibility_variables_cache() ) == visibility_type::CLEAR ||
                                  // or if an actual center tile is transparent or next to a memorized tile
-                                 ( !overridden && ( is_transparent || is_memorized( neighbour.raw() ) ) );
+                                 ( !overridden && ( is_transparent || is_memorized( neighbour ) ) );
         if( may_connect ) {
             const ter_t &neighbour_terrain = neighbour_overridden ?
                                              neighbour_override->second.obj() : ter( neighbour ).obj();
@@ -2265,11 +2219,6 @@ uint8_t map::get_known_rotates_to_f( const tripoint_bub_ms &p,
 /*
  * Get the results of harvesting this tile's furniture or terrain
  */
-const harvest_id &map::get_harvest( const tripoint &pos ) const
-{
-    return map::get_harvest( tripoint_bub_ms( pos ) );
-}
-
 const harvest_id &map::get_harvest( const tripoint_bub_ms &pos ) const
 {
     const furn_id furn_here = furn( pos );
@@ -2316,11 +2265,6 @@ const std::set<std::string> &map::get_harvest_names( const tripoint_bub_ms &pos 
 /*
  * Get the terrain transforms_into id (what will the terrain transforms into)
  */
-ter_id map::get_ter_transforms_into( const tripoint &p ) const
-{
-    return map::get_ter_transforms_into( tripoint_bub_ms( p ) );
-}
-
 ter_id map::get_ter_transforms_into( const tripoint_bub_ms &p ) const
 {
     return ter( p ).obj().transforms_into.id();
@@ -2330,11 +2274,6 @@ ter_id map::get_ter_transforms_into( const tripoint_bub_ms &p ) const
  * Examines the tile pos, with character as the "examinator"
  * Casts Character to player because player/NPC split isn't done yet
  */
-void map::examine( Character &you, const tripoint &pos ) const
-{
-    map::examine( you, tripoint_bub_ms( pos ) );
-}
-
 void map::examine( Character &you, const tripoint_bub_ms &pos ) const
 {
     const furn_t furn_here = furn( pos ).obj();
@@ -2343,11 +2282,6 @@ void map::examine( Character &you, const tripoint_bub_ms &pos ) const
     } else {
         ter( pos ).obj().examine( dynamic_cast<Character &>( you ), pos );
     }
-}
-
-bool map::is_harvestable( const tripoint &pos ) const
-{
-    return map::is_harvestable( tripoint_bub_ms( pos ) );
 }
 
 bool map::is_harvestable( const tripoint_bub_ms &pos ) const
@@ -2478,6 +2412,11 @@ std::string map::tername( const tripoint_bub_ms &p ) const
 
 std::string map::features( const tripoint &p ) const
 {
+    return map::features( tripoint_bub_ms( p ) );
+}
+
+std::string map::features( const tripoint_bub_ms &p ) const
+{
     std::string result;
     const auto add = [&]( const std::string & text ) {
         if( !result.empty() ) {
@@ -2506,11 +2445,6 @@ std::string map::features( const tripoint &p ) const
             has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH, p ) ||
             has_flag( ter_furn_flag::TFLAG_FLAMMABLE_HARD, p ), _( "Flammable." ) );
     return result;
-}
-
-std::string map::features( const tripoint_bub_ms &p ) const
-{
-    return map::features( p.raw() );
 }
 
 int map::move_cost_internal( const furn_t &furniture, const ter_t &terrain, const field &field,
@@ -2610,22 +2544,22 @@ int map::move_cost( const tripoint_bub_ms &p, const vehicle *ignored_vehicle ) c
 
 bool map::impassable( const tripoint &p ) const
 {
-    return !passable( p );
+    return impassable( tripoint_bub_ms( p ) );
 }
 
 bool map::impassable( const tripoint_bub_ms &p ) const
 {
-    return impassable( p.raw() );
+    return !passable( p );
 }
 
 bool map::passable( const tripoint &p ) const
 {
-    return move_cost( p ) != 0;
+    return passable( tripoint_bub_ms( p ) );
 }
 
 bool map::passable( const tripoint_bub_ms &p ) const
 {
-    return passable( p.raw() );
+    return move_cost( p ) != 0;
 }
 
 int map::move_cost_ter_furn( const tripoint &p ) const
@@ -2668,11 +2602,6 @@ bool map::impassable_ter_furn( const tripoint &p ) const
 bool map::impassable_ter_furn( const tripoint_bub_ms &p ) const
 {
     return !passable_ter_furn( p );
-}
-
-bool map::passable_ter_furn( const tripoint &p ) const
-{
-    return map::passable_ter_furn( tripoint_bub_ms( p ) );
 }
 
 bool map::passable_ter_furn( const tripoint_bub_ms &p ) const
@@ -3315,7 +3244,7 @@ bool map::can_put_items_ter_furn( const tripoint_bub_ms &p ) const
 
 bool map::has_flag_ter( const std::string &flag, const tripoint &p ) const
 {
-    return ter( p ).obj().has_flag( flag );
+    return ter( tripoint_bub_ms( p ) ).obj().has_flag( flag );
 }
 
 bool map::has_flag_ter( const std::string &flag, const tripoint_bub_ms &p ) const
@@ -3362,7 +3291,7 @@ bool map::has_flag( const ter_furn_flag flag, const tripoint_bub_ms &p ) const
 
 bool map::has_flag_ter( const ter_furn_flag flag, const tripoint &p ) const
 {
-    return ter( p ).obj().has_flag( flag );
+    return ter( tripoint_bub_ms( p ) ).obj().has_flag( flag );
 }
 
 bool map::has_flag_ter( const ter_furn_flag flag, const tripoint_bub_ms &p ) const
@@ -7841,13 +7770,13 @@ bool map::sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, const int ra
 
     // Ugly `if` for now
     if( F.z() == T.z() ) {
-        bresenham( F.xy().raw(), T.xy().raw(), bresenham_slope,
-        [this, f_transparent, &visible, &T]( const point & new_point ) {
+        bresenham( F.xy(), T.xy(), bresenham_slope,
+        [this, f_transparent, &visible, &T]( const point_bub_ms & new_point ) {
             // Exit before checking the last square, it's still visible even if opaque.
-            if( new_point.x == T.x() && new_point.y == T.y() ) {
+            if( new_point.x() == T.x() && new_point.y() == T.y() ) {
                 return false;
             }
-            if( !( this->*f_transparent )( tripoint_bub_ms( new_point.x, new_point.y, T.z() ) ) ) {
+            if( !( this->*f_transparent )( { new_point.x(), new_point.y(), T.z()} ) ) {
                 visible = false;
                 return false;
             }
@@ -7857,27 +7786,27 @@ bool map::sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, const int ra
         return visible;
     }
 
-    tripoint last_point = F.raw();
-    bresenham( F.raw(), T.raw(), bresenham_slope, 0,
-    [this, f_transparent, &visible, &T, &last_point]( const tripoint & new_point ) {
+    tripoint_bub_ms last_point = F;
+    bresenham( F, T, bresenham_slope, 0,
+    [this, f_transparent, &visible, &T, &last_point]( const tripoint_bub_ms & new_point ) {
         // Exit before checking the last square if it's not a vertical transition,
         // it's still visible even if opaque.
-        if( new_point == T.raw() && last_point.z == T.z() ) {
+        if( new_point == T && last_point.z() == T.z() ) {
             return false;
         }
 
         // TODO: Allow transparent floors (and cache them!)
-        if( new_point.z == last_point.z ) {
-            if( !( this->*f_transparent )( tripoint_bub_ms( new_point ) ) ) {
+        if( new_point.z() == last_point.z() ) {
+            if( !( this->*f_transparent )( new_point ) ) {
                 visible = false;
                 return false;
             }
         } else {
-            const int max_z = std::max( new_point.z, last_point.z );
+            const int max_z = std::max( new_point.z(), last_point.z() );
             if( ( has_floor_or_support( { point_bub_ms( new_point.xy() ), max_z } ) ||
-                  !( this->*f_transparent )( { point_bub_ms( new_point.xy() ), last_point.z } ) ) &&
+                  !( this->*f_transparent )( { point_bub_ms( new_point.xy() ), last_point.z()} ) ) &&
                 ( has_floor_or_support( { point_bub_ms( last_point.xy() ), max_z } ) ||
-                  !( this->*f_transparent )( { point_bub_ms( last_point.xy() ), new_point.z } ) ) ) {
+                  !( this->*f_transparent )( { point_bub_ms( last_point.xy() ), new_point.z()} ) ) ) {
                 visible = false;
                 return false;
             }
@@ -7899,16 +7828,16 @@ int map::obstacle_coverage( const tripoint_bub_ms &loc1, const tripoint_bub_ms &
     }
     const point a( std::abs( loc1.x() - loc2.x() ) * 2, std::abs( loc1.y() - loc2.y() ) * 2 );
     int offset = std::min( a.x, a.y ) - ( std::max( a.x, a.y ) / 2 );
-    tripoint obstaclepos;
-    bresenham( loc2.raw(), loc1.raw(), offset, 0, [&obstaclepos]( const tripoint & new_point ) {
+    tripoint_bub_ms obstaclepos;
+    bresenham( loc2, loc1, offset, 0, [&obstaclepos]( const tripoint_bub_ms & new_point ) {
         // Only adjacent tile between you and enemy is checked for cover.
         obstaclepos = new_point;
         return false;
     } );
-    if( const furn_id obstacle_f = furn( obstaclepos ) ) {
+    if( const furn_id obstacle_f = furn( tripoint_bub_ms( obstaclepos ) ) ) {
         return obstacle_f->coverage;
     }
-    if( const optional_vpart_position vp = veh_at( obstaclepos ) ) {
+    if( const optional_vpart_position vp = veh_at( tripoint_bub_ms( obstaclepos ) ) ) {
         if( vp->obstacle_at_part() ) {
             return 60;
         } else if( !vp->part_with_feature( VPFLAG_AISLE, true ) ) {
@@ -7991,10 +7920,10 @@ int map::ledge_coverage( const tripoint_bub_ms &viewer_p, const tripoint_bub_ms 
         high_p = target_p;
         low_p = viewer_p;
     }
-    tripoint ledge_p = high_p.raw();
-    bresenham( tripoint( low_p.xy().raw(), high_p.z() ), high_p.raw(), 0, 0, [this,
-    &ledge_p]( const tripoint & new_point ) {
-        if( dont_draw_lower_floor( tripoint_bub_ms( new_point ) ) ) {
+    tripoint_bub_ms ledge_p = high_p;
+    bresenham( tripoint_bub_ms( low_p.xy(), high_p.z() ), high_p, 0, 0, [this,
+    &ledge_p]( const tripoint_bub_ms & new_point ) {
+        if( dont_draw_lower_floor( new_point ) ) {
             ledge_p = new_point;
             return false;
         }
@@ -8003,7 +7932,7 @@ int map::ledge_coverage( const tripoint_bub_ms &viewer_p, const tripoint_bub_ms 
 
     // Height of each z-level in grids
     const float zlevel_to_grid_ratio = 2.0f;
-    float dist_to_ledge_base = trig_dist( viewer_p, tripoint_bub_ms( ledge_p.x, ledge_p.y,
+    float dist_to_ledge_base = trig_dist( viewer_p, tripoint_bub_ms( ledge_p.x(), ledge_p.y(),
                                           viewer_p.z() ) );
     // Adjustment to ledge distance because ledge is assumed to be between two grids
     dist_to_ledge_base += ( viewer_p.z() < target_p.z() ) ? -0.5f : 0.5f;
@@ -8011,7 +7940,7 @@ int map::ledge_coverage( const tripoint_bub_ms &viewer_p, const tripoint_bub_ms 
     // Absolute level of viewer's eye
     const float abs_eye_z = viewer_p.z() * zlevel_to_grid_ratio + eye_level;
     // "Opposite" of the angle between the eye level and ledge
-    const float eye_ledge_z_delta = ( ledge_p.z * zlevel_to_grid_ratio ) - abs_eye_z;
+    const float eye_ledge_z_delta = ( ledge_p.z() * zlevel_to_grid_ratio ) - abs_eye_z;
     const float tangent = eye_ledge_z_delta / dist_to_ledge_base;
     // Absolute level concealed by ledge, anything below this point is invisible
     const float covered_z = abs_eye_z + ( tangent * flat_dist );
@@ -8216,25 +8145,31 @@ void map::reachable_flood_steps( std::vector<tripoint_bub_ms> &reachable_pts,
 bool map::clear_path( const tripoint &f, const tripoint &t, const int range,
                       const int cost_min, const int cost_max ) const
 {
-    if( std::abs( f.z - t.z ) > fov_3d_z_range ) {
+    return clear_path( tripoint_bub_ms( f ), tripoint_bub_ms( t ), range, cost_min, cost_max );
+}
+
+bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const int range,
+                      const int cost_min, const int cost_max ) const
+{
+    if( std::abs( f.z() - t.z() ) > fov_3d_z_range ) {
         return false;
     }
 
     // Ugly `if` for now
-    if( f.z == t.z ) {
+    if( f.z() == t.z() ) {
         if( ( range >= 0 && range < rl_dist( f.xy(), t.xy() ) ) ||
             !inbounds( t ) ) {
             return false; // Out of range!
         }
         bool is_clear = true;
         bresenham( f.xy(), t.xy(), 0,
-        [this, &is_clear, cost_min, cost_max, &t]( const point & new_point ) {
+        [this, &is_clear, cost_min, cost_max, &t]( const point_bub_ms & new_point ) {
             // Exit before checking the last square, it's still reachable even if it is an obstacle.
-            if( new_point.x == t.x && new_point.y == t.y ) {
+            if( new_point.x() == t.x() && new_point.y() == t.y() ) {
                 return false;
             }
 
-            const int cost = this->move_cost( point_bub_ms( new_point ) );
+            const int cost = this->move_cost( new_point );
             if( cost < cost_min || cost > cost_max ) {
                 is_clear = false;
                 return false;
@@ -8249,16 +8184,16 @@ bool map::clear_path( const tripoint &f, const tripoint &t, const int range,
         return false; // Out of range!
     }
     bool is_clear = true;
-    tripoint last_point = f;
+    tripoint_bub_ms last_point = f;
     bresenham( f, t, 0, 0,
-    [this, &is_clear, cost_min, cost_max, t, &last_point]( const tripoint & new_point ) {
+    [this, &is_clear, cost_min, cost_max, t, &last_point]( const tripoint_bub_ms & new_point ) {
         // Exit before checking the last square, it's still reachable even if it is an obstacle.
         if( new_point == t ) {
             return false;
         }
 
         // We have to check a weird case where the move is both vertical and horizontal
-        if( new_point.z == last_point.z ) {
+        if( new_point.z() == last_point.z() ) {
             const int cost = move_cost( new_point );
             if( cost < cost_min || cost > cost_max ) {
                 is_clear = false;
@@ -8266,16 +8201,16 @@ bool map::clear_path( const tripoint &f, const tripoint &t, const int range,
             }
         } else {
             bool this_clear = false;
-            const int max_z = std::max( new_point.z, last_point.z );
-            if( !has_floor_or_support( {point_bub_ms( new_point.xy() ), max_z} ) ) {
-                const int cost = move_cost( {new_point.xy(), last_point.z} );
+            const int max_z = std::max( new_point.z(), last_point.z() );
+            if( !has_floor_or_support( { point_bub_ms( new_point.xy() ), max_z } ) ) {
+                const int cost = move_cost( tripoint_bub_ms{ new_point.xy(), last_point.z()} );
                 if( cost > cost_min && cost < cost_max ) {
                     this_clear = true;
                 }
             }
 
-            if( !this_clear && has_floor_or_support( {point_bub_ms( last_point.xy() ), max_z} ) ) {
-                const int cost = move_cost( {last_point.xy(), new_point.z} );
+            if( !this_clear && has_floor_or_support( { point_bub_ms( last_point.xy() ), max_z } ) ) {
+                const int cost = move_cost( tripoint_bub_ms{ last_point.xy(), new_point.z()} );
                 if( cost > cost_min && cost < cost_max ) {
                     this_clear = true;
                 }
@@ -8291,12 +8226,6 @@ bool map::clear_path( const tripoint &f, const tripoint &t, const int range,
         return true;
     } );
     return is_clear;
-}
-
-bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const int range,
-                      const int cost_min, const int cost_max ) const
-{
-    return clear_path( f.raw(), t.raw(), range, cost_min, cost_max );
 }
 
 bool map::accessible_items( const tripoint &t ) const
@@ -10405,7 +10334,7 @@ void map::draw_rough_circle_ter( const ter_id &type, const point_bub_ms &p, int 
 void map::draw_rough_circle_furn( const furn_id &type, const point_bub_ms &p, int rad )
 {
     draw_rough_circle( [this, type]( const point & q ) {
-        if( !is_open_air( tripoint( q, abs_sub.z() ) ) ) {
+        if( !is_open_air( tripoint_bub_ms( q.x, q.y, abs_sub.z() ) ) ) {
             this->furn_set( q, type );
         }
     }, p.raw(), rad );

--- a/src/map.h
+++ b/src/map.h
@@ -552,15 +552,12 @@ class map
         void clear_spawns();
         void clear_traps();
 
-        const_maptile maptile_at( const tripoint &p ) const;
         const_maptile maptile_at( const tripoint_bub_ms &p ) const;
         // TODO: Get rid of untyped overload
         maptile maptile_at( const tripoint &p );
         maptile maptile_at( const tripoint_bub_ms &p );
     private:
         // Versions of the above that don't do bounds checks
-        // TODO: Get rid of untyped overload.
-        const_maptile maptile_at_internal( const tripoint &p ) const;
         const_maptile maptile_at_internal( const tripoint_bub_ms &p ) const;
         // TODO: Get rid of untyped overload.
         maptile maptile_at_internal( const tripoint &p );
@@ -641,8 +638,6 @@ class map
         // TODO: Get rid of untyped overload.
         bool impassable_ter_furn( const tripoint &p ) const;
         bool impassable_ter_furn( const tripoint_bub_ms &p ) const;
-        // TODO: Get rid of untyped overload.
-        bool passable_ter_furn( const tripoint &p ) const;
         bool passable_ter_furn( const tripoint_bub_ms &p ) const;
 
         /**
@@ -860,8 +855,6 @@ class map
         bool vehproceed( VehicleList &vehicle_list );
 
         // Vehicles
-        // TODO: Get rid of untyped overload.
-        VehicleList get_vehicles( const tripoint &start, const tripoint &end );
         VehicleList get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_ms &end );
         /**
         * Checks if tile is occupied by vehicle and by which part.
@@ -873,27 +866,18 @@ class map
         optional_vpart_position veh_at( const tripoint_abs_ms &p ) const;
         optional_vpart_position veh_at( const tripoint_bub_ms &p ) const;
         vehicle *veh_at_internal( const tripoint_bub_ms &p, int &part_num );
-        // TODO: get rid of untyped overload.
-        const vehicle *veh_at_internal( const tripoint &p, int &part_num ) const;
         const vehicle *veh_at_internal( const tripoint_bub_ms &p, int &part_num ) const;
         // Put player on vehicle at x,y
-        // TODO: get rid of untyped overload
-        void board_vehicle( const tripoint &p, Character *pl );
         void board_vehicle( const tripoint_bub_ms &p, Character *pl );
         // Remove given passenger from given vehicle part.
         // If dead_passenger, then null passenger is acceptable.
         void unboard_vehicle( const vpart_reference &, Character *passenger,
                               bool dead_passenger = false );
         // Remove passenger from vehicle at p.
-        // TODO: Get rid of untyped overload.
-        void unboard_vehicle( const tripoint &p, bool dead_passenger = false );
         void unboard_vehicle( const tripoint_bub_ms &p, bool dead_passenger = false );
         // Change vehicle coordinates and move vehicle's driver along.
         // WARNING: not checking collisions!
         // optionally: include a list of parts to displace instead of the entire vehicle
-        // TODO: Get rid of untyped overload.
-        bool displace_vehicle( vehicle &veh, const tripoint &dp, bool adjust_pos = true,
-                               const std::set<int> &parts_to_move = {} );
         bool displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp, bool adjust_pos = true,
                                const std::set<int> &parts_to_move = {} );
         // make sure a vehicle that is split across z-levels is properly supported
@@ -918,13 +902,9 @@ class map
 
         // Actually moves the vehicle
         // Unlike displace_vehicle, this one handles collisions
-        // TODO: Get rid of untyped overload.
-        vehicle *move_vehicle( vehicle &veh, const tripoint &dp, const tileray &facing );
         vehicle *move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tileray &facing );
 
         // Furniture
-        // TODO: Get rid of untyped overload.
-        void set( const tripoint &p, const ter_id &new_terrain, const furn_id &new_furniture );
         void set( const tripoint_bub_ms &p, const ter_id &new_terrain, const furn_id &new_furniture );
         void set( const point_bub_ms &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
             furn_set( p, new_furniture );
@@ -978,7 +958,7 @@ class map
         // TODO: Get rid of untyped overload.
         bool furn_set( const point &p, const furn_id &new_furniture,
                        bool avoid_creatures = false ) { // TODO: Get rid of untyped version.
-            return furn_set( tripoint( p, abs_sub.z() ), new_furniture, false, avoid_creatures );
+            return furn_set( tripoint_bub_ms( p.x, p.y, abs_sub.z() ), new_furniture, false, avoid_creatures );
         }
         bool furn_set( const point_bub_ms &p, const furn_id &new_furniture, bool avoid_creatures = false ) {
             return furn_set( tripoint_bub_ms( p, abs_sub.z() ), new_furniture, false, avoid_creatures );
@@ -1057,8 +1037,6 @@ class map
         /**
          * Returns the full harvest list, for spawning.
          */
-        // TODO: Get rid of untyped overload.
-        const harvest_id &get_harvest( const tripoint &p ) const;
         const harvest_id &get_harvest( const tripoint_bub_ms &p ) const;
         /**
          * Returns names of the items that would be dropped.
@@ -1066,8 +1044,6 @@ class map
         // TODO: Get rid of untyped overload.
         const std::set<std::string> &get_harvest_names( const tripoint &p ) const;
         const std::set<std::string> &get_harvest_names( const tripoint_bub_ms &p ) const;
-        // TODO: Get rid of untyped overload.
-        ter_id get_ter_transforms_into( const tripoint &p ) const;
         ter_id get_ter_transforms_into( const tripoint_bub_ms &p ) const;
 
         // TODO: fix point types (remove the first overload)
@@ -1075,7 +1051,7 @@ class map
         bool ter_set( const tripoint_bub_ms &, const ter_id &new_terrain, bool avoid_creatures = false );
         // TODO: fix point types (remove the first overload)
         bool ter_set( const point &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
-            return ter_set( tripoint( p, abs_sub.z() ), new_terrain, avoid_creatures );
+            return ter_set( tripoint_bub_ms( p.x, p.y, abs_sub.z() ), new_terrain, avoid_creatures );
         }
         bool ter_set( const point_bub_ms &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
             return ter_set( tripoint_bub_ms( p, abs_sub.z() ), new_terrain, avoid_creatures );
@@ -1085,7 +1061,7 @@ class map
         std::string tername( const tripoint &p ) const;
         std::string tername( const tripoint_bub_ms &p ) const;
         std::string tername( const point &p ) const {
-            return tername( tripoint( p, abs_sub.z() ) );
+            return tername( tripoint_bub_ms( p.x, p.y, abs_sub.z() ) );
         }
         // TODO: Get rid of untyped overload.
         std::string tername( const point_bub_ms &p ) const {
@@ -1146,15 +1122,11 @@ class map
          * Calls the examine function of furniture or terrain at given tile, for given character.
          * Will only examine terrain if furniture had @ref iexamine::none as the examine function.
          */
-        // TODO: get rid of untyped overload.
-        void examine( Character &you, const tripoint &pos ) const;
         void examine( Character &you, const tripoint_bub_ms &pos ) const;
 
         /**
          * Returns true if point at pos is harvestable right now, with no extra tools.
          */
-        // TODO: Get rid of untyped overload.
-        bool is_harvestable( const tripoint &pos ) const;
         bool is_harvestable( const tripoint_bub_ms &pos ) const;
 
         // Flags
@@ -2727,7 +2699,7 @@ class tinymap : private map
         }
         // TODO: Get rid of untyped overload.
         bool ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
-            return map::ter_set( p, new_terrain, avoid_creatures );
+            return map::ter_set( tripoint_bub_ms( p ), new_terrain, avoid_creatures );
         }
         bool ter_set( const tripoint_omt_ms &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
             return map::ter_set( rebase_bub( p ), new_terrain, avoid_creatures );
@@ -2755,7 +2727,7 @@ class tinymap : private map
         }
         // TODO: Get rid of untyped overload.
         bool has_furn( const tripoint &p ) const {
-            return map::has_furn( p );
+            return map::has_furn( tripoint_bub_ms( p ) );
         }
         bool has_furn( const tripoint_omt_ms &p ) const {
             return map::has_furn( rebase_bub( p ) );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -329,37 +329,37 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
 
     for( int x = 0; x < SEEX * 2; x++ ) {
         for( int y = 0; y < SEEY * 2; y++ ) {
-            if( m.veh_at( tripoint( x,  y, abs_sub.z ) ) &&
-                m.ter( tripoint( x, y, abs_sub.z ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
-                m.ter_set( tripoint( x, y, abs_sub.z ), ter_t_dirtmound );
+            if( m.veh_at( tripoint_bub_ms( x,  y, abs_sub.z ) ) &&
+                m.ter( tripoint_bub_ms( x, y, abs_sub.z ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
+                m.ter_set( tripoint_bub_ms( x, y, abs_sub.z ), ter_t_dirtmound );
             } else {
                 if( x >= c.x - dice( 1, 5 ) && x <= c.x + dice( 1, 5 ) && y >= c.y - dice( 1, 5 ) &&
                     y <= c.y + dice( 1, 5 ) ) {
                     if( one_in( 7 ) &&
-                        m.ter( tripoint( x, y, abs_sub.z ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
-                        m.ter_set( tripoint( x, y, abs_sub.z ), ter_t_dirtmound );
+                        m.ter( tripoint_bub_ms( x, y, abs_sub.z ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
+                        m.ter_set( tripoint_bub_ms( x, y, abs_sub.z ), ter_t_dirtmound );
                     }
                 }
                 if( x >= c.x - dice( 1, 6 ) && x <= c.x + dice( 1, 6 ) && y >= c.y - dice( 1, 6 ) &&
                     y <= c.y + dice( 1, 6 ) ) {
                     if( !one_in( 5 ) ) {
-                        m.make_rubble( tripoint( x,  y, abs_sub.z ), furn_f_wreckage, true );
-                        if( m.ter( tripoint( x, y, abs_sub.z ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
-                            m.ter_set( tripoint( x, y, abs_sub.z ), ter_t_dirtmound );
+                        m.make_rubble( tripoint_bub_ms( x,  y, abs_sub.z ), furn_f_wreckage, true );
+                        if( m.ter( tripoint_bub_ms( x, y, abs_sub.z ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
+                            m.ter_set( tripoint_bub_ms( x, y, abs_sub.z ), ter_t_dirtmound );
                         }
                     } else if( m.is_bashable( tripoint_bub_ms( x, y, abs_sub.z ) ) ) {
-                        m.destroy( tripoint( x,  y, abs_sub.z ), true );
-                        if( m.ter( tripoint( x, y, abs_sub.z ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
-                            m.ter_set( tripoint( x, y, abs_sub.z ), ter_t_dirtmound );
+                        m.destroy( tripoint_bub_ms( x,  y, abs_sub.z ), true );
+                        if( m.ter( tripoint_bub_ms( x, y, abs_sub.z ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
+                            m.ter_set( tripoint_bub_ms( x, y, abs_sub.z ), ter_t_dirtmound );
                         }
                     }
 
                 } else if( one_in( 4 + ( std::abs( x - c.x ) + std::abs( y -
                                          c.y ) ) ) ) { // 1 in 10 chance of being wreckage anyway
-                    m.make_rubble( tripoint( x,  y, abs_sub.z ), furn_f_wreckage, true );
+                    m.make_rubble( tripoint_bub_ms( x,  y, abs_sub.z ), furn_f_wreckage, true );
                     if( !one_in( 3 ) ) {
-                        if( m.ter( tripoint( x, y, abs_sub.z ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
-                            m.ter_set( tripoint( x, y, abs_sub.z ), ter_t_dirtmound );
+                        if( m.ter( tripoint_bub_ms( x, y, abs_sub.z ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
+                            m.ter_set( tripoint_bub_ms( x, y, abs_sub.z ), ter_t_dirtmound );
                         }
                     }
                 }
@@ -1186,7 +1186,7 @@ static bool mx_grove( map &m, const tripoint &abs_sub )
     bool found_tree = false;
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
-            const tripoint location( i, j, abs_sub.z );
+            const tripoint_bub_ms location( i, j, abs_sub.z );
             if( m.has_flag_ter( ter_furn_flag::TFLAG_TREE, location ) ) {
                 tree = m.ter( location );
                 found_tree = true;
@@ -1221,7 +1221,7 @@ static bool mx_shrubbery( map &m, const tripoint &abs_sub )
     bool found_shrubbery = false;
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
-            const tripoint location( i, j, abs_sub.z );
+            const tripoint_bub_ms location( i, j, abs_sub.z );
             if( m.has_flag_ter( ter_furn_flag::TFLAG_SHRUB, location ) ) {
                 shrubbery = m.ter( location );
                 found_shrubbery = true;

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -2164,9 +2164,9 @@ std::tuple<maptile, maptile, maptile> map::get_wind_blockers( const int &winddir
         }
     }
 
-    const maptile remove_tile = maptile_at( removepoint.raw() );
-    const maptile remove_tile2 = maptile_at( removepoint2.raw() );
-    const maptile remove_tile3 = maptile_at( removepoint3.raw() );
+    const maptile remove_tile = maptile_at( removepoint );
+    const maptile remove_tile2 = maptile_at( removepoint2 );
+    const maptile remove_tile3 = maptile_at( removepoint3 );
     return std::make_tuple( remove_tile, remove_tile2, remove_tile3 );
 }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3057,7 +3057,7 @@ class jmapgen_furniture : public jmapgen_piece
             if( chosen_id.id().is_null() ) {
                 return;
             }
-            if( !dat.m.furn_set( tripoint( x.get(), y.get(), dat.zlevel() + z.get() ), chosen_id ) ) {
+            if( !dat.m.furn_set( tripoint_bub_ms( x.get(), y.get(), dat.zlevel() + z.get() ), chosen_id ) ) {
                 debugmsg( "Problem setting furniture in %s", context );
             }
         }
@@ -3628,15 +3628,15 @@ class jmapgen_remove_vehicles : public jmapgen_piece
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
                     const std::string &/*context*/ ) const override {
 
-            const tripoint start( x.val, y.val, dat.zlevel() + z.get() );
-            const tripoint end( x.valmax, y.valmax, dat.zlevel() + z.get() );
-            const tripoint_range<tripoint> range = tripoint_range<tripoint>( start, end );
-            for( const tripoint &p : range ) {
+            const tripoint_bub_ms start( int( x.val ), int( y.val ), dat.zlevel() + z.get() );
+            const tripoint_bub_ms end( int( x.valmax ), int( y.valmax ), dat.zlevel() + z.get() );
+            const tripoint_range<tripoint_bub_ms> range = tripoint_range<tripoint_bub_ms>( start, end );
+            for( const tripoint_bub_ms &p : range ) {
                 if( optional_vpart_position vp = dat.m.veh_at( p ) ) {
                     const auto rit = std::find( vehicles_to_remove.begin(), vehicles_to_remove.end(),
                                                 vp->vehicle().type );
                     if( rit != vehicles_to_remove.end() ) {
-                        get_map().remove_vehicle_from_cache( &vp->vehicle(), start.z, end.z );
+                        get_map().remove_vehicle_from_cache( &vp->vehicle(), start.z(), end.z() );
                         dat.m.destroy_vehicle( &vp->vehicle() );
                     }
                 }
@@ -5157,30 +5157,33 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
             }
             break;
             case JMAPGEN_SETMAP_LINE_TRAP: {
-                const std::vector<point> line = line_to( point( x_get(), y_get() ), point( x2_get(), y2_get() ),
-                                                0 );
-                for( const point &i : line ) {
+                const std::vector<point_bub_ms> line = line_to( point_bub_ms( x_get(), y_get() ),
+                                                       point_bub_ms( x2_get(), y2_get() ),
+                                                       0 );
+                for( const point_bub_ms &i : line ) {
                     // TODO: the trap_id should be stored separately and not be wrapped in an jmapgen_int
-                    mtrap_set( &m, tripoint_bub_ms( i.x, i.y, z_level ), trap_id( val.get() ),
+                    mtrap_set( &m, tripoint_bub_ms( i.x(), i.y(), z_level ), trap_id( val.get() ),
                                dat.has_flag( jmapgen_flags::avoid_creatures ) );
                 }
             }
             break;
             case JMAPGEN_SETMAP_LINE_TRAP_REMOVE: {
-                const std::vector<point> line = line_to( point( x_get(), y_get() ), point( x2_get(), y2_get() ),
-                                                0 );
-                for( const point &i : line ) {
+                const std::vector<point_bub_ms> line = line_to( point_bub_ms( x_get(), y_get() ),
+                                                       point_bub_ms( x2_get(), y2_get() ),
+                                                       0 );
+                for( const point_bub_ms &i : line ) {
                     // TODO: the trap_id should be stored separately and not be wrapped in an jmapgen_int
-                    mremove_trap( &m, tripoint_bub_ms( i.x, i.y, z_level ), trap_id( val.get() ).id() );
+                    mremove_trap( &m, tripoint_bub_ms( i.x(), i.y(), z_level ), trap_id( val.get() ).id() );
                 }
             }
             break;
             case JMAPGEN_SETMAP_LINE_CREATURE_REMOVE: {
-                const std::vector<point> line = line_to( point( x_get(), y_get() ), point( x2_get(), y2_get() ),
-                                                0 );
-                for( const point &i : line ) {
+                const std::vector<point_bub_ms> line = line_to( point_bub_ms( x_get(), y_get() ),
+                                                       point_bub_ms( x2_get(), y2_get() ),
+                                                       0 );
+                for( const point_bub_ms &i : line ) {
                     Creature *tmp_critter = get_creature_tracker().creature_at( tripoint_abs_ms( m.getglobal(
-                                                tripoint_bub_ms( i.x, i.y,
+                                                tripoint_bub_ms( i.x(), i.y(),
                                                         z_level ) ) ), true );
                     if( tmp_critter && !tmp_critter->is_avatar() ) {
                         tmp_critter->die( nullptr );
@@ -5189,26 +5192,29 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
             }
             break;
             case JMAPGEN_SETMAP_LINE_ITEM_REMOVE: {
-                const std::vector<point> line = line_to( point( x_get(), y_get() ), point( x2_get(), y2_get() ),
-                                                0 );
-                for( const point &i : line ) {
-                    m.i_clear( tripoint_bub_ms( i.x, i.y, z_level ) );
+                const std::vector<point_bub_ms> line = line_to( point_bub_ms( x_get(), y_get() ),
+                                                       point_bub_ms( x2_get(), y2_get() ),
+                                                       0 );
+                for( const point_bub_ms &i : line ) {
+                    m.i_clear( tripoint_bub_ms( i.x(), i.y(), z_level ) );
                 }
             }
             break;
             case JMAPGEN_SETMAP_LINE_FIELD_REMOVE: {
-                const std::vector<point> line = line_to( point( x_get(), y_get() ), point( x2_get(), y2_get() ),
-                                                0 );
-                for( const point &i : line ) {
-                    mremove_fields( &m, tripoint_bub_ms( i.x, i.y, z_level ) );
+                const std::vector<point_bub_ms> line = line_to( point_bub_ms( x_get(), y_get() ),
+                                                       point_bub_ms( x2_get(), y2_get() ),
+                                                       0 );
+                for( const point_bub_ms &i : line ) {
+                    mremove_fields( &m, tripoint_bub_ms( i.x(), i.y(), z_level ) );
                 }
             }
             break;
             case JMAPGEN_SETMAP_LINE_RADIATION: {
-                const std::vector<point> line = line_to( point( x_get(), y_get() ), point( x2_get(), y2_get() ),
-                                                0 );
-                for( const point &i : line ) {
-                    m.set_radiation( tripoint_bub_ms( i.x, i.y, z_level ), static_cast<int>( val.get() ) );
+                const std::vector<point_bub_ms> line = line_to( point_bub_ms( x_get(), y_get() ),
+                                                       point_bub_ms( x2_get(), y2_get() ),
+                                                       0 );
+                for( const point_bub_ms &i : line ) {
+                    m.set_radiation( tripoint_bub_ms( i.x(), i.y(), z_level ), static_cast<int>( val.get() ) );
                 }
             }
             break;
@@ -7038,7 +7044,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
 
     for( std::vector<int>::const_iterator part = frame_indices.begin();
          part != frame_indices.end(); part++ ) {
-        const tripoint p = veh_to_add->global_part_pos3( *part );
+        const tripoint_bub_ms p = veh_to_add->bub_part_pos( *part );
 
         if( veh_to_add->part( *part ).is_fake ) {
             continue;

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -1331,79 +1331,79 @@ void mapgen_lake_shore( mapgendata &dat )
     const int sector_length = SEEX * 2 / 3;
 
     // Define the corners of the map. These won't change.
-    static constexpr point nw_corner{};
-    static constexpr point ne_corner( SEEX * 2 - 1, 0 );
-    static constexpr point se_corner( SEEX * 2 - 1, SEEY * 2 - 1 );
-    static constexpr point sw_corner( 0, SEEY * 2 - 1 );
+    static constexpr point_bub_ms nw_corner{};
+    static constexpr point_bub_ms ne_corner( SEEX * 2 - 1, 0 );
+    static constexpr point_bub_ms se_corner( SEEX * 2 - 1, SEEY * 2 - 1 );
+    static constexpr point_bub_ms sw_corner( 0, SEEY * 2 - 1 );
 
     // Define the four points that make up our polygon that we'll later pull line segments from for
     // the actual shoreline.
-    point nw = nw_corner;
-    point ne = ne_corner;
-    point se = se_corner;
-    point sw = sw_corner;
+    point_bub_ms nw = nw_corner;
+    point_bub_ms ne = ne_corner;
+    point_bub_ms se = se_corner;
+    point_bub_ms sw = sw_corner;
 
-    std::vector<std::vector<point>> line_segments;
+    std::vector<std::vector<point_bub_ms>> line_segments;
 
     // This section is about pushing the straight N, S, E, or W borders inward when adjacent to an actual lake.
     if( n_lake ) {
-        nw.y += sector_length;
-        ne.y += sector_length;
+        nw.y() += sector_length;
+        ne.y() += sector_length;
     }
 
     if( s_lake ) {
-        sw.y -= sector_length;
-        se.y -= sector_length;
+        sw.y() -= sector_length;
+        se.y() -= sector_length;
     }
 
     if( w_lake ) {
-        nw.x += sector_length;
-        sw.x += sector_length;
+        nw.x() += sector_length;
+        sw.x() += sector_length;
     }
 
     if( e_lake ) {
-        ne.x -= sector_length;
-        se.x -= sector_length;
+        ne.x() -= sector_length;
+        se.x() -= sector_length;
     }
 
     // This section is about pushing the corners inward when adjacent to a lake that curves into a river bank.
     if( n_river_bank ) {
         if( w_lake && nw_lake ) {
-            nw.x += sector_length;
+            nw.x() += sector_length;
         }
 
         if( e_lake && ne_lake ) {
-            ne.x -= sector_length;
+            ne.x() -= sector_length;
         }
     }
 
     if( e_river_bank ) {
         if( s_lake && se_lake ) {
-            se.y -= sector_length;
+            se.y() -= sector_length;
         }
 
         if( n_lake && ne_lake ) {
-            ne.y += sector_length;
+            ne.y() += sector_length;
         }
     }
 
     if( s_river_bank ) {
         if( w_lake && sw_lake ) {
-            sw.x += sector_length;
+            sw.x() += sector_length;
         }
 
         if( e_lake && se_lake ) {
-            se.x -= sector_length;
+            se.x() -= sector_length;
         }
     }
 
     if( w_river_bank ) {
         if( s_lake && sw_lake ) {
-            sw.y -= sector_length;
+            sw.y() -= sector_length;
         }
 
         if( n_lake && nw_lake ) {
-            nw.y += sector_length;
+            nw.y() += sector_length;
         }
     }
 
@@ -1413,17 +1413,17 @@ void mapgen_lake_shore( mapgendata &dat )
     // our original set--we end up cutting the corner off our polygonal box.
     if( nw_lake ) {
         if( n_lake && w_lake ) {
-            nw.x += sector_length / 2;
-            nw.y += sector_length / 2;
+            nw.x() += sector_length / 2;
+            nw.y() += sector_length / 2;
         } else if( ( n_shore || n_river_bank ) && ( w_shore || w_river_bank ) ) {
-            point n = nw_corner;
-            point w = nw_corner;
+            point_bub_ms n = nw_corner;
+            point_bub_ms w = nw_corner;
 
-            n.x += sector_length * ( n_river_bank ? 2 : 1 );
-            w.y += sector_length * ( w_river_bank ? 2 : 1 );
+            n.x() += sector_length * ( n_river_bank ? 2 : 1 );
+            w.y() += sector_length * ( w_river_bank ? 2 : 1 );
 
-            n.y += n_river_bank ? sector_length / 2 : 0;
-            w.x += w_river_bank ? sector_length / 2 : 0;
+            n.y() += n_river_bank ? sector_length / 2 : 0;
+            w.x() += w_river_bank ? sector_length / 2 : 0;
 
             if( w_river_bank ) {
                 line_segments.push_back( { sw, w } );
@@ -1439,17 +1439,17 @@ void mapgen_lake_shore( mapgendata &dat )
 
     if( ne_lake ) {
         if( n_lake && e_lake ) {
-            ne.x -= sector_length / 2;
-            ne.y += sector_length / 2;
+            ne.x() -= sector_length / 2;
+            ne.y() += sector_length / 2;
         } else if( ( n_shore || n_river_bank ) && ( e_shore || e_river_bank ) ) {
-            point n = ne_corner;
-            point e = ne_corner;
+            point_bub_ms n = ne_corner;
+            point_bub_ms e = ne_corner;
 
-            n.x -= sector_length * ( n_river_bank ? 2 : 1 );
-            e.y += sector_length * ( e_river_bank ? 2 : 1 );
+            n.x() -= sector_length * ( n_river_bank ? 2 : 1 );
+            e.y() += sector_length * ( e_river_bank ? 2 : 1 );
 
-            n.y += n_river_bank ? sector_length / 2 : 0;
-            e.x -= e_river_bank ? sector_length / 2 : 0;
+            n.y() += n_river_bank ? sector_length / 2 : 0;
+            e.x() -= e_river_bank ? sector_length / 2 : 0;
 
             if( e_river_bank ) {
                 line_segments.push_back( { se, e } );
@@ -1465,17 +1465,17 @@ void mapgen_lake_shore( mapgendata &dat )
 
     if( sw_lake ) {
         if( s_lake && w_lake ) {
-            sw.x += sector_length / 2;
-            sw.y -= sector_length / 2;
+            sw.x() += sector_length / 2;
+            sw.y() -= sector_length / 2;
         } else if( ( s_shore || s_river_bank ) && ( w_shore || w_river_bank ) ) {
-            point s = sw_corner;
-            point w = sw_corner;
+            point_bub_ms s = sw_corner;
+            point_bub_ms w = sw_corner;
 
-            s.x += sector_length * ( s_river_bank ? 2 : 1 );
-            w.y -= sector_length * ( w_river_bank ? 2 : 1 );
+            s.x() += sector_length * ( s_river_bank ? 2 : 1 );
+            w.y() -= sector_length * ( w_river_bank ? 2 : 1 );
 
-            s.y -= s_river_bank ? sector_length / 2 : 0;
-            w.x += w_river_bank ? sector_length / 2 : 0;
+            s.y() -= s_river_bank ? sector_length / 2 : 0;
+            w.x() += w_river_bank ? sector_length / 2 : 0;
 
             if( w_river_bank ) {
                 line_segments.push_back( { nw, w } );
@@ -1491,17 +1491,17 @@ void mapgen_lake_shore( mapgendata &dat )
 
     if( se_lake ) {
         if( s_lake && e_lake ) {
-            se.x -= sector_length / 2;
-            se.y -= sector_length / 2;
+            se.x() -= sector_length / 2;
+            se.y() -= sector_length / 2;
         } else if( ( s_shore || s_river_bank ) && ( e_shore || e_river_bank ) ) {
-            point s = se_corner;
-            point e = se_corner;
+            point_bub_ms s = se_corner;
+            point_bub_ms e = se_corner;
 
-            s.x -= sector_length * ( s_river_bank ? 2 : 1 );
-            e.y -= sector_length * ( e_river_bank ? 2 : 1 );
+            s.x() -= sector_length * ( s_river_bank ? 2 : 1 );
+            e.y() -= sector_length * ( e_river_bank ? 2 : 1 );
 
-            s.y -= s_river_bank ? sector_length / 2 : 0;
-            e.x -= e_river_bank ? sector_length / 2 : 0;
+            s.y() -= s_river_bank ? sector_length / 2 : 0;
+            e.x() -= e_river_bank ? sector_length / 2 : 0;
 
             if( e_river_bank ) {
                 line_segments.push_back( { ne, e } );
@@ -1520,31 +1520,31 @@ void mapgen_lake_shore( mapgendata &dat )
     // at the map boundaries, but have subsequently been perturbed by the adjacent terrains.
     // Let's look at them and see which ones differ from their original state and should
     // form our shoreline.
-    if( nw.y != nw_corner.y || ne.y != ne_corner.y ) {
+    if( nw.y() != nw_corner.y() || ne.y() != ne_corner.y() ) {
         line_segments.push_back( { nw, ne } );
     }
 
-    if( ne.x != ne_corner.x || se.x != se_corner.x ) {
+    if( ne.x() != ne_corner.x() || se.x() != se_corner.x() ) {
         line_segments.push_back( { ne, se } );
     }
 
-    if( se.y != se_corner.y || sw.y != sw_corner.y ) {
+    if( se.y() != se_corner.y() || sw.y() != sw_corner.y() ) {
         line_segments.push_back( { se, sw } );
     }
 
-    if( sw.x != sw_corner.x || nw.x != nw_corner.x ) {
+    if( sw.x() != sw_corner.x() || nw.x() != nw_corner.x() ) {
         line_segments.push_back( { sw, nw } );
     }
 
-    static constexpr inclusive_rectangle<point> map_boundaries( nw_corner, se_corner );
+    static constexpr inclusive_rectangle<point_bub_ms> map_boundaries( nw_corner, se_corner );
 
     // This will draw our shallow water coastline from the "from" point to the "to" point.
     // It buffers the points a bit for a thicker line. It also clears any furniture that might
     // be in the location as a result of our extending adjacent mapgen.
-    const auto draw_shallow_water = [&]( const point & from, const point & to ) {
-        std::vector<point> points = line_to( from, to );
-        for( point &p : points ) {
-            for( const point &bp : closest_points_first( p, 1 ) ) {
+    const auto draw_shallow_water = [&]( const point_bub_ms & from, const point_bub_ms & to ) {
+        std::vector<point_bub_ms> points = line_to( from, to );
+        for( point_bub_ms &p : points ) {
+            for( const point_bub_ms &bp : closest_points_first( p, 1 ) ) {
                 if( !map_boundaries.contains( bp ) ) {
                     continue;
                 }
@@ -1558,10 +1558,10 @@ void mapgen_lake_shore( mapgendata &dat )
 
     // Given two points, return a point that is midway between the two points and then
     // jittered by a random amount in proportion to the length of the line segment.
-    const auto jittered_midpoint = [&]( const point & from, const point & to ) {
+    const auto jittered_midpoint = [&]( const point_bub_ms & from, const point_bub_ms & to ) {
         const int jitter = rl_dist( from, to ) / 4;
-        const point midpoint( ( from.x + to.x ) / 2 + rng( -jitter, jitter ),
-                              ( from.y + to.y ) / 2 + rng( -jitter, jitter ) );
+        const point_bub_ms midpoint( ( from.x() + to.x() ) / 2 + rng( -jitter, jitter ),
+                                     ( from.y() + to.y() ) / 2 + rng( -jitter, jitter ) );
         return midpoint;
     };
 
@@ -1569,9 +1569,9 @@ void mapgen_lake_shore( mapgendata &dat )
     // set of line segments by splitting the line into four segments with jittered
     // midpoints, and then draw shallow water for four each of those.
     for( auto &ls : line_segments ) {
-        const point mp1 = jittered_midpoint( ls[0], ls[1] );
-        const point mp2 = jittered_midpoint( ls[0], mp1 );
-        const point mp3 = jittered_midpoint( mp1, ls[1] );
+        const point_bub_ms mp1 = jittered_midpoint( ls[0], ls[1] );
+        const point_bub_ms mp2 = jittered_midpoint( ls[0], mp1 );
+        const point_bub_ms mp3 = jittered_midpoint( mp1, ls[1] );
 
         draw_shallow_water( ls[0], mp2 );
         draw_shallow_water( mp2, mp1 );
@@ -1582,19 +1582,19 @@ void mapgen_lake_shore( mapgendata &dat )
     // Now that we've done our ground mapgen and laid down a contiguous shoreline of shallow water,
     // we'll floodfill the sections adjacent to the lake with deep water. As before, we also clear
     // out any furniture that we placed by the extended mapgen.
-    std::unordered_set<point> visited;
+    std::unordered_set<point_bub_ms> visited;
 
-    const auto should_fill = [&]( const point & p ) {
+    const auto should_fill = [&]( const point_bub_ms & p ) {
         if( !map_boundaries.contains( p ) ) {
             return false;
         }
         return m->ter( p ) != ter_str_id::NULL_ID();
     };
 
-    const auto fill_deep_water = [&]( const point & starting_point ) {
-        std::vector<point> water_points = ff::point_flood_fill_4_connected( starting_point, visited,
-                                          should_fill );
-        for( point &wp : water_points ) {
+    const auto fill_deep_water = [&]( const point_bub_ms & starting_point ) {
+        std::vector<point_bub_ms> water_points = ff::point_flood_fill_4_connected( starting_point, visited,
+                should_fill );
+        for( point_bub_ms &wp : water_points ) {
             m->ter_set( wp, ter_t_water_dp );
             m->furn_set( wp, furn_str_id::NULL_ID() );
         }
@@ -1731,96 +1731,96 @@ void mapgen_ocean_shore( mapgendata &dat )
     const int sector_length = SEEX - 1;
 
     // Define the corners of the map. These won't change.
-    static constexpr point nw_corner{};
-    static constexpr point ne_corner( SEEX * 2 - 1, 0 );
-    static constexpr point se_corner( SEEX * 2 - 1, SEEY * 2 - 1 );
-    static constexpr point sw_corner( 0, SEEY * 2 - 1 );
+    static constexpr point_bub_ms nw_corner{};
+    static constexpr point_bub_ms ne_corner( SEEX * 2 - 1, 0 );
+    static constexpr point_bub_ms se_corner( SEEX * 2 - 1, SEEY * 2 - 1 );
+    static constexpr point_bub_ms sw_corner( 0, SEEY * 2 - 1 );
 
     // Define the four points that make up our polygon that we'll later pull line segments from for
     // the actual shoreline.
-    point nw = nw_corner;
-    point ne = ne_corner;
-    point se = se_corner;
-    point sw = sw_corner;
+    point_bub_ms nw = nw_corner;
+    point_bub_ms ne = ne_corner;
+    point_bub_ms se = se_corner;
+    point_bub_ms sw = sw_corner;
 
-    std::vector<std::vector<point>> line_segments;
+    std::vector<std::vector<point_bub_ms>> line_segments;
     int ns_direction_adjust = 0;
     int ew_direction_adjust = 0;
     int sand_margin = dat.region.overmap_ocean.sandy_beach_width / 2;
     // This section is about pushing the straight N, S, E, or W borders inward when adjacent to an actual ocean.
     if( n_ocean ) {
-        nw.y += sector_length;
-        ne.y += sector_length;
+        nw.y() += sector_length;
+        ne.y() += sector_length;
     }
 
     if( s_ocean ) {
-        sw.y -= sector_length;
-        se.y -= sector_length;
+        sw.y() -= sector_length;
+        se.y() -= sector_length;
     }
 
     if( w_ocean ) {
-        nw.x += sector_length;
-        sw.x += sector_length;
+        nw.x() += sector_length;
+        sw.x() += sector_length;
     }
 
     if( e_ocean ) {
-        ne.x -= sector_length;
-        se.x -= sector_length;
+        ne.x() -= sector_length;
+        se.x() -= sector_length;
     }
 
     if( n_river_bank ) {
         if( w_ocean && nw_ocean ) {
-            nw.x += sector_length;
+            nw.x() += sector_length;
         }
 
         if( e_ocean && ne_ocean ) {
-            ne.x -= sector_length;
+            ne.x() -= sector_length;
         }
     }
 
     if( e_river_bank ) {
         if( s_ocean && se_ocean ) {
-            se.y -= sector_length;
+            se.y() -= sector_length;
         }
 
         if( n_ocean && ne_ocean ) {
-            ne.y += sector_length;
+            ne.y() += sector_length;
         }
     }
 
     if( s_river_bank ) {
         if( w_ocean && sw_ocean ) {
-            sw.x += sector_length;
+            sw.x() += sector_length;
         }
 
         if( e_ocean && se_ocean ) {
-            se.x -= sector_length;
+            se.x() -= sector_length;
         }
     }
 
     if( w_river_bank ) {
         if( s_ocean && sw_ocean ) {
-            sw.y -= sector_length;
+            sw.y() -= sector_length;
         }
 
         if( n_ocean && nw_ocean ) {
-            nw.y += sector_length;
+            nw.y() += sector_length;
         }
     }
 
     if( nw_ocean ) {
         if( n_ocean && w_ocean ) {
-            nw.x += sector_length / 2;
-            nw.y += sector_length / 2;
+            nw.x() += sector_length / 2;
+            nw.y() += sector_length / 2;
         } else if( ( n_shore || n_river_bank ) && ( w_shore || w_river_bank ) ) {
-            point n = nw_corner;
-            point w = nw_corner;
+            point_bub_ms n = nw_corner;
+            point_bub_ms w = nw_corner;
 
-            n.x += sector_length * ( n_river_bank ? 2 : 1 );
-            w.y += sector_length * ( w_river_bank ? 2 : 1 );
+            n.x() += sector_length * ( n_river_bank ? 2 : 1 );
+            w.y() += sector_length * ( w_river_bank ? 2 : 1 );
 
-            n.y += n_river_bank ? sector_length / 2 : 0;
-            w.x += w_river_bank ? sector_length / 2 : 0;
+            n.y() += n_river_bank ? sector_length / 2 : 0;
+            w.x() += w_river_bank ? sector_length / 2 : 0;
 
             if( w_river_bank ) {
                 line_segments.push_back( { sw, w } );
@@ -1841,17 +1841,17 @@ void mapgen_ocean_shore( mapgendata &dat )
 
     if( ne_ocean ) {
         if( n_ocean && e_ocean ) {
-            ne.x -= sector_length / 2;
-            ne.y += sector_length / 2;
+            ne.x() -= sector_length / 2;
+            ne.y() += sector_length / 2;
         } else if( ( n_shore || n_river_bank ) && ( e_shore || e_river_bank ) ) {
-            point n = ne_corner;
-            point e = ne_corner;
+            point_bub_ms n = ne_corner;
+            point_bub_ms e = ne_corner;
 
-            n.x -= sector_length * ( n_river_bank ? 2 : 1 );
-            e.y += sector_length * ( e_river_bank ? 2 : 1 );
+            n.x() -= sector_length * ( n_river_bank ? 2 : 1 );
+            e.y() += sector_length * ( e_river_bank ? 2 : 1 );
 
-            n.y += n_river_bank ? sector_length / 2 : 0;
-            e.x -= e_river_bank ? sector_length / 2 : 0;
+            n.y() += n_river_bank ? sector_length / 2 : 0;
+            e.x() -= e_river_bank ? sector_length / 2 : 0;
 
             if( e_river_bank ) {
                 line_segments.push_back( { se, e } );
@@ -1873,17 +1873,17 @@ void mapgen_ocean_shore( mapgendata &dat )
 
     if( sw_ocean ) {
         if( s_ocean && w_ocean ) {
-            sw.x += sector_length / 2;
-            sw.y -= sector_length / 2;
+            sw.x() += sector_length / 2;
+            sw.y() -= sector_length / 2;
         } else if( ( s_shore || s_river_bank ) && ( w_shore || w_river_bank ) ) {
-            point s = sw_corner;
-            point w = sw_corner;
+            point_bub_ms s = sw_corner;
+            point_bub_ms w = sw_corner;
 
-            s.x += sector_length * ( s_river_bank ? 2 : 1 );
-            w.y -= sector_length * ( w_river_bank ? 2 : 1 );
+            s.x() += sector_length * ( s_river_bank ? 2 : 1 );
+            w.y() -= sector_length * ( w_river_bank ? 2 : 1 );
 
-            s.y -= s_river_bank ? sector_length / 2 : 0;
-            w.x += w_river_bank ? sector_length / 2 : 0;
+            s.y() -= s_river_bank ? sector_length / 2 : 0;
+            w.x() += w_river_bank ? sector_length / 2 : 0;
 
             if( w_river_bank ) {
                 line_segments.push_back( { nw, w } );
@@ -1904,17 +1904,17 @@ void mapgen_ocean_shore( mapgendata &dat )
 
     if( se_ocean ) {
         if( s_ocean && e_ocean ) {
-            se.x -= sector_length / 2;
-            se.y -= sector_length / 2;
+            se.x() -= sector_length / 2;
+            se.y() -= sector_length / 2;
         } else if( ( s_shore || s_river_bank ) && ( e_shore || e_river_bank ) ) {
-            point s = se_corner;
-            point e = se_corner;
+            point_bub_ms s = se_corner;
+            point_bub_ms e = se_corner;
 
-            s.x -= sector_length * ( s_river_bank ? 2 : 1 );
-            e.y -= sector_length * ( e_river_bank ? 2 : 1 );
+            s.x() -= sector_length * ( s_river_bank ? 2 : 1 );
+            e.y() -= sector_length * ( e_river_bank ? 2 : 1 );
 
-            s.y -= s_river_bank ? sector_length / 2 : 0;
-            e.x -= e_river_bank ? sector_length / 2 : 0;
+            s.y() -= s_river_bank ? sector_length / 2 : 0;
+            e.x() -= e_river_bank ? sector_length / 2 : 0;
 
             if( e_river_bank ) {
                 line_segments.push_back( { ne, e } );
@@ -1940,49 +1940,49 @@ void mapgen_ocean_shore( mapgendata &dat )
     // Let's look at them and see which ones differ from their original state and should
     // form our shoreline.
 
-    if( nw.y != nw_corner.y || ne.y != ne_corner.y ) {
+    if( nw.y() != nw_corner.y() || ne.y() != ne_corner.y() ) {
         ns_direction_adjust -= sand_margin * 2;
         line_segments.push_back( { nw, ne } );
     }
 
-    if( ne.x != ne_corner.x || se.x != se_corner.x ) {
+    if( ne.x() != ne_corner.x() || se.x() != se_corner.x() ) {
         ew_direction_adjust += sand_margin * 2;
         line_segments.push_back( { ne, se } );
     }
 
-    if( se.y != se_corner.y || sw.y != sw_corner.y ) {
+    if( se.y() != se_corner.y() || sw.y() != sw_corner.y() ) {
         ns_direction_adjust += sand_margin * 2;
         line_segments.push_back( { se, sw } );
     }
 
-    if( sw.x != sw_corner.x || nw.x != nw_corner.x ) {
+    if( sw.x() != sw_corner.x() || nw.x() != nw_corner.x() ) {
         ew_direction_adjust -= sand_margin * 2;
         line_segments.push_back( { sw, nw } );
     }
 
-    static constexpr inclusive_rectangle<point> map_boundaries( nw_corner, se_corner );
+    static constexpr inclusive_rectangle<point_bub_ms> map_boundaries( nw_corner, se_corner );
 
     // This will draw our shallow water coastline from the "from" point to the "to" point.
     // It buffers the points a bit for a thicker line. It also clears any furniture that might
     // be in the location as a result of our extending adjacent mapgen.
-    const auto draw_shallow_water = [&]( const point & from, const point & to ) {
-        point from_mod = from;
-        point to_mod = to;
-        if( from.x != 0 && from.x != SEEX * 2 - 1 ) {
-            from_mod.x += ew_direction_adjust;
+    const auto draw_shallow_water = [&]( const point_bub_ms & from, const point_bub_ms & to ) {
+        point_bub_ms from_mod = from;
+        point_bub_ms to_mod = to;
+        if( from.x() != 0 && from.x() != SEEX * 2 - 1 ) {
+            from_mod.x() += ew_direction_adjust;
         }
-        if( from.y != 0 && from.y != SEEX * 2 - 1 ) {
-            from_mod.y += ns_direction_adjust;
+        if( from.y() != 0 && from.y() != SEEX * 2 - 1 ) {
+            from_mod.y() += ns_direction_adjust;
         }
-        if( to.x != 0 && to.x != SEEX * 2 - 1 ) {
-            to_mod.x += ew_direction_adjust;
+        if( to.x() != 0 && to.x() != SEEX * 2 - 1 ) {
+            to_mod.x() += ew_direction_adjust;
         }
-        if( to.y != 0 && to.y != SEEX * 2 - 1 ) {
-            to_mod.y += ns_direction_adjust;
+        if( to.y() != 0 && to.y() != SEEX * 2 - 1 ) {
+            to_mod.y() += ns_direction_adjust;
         }
-        std::vector<point> points = line_to( from_mod, to_mod );
-        for( point &p : points ) {
-            for( const point &bp : closest_points_first( p, sand_margin ) ) {
+        std::vector<point_bub_ms> points = line_to( from_mod, to_mod );
+        for( point_bub_ms &p : points ) {
+            for( const point_bub_ms &bp : closest_points_first( p, sand_margin ) ) {
                 if( !map_boundaries.contains( bp ) ) {
                     continue;
                 }
@@ -1992,10 +1992,10 @@ void mapgen_ocean_shore( mapgendata &dat )
         }
     };
     // This will draw our sandy beach coastline from the "from" point to the "to" point.
-    const auto draw_sand = [&]( const point & from, const point & to ) {
-        std::vector<point> points = line_to( from, to );
-        for( point &p : points ) {
-            for( const point &bp : closest_points_first( p, sand_margin ) ) {
+    const auto draw_sand = [&]( const point_bub_ms & from, const point_bub_ms & to ) {
+        std::vector<point_bub_ms> points = line_to( from, to );
+        for( point_bub_ms &p : points ) {
+            for( const point_bub_ms &bp : closest_points_first( p, sand_margin ) ) {
                 if( !map_boundaries.contains( bp ) ) {
                     continue;
                 }
@@ -2004,7 +2004,7 @@ void mapgen_ocean_shore( mapgendata &dat )
                 m->ter_set( bp, ter_str_id::NULL_ID() );
                 m->furn_set( bp, furn_str_id::NULL_ID() );
             }
-            for( const point &bp : closest_points_first( p, sand_margin + 1 ) ) {
+            for( const point_bub_ms &bp : closest_points_first( p, sand_margin + 1 ) ) {
                 if( !map_boundaries.contains( bp ) ) {
                     continue;
                 }
@@ -2017,10 +2017,10 @@ void mapgen_ocean_shore( mapgendata &dat )
 
     // Given two points, return a point that is midway between the two points and then
     // jittered by a random amount in proportion to the length of the line segment.
-    const auto jittered_midpoint = [&]( const point & from, const point & to ) {
+    const auto jittered_midpoint = [&]( const point_bub_ms & from, const point_bub_ms & to ) {
         const int jitter = rl_dist( from, to ) / 5;
-        const point midpoint( ( from.x + to.x ) / 2 + rng( -jitter, jitter ),
-                              ( from.y + to.y ) / 2 + rng( -jitter, jitter ) );
+        const point_bub_ms midpoint( ( from.x() + to.x() ) / 2 + rng( -jitter, jitter ),
+                                     ( from.y() + to.y() ) / 2 + rng( -jitter, jitter ) );
         return midpoint;
     };
 
@@ -2030,9 +2030,9 @@ void mapgen_ocean_shore( mapgendata &dat )
     // Draw water after the sand to make sure we don't get too much sand.  Everyone hates sand,
     // it's coarse and - you know what, never mind.
     for( auto &ls : line_segments ) {
-        const point mp1 = jittered_midpoint( ls[0], ls[1] );
-        const point mp2 = jittered_midpoint( ls[0], mp1 );
-        const point mp3 = jittered_midpoint( mp1, ls[1] );
+        const point_bub_ms mp1 = jittered_midpoint( ls[0], ls[1] );
+        const point_bub_ms mp2 = jittered_midpoint( ls[0], mp1 );
+        const point_bub_ms mp3 = jittered_midpoint( mp1, ls[1] );
 
         draw_shallow_water( ls[0], mp2 );
         draw_shallow_water( mp2, mp1 );
@@ -2047,9 +2047,9 @@ void mapgen_ocean_shore( mapgendata &dat )
     // Now that we've done our ground mapgen and laid down a contiguous shoreline of shallow water,
     // we'll floodfill the sections adjacent to the ocean with deep water. As before, we also clear
     // out any furniture that we placed by the extended mapgen.
-    std::unordered_set<point> visited;
+    std::unordered_set<point_bub_ms> visited;
 
-    const auto should_fill = [&]( const point & p ) {
+    const auto should_fill = [&]( const point_bub_ms & p ) {
         if( !map_boundaries.contains( p ) ) {
             return false;
         }
@@ -2057,10 +2057,10 @@ void mapgen_ocean_shore( mapgendata &dat )
                m->ter( p ) != ter_t_swater_surf;
     };
 
-    const auto fill_deep_water = [&]( const point & starting_point ) {
-        std::vector<point> water_points = ff::point_flood_fill_4_connected( starting_point, visited,
-                                          should_fill );
-        for( point &wp : water_points ) {
+    const auto fill_deep_water = [&]( const point_bub_ms & starting_point ) {
+        std::vector<point_bub_ms> water_points = ff::point_flood_fill_4_connected( starting_point, visited,
+                should_fill );
+        for( point_bub_ms &wp : water_points ) {
             m->ter_set( wp, ter_t_swater_dp );
             m->furn_set( wp, furn_str_id::NULL_ID() );
         }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -521,17 +521,17 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
     if( grab_data.pull_chance > -1 && x_in_y( grab_data.pull_chance, 100 ) ) {
         add_msg_debug( debugmode::DF_MATTACK, "Pull chance roll succeeded" );
 
-        int pull_range = std::min( range, rl_dist( z.pos(), target->pos() ) + 1 );
-        tripoint pt = target->pos();
+        int pull_range = std::min( range, rl_dist( z.pos_bub(), target->pos_bub() ) + 1 );
+        tripoint_bub_ms pt = target->pos_bub();
         while( pull_range > 0 ) {
             // Recalculate the ray each step
             // We can't depend on either the target position being constant (obviously),
             // but neither on z pos staying constant, because we may want to shift the map mid-pull
-            const units::angle dir = coord_to_angle( target->pos(), z.pos() );
+            const units::angle dir = coord_to_angle( target->pos_bub(), z.pos_bub() );
             tileray tdir( dir );
             tdir.advance();
-            pt.x = target->posx() + tdir.dx();
-            pt.y = target->posy() + tdir.dy();
+            pt.x() = target->posx() + tdir.dx();
+            pt.y() = target->posy() + tdir.dy();
             //Cancel the grab if the space is occupied by something
             if( !g->is_empty( pt ) ) {
                 break;
@@ -542,9 +542,9 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
                     here.unboard_vehicle( foe->pos_bub() );
                 }
 
-                if( foe->is_avatar() && ( pt.x < HALF_MAPSIZE_X || pt.y < HALF_MAPSIZE_Y ||
-                                          pt.x >= HALF_MAPSIZE_X + SEEX || pt.y >= HALF_MAPSIZE_Y + SEEY ) ) {
-                    g->update_map( pt.x, pt.y );
+                if( foe->is_avatar() && ( pt.x() < HALF_MAPSIZE_X || pt.y() < HALF_MAPSIZE_Y ||
+                                          pt.x() >= HALF_MAPSIZE_X + SEEX || pt.y() >= HALF_MAPSIZE_Y + SEEY ) ) {
+                    g->update_map( pt.x(), pt.y() );
                 }
             }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1835,7 +1835,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
     }
     map &here = get_map();
     if( technique.knockback_dist && !t.has_flag( mon_flag_IMMOBILE ) ) {
-        const tripoint prev_pos = t.pos(); // track target startpoint for knockback_follow
+        const tripoint_bub_ms prev_pos = t.pos_bub(); // track target startpoint for knockback_follow
         const point kb_offset( rng( -technique.knockback_spread, technique.knockback_spread ),
                                rng( -technique.knockback_spread, technique.knockback_spread ) );
         tripoint kb_point( posx() + kb_offset.x, posy() + kb_offset.y, posz() );
@@ -1857,7 +1857,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
 
             // Check if it's possible to move to the new tile
             bool move_issue =
-                g->is_dangerous_tile( prev_pos ) || // Tile contains fire, etc
+                g->is_dangerous_tile( prev_pos.raw() ) || // Tile contains fire, etc
                 ( to_swimmable && to_deepwater ) || // Dive into deep water
                 is_mounted() ||
                 ( veh0 != nullptr && std::abs( veh0->velocity ) > 100 ) || // Diving from moving vehicle
@@ -1865,8 +1865,8 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
                 has_effect( effect_amigara ) ||
                 has_flag( json_flag_GRAB );
             if( !move_issue ) {
-                if( t.pos() != prev_pos ) {
-                    g->place_player( prev_pos );
+                if( t.pos_bub() != prev_pos ) {
+                    g->place_player( prev_pos.raw() );
                     g->on_move_effects();
                 }
             }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1082,7 +1082,7 @@ void game::chat()
                 return;
             }
 
-            if( here.impassable( tripoint( *p ) ) ) {
+            if( here.impassable( tripoint_bub_ms( *p ) ) ) {
                 add_msg( m_info, _( "This destination can't be reached." ) );
                 return;
             }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -407,22 +407,22 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
     const int max_length = settings.max_length;
 
     const int pad = 16;  // Should be much bigger - low value makes pathfinders dumb!
-    tripoint min( std::min( f.x, t.x ) - pad, std::min( f.y, t.y ) - pad, std::min( f.z, t.z ) );
-    tripoint max( std::max( f.x, t.x ) + pad, std::max( f.y, t.y ) + pad, std::max( f.z, t.z ) );
-    clip_to_bounds( min.x, min.y, min.z );
-    clip_to_bounds( max.x, max.y, max.z );
+    tripoint_bub_ms min( std::min( f.x, t.x ) - pad, std::min( f.y, t.y ) - pad, std::min( f.z, t.z ) );
+    tripoint_bub_ms max( std::max( f.x, t.x ) + pad, std::max( f.y, t.y ) + pad, std::max( f.z, t.z ) );
+    clip_to_bounds( min.x(), min.y(), min.z() );
+    clip_to_bounds( max.x(), max.y(), max.z() );
 
-    pf.reset( min.z, max.z );
+    pf.reset( min.z(), max.z() );
 
     pf.add_point( 0, 0, f, f );
 
     bool done = false;
 
     do {
-        tripoint cur = pf.get_next();
+        tripoint_bub_ms cur( pf.get_next() );
 
-        const int parent_index = flat_index( cur.xy() );
-        path_data_layer &layer = pf.get_layer( cur.z );
+        const int parent_index = flat_index( cur.xy().raw() );
+        path_data_layer &layer = pf.get_layer( cur.z() );
         if( layer.closed[parent_index] ) {
             continue;
         }
@@ -432,15 +432,15 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
             return std::vector<tripoint>();
         }
 
-        if( cur == t ) {
+        if( cur.raw() == t ) {
             done = true;
             break;
         }
 
         layer.closed[parent_index] = true;
 
-        const pathfinding_cache &pf_cache = get_pathfinding_cache_ref( cur.z );
-        const PathfindingFlags cur_special = pf_cache.special[cur.x][cur.y];
+        const pathfinding_cache &pf_cache = get_pathfinding_cache_ref( cur.z() );
+        const PathfindingFlags cur_special = pf_cache.special[cur.x()][cur.y()];
 
         // 7 3 5
         // 1 . 2
@@ -448,15 +448,15 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
         constexpr std::array<int, 8> x_offset{{ -1,  1,  0,  0,  1, -1, -1, 1 }};
         constexpr std::array<int, 8> y_offset{{  0,  0, -1,  1, -1,  1, -1, 1 }};
         for( size_t i = 0; i < 8; i++ ) {
-            const tripoint p( cur.x + x_offset[i], cur.y + y_offset[i], cur.z );
-            const int index = flat_index( p.xy() );
+            const tripoint_bub_ms p( cur.x() + x_offset[i], cur.y() + y_offset[i], cur.z() );
+            const int index = flat_index( p.xy().raw() );
 
             // TODO: Remove this and instead have sentinels at the edges
-            if( p.x < min.x || p.x >= max.x || p.y < min.y || p.y >= max.y ) {
+            if( p.x() < min.x() || p.x() >= max.x() || p.y() < min.y() || p.y() >= max.y() ) {
                 continue;
             }
 
-            if( p != t && avoid( p ) ) {
+            if( p.raw() != t && avoid( p.raw() ) ) {
                 layer.closed[index] = true;
                 continue;
             }
@@ -466,9 +466,9 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
             }
 
             // Penalize for diagonals or the path will look "unnatural"
-            int newg = layer.gscore[parent_index] + ( ( cur.x != p.x && cur.y != p.y ) ? 1 : 0 );
+            int newg = layer.gscore[parent_index] + ( ( cur.x() != p.x() && cur.y() != p.y() ) ? 1 : 0 );
 
-            const PathfindingFlags p_special = pf_cache.special[p.x][p.y];
+            const PathfindingFlags p_special = pf_cache.special[p.x()][p.y()];
             const int cost = extra_cost( tripoint_bub_ms( cur ), tripoint_bub_ms( p ), settings, p_special );
             if( cost < 0 ) {
                 if( cost == PF_IMPASSABLE ) {
@@ -488,15 +488,15 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
                 const trap &trp = ter_trp.is_benign() ? tile.get_trap_t() : ter_trp;
                 if( !trp.is_benign() && terrain.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ) {
                     // Warning: really expensive, needs a cache
-                    tripoint below( p.xy(), p.z - 1 );
+                    tripoint_bub_ms below( p + tripoint_below );
                     if( valid_move( p, below, false, true ) ) {
                         if( !has_flag( ter_furn_flag::TFLAG_NO_FLOOR, below ) ) {
                             // Otherwise this would have been a huge fall
-                            path_data_layer &layer = pf.get_layer( p.z - 1 );
+                            path_data_layer &layer = pf.get_layer( p.z() - 1 );
                             // From cur, not p, because we won't be walking on air
                             pf.add_point( layer.gscore[parent_index] + 10,
-                                          layer.score[parent_index] + 10 + 2 * rl_dist( below, t ),
-                                          cur, below );
+                                          layer.score[parent_index] + 10 + 2 * rl_dist( below.raw(), t ),
+                                          cur.raw(), below.raw() );
                         }
 
                         // Close p, because we won't be walking on it
@@ -506,7 +506,7 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
                 }
             }
 
-            pf.add_point( newg, newg + 2 * rl_dist( p, t ), cur, p );
+            pf.add_point( newg, newg + 2 * rl_dist( p.raw(), t ), cur.raw(), p.raw() );
         }
 
         // TODO: We should be able to go up ramps even if we can't climb stairs.
@@ -519,79 +519,79 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
         bool rope_ladder = false;
         const const_maptile &parent_tile = maptile_at_internal( cur );
         const ter_t &parent_terrain = parent_tile.get_ter_t();
-        if( settings.allow_climb_stairs && cur.z > min.z &&
+        if( settings.allow_climb_stairs && cur.z() > min.z() &&
             parent_terrain.has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) ) {
             std::optional<tripoint> opt_dest = g->find_or_make_stairs( get_map(),
-                                               cur.z - 1, rope_ladder, false, cur );
+                                               cur.z() - 1, rope_ladder, false, cur.raw() );
             if( !opt_dest ) {
                 continue;
             }
-            tripoint dest = opt_dest.value();
-            if( vertical_move_destination( *this, ter_furn_flag::TFLAG_GOES_UP, dest ) ) {
+            tripoint_bub_ms dest( opt_dest.value() );
+            if( vertical_move_destination( *this, ter_furn_flag::TFLAG_GOES_UP, dest.raw() ) ) {
                 if( !inbounds( dest ) ) {
                     continue;
                 }
-                path_data_layer &layer = pf.get_layer( dest.z );
+                path_data_layer &layer = pf.get_layer( dest.z() );
                 pf.add_point( layer.gscore[parent_index] + 2,
-                              layer.score[parent_index] + 2 * rl_dist( dest, t ),
-                              cur, dest );
+                              layer.score[parent_index] + 2 * rl_dist( dest.raw(), t ),
+                              cur.raw(), dest.raw() );
             }
         }
-        if( settings.allow_climb_stairs && cur.z < max.z &&
+        if( settings.allow_climb_stairs && cur.z() < max.z() &&
             parent_terrain.has_flag( ter_furn_flag::TFLAG_GOES_UP ) ) {
             std::optional<tripoint> opt_dest = g->find_or_make_stairs( get_map(),
-                                               cur.z + 1, rope_ladder, false, cur );
+                                               cur.z() + 1, rope_ladder, false, cur.raw() );
             if( !opt_dest ) {
                 continue;
             }
-            tripoint dest = opt_dest.value();
-            if( vertical_move_destination( *this, ter_furn_flag::TFLAG_GOES_DOWN, dest ) ) {
+            tripoint_bub_ms dest( opt_dest.value() );
+            if( vertical_move_destination( *this, ter_furn_flag::TFLAG_GOES_DOWN, dest.raw() ) ) {
                 if( !inbounds( dest ) ) {
                     continue;
                 }
-                path_data_layer &layer = pf.get_layer( dest.z );
+                path_data_layer &layer = pf.get_layer( dest.z() );
                 pf.add_point( layer.gscore[parent_index] + 2,
-                              layer.score[parent_index] + 2 * rl_dist( dest, t ),
-                              cur, dest );
+                              layer.score[parent_index] + 2 * rl_dist( dest.raw(), t ),
+                              cur.raw(), dest.raw() );
             }
         }
-        if( cur.z < max.z && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP ) &&
-            valid_move( cur, tripoint( cur.xy(), cur.z + 1 ), false, true ) ) {
-            path_data_layer &layer = pf.get_layer( cur.z + 1 );
+        if( cur.z() < max.z() && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP ) &&
+            valid_move( cur, cur + tripoint_above, false, true ) ) {
+            path_data_layer &layer = pf.get_layer( cur.z() + 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint_bub_ms above( cur.x + x_offset[it], cur.y + y_offset[it], cur.z + 1 );
+                const tripoint_bub_ms above( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() + 1 );
                 if( !inbounds( above ) ) {
                     continue;
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
                               layer.score[parent_index] + 4 + 2 * rl_dist( above.raw(), t ),
-                              cur, above.raw() );
+                              cur.raw(), above.raw() );
             }
         }
-        if( cur.z < max.z && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_UP ) &&
-            valid_move( cur, tripoint( cur.xy(), cur.z + 1 ), false, true, true ) ) {
-            path_data_layer &layer = pf.get_layer( cur.z + 1 );
+        if( cur.z() < max.z() && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_UP ) &&
+            valid_move( cur, cur + tripoint_above, false, true, true ) ) {
+            path_data_layer &layer = pf.get_layer( cur.z() + 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint_bub_ms above( cur.x + x_offset[it], cur.y + y_offset[it], cur.z + 1 );
+                const tripoint_bub_ms above( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() + 1 );
                 if( !inbounds( above ) ) {
                     continue;
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
                               layer.score[parent_index] + 4 + 2 * rl_dist( above.raw(), t ),
-                              cur, above.raw() );
+                              cur.raw(), above.raw() );
             }
         }
-        if( cur.z > min.z && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN ) &&
-            valid_move( cur, tripoint( cur.xy(), cur.z - 1 ), false, true, true ) ) {
-            path_data_layer &layer = pf.get_layer( cur.z - 1 );
+        if( cur.z() > min.z() && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN ) &&
+            valid_move( cur, cur + tripoint_below, false, true, true ) ) {
+            path_data_layer &layer = pf.get_layer( cur.z() - 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint_bub_ms below( cur.x + x_offset[it], cur.y + y_offset[it], cur.z - 1 );
+                const tripoint_bub_ms below( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() - 1 );
                 if( !inbounds( below ) ) {
                     continue;
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
                               layer.score[parent_index] + 4 + 2 * rl_dist( below.raw(), t ),
-                              cur, below.raw() );
+                              cur.raw(), below.raw() );
             }
         }
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1747,8 +1747,8 @@ void sfx::do_footstep()
     sfx_time = end_sfx_timestamp - start_sfx_timestamp;
     if( std::chrono::duration_cast<std::chrono::milliseconds> ( sfx_time ).count() > 400 ) {
         const Character &player_character = get_player_character();
-        int heard_volume = sfx::get_heard_volume( player_character.pos() );
-        const auto terrain = get_map().ter( player_character.pos() ).id();
+        int heard_volume = sfx::get_heard_volume( player_character.pos_bub() );
+        const auto terrain = get_map().ter( player_character.pos_bub() ).id();
         static const std::set<ter_str_id> grass = {
             ter_t_grass,
             ter_t_shrub,

--- a/src/test_data.h
+++ b/src/test_data.h
@@ -7,6 +7,7 @@
 #include <set>
 #include <vector>
 
+#include "coordinates.h"
 #include "point.h"
 #include "type_id.h"
 #include "pocket_type.h"
@@ -53,9 +54,9 @@ struct pocket_mod_test_data {
 
 struct npc_boarding_test_data {
     vproto_id veh_prototype;
-    tripoint player_pos;
-    tripoint npc_pos;
-    tripoint npc_target;
+    tripoint_bub_ms player_pos;
+    tripoint_bub_ms npc_pos;
+    tripoint_bub_ms npc_target;
 
     void deserialize( const JsonObject &jo );
 };

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -244,7 +244,7 @@ void timed_event::actualize()
             }
             // Check if we should print a message
             if( flood_buf[player_character.posx()][player_character.posy()] != here.ter(
-                    player_character.pos() ) ) {
+                    player_character.pos_bub() ) ) {
                 if( flood_buf[player_character.posx()][player_character.posy()] == ter_t_water_sh ) {
                     add_msg( m_warning, _( "Water quickly floods up to your knees." ) );
                     get_memorial().add(

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -54,7 +54,8 @@ vpart_id vpart_appliance_from_item( const itype_id &item_id )
     return vpart_ap_standing_lamp;
 }
 
-void place_appliance( const tripoint &p, const vpart_id &vpart, const std::optional<item> &base )
+void place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
+                      const std::optional<item> &base )
 {
 
     const vpart_info &vpinfo = vpart.obj();
@@ -89,7 +90,7 @@ void place_appliance( const tripoint &p, const vpart_id &vpart, const std::optio
 
     // Connect to any neighbouring appliances or wires once
     std::unordered_set<const vehicle *> connected_vehicles;
-    for( const tripoint &trip : here.points_in_radius( p, 1 ) ) {
+    for( const tripoint_bub_ms &trip : here.points_in_radius( p, 1 ) ) {
         const optional_vpart_position vp = here.veh_at( trip );
         if( !vp ) {
             continue;
@@ -102,7 +103,7 @@ void place_appliance( const tripoint &p, const vpart_id &vpart, const std::optio
                 continue;
             }
             if( connected_vehicles.find( &veh_target ) == connected_vehicles.end() ) {
-                veh->connect( p, trip );
+                veh->connect( p.raw(), trip.raw() );
                 connected_vehicles.insert( &veh_target );
             }
         }

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -9,7 +9,7 @@ class vehicle;
 class ui_adaptor;
 
 vpart_id vpart_appliance_from_item( const itype_id &item_id );
-void place_appliance( const tripoint &p, const vpart_id &vpart,
+void place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
                       const std::optional<item> &base = std::nullopt );
 
 /**

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2203,7 +2203,7 @@ void veh_interact::move_cursor( const point &d, int dstart_at )
     cpart = part_at( point_zero );
     const point vd = -dd;
     const point q = veh->coord_translate( vd );
-    const tripoint vehp = veh->global_pos3() + q;
+    const tripoint_bub_ms vehp = veh->pos_bub() + q;
     const bool has_critter = get_creature_tracker().creature_at( vehp );
     map &here = get_map();
     terrain_here = here.ter( vehp ).obj();
@@ -2252,7 +2252,7 @@ void veh_interact::move_cursor( const point &d, int dstart_at )
     }
 
     /* Update the lifting quality to be the that is available for this newly selected tile */
-    cache_tool_availability_update_lifting( vehp );
+    cache_tool_availability_update_lifting( vehp.raw() );
 }
 
 void veh_interact::display_grid()
@@ -2375,7 +2375,7 @@ void veh_interact::display_veh()
     }
 
     const point pt_disp( getmaxx( w_disp ) / 2, getmaxy( w_disp ) / 2 );
-    const tripoint pos_at_cursor = veh->global_pos3() + veh->coord_translate( -dd );
+    const tripoint_bub_ms pos_at_cursor = veh->pos_bub() + veh->coord_translate( -dd );
     const optional_vpart_position ovp = here.veh_at( pos_at_cursor );
     col_at_cursor = hilite( col_at_cursor );
     if( here.impassable_ter_furn( pos_at_cursor ) || ( ovp && &ovp->vehicle() != veh ) ) {
@@ -3154,7 +3154,7 @@ void veh_interact::complete_vehicle( Character &you )
                 orient_part( &veh, vpinfo, partnum, q );
             }
 
-            const tripoint vehp = veh.global_pos3() + tripoint( q, 0 );
+            const tripoint_bub_ms vehp = veh.pos_bub() + tripoint( q, 0 );
             // TODO: allow boarding for non-players as well.
             Character *const pl = get_creature_tracker().creature_at<Character>( vehp );
             if( vpinfo.has_flag( VPFLAG_BOARDABLE ) && pl ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -156,7 +156,7 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
     const player_activity &act = player_character.activity;
     map &here = get_map();
     if( act.id() == ACT_VEHICLE && act.moves_left > 0 && act.values.size() > 6 ) {
-        if( veh_pointer_or_null( here.veh_at( tripoint( act.values[0], act.values[1],
+        if( veh_pointer_or_null( here.veh_at( tripoint_bub_ms( act.values[0], act.values[1],
                                               player_character.posz() ) ) ) == &veh ) {
             if( act.values[6] >= part ) {
                 player_character.cancel_activity();
@@ -712,15 +712,15 @@ std::set<point> vehicle::immediate_path( const units::angle &rotate )
     tileray collision_vector;
     collision_vector.init( adjusted_angle );
     map &here = get_map();
-    point top_left_actual = global_pos3().xy() + coord_translate( front_left );
-    point top_right_actual = global_pos3().xy() + coord_translate( front_right );
-    std::vector<point> front_row = line_to( here.getglobal( tripoint_bub_ms{top_left_actual.x, top_left_actual.y, here.get_abs_sub().z()} ).xy().raw(),
-                                            here.getglobal( tripoint_bub_ms{ top_right_actual.x, top_right_actual.y, here.get_abs_sub().z() } ).xy().raw() );
-    for( const point &elem : front_row ) {
+    point_bub_ms top_left_actual = pos_bub().xy() + coord_translate( front_left );
+    point_bub_ms top_right_actual = pos_bub().xy() + coord_translate( front_right );
+    std::vector<point_abs_ms> front_row = line_to( here.getglobal( tripoint_bub_ms{top_left_actual.x(), top_left_actual.y(), here.get_abs_sub().z()} ).xy(),
+                                          here.getglobal( tripoint_bub_ms{ top_right_actual.x(), top_right_actual.y(), here.get_abs_sub().z()} ).xy() );
+    for( const point_abs_ms &elem : front_row ) {
         for( int i = 0; i < distance_to_check; ++i ) {
             collision_vector.advance( i );
-            point point_to_add = elem + point( collision_vector.dx(), collision_vector.dy() );
-            points_to_check.emplace( point_to_add );
+            point_abs_ms point_to_add = elem + point( collision_vector.dx(), collision_vector.dy() );
+            points_to_check.emplace( point_to_add.raw() );
         }
     }
     collision_check_points = points_to_check;
@@ -1564,7 +1564,7 @@ std::vector<vehicle::rackable_vehicle> vehicle::find_vehicles_to_rack( int rack 
             vehicle *veh_matched = nullptr;
             std::set<tripoint> parts_matched;
             for( const int &rack_part : filtered_rack ) {
-                const tripoint search_pos = global_part_pos3( rack_part ) + offset;
+                const tripoint_bub_ms search_pos = bub_part_pos( rack_part ) + offset;
                 const optional_vpart_position ovp = get_map().veh_at( search_pos );
                 if( !ovp || &ovp->vehicle() == this || ovp->vehicle().is_appliance() ) {
                     continue;
@@ -1574,7 +1574,7 @@ std::vector<vehicle::rackable_vehicle> vehicle::find_vehicles_to_rack( int rack 
                     veh_matched = test_veh;
                     parts_matched.clear();
                 }
-                parts_matched.insert( search_pos );
+                parts_matched.insert( search_pos.raw() );
 
                 std::set<tripoint> test_veh_points;
                 for( const vpart_reference &vpr : test_veh->get_all_parts() ) {
@@ -6838,29 +6838,29 @@ void vehicle::do_towing_move()
 
         default:
             towed_veh->skidding = true;
-            std::vector<tripoint> lineto = line_to( here.bub_from_abs( towed_tow_point ).raw(),
-                                                    here.bub_from_abs( tower_tow_point ).raw() );
-            tripoint nearby_destination;
+            std::vector<tripoint_bub_ms> lineto = line_to( here.bub_from_abs( towed_tow_point ),
+                                                  here.bub_from_abs( tower_tow_point ) );
+            tripoint_bub_ms nearby_destination;
             if( lineto.size() >= 2 ) {
                 nearby_destination = lineto[1];
             } else {
-                nearby_destination = tower_tow_point.raw();
+                nearby_destination = here.bub_from_abs( tower_tow_point );
             }
-            const tripoint destination_delta( here.bub_from_abs( tower_tow_point ).raw().xy() -
-                                              nearby_destination.xy() +
-                                              tripoint( 0, 0, towed_veh->global_pos3().z ) );
-            const tripoint move_destination( clamp( destination_delta.x, -1, 1 ),
-                                             clamp( destination_delta.y, -1, 1 ),
-                                             clamp( destination_delta.z, -1, 1 ) );
+            const tripoint_rel_ms destination_delta( here.bub_from_abs( tower_tow_point ).xy() -
+                    nearby_destination.xy() +
+                    tripoint_rel_ms( 0, 0, towed_veh->pos_bub().z() ) );
+            const tripoint_rel_ms move_destination( clamp( destination_delta.x(), -1, 1 ),
+                                                    clamp( destination_delta.y(), -1, 1 ),
+                                                    clamp( destination_delta.z(), -1, 1 ) );
             here.move_vehicle( *towed_veh, move_destination, towed_veh->face );
-            towed_veh->move = tileray( destination_delta.xy() );
+            towed_veh->move = tileray( destination_delta.xy().raw() );
     }
 }
 
 bool vehicle::is_external_part( const tripoint &part_pt ) const
 {
     map &here = get_map();
-    for( const tripoint &elem : here.points_in_radius( part_pt, 1 ) ) {
+    for( const tripoint_bub_ms &elem : here.points_in_radius( tripoint_bub_ms( part_pt ), 1 ) ) {
         const optional_vpart_position vp = here.veh_at( elem );
         if( !vp ) {
             return true;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2437,7 +2437,7 @@ class DefaultRemovePartHandler : public RemovePartHandler
         ~DefaultRemovePartHandler() override = default;
 
         void unboard( const tripoint &loc ) override {
-            get_map().unboard_vehicle( loc );
+            get_map().unboard_vehicle( tripoint_bub_ms( loc ) );
         }
         void add_item_or_charges( const tripoint &loc, item it, bool /*permit_oob*/ ) override {
             get_map().add_item_or_charges( loc, std::move( it ) );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1666,7 +1666,7 @@ void vehicle::precalculate_vehicle_turning( units::angle new_turn_dir, bool chec
         coord_translate( mdir.dir(), this->pivot_point(), wheel.mount,
                          wheel_point );
 
-        tripoint wheel_tripoint = global_pos3() + wheel_point;
+        tripoint_bub_ms wheel_tripoint = pos_bub() + wheel_point;
 
         // maximum number of incorrect tiles for this type of turn(diagonal or not)
         const int allowed_incorrect_tiles_diagonal = 1;
@@ -1964,20 +1964,20 @@ vehicle *vehicle::act_on_map()
         mdir = face;
     }
 
-    tripoint dp;
+    tripoint_rel_ms dp;
     if( std::abs( velocity ) >= 20 && !falling_only ) {
         mdir.advance( velocity < 0 ? -1 : 1 );
-        dp.x = mdir.dx();
-        dp.y = mdir.dy();
+        dp.x() = mdir.dx();
+        dp.y() = mdir.dy();
     }
 
     if( should_fall ) {
-        dp.z = -1;
+        dp.z() = -1;
         is_flying = false;
     } else {
-        dp.z = requested_z_change;
+        dp.z() = requested_z_change;
         requested_z_change = 0;
-        if( dp.z > 0 && is_rotorcraft() ) {
+        if( dp.z() > 0 && is_rotorcraft() ) {
             is_flying = true;
         }
     }
@@ -2134,7 +2134,7 @@ float map::vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modi
     for( const int wheel_idx : veh.wheelcache ) {
         const vehicle_part &vp = veh.part( wheel_idx );
         const vpart_info &vpi = vp.info();
-        const tripoint pp = veh.global_part_pos3( vp );
+        const tripoint_bub_ms pp = veh.bub_part_pos( vp );
         const ter_t &tr = ter( pp ).obj();
         if( tr.has_flag( ter_furn_flag::TFLAG_DEEP_WATER ) ||
             tr.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ) {
@@ -2189,11 +2189,11 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
             continue;
         }
 
-        const tripoint part_pos = veh.global_part_pos3( ps );
-        if( rider->pos() != part_pos ) {
+        const tripoint_bub_ms part_pos = veh.bub_part_pos( ps );
+        if( rider->pos_bub() != part_pos ) {
             debugmsg( "throw passenger: passenger at %d,%d,%d, part at %d,%d,%d",
                       rider->posx(), rider->posy(), rider->posz(),
-                      part_pos.x, part_pos.y, part_pos.z );
+                      part_pos.x(), part_pos.y(), part_pos.z() );
             veh.part( ps ).remove_flag( vp_flag::passenger_flag );
             continue;
         }
@@ -2275,7 +2275,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
                                                "the power of the impact!" ), veh.name );
                 unboard_vehicle( part_pos );
             } else {
-                add_msg_if_player_sees( part_pos, m_bad,
+                add_msg_if_player_sees( part_pos.raw(), m_bad,
                                         _( "The %s is hurled from %s's by the power of the impact!" ),
                                         pet->disp_name(), veh.name );
             }

--- a/tests/cardio_test.cpp
+++ b/tests/cardio_test.cpp
@@ -62,8 +62,8 @@ static int running_steps( Character &they, const ter_str_id &terrain = ter_t_pav
     REQUIRE_FALSE( they.is_wearing_shoes() );
     REQUIRE_FALSE( they.is_npc() );
     // You put your left foot in, you put your right foot in
-    const tripoint left = they.pos();
-    const tripoint right = left + tripoint_east;
+    const tripoint_bub_ms left = they.pos_bub();
+    const tripoint_bub_ms right = left + tripoint_east;
     // You ensure two tiles of terrain to hokey-pokey in
     here.ter_set( left, terrain );
     here.ter_set( right, terrain );
@@ -84,10 +84,10 @@ static int running_steps( Character &they, const ter_str_id &terrain = ter_t_pav
     while( they.can_run() && steps < STOP_STEPS ) {
         // Step right on even steps, left on odd steps
         if( steps % 2 == 0 ) {
-            REQUIRE( they.pos() == left );
+            REQUIRE( they.pos_bub() == left );
             REQUIRE( g->walk_move( right, false, false ) );
         } else {
-            REQUIRE( they.pos() == right );
+            REQUIRE( they.pos_bub() == right );
             REQUIRE( g->walk_move( left, false, false ) );
         }
         ++steps;

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -509,8 +509,8 @@ TEST_CASE( "suffering_from_asphyxiation", "[char][suffer][oxygen][grab]" )
 
         map &here = get_map();
         WHEN( "crushed against two walls by two grabbers" ) {
-            here.ter_set( dummy.pos() + tripoint_south, ter_t_rock_wall );
-            here.ter_set( dummy.pos() + tripoint_north, ter_t_rock_wall );
+            here.ter_set( dummy.pos_bub() + tripoint_south, ter_t_rock_wall );
+            here.ter_set( dummy.pos_bub() + tripoint_north, ter_t_rock_wall );
             REQUIRE( here.impassable( dummy.pos_bub() + tripoint_south ) );
             REQUIRE( here.impassable( dummy.pos_bub() + tripoint_north ) );
 

--- a/tests/connect_rotate_test.cpp
+++ b/tests/connect_rotate_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE( "walls_should_be_unconnected_without_nearby_walls", "[multitile][conn
     std::bitset<NUM_TERCONN> wall;
     wall.set( get_connect_group( "WALL" ).index );
 
-    tripoint pos = get_avatar().pos() + point_east + point_east;
+    tripoint_bub_ms pos = get_avatar().pos_bub() + point_east + point_east;
 
     int subtile = 0;
     int rotation = 0;
@@ -48,7 +48,7 @@ TEST_CASE( "walls_should_be_unconnected_without_nearby_walls", "[multitile][conn
         REQUIRE( here.ter_set( pos + point_north, ter_t_floor ) );
 
         THEN( "the wall should be unconnected" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == unconnected );
             CHECK( rotation == 0 );
@@ -65,7 +65,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_end_pieces", "[multitile][connects]
     std::bitset<NUM_TERCONN> wall;
     wall.set( get_connect_group( "WALL" ).index );
 
-    tripoint pos = get_avatar().pos() + point_east + point_east;
+    tripoint_bub_ms pos = get_avatar().pos_bub() + point_east + point_east;
 
     int subtile = 0;
     int rotation = 0;
@@ -78,7 +78,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_end_pieces", "[multitile][connects]
         REQUIRE( here.ter_set( pos + point_west, ter_t_floor ) );
 
         THEN( "the wall should be connected as end_piece N" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == end_piece );
             CHECK( rotation == 0 );
@@ -91,7 +91,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_end_pieces", "[multitile][connects]
         REQUIRE( here.ter_set( pos + point_west, ter_t_floor ) );
 
         THEN( "the wall should be connected as end_piece W" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == end_piece );
             CHECK( rotation == 1 );
@@ -104,7 +104,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_end_pieces", "[multitile][connects]
         REQUIRE( here.ter_set( pos + point_west, ter_t_floor ) );
 
         THEN( "the wall should be connected as end_piece S" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == end_piece );
             CHECK( rotation == 2 );
@@ -117,7 +117,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_end_pieces", "[multitile][connects]
         REQUIRE( here.ter_set( pos + point_west, ter_t_wall ) );
 
         THEN( "the wall should be connected as end_piece E" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == end_piece );
             CHECK( rotation == 3 );
@@ -134,7 +134,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_corners", "[multitile][connects]" )
     std::bitset<NUM_TERCONN> wall;
     wall.set( get_connect_group( "WALL" ).index );
 
-    tripoint pos = get_avatar().pos() + point_east + point_east;
+    tripoint_bub_ms pos = get_avatar().pos_bub() + point_east + point_east;
 
     int subtile = 0;
     int rotation = 0;
@@ -147,7 +147,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_corners", "[multitile][connects]" )
         REQUIRE( here.ter_set( pos + point_west, ter_t_floor ) );
 
         THEN( "the wall should be connected as corner NW" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == corner );
             CHECK( rotation == 0 );
@@ -160,7 +160,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_corners", "[multitile][connects]" )
         REQUIRE( here.ter_set( pos + point_west, ter_t_floor ) );
 
         THEN( "the wall should be connected as corner SW" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == corner );
             CHECK( rotation == 1 );
@@ -173,7 +173,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_corners", "[multitile][connects]" )
         REQUIRE( here.ter_set( pos + point_west, ter_t_wall ) );
 
         THEN( "the wall should be connected as corner SE" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == corner );
             CHECK( rotation == 2 );
@@ -186,7 +186,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_corners", "[multitile][connects]" )
         REQUIRE( here.ter_set( pos + point_west, ter_t_wall ) );
 
         THEN( "the wall should be connected as corner NE" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == corner );
             CHECK( rotation == 3 );
@@ -203,7 +203,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_edges", "[multitile][connects]" )
     std::bitset<NUM_TERCONN> wall;
     wall.set( get_connect_group( "WALL" ).index );
 
-    tripoint pos = get_avatar().pos() + point_east + point_east;
+    tripoint_bub_ms pos = get_avatar().pos_bub() + point_east + point_east;
 
     int subtile = 0;
     int rotation = 0;
@@ -216,7 +216,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_edges", "[multitile][connects]" )
         REQUIRE( here.ter_set( pos + point_west, ter_t_floor ) );
 
         THEN( "the wall should be connected as edge NS" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == edge );
             CHECK( rotation == 0 );
@@ -229,7 +229,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_edges", "[multitile][connects]" )
         REQUIRE( here.ter_set( pos + point_west, ter_t_wall ) );
 
         THEN( "the wall should be connected as edge EW" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == edge );
             CHECK( rotation == 1 );
@@ -246,7 +246,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multiti
     std::bitset<NUM_TERCONN> wall;
     wall.set( get_connect_group( "WALL" ).index );
 
-    tripoint pos = get_avatar().pos() + point_east + point_east;
+    tripoint_bub_ms pos = get_avatar().pos_bub() + point_east + point_east;
 
     int subtile = 0;
     int rotation = 0;
@@ -259,7 +259,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multiti
         REQUIRE( here.ter_set( pos + point_west, ter_t_wall ) );
 
         THEN( "the wall should be connected as t-connection N" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == t_connection );
             CHECK( rotation == 0 );
@@ -272,7 +272,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multiti
         REQUIRE( here.ter_set( pos + point_west, ter_t_floor ) );
 
         THEN( "the wall should be connected as t-connection W" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == t_connection );
             CHECK( rotation == 1 );
@@ -285,7 +285,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multiti
         REQUIRE( here.ter_set( pos + point_west, ter_t_wall ) );
 
         THEN( "the wall should be connected as t-connection S" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == t_connection );
             CHECK( rotation == 2 );
@@ -298,7 +298,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multiti
         REQUIRE( here.ter_set( pos + point_west, ter_t_wall ) );
 
         THEN( "the wall should be connected as t-connection E" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == t_connection );
             CHECK( rotation == 3 );
@@ -312,7 +312,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multiti
         REQUIRE( here.ter_set( pos + point_west, ter_t_wall ) );
 
         THEN( "the wall should be connected as center" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == center );
             CHECK( rotation == 0 );
@@ -331,7 +331,7 @@ TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multi
     std::bitset<NUM_TERCONN> wall;
     wall.set( get_connect_group( "WALL" ).index );
 
-    tripoint pos = get_avatar().pos() + point_east + point_east;
+    tripoint_bub_ms pos = get_avatar().pos_bub() + point_east + point_east;
 
     int subtile = 0;
     int rotation = 0;
@@ -344,7 +344,7 @@ TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multi
         REQUIRE( here.ter_set( pos + point_north, ter_t_wall ) );
 
         THEN( "the window should be connected as NS, with W positive" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, floor );
             CHECK( subtile == edge );
             CHECK( rotation == 0 );
@@ -357,7 +357,7 @@ TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multi
         REQUIRE( here.ter_set( pos + point_north, ter_t_floor ) );
 
         THEN( "the window should be connected EW, with N positive" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, floor );
             CHECK( subtile == edge );
             CHECK( rotation == 3 );
@@ -370,7 +370,7 @@ TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multi
         REQUIRE( here.ter_set( pos + point_north, ter_t_wall ) );
 
         THEN( "the window should be connected as NS, with E positive" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, floor );
             CHECK( subtile == edge );
             CHECK( rotation == 2 );
@@ -383,7 +383,7 @@ TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multi
         REQUIRE( here.ter_set( pos + point_north, ter_t_pavement ) );
 
         THEN( "the window should be connected as EW, with S positive" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, floor );
             CHECK( subtile == edge );
             CHECK( rotation == 1 );
@@ -397,7 +397,7 @@ TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multi
         REQUIRE( here.ter_set( pos + point_north, ter_t_wall ) );
 
         THEN( "the window should be connected as NS, with E and W negative" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, floor );
             CHECK( subtile == edge );
             CHECK( rotation == 4 );
@@ -410,7 +410,7 @@ TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multi
         REQUIRE( here.ter_set( pos + point_north, ter_t_pavement ) );
 
         THEN( "the window should be connected as EW, with N and S negative" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, floor );
             CHECK( subtile == edge );
             CHECK( rotation == 7 );
@@ -423,7 +423,7 @@ TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multi
         REQUIRE( here.ter_set( pos + point_north, ter_t_wall ) );
 
         THEN( "the window should be connected as NS, with E and W negative" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, floor );
             CHECK( subtile == edge );
             CHECK( rotation == 6 );
@@ -436,7 +436,7 @@ TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multi
         REQUIRE( here.ter_set( pos + point_north, ter_t_floor ) );
 
         THEN( "the window should be connected as EW, with N and S positive" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, floor );
             CHECK( subtile == edge );
             CHECK( rotation == 5 );
@@ -454,7 +454,7 @@ TEST_CASE( "unconnected_windows_rotate_to_indoor_floor", "[multitile][rotates]" 
     std::bitset<NUM_TERCONN> floor;
     floor.set( get_connect_group( "INDOORFLOOR" ).index );
 
-    tripoint pos = get_avatar().pos() + point_east + point_east;
+    tripoint_bub_ms pos = get_avatar().pos_bub() + point_east + point_east;
 
     int subtile = 0;
     int rotation = 0;
@@ -467,7 +467,7 @@ TEST_CASE( "unconnected_windows_rotate_to_indoor_floor", "[multitile][rotates]" 
         REQUIRE( here.ter_set( pos + point_north, ter_t_pavement ) );
 
         THEN( "the window should be unconnected" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     none, floor );
             CHECK( subtile == unconnected );
             CHECK( rotation == 15 );
@@ -481,7 +481,7 @@ TEST_CASE( "unconnected_windows_rotate_to_indoor_floor", "[multitile][rotates]" 
         REQUIRE( here.ter_set( pos + point_north, ter_t_floor ) );
 
         THEN( "the window rotate to the north" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     none, floor );
             CHECK( subtile == unconnected );
             CHECK( rotation == 2 );
@@ -494,7 +494,7 @@ TEST_CASE( "unconnected_windows_rotate_to_indoor_floor", "[multitile][rotates]" 
         REQUIRE( here.ter_set( pos + point_north, ter_t_pavement ) );
 
         THEN( "the window rotate to the east" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     none, floor );
             CHECK( subtile == unconnected );
             CHECK( rotation == 3 );
@@ -507,7 +507,7 @@ TEST_CASE( "unconnected_windows_rotate_to_indoor_floor", "[multitile][rotates]" 
         REQUIRE( here.ter_set( pos + point_north, ter_t_pavement ) );
 
         THEN( "the window rotate to the south" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     none, floor );
             CHECK( subtile == unconnected );
             CHECK( rotation == 0 );
@@ -520,7 +520,7 @@ TEST_CASE( "unconnected_windows_rotate_to_indoor_floor", "[multitile][rotates]" 
         REQUIRE( here.ter_set( pos + point_north, ter_t_pavement ) );
 
         THEN( "the window rotate to the west" ) {
-            cata_tiles_test_helper::get_connect_values( pos, subtile, rotation,
+            cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     none, floor );
             CHECK( subtile == unconnected );
             CHECK( rotation == 1 );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -439,7 +439,7 @@ static void prep_craft( const recipe_id &rid, const std::vector<item> &tools,
     clear_avatar();
     clear_map();
 
-    const tripoint test_origin( 60, 60, 0 );
+    const tripoint_bub_ms test_origin( 60, 60, 0 );
     Character &player_character = get_player_character();
     player_character.toggle_trait( trait_DEBUG_CNF );
     player_character.setpos( test_origin );
@@ -449,7 +449,7 @@ static void prep_craft( const recipe_id &rid, const std::vector<item> &tools,
         grant_profs_to_character( player_character, r );
     }
 
-    const tripoint battery_pos = test_origin + tripoint_north;
+    const tripoint_bub_ms battery_pos = test_origin + tripoint_north;
     std::optional<item> battery_item( "test_storage_battery" );
     place_appliance( battery_pos, vpart_ap_test_storage_battery, battery_item );
 

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -750,7 +750,7 @@ static void merge_invlet_test( avatar &dummy, inventory_location from )
 TEST_CASE( "Inventory_letter_test", "[.invlet]" )
 {
     avatar &dummy = get_avatar();
-    const tripoint spot( 60, 60, 0 );
+    const tripoint_bub_ms spot( 60, 60, 0 );
     clear_map();
     dummy.setpos( spot );
     get_map().ter_set( spot, ter_id( "t_dirt" ) );

--- a/tests/item_spawn_test.cpp
+++ b/tests/item_spawn_test.cpp
@@ -58,7 +58,7 @@ TEST_CASE( "correct_amounts_of_an_item_spawn_inside_a_container", "[item_spawn]"
                             vehicle *veh = here.add_vehicle( cs_data.vehicle, vehpos, 0_degrees, 0, 0 );
                             REQUIRE( veh );
                             REQUIRE( here.get_vehicles().size() == 1 );
-                            const tripoint pos( point_zero, veh->sm_pos.z );
+                            const tripoint_bub_ms pos( point_bub_ms_zero, veh->sm_pos.z );
                             const std::optional<vpart_reference> ovp_cargo = here.veh_at( pos ).cargo();
                             REQUIRE( ovp_cargo );
                             for( item &it : ovp_cargo->items() ) {

--- a/tests/line_test.cpp
+++ b/tests/line_test.cpp
@@ -75,11 +75,11 @@ static std::vector <point> canonical_line_to( const point &p1, const point &p2, 
     return ret;
 }
 
-static void check_bresenham( const tripoint &source, const tripoint &destination,
-                             const std::vector<tripoint> &path )
+static void check_bresenham( const tripoint_bub_ms &source, const tripoint_bub_ms &destination,
+                             const std::vector<tripoint_bub_ms> &path )
 {
-    std::vector<tripoint> generated_path;
-    bresenham( source, destination, 0, 0, [&generated_path]( const tripoint & current_point ) {
+    std::vector<tripoint_bub_ms> generated_path;
+    bresenham( source, destination, 0, 0, [&generated_path]( const tripoint_bub_ms & current_point ) {
         generated_path.push_back( current_point );
         return true;
     } );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -65,10 +65,10 @@ TEST_CASE( "destroy_grabbed_furniture" )
     clear_map();
     avatar &player_character = get_avatar();
     GIVEN( "Furniture grabbed by the player" ) {
-        const tripoint test_origin( 60, 60, 0 );
+        const tripoint_bub_ms test_origin( 60, 60, 0 );
         map &here = get_map();
         player_character.setpos( test_origin );
-        const tripoint grab_point = test_origin + tripoint_east;
+        const tripoint_bub_ms grab_point = test_origin + tripoint_east;
         here.furn_set( grab_point, furn_id( "f_chair" ) );
         player_character.grab( object_type::FURNITURE, tripoint_rel_ms_east );
         REQUIRE( player_character.get_grab_type() == object_type::FURNITURE );
@@ -99,9 +99,9 @@ TEST_CASE( "map_bounds_checking" )
                 if( x < 0 || x >= MAPSIZE_X ||
                     y < 0 || y >= MAPSIZE_Y ||
                     z < -OVERMAP_DEPTH || z > OVERMAP_HEIGHT ) {
-                    CHECK( !m.ter( tripoint{ x, y, z } ) );
+                    CHECK( !m.ter( tripoint_bub_ms{ x, y, z } ) );
                 } else {
-                    CHECK( m.ter( tripoint{ x, y, z } ) );
+                    CHECK( m.ter( tripoint_bub_ms{ x, y, z } ) );
                 }
             }
         }

--- a/tests/map_test_case.cpp
+++ b/tests/map_test_case.cpp
@@ -5,20 +5,21 @@
 #include <string>
 
 #include "field.h"
+#include "coordinate_constants.h" // Has to come after field.h, or its contents is rejected.
 #include "level_cache.h"
 #include "map.h"
 #include "map_test_case.h"
 
-tripoint map_test_case::get_origin()
+tripoint_bub_ms map_test_case::get_origin()
 {
     if( origin ) {
         return *origin;
     }
 
-    std::optional<point> res = std::nullopt;
+    std::optional<point_bub_ms> res = std::nullopt;
 
     if( anchor_char ) {
-        for_each_tile( tripoint_zero, [&]( map_test_case::tile & t ) {
+        for_each_tile( tripoint_bub_ms_zero, [&]( map_test_case::tile & t ) {
             if( t.setup_c == *anchor_char ) {
                 if( res ) {
                     FAIL( "Origin char '" << *anchor_char << "' is found more than once in setup" );
@@ -31,10 +32,10 @@ tripoint map_test_case::get_origin()
             FAIL( "Origin char '" << *anchor_char << "' is not found in setup" );
         }
     } else {
-        res = point_zero;
+        res = point_bub_ms_zero;
     }
 
-    origin = anchor_map_pos - tripoint( *res, 0 );
+    origin = anchor_map_pos - tripoint_bub_ms( *res, 0 ).raw();
     return *origin;
 }
 
@@ -48,7 +49,7 @@ int map_test_case::get_height() const
     return setup.size();
 }
 
-void map_test_case::for_each_tile( const tripoint &tmp_origin,
+void map_test_case::for_each_tile( const tripoint_bub_ms &tmp_origin,
                                    const std::function<void( map_test_case::tile & )> &callback ) const
 {
     int width = get_width();
@@ -159,7 +160,7 @@ void map_test_case::reflect_y()
 
 void map_test_case::set_anchor_char_from( const std::set<char> &chars )
 {
-    for_each_tile( tripoint_zero, [&]( tile t ) {
+    for_each_tile( tripoint_bub_ms_zero, [&]( tile t ) {
         if( chars.count( t.setup_c ) ) {
             anchor_char = t.setup_c;
         }
@@ -184,20 +185,20 @@ std::string map_test_case::generate_transform_combinations()
     return out.str();
 }
 
-void map_test_case::validate_anchor_point( const tripoint &p )
+void map_test_case::validate_anchor_point( const tripoint_bub_ms &p )
 {
     INFO( "checking point: " << p );
-    tripoint origin_p = get_origin();
-    REQUIRE( origin_p.z == p.z );
+    tripoint_bub_ms origin_p = get_origin();
+    REQUIRE( origin_p.z() == p.z() );
     REQUIRE( p == anchor_map_pos );
     // offset is anchor_map_pos in `map_test_case` local coords
-    tripoint offset = p - origin_p;
-    REQUIRE( offset.y >= 0 );
-    REQUIRE( offset.y < get_height() );
-    REQUIRE( offset.x >= 0 );
-    REQUIRE( offset.x < get_width() );
+    tripoint_rel_ms offset = p - origin_p;
+    REQUIRE( offset.y() >= 0 );
+    REQUIRE( offset.y() < get_height() );
+    REQUIRE( offset.x() >= 0 );
+    REQUIRE( offset.x() < get_width() );
 
-    char setup_anchor_char = setup[offset.y][offset.x];
+    char setup_anchor_char = setup[offset.y()][offset.x()];
     REQUIRE( anchor_char );
     REQUIRE( setup_anchor_char == *anchor_char );
 }
@@ -229,17 +230,17 @@ static std::string print_and_format_helper( map_test_case &t, int zshift,
     tripoint shift = tripoint( point_zero, zshift );
     return map_test_case_common::printers::format_2d_array(
     t.map_tiles_str( [&]( map_test_case::tile t, std::ostringstream & out ) {
-        print_tile( t.p + shift, out );
+        print_tile( ( t.p + shift ).raw(), out );
     } ) );
 }
 
 static std::string print_and_format_helper( map_test_case &t, int zshift,
         std::function<void( const tripoint_bub_ms &p, std::ostringstream &out )> print_tile )
 {
-    tripoint_bub_ms shift = { point_bub_ms( point_zero ), zshift };
+    tripoint shift = tripoint( point_zero, zshift );
     return map_test_case_common::printers::format_2d_array(
     t.map_tiles_str( [&]( map_test_case::tile t, std::ostringstream & out ) {
-        print_tile( t.p + shift, out );
+        print_tile( ( t.p + shift ), out );
     } ) );
 }
 
@@ -257,7 +258,7 @@ std::string map_test_case_common::printers::fields( map_test_case &t, int zshift
 
 std::string map_test_case_common::printers::transparency( map_test_case &t, int zshift )
 {
-    const level_cache &cache = get_map().access_cache( t.get_origin().z + zshift );
+    const level_cache &cache = get_map().access_cache( t.get_origin().z() + zshift );
     return print_and_format_helper( t, zshift, [&]( tripoint p, auto & out ) {
         out << std::setprecision( 3 ) << cache.transparency_cache[p.x][p.y] << ' ';
     } );
@@ -265,7 +266,7 @@ std::string map_test_case_common::printers::transparency( map_test_case &t, int 
 
 std::string map_test_case_common::printers::seen( map_test_case &t, int zshift )
 {
-    const auto &cache = get_map().access_cache( t.get_origin().z + zshift ).seen_cache;
+    const auto &cache = get_map().access_cache( t.get_origin().z() + zshift ).seen_cache;
     return print_and_format_helper( t, zshift, [&]( tripoint p, auto & out ) {
         out << std::setprecision( 3 ) << cache[p.x][p.y] << ' ';
     } );
@@ -273,7 +274,7 @@ std::string map_test_case_common::printers::seen( map_test_case &t, int zshift )
 
 std::string map_test_case_common::printers::lm( map_test_case &t, int zshift )
 {
-    const level_cache &cache = get_map().access_cache( t.get_origin().z + zshift );
+    const level_cache &cache = get_map().access_cache( t.get_origin().z() + zshift );
     return print_and_format_helper( t, zshift, [&]( tripoint p, auto & out ) {
         out << cache.lm[p.x][p.y].to_string() << ' ';
     } );
@@ -281,7 +282,7 @@ std::string map_test_case_common::printers::lm( map_test_case &t, int zshift )
 
 std::string map_test_case_common::printers::apparent_light( map_test_case &t, int zshift )
 {
-    const level_cache &cache = get_map().access_cache( t.get_origin().z + zshift );
+    const level_cache &cache = get_map().access_cache( t.get_origin().z() + zshift );
     return print_and_format_helper( t, zshift, [&]( tripoint_bub_ms p, auto & out ) {
         out << std::setprecision( 3 ) << map::apparent_light_helper( cache, p ).apparent_light << ' ';
     } );
@@ -289,7 +290,7 @@ std::string map_test_case_common::printers::apparent_light( map_test_case &t, in
 
 std::string map_test_case_common::printers::obstructed( map_test_case &t, int zshift )
 {
-    const level_cache &cache = get_map().access_cache( t.get_origin().z + zshift );
+    const level_cache &cache = get_map().access_cache( t.get_origin().z() + zshift );
     return print_and_format_helper( t, zshift, [&]( tripoint_bub_ms p, auto & out ) {
         bool obs = map::apparent_light_helper( cache, p ).obstructed;
         out << ( obs ? '#' : '.' );
@@ -298,7 +299,7 @@ std::string map_test_case_common::printers::obstructed( map_test_case &t, int zs
 
 std::string map_test_case_common::printers::floor( map_test_case &t, int zshift )
 {
-    const level_cache &cache = get_map().access_cache( t.get_origin().z + zshift );
+    const level_cache &cache = get_map().access_cache( t.get_origin().z() + zshift );
     return print_and_format_helper( t, zshift, [&]( tripoint p, auto & out ) {
         out << ( cache.floor_cache[p.x][p.y] ? '#' : '.' );
     } );
@@ -361,7 +362,7 @@ tile_predicate ter_set(
 {
     return [ = ]( map_test_case::tile t ) {
         REQUIRE( ter.is_valid() );
-        tripoint p = t.p + shift;
+        tripoint_bub_ms p( t.p + shift );
         get_map().ter_set( p, ter );
         return true;
     };

--- a/tests/map_test_case.h
+++ b/tests/map_test_case.h
@@ -10,6 +10,7 @@
 
 #include "cata_catch.h"
 #include "map.h"
+#include "coordinate_constants.h" // Has to come after map.h or its contents is rejected by the compiler.
 #include "mapdata.h"
 #include "point.h"
 
@@ -49,7 +50,7 @@ class map_test_case
             // current char from `expected_results`
             char expect_c;
             // current point in map coords
-            tripoint p;
+            tripoint_bub_ms p;
             // current point in local coords [0..width) [0..height)
             point p_local;
         };
@@ -78,7 +79,7 @@ class map_test_case
          *  For example, it can be the center of the map or player's coordinates.
          *  This test will align `anchor_char` (in `setup`) with given map coordinates.
          */
-        tripoint anchor_map_pos = tripoint_zero;
+        tripoint_bub_ms anchor_map_pos = tripoint_bub_ms_zero;
 
         /**
          * Invokes callback for each tile of the input map.
@@ -107,7 +108,7 @@ class map_test_case
         int get_width() const;
 
         // returns calculated "origin" point, i.e. shift relative to the map
-        tripoint get_origin();
+        tripoint_bub_ms get_origin();
 
         // automatically set `anchor_char` from the list of given chars to the one that is present in the `setup`
         void set_anchor_char_from( const std::set<char> &chars );
@@ -138,19 +139,19 @@ class map_test_case
          * (and performing other sanity checks)
          * @param p tripoint in map coordinates that is expected to align with the `anchor_map_pos`
          */
-        void validate_anchor_point( const tripoint &p );
+        void validate_anchor_point( const tripoint_bub_ms &p );
 
     private:
         // origin (0,0) of this `map_test_case` in `map` coordinates
         // based on `anchor_map_pos` and `anchor_char`, lazily calculated when needed, reset on transformations
-        std::optional<tripoint> origin = std::nullopt;
+        std::optional<tripoint_bub_ms> origin = std::nullopt;
 
         // flag that internal sanity checks are completed, resets on transformations
         bool checks_complete = false;
 
         void do_internal_checks();
 
-        void for_each_tile( const tripoint &tmp_origin,
+        void for_each_tile( const tripoint_bub_ms &tmp_origin,
                             const std::function<void( tile & )> &callback ) const;
 
 };

--- a/tests/map_test_case_test.cpp
+++ b/tests/map_test_case_test.cpp
@@ -84,12 +84,12 @@ TEST_CASE( "map_test_case_transform_consistency", "[map_test_case]" )
     }
 
     // assumes tst.anchor_map_pos == tripoint_zero
-    CHECK( tst.get_origin() == tripoint_north_west );
-    tst.validate_anchor_point( tripoint_zero );
+    CHECK( tst.get_origin() == tripoint_bub_ms( tripoint_north_west ) );
+    tst.validate_anchor_point( tripoint_bub_ms( tripoint_zero ) );
 
     std::set<tripoint> tiles;
     tst.for_each_tile( [&]( mtc::tile t ) {
-        tiles.emplace( t.p );
+        tiles.emplace( t.p.raw() );
     } );
 
     CHECK( tiles.size() == 9 );
@@ -104,7 +104,7 @@ TEST_CASE( "map_test_case_transform_consistency", "[map_test_case]" )
 
     tst.for_each_tile( [&]( mtc::tile t ) {
         CHECK( t.expect_c == t.setup_c );
-        CHECK( tiles.count( t.p ) == 1 );
+        CHECK( tiles.count( t.p.raw() ) == 1 );
     } );
 }
 
@@ -125,7 +125,7 @@ TEST_CASE( "map_test_case_transform_non_square", "[map_test_case]" )
 
     SECTION( tst.generate_transform_combinations() ) {
     }
-    tst.validate_anchor_point( tripoint_zero );
+    tst.validate_anchor_point( tripoint_bub_ms( tripoint_zero ) );
 
     CAPTURE( tst.get_width(), tst.get_height() );
     CHECK(
@@ -136,7 +136,7 @@ TEST_CASE( "map_test_case_transform_non_square", "[map_test_case]" )
     CAPTURE( tst.get_origin() );
     CHECK( std::set<tripoint> {
         tripoint_zero, {-4, 0, 0}, {0, -4, 0}
-    } .count( tst.get_origin() ) );
+    } .count( tst.get_origin().raw() ) );
 
     tst.for_each_tile( [&]( mtc::tile t ) {
         CHECK( t.expect_c - 'a' == t.setup_c - '1' );

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -34,7 +34,7 @@ void check_vehicle_still_works( vehicle &veh )
     here.displace_vehicle( veh, startp - veh.pos_bub() );
 }
 
-vehicle *add_test_vehicle( map &m, tripoint loc )
+vehicle *add_test_vehicle( map &m, tripoint_bub_ms loc )
 {
     return m.add_vehicle( vehicle_prototype_shopping_cart, loc, -90_degrees, 100, 0 );
 }
@@ -44,22 +44,22 @@ void remote_add_test_vehicle( map &m )
     wipe_map_terrain( &m );
     m.clear_traps();
     REQUIRE( m.get_vehicles().empty() );
-    add_test_vehicle( m, tripoint_zero );
+    add_test_vehicle( m, tripoint_bub_ms_zero );
     REQUIRE( m.get_vehicles().size() == 1 );
     REQUIRE( m.veh_at( tripoint_bub_ms_zero ).has_value() );
 }
 
 template<typename F, typename ID>
-void local_test( vehicle *veh, tripoint const &test_loc, F const &fmg, ID const &id )
+void local_test( vehicle *veh, tripoint_bub_ms const &test_loc, F const &fmg, ID const &id )
 {
     map &here = get_map();
     tripoint_abs_omt const this_test_omt =
         project_to<coords::omt>( get_map().getglobal( test_loc ) );
-    tripoint const this_test_loc = test_loc + point_east;
+    tripoint_bub_ms const this_test_loc = test_loc + point_east;
     vehicle *const veh2 = add_test_vehicle( here, this_test_loc );
     REQUIRE( here.veh_at( this_test_loc ).has_value() );
     REQUIRE( here.get_vehicles().size() == 2 );
-    REQUIRE( veh->global_pos3() == veh2->global_pos3() - point_east );
+    REQUIRE( veh->pos_bub() == veh2->pos_bub() - point_east );
     REQUIRE( veh->sm_pos == veh2->sm_pos );
 
     manual_mapgen( this_test_omt, fmg, id );
@@ -68,7 +68,7 @@ void local_test( vehicle *veh, tripoint const &test_loc, F const &fmg, ID const 
 }
 
 template<typename F, typename ID>
-void remote_test( vehicle *veh, tripoint const &test_loc, F const &fmg, ID const &id )
+void remote_test( vehicle *veh, tripoint_bub_ms const &test_loc, F const &fmg, ID const &id )
 {
     map &here = get_map();
     tripoint_abs_omt const this_test_omt =
@@ -101,7 +101,7 @@ TEST_CASE( "mapgen_remove_vehicles" )
     here.board_vehicle( start_loc, &get_avatar() );
     veh->start_engines( &get_avatar(), true );
 
-    tripoint const test_loc = get_avatar().pos();
+    tripoint_bub_ms const test_loc = get_avatar().pos_bub();
     check_vehicle_still_works( *veh );
 
     SECTION( "nested remove_vehicle outside of main map" ) {

--- a/tests/modify_morale_test.cpp
+++ b/tests/modify_morale_test.cpp
@@ -96,7 +96,7 @@ TEST_CASE( "dining_with_table_and_chair", "[food][modify_morale][table][chair]" 
     map &here = get_map();
     avatar dummy;
     dummy.set_body();
-    const tripoint avatar_pos( 60, 60, 0 );
+    const tripoint_bub_ms avatar_pos( 60, 60, 0 );
     dummy.setpos( avatar_pos );
     dummy.worn.wear_item( dummy, item( "backpack" ), false, false );
 

--- a/tests/move_cost_test.cpp
+++ b/tests/move_cost_test.cpp
@@ -101,13 +101,13 @@ TEST_CASE( "footwear_may_affect_movement_cost", "[move_cost][shoes]" )
         REQUIRE( ava.get_modifier( character_modifier_limb_run_cost_mod ) == Approx( 1.11696 ) );
         WHEN( "on pavement and running" ) {
             ava.set_movement_mode( move_mode_run );
-            here.ter_set( ava.pos(), ter_t_pavement );
+            here.ter_set( ava.pos_bub(), ter_t_pavement );
             THEN( "much faster than sneakers" ) {
                 CHECK( ava.run_cost( 100 ) == 27 );
             }
         }
         WHEN( "on grass" ) {
-            here.ter_set( ava.pos(), ter_t_grass );
+            here.ter_set( ava.pos_bub(), ter_t_grass );
             THEN( "much slower than sneakers" ) {
                 CHECK( ava.run_cost( 100 ) == 167 );
             }
@@ -121,13 +121,13 @@ TEST_CASE( "footwear_may_affect_movement_cost", "[move_cost][shoes]" )
         REQUIRE( ava.get_modifier( character_modifier_limb_run_cost_mod ) == Approx( 1.11696 ) );
         WHEN( "on pavement and running" ) {
             ava.set_movement_mode( move_mode_run );
-            here.ter_set( ava.pos(), ter_t_pavement );
+            here.ter_set( ava.pos_bub(), ter_t_pavement );
             THEN( "faster than sneakers" ) {
                 CHECK( ava.run_cost( 100 ) == 39 );
             }
         }
         WHEN( "on grass" ) {
-            here.ter_set( ava.pos(), ter_t_grass );
+            here.ter_set( ava.pos_bub(), ter_t_grass );
             THEN( "slower than sneakers" ) {
                 CHECK( ava.run_cost( 100 ) == 145 );
             }
@@ -141,13 +141,13 @@ TEST_CASE( "footwear_may_affect_movement_cost", "[move_cost][shoes]" )
         REQUIRE( ava.get_modifier( character_modifier_limb_run_cost_mod ) == Approx( 1.0 ) );
         WHEN( "on pavement and running" ) {
             ava.set_movement_mode( move_mode_run );
-            here.ter_set( ava.pos(), ter_t_pavement );
+            here.ter_set( ava.pos_bub(), ter_t_pavement );
             THEN( "slightly faster than sneakers" ) {
                 CHECK( ava.run_cost( 100 ) == 42 );
             }
         }
         WHEN( "on grass" ) {
-            here.ter_set( ava.pos(), ter_t_grass );
+            here.ter_set( ava.pos_bub(), ter_t_grass );
             THEN( "slightly slower than sneakers" ) {
                 CHECK( ava.run_cost( 100 ) == 110 );
             }

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -328,7 +328,7 @@ static void check_npc_movement( const tripoint &origin )
     }
 }
 
-static npc *make_companion( const tripoint &npc_pos )
+static npc *make_companion( const tripoint_bub_ms &npc_pos )
 {
     shared_ptr_fast<npc> guy = make_shared_fast<npc>();
     guy->normalize();
@@ -352,7 +352,7 @@ TEST_CASE( "npc-board-player-vehicle" )
     for( std::pair<const std::string, npc_boarding_test_data> &given : test_data::npc_boarding_data ) {
         GIVEN( given.first ) {
             npc_boarding_test_data &data = given.second;
-            g->place_player( data.player_pos );
+            g->place_player( data.player_pos.raw() );
             clear_map();
             map &here = get_map();
             Character &pc = get_player_character();
@@ -376,7 +376,7 @@ TEST_CASE( "npc-board-player-vehicle" )
             */
 
             int turns = 0;
-            while( turns++ < 100 && companion->pos() != data.npc_target ) {
+            while( turns++ < 100 && companion->pos_bub() != data.npc_target ) {
                 companion->set_moves( 100 );
                 /* Uncommment for extra debug info
                 tripoint npc_pos = companion->pos();
@@ -424,7 +424,7 @@ TEST_CASE( "npc-board-player-vehicle" )
                     }
                 }
             }
-            CHECK( companion->pos() == data.npc_target );
+            CHECK( companion->pos_bub() == data.npc_target );
         }
     }
 }

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -589,8 +589,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_str_id::NULL_ID() );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_str_id::NULL_ID() );
+            mp.ter_set( tripoint_bub_ms_zero, ter_str_id::NULL_ID() );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_str_id::NULL_ID() );
 
             item_location boltcutter = setup_dummy();
             setup_activity( boltcutter );
@@ -604,8 +604,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_t_dirt );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_t_dirt );
+            mp.ter_set( tripoint_bub_ms_zero, ter_t_dirt );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_t_dirt );
 
             item_location boltcutter = setup_dummy();
             setup_activity( boltcutter );
@@ -619,8 +619,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_boltcut1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_boltcut1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_boltcut1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_boltcut1 );
 
             item_location boltcutter = setup_dummy();
             setup_activity( boltcutter );
@@ -634,8 +634,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_boltcut1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_boltcut1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_boltcut1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_boltcut1 );
 
             item_location boltcutter = setup_dummy();
             setup_activity( boltcutter );
@@ -649,8 +649,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_boltcut1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_boltcut1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_boltcut1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_boltcut1 );
 
             item_location boltcutter = setup_dummy();
             setup_activity( boltcutter );
@@ -668,8 +668,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_boltcut1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_boltcut1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_boltcut1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_boltcut1 );
 
             item_location boltcutter = setup_dummy();
             setup_activity( boltcutter );
@@ -689,8 +689,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_boltcut3 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_boltcut3 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_boltcut3 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_boltcut3 );
 
             item battery( itype_test_battery_disposable );
             battery.ammo_set( battery.ammo_default(), 2 );
@@ -730,8 +730,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_boltcut1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_boltcut1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_boltcut1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_boltcut1 );
 
             item_location boltcutter = setup_dummy();
             setup_activity( boltcutter );
@@ -741,7 +741,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "terrain gets converted to new terrain type" ) {
-                CHECK( mp.ter( tripoint_zero ) == ter_t_dirt );
+                CHECK( mp.ter( tripoint_bub_ms_zero ) == ter_t_dirt );
             }
         }
 
@@ -749,8 +749,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_boltcut1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_boltcut1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_boltcut1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_boltcut1 );
 
             item_location boltcutter = setup_dummy();
             setup_activity( boltcutter );
@@ -760,7 +760,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "furniture gets converted to new furniture type" ) {
-                CHECK( mp.furn( tripoint_zero ) == furn_str_id::NULL_ID() );
+                CHECK( mp.furn( tripoint_bub_ms_zero ) == furn_str_id::NULL_ID() );
             }
         }
 
@@ -768,8 +768,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_boltcut2 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_boltcut2 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_boltcut2 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_boltcut2 );
 
             item_location boltcutter = setup_dummy();
             setup_activity( boltcutter );
@@ -779,7 +779,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "furniture gets converted to new furniture type" ) {
-                CHECK( mp.furn( tripoint_zero ) == furn_test_f_boltcut1 );
+                CHECK( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_boltcut1 );
             }
         }
 
@@ -787,8 +787,8 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_boltcut2 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_boltcut2 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_boltcut2 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_boltcut2 );
 
             item_location boltcutter = setup_dummy();
             setup_activity( boltcutter );
@@ -806,7 +806,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
                 CHECK( dummy.activity.id() == ACT_NULL );
 
                 THEN( "player receives the items" ) {
-                    const map_stack items = get_map().i_at( tripoint_zero );
+                    const map_stack items = get_map().i_at( tripoint_bub_ms_zero );
                     int count_amount = 0;
                     int count_random = 0;
                     for( const item &it : items ) {
@@ -843,7 +843,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
     };
 
     auto setup_activity = [&dummy]( const item_location & torch ) -> void {
-        hacksaw_activity_actor act{tripoint_bub_ms( tripoint_zero ), torch};
+        hacksaw_activity_actor act{tripoint_bub_ms_zero, torch};
         act.testing = true;
         dummy.assign_activity( act );
     };
@@ -853,8 +853,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_str_id::NULL_ID() );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_str_id::NULL_ID() );
+            mp.ter_set( tripoint_bub_ms_zero, ter_str_id::NULL_ID() );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_str_id::NULL_ID() );
 
             item_location hacksaw = setup_dummy();
             setup_activity( hacksaw );
@@ -868,8 +868,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_t_dirt );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_t_dirt );
+            mp.ter_set( tripoint_bub_ms_zero, ter_t_dirt );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_t_dirt );
 
             item_location hacksaw = setup_dummy();
             setup_activity( hacksaw );
@@ -883,8 +883,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_hacksaw1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_hacksaw1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_hacksaw1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_hacksaw1 );
 
             item_location hacksaw = setup_dummy();
             setup_activity( hacksaw );
@@ -898,8 +898,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_hacksaw1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_hacksaw1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_hacksaw1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_hacksaw1 );
 
             item_location hacksaw = setup_dummy();
             setup_activity( hacksaw );
@@ -913,8 +913,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_hacksaw1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_hacksaw1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_hacksaw1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_hacksaw1 );
 
             item_location hacksaw = setup_dummy();
             setup_activity( hacksaw );
@@ -932,8 +932,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_hacksaw1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_hacksaw1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_hacksaw1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_hacksaw1 );
 
             item_location hacksaw = setup_dummy();
             setup_activity( hacksaw );
@@ -953,8 +953,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_hacksaw3 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_hacksaw3 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_hacksaw3 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_hacksaw3 );
 
             item battery( itype_test_battery_disposable );
             battery.ammo_set( battery.ammo_default() );
@@ -995,8 +995,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_hacksaw1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_hacksaw1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_hacksaw1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_hacksaw1 );
 
             item_location hacksaw = setup_dummy();
             setup_activity( hacksaw );
@@ -1006,7 +1006,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "terrain gets converted to new terrain type" ) {
-                CHECK( mp.ter( tripoint_zero ) == ter_t_dirt );
+                CHECK( mp.ter( tripoint_bub_ms_zero ) == ter_t_dirt );
             }
         }
 
@@ -1014,8 +1014,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_hacksaw1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_hacksaw1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_hacksaw1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_hacksaw1 );
 
             item_location hacksaw = setup_dummy();
             setup_activity( hacksaw );
@@ -1025,7 +1025,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "furniture gets converted to new furniture type" ) {
-                CHECK( mp.furn( tripoint_zero ) == furn_str_id::NULL_ID() );
+                CHECK( mp.furn( tripoint_bub_ms_zero ) == furn_str_id::NULL_ID() );
             }
         }
 
@@ -1033,8 +1033,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_hacksaw2 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_hacksaw2 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_hacksaw2 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_hacksaw2 );
 
             item_location hacksaw = setup_dummy();
             setup_activity( hacksaw );
@@ -1044,7 +1044,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "furniture gets converted to new furniture type" ) {
-                CHECK( mp.furn( tripoint_zero ) == furn_test_f_hacksaw1 );
+                CHECK( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_hacksaw1 );
             }
         }
 
@@ -1052,8 +1052,8 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_hacksaw2 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_hacksaw2 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_hacksaw2 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_hacksaw2 );
 
             item_location hacksaw = setup_dummy();
             setup_activity( hacksaw );
@@ -1071,7 +1071,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
                 CHECK( dummy.activity.id() == ACT_NULL );
 
                 THEN( "player receives the items" ) {
-                    const map_stack items = get_map().i_at( tripoint_zero );
+                    const map_stack items = get_map().i_at( tripoint_bub_ms_zero );
                     int count_amount = 0;
                     int count_random = 0;
                     for( const item &it : items ) {
@@ -1119,8 +1119,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_str_id::NULL_ID() );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_str_id::NULL_ID() );
+            mp.ter_set( tripoint_bub_ms_zero, ter_str_id::NULL_ID() );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_str_id::NULL_ID() );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1134,8 +1134,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_t_dirt );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_t_dirt );
+            mp.ter_set( tripoint_bub_ms_zero, ter_t_dirt );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_t_dirt );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1149,8 +1149,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_oxytorch1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_oxytorch1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_oxytorch1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_oxytorch1 );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1164,8 +1164,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_oxytorch1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_oxytorch1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_oxytorch1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_oxytorch1 );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1179,8 +1179,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_oxytorch1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_oxytorch1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_oxytorch1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_oxytorch1 );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1198,8 +1198,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_oxytorch1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_oxytorch1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_oxytorch1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_oxytorch1 );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1219,8 +1219,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_oxytorch3 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_oxytorch3 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_oxytorch3 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_oxytorch3 );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1250,8 +1250,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_oxytorch1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_oxytorch1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_oxytorch1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_oxytorch1 );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1261,7 +1261,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "terrain gets converted to new terrain type" ) {
-                CHECK( mp.ter( tripoint_zero ) == ter_t_dirt );
+                CHECK( mp.ter( tripoint_bub_ms_zero ) == ter_t_dirt );
             }
         }
 
@@ -1269,8 +1269,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_oxytorch1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_oxytorch1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_oxytorch1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_oxytorch1 );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1280,7 +1280,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "furniture gets converted to new furniture type" ) {
-                CHECK( mp.furn( tripoint_zero ) == furn_str_id::NULL_ID() );
+                CHECK( mp.furn( tripoint_bub_ms_zero ) == furn_str_id::NULL_ID() );
             }
         }
 
@@ -1288,8 +1288,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_oxytorch2 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_oxytorch2 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_oxytorch2 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_oxytorch2 );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1299,7 +1299,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "furniture gets converted to new furniture type" ) {
-                CHECK( mp.furn( tripoint_zero ) == furn_test_f_oxytorch1 );
+                CHECK( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_oxytorch1 );
             }
         }
 
@@ -1307,8 +1307,8 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_oxytorch2 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_oxytorch2 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_oxytorch2 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_oxytorch2 );
 
             item_location welding_torch = setup_dummy();
             setup_activity( welding_torch );
@@ -1326,7 +1326,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
                 CHECK( dummy.activity.id() == ACT_NULL );
 
                 THEN( "player receives the items" ) {
-                    const map_stack items = get_map().i_at( tripoint_zero );
+                    const map_stack items = get_map().i_at( tripoint_bub_ms_zero );
                     int count_amount = 0;
                     int count_random = 0;
                     for( const item &it : items ) {
@@ -1372,8 +1372,8 @@ TEST_CASE( "prying", "[activity][prying]" )
     };
 
     auto setup_activity = [&dummy]( const item_location & tool,
-    const tripoint &target = tripoint_zero ) -> void {
-        prying_activity_actor act{target, tool};
+    const tripoint_bub_ms &target = tripoint_bub_ms_zero ) -> void {
+        prying_activity_actor act{target.raw(), tool};
         act.testing = true;
         dummy.assign_activity( act );
     };
@@ -1416,8 +1416,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_str_id::NULL_ID() );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_str_id::NULL_ID() );
+            mp.ter_set( tripoint_bub_ms_zero, ter_str_id::NULL_ID() );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_str_id::NULL_ID() );
 
             item_location prying_tool = setup_dummy( true );
             setup_activity( prying_tool );
@@ -1431,8 +1431,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_t_dirt );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_t_dirt );
+            mp.ter_set( tripoint_bub_ms_zero, ter_t_dirt );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_t_dirt );
 
             item_location prying_tool = setup_dummy( true );
             setup_activity( prying_tool );
@@ -1446,8 +1446,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_prying1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_prying1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_prying1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_prying1 );
 
             item_location prying_tool = setup_dummy( true );
             setup_activity( prying_tool );
@@ -1461,8 +1461,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_prying1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_prying1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_prying1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_prying1 );
 
             item_location prying_tool = setup_dummy( true );
             setup_activity( prying_tool );
@@ -1476,8 +1476,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_prying1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_prying1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_prying1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_prying1 );
 
             item_location prying_tool = setup_dummy( true );
             setup_activity( prying_tool );
@@ -1495,8 +1495,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_prying1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_prying1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_prying1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_prying1 );
 
             item_location prying_tool = setup_dummy( true );
             setup_activity( prying_tool );
@@ -1516,8 +1516,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_prying1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_prying1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_prying1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_prying1 );
 
             item_location prying_tool = setup_dummy( true );
             setup_activity( prying_tool );
@@ -1527,7 +1527,7 @@ TEST_CASE( "prying", "[activity][prying]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "terrain gets converted to new terrain type" ) {
-                CHECK( mp.ter( tripoint_zero ) == ter_t_dirt );
+                CHECK( mp.ter( tripoint_bub_ms_zero ) == ter_t_dirt );
             }
         }
 
@@ -1535,8 +1535,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.furn_set( tripoint_zero, furn_test_f_prying1 );
-            REQUIRE( mp.furn( tripoint_zero ) == furn_test_f_prying1 );
+            mp.furn_set( tripoint_bub_ms_zero, furn_test_f_prying1 );
+            REQUIRE( mp.furn( tripoint_bub_ms_zero ) == furn_test_f_prying1 );
 
             item_location prying_tool = setup_dummy( true );
             setup_activity( prying_tool );
@@ -1546,7 +1546,7 @@ TEST_CASE( "prying", "[activity][prying]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "furniture gets converted to new furniture type" ) {
-                CHECK( mp.furn( tripoint_zero ) == furn_str_id::NULL_ID() );
+                CHECK( mp.furn( tripoint_bub_ms_zero ) == furn_str_id::NULL_ID() );
             }
         }
     }
@@ -1556,8 +1556,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_prying2 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_prying2 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_prying2 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_prying2 );
 
             item_location prying_tool = setup_dummy( true );
             setup_activity( prying_tool );
@@ -1567,7 +1567,7 @@ TEST_CASE( "prying", "[activity][prying]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "activity fails" ) {
-                CHECK( mp.ter( tripoint_zero ) == ter_test_t_prying2 );
+                CHECK( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_prying2 );
             }
         }
 
@@ -1575,8 +1575,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_prying2 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_prying2 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_prying2 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_prying2 );
 
             item_location prying_tool = setup_dummy( false );
             setup_activity( prying_tool );
@@ -1586,7 +1586,7 @@ TEST_CASE( "prying", "[activity][prying]" )
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
             THEN( "terrain gets converted to new type" ) {
-                CHECK( mp.ter( tripoint_zero ) == ter_t_dirt );
+                CHECK( mp.ter( tripoint_bub_ms_zero ) == ter_t_dirt );
             }
         }
 
@@ -1594,7 +1594,7 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            const tripoint terrain_pos = dummy.pos() + tripoint_north;
+            const tripoint_bub_ms terrain_pos = dummy.pos_bub() + tripoint_north;
 
             mp.ter_set( terrain_pos, ter_test_t_prying4 );
             REQUIRE( mp.ter( terrain_pos ) == ter_test_t_prying4 );
@@ -1630,8 +1630,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             clear_map();
             clear_avatar();
 
-            mp.ter_set( tripoint_zero, ter_test_t_prying1 );
-            REQUIRE( mp.ter( tripoint_zero ) == ter_test_t_prying1 );
+            mp.ter_set( tripoint_bub_ms_zero, ter_test_t_prying1 );
+            REQUIRE( mp.ter( tripoint_bub_ms_zero ) == ter_test_t_prying1 );
 
             item_location prying_tool = setup_dummy( true );
             setup_activity( prying_tool );
@@ -1649,7 +1649,7 @@ TEST_CASE( "prying", "[activity][prying]" )
                 CHECK( dummy.activity.id() == ACT_NULL );
 
                 THEN( "player receives the items" ) {
-                    const map_stack items = get_map().i_at( tripoint_zero );
+                    const map_stack items = get_map().i_at( tripoint_bub_ms_zero );
                     int count_amount = 0;
                     int count_random = 0;
                     for( const item &it : items ) {
@@ -1815,7 +1815,7 @@ TEST_CASE( "activity_interruption_by_distractions", "[activity][interruption]" )
             CHECK( dists.empty() );
 
             THEN( "interruption by zombie moving towards dummy" ) {
-                zombie.set_dest( get_map().getglobal( dummy.pos() ) );
+                zombie.set_dest( get_map().getglobal( dummy.pos_bub() ) );
                 int turns = 0;
                 do {
                     move_monster_turn( zombie );
@@ -1831,7 +1831,7 @@ TEST_CASE( "activity_interruption_by_distractions", "[activity][interruption]" )
         SECTION( act + " enemy nearby, but no line of sight" ) {
             cleanup( dummy );
 
-            m.ter_set( dummy.pos() + tripoint_east, ter_t_wall );
+            m.ter_set( dummy.pos_bub() + tripoint_east, ter_t_wall );
             monster &zombie = spawn_test_monster( mon_zombie.str(), zombie_pos_near );
             update_cache( m );
 

--- a/tests/shadowcasting_test.cpp
+++ b/tests/shadowcasting_test.cpp
@@ -84,7 +84,7 @@ static void oldCastLight(
  * This is checking whether bresenham visibility checks match shadowcasting (they don't).
  */
 static bool bresenham_visibility_check(
-    const point &offset, const point &p,
+    const point_bub_ms &offset, const point_bub_ms &p,
     const cata::mdarray<float, point_bub_ms> &transparency_cache )
 {
     if( offset == p ) {
@@ -93,8 +93,8 @@ static bool bresenham_visibility_check(
     bool visible = true;
     const int junk = 0;
     bresenham( p, offset, junk,
-    [&transparency_cache, &visible]( const point & new_point ) {
-        if( transparency_cache[new_point.x][new_point.y] <=
+    [&transparency_cache, &visible]( const point_bub_ms & new_point ) {
+        if( transparency_cache[new_point.x()][new_point.y()] <=
             LIGHT_TRANSPARENCY_SOLID ) {
             visible = false;
             return false;
@@ -164,7 +164,7 @@ void print_grid_comparison(
             const bool shadowcasting_disagrees =
                 is_nonzero( control[x][y] ) != is_nonzero( experiment[x][y] );
             const bool bresenham_disagrees =
-                bresenham_visibility_check( offset.raw(), point( x, y ), transparency_cache ) !=
+                bresenham_visibility_check( offset, point_bub_ms( x, y ), transparency_cache ) !=
                 is_nonzero( experiment[x][y] );
 
             if( shadowcasting_disagrees && bresenham_disagrees ) {
@@ -276,7 +276,7 @@ static void shadowcasting_runoff( const int iterations, const bool test_bresenha
     for( int x = 0; test_bresenham && passed && x < MAPSIZE * SEEX; ++x ) {
         for( int y = 0; y < MAPSIZE * SEEX; ++y ) {
             // Check that both agree on the outcome, but not necessarily the same values.
-            if( bresenham_visibility_check( offset.raw(), point( x, y ), transparency_cache ) !=
+            if( bresenham_visibility_check( offset, point_bub_ms( x, y ), transparency_cache ) !=
                 ( seen_squares_experiment[x][y] > LIGHT_TRANSPARENCY_SOLID ) ) {
                 passed = false;
                 break;

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -208,7 +208,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
     const float starting_fuel_per = fuel_percentage_left( veh, starting_fuel );
     REQUIRE( std::abs( starting_fuel_per - 1.0f ) < 0.001f );
 
-    const tripoint starting_point = veh.global_pos3();
+    const tripoint_bub_ms starting_point = veh.pos_bub();
     veh.tags.insert( "IN_CONTROL_OVERRIDE" );
     veh.engine_on = true;
 
@@ -235,9 +235,9 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
             REQUIRE( here.ter( pos ) );
         }
         // How much it moved
-        tiles_travelled += square_dist( starting_point, veh.global_pos3() );
+        tiles_travelled += square_dist( starting_point, veh.pos_bub() );
         // Bring it back to starting point to prevent it from leaving the map
-        const tripoint displacement = starting_point - veh.global_pos3();
+        const tripoint_rel_ms displacement = starting_point - veh.pos_bub();
         here.displace_vehicle( veh, displacement );
         if( reset_velocity_turn < 0 ) {
             continue;

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -40,7 +40,7 @@ static void test_repair( const std::vector<item> &tools, bool plug_in_tools, boo
 
     const tripoint_bub_ms battery_pos = test_origin + tripoint_north_west;
     std::optional<item> battery_item( "test_storage_battery" );
-    place_appliance( battery_pos.raw(), vpart_ap_test_storage_battery, battery_item );
+    place_appliance( battery_pos, vpart_ap_test_storage_battery, battery_item );
 
     for( const item &gear : tools ) {
         item_location added_tool = player_character.i_add( gear );

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -54,24 +54,24 @@ static void clear_game_and_set_ramp( const int transit_x, bool use_ramp, bool up
         for( int y = 0; y < SEEY * MAPSIZE; y++ ) {
             for( int x = 0; x < transit_x; x++ ) {
                 const int mid = up ? upper_zlevel : lower_zlevel;
-                here.ter_set( tripoint( x, y, mid - 2 ), ter_id( "t_rock" ) );
-                here.ter_set( tripoint( x, y, mid - 1 ), ter_id( "t_rock" ) );
-                here.ter_set( tripoint( x, y, mid ), ter_id( "t_pavement" ) );
-                here.ter_set( tripoint( x, y, mid + 1 ), ter_id( "t_open_air" ) );
-                here.ter_set( tripoint( x, y, mid + 2 ), ter_id( "t_open_air" ) );
+                here.ter_set( tripoint_bub_ms( x, y, mid - 2 ), ter_id( "t_rock" ) );
+                here.ter_set( tripoint_bub_ms( x, y, mid - 1 ), ter_id( "t_rock" ) );
+                here.ter_set( tripoint_bub_ms( x, y, mid ), ter_id( "t_pavement" ) );
+                here.ter_set( tripoint_bub_ms( x, y, mid + 1 ), ter_id( "t_open_air" ) );
+                here.ter_set( tripoint_bub_ms( x, y, mid + 2 ), ter_id( "t_open_air" ) );
             }
-            const tripoint ramp_up_low = tripoint( lowx, y, lower_zlevel );
-            const tripoint ramp_up_high = tripoint( highx, y, lower_zlevel );
-            const tripoint ramp_down_low = tripoint( lowx, y, upper_zlevel );
-            const tripoint ramp_down_high = tripoint( highx, y, upper_zlevel );
+            const tripoint_bub_ms ramp_up_low = tripoint_bub_ms( lowx, y, lower_zlevel );
+            const tripoint_bub_ms ramp_up_high = tripoint_bub_ms( highx, y, lower_zlevel );
+            const tripoint_bub_ms ramp_down_low = tripoint_bub_ms( lowx, y, upper_zlevel );
+            const tripoint_bub_ms ramp_down_high = tripoint_bub_ms( highx, y, upper_zlevel );
             here.ter_set( ramp_up_low, ter_id( "t_ramp_up_low" ) );
             here.ter_set( ramp_up_high, ter_id( "t_ramp_up_high" ) );
             here.ter_set( ramp_down_low, ter_id( "t_ramp_down_low" ) );
             here.ter_set( ramp_down_high, ter_id( "t_ramp_down_high" ) );
             for( int x = transit_x + 2; x < SEEX * MAPSIZE; x++ ) {
-                here.ter_set( tripoint( x, y, 1 ), ter_id( "t_open_air" ) );
-                here.ter_set( tripoint( x, y, 0 ), ter_id( "t_pavement" ) );
-                here.ter_set( tripoint( x, y, -1 ), ter_id( "t_rock" ) );
+                here.ter_set( tripoint_bub_ms( x, y, 1 ), ter_id( "t_open_air" ) );
+                here.ter_set( tripoint_bub_ms( x, y, 0 ), ter_id( "t_pavement" ) );
+                here.ter_set( tripoint_bub_ms( x, y, -1 ), ter_id( "t_rock" ) );
             }
         }
     }
@@ -299,8 +299,8 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
 
     for( int y = 0; y < SEEY * MAPSIZE; y++ ) {
         for( int x = 0; x < SEEX * MAPSIZE; x++ ) {
-            here.ter_set( tripoint( x, y, 1 ), ter_id( "t_open_air" ) );
-            here.ter_set( tripoint( x, y, 0 ), ter_id( "t_pavement" ) );
+            here.ter_set( tripoint_bub_ms( x, y, 1 ), ter_id( "t_open_air" ) );
+            here.ter_set( tripoint_bub_ms( x, y, 0 ), ter_id( "t_pavement" ) );
         }
     }
 

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -181,7 +181,7 @@ struct vision_test_case {
             t.set_anchor_char_from( {anchor_char} );
         }
         REQUIRE( t.anchor_char.has_value() );
-        t.anchor_map_pos = player_character.pos();
+        t.anchor_map_pos = player_character.pos_bub();
 
         if( flags.crouching ) {
             player_character.set_movement_mode( move_mode_crouch );
@@ -207,11 +207,11 @@ struct vision_test_case {
 
         // Sanity check on player placement in relation to `t`
         // must be invoked after transformations are applied to `t`
-        t.validate_anchor_point( player_character.pos() );
+        t.validate_anchor_point( player_character.pos_bub() );
 
         SECTION( section_name.str() ) {
             t.for_each_tile( set_up_tiles );
-            int zlev = t.get_origin().z;
+            int zlev = t.get_origin().z();
             map &here = get_map();
             // We have to run the whole thing twice, because the first time through the
             // player's vision_threshold is based on the previous lighting level (so
@@ -1108,7 +1108,7 @@ TEST_CASE( "vision_inside_meth_lab", "[shadowcasting][vision][moncam]" )
     };
 
     vehicle *v = nullptr;
-    std::optional<tripoint> door = std::nullopt;
+    std::optional<tripoint_bub_ms> door = std::nullopt;
 
     // opens or closes a specific door (marked as 'D')
     // this is called twice: after either vehicle or door is set

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -65,9 +65,9 @@ TEST_CASE( "visitable_remove", "[visitable]" )
     map &here = get_map();
 
     // check if all tiles within radius are loaded within current submap and passable
-    const auto suitable = [&here]( const tripoint & pos, const int radius ) {
-        std::vector<tripoint> tiles = closest_points_first( pos, radius );
-        return std::all_of( tiles.begin(), tiles.end(), [&here]( const tripoint & e ) {
+    const auto suitable = [&here]( const tripoint_bub_ms & pos, const int radius ) {
+        std::vector<tripoint_bub_ms> tiles = closest_points_first( pos, radius );
+        return std::all_of( tiles.begin(), tiles.end(), [&here]( const tripoint_bub_ms & e ) {
             if( !here.inbounds( e ) ) {
                 return false;
             }
@@ -81,11 +81,11 @@ TEST_CASE( "visitable_remove", "[visitable]" )
 
     // move player randomly until we find a suitable position
     constexpr int num_trials = 100;
-    for( int i = 0; i < num_trials && !suitable( p.pos(), 1 ); ++i ) {
+    for( int i = 0; i < num_trials && !suitable( p.pos_bub(), 1 ); ++i ) {
         CHECK( !p.in_vehicle );
-        p.setpos( random_entry( closest_points_first( p.pos(), 1 ) ) );
+        p.setpos( random_entry( closest_points_first( p.pos_bub(), 1 ) ) );
     }
-    REQUIRE( suitable( p.pos(), 1 ) );
+    REQUIRE( suitable( p.pos_bub(), 1 ) );
 
     item temp_liquid( liquid_id );
     item obj = temp_liquid.in_container( temp_liquid.type->default_container.value_or( itype_null ) );
@@ -424,12 +424,12 @@ TEST_CASE( "visitable_remove", "[visitable]" )
     }
 
     GIVEN( "An adjacent vehicle contains several bottles of water" ) {
-        std::vector<tripoint> tiles = closest_points_first( p.pos(), 1 );
+        std::vector<tripoint_bub_ms> tiles = closest_points_first( p.pos_bub(), 1 );
         tiles.erase( tiles.begin() ); // player tile
         tripoint_bub_ms veh = tripoint_bub_ms( random_entry( tiles ) );
         REQUIRE( here.add_vehicle( vehicle_prototype_shopping_cart, veh, 0_degrees, 0, 0 ) );
 
-        REQUIRE( std::count_if( tiles.begin(), tiles.end(), [&here]( const tripoint & e ) {
+        REQUIRE( std::count_if( tiles.begin(), tiles.end(), [&here]( const tripoint_bub_ms & e ) {
             return static_cast<bool>( here.veh_at( e ) );
         } ) == 1 );
 
@@ -444,7 +444,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
             v->add_item( vp->part(), obj );
         }
 
-        vehicle_selector sel( p.pos(), 1 );
+        vehicle_selector sel( p.pos_bub().raw(), 1 );
 
         REQUIRE( count_items( sel, container_id ) == count );
         REQUIRE( count_items( sel, liquid_id ) == count );

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -22,7 +22,7 @@ static void setup_test_lake()
 
     build_water_test_map( t_water_dp, t_water_cube, t_lake_bed );
     const map &here = get_map();
-    constexpr tripoint test_origin( 60, 60, 0 );
+    constexpr tripoint_bub_ms test_origin( 60, 60, 0 );
 
     REQUIRE( here.ter( test_origin ) == t_water_dp );
     REQUIRE( here.ter( test_origin + tripoint_below ) == t_water_cube );
@@ -36,7 +36,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     Character &dummy = get_player_character();
     map &here = get_map();
-    constexpr tripoint test_origin( 60, 60, 0 );
+    constexpr tripoint_bub_ms test_origin( 60, 60, 0 );
 
     GIVEN( "avatar is above water at z0" ) {
         dummy.set_underwater( false );
@@ -47,8 +47,8 @@ TEST_CASE( "avatar_diving", "[diving]" )
             g->vertical_move( -1, false );
 
             THEN( "avatar is underwater at z0" ) {
-                REQUIRE( dummy.pos() == test_origin );
-                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_dp" ) );
+                REQUIRE( dummy.pos_bub() == test_origin );
+                REQUIRE( here.ter( dummy.pos_bub() ) == ter_id( "t_water_dp" ) );
                 REQUIRE( dummy.is_underwater() );
             }
         }
@@ -57,8 +57,8 @@ TEST_CASE( "avatar_diving", "[diving]" )
             g->vertical_move( 1, false );
 
             THEN( "avatar is not underwater at z0" ) {
-                REQUIRE( dummy.pos() == test_origin );
-                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_dp" ) );
+                REQUIRE( dummy.pos_bub() == test_origin );
+                REQUIRE( here.ter( dummy.pos_bub() ) == ter_id( "t_water_dp" ) );
                 REQUIRE( !dummy.is_underwater() );
             }
         }
@@ -73,8 +73,8 @@ TEST_CASE( "avatar_diving", "[diving]" )
             g->vertical_move( -1, false );
 
             THEN( "avatar is underwater at z-1" ) {
-                REQUIRE( dummy.pos() == test_origin + tripoint_below );
-                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_cube" ) );
+                REQUIRE( dummy.pos_bub() == test_origin + tripoint_below );
+                REQUIRE( here.ter( dummy.pos_bub() ) == ter_id( "t_water_cube" ) );
                 REQUIRE( dummy.is_underwater() );
             }
         }
@@ -83,8 +83,8 @@ TEST_CASE( "avatar_diving", "[diving]" )
             g->vertical_move( 1, false );
 
             THEN( "avatar is not underwater at z0" ) {
-                REQUIRE( dummy.pos() == test_origin );
-                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_dp" ) );
+                REQUIRE( dummy.pos_bub() == test_origin );
+                REQUIRE( here.ter( dummy.pos_bub() ) == ter_id( "t_water_dp" ) );
                 REQUIRE( !dummy.is_underwater() );
             }
         }
@@ -99,8 +99,8 @@ TEST_CASE( "avatar_diving", "[diving]" )
             g->vertical_move( -1, false );
 
             THEN( "avatar is underwater at z-2" ) {
-                REQUIRE( dummy.pos() == test_origin + tripoint( 0, 0, -2 ) );
-                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_lake_bed" ) );
+                REQUIRE( dummy.pos_bub() == test_origin + tripoint( 0, 0, -2 ) );
+                REQUIRE( here.ter( dummy.pos_bub() ) == ter_id( "t_lake_bed" ) );
                 REQUIRE( dummy.is_underwater() );
             }
         }
@@ -109,8 +109,8 @@ TEST_CASE( "avatar_diving", "[diving]" )
             g->vertical_move( 1, false );
 
             THEN( "avatar is underwater at z0" ) {
-                REQUIRE( dummy.pos() == test_origin );
-                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_dp" ) );
+                REQUIRE( dummy.pos_bub() == test_origin );
+                REQUIRE( here.ter( dummy.pos_bub() ) == ter_id( "t_water_dp" ) );
                 REQUIRE( dummy.is_underwater() );
             }
         }
@@ -125,8 +125,8 @@ TEST_CASE( "avatar_diving", "[diving]" )
             g->vertical_move( -1, false );
 
             THEN( "avatar is underwater at z-2" ) {
-                REQUIRE( dummy.pos() == test_origin + tripoint( 0, 0, -2 ) );
-                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_lake_bed" ) );
+                REQUIRE( dummy.pos_bub() == test_origin + tripoint( 0, 0, -2 ) );
+                REQUIRE( here.ter( dummy.pos_bub() ) == ter_id( "t_lake_bed" ) );
                 REQUIRE( dummy.is_underwater() );
             }
         }
@@ -135,8 +135,8 @@ TEST_CASE( "avatar_diving", "[diving]" )
             g->vertical_move( 1, false );
 
             THEN( "avatar is underwater at z-1" ) {
-                REQUIRE( dummy.pos() == test_origin + tripoint_below );
-                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_cube" ) );
+                REQUIRE( dummy.pos_bub() == test_origin + tripoint_below );
+                REQUIRE( here.ter( dummy.pos_bub() ) == ter_id( "t_water_cube" ) );
                 REQUIRE( dummy.is_underwater() );
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Chip away at untyped -> typed coordinate conversion.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Go through a bit of map.cpp  and convert to typed coordinates. This involves converting some usages deemed reasonably straight forward, and then removing the untyped operations if no uses remain.

Dealt with the pain-in-the-butt Bresenham operations, as they mess up any attempts to typify the operations they exist in.

Encountered a bug in vehicle.cpp operation vehicle::do_towing_mode(), where an abs value was set as the fallback value to an untyped variable that's otherwise used as a bub one. Changed the fallback assignment to convert the abs value to a bub one. I've got no idea if the fallback is used anywhere and how to test the change. Ought to be reviewed a bit extra carefully.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leave an untyped Bresenham operation for line_to to use. In that case it should probably not be exposed, but sit in line.cpp only.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded a save, walked up a ramp, jumped into a car and drove through some hay bales, over a zombie corpse and its inventory, into a couple of turkeys, and finally smashing into another vehicle. Nothing odd seen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I had a rather unpleasant experience with testing code, where adding #include "coordinate_constants.h" caused the compiler to go nuts and complain that much (all?) of the contents of that file to be invalid, stopping after 100 useless complaints ("useless" as in "not providing any information that can be used to identify the issue"). Experimentation showed that inclusion would work if made further down the list (out of alphabetic order). I ended up doing so with two files, but think there is one or more cases where I'd given up and resorted to converting untyped constants to typed ones as a work around (the two existing cases were reverted from the work around).
I'm fairly sure the tests will demand the include files to be in alphabetic order, and I think there's some way to tell these tests to bugger off when they want you to change things in ways that don't work, so I'd be grateful to be told what need to be done to achieve that.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
