### PR TITLE
Fix floating-point precision problem in apply_light_arc

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1313,153 +1313,75 @@ void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, 
     cata::mdarray<float, point_bub_ms> &transparency_cache =
         cache.transparency_cache;
 
-    // Normalize (should work with negative values too)
-    units::angle wangle = wideangle / 2.0;
-    units::angle oangle = angle - wangle;
-    units::angle cangle = angle + wangle;
+    // Normalize
+    const units::angle wangle = wideangle / 2.0;
+    const units::angle oangle = fmod( angle - wangle, 360_degrees );
+    const units::angle cangle = oangle + wideangle;
 
-    //cut pre-subsection
-    if( fmod( oangle, 45_degrees ) != 0_degrees ) {
-        units::angle preangle = oangle;
-        oangle = 45_degrees * std::ceil( to_degrees( oangle ) / 45 );
-        switch( static_cast<int>( std::floor( ( preangle + 360_degrees ) / 45_degrees ) ) % 8 ) {
+    // Sweep over every octant
+    int i = 0;
+    while( true ) {
+        int start = i;
+        int end = i + 1;
+        units::angle start_angle;
+        units::angle end_angle;
+        // This octant doesn't overlap with illuminated area
+        if( 45_degrees * end < oangle ) {
+            ++i;
+            continue;
+        }
+        // Finish processing
+        if( 45_degrees * start > cangle ) {
+            break;
+        }
+        // Unified way to cast light in one octant
+        start_angle = std::max( 45_degrees * start, oangle );
+        end_angle = std::min( 45_degrees * end, cangle );
+
+        // i is positive
+        switch( i % 8 ) {
             case 0:
                 castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
                           update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, 1.0, tan( preangle ) );
+                              lm, transparency_cache, p2, 0, luminance, 1, tan( end_angle ), tan( start_angle ) );
                 break;
             case 1:
                 castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                           update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, cot( preangle ), 0.0 );
+                              lm, transparency_cache, p2, 0, luminance, 1, cot( start_angle ), cot( end_angle ) );
                 break;
             case 2:
                 castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                           update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, 1.0, -cot( preangle ) );
+                              lm, transparency_cache, p2, 0, luminance, 1, -cot( end_angle ), -cot( start_angle ) );
                 break;
             case 3:
                 castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
                           update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, -tan( preangle ), 0.0 );
+                              lm, transparency_cache, p2, 0, luminance, 1, -tan( start_angle ), -tan( end_angle ) );
                 break;
             case 4:
                 castLight < 0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
                           update_light_quadrants, accumulate_transparency >(
-                              lm, transparency_cache, p2, 0, luminance, 1, 1.0, tan( preangle ) );
+                              lm, transparency_cache, p2, 0, luminance, 1, tan( end_angle ), tan( start_angle ) );
                 break;
             case 5:
                 castLight < 1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                           update_light_quadrants, accumulate_transparency >(
-                              lm, transparency_cache, p2, 0, luminance, 1, cot( preangle ), 0.0 );
+                              lm, transparency_cache, p2, 0, luminance, 1, cot( start_angle ), cot( end_angle ) );
                 break;
             case 6:
                 castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                           update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, 1.0, -cot( preangle ) );
+                              lm, transparency_cache, p2, 0, luminance, 1, -cot( end_angle ), -cot( start_angle ) );
                 break;
             case 7:
                 castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
                           update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, -tan( preangle ), 0.0 );
+                              lm, transparency_cache, p2, 0, luminance, 1, -tan( start_angle ), -tan( end_angle ) );
                 break;
         }
-    }
-    int numoct = std::floor( to_degrees( cangle - oangle ) / 45 );
-    int firstoct = static_cast<int>( std::lround( to_degrees( oangle ) / 45 ) );
-    oangle += numoct * 45_degrees;
-    wangle = cangle - oangle;
-
-    for( int i = firstoct; i < numoct + firstoct; i++ ) {
-        //if arc crosses 0 degrees, i.e. sectors 7-0-1, offset back to sector 0 after 7
-        switch( ( i + 8 ) % 8 ) {
-            case 0:
-                castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance );
-                break;
-            case 1:
-                castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance );
-                break;
-            case 2:
-                castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance );
-                break;
-            case 3:
-                castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance );
-                break;
-            case 4:
-                castLight < 0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance );
-                break;
-            case 5:
-                castLight < 1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance );
-                break;
-            case 6:
-                castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance );
-                break;
-            case 7:
-                castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance );
-                break;
-        }
-    }
-    if( wangle == 0_degrees ) {
-        return;
-    }
-
-    switch( static_cast<int>( std::floor( oangle / 45_degrees ) ) % 8 ) {
-        case 0:
-            castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
-                      update_light_quadrants, accumulate_transparency > (
-                          lm, transparency_cache, p2, 0, luminance, 1, tan( cangle ), tan( oangle ) );
-            break;
-        case 1:
-            castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                      update_light_quadrants, accumulate_transparency > (
-                          lm, transparency_cache, p2, 0, luminance, 1, cot( oangle ), cot( cangle ) );
-            break;
-        case 2:
-            castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                      update_light_quadrants, accumulate_transparency > (
-                          lm, transparency_cache, p2, 0, luminance, 1, -cot( cangle ), -cot( oangle ) );
-            break;
-        case 3:
-            castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
-                      update_light_quadrants, accumulate_transparency > (
-                          lm, transparency_cache, p2, 0, luminance, 1, -tan( oangle ), -tan( cangle ) );
-            break;
-        case 4:
-            castLight < 0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
-                      update_light_quadrants, accumulate_transparency >(
-                          lm, transparency_cache, p2, 0, luminance, 1, tan( cangle ), tan( oangle ) );
-            break;
-        case 5:
-            castLight < 1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                      update_light_quadrants, accumulate_transparency >(
-                          lm, transparency_cache, p2, 0, luminance, 1, cot( oangle ), cot( cangle ) );
-            break;
-        case 6:
-            castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                      update_light_quadrants, accumulate_transparency > (
-                          lm, transparency_cache, p2, 0, luminance, 1, -cot( cangle ), -cot( oangle ) );
-            break;
-        case 7:
-            castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
-                      update_light_quadrants, accumulate_transparency > (
-                          lm, transparency_cache, p2, 0, luminance, 1, -tan( oangle ), -tan( cangle ) );
-            break;
+        i++;
     }
 }
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1313,9 +1313,9 @@ void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, 
     cata::mdarray<float, point_bub_ms> &transparency_cache =
         cache.transparency_cache;
 
-    // Normalize
     const units::angle wangle = wideangle / 2.0;
-    const units::angle oangle = fmod( angle - wangle, 360_degrees );
+    // Normalize so oangle is between 0 and 360 degrees
+    const units::angle oangle = fmod( fmod( angle - wangle, 360_degrees ) + 360_degrees, 360_degrees );
     const units::angle cangle = oangle + wideangle;
 
     // Sweep over every octant


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix floating-point precision problem in apply_light_arc"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #76909
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Instead of using std::floor to determine which octant the light beam should fall into, I'd rather compare the boundaries of light beam with octant boundaries to make sure nothing is incorrectly rounded.

This also simplified the code by using a unified approach to cast light into one octant.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Fix the rounding problem of units::angle : Would love to leave that to more authoritative ones to decide.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. Install a headlight pointing at 45° from straight forward (installing, then pressing up and then left) and drive around, making sure the light beam looks fine.
2. Install a headlight pointing at 27° from straight forward (installing, then pressing up x2 and then left) and drive around, making sure the light beam looks fine.
3. Install a wide angle headlight pointing at 45° from straight forward (installing, then pressing up and then left) and drive around, making sure the light beam looks fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
