### PR TITLE
Remove migo_bio_tech from spawns

### DIFF
--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -1311,6 +1311,10 @@
   {
     "id": "migo_bio_tech",
     "type": "TOOL",
+    "//": [
+      "intentionally do not spawn anywhere, until migo interest would be implemented",
+      "for now, works only as reference for eoc-item-variable interaction"
+    ],
     "name": { "str_sp": "Mi-go Biotech" },
     "conditional_names": [
       { "type": "VAR", "condition": "npctalk_var_mbt_f_function", "value": "morale", "name": { "str_sp": "%s (happy)" } },
@@ -1334,7 +1338,8 @@
       }
     ],
     "description": "A piece of mi-go biotechnology.",
-    "weight": "1 g",
+    "material": [ "alien_resin" ],
+    "weight": "250 g",
     "volume": "250 ml",
     "price": "30 USD",
     "price_postapoc": "100 USD",

--- a/data/json/mapgen/lab/lab_modular/lab_nests_modular/lab_nested_mutagen.json
+++ b/data/json/mapgen/lab/lab_modular/lab_nests_modular/lab_nested_mutagen.json
@@ -254,8 +254,7 @@
       },
       "place_loot": [
         { "group": "tools_mutation", "x": [ 3, 5 ], "y": 3, "chance": 70 },
-        { "group": "common_mutation_books", "x": [ 3, 5 ], "y": 4, "chance": 70 },
-        { "item": "migo_bio_tech", "x": 3, "y": 3, "chance": 100 }
+        { "group": "common_mutation_books", "x": [ 3, 5 ], "y": 4, "chance": 70 }
       ]
     }
   },

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -375,7 +375,6 @@
       "tallow_tainted",
       "hi_q_distillate",
       "rosin",
-      "migo_bio_tech",
       "meat_fatty_cooked",
       "telepad",
       "chem_turpentine",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
While migo biotech is a great example of eoc interacting with item, it was intended to be used with entire new mechanic where migo track you the more you use this tech, with heavy consequences
Without this mechanic, migo biotech is just a drug with no consequences
and migo interest was never implemented
#### Describe the solution
remove migo biotech from spawn in labs
fix density while i'm here