### PR TITLE
Now it's possible to complete Gemma Johnstone's 'Retrieve the fertility supplements' mission

### DIFF
--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -674,7 +674,7 @@
         "search_range": 1000,
         "min_distance": 3
       },
-      "update_mapgen": { "place_item": [ { "item": "fert_supplement", "x": 15, "y": 15, "amount": 1 } ] }
+      "update_mapgen": { "place_items": [ { "item": "fertility_supplements", "x": 15, "y": 15 } ] }
     },
     "end": {
       "effect": [ { "u_spawn_item": "icon", "count": 10 }, { "npc_add_var": "mission_meeting_gemma_got_supplements", "value": "yes" } ],
@@ -1389,5 +1389,12 @@
       "success_lie": "If you see this, it's a bug.",
       "failure": "Of course, you have no evidence."
     }
+  },
+  {
+    "type": "item_group",
+    "id": "fertility_supplements",
+    "subtype": "collection",
+    "container-item": "bottle_plastic_pill_supplement",
+    "entries": [ { "item": "fert_supplement", "container-item": "null", "count": 25 } ]
   }
 ]

--- a/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
+++ b/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
@@ -12,6 +12,7 @@
       "TALK_GODCO_Gemma_Joinee"
     ],
     "responses": [
+      { "text": "About that job…", "topic": "TALK_MISSION_INQUIRE", "condition": "has_assigned_mission" },
       {
         "text": "What's your story?",
         "topic": "TALK_GODCO_Gemma_Story",


### PR DESCRIPTION
#### Summary
Bugfixes "Now it's possible to complete Gemma Johnstone's 'Retrieve the fertility supplements' mission"

#### Purpose of change
* Closes #68031.

#### Describe the solution
Based on #68735 by @MNG-cataclysm. I replaced `place_loot` with `place_items`, and changed item group definition so it will spawn 25 pills in a single bottle.

#### Describe alternatives you've considered
None.

#### Testing
Got the mission. Teleported to the pharmacy. Got a bottle with 25 pills. Teleported back to Gemma. Successfully completed the mission by giving her the pills.

#### Additional context
None.