### PR TITLE
Forbid modding integrated tools

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5346,6 +5346,11 @@ std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint 
             return false;
         }
 
+        // can't mod integrated tools
+        if( e.has_flag( flag_INTEGRATED ) ) {
+            return false;
+        }
+
         // can only attach to unmodified tools that use compatible ammo
         return std::any_of( it->type->mod->acceptable_ammo.begin(),
         it->type->mod->acceptable_ammo.end(), [&]( const ammotype & at ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Forbid modding integrated tools"

#### Purpose of change
* Closes #67586.

#### Describe the solution
Added check for integrated tools in `iuse::toolmod_attach`.

#### Describe alternatives you've considered
None.

#### Testing
Installed Integrated multitool CBM. Got heavy battery mod. Tried to install mod. Integrated welder wasn't in a list of possible targets.

#### Additional context
![изображение](https://github.com/user-attachments/assets/cc1da861-9b2d-4552-838c-24158f91b6c6)
![изображение](https://github.com/user-attachments/assets/02d5af84-80fc-4958-aa02-35ffcce9c79d)
