### PR TITLE
Bunny ears

### DIFF
--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -2060,7 +2060,22 @@
     "name": { "str": "pair of faux fur cat ears", "str_pl": "pairs of faux fur cat ears" },
     "description": "A fuzzy pair of garishly colored cat ears on a headband.  It does nothing, but there's no reason not to look good even if no one's looking.",
     "material": [ "faux_fur" ],
-    "color": "pink"
+    "color": "pink",
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "faux_fur_cat_ears",
+        "name": { "str": "pair of faux fur cat ears", "str_pl": "pairs of faux fur cat ears" },
+        "description": "A fuzzy pair of garishly colored cat ears on a headband.  It does nothing, but there's no reason not to look good even if no one's looking.",
+        "color": "pink"
+      },
+      {
+        "id": "bunny_ears_white",
+        "name": { "str": "pair of white bunny ears", "str_pl": "pairs of white bunny ears" },
+        "description": "A fuzzy pair of white bunny ears.  It does nothing, but there's no reason to look good even if no one's looking.",
+        "color": "light_gray"
+      }
+    ]
   },
   {
     "id": "fur_cat_tail",


### PR DESCRIPTION


#### Summary
None


#### Purpose of change

Add bunny ears cuz why not.

#### Describe the solution

add wearable bunny ears as a variant for the faux fur cat ears.

#### Describe alternatives you've considered

keeping it to myself.

#### Testing

![Screenshot_20241009_144633](https://github.com/user-attachments/assets/ed72df25-cfd0-4e25-8906-752b219fea47)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
