### PR TITLE
Always show player's destination as possible goto-location option

### DIFF
--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -381,10 +381,10 @@ void talk_function::goto_location( npc &p )
         selection_menu.addentry( i++, true, MENU_AUTOASSIGN, pgettext( "camp", "%1$s at %2$s" ),
                                  iter->camp_name(), iter->camp_omt_pos().to_string() );
     }
-    selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "My current location" ) );
-    if( !player_character.omt_path.empty() ) {
-        selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "My destination" ) );
-    }
+    selection_menu.addentry( i++, p.global_omt_location() != player_character.global_omt_location(),
+                             MENU_AUTOASSIGN, _( "My current location" ) );
+    selection_menu.addentry( i++, !player_character.omt_path.empty(), MENU_AUTOASSIGN,
+                             _( "My destination" ) );
     selection_menu.addentry( i, true, MENU_AUTOASSIGN, _( "Cancel" ) );
     selection_menu.selected = 0;
     selection_menu.query();


### PR DESCRIPTION
#### Summary
Interface "Misc. improvements to NPC goto-location options"

#### Purpose of change
It bugged me a bit that finding this option relied on having a destination set when you talked to a NPC about it.

#### Describe the solution
I realized we can just *always show the option* but selectively disable it if the player doesn't have a destination. That's just a feature that uilist has built-in.

I then realized I should do the same thing for "My current location", so you don't tell your buddy standing next to you to haul their butt over.

#### Describe alternatives you've considered

#### Testing


https://github.com/user-attachments/assets/06ab5f32-bbbc-4d38-88d9-9dd69a5718a4



#### Additional context

