### PR TITLE
[Xedra Evolved] Dreamsmithing procgen expansion (enchants)

### DIFF
--- a/data/mods/Xedra_Evolved/itemgroups/dreamsmith_procgen.json
+++ b/data/mods/Xedra_Evolved/itemgroups/dreamsmith_procgen.json
@@ -383,7 +383,7 @@
         "item": "dreamforged_fullhelmet",
         "custom-flags": "FIT",
         "artifact": {
-          "procgen_id": "dreamsmith_lottery_def",
+          "procgen_id": "dreamsmith_lottery_def_head",
           "rules": { "power_level": 5000, "max_attributes": 4, "max_negative_power": 0, "resonant": false }
         },
         "prob": 100
@@ -399,7 +399,7 @@
         "item": "dreamforged_helmet",
         "custom-flags": "FIT",
         "artifact": {
-          "procgen_id": "dreamsmith_lottery_def",
+          "procgen_id": "dreamsmith_lottery_def_head",
           "rules": { "power_level": 5000, "max_attributes": 4, "max_negative_power": 0, "resonant": false }
         },
         "prob": 100
@@ -415,7 +415,7 @@
         "item": "dreamforged_plate_armor",
         "custom-flags": "FIT",
         "artifact": {
-          "procgen_id": "dreamsmith_lottery_def",
+          "procgen_id": "dreamsmith_lottery_def_body",
           "rules": { "power_level": 5000, "max_attributes": 4, "max_negative_power": 0, "resonant": false }
         },
         "prob": 100
@@ -431,7 +431,7 @@
         "item": "dreamforged_armguard_plate",
         "custom-flags": "FIT",
         "artifact": {
-          "procgen_id": "dreamsmith_lottery_def",
+          "procgen_id": "dreamsmith_lottery_def_body",
           "rules": { "power_level": 5000, "max_attributes": 4, "max_negative_power": 0, "resonant": false }
         },
         "prob": 100
@@ -447,7 +447,7 @@
         "item": "dreamforged_boots",
         "custom-flags": "FIT",
         "artifact": {
-          "procgen_id": "dreamsmith_lottery_def",
+          "procgen_id": "dreamsmith_lottery_def_feet",
           "rules": { "power_level": 5000, "max_attributes": 4, "max_negative_power": 0, "resonant": false }
         },
         "prob": 100

--- a/data/mods/Xedra_Evolved/itemgroups/dreamsmith_procgen.json
+++ b/data/mods/Xedra_Evolved/itemgroups/dreamsmith_procgen.json
@@ -431,7 +431,7 @@
         "item": "dreamforged_armguard_plate",
         "custom-flags": "FIT",
         "artifact": {
-          "procgen_id": "dreamsmith_lottery_def_body",
+          "procgen_id": "dreamsmith_lottery_def_hands",
           "rules": { "power_level": 5000, "max_attributes": 4, "max_negative_power": 0, "resonant": false }
         },
         "prob": 100

--- a/data/mods/Xedra_Evolved/procgen/dreamsmith_procgen.json
+++ b/data/mods/Xedra_Evolved/procgen/dreamsmith_procgen.json
@@ -684,7 +684,7 @@
       }
     ],
     "type_weights": [ { "weight": 100, "value": "passive_enchantment_add" } ],
-    "items": [ { "weight": 100, "item": "dreamforged_plate_armor" }, { "weight": 100, "item": "dreamforged_armguard_plate" } ]
+    "items": [ { "weight": 100, "item": "dreamforged_plate_armor" } ]
   },
   {
     "type": "relic_procgen_data",
@@ -865,7 +865,7 @@
       }
     ],
     "type_weights": [ { "weight": 100, "value": "passive_enchantment_add" } ],
-    "items": [ { "weight": 100, "item": "dreamforged_plate_armor" }, { "weight": 100, "item": "dreamforged_armguard_plate" } ]
+    "items": [ { "weight": 100, "item": "dreamforged_armguard_plate" } ]
   },
   {
     "type": "relic_procgen_data",

--- a/data/mods/Xedra_Evolved/procgen/dreamsmith_procgen.json
+++ b/data/mods/Xedra_Evolved/procgen/dreamsmith_procgen.json
@@ -688,6 +688,187 @@
   },
   {
     "type": "relic_procgen_data",
+    "id": "dreamsmith_lottery_def_hands",
+    "//": "In addition to stats and armor, this pool should related to the concept of adroitness or martial skill",
+    "passive_add_procgen_values": [
+      { "weight": 100, "min_value": -1, "max_value": -20, "type": "ARMOR_ACID", "increment": -1, "power_per_increment": 75 },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_BASH",
+        "increment": -1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_BIO",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_BULLET",
+        "increment": -1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_COLD",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_CUT",
+        "increment": -1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_ELEC",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_HEAT",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_STAB",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "DEXTERITY",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "INTELLIGENCE",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "PERCEPTION",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "STRENGTH",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 500,
+        "type": "MAX_MANA",
+        "increment": 100,
+        "power_per_increment": 600,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 3000,
+        "type": "MAX_STAMINA",
+        "increment": 500,
+        "power_per_increment": 500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 10,
+        "type": "BLEED_STOP_BONUS",
+        "increment": 1,
+        "power_per_increment": 100,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 1,
+        "type": "BONUS_BLOCK",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -50,
+        "type": "OBTAIN_COST_MULTIPLIER",
+        "increment": 2,
+        "power_per_increment": 100,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 10,
+        "type": "THROW_STR",
+        "increment": 1,
+        "power_per_increment": 250,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 20,
+        "type": "THROW_DAMAGE",
+        "increment": 1,
+        "power_per_increment": 100,
+        "ench_has": "WORN"
+      }
+    ],
+    "type_weights": [ { "weight": 100, "value": "passive_enchantment_add" } ],
+    "items": [ { "weight": 100, "item": "dreamforged_plate_armor" }, { "weight": 100, "item": "dreamforged_armguard_plate" } ]
+  },
+  {
+    "type": "relic_procgen_data",
     "id": "dreamsmith_lottery_def_feet",
     "//": "In addition to stats and armor, this pool should related to the movement or stealth",
     "passive_add_procgen_values": [

--- a/data/mods/Xedra_Evolved/procgen/dreamsmith_procgen.json
+++ b/data/mods/Xedra_Evolved/procgen/dreamsmith_procgen.json
@@ -300,6 +300,7 @@
   {
     "type": "relic_procgen_data",
     "id": "dreamsmith_lottery_def_head",
+    "//": "In addition to stats and armor, this pool should related to perception, sight, or vision",
     "passive_add_procgen_values": [
       { "weight": 100, "min_value": -1, "max_value": -20, "type": "ARMOR_ACID", "increment": -1, "power_per_increment": 75 },
       {
@@ -463,33 +464,6 @@
         "increment": 2,
         "power_per_increment": 500,
         "ench_has": "WORN"
-      },
-      {
-        "weight": 100,
-        "min_value": 1,
-        "max_value": 10,
-        "type": "REGEN_HP",
-        "increment": 1,
-        "power_per_increment": 300,
-        "ench_has": "WORN"
-      },
-      {
-        "weight": 100,
-        "min_value": 1,
-        "max_value": 100,
-        "type": "REGEN_MANA",
-        "increment": 10,
-        "power_per_increment": 300,
-        "ench_has": "WORN"
-      },
-      {
-        "weight": 100,
-        "min_value": 1,
-        "max_value": 20,
-        "type": "REGEN_STAMINA",
-        "increment": 1,
-        "power_per_increment": 150,
-        "ench_has": "WORN"
       }
     ],
     "type_weights": [ { "weight": 100, "value": "passive_enchantment_add" } ],
@@ -498,6 +472,7 @@
   {
     "type": "relic_procgen_data",
     "id": "dreamsmith_lottery_def_body",
+    "//": "In addition to stats and armor, this pool should related to the concept of defense or avoiding attack or environmental protection",
     "passive_add_procgen_values": [
       { "weight": 100, "min_value": -1, "max_value": -20, "type": "ARMOR_ACID", "increment": -1, "power_per_increment": 75 },
       {
@@ -648,9 +623,18 @@
         "weight": 100,
         "min_value": 0.01,
         "max_value": 0.05,
-        "type": "FORCEFIELD",
+        "type": "EVASION",
         "increment": 0.01,
         "power_per_increment": 750,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 4,
+        "type": "DODGE_CHANCE",
+        "increment": 1,
+        "power_per_increment": 1000,
         "ench_has": "WORN"
       },
       {
@@ -705,6 +689,7 @@
   {
     "type": "relic_procgen_data",
     "id": "dreamsmith_lottery_def_feet",
+    "//": "In addition to stats and armor, this pool should related to the movement or stealth",
     "passive_add_procgen_values": [
       { "weight": 100, "min_value": -1, "max_value": -20, "type": "ARMOR_ACID", "increment": -1, "power_per_increment": 75 },
       {
@@ -862,20 +847,11 @@
       },
       {
         "weight": 100,
-        "min_value": -1,
-        "max_value": -15,
-        "type": "FALL_DAMAGE",
-        "increment": -1,
-        "power_per_increment": 75,
-        "ench_has": "WORN"
-      },
-      {
-        "weight": 100,
-        "min_value": 0.01,
-        "max_value": 0.05,
-        "type": "EVASION",
-        "increment": 0.01,
-        "power_per_increment": 750,
+        "min_value": 1,
+        "max_value": 25,
+        "type": "STEALTH_MODIFIER",
+        "increment": 1,
+        "power_per_increment": 100,
         "ench_has": "WORN"
       },
       {

--- a/data/mods/Xedra_Evolved/procgen/dreamsmith_procgen.json
+++ b/data/mods/Xedra_Evolved/procgen/dreamsmith_procgen.json
@@ -257,6 +257,15 @@
         "increment": 0.1,
         "power_per_increment": 2000,
         "ench_has": "WIELD"
+      },
+      {
+        "weight": 100,
+        "min_value": 0,
+        "max_value": 0.8,
+        "type": "WEAKPOINT_ACCURACY",
+        "increment": 0.1,
+        "power_per_increment": 500,
+        "ench_has": "WIELD"
       }
     ],
     "type_weights": [ { "weight": 100, "value": "passive_enchantment_add" }, { "weight": 50, "value": "passive_enchantment_mult" } ],
@@ -290,7 +299,205 @@
   },
   {
     "type": "relic_procgen_data",
-    "id": "dreamsmith_lottery_def",
+    "id": "dreamsmith_lottery_def_head",
+    "passive_add_procgen_values": [
+      { "weight": 100, "min_value": -1, "max_value": -20, "type": "ARMOR_ACID", "increment": -1, "power_per_increment": 75 },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_BASH",
+        "increment": -1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_BIO",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_BULLET",
+        "increment": -1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_COLD",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_CUT",
+        "increment": -1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_ELEC",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_HEAT",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_STAB",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "DEXTERITY",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "INTELLIGENCE",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "PERCEPTION",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "STRENGTH",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 50,
+        "type": "SIGHT_RANGE_ELECTRIC",
+        "increment": 25,
+        "power_per_increment": 750,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 3,
+        "max_value": 25,
+        "type": "SIGHT_RANGE_MINDS",
+        "increment": 2,
+        "power_per_increment": 250,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 3,
+        "max_value": 25,
+        "type": "SIGHT_RANGE_NETHER",
+        "increment": 2,
+        "power_per_increment": 250,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 25,
+        "type": "NIGHT_VIS",
+        "increment": 2,
+        "power_per_increment": 250,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 10,
+        "type": "RANGE",
+        "increment": 1,
+        "power_per_increment": 400,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 2,
+        "max_value": 10,
+        "type": "OVERMAP_SIGHT",
+        "increment": 2,
+        "power_per_increment": 500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 10,
+        "type": "REGEN_HP",
+        "increment": 1,
+        "power_per_increment": 300,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 100,
+        "type": "REGEN_MANA",
+        "increment": 10,
+        "power_per_increment": 300,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 20,
+        "type": "REGEN_STAMINA",
+        "increment": 1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      }
+    ],
+    "type_weights": [ { "weight": 100, "value": "passive_enchantment_add" } ],
+    "items": [ { "weight": 100, "item": "dreamforged_fullhelmet" }, { "weight": 100, "item": "dreamforged_helmet" } ]
+  },
+  {
+    "type": "relic_procgen_data",
+    "id": "dreamsmith_lottery_def_body",
     "passive_add_procgen_values": [
       { "weight": 100, "min_value": -1, "max_value": -20, "type": "ARMOR_ACID", "increment": -1, "power_per_increment": 75 },
       {
@@ -430,19 +637,19 @@
       },
       {
         "weight": 100,
-        "min_value": -1,
-        "max_value": -50,
-        "type": "FOOTSTEP_NOISE",
-        "increment": -1,
-        "power_per_increment": 30,
+        "min_value": 0.01,
+        "max_value": 0.05,
+        "type": "FORCEFIELD",
+        "increment": 0.01,
+        "power_per_increment": 750,
         "ench_has": "WORN"
       },
       {
         "weight": 100,
-        "min_value": 1,
-        "max_value": 50,
-        "type": "SIGHT_RANGE_ELECTRIC",
-        "increment": 25,
+        "min_value": 0.01,
+        "max_value": 0.05,
+        "type": "FORCEFIELD",
+        "increment": 0.01,
         "power_per_increment": 750,
         "ench_has": "WORN"
       },
@@ -493,12 +700,204 @@
       }
     ],
     "type_weights": [ { "weight": 100, "value": "passive_enchantment_add" } ],
-    "items": [
-      { "weight": 100, "item": "dreamforged_fullhelmet" },
-      { "weight": 100, "item": "dreamforged_helmet" },
-      { "weight": 100, "item": "dreamforged_plate_armor" },
-      { "weight": 100, "item": "dreamforged_armguard_plate" },
-      { "weight": 100, "item": "dreamforged_boots" }
-    ]
+    "items": [ { "weight": 100, "item": "dreamforged_plate_armor" }, { "weight": 100, "item": "dreamforged_armguard_plate" } ]
+  },
+  {
+    "type": "relic_procgen_data",
+    "id": "dreamsmith_lottery_def_feet",
+    "passive_add_procgen_values": [
+      { "weight": 100, "min_value": -1, "max_value": -20, "type": "ARMOR_ACID", "increment": -1, "power_per_increment": 75 },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_BASH",
+        "increment": -1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_BIO",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_BULLET",
+        "increment": -1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_COLD",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_CUT",
+        "increment": -1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_ELEC",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_HEAT",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -20,
+        "type": "ARMOR_STAB",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 1,
+        "type": "BONUS_DODGE",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "DEXTERITY",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "INTELLIGENCE",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "PERCEPTION",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 2,
+        "type": "STRENGTH",
+        "increment": 1,
+        "power_per_increment": 1500,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -50,
+        "type": "FOOTSTEP_NOISE",
+        "increment": -1,
+        "power_per_increment": 30,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -25,
+        "type": "MOVE_COST",
+        "increment": -1,
+        "power_per_increment": 150,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -15,
+        "type": "MOVECOST_FLATGROUND_MOD",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -15,
+        "type": "MOVECOST_OBSTACLE_MOD",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": -1,
+        "max_value": -15,
+        "type": "FALL_DAMAGE",
+        "increment": -1,
+        "power_per_increment": 75,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 0.01,
+        "max_value": 0.05,
+        "type": "EVASION",
+        "increment": 0.01,
+        "power_per_increment": 750,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 500,
+        "type": "MAX_MANA",
+        "increment": 100,
+        "power_per_increment": 600,
+        "ench_has": "WORN"
+      },
+      {
+        "weight": 100,
+        "min_value": 1,
+        "max_value": 3000,
+        "type": "MAX_STAMINA",
+        "increment": 500,
+        "power_per_increment": 500,
+        "ench_has": "WORN"
+      }
+    ],
+    "type_weights": [ { "weight": 100, "value": "passive_enchantment_add" } ],
+    "items": [ { "weight": 100, "item": "dreamforged_boots" } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Dreamsmithing procgen expansion (enchants)"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I noticed a lot of the newer enchants weren't possible to roll on dreamsmithed gear, so I thought I'd add them in.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1) Split up worn dreamsmithing items into four pools--head, body, hands, and feet. All of them can gain armor and stats, but only the head can gain vision enchantments (`SIGHT_RANGE_MINDS`, `NIGHT_VIS`, and so on), only the body can gain regen enchantments as well as the powerful defensive enchants (`FORCEFIELD`, `DODGE_CHANCE`, or `EVASION`), only the hands can gain enchants related to dexterity or skill (like `OBTAIN_COST_MULTIPLIER`, `THROW_STR`, or `BONUS_BLOCK`), and only the feet can gain movement-related enchants (like `MOVECOST_OBSTACLE_MOD` or `MOVE_COST`)

It's my intention in a future PR to add dreamsmithed jewelry that pulls from a larger pool but doesn't have the stat or armor boosting enchants, as well as add dreamsmithed clothing that pulls from a similar pool.

2) Add various new enchants to these pools as appropriate. Also add some new enchants, like `WEAKPOINT_ACCURACY`, to weapon enchants.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Helm giving SIGHT_RANGE_MINDS:

![Untitled2](https://github.com/user-attachments/assets/5816d727-6af5-499d-ab3b-f798ced91ee9)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Some of these enchants are pretty hard or impossible to discover (`EVASION` or `BLEED_STOP_BONUS`, for example), so it'd be really nice if there were some way to learn about them or a way to just display them in the interface for mods.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
