### PR TITLE
Characters at high pain vocalize their pain on taking more damage

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8043,6 +8043,39 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
     enchantment_cache->cast_hit_me( *this, source );
 }
 
+void Character::vocalize_pain_on_take_dmg()
+{
+    const int perceived_pain = get_perceived_pain();
+    if( perceived_pain <= 0 ) {
+        return;
+    }
+    const int loudest_scream_possible = get_shout_volume();
+    // tracks pain on a scale similar to display::pain_text_color, but not exactly
+    const double pain_scale = perceived_pain / 10.0;
+    if( pain_scale > 7 ) { // severe pain
+        if( is_npc() ) {
+            add_msg_if_player_sees( pos_bub(), _( "%s babbles incoherently." ), get_name() );
+        }
+        add_msg_if_player( "Who's that screaming?  Shut up, you're trying not to die here.  Shut up.  Shut up.  Shut up.  Shut up.  Shut up.  Shut up." );
+        sounds::sound( pos_bub(), loudest_scream_possible, sounds::sound_t::combat,
+                       _( "unintelligible pained screeching!" ), false, "pain_shout", "max" );
+    } else if( pain_scale > 5 ) { // unmanageable pain
+        if( is_npc() ) {
+            add_msg_if_player_sees( pos_bub(), _( "%s is yelling in pain." ), get_name() );
+        }
+        add_msg_if_player( "That <swear> hurts!  You can't keep your voice in." );
+        sounds::sound( pos_bub(), loudest_scream_possible / 2, sounds::sound_t::combat,
+                       _( "someone howling in pain!" ), false, "pain_shout", "moderate" );
+    } else if( pain_scale > 3 ) { // distracting pain
+        if( is_npc() ) {
+            add_msg_if_player_sees( pos_bub(), _( "%s audibly exhales in pain." ), get_name() );
+        }
+        add_msg_if_player( "That <swear> hurts!  You can't keep your voice in." );
+        sounds::sound( pos_bub(), loudest_scream_possible / 3, sounds::sound_t::combat,
+                       _( "a pained gasp!" ), false, "pain_shout", "min" );
+    }
+}
+
 /*
     Where damage to character is actually applied to hit body parts
     Might be where to put bleed stuff rather than in player::deal_damage()
@@ -8105,6 +8138,10 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
         if( remove_med > 0 && has_effect( effect_disinfected, part_to_damage.id() ) ) {
             reduce_healing_effect( effect_disinfected, remove_med, part_to_damage );
         }
+    }
+
+    if( dam > 0 ) {
+        vocalize_pain_on_take_dmg();
     }
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -1266,6 +1266,9 @@ class Character : public Creature, public visitable
         // any side effects that might happen when the Character hits a Creature
         void did_hit( Creature &target );
 
+        // Should only be called when damage is actually taken.
+        // Handles determining loudness, log message, and calling sounds::sound
+        void vocalize_pain_on_take_dmg();
         /** Actually hurt the player, hurts a body_part directly, no armor reduction */
         void apply_damage( Creature *source, bodypart_id hurt, int dam,
                            bool bypass_med = false ) override;


### PR DESCRIPTION
#### Summary
Features "Characters(including you!) at high pain vocalize their pain on taking more damage"

#### Purpose of change
Our combat is surprisingly silent and somber despite the genre

#### Describe the solution
Make 'em scream. If you're struggling for your life and your legs are getting gnawed off, you're going to let the whole world know no matter how bad (or good) an idea that is. Most likely you'll attract some more zombies to the sound, but NPCs on guard are able to react to sounds too.

Part of my intent is also to give some more 'humanity' to our NPC encounters. It's very easy for a player to tritely mash tab through the death of a NPC. It's a lot harder when they yell and scream in pain. (Did I mention this both makes ingame sounds, and plays sounds through the sound engine? I didn't add sounds for it to CC-sounds, but I might!)

The reason it only triggers on taking damage is a simple rate limit and sanity check. It may need to be further restricted or only fire once every [period of time] but I haven't determined that yet.

I would like to move this text to json snippets before I undraft it. The current text is largely placeholder.

#### Describe alternatives you've considered

#### Testing
Initial testing shows that it works, but I'd like to polish this up before marking it ready.

#### Additional context
