### PR TITLE
Kill loadscreen during character creation

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -34,6 +34,7 @@
 #include "inventory.h"
 #include "item.h"
 #include "json.h"
+#include "loading_ui.h"
 #include "localized_comparator.h"
 #include "magic.h"
 #include "magic_enchantment.h"
@@ -672,6 +673,7 @@ static int calculate_cumulative_experience( int level )
 
 bool avatar::create( character_type type, const std::string &tempname )
 {
+    loading_ui::done();
     set_wielded_item( item() );
 
     prof = profession::generic();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #76934

#### Describe the solution
Just call loading_ui::done() when character creation starts, always.

Loading an existing character never gets here, because they're loading an existing character (duh)

We don't need to cache the image, because it doesn't get re-used when character creation is done anyway. https://github.com/CleverRaven/Cataclysm-DDA/blob/f18d1e3c4a2ee14570bef188c811706f224b7963/src/game.cpp#L889-L893

#### Describe alternatives you've considered
I posted a much more complicated patch in the linked issue. While I wanted an excuse to play with std::swap, it's better if we go with the simple solution :)

#### Testing
Make new character - loading image disappears during char creation

Loading existing character - single randomized loading screen persists through load

#### Additional context
