### PR TITLE
Add new appliance, the glassblower's crucible

### DIFF
--- a/data/json/construction/appliances.json
+++ b/data/json/construction/appliances.json
@@ -291,6 +291,18 @@
   },
   {
     "type": "construction",
+    "id": "app_glassblowers_crucible",
+    "group": "place_glassblowers_crucible",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "5 m",
+    "components": [ [ [ "glassblowers_crucible", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_special": "done_appliance",
+    "activity_level": "BRISK_EXERCISE"
+  },
+  {
+    "type": "construction",
     "id": "app_forge",
     "group": "place_electric_forge",
     "category": "APPLIANCE",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1317,6 +1317,11 @@
   },
   {
     "type": "construction_group",
+    "id": "place_glassblowers_crucible",
+    "name": "Place Glassblower's Crucible"
+  },
+  {
+    "type": "construction_group",
     "id": "place_drill_press",
     "name": "Place Drill Press"
   },

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -1066,7 +1066,7 @@
     "name": { "str": "glassblower's crucible" },
     "color": "brown",
     "categories": [ "utility" ],
-    "description": "An electric crucible, powered by your electric grid.  Designed for melting large quantities of glass, it needs to be placed and plugged into a power source.",
+    "description": "An electric crucible, powered by your electric grid.  Designed for melting large quantities of glass for batch crafting and production of large items, it needs to be placed and plugged into a power source.",
     "broken_color": "yellow_red",
     "damage_modifier": 10,
     "damage_reduction": { "all": 30 },

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -1082,4 +1082,5 @@
       { "item": "rock", "count": [ 6, 12 ] }
     ],
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
-  },
+  }
+]

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -1083,4 +1083,3 @@
     ],
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
-]

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -1059,5 +1059,28 @@
     ],
     "damage_reduction": { "all": 50 },
     "variants": [ { "symbols": "&", "symbols_broken": "#" } ]
-  }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_glassblowers_crucible",
+    "name": { "str": "glassblower's crucible" },
+    "color": "brown",
+    "categories": [ "utility" ],
+    "description": "An electric crucible, powered by your electric grid. Designed for melting large quantities of glass, it needs to be placed and plugged into a power source.",
+    "broken_color": "yellow_red",
+    "damage_modifier": 10,
+    "damage_reduction": { "all": 30 },
+    "durability": 80,
+    "flags": [ "OBSTACLE", "APPLIANCE" ],
+    "pseudo_tools": [ { "id": "glassblowers_crucible_tool" } ],
+    "item": "glassblowers_crucible",
+    "breaks_into": [
+      { "item": "cable", "charges": [ 0, 4 ] },
+      { "item": "scrap", "count": [ 8, 12 ] },
+      { "item": "steel_chunk", "count": [ 2, 4 ] },
+      { "item": "ceramic_shard", "count": [ 21, 42 ] },
+      { "item": "rock", "count": [ 6, 12 ] }
+    ],
+    "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
+  },
 ]

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -1066,7 +1066,7 @@
     "name": { "str": "glassblower's crucible" },
     "color": "brown",
     "categories": [ "utility" ],
-    "description": "An electric crucible, powered by your electric grid. Designed for melting large quantities of glass, it needs to be placed and plugged into a power source.",
+    "description": "An electric crucible, powered by your electric grid.  Designed for melting large quantities of glass, it needs to be placed and plugged into a power source.",
     "broken_color": "yellow_red",
     "damage_modifier": 10,
     "damage_reduction": { "all": 30 },

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -403,5 +403,21 @@
     "price_postapoc": "20 USD",
     "symbol": "&",
     "color": "light_gray"
+  },
+  {
+    "type": "GENERIC",
+    "category": "other",
+    "id": "glassblowers_crucible",
+    "name": { "str": "disconnected glassblower's crucible" },
+    "description": "An electric crucible, powered by your electric grid. Designed for melting large quantities of glass, it needs to be placed and plugged into a power source."",
+    "//": "Loosely based off Jen-Ken Kiln - Crucible 1813, but homemade",
+    "weight": "50 kg",
+    "material": [ "steel", "clay" ],
+    "volume": "62500 ml",
+    "longest_side": "100 cm",
+    "price": "2179 USD",
+    "price_postapoc": "25 USD",
+    "symbol": "O",
+    "color": "brown"
   }
 ]

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -417,7 +417,7 @@
     "longest_side": "100 cm",
     "price": "2179 USD",
     "price_postapoc": "25 USD",
-    "symbol": "O",
+    "symbol": "o",
     "color": "brown"
   }
 ]

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -409,7 +409,7 @@
     "category": "other",
     "id": "glassblowers_crucible",
     "name": { "str": "disconnected glassblower's crucible" },
-    "description": "An electric crucible, powered by your electric grid. Designed for melting large quantities of glass, it needs to be placed and plugged into a power source."",
+    "description": "An electric crucible, powered by your electric grid. Designed for melting large quantities of glass, it needs to be placed and plugged into a power source.",
     "//": "Loosely based off Jen-Ken Kiln - Crucible 1813, but homemade",
     "weight": "50 kg",
     "material": [ "steel", "clay" ],

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -409,7 +409,7 @@
     "category": "other",
     "id": "glassblowers_crucible",
     "name": { "str": "disconnected glassblower's crucible" },
-    "description": "An electric crucible, powered by your electric grid. Designed for melting large quantities of glass, it needs to be placed and plugged into a power source.",
+    "description": "An electric crucible, powered by your electric grid.  Designed for melting large quantities of glass, it needs to be placed and plugged into a power source.",
     "//": "Loosely based off Jen-Ken Kiln - Crucible 1813, but homemade",
     "weight": "50 kg",
     "material": [ "steel", "clay" ],

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -409,7 +409,7 @@
     "category": "other",
     "id": "glassblowers_crucible",
     "name": { "str": "disconnected glassblower's crucible" },
-    "description": "An electric crucible, powered by your electric grid.  Designed for melting large quantities of glass, it needs to be placed and plugged into a power source.",
+    "description": "An electric crucible, powered by your electric grid.  Designed for melting large quantities of glass for batch crafting and production of large items, it needs to be placed and plugged into a power source.",
     "//": "Loosely based off Jen-Ken Kiln - Crucible 1813, but homemade",
     "weight": "50 kg",
     "material": [ "steel", "clay" ],

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -276,6 +276,15 @@
     "charged_qualities": [ [ "DRILL", 3 ] ]
   },
   {
+    "id": "glassblowers_crucible_tool",
+    "type": "TOOL",
+    "name": { "str": "glassblower's crucible" },
+    "copy-from": "fake_appliance_tool",
+    "symbol": "o", 
+    "color": "brown",
+    "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] }
+  },
+  {
     "id": "tablesaw_tool",
     "type": "TOOL",
     "name": { "str": "table saw" },

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -280,7 +280,7 @@
     "type": "TOOL",
     "name": { "str": "glassblower's crucible" },
     "copy-from": "fake_appliance_tool",
-    "symbol": "o", 
+    "symbol": "o",
     "color": "brown",
     "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] }
   },

--- a/data/json/items/tool/pseudo.json
+++ b/data/json/items/tool/pseudo.json
@@ -69,5 +69,14 @@
     "symbol": "H",
     "color": "light_cyan",
     "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] }
+  },
+  {
+    "id": "glassblowers_crucible_tool",
+    "type": "TOOL",
+    "name": { "str": "glassblower's crucible" },
+    "copy-from": "fake_item",
+    "symbol": "o",
+    "color": "brown",
+    "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] }
   }
 ]

--- a/data/json/items/tool/pseudo.json
+++ b/data/json/items/tool/pseudo.json
@@ -69,14 +69,5 @@
     "symbol": "H",
     "color": "light_cyan",
     "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] }
-  },
-  {
-    "id": "glassblowers_crucible_tool",
-    "type": "TOOL",
-    "name": { "str": "glassblower's crucible" },
-    "copy-from": "fake_item",
-    "symbol": "o",
-    "color": "brown",
-    "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] }
   }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1210,7 +1210,7 @@
     {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
-    "result": "glassblower_crucible",
+    "result": "glassblowers_crucible",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
     "skill_used": "fabrication",
@@ -1220,26 +1220,14 @@
     "decomp_learn": 4,
     "autolearn": false,
     "book_learn": [
-      [ "glassblowing_book", 5 ],
+      [ "glassblowing_book", 5 ]
     ],
-    "using": [ [ "welding_standard", 100 ],
+    "using": [ [ "welding_standard", 100 ] ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
       { "id": "SAW_M", "level": 1 },
       { "id": "SCREW", "level": 1 },
       { "id": "WRENCH", "level": 1 }
-    ],
-    "tools": [
-      [
-        [ "welder", 200 ],
-        [ "welding_kit", 200 ],
-        [ "welder_crude", 300 ],
-        [ "integrated_welder", 300 ],
-        [ "soldering_iron", 300 ],
-        [ "soldering_iron_portable", 300 ],
-        [ "integrated_electrokit", 300 ],
-        [ "oxy_torch", 40 ]
-      ]
     ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_pottery" }],
     "components": [

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1207,6 +1207,56 @@
       [ [ "fire_brick", 8 ] ]
     ]
   },
+    {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "glassblower_crucible",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "3 h",
+    "reversible": true,
+    "decomp_learn": 4,
+    "autolearn": false,
+    "book_learn": [
+      [ "glassblowing_book", 5 ],
+    ],
+    "using": [ [ "welding_standard", 100 ],
+    "qualities": [
+      { "id": "HAMMER", "level": 2 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "SCREW", "level": 1 },
+      { "id": "WRENCH", "level": 1 }
+    ],
+    "tools": [
+      [
+        [ "welder", 200 ],
+        [ "welding_kit", 200 ],
+        [ "welder_crude", 300 ],
+        [ "integrated_welder", 300 ],
+        [ "soldering_iron", 300 ],
+        [ "soldering_iron_portable", 300 ],
+        [ "integrated_electrokit", 300 ],
+        [ "oxy_torch", 40 ]
+      ]
+    ],
+    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_pottery" }],
+    "components": [
+      [ [ "element", 8 ], [ "crude_heating_element", 12 ] ],
+      [ [ "pot_canning_clay", 1 ] ],
+      [ [ "cable", 4 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "fire_brick", 25 ] ],
+      [ [ "clay_lump", 10 ] ],
+      [ [ "pipe", 8 ] ],
+      [ [ "pipe_fittings", 4 ] ],
+      [ [ "sheet_metal_small", 4 ] ],
+      [ [ "small_lcd_screen", 1 ] ],
+      [ [ "processor", 1 ] ],
+      [ [ "thermostat", 1 ] ]
+    ]
+  },
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1207,7 +1207,7 @@
       [ [ "fire_brick", 8 ] ]
     ]
   },
-    {
+  {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
     "result": "glassblowers_crucible",
@@ -1219,9 +1219,7 @@
     "reversible": true,
     "decomp_learn": 4,
     "autolearn": false,
-    "book_learn": [
-      [ "glassblowing_book", 5 ]
-    ],
+    "book_learn": [ [ "glassblowing_book", 5 ] ],
     "using": [ [ "welding_standard", 100 ] ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
@@ -1229,7 +1227,7 @@
       { "id": "SCREW", "level": 1 },
       { "id": "WRENCH", "level": 1 }
     ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_pottery" }],
+    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_pottery" } ],
     "components": [
       [ [ "element", 8 ], [ "crude_heating_element", 12 ] ],
       [ [ "pot_canning_clay", 1 ] ],

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -431,9 +431,9 @@
       [ [ "forge", 150 ] ],
       [ [ "casting_mold_small", -1 ] ]
     ],
-    "components": [ 
+    "components": [
       [ [ "glass_shard", 13 ], [ "flask_glass", 20 ], [ "test_tube", 27 ], [ "marble", 318 ] ],
-      [ [ "scrap", 1] ],
+      [ [ "scrap", 1 ] ],
       [ [ "chunk_rubber", 1 ] ]
     ]
   },

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -413,6 +413,33 @@
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
+    "result": "jar_3l_glass_sealed",
+    "id_suffix": "glassblowers_crucible",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_CONTAINERS",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "2 h 30 m",
+    "batch_time_factors": [ 80, 1 ],
+    "book_learn": [ [ "glassblowing_book", 5 ] ],
+    "proficiencies": [ { "proficiency": "prof_glassblowing" } ],
+    "qualities": [ { "id": "CHISEL", "level": 2 } ],
+    "tools": [
+      [ [ "metalworking_tongs_any", 1, "LIST" ] ],
+      [ [ "pipe", -1 ] ],
+      [ [ "glassblowers_crucible_tool", 4800 ] ],
+      [ [ "forge", 150 ] ],
+      [ [ "casting_mold_small", -1 ] ]
+    ],
+    "components": [ 
+      [ [ "glass_shard", 13 ], [ "flask_glass", 20 ], [ "test_tube", 27 ], [ "marble", 318 ] ],
+      [ [ "scrap", 1] ],
+      [ [ "chunk_rubber", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
     "result": "bottle_glass",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_CONTAINERS",


### PR DESCRIPTION
#### Summary
Features "Add a new appliance, the glassblower's crucible"

#### Purpose of change
I intend to begin going through the glass crafting recipes and implement batch crafting savings to them, because when crafting more than one of a glass item, you should only have to spend the time melting the glass once, and this isn't represented in the game. This being said, the current implementation of of crafting glass items relies on the 2 liter crucible and a furnace, which is fine for small items, but insufficient for batch crafting say, 10-20 3L glass jars, hence the addition of a dedicated appliance.

#### Describe the solution
While working on this addition, I kind of spewed my thought process into a text file, which I will copy paste into the additional context section, so most of my logic for doing things the way I did can be found there.

My solution is to implement a new appliance, the glassblower's crucible. This is constructed using two clay vessels, one nested inside the other, with a layer of fire bricks and heating elements sandwiched between them. It uses a thermostat to monitor the temperature of the crucible. I used an abstract value of 10L as the capacity of the crucible, more information on why this value was chosen can be found in my notes in additional context. 

There are currently no recipes using the pseudo tool this appliance provides, as this PR is just to implement the appliance itself, and I will begin adjusting glassblowing recipes to use this tool, and give them batch crafting savings related to melting all the glass up front. More information on how that will work is in my notes in additional context.

#### Describe alternatives you've considered

Two alternatives I considered were to not implement this new appliance, and just proceed with giving glassblowing recipes batch crafting savings anyways, but logically, since the batch crafting savings come from the idea of melting all the glass at once, and as an example, 1 3L glass jar contains 0.95kg of glass, and the density of soda-lime glass is 2.5g/ml, that means there are 380ml of glass making up that jar. So batch crafting 20 of these jars would mean you are using 7.6L of glass, which is far more than the 2L crucible currently used in this recipe can handle. So I consider this alternative to be inferior

The second alternative I considered would be more true to life. It would still involve adding in the new appliance, but instead of just being a pseudo tool, when turned off it would have an interface like the smoking rack where you can insert items with the material type "glass". When turned on, it would have a 2-8 hour processing time based on the volume of glass inserted, after which it converts the volume of glass you inserted into a pseudo item "molten glass". You would not be able to extract this item. The crucible remains on after the processing time, continuing to draw power until turned off. If turned off, the molten glass is converted to an equivalent volume of glass shards. In this alternative, crafting recipes would require the active crucible in range, as well as sufficient quantity of the molten glass pseudo item to consume. This alternative is in my opinion the superior alternative, but would require actual coding, and I don't know C.

#### Testing
 
Loaded up a new world and set skills to level 10. Checked the crafting menu for the recipe, and as expected, did not find it. Spawned and read the glassblowers handbook. Rechecked the crafting menu, and the recipe was there. Spawned the crucible and a battery, and placed both. Adjusted the crafting recipe for 3L glass jar in my files to use the glassblower's crucible with 1 watts instead of the clay crucible (this is not a change in this PR, I made this change on my machine for the express purpose of testing that the pseudo tool was working), and was able to craft as expected with the crucible placed nearby.

#### Additional context

don't think advanced welding should really have any impact as you would only really be welding a very basic cylinder to hold the entire apparatus on the pipe stand?

included processor board, small lcd screen, and bi-metal thermostat as most modern kilns seem to be able to be able to have a programmed heating schedule. Presumably the glassblowers handbook would contain details on these schedules. This crafting requirement could be removed, although I think it's cool and gives another (limited) use for these rarely used components. Alternative could also be circuit board and bi-metal thermostat, to simulate an analog circuit, with something like an adjustment screw on the bimetal strip to adjust the set temperature. Feedback welcome here.

Weight of all components: ~49.47kg
Volume of item: at least 25 for the clay canning pot, which is the main body of the crucible, plus a bit for the pipe stand. One set of dimensions for a cylinder with a volume of 25L would be ~50cm tall by ~25 cm across, or ~1ft across by ~1.6ft tall. Having the top of the crucible around waist high would be ideal, (there is like no information on what the average height above ground level "waist height" is, so I literally just measured it based on myself, a 5'11" male, and got 3'3", or 99cm, so I'm going with 1 meter) so we can figure the overall form factor of the crucible would be a rectangular frame of 25cm x 25cm x 100cm, or a total of 62.5L. All of the electronics can be assumed to be contained within the space of the frame under the canning pot, with controls in one of the corners of the frame between the cylinder of the crucible and the rectangular frame, so everything fits within this rectangular profile. 

I have *NO* clue what to value this at post apoc. Presumably, the ability to create glass jars would be pretty valuable to budding communities, as this allows for long term preservation of food. Feedback in this regard would be greatly appreciated.

Thought about adding looks_like electric kiln, but unsure. It doesn't really look like the electric kiln so this would only serve as a place holder texture, so opting to leave it alone. Using a brown "o" as the symbol, as it is effectively a clay cylinder inside another clay cylinder, with a round clay lid. So yeah, I guess

Thought about saying "Designed for melting up to 10 liters of glass" in the description instead of "Designed for melting large quantities of glass", but I'm not sure how that would look/interact with users selecting their own system of units or translation teams, so opted for the more generic option. 

Volume of glass held by the crucible (this is not represented in game at all, but for item design purposes I want to set a value)- 10L? Talking to some glasssblowers on r/glassblowing, they seem to measure crucible size in pounds of glass it holds, rather than volume, so using the density of molten glass (2.5mg/ml) this would hold roughly 55lbs of molten glass if completely filled, so realistically around 50lbs max. According to them, an 80lb crucible filled with glass and turned on in the morning would be ready to use by afternoon (they didn't give specific hours, so I take that to mean 8am-12pm, or 4 hours prep), so I'm figuring we really want to keep it smaller than that until someone more skilled than me in coding decides to sit down and create a smoking rack style kiln that you plug in, load up with glass shards/glass materials, turn on, and it converts them to equivalent volume of 'molten_glass" stored as a variable over the course of 'x' number of hours, and then that can then be used as the material component for larger glass crafting projects. The kiln would continue to draw that power until shut off after done with the project. But I think that is way more ambitious than what I am capable of. For future reference, in case anyone decides to take on such a project, the glassblowers from reddit say a 600lb furnace studio crucible from one posters job took around 2 days to fill from empty, 200lb furnace filled over the course of 1 day, and left overnight, ready to use the next morning, then 80lb furnace loaded in the morning, ready by afternoon. And quote "The main thing with melting glass and the time till it is ready is about bubbles in the glass. If you don’t care about bubbles the time till it’s “ready” is shorter but the quality of the glass would be lower." This all said, I think keeping our crucible at 50lbs or lower, we can base recipes craft times on 2 hours for heating up the glass plus whatever the craft time for the item is, and use batch crafting system to remove the 2 hour melting time from subsequent crafts. We can assume if someone is doing some absurd batch craft where the total amount of glass used is over 50lbs, they are adding additional glass into the crucible as they craft, so there is never more than 50lbs in the crucible at one time. Overall, the effect of this change is crafting single large glass items will likely increase, but crafting large batches, eg 3L glass jars for canning, should take less time. Small glass items recipes, eg test tubes/.5L glass jars can remain unchanged, continuing to use the forge/kiln + crucible method, potentially with the option for a secondary recipe using the glassblower's crucible that enables more time efficiency with batch crafting

Crafting recipe based on clay pot oven and electric kiln. this being said I kind of feel like the clay pot oven should need more than 2 fire bricks, as they are .5L volume, and meant to be taking up the empty space between the Canning pot, 25L, and clay pot, 2L. This means there are 22L of empty space in this arrangement, but that's beyond this PR, and honestly the clay pots are all over the place in terms of volume of container vs clay required, so maybe I'll look at that another time.

"breaks_into" - another field I'm kind of guestimating on. The number of ceramic shards from breaking seems high, but looking at volumes, the total volume of clay used in crafting was 4.25L (25x.25), and a ceramic shard has a volume of .05L, so realistically it has 85 shards worth of clay in it, so figured max return of like 50% of those? IDK, I'm spitballing here lol. The rocks come from the fire bricks.

Reference item
https://kilnfrog.com/products/jen-ken-kiln-crucible-1813
https://kilnfrog.com/products/double-wall-crucible

The first link has a capacity of around 53L, so nearly identical to the item describe by this PR. For reference when it comes time to adjust recipes to use this item, the power draw is listed as 7200 watts.


PS: I apologize the commit changelog is kind of a mess, this is my first time making any real changes aside from changing one or two lines in a json file, and I was trying to do the edits in the browser code editor as I went, which I realized about 90% of the way through was NOT the right approach. For future changes I intend to make my code changes client side and learn how to use git to push those back to my github branch.