### PR TITLE
Portal Storm Voice's Subtle Foreshadowing

### DIFF
--- a/data/json/npcs/EOC_talkers/portal_storm.json
+++ b/data/json/npcs/EOC_talkers/portal_storm.json
@@ -98,7 +98,7 @@
     "responses": [
       { "text": "No ", "topic": "TALK_PORTAL_STORM_DO_FOR_ME" },
       {
-        "text": "Will it.  'Your gut feels like this is jumping out of a plane without a parachute.'",
+        "text": "Will it.  <color_red>'Your gut feels like this is jumping out of a plane without a parachute.'</color>",
         "topic": "TALK_PORTAL_STORM_WILL_IT",
         "effect": { "give_achievement": "escaped_the_cataclysm" }
       },


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
After i've been told by Night Pryanik in #66510 that text can be colored, i can finally do the one thing i want to do using it: Give a 'subtle foreshadowing' on the 'Will it' dialogue topic, specifically the part about jumping off plane without parachutes.


#### Describe the solution

give `<color_red> </color>` to `'Your gut feels like this is jumping out of a plane without a parachute.'`

#### Describe alternatives you've considered

No subtle foreshadowing.
#### Testing

![Screenshot_20241010_230837](https://github.com/user-attachments/assets/68d4a7dc-a25a-4b7d-8d64-79a48c953f4d)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
