### PR TITLE
[Xedra Evolved] Dreamforged Nail

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/dreamsmith.json
+++ b/data/mods/Xedra_Evolved/eocs/dreamsmith.json
@@ -97,7 +97,8 @@
           "dreamforged_picklocks",
           "dreamforged_scalpel",
           "dreamforged_e_tool",
-          "dreamforged_ax"
+          "dreamforged_ax",
+          "dreamforged_nail"
         ],
         "type": "recipe",
         "true_eocs": {

--- a/data/mods/Xedra_Evolved/items/components.json
+++ b/data/mods/Xedra_Evolved/items/components.json
@@ -12,4 +12,4 @@
     "symbol": "=",
     "color": "light_gray"
   }
-] 
+]

--- a/data/mods/Xedra_Evolved/items/components.json
+++ b/data/mods/Xedra_Evolved/items/components.json
@@ -1,4 +1,4 @@
-[  
+[
   {
     "id": "dreamforged_nail",
     "type": "AMMO",

--- a/data/mods/Xedra_Evolved/items/components.json
+++ b/data/mods/Xedra_Evolved/items/components.json
@@ -1,0 +1,15 @@
+[  
+  {
+    "id": "dreamforged_nail",
+    "type": "AMMO",
+    "copy-from": "nail",
+    "name": { "str": "dreamforged nail" },
+    "description": "A pin-shaped piece of steel.  It can be used to construct various things with a hammer.  Forged from dreamdross, which makes it much lighter.",
+    "proportional": { "weight": 0.25, "melee_damage": { "bash": 0.25 } },
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "forged_dreamstuff" ],
+    "symbol": "=",
+    "color": "light_gray"
+  }
+] 

--- a/data/mods/Xedra_Evolved/recipes/components.json
+++ b/data/mods/Xedra_Evolved/recipes/components.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "recipe",
+    "activity_level": "ACTIVE_EXERCISE",
+    "proficiencies": [ { "proficiency": "prof_dreamsmithing" } ],
+    "result": "dreamforged_nail",
+    "qualities": [ { "id": "DREAM_HAMMER", "level": 1 } ],
+    "components": [ [ [ "scrap_dreamdross", 100 ], [ "dreamdross_lump", 10 ] ] ],
+    "time": "3 h",
+    "skill_used": "deduction",
+    "difficulty": 2,
+    "flags": [ "SECRET" ],
+    "category": "CC_XEDRA",
+    "subcategory": "CSC_XEDRA_MISC"
+  }
+]

--- a/data/mods/Xedra_Evolved/requirements/components.json
+++ b/data/mods/Xedra_Evolved/requirements/components.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "nails",
+    "type": "requirement",
+    "extend": { "components": [ [ [ "dreamforged_nail", 1 ] ] ] }
+  }
+]


### PR DESCRIPTION


#### Summary
Mods "Adds dreamforged nail as one of the things dreamsmith can dream smith."


#### Purpose of change
I imagine dreamsmith can dream smiths themselves some dreamforged nail they can use on non-dreamsmithing crafts and constructions, so i add it.

#### Describe the solution

Adds dreamforged nails.

#### Describe alternatives you've considered

Not filling the spare part niche dreamsmith can fill.

#### Testing

I put it in as a mod and do the following:

1. Checking the dreamforged nail recipe and craft it. It gives me 100 dreamforged nails as expected.
![Screenshot_20241011_022705_1](https://github.com/user-attachments/assets/252b5d8f-e4e4-47d5-af3d-5f1824ed0915)

2. Examine the item to see that it is infact dreamforged nail and checking that i dont forgot to rename it when i was copy pasting some other dreamforged item json.
![Screenshot_20241011_022738_1](https://github.com/user-attachments/assets/8c326acc-7094-480d-8b69-7f6644a195b6)

4. Check other crafting and construction recipe that uses nails and see the dreamforged nail in the list of nails.
![Screenshot_20241011_022830_1](https://github.com/user-attachments/assets/b96a1688-4851-4d29-a84c-b4a869143441)
![Screenshot_20241011_025130](https://github.com/user-attachments/assets/7f4c5077-6b58-4d3e-8d03-0b6533b138b8)



#### Additional context

Maybe i should add dreamforged nuts and bolts next after this. Atleast i have something to work with.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
