### PR TITLE
Mod Compatibility 2: Prevent Error from duplicate ids within mod_interactions folder

### DIFF
--- a/data/mods/Magiclysm/mod_interactions/bombastic_perks/test_file.json
+++ b/data/mods/Magiclysm/mod_interactions/bombastic_perks/test_file.json
@@ -1,0 +1,17 @@
+[
+    {
+        "type": "mutation",
+        "id": "MANA_ADD2",
+        "name": "Mana Efficiency",
+        "points": 3,
+        "description": "You are able to store more mana in your body than usual.",
+        "cancels": [ "MANA_SUB1", "MANA_SUB2", "MANA_SUB3" ],
+        "changes_to": [ "MANA_ADD3" ],
+        "types": [ "MANA_ADD" ],
+        "category": [ "DRAGON_BLACK", "MANATOUCHED", "SPECIES_ELF" ],
+        "starting_trait": true,
+        "prereqs": [ "MANA_ADD1" ],
+        "flags": [ "NON_THRESH" ],
+        "enchantments": [ { "values": [ { "value": "MAX_MANA", "add": 1000 } ] } ]
+      }
+]

--- a/doc/MOD_COMPATABILITY.md
+++ b/doc/MOD_COMPATABILITY.md
@@ -19,15 +19,4 @@ Files located within the mod_interactions folders are always loaded after other 
 
 ## Limitations
 
-Currently, this functionality only loads / unloads files based on if other mods are active for the particular world.  It does not suppress any other warnings beyond this function.
-
-In particular, when designing mod compatability content an author will likely want to redefine certain ids to have new definitions, flags, etc.  If attempting to do this within the same overall mod folder, this will throw a duplicate definition error.  To get around this, instead of a mod redefining its own content within its own mod_interactions folder, the author should redefine its own content using the other mods mod_interaction folder.
-
-Example:
-Mod 1: Mind Over Matter (id:mindovermatter)
-Mod 2: Xedra Evolved (id:xedra_evolved)
-
-If xedra wants an item to have extra damage while Mind Over Matter is loaded, the author should place the new definition in the following:
-MindOverMatter/mod_interactions/xedra_evolved/xedra_compat_data.json
-
-TODO: remove this limitation entirely by adjusting the check to take into account the mod_interaction id source as well
+Individual mod interaction folders can only support a single mod to load / unload.  IE, a folder may be named "mindovermatter", it may not be named "mindovermatter,xedra_evolved" or some other variation.

--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -401,9 +401,9 @@ std::string achievement::time_bound::ui_text( bool is_conduct ) const
     return colorize( message, c );
 }
 
-void achievement::load_achievement( const JsonObject &jo, const std::string &src )
+void achievement::load_achievement( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    achievement_factory.load( jo, src );
+    achievement_factory.load( jo, src, second_src );
 }
 
 void achievement::finalize()
@@ -430,7 +430,7 @@ void achievement::reset()
     achievement_factory.reset();
 }
 
-void achievement::load( const JsonObject &jo, const std::string_view )
+void achievement::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     is_conduct_ = jo.get_string( "type" ) == "conduct";

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -73,6 +73,7 @@ class achievement
 
         achievement_id id;
         std::vector<std::pair<achievement_id, mod_id>> src;
+        std::vector<std::pair<achievement_id, mod_id>> second_src;
         bool was_loaded = false;
 
         const translation &name() const {

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -63,9 +63,9 @@ class achievement
     public:
         achievement() = default;
 
-        void load( const JsonObject &, std::string_view );
+        void load( const JsonObject &, std::string_view, std::string_view );
         void check() const;
-        static void load_achievement( const JsonObject &, const std::string & );
+        static void load_achievement( const JsonObject &, const std::string &, const std::string & );
         static void finalize();
         static void check_consistency();
         static const std::vector<achievement> &get_all();

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -57,9 +57,9 @@ bool string_id<add_type>::is_valid() const
     return add_type_factory.is_valid( *this );
 }
 
-void add_type::load_add_types( const JsonObject &jo, const std::string &src )
+void add_type::load_add_types( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    add_type_factory.load( jo, src );
+    add_type_factory.load( jo, src, second_src );
 }
 
 void add_type::reset()
@@ -362,7 +362,7 @@ bool addiction::run_effect( Character &u )
     return ret;
 }
 
-void add_type::load( const JsonObject &jo, const std::string_view )
+void add_type::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "type_name", _type_name );

--- a/src/addiction.h
+++ b/src/addiction.h
@@ -25,10 +25,10 @@ struct add_type {
     public:
         addiction_id id;
         bool was_loaded = false;
-        static void load_add_types( const JsonObject &jo, const std::string &src );
+        static void load_add_types( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
         static void check_add_types();
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, std::string_view );
         static const std::vector<add_type> &get_all();
 
         const translation &get_name() const {

--- a/src/ammo_effect.cpp
+++ b/src/ammo_effect.cpp
@@ -62,7 +62,7 @@ int_id<ammo_effect>::int_id( const ammo_effect_str_id &id ) : _id( id.id() )
 {
 }
 
-void ammo_effect::load( const JsonObject &jo, const std::string_view )
+void ammo_effect::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     optional( jo, was_loaded, "trigger_chance", trigger_chance, 1 );
 
@@ -152,9 +152,9 @@ size_t ammo_effect::count()
     return get_all_ammo_effects().size();
 }
 
-void ammo_effects::load( const JsonObject &jo, const std::string &src )
+void ammo_effects::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    get_all_ammo_effects().load( jo, src );
+    get_all_ammo_effects().load( jo, src, second_src );
 }
 
 void ammo_effects::finalize_all()

--- a/src/ammo_effect.h
+++ b/src/ammo_effect.h
@@ -21,7 +21,7 @@ generic_factory<ammo_effect> &get_all_ammo_effects();
 
 struct ammo_effect {
     public:
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, std::string_view );
         void finalize();
         void check() const;
         fake_spell spell_data;
@@ -66,7 +66,7 @@ struct ammo_effect {
 namespace ammo_effects
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void finalize_all();
 void check_consistency();
 void reset();

--- a/src/ammo_effect.h
+++ b/src/ammo_effect.h
@@ -58,6 +58,7 @@ struct ammo_effect {
         // Used by generic_factory
         ammo_effect_str_id id;
         std::vector<std::pair<ammo_effect_str_id, mod_id>> src;
+        std::vector<std::pair<ammo_effect_str_id, mod_id>> second_src;
         bool was_loaded = false;
 
         static size_t count();

--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -52,12 +52,12 @@ const anatomy &anatomy_id::obj() const
     return anatomy_factory.obj( *this );
 }
 
-void anatomy::load_anatomy( const JsonObject &jo, const std::string &src )
+void anatomy::load_anatomy( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    anatomy_factory.load( jo, src );
+    anatomy_factory.load( jo, src, second_src );
 }
 
-void anatomy::load( const JsonObject &jo, const std::string_view )
+void anatomy::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "parts", unloaded_bps );

--- a/src/anatomy.h
+++ b/src/anatomy.h
@@ -64,11 +64,11 @@ class anatomy
         void add_body_part( const bodypart_str_id &new_bp );
         // TODO: remove_body_part
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void finalize();
         void check() const;
 
-        static void load_anatomy( const JsonObject &jo, const std::string &src );
+        static void load_anatomy( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
         static void reset();
         static void finalize_all();

--- a/src/anatomy.h
+++ b/src/anatomy.h
@@ -34,6 +34,7 @@ class anatomy
     public:
         anatomy_id id;
         std::vector<std::pair<anatomy_id, mod_id>> src;
+        std::vector<std::pair<anatomy_id, mod_id>> second_src;
         bool was_loaded = false;
 
         anatomy() = default;

--- a/src/ascii_art.cpp
+++ b/src/ascii_art.cpp
@@ -31,12 +31,12 @@ bool string_id<ascii_art>::is_valid() const
     return ascii_art_factory.is_valid( *this );
 }
 
-void ascii_art::load_ascii_art( const JsonObject &jo, const std::string &src )
+void ascii_art::load_ascii_art( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    ascii_art_factory.load( jo, src );
+    ascii_art_factory.load( jo, src, second_src );
 }
 
-void ascii_art::load( const JsonObject &jo, const std::string_view )
+void ascii_art::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     assign( jo, "id", id );
 

--- a/src/ascii_art.h
+++ b/src/ascii_art.h
@@ -22,6 +22,7 @@ class ascii_art
 
         ascii_art_id id;
         std::vector<std::pair<ascii_art_id, mod_id>> src;
+        std::vector<std::pair<ascii_art_id, mod_id>> second_src;
         std::vector<std::string> picture;
 };
 

--- a/src/ascii_art.h
+++ b/src/ascii_art.h
@@ -14,10 +14,10 @@ class JsonObject;
 class ascii_art
 {
     public:
-        static void load_ascii_art( const JsonObject &jo, const std::string &src );
+        static void load_ascii_art( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
 
-        void load( const JsonObject &jo, std::string_view );
+        void load( const JsonObject &jo, std::string_view, const std::string_view );
         bool was_loaded = false;
 
         ascii_art_id id;

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -129,12 +129,12 @@ const node_t &string_id<node_t>::obj() const
     return behavior_factory.obj( *this );
 }
 
-void behavior::load_behavior( const JsonObject &jo, const std::string &src )
+void behavior::load_behavior( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    behavior_factory.load( jo, src );
+    behavior_factory.load( jo, src, second_src );
 }
 
-void node_t::load( const JsonObject &jo, const std::string_view )
+void node_t::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     // We don't initialize the node unless it has no children (opportunistic optimization).
     // Instead we initialize a parallel struct that holds the labels until finalization.

--- a/src/behavior.h
+++ b/src/behavior.h
@@ -71,7 +71,7 @@ class node_t
         void add_child( const node_t *new_child );
 
         // Loading interface.
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void check() const;
         string_id<node_t> id;
         std::vector<std::pair<string_id<node_t>, mod_id>> src;
@@ -87,7 +87,7 @@ class node_t
 };
 
 // Deserialization support.
-void load_behavior( const JsonObject &jo, const std::string &src );
+void load_behavior( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
 void reset();
 

--- a/src/behavior.h
+++ b/src/behavior.h
@@ -75,6 +75,7 @@ class node_t
         void check() const;
         string_id<node_t> id;
         std::vector<std::pair<string_id<node_t>, mod_id>> src;
+        std::vector<std::pair<string_id<node_t>, mod_id>> second_src;
         bool was_loaded = false;
     private:
         std::vector<const node_t *> children;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -368,15 +368,15 @@ void bionic_data::load( const JsonObject &jsobj, const std::string_view src, con
     optional( jsobj, was_loaded, "deactivated_close_ui", deactivated_close_ui, false );
 
     for( JsonValue jv : jsobj.get_array( "activated_eocs" ) ) {
-        activated_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        activated_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 
     for( JsonValue jv : jsobj.get_array( "processed_eocs" ) ) {
-        processed_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        processed_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 
     for( JsonValue jv : jsobj.get_array( "deactivated_eocs" ) ) {
-        deactivated_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        deactivated_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 
     int enchant_num = 0;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -306,7 +306,7 @@ static social_modifiers load_bionic_social_mods( const JsonObject &jo )
     return ret;
 }
 
-void bionic_data::load( const JsonObject &jsobj, const std::string_view src )
+void bionic_data::load( const JsonObject &jsobj, const std::string_view src, const std::string &second_src )
 {
 
     mandatory( jsobj, was_loaded, "id", id );
@@ -382,7 +382,7 @@ void bionic_data::load( const JsonObject &jsobj, const std::string_view src )
     int enchant_num = 0;
     for( JsonValue jv : jsobj.get_array( "enchantments" ) ) {
         std::string enchant_name = "INLINE_ENCH_" + name + "_" + std::to_string( enchant_num++ );
-        enchantments.push_back( enchantment::load_inline_enchantment( jv, src, enchant_name ) );
+        enchantments.push_back( enchantment::load_inline_enchantment( jv, src, enchant_name, second_src ) );
     }
 
     if( jsobj.has_array( "encumbrance" ) ) {
@@ -442,14 +442,14 @@ void bionic_data::finalize()
     }
 }
 
-void bionic_data::load_bionic( const JsonObject &jo, const std::string &src )
+void bionic_data::load_bionic( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    bionic_factory.load( jo, src );
+    bionic_factory.load( jo, src, second_src );
 }
 
 std::map<bionic_id, bionic_id> bionic_data::migrations;
 
-void bionic_data::load_bionic_migration( const JsonObject &jo, const std::string_view )
+void bionic_data::load_bionic_migration( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     const bionic_id from( jo.get_string( "from" ) );
     const bionic_id to = jo.has_string( "to" )

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -64,6 +64,7 @@ struct bionic_data {
     /**Requirement to bionic installation - this is a crafting requirement such as soldering_standard or surface_heat*/
     requirement_id installation_requirement;
     std::vector<std::pair<bionic_id, mod_id>> src;
+    std::vector<std::pair<bionic_id, mod_id>> second_src;
     /**Fuel types that can be used by this bionic*/
     std::vector<material_id> fuel_opts;
     /** effect_on_conditions triggered when this bionic is activated */

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -184,15 +184,15 @@ struct bionic_data {
 
     itype_id itype() const;
 
-    void load( const JsonObject &obj, std::string_view src );
+    void load( const JsonObject &obj, std::string_view src, const std::string &second_src );
     void finalize();
-    static void load_bionic( const JsonObject &jo, const std::string &src );
+    static void load_bionic( const JsonObject &jo, const std::string &src, const std::string &second_src );
     static void finalize_bionic();
     static const std::vector<bionic_data> &get_all();
     static void check_bionic_consistency();
 
     static std::map<bionic_id, bionic_id> migrations;
-    static void load_bionic_migration( const JsonObject &jo, std::string_view );
+    static void load_bionic_migration( const JsonObject &jo, std::string_view, std::string_view );
 };
 
 struct bionic {

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -62,9 +62,9 @@ bool string_id<bodygraph>::is_valid() const
     return bodygraph_factory.is_valid( *this );
 }
 
-void bodygraph::load_bodygraphs( const JsonObject &jo, const std::string &src )
+void bodygraph::load_bodygraphs( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    bodygraph_factory.load( jo, src );
+    bodygraph_factory.load( jo, src, second_src );
 }
 
 void bodygraph::reset()
@@ -87,7 +87,7 @@ void bodygraph::check_all()
     bodygraph_factory.check();
 }
 
-void bodygraph::load( const JsonObject &jo, const std::string_view )
+void bodygraph::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     optional( jo, was_loaded, "parent_bodypart", parent_bp );
     optional( jo, was_loaded, "fill_sym", fill_sym );

--- a/src/bodygraph.h
+++ b/src/bodygraph.h
@@ -60,12 +60,12 @@ struct bodygraph {
     nc_color fill_color = c_white;
     bool was_loaded = false;
 
-    static void load_bodygraphs( const JsonObject &jo, const std::string &src );
+    static void load_bodygraphs( const JsonObject &jo, const std::string &src, const std::string &second_src );
     static void finalize_all();
     static void check_all();
     static void reset();
     static const std::vector<bodygraph> &get_all();
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
     void finalize();
     void check() const;
 };

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -145,9 +145,9 @@ bool string_id<limb_score>::is_valid() const
     return limb_score_factory.is_valid( *this );
 }
 
-void limb_score::load_limb_scores( const JsonObject &jo, const std::string &src )
+void limb_score::load_limb_scores( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    limb_score_factory.load( jo, src );
+    limb_score_factory.load( jo, src, second_src );
 }
 
 void limb_score::reset()
@@ -160,7 +160,7 @@ const std::vector<limb_score> &limb_score::get_all()
     return limb_score_factory.get_all();
 }
 
-void limb_score::load( const JsonObject &jo, const std::string_view )
+void limb_score::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", _name );
@@ -239,9 +239,9 @@ const bodypart_str_id &convert_bp( body_part bp )
     return body_parts[static_cast<size_t>( bp )];
 }
 
-void body_part_type::load_bp( const JsonObject &jo, const std::string &src )
+void body_part_type::load_bp( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    body_part_factory.load( jo, src );
+    body_part_factory.load( jo, src, second_src );
 }
 
 body_part_type::type body_part_type::primary_limb_type() const
@@ -287,7 +287,7 @@ const std::vector<body_part_type> &body_part_type::get_all()
     return body_part_factory.get_all();
 }
 
-void body_part_type::load( const JsonObject &jo, const std::string_view )
+void body_part_type::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
 

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -126,6 +126,7 @@ struct limb_score {
     private:
         limb_score_id id;
         std::vector<std::pair<limb_score_id, mod_id>> src;
+        std::vector<std::pair<limb_score_id, mod_id>> second_src;
         translation _name;
         bool wound_affect = true;
         bool encumb_affect = true;
@@ -203,6 +204,7 @@ struct body_part_type {
         };
 
         std::vector<std::pair<bodypart_str_id, mod_id>> src;
+        std::vector<std::pair<bodypart_str_id, mod_id>> second_src;
 
         /** Sub-location of the body part used for encumberance, coverage and determining protection
          */

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -106,9 +106,9 @@ struct stat_hp_mods {
 
 struct limb_score {
     public:
-        static void load_limb_scores( const JsonObject &jo, const std::string &src );
+        static void load_limb_scores( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         static const std::vector<limb_score> &get_all();
 
         const limb_score_id &getId() const {
@@ -345,11 +345,11 @@ struct body_part_type {
         // if secondary is true instead returns a part from only the secondary sublocations
         sub_bodypart_id random_sub_part( bool secondary ) const;
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void finalize();
         void check() const;
 
-        static void load_bp( const JsonObject &jo, const std::string &src );
+        static void load_bp( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static const std::vector<body_part_type> &get_all();
 
         // Clears all bps

--- a/src/butchery_requirements.cpp
+++ b/src/butchery_requirements.cpp
@@ -33,9 +33,9 @@ bool string_id<butchery_requirements>::is_valid() const
     return butchery_req_factory.is_valid( *this );
 }
 
-void butchery_requirements::load_butchery_req( const JsonObject &jo, const std::string &src )
+void butchery_requirements::load_butchery_req( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    butchery_req_factory.load( jo, src );
+    butchery_req_factory.load( jo, src, second_src );
 }
 
 const std::vector<butchery_requirements> &butchery_requirements::get_all()
@@ -53,7 +53,7 @@ bool butchery_requirements::is_valid() const
     return butchery_req_factory.is_valid( this->id );
 }
 
-void butchery_requirements::load( const JsonObject &jo, const std::string_view )
+void butchery_requirements::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     for( const JsonMember member : jo.get_object( "requirements" ) ) {
         float modifier = std::stof( member.name() );

--- a/src/butchery_requirements.h
+++ b/src/butchery_requirements.h
@@ -32,8 +32,8 @@ class butchery_requirements
         std::pair<float, requirement_id> get_fastest_requirements(
             const read_only_visitable &crafting_inv, creature_size size, butcher_type butcher ) const;
 
-        static void load_butchery_req( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, std::string_view );
+        static void load_butchery_req( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load( const JsonObject &jo, std::string_view, const std::string_view );
         static const std::vector<butchery_requirements> &get_all();
         static void check_consistency();
         static void reset();

--- a/src/butchery_requirements.h
+++ b/src/butchery_requirements.h
@@ -27,6 +27,7 @@ class butchery_requirements
         bool was_loaded = false;
         string_id<butchery_requirements> id;
         std::vector<std::pair<string_id<butchery_requirements>, mod_id>> src;
+        std::vector<std::pair<string_id<butchery_requirements>, mod_id>> second_src;
 
         // tries to find the requirement with the highest speed bonus. if it fails it returns std::nullopt
         std::pair<float, requirement_id> get_fastest_requirements(

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -54,9 +54,9 @@ bool string_id<character_modifier>::is_valid() const
     return character_modifier_factory.is_valid( *this );
 }
 
-void character_modifier::load_character_modifiers( const JsonObject &jo, const std::string &src )
+void character_modifier::load_character_modifiers( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    character_modifier_factory.load( jo, src );
+    character_modifier_factory.load( jo, src, second_src );
 }
 
 void character_modifier::reset()
@@ -104,7 +104,7 @@ static float load_float_or_maxmovecost( const JsonObject &jo, const std::string 
     return val;
 }
 
-void character_modifier::load( const JsonObject &jo, const std::string_view )
+void character_modifier::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "description", desc );

--- a/src/character_modifier.h
+++ b/src/character_modifier.h
@@ -59,6 +59,7 @@ struct character_modifier {
         std::map<limb_score_id, float> limbscores;
         mod_type limbscore_modop = MULT;
         std::vector<std::pair<character_modifier_id, mod_id>> src;
+        std::vector<std::pair<character_modifier_id, mod_id>> second_src;
         body_part_type::type limbtype = body_part_type::type::num_types;
         translation desc = translation();
         mod_type modtype = mod_type::NONE;

--- a/src/character_modifier.h
+++ b/src/character_modifier.h
@@ -24,9 +24,9 @@ struct character_modifier {
             MULT
         };
 
-        static void load_character_modifiers( const JsonObject &jo, const std::string &src );
+        static void load_character_modifiers( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         static const std::vector<character_modifier> &get_all();
 
         // Use this to obtain the calculated modifier

--- a/src/city.cpp
+++ b/src/city.cpp
@@ -36,9 +36,9 @@ bool string_id<city>::is_valid() const
     return get_city_factory().is_valid( *this );
 }
 
-void city::load_city( const JsonObject &jo, const std::string &src )
+void city::load_city( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    get_city_factory().load( jo, src );
+    get_city_factory().load( jo, src, second_src );
 }
 
 void city::finalize()
@@ -71,7 +71,7 @@ void city::reset()
     get_city_factory().reset();
 }
 
-void city::load( const JsonObject &jo, const std::string_view )
+void city::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
 
     mandatory( jo, was_loaded, "id", id );

--- a/src/city.h
+++ b/src/city.h
@@ -13,9 +13,9 @@ class JsonObject;
 template <typename T> class generic_factory;
 
 struct city {
-    void load( const JsonObject &, std::string_view );
+    void load( const JsonObject &, std::string_view, const std::string_view );
     void check() const;
-    static void load_city( const JsonObject &, const std::string & );
+    static void load_city( const JsonObject &, const std::string &, const std::string & );
     static void finalize();
     static void check_consistency();
     static const std::vector<city> &get_all();

--- a/src/climbing.cpp
+++ b/src/climbing.cpp
@@ -76,9 +76,9 @@ const std::vector<climbing_aid> &climbing_aid::get_all()
     return climbing_aid_factory.get_all();
 }
 
-void climbing_aid::load_climbing_aid( const JsonObject &jo, const std::string &src )
+void climbing_aid::load_climbing_aid( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    climbing_aid_factory.load( jo, src );
+    climbing_aid_factory.load( jo, src, second_src );
 }
 
 void climbing_aid::finalize()
@@ -131,7 +131,7 @@ void climbing_aid::reset()
     climbing_aid_default_ptr = nullptr;
 }
 
-void climbing_aid::load( const JsonObject &jo, std::string_view )
+void climbing_aid::load( const JsonObject &jo, std::string_view, const std::string_view )
 {
     optional( jo, was_loaded, "slip_chance_mod", slip_chance_mod );
     mandatory( jo, was_loaded, "down", down );

--- a/src/climbing.h
+++ b/src/climbing.h
@@ -55,11 +55,11 @@ class climbing_aid
             void deserialize( const JsonObject &jo );
         };
 
-        static void load_climbing_aid( const JsonObject &jo, const std::string &src );
+        static void load_climbing_aid( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void finalize();
         static void check_consistency();
         static void reset();
-        void load( const JsonObject &jo, std::string_view );
+        void load( const JsonObject &jo, std::string_view, const std::string_view );
 
 
         using lookup = std::vector<std::unordered_multimap<std::string, const climbing_aid *> >;

--- a/src/climbing.h
+++ b/src/climbing.h
@@ -144,6 +144,7 @@ class climbing_aid
         // Identity of the climbing aid, and index in get_all() list.
         climbing_aid_id id;
         std::vector<std::pair<climbing_aid_id, mod_id>> src;
+        std::vector<std::pair<climbing_aid_id, mod_id>> second_src;
 
         // Every climbing aid is based on one primary requirement without which it can't be used.
         condition base_condition;

--- a/src/clothing_mod.cpp
+++ b/src/clothing_mod.cpp
@@ -64,7 +64,7 @@ std::string enum_to_string<clothing_mod_type>( clothing_mod_type data )
 
 } // namespace io
 
-void clothing_mod::load( const JsonObject &jo, const std::string_view )
+void clothing_mod::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "flag", flag );
     mandatory( jo, was_loaded, "item", item_string );
@@ -131,9 +131,9 @@ size_t clothing_mod::count()
     return all_clothing_mods.size();
 }
 
-void clothing_mods::load( const JsonObject &jo, const std::string &src )
+void clothing_mods::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    all_clothing_mods.load( jo, src );
+    all_clothing_mods.load( jo, src, second_src );
 }
 
 void clothing_mods::reset()

--- a/src/clothing_mod.h
+++ b/src/clothing_mod.h
@@ -48,6 +48,7 @@ struct clothing_mod {
 
     clothing_mod_id id;
     std::vector<std::pair<clothing_mod_id, mod_id>> src;
+    std::vector<std::pair<clothing_mod_id, mod_id>> second_src;
     bool was_loaded = false;
 
     flag_id flag;

--- a/src/clothing_mod.h
+++ b/src/clothing_mod.h
@@ -42,7 +42,7 @@ struct mod_value {
 };
 
 struct clothing_mod {
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
     float get_mod_val( const clothing_mod_type &type, const item &it ) const;
     bool has_mod_type( const clothing_mod_type &type ) const;
 
@@ -75,7 +75,7 @@ constexpr std::array<clothing_mod_type, 9> all_clothing_mod_types = {{
     }
 };
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void reset();
 
 const std::vector<clothing_mod> &get_all();

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -148,9 +148,9 @@ const std::vector<zone_type> &zone_type::get_all()
     return zone_type_factory.get_all();
 }
 
-void zone_type::load_zones( const JsonObject &jo, const std::string &src )
+void zone_type::load_zones( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    zone_type_factory.load( jo, src );
+    zone_type_factory.load( jo, src, second_src );
 }
 
 void zone_type::reset()
@@ -158,7 +158,7 @@ void zone_type::reset()
     zone_type_factory.reset();
 }
 
-void zone_type::load( const JsonObject &jo, const std::string_view )
+void zone_type::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "id", id );

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -48,6 +48,7 @@ class zone_type
 
         zone_type_id id;
         std::vector<std::pair<zone_type_id, mod_id>> src;
+        std::vector<std::pair<zone_type_id, mod_id>> second_src;
         bool was_loaded = false;
 
         zone_type() = default;

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -62,9 +62,9 @@ class zone_type
         bool can_be_personal = false;
         bool hidden = false;
 
-        static void load_zones( const JsonObject &jo, const std::string &src );
+        static void load_zones( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
-        void load( const JsonObject &jo, std::string_view );
+        void load( const JsonObject &jo, std::string_view, const std::string_view );
         /**
          * All zone types in the game.
          */

--- a/src/construction_category.cpp
+++ b/src/construction_category.cpp
@@ -53,7 +53,7 @@ const string_id<construction_category> &int_id<construction_category>::id() cons
     return all_construction_categories.convert( *this );
 }
 
-void construction_category::load( const JsonObject &jo, const std::string_view )
+void construction_category::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
 }
@@ -63,9 +63,9 @@ size_t construction_category::count()
     return all_construction_categories.size();
 }
 
-void construction_categories::load( const JsonObject &jo, const std::string &src )
+void construction_categories::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    all_construction_categories.load( jo, src );
+    all_construction_categories.load( jo, src, second_src );
 }
 
 void construction_categories::reset()

--- a/src/construction_category.h
+++ b/src/construction_category.h
@@ -14,7 +14,7 @@
 class JsonObject;
 
 struct construction_category {
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
         construction_category_id id;
         std::vector<std::pair<construction_category_id, mod_id>> src;
@@ -32,7 +32,7 @@ struct construction_category {
 namespace construction_categories
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void reset();
 
 const std::vector<construction_category> &get_all();

--- a/src/construction_category.h
+++ b/src/construction_category.h
@@ -18,6 +18,7 @@ struct construction_category {
 
         construction_category_id id;
         std::vector<std::pair<construction_category_id, mod_id>> src;
+        std::vector<std::pair<construction_category_id, mod_id>> second_src;
         bool was_loaded = false;
 
         std::string name() const {

--- a/src/construction_group.cpp
+++ b/src/construction_group.cpp
@@ -53,7 +53,7 @@ const string_id<construction_group> &int_id<construction_group>::id() const
     return all_construction_groups.convert( *this );
 }
 
-void construction_group::load( const JsonObject &jo, const std::string_view )
+void construction_group::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
 }
@@ -68,9 +68,9 @@ size_t construction_group::count()
     return all_construction_groups.size();
 }
 
-void construction_groups::load( const JsonObject &jo, const std::string &src )
+void construction_groups::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    all_construction_groups.load( jo, src );
+    all_construction_groups.load( jo, src, second_src );
 }
 
 void construction_groups::reset()

--- a/src/construction_group.h
+++ b/src/construction_group.h
@@ -18,6 +18,7 @@ struct construction_group {
 
         construction_group_str_id id;
         std::vector<std::pair<construction_group_str_id, mod_id>> src;
+        std::vector<std::pair<construction_group_str_id, mod_id>> second_src;
         bool was_loaded = false;
 
         std::string name() const;

--- a/src/construction_group.h
+++ b/src/construction_group.h
@@ -14,7 +14,7 @@
 class JsonObject;
 
 struct construction_group {
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
         construction_group_str_id id;
         std::vector<std::pair<construction_group_str_id, mod_id>> src;
@@ -31,7 +31,7 @@ struct construction_group {
 namespace construction_groups
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void reset();
 
 const std::vector<construction_group> &get_all();

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -143,12 +143,12 @@ static std::string get_cat_unprefixed( const std::string_view prefixed_name )
     return std::string( prefixed_name.substr( 3, prefixed_name.size() - 3 ) );
 }
 
-void load_recipe_category( const JsonObject &jsobj, const std::string &src )
+void load_recipe_category( const JsonObject &jsobj, const std::string &src, const std::string &second_src )
 {
-    craft_cat_list.load( jsobj, src );
+    craft_cat_list.load( jsobj, src, second_src );
 }
 
-void crafting_category::load( const JsonObject &jo, const std::string_view )
+void crafting_category::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     // Ensure id is correct
     if( id.str().find( "CC_" ) != 0 ) {

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -23,7 +23,7 @@ class recipe;
 std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &batch_size_out,
         const recipe_id &goto_recipe, Character *crafter, std::string filterstring = "" );
 
-void load_recipe_category( const JsonObject &jsobj, const std::string &src );
+void load_recipe_category( const JsonObject &jsobj, const std::string &src, const std::string &second_src );
 void reset_recipe_categories();
 
 // Returns nullptr if the category does not exist, or a pointer to its vector
@@ -40,7 +40,7 @@ struct crafting_category {
     bool is_wildcard;
     std::vector<std::string> subcategories;
 
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
 };
 
 #endif // CATA_SRC_CRAFTING_GUI_H

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -112,7 +112,7 @@ static damage_info_order::info_disp read_info_disp( const std::string &s )
     }
 }
 
-void damage_type::load( const JsonObject &jo, std::string_view src, const std::string_view )
+void damage_type::load( const JsonObject &jo, std::string_view src, const std::string_view second_src )
 {
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "skill", skill, skill_id::NULL_ID() );
@@ -151,11 +151,11 @@ void damage_type::load( const JsonObject &jo, std::string_view src, const std::s
     }
 
     for( JsonValue jv : jo.get_array( "onhit_eocs" ) ) {
-        onhit_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, std::string( src ) ) );
+        onhit_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, std::string( src ), second_src ) );
     }
 
     for( JsonValue jv : jo.get_array( "ondamage_eocs" ) ) {
-        ondamage_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, std::string( src ) ) );
+        ondamage_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, std::string( src ), second_src ) );
     }
 }
 

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -65,9 +65,9 @@ bool string_id<damage_info_order>::is_valid() const
     return damage_info_order_factory.is_valid( *this );
 }
 
-void damage_type::load_damage_types( const JsonObject &jo, const std::string &src )
+void damage_type::load_damage_types( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    damage_type_factory.load( jo, src );
+    damage_type_factory.load( jo, src, second_src );
 }
 
 void damage_type::reset()
@@ -80,9 +80,9 @@ const std::vector<damage_type> &damage_type::get_all()
     return damage_type_factory.get_all();
 }
 
-void damage_info_order::load_damage_info_orders( const JsonObject &jo, const std::string &src )
+void damage_info_order::load_damage_info_orders( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    damage_info_order_factory.load( jo, src );
+    damage_info_order_factory.load( jo, src, second_src );
 }
 
 void damage_info_order::reset()
@@ -112,7 +112,7 @@ static damage_info_order::info_disp read_info_disp( const std::string &s )
     }
 }
 
-void damage_type::load( const JsonObject &jo, std::string_view src )
+void damage_type::load( const JsonObject &jo, std::string_view src, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "skill", skill, skill_id::NULL_ID() );
@@ -188,7 +188,7 @@ void damage_info_order::damage_info_order_entry::load( const JsonObject &jo,
     }
 }
 
-void damage_info_order::load( const JsonObject &jo, std::string_view )
+void damage_info_order::load( const JsonObject &jo, std::string_view, const std::string_view )
 {
     dmg_type = damage_type_id( id.c_str() );
     bionic_info.load( jo, "bionic_info" );

--- a/src/damage.h
+++ b/src/damage.h
@@ -52,10 +52,10 @@ struct damage_type {
                            bodypart_str_id bp, double total_damage = 0.0,
                            double damage_taken = 0.0 ) const;
 
-    static void load_damage_types( const JsonObject &jo, const std::string &src );
+    static void load_damage_types( const JsonObject &jo, const std::string &src, const std::string &second_src );
     static void reset();
     static void check();
-    void load( const JsonObject &jo, std::string_view );
+    void load( const JsonObject &jo, std::string_view, const std::string_view );
     static const std::vector<damage_type> &get_all();
 };
 
@@ -89,11 +89,11 @@ struct damage_info_order {
     damage_info_order_entry ablative_info;
     bool was_loaded = false;
 
-    static void load_damage_info_orders( const JsonObject &jo, const std::string &src );
+    static void load_damage_info_orders( const JsonObject &jo, const std::string &src, const std::string &second_src );
     static void reset();
     static void finalize_all();
     void finalize();
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
     static const std::vector<damage_info_order> &get_all();
     static const std::vector<damage_info_order> &get_all( info_type sort_by );
 };

--- a/src/damage.h
+++ b/src/damage.h
@@ -55,7 +55,7 @@ struct damage_type {
     static void load_damage_types( const JsonObject &jo, const std::string &src, const std::string &second_src );
     static void reset();
     static void check();
-    void load( const JsonObject &jo, std::string_view, const std::string_view );
+    void load( const JsonObject &jo, std::string_view, const std::string_view second_src );
     static const std::vector<damage_type> &get_all();
 };
 

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -510,7 +510,7 @@ class json_talk_topic
 };
 
 void unload_talk_topics();
-void load_talk_topic( const JsonObject &jo, std::string_view src );
+void load_talk_topic( const JsonObject &jo, std::string_view src, const std::string &second_src );
 void get_raw_debug_fields( const JsonObject &jo, std::map<std::string, std::string> &debug_info );
 
 #endif // CATA_SRC_DIALOGUE_H

--- a/src/disease.cpp
+++ b/src/disease.cpp
@@ -24,12 +24,12 @@ bool string_id<disease_type>::is_valid() const
     return disease_factory.is_valid( *this );
 }
 
-void disease_type::load_disease_type( const JsonObject &jo, const std::string &src )
+void disease_type::load_disease_type( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    disease_factory.load( jo, src );
+    disease_factory.load( jo, src, second_src );
 }
 
-void disease_type::load( const JsonObject &jo, const std::string_view )
+void disease_type::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     disease_type new_disease;
 

--- a/src/disease.h
+++ b/src/disease.h
@@ -17,9 +17,9 @@ class JsonObject;
 class disease_type
 {
     public:
-        static void load_disease_type( const JsonObject &jo, const std::string &src );
+        static void load_disease_type( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
-        void load( const JsonObject &jo, std::string_view );
+        void load( const JsonObject &jo, std::string_view, const std::string_view );
         static const std::vector<disease_type> &get_all();
         static void check_disease_consistency();
         bool was_loaded = false;

--- a/src/disease.h
+++ b/src/disease.h
@@ -26,6 +26,7 @@ class disease_type
 
         diseasetype_id id;
         std::vector<std::pair<diseasetype_id, mod_id>> src;
+        std::vector<std::pair<diseasetype_id, mod_id>> second_src;
         time_duration min_duration = 1_turns;
         time_duration max_duration = 1_turns;
         int min_intensity = 1;

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1503,7 +1503,7 @@ static const std::unordered_set<efftype_id> hardcoded_movement_impairing = {{
     }
 };
 
-void load_effect_type( const JsonObject &jo, const std::string_view src )
+void load_effect_type( const JsonObject &jo, const std::string_view src, const std::string_view second_src )
 {
     effect_type new_etype;
     new_etype.id = efftype_id( jo.get_string( "id" ) );
@@ -1605,7 +1605,7 @@ void load_effect_type( const JsonObject &jo, const std::string_view src )
     for( JsonValue jv : jo.get_array( "enchantments" ) ) {
         std::string enchant_name = "INLINE_ENCH_" + new_etype.id.str() + "_" + std::to_string(
                                        enchant_num++ );
-        new_etype.enchantments.push_back( enchantment::load_inline_enchantment( jv, src, enchant_name ) );
+        new_etype.enchantments.push_back( enchantment::load_inline_enchantment( jv, src, enchant_name, second_src ) );
     }
     effect_types[new_etype.id] = new_etype;
 }

--- a/src/effect.h
+++ b/src/effect.h
@@ -103,7 +103,7 @@ struct effect_dur_mod {
 
 class effect_type
 {
-        friend void load_effect_type( const JsonObject &jo, std::string_view src );
+        friend void load_effect_type( const JsonObject &jo, std::string_view src, const std::string_view second_src );
         friend class effect;
     public:
         enum class memorial_gender : int {
@@ -444,7 +444,7 @@ class effect
 
 };
 
-void load_effect_type( const JsonObject &jo, std::string_view src );
+void load_effect_type( const JsonObject &jo, std::string_view src, const std::string_view second_src );
 void reset_effect_types();
 const std::map<efftype_id, effect_type> &get_effect_types();
 

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -75,7 +75,7 @@ void effect_on_conditions::check_consistency()
 {
 }
 
-void effect_on_condition::load( const JsonObject &jo, const std::string_view src )
+void effect_on_condition::load( const JsonObject &jo, const std::string_view src, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     optional( jo, was_loaded, "eoc_type", type, eoc_type::NUM_EOC_TYPES );
@@ -123,7 +123,7 @@ effect_on_condition_id effect_on_conditions::load_inline_eoc( const JsonValue &j
         return effect_on_condition_id( jv.get_string() );
     } else if( jv.test_object() ) {
         effect_on_condition inline_eoc;
-        inline_eoc.load( jv.get_object(), src );
+        inline_eoc.load( jv.get_object(), src, "" );
         mod_tracker::assign_src( inline_eoc, src );
         effect_on_condition_factory.insert( inline_eoc );
         return inline_eoc.id;
@@ -504,9 +504,9 @@ void effect_on_conditions::reset()
     effect_on_condition_factory.reset();
 }
 
-void effect_on_conditions::load( const JsonObject &jo, const std::string &src )
+void effect_on_conditions::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    effect_on_condition_factory.load( jo, src );
+    effect_on_condition_factory.load( jo, src, second_src );
 }
 
 void eoc_events::clear()

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -117,14 +117,14 @@ void effect_on_condition::load( const JsonObject &jo, const std::string_view src
 }
 
 effect_on_condition_id effect_on_conditions::load_inline_eoc( const JsonValue &jv,
-        const std::string_view src )
+        const std::string_view src, const std::string_view second_src )
 {
     if( jv.test_string() ) {
         return effect_on_condition_id( jv.get_string() );
     } else if( jv.test_object() ) {
         effect_on_condition inline_eoc;
         inline_eoc.load( jv.get_object(), src, "" );
-        mod_tracker::assign_src( inline_eoc, src );
+        mod_tracker::assign_src( inline_eoc, src, second_src );
         effect_on_condition_factory.insert( inline_eoc );
         return inline_eoc.id;
     } else {

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -74,7 +74,7 @@ struct effect_on_condition {
         bool check_deactivate( dialogue &d ) const;
         bool test_condition( dialogue &d ) const;
         void apply_true_effects( dialogue &d ) const;
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void finalize();
         void check() const;
         effect_on_condition() = default;
@@ -88,7 +88,7 @@ void finalize_all();
 /** Clear all loaded effects on condition (invalidating any pointers) */
 void reset();
 /** Load effect on condition from JSON definition */
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 /** Checks all loaded from JSON are valid */
 void check_consistency();
 /** Sets up the initial queue for a new character */

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -60,6 +60,7 @@ struct effect_on_condition {
         bool global = false;
         effect_on_condition_id id;
         std::vector<std::pair<effect_on_condition_id, mod_id>> src;
+        std::vector<std::pair<effect_on_condition_id, mod_id>> second_src;
         eoc_type type;
         std::function<bool( dialogue & )> condition;
         std::function<bool( dialogue & )> deactivate_condition;
@@ -96,7 +97,7 @@ void load_new_character( Character &you );
 /** Load any new eocs that don't exist in the save. */
 void load_existing_character( Character &you );
 /** Loads an inline eoc */
-effect_on_condition_id load_inline_eoc( const JsonValue &jv, std::string_view src );
+effect_on_condition_id load_inline_eoc( const JsonValue &jv, std::string_view src, std::string_view second_src );
 /** queue an eoc to happen in the future */
 void queue_effect_on_condition( time_duration duration, effect_on_condition_id eoc,
                                 Character &you, const std::unordered_map<std::string, std::string> &context );

--- a/src/end_screen.cpp
+++ b/src/end_screen.cpp
@@ -20,12 +20,12 @@ bool string_id<end_screen>::is_valid() const
     return end_screen_factory.is_valid( *this );
 }
 
-void end_screen::load_end_screen( const JsonObject &jo, const std::string &src )
+void end_screen::load_end_screen( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    end_screen_factory.load( jo, src );
+    end_screen_factory.load( jo, src, second_src );
 }
 
-void end_screen::load( const JsonObject &jo, std::string_view )
+void end_screen::load( const JsonObject &jo, std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "picture_id", picture_id );

--- a/src/end_screen.h
+++ b/src/end_screen.h
@@ -13,9 +13,9 @@ class JsonObject;
 
 struct end_screen {
     public:
-        static void load_end_screen( const JsonObject &jo, const std::string &src );
+        static void load_end_screen( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
-        void load( const JsonObject &jo, std::string_view );
+        void load( const JsonObject &jo, std::string_view, const std::string_view );
         static const std::vector<end_screen> &get_all();
         bool was_loaded = false;
 

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -74,9 +74,9 @@ bool string_id<event_transformation>::is_valid() const
     return event_transformation_factory.is_valid( *this );
 }
 
-void event_transformation::load_transformation( const JsonObject &jo, const std::string &src )
+void event_transformation::load_transformation( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    event_transformation_factory.load( jo, src );
+    event_transformation_factory.load( jo, src, second_src );
 }
 
 void event_transformation::check_consistency()
@@ -101,9 +101,9 @@ bool string_id<event_statistic>::is_valid() const
     return event_statistic_factory.is_valid( *this );
 }
 
-void event_statistic::load_statistic( const JsonObject &jo, const std::string &src )
+void event_statistic::load_statistic( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    event_statistic_factory.load( jo, src );
+    event_statistic_factory.load( jo, src, second_src );
 }
 
 void event_statistic::check_consistency()
@@ -128,9 +128,9 @@ bool string_id<score>::is_valid() const
     return score_factory.is_valid( *this );
 }
 
-void score::load_score( const JsonObject &jo, const std::string &src )
+void score::load_score( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    score_factory.load( jo, src );
+    score_factory.load( jo, src, second_src );
 }
 
 void score::check_consistency()
@@ -701,7 +701,7 @@ std::unique_ptr<stats_tracker_state> event_transformation::watch( stats_tracker 
     return impl_->watch( stats );
 }
 
-void event_transformation::load( const JsonObject &jo, const std::string_view )
+void event_transformation::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     std::map<std::string, new_field> new_fields;
     optional( jo, was_loaded, "new_fields", new_fields );
@@ -1217,7 +1217,7 @@ std::unique_ptr<stats_tracker_state> event_statistic::watch( stats_tracker &stat
     return impl_->watch( stats );
 }
 
-void event_statistic::load( const JsonObject &jo, const std::string_view )
+void event_statistic::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     std::string type;
     mandatory( jo, was_loaded, "stat_type", type );
@@ -1297,7 +1297,7 @@ cata_variant score::value( stats_tracker &stats ) const
     return stats.value_of( stat_ );
 }
 
-void score::load( const JsonObject &jo, const std::string_view )
+void score::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     optional( jo, was_loaded, "description", description_ );
     mandatory( jo, was_loaded, "statistic", stat_ );

--- a/src/event_statistics.h
+++ b/src/event_statistics.h
@@ -48,9 +48,9 @@ class event_transformation
         event_multiset value( stats_tracker & ) const;
         std::unique_ptr<stats_tracker_state> watch( stats_tracker & ) const;
 
-        void load( const JsonObject &, std::string_view );
+        void load( const JsonObject &, std::string_view, const std::string_view );
         void check() const;
-        static void load_transformation( const JsonObject &, const std::string & );
+        static void load_transformation( const JsonObject &, const std::string &, const std::string & );
         static void check_consistency();
         static void reset();
 
@@ -74,9 +74,9 @@ class event_statistic
         cata_variant value( stats_tracker & ) const;
         std::unique_ptr<stats_tracker_state> watch( stats_tracker & ) const;
 
-        void load( const JsonObject &, std::string_view );
+        void load( const JsonObject &, std::string_view, const std::string_view );
         void check() const;
-        static void load_statistic( const JsonObject &, const std::string & );
+        static void load_statistic( const JsonObject &, const std::string &, const std::string & );
         static void check_consistency();
         static void reset();
 
@@ -106,9 +106,9 @@ class score
         std::string description( stats_tracker & ) const;
         cata_variant value( stats_tracker & ) const;
 
-        void load( const JsonObject &, std::string_view );
+        void load( const JsonObject &, std::string_view, const std::string_view );
         void check() const;
-        static void load_score( const JsonObject &, const std::string & );
+        static void load_score( const JsonObject &, const std::string &, const std::string & );
         static void check_consistency();
         static const std::vector<score> &get_all();
         static void reset();

--- a/src/event_statistics.h
+++ b/src/event_statistics.h
@@ -56,6 +56,7 @@ class event_transformation
 
         string_id<event_transformation> id;
         std::vector<std::pair<string_id<event_transformation>, mod_id>> src;
+        std::vector<std::pair<string_id<event_transformation>, mod_id>> second_src;
         bool was_loaded = false;
 
         event_fields_type fields() const;
@@ -82,6 +83,7 @@ class event_statistic
 
         string_id<event_statistic> id;
         std::vector<std::pair<string_id<event_statistic>, mod_id>> src;
+        std::vector<std::pair<string_id<event_statistic>, mod_id>> second_src;
         bool was_loaded = false;
 
         const translation &description() const {
@@ -115,6 +117,7 @@ class score
 
         string_id<score> id;
         std::vector<std::pair<string_id<score>, mod_id>> src;
+        std::vector<std::pair<string_id<score>, mod_id>> second_src;
         bool was_loaded = false;
     private:
         translation description_;

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -50,14 +50,14 @@ const fault_id &faults::random_of_type_item_has( const item &it, const std::stri
     return fault_id::NULL_ID();
 }
 
-void faults::load_fault( const JsonObject &jo, const std::string &src )
+void faults::load_fault( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    fault_factory.load( jo, src );
+    fault_factory.load( jo, src, second_src );
 }
 
-void faults::load_fix( const JsonObject &jo, const std::string &src )
+void faults::load_fix( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    fault_fixes_factory.load( jo, src );
+    fault_fixes_factory.load( jo, src, second_src );
 }
 
 void faults::reset()
@@ -155,7 +155,7 @@ const std::set<fault_fix_id> &fault::get_fixes() const
     return fixes;
 }
 
-void fault::load( const JsonObject &jo, std::string_view )
+void fault::load( const JsonObject &jo, std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "description", description_ );
@@ -180,7 +180,7 @@ const requirement_data &fault_fix::get_requirements() const
     return *requirements;
 }
 
-void fault_fix::load( const JsonObject &jo, std::string_view )
+void fault_fix::load( const JsonObject &jo, std::string_view, const std::string_view )
 {
     fault_fix f;
     mandatory( jo, was_loaded, "name", name );

--- a/src/fault.h
+++ b/src/fault.h
@@ -22,8 +22,8 @@ struct requirement_data;
 
 namespace faults
 {
-void load_fault( const JsonObject &jo, const std::string &src );
-void load_fix( const JsonObject &jo, const std::string &src );
+void load_fault( const JsonObject &jo, const std::string &src, const std::string &second_src );
+void load_fix( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
 void reset();
 void finalize();
@@ -57,7 +57,7 @@ class fault_fix
 
         void finalize();
     private:
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void check() const;
         bool was_loaded = false; // used by generic_factory
         friend class generic_factory<fault_fix>;
@@ -78,7 +78,7 @@ class fault
 
         const std::set<fault_fix_id> &get_fixes() const;
     private:
-        void load( const JsonObject &jo, std::string_view );
+        void load( const JsonObject &jo, std::string_view, const std::string_view );
         void check() const;
         bool was_loaded = false; // used by generic_factory
         friend class generic_factory<fault>;

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -177,7 +177,7 @@ const field_intensity_level &field_type::get_intensity_level( int level ) const
     return intensity_levels[level];
 }
 
-void field_type::load( const JsonObject &jo, const std::string_view )
+void field_type::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     optional( jo, was_loaded, "legacy_enum_id", legacy_enum_id, -1 );
     for( const JsonObject jao : jo.get_array( "intensity_levels" ) ) {
@@ -359,9 +359,9 @@ size_t field_type::count()
     return get_all_field_types().size();
 }
 
-void field_types::load( const JsonObject &jo, const std::string &src )
+void field_types::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    get_all_field_types().load( jo, src );
+    get_all_field_types().load( jo, src, second_src );
 }
 
 void field_types::finalize_all()

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -67,6 +67,7 @@ struct field_immunity_data {
 struct field_effect {
     efftype_id id;
     std::vector<std::pair<efftype_id, mod_id>> src;
+    std::vector<std::pair<efftype_id, mod_id>> second_src;
     time_duration min_duration = 0_seconds;
     time_duration max_duration = 0_seconds;
     int intensity = 0;
@@ -188,6 +189,7 @@ struct field_type {
         // Used by generic_factory
         field_type_str_id id;
         std::vector<std::pair<field_type_str_id, mod_id>> src;
+        std::vector<std::pair<field_type_str_id, mod_id>> second_src;
         bool was_loaded = false;
 
         int legacy_enum_id = -1;

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -181,7 +181,7 @@ struct field_type;
 
 struct field_type {
     public:
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void finalize();
         void check() const;
 
@@ -269,7 +269,7 @@ struct field_type {
 namespace field_types
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void finalize_all();
 void check_consistency();
 void reset();

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -412,7 +412,7 @@ const json_flag &json_flag::get( const std::string &id )
     return f_id.is_valid() ? *f_id : null_value;
 }
 
-void json_flag::load( const JsonObject &jo, const std::string_view )
+void json_flag::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     // TODO: mark fields as mandatory where appropriate
     optional( jo, was_loaded, "info", info_ );
@@ -437,9 +437,9 @@ void json_flag::reset()
     json_flags_all.reset();
 }
 
-void json_flag::load_all( const JsonObject &jo, const std::string &src )
+void json_flag::load_all( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    json_flags_all.load( jo, src );
+    json_flags_all.load( jo, src, second_src );
 }
 
 void json_flag::check() const

--- a/src/flag.h
+++ b/src/flag.h
@@ -481,10 +481,10 @@ class json_flag
         int taste_mod_ = 0;
 
         /** Load flag definition from JSON */
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
         /** Load all flags from JSON */
-        static void load_all( const JsonObject &jo, const std::string &src );
+        static void load_all( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
         /** finalize */
         static void finalize_all( );

--- a/src/flag.h
+++ b/src/flag.h
@@ -406,6 +406,7 @@ class json_flag
         // used by generic_factory
         flag_id id = flag_NULL;
         std::vector<std::pair<flag_id, mod_id>> src;
+        std::vector<std::pair<flag_id, mod_id>> second_src;
         bool was_loaded = false;
 
         json_flag() = default;

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -54,6 +54,7 @@ struct gate_data {
 
     gate_id id;
     std::vector<std::pair<gate_id, mod_id>> src;
+    std::vector<std::pair<gate_id, mod_id>> second_src;
 
     ter_str_id door;
     ter_str_id floor;

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -68,7 +68,7 @@ struct gate_data {
     int bash_dmg;
     bool was_loaded;
 
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
     void check() const;
 
     bool is_suitable_wall( const tripoint_bub_ms &pos ) const;
@@ -83,7 +83,7 @@ generic_factory<gate_data> gates_data( "gate type" );
 
 } // namespace
 
-void gate_data::load( const JsonObject &jo, const std::string_view )
+void gate_data::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "door", door );
     mandatory( jo, was_loaded, "floor", floor );
@@ -143,9 +143,9 @@ bool gate_data::is_suitable_wall( const tripoint_bub_ms &pos ) const
     return iter != walls.end();
 }
 
-void gates::load( const JsonObject &jo, const std::string &src )
+void gates::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    gates_data.load( jo, src );
+    gates_data.load( jo, src, second_src );
 }
 
 void gates::check()

--- a/src/gates.h
+++ b/src/gates.h
@@ -15,7 +15,7 @@ class map;
 namespace gates
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void check();
 void reset();
 

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -299,7 +299,7 @@ class generic_factory
             }
             if( jo.has_string( id_member_name ) ) {
                 def.id = string_id<T>( jo.get_string( id_member_name ) );
-                mod_tracker::assign_src( def, src );
+                mod_tracker::assign_src( def, src, second_src );
                 def.load( jo, src, second_src );
                 insert( def );
 
@@ -320,7 +320,7 @@ class generic_factory
                         break;
                     }
                     def.id = string_id<T>( e );
-                    mod_tracker::assign_src( def, src );
+                    mod_tracker::assign_src( def, src, second_src );
                     def.load( jo, src, second_src );
                     insert( def );
                 }
@@ -331,7 +331,7 @@ class generic_factory
 
             } else if( jo.has_string( legacy_id_member_name ) ) {
                 def.id = string_id<T>( jo.get_string( legacy_id_member_name ) );
-                mod_tracker::assign_src( def, src );
+                mod_tracker::assign_src( def, src, second_src );
                 def.load( jo, src, second_src );
                 insert( def );
 
@@ -352,7 +352,7 @@ class generic_factory
                         break;
                     }
                     def.id = string_id<T>( e );
-                    mod_tracker::assign_src( def, src );
+                    mod_tracker::assign_src( def, src, second_src );
                     def.load( jo, src, second_src );
                     insert( def );
                 }

--- a/src/global_vars.h
+++ b/src/global_vars.h
@@ -52,7 +52,7 @@ class global_variables
         void serialize( JsonOut &jsout ) const;
 
         std::map<std::string, std::string> migrations; // NOLINT(cata-serialize)
-        static void load_migrations( const JsonObject &jo, const std::string_view &src );
+        static void load_migrations( const JsonObject &jo, const std::string_view &src, const std::string_view &second_src );
 
     private:
         std::unordered_map<std::string, std::string> global_values;

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -98,9 +98,9 @@ bool harvest_list::has_entry_type( const harvest_drop_type_id &type ) const
     return false;
 }
 
-void harvest_drop_type::load_harvest_drop_types( const JsonObject &jo, const std::string &src )
+void harvest_drop_type::load_harvest_drop_types( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    harvest_drop_type_factory.load( jo, src );
+    harvest_drop_type_factory.load( jo, src, second_src );
 }
 
 void harvest_drop_type::reset()
@@ -108,7 +108,7 @@ void harvest_drop_type::reset()
     harvest_drop_type_factory.reset();
 }
 
-void harvest_drop_type::load( const JsonObject &jo, const std::string_view )
+void harvest_drop_type::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     harvest_skills.clear();
     optional( jo, was_loaded, "group", is_group_, false );
@@ -193,7 +193,7 @@ void harvest_list::finalize_all()
     }
 }
 
-void harvest_list::load( const JsonObject &obj, const std::string_view )
+void harvest_list::load( const JsonObject &obj, const std::string_view, const std::string_view )
 {
     mandatory( obj, was_loaded, "id", id );
     mandatory( obj, was_loaded, "entries", entries_, harvest_entry_reader{} );
@@ -204,9 +204,9 @@ void harvest_list::load( const JsonObject &obj, const std::string_view )
     optional( obj, was_loaded, "leftovers", leftovers, itype_ruined_chunks );
 }
 
-void harvest_list::load_harvest_list( const JsonObject &jo, const std::string &src )
+void harvest_list::load_harvest_list( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    harvest_list_factory.load( jo, src );
+    harvest_list_factory.load( jo, src, second_src );
 }
 
 const std::vector<harvest_list> &harvest_list::get_all()

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -21,9 +21,9 @@ using butchery_requirements_id = string_id<butchery_requirements>;
 class harvest_drop_type
 {
     public:
-        static void load_harvest_drop_types( const JsonObject &jo, const std::string &src );
+        static void load_harvest_drop_types( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         static const std::vector<harvest_drop_type> &get_all();
 
         const harvest_drop_type_id &getId() {
@@ -147,8 +147,8 @@ class harvest_list
         static void reset();
 
         bool was_loaded = false;
-        void load( const JsonObject &obj, std::string_view );
-        static void load_harvest_list( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &obj, std::string_view, const std::string_view );
+        static void load_harvest_list( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static const std::vector<harvest_list> &get_all();
 
     private:

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -55,6 +55,7 @@ class harvest_drop_type
     private:
         harvest_drop_type_id id;
         std::vector<std::pair<harvest_drop_type_id, mod_id>> src;
+        std::vector<std::pair<harvest_drop_type_id, mod_id>> second_src;
         bool is_group_;
         bool dissect_only_;
         bool was_loaded = false;
@@ -104,6 +105,7 @@ class harvest_list
 
         harvest_id id;
         std::vector<std::pair<harvest_id, mod_id>> src;
+        std::vector<std::pair<harvest_id, mod_id>> second_src;
 
         std::string message() const;
 

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -265,7 +265,7 @@ void eoc_examine_actor::call( Character &you, const tripoint_bub_ms &examp ) con
 void eoc_examine_actor::load( const JsonObject &jo, const std::string &src )
 {
     for( JsonValue jv : jo.get_array( "effect_on_conditions" ) ) {
-        eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, src, "" ) );
     }
 }
 

--- a/src/init.h
+++ b/src/init.h
@@ -61,7 +61,7 @@ class DynamicDataLoader
          * JSON data dependent upon as-yet unparsed definitions
          * first: JSON source location, second: source identifier
          */
-        using deferred_json = std::list<std::pair<JsonObject, std::string>>;
+        using deferred_json = std::list<std::tuple<JsonObject, std::string, std::string>>;
 
     private:
         bool finalized = false;
@@ -77,17 +77,17 @@ class DynamicDataLoader
          */
         using type_string = std::string;
         using t_type_function_map =
-            std::map<type_string, std::function<void( const JsonObject &, const std::string &, const cata_path &, const cata_path & )>>;
+            std::map<type_string, std::function<void( const JsonObject &, const std::string &, const cata_path &, const cata_path &, const std::string & )>>;
         using str_vec = std::vector<std::string>;
         t_type_function_map type_function_map;
         void add( const std::string &type, const std::function<void( const JsonObject & )> &f );
         void add( const std::string &type,
-                  const std::function<void( const JsonObject &, const std::string & )> &f );
+                  const std::function<void( const JsonObject &, const std::string &, const std::string & )> &f );
         void add( const std::string &type,
-                  const std::function<void( const JsonObject &, const std::string &, const std::string &, const std::string & )>
+                  const std::function<void( const JsonObject &, const std::string &, const std::string &, const std::string &, const std::string & )>
                   &f );
         void add( const std::string &type,
-                  const std::function<void( const JsonObject &, const std::string &, const cata_path &, const cata_path & )>
+                  const std::function<void( const JsonObject &, const std::string &, const cata_path &, const cata_path &, const std::string & )>
                   &f );
         /**
          * Load all the types from that json data.
@@ -99,7 +99,7 @@ class DynamicDataLoader
          * @throws std::exception on all kind of errors.
          */
         void load_all_from_json( const JsonValue &jsin, const std::string &src,
-                                 const cata_path &base_path, const cata_path &full_path );
+                                 const cata_path &base_path, const cata_path &full_path, const std::string &second_src = "" );
         /**
          * Load a single object from a json object.
          * @param jo The json object to load the C++-object from.
@@ -108,7 +108,7 @@ class DynamicDataLoader
          */
         void load_object( const JsonObject &jo, const std::string &src,
                           const cata_path &base_path = cata_path{},
-                          const cata_path &full_path = cata_path{} );
+                          const cata_path &full_path = cata_path{}, const std::string &second_src = "" );
 
         DynamicDataLoader();
         ~DynamicDataLoader();

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -40,9 +40,9 @@ const std::vector<item_category> &item_category::get_all()
     return item_category_factory.get_all();
 }
 
-void item_category::load_item_cat( const JsonObject &jo, const std::string &src )
+void item_category::load_item_cat( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    item_category_factory.load( jo, src );
+    item_category_factory.load( jo, src, second_src );
 }
 
 void item_category::reset()
@@ -50,7 +50,7 @@ void item_category::reset()
     item_category_factory.reset();
 }
 
-void item_category::load( const JsonObject &jo, const std::string_view )
+void item_category::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name_header", name_header_ );

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -48,6 +48,7 @@ class item_category
         /** Unique ID of this category, used when loading from JSON. */
         item_category_id id;
         std::vector<std::pair<item_category_id, mod_id>> src;
+        std::vector<std::pair<item_category_id, mod_id>> second_src;
 
         item_category() = default;
         /**

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -90,9 +90,9 @@ class item_category
         bool was_loaded = false;
 
         static const std::vector<item_category> &get_all();
-        static void load_item_cat( const JsonObject &jo, const std::string &src );
+        static void load_item_cat( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
-        void load( const JsonObject &jo, std::string_view );
+        void load( const JsonObject &jo, std::string_view, const std::string_view );
 };
 
 struct item_category_spawn_rates {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2602,7 +2602,7 @@ void Item_factory::load_slot_optional( cata::value_ptr<SlotType> &slotptr, const
     load_slot( slotptr, slotjo, src );
 }
 
-bool Item_factory::load_definition( const JsonObject &jo, const std::string &src, itype &def )
+bool Item_factory::load_definition( const JsonObject &jo, const std::string &src, itype &def, const std::string &second_src )
 {
     cata_assert( !frozen );
 
@@ -2632,7 +2632,7 @@ bool Item_factory::load_definition( const JsonObject &jo, const std::string &src
         return true;
     }
 
-    deferred.emplace_back( jo, src );
+    deferred.emplace_back( jo, src, second_src );
     jo.allow_omitted_members();
     return false;
 }
@@ -2709,10 +2709,10 @@ void islot_ammo::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void Item_factory::load_ammo( const JsonObject &jo, const std::string &src )
+void Item_factory::load_ammo( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         assign( jo, "stack_size", def.stack_size, src == "dda", 1 );
         if( def.was_loaded ) {
             if( def.ammo ) {
@@ -2725,7 +2725,7 @@ void Item_factory::load_ammo( const JsonObject &jo, const std::string &src )
             def.ammo = cata::make_value<islot_ammo>();
         }
         def.ammo->load( jo );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -2739,10 +2739,10 @@ void islot_engine::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void Item_factory::load_engine( const JsonObject &jo, const std::string &src )
+void Item_factory::load_engine( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         if( def.was_loaded ) {
             if( def.engine ) {
                 def.engine->was_loaded = true;
@@ -2754,7 +2754,7 @@ void Item_factory::load_engine( const JsonObject &jo, const std::string &src )
             def.engine = cata::make_value<islot_engine>();
         }
         def.engine->load( jo );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -2769,10 +2769,10 @@ void islot_wheel::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void Item_factory::load_wheel( const JsonObject &jo, const std::string &src )
+void Item_factory::load_wheel( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         if( def.was_loaded ) {
             if( def.wheel ) {
                 def.wheel->was_loaded = true;
@@ -2784,7 +2784,7 @@ void Item_factory::load_wheel( const JsonObject &jo, const std::string &src )
             def.wheel = cata::make_value<islot_wheel>();
         }
         def.wheel->load( jo );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -2854,20 +2854,20 @@ void Item_factory::load( islot_gun &slot, const JsonObject &jo, const std::strin
     assign( jo, "hurt_part_when_fired", slot.hurt_part_when_fired );
 }
 
-void Item_factory::load_gun( const JsonObject &jo, const std::string &src )
+void Item_factory::load_gun( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         load_slot( def.gun, jo, src );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
 // TODO: Refactor this with load_tool_armor
-void Item_factory::load_armor( const JsonObject &jo, const std::string &src )
+void Item_factory::load_armor( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         if( def.was_loaded ) {
             if( def.armor ) {
                 def.armor->was_loaded = true;
@@ -2879,14 +2879,14 @@ void Item_factory::load_armor( const JsonObject &jo, const std::string &src )
             def.armor = cata::make_value<islot_armor>();
         }
         def.armor->load( jo );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
-void Item_factory::load_pet_armor( const JsonObject &jo, const std::string &src )
+void Item_factory::load_pet_armor( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         if( def.was_loaded ) {
             if( def.pet_armor ) {
                 def.pet_armor->was_loaded = true;
@@ -2898,7 +2898,7 @@ void Item_factory::load_pet_armor( const JsonObject &jo, const std::string &src 
             def.pet_armor = cata::make_value<islot_pet_armor>();
         }
         def.pet_armor->load( jo );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -3158,12 +3158,12 @@ void Item_factory::load( islot_tool &slot, const JsonObject &jo, const std::stri
     }
 }
 
-void Item_factory::load_tool( const JsonObject &jo, const std::string &src )
+void Item_factory::load_tool( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         load_slot( def.tool, jo, src );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -3210,21 +3210,21 @@ void Item_factory::load( islot_mod &slot, const JsonObject &jo, const std::strin
     }
 }
 
-void Item_factory::load_toolmod( const JsonObject &jo, const std::string &src )
+void Item_factory::load_toolmod( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         load_slot( def.mod, jo, src );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
 // TODO: Refactor this with load_armor
 // This function does load_slot( def.tool ), but otherwise they are the same
-void Item_factory::load_tool_armor( const JsonObject &jo, const std::string &src )
+void Item_factory::load_tool_armor( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         load_slot( def.tool, jo, src );
         if( def.was_loaded ) {
             if( def.armor ) {
@@ -3237,7 +3237,7 @@ void Item_factory::load_tool_armor( const JsonObject &jo, const std::string &src
             def.armor = cata::make_value<islot_armor>();
         }
         def.armor->load( jo );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -3262,10 +3262,10 @@ void islot_book::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void Item_factory::load_book( const JsonObject &jo, const std::string &src )
+void Item_factory::load_book( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         if( def.was_loaded ) {
             if( def.book ) {
                 def.book->was_loaded = true;
@@ -3277,7 +3277,7 @@ void Item_factory::load_book( const JsonObject &jo, const std::string &src )
             def.book = cata::make_value<islot_book>();
         }
         def.book->load( jo );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -3457,13 +3457,13 @@ void islot_compostable::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void Item_factory::load_comestible( const JsonObject &jo, const std::string &src )
+void Item_factory::load_comestible( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         assign( jo, "stack_size", def.stack_size, src == "dda", 1 );
         load_slot( def.comestible, jo, src );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -3557,13 +3557,13 @@ void Item_factory::load( islot_gunmod &slot, const JsonObject &jo, const std::st
     assign( jo, "barrel_length", slot.barrel_length );
 }
 
-void Item_factory::load_gunmod( const JsonObject &jo, const std::string &src )
+void Item_factory::load_gunmod( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         load_slot( def.gunmod, jo, src );
         load_slot( def.mod, jo, src );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -3579,12 +3579,12 @@ void Item_factory::load( islot_magazine &slot, const JsonObject &jo, const std::
     assign( jo, "linkage", slot.linkage, strict );
 }
 
-void Item_factory::load_magazine( const JsonObject &jo, const std::string &src )
+void Item_factory::load_magazine( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         load_slot( def.magazine, jo, src );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -3598,10 +3598,10 @@ void islot_battery::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void Item_factory::load_battery( const JsonObject &jo, const std::string &src )
+void Item_factory::load_battery( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         if( def.was_loaded ) {
             if( def.battery ) {
                 def.battery->was_loaded = true;
@@ -3613,7 +3613,7 @@ void Item_factory::load_battery( const JsonObject &jo, const std::string &src )
             def.battery = cata::make_value<islot_battery>();
         }
         def.battery->load( jo );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -3633,20 +3633,20 @@ void Item_factory::load( islot_bionic &slot, const JsonObject &jo, const std::st
     assign( jo, "installation_data", slot.installation_data );
 }
 
-void Item_factory::load_bionic( const JsonObject &jo, const std::string &src )
+void Item_factory::load_bionic( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
+    if( load_definition( jo, src, def, second_src ) ) {
         load_slot( def.bionic, jo, src );
-        load_basic_info( jo, def, src );
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
-void Item_factory::load_generic( const JsonObject &jo, const std::string &src )
+void Item_factory::load_generic( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     itype def;
-    if( load_definition( jo, src, def ) ) {
-        load_basic_info( jo, def, src );
+    if( load_definition( jo, src, def, second_src ) ) {
+        load_basic_info( jo, def, src, second_src );
     }
 }
 
@@ -4158,7 +4158,7 @@ static void replace_materials( const JsonObject &jo, itype &def )
     }
 }
 
-void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std::string &src )
+void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std::string &src, const std::string &second_src )
 {
     bool strict = src == "dda";
 
@@ -4816,8 +4816,9 @@ void Item_factory::clear()
     migrations.clear();
 
     /* Avoid unvisited member errors when iterating on json */
-    for( std::pair<JsonObject, std::string> &deferred_json : deferred ) {
-        deferred_json.first.allow_omitted_members();
+    for( std::tuple<JsonObject, std::string, std::string> &deferred_json : deferred ) {
+        // deferred_json.first.allow_omitted_members();
+        std::get<0>(deferred_json).allow_omitted_members();
     }
     deferred.clear();
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1656,7 +1656,7 @@ class iuse_function_wrapper : public iuse_actor
             return std::make_unique<iuse_function_wrapper>( *this );
         }
 
-        void load( const JsonObject &, const std::string & ) override {}
+        void load( const JsonObject &, const std::string &, const std::string & ) override {}
 };
 
 class iuse_function_wrapper_with_info : public iuse_function_wrapper
@@ -2583,7 +2583,7 @@ Item_spawn_data *Item_factory::get_group( const item_group_id &group_tag )
 
 template<typename SlotType>
 void Item_factory::load_slot( cata::value_ptr<SlotType> &slotptr, const JsonObject &jo,
-                              const std::string &src )
+                              const std::string &src, const std::string &second_src )
 {
     if( !slotptr ) {
         slotptr = cata::make_value<SlotType>();
@@ -2593,13 +2593,13 @@ void Item_factory::load_slot( cata::value_ptr<SlotType> &slotptr, const JsonObje
 
 template<typename SlotType>
 void Item_factory::load_slot_optional( cata::value_ptr<SlotType> &slotptr, const JsonObject &jo,
-                                       const std::string_view member, const std::string &src )
+                                       const std::string_view member, const std::string &src, const std::string &second_src )
 {
     if( !jo.has_member( member ) ) {
         return;
     }
     JsonObject slotjo = jo.get_object( member );
-    load_slot( slotptr, slotjo, src );
+    load_slot( slotptr, slotjo, src, second_src );
 }
 
 bool Item_factory::load_definition( const JsonObject &jo, const std::string &src, itype &def, const std::string &second_src )
@@ -2858,7 +2858,7 @@ void Item_factory::load_gun( const JsonObject &jo, const std::string &src, const
 {
     itype def;
     if( load_definition( jo, src, def, second_src ) ) {
-        load_slot( def.gun, jo, src );
+        load_slot( def.gun, jo, src, second_src );
         load_basic_info( jo, def, src, second_src );
     }
 }
@@ -3162,7 +3162,7 @@ void Item_factory::load_tool( const JsonObject &jo, const std::string &src, cons
 {
     itype def;
     if( load_definition( jo, src, def, second_src ) ) {
-        load_slot( def.tool, jo, src );
+        load_slot( def.tool, jo, src, second_src );
         load_basic_info( jo, def, src, second_src );
     }
 }
@@ -3214,7 +3214,7 @@ void Item_factory::load_toolmod( const JsonObject &jo, const std::string &src, c
 {
     itype def;
     if( load_definition( jo, src, def, second_src ) ) {
-        load_slot( def.mod, jo, src );
+        load_slot( def.mod, jo, src, second_src );
         load_basic_info( jo, def, src, second_src );
     }
 }
@@ -3225,7 +3225,7 @@ void Item_factory::load_tool_armor( const JsonObject &jo, const std::string &src
 {
     itype def;
     if( load_definition( jo, src, def, second_src ) ) {
-        load_slot( def.tool, jo, src );
+        load_slot( def.tool, jo, src, second_src );
         if( def.was_loaded ) {
             if( def.armor ) {
                 def.armor->was_loaded = true;
@@ -3383,7 +3383,7 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
     }
 
     for( JsonValue jv : jo.get_array( "consumption_effect_on_conditions" ) ) {
-        slot.consumption_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        slot.consumption_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, "replaceThis" ) );
     }
 
     if( jo.has_member( "nutrition" ) && got_calories ) {
@@ -3462,7 +3462,7 @@ void Item_factory::load_comestible( const JsonObject &jo, const std::string &src
     itype def;
     if( load_definition( jo, src, def, second_src ) ) {
         assign( jo, "stack_size", def.stack_size, src == "dda", 1 );
-        load_slot( def.comestible, jo, src );
+        load_slot( def.comestible, jo, src, second_src );
         load_basic_info( jo, def, src, second_src );
     }
 }
@@ -3561,8 +3561,8 @@ void Item_factory::load_gunmod( const JsonObject &jo, const std::string &src, co
 {
     itype def;
     if( load_definition( jo, src, def, second_src ) ) {
-        load_slot( def.gunmod, jo, src );
-        load_slot( def.mod, jo, src );
+        load_slot( def.gunmod, jo, src, second_src );
+        load_slot( def.mod, jo, src, second_src );
         load_basic_info( jo, def, src, second_src );
     }
 }
@@ -3583,7 +3583,7 @@ void Item_factory::load_magazine( const JsonObject &jo, const std::string &src, 
 {
     itype def;
     if( load_definition( jo, src, def, second_src ) ) {
-        load_slot( def.magazine, jo, src );
+        load_slot( def.magazine, jo, src, second_src );
         load_basic_info( jo, def, src, second_src );
     }
 }
@@ -3637,7 +3637,7 @@ void Item_factory::load_bionic( const JsonObject &jo, const std::string &src, co
 {
     itype def;
     if( load_definition( jo, src, def, second_src ) ) {
-        load_slot( def.bionic, jo, src );
+        load_slot( def.bionic, jo, src, second_src );
         load_basic_info( jo, def, src, second_src );
     }
 }
@@ -4403,8 +4403,8 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         }
     }
 
-    set_use_methods_from_json( jo, src, "use_action", def.use_methods, def.ammo_scale );
-    set_use_methods_from_json( jo, src, "tick_action", def.tick_action, def.ammo_scale );
+    set_use_methods_from_json( jo, src, "use_action", def.use_methods, def.ammo_scale, second_src );
+    set_use_methods_from_json( jo, src, "tick_action", def.tick_action, def.ammo_scale, second_src );
 
     assign( jo, "countdown_interval", def.countdown_interval );
     assign( jo, "revert_to", def.revert_to, strict );
@@ -4414,7 +4414,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
 
     } else if( jo.has_object( "countdown_action" ) ) {
         JsonObject tmp = jo.get_object( "countdown_action" );
-        use_function fun = usage_from_object( tmp, src ).second;
+        use_function fun = usage_from_object( tmp, src, second_src ).second;
         if( fun ) {
             def.countdown_action = fun;
         }
@@ -4425,7 +4425,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
 
     } else if( jo.has_object( "drop_action" ) ) {
         JsonObject tmp = jo.get_object( "drop_action" );
-        use_function fun = usage_from_object( tmp, src ).second;
+        use_function fun = usage_from_object( tmp, src, second_src ).second;
         if( fun ) {
             def.drop_action = fun;
         }
@@ -4451,13 +4451,13 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     assign( jo, "armor_data", def.armor, src == "dda" );
     assign( jo, "pet_armor_data", def.pet_armor, src == "dda" );
     assign( jo, "book_data", def.book, src == "dda" );
-    load_slot_optional( def.gun, jo, "gun_data", src );
-    load_slot_optional( def.bionic, jo, "bionic_data", src );
+    load_slot_optional( def.gun, jo, "gun_data", src, second_src );
+    load_slot_optional( def.bionic, jo, "bionic_data", src, second_src );
     assign( jo, "ammo_data", def.ammo, src == "dda" );
     assign( jo, "seed_data", def.seed, src == "dda" );
     assign( jo, "brewable", def.brewable, src == "dda" );
     assign( jo, "compostable", def.compostable, src == "dda" );
-    load_slot_optional( def.relic_data, jo, "relic_data", src );
+    load_slot_optional( def.relic_data, jo, "relic_data", src, second_src );
     assign( jo, "milling", def.milling_data, src == "dda" );
 
     // optional gunmod slot may also specify mod data
@@ -4465,8 +4465,8 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         // use the same JsonObject for the two load_slot calls to avoid
         // warnings about unvisited Json members
         JsonObject jo_gunmod = jo.get_object( "gunmod_data" );
-        load_slot( def.gunmod, jo_gunmod, src );
-        load_slot( def.mod, jo_gunmod, src );
+        load_slot( def.gunmod, jo_gunmod, src, second_src );
+        load_slot( def.mod, jo_gunmod, src, second_src );
     }
 
     if( jo.has_string( "abstract" ) ) {
@@ -4479,7 +4479,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     check_and_create_magazine_pockets( def );
     add_special_pockets( def );
 
-    mod_tracker::assign_src( def, src );
+    mod_tracker::assign_src( def, src, second_src );
 
     if( def.magazines.empty() ) {
         migrate_mag_from_pockets( def );
@@ -5203,7 +5203,7 @@ void Item_factory::load_item_group_data( const JsonObject &jsobj, Item_group *ig
 
 void Item_factory::set_use_methods_from_json( const JsonObject &jo, const std::string &src,
         const std::string &member, std::map<std::string, use_function> &use_methods,
-        std::map<std::string, int> &ammo_scale )
+        std::map<std::string, int> &ammo_scale, const std::string &second_src )
 {
     if( !jo.has_member( member ) ) {
         return;
@@ -5218,7 +5218,7 @@ void Item_factory::set_use_methods_from_json( const JsonObject &jo, const std::s
                 emplace_usage( use_methods, type );
             } else if( entry.test_object() ) {
                 JsonObject obj = entry.get_object();
-                std::pair<std::string, use_function> fun = usage_from_object( obj, src );
+                std::pair<std::string, use_function> fun = usage_from_object( obj, src, second_src );
                 if( fun.second ) {
                     use_methods.insert( fun );
                     if( obj.has_int( "ammo_scale" ) ) {
@@ -5242,7 +5242,7 @@ void Item_factory::set_use_methods_from_json( const JsonObject &jo, const std::s
             emplace_usage( use_methods, type );
         } else if( jo.has_object( member ) ) {
             JsonObject obj = jo.get_object( member );
-            std::pair<std::string, use_function> fun = usage_from_object( obj, src );
+            std::pair<std::string, use_function> fun = usage_from_object( obj, src, second_src );
             if( fun.second ) {
                 use_methods.insert( fun );
                 if( obj.has_int( "ammo_scale" ) ) {
@@ -5267,7 +5267,7 @@ void Item_factory::emplace_usage( std::map<std::string, use_function> &container
 }
 
 std::pair<std::string, use_function> Item_factory::usage_from_object( const JsonObject &obj,
-        const std::string &src )
+        const std::string &src, const std::string &second_src )
 {
     std::string type = obj.get_string( "type" );
 
@@ -5285,7 +5285,7 @@ std::pair<std::string, use_function> Item_factory::usage_from_object( const Json
         return std::make_pair( type, use_function() );
     }
 
-    method.get_actor_ptr()->load( obj, src );
+    method.get_actor_ptr()->load( obj, src, second_src );
     return std::make_pair( type, method );
 }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2588,7 +2588,7 @@ void Item_factory::load_slot( cata::value_ptr<SlotType> &slotptr, const JsonObje
     if( !slotptr ) {
         slotptr = cata::make_value<SlotType>();
     }
-    load( *slotptr, jo, src );
+    load( *slotptr, jo, src, second_src );
 }
 
 template<typename SlotType>
@@ -2809,7 +2809,7 @@ void itype_variant_data::load( const JsonObject &jo )
     optional( jo, false, "expand_snippets", expand_snippets );
 }
 
-void Item_factory::load( islot_gun &slot, const JsonObject &jo, const std::string &src )
+void Item_factory::load( islot_gun &slot, const JsonObject &jo, const std::string &src, const std::string & )
 {
     bool strict = src == "dda";
     assign( jo, "skill", slot.skill_used, strict );
@@ -3120,7 +3120,7 @@ void islot_pet_armor::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void Item_factory::load( islot_tool &slot, const JsonObject &jo, const std::string &src )
+void Item_factory::load( islot_tool &slot, const JsonObject &jo, const std::string &src, const std::string & )
 {
     bool strict = src == "dda";
 
@@ -3167,12 +3167,12 @@ void Item_factory::load_tool( const JsonObject &jo, const std::string &src, cons
     }
 }
 
-void Item_factory::load( relic &slot, const JsonObject &jo, const std::string_view )
+void Item_factory::load( relic &slot, const JsonObject &jo, const std::string_view, const std::string & )
 {
     slot.load( jo );
 }
 
-void Item_factory::load( islot_mod &slot, const JsonObject &jo, const std::string &src )
+void Item_factory::load( islot_mod &slot, const JsonObject &jo, const std::string &src, const std::string & )
 {
     bool strict = src == "dda";
 
@@ -3281,7 +3281,7 @@ void Item_factory::load_book( const JsonObject &jo, const std::string &src, cons
     }
 }
 
-void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std::string &src )
+void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     bool strict = src == "dda";
 
@@ -3383,7 +3383,7 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
     }
 
     for( JsonValue jv : jo.get_array( "consumption_effect_on_conditions" ) ) {
-        slot.consumption_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, "replaceThis" ) );
+        slot.consumption_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 
     if( jo.has_member( "nutrition" ) && got_calories ) {
@@ -3484,7 +3484,7 @@ void islot_seed::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void Item_factory::load( islot_gunmod &slot, const JsonObject &jo, const std::string &src )
+void Item_factory::load( islot_gunmod &slot, const JsonObject &jo, const std::string &src, const std::string & )
 {
     bool strict = src == "dda";
 
@@ -3567,7 +3567,7 @@ void Item_factory::load_gunmod( const JsonObject &jo, const std::string &src, co
     }
 }
 
-void Item_factory::load( islot_magazine &slot, const JsonObject &jo, const std::string &src )
+void Item_factory::load( islot_magazine &slot, const JsonObject &jo, const std::string &src, const std::string & )
 {
     bool strict = src == "dda";
     assign( jo, "ammo_type", slot.type, strict );
@@ -3617,7 +3617,7 @@ void Item_factory::load_battery( const JsonObject &jo, const std::string &src, c
     }
 }
 
-void Item_factory::load( islot_bionic &slot, const JsonObject &jo, const std::string &src )
+void Item_factory::load( islot_bionic &slot, const JsonObject &jo, const std::string &src, const std::string & )
 {
     bool strict = src == "dda";
 

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -316,14 +316,14 @@ class Item_factory
         void load_slot_optional( cata::value_ptr<SlotType> &slotptr, const JsonObject &jo,
                                  std::string_view member, const std::string &src, const std::string &second_src );
 
-        void load( islot_tool &slot, const JsonObject &jo, const std::string &src );
-        void load( islot_comestible &slot, const JsonObject &jo, const std::string &src );
-        void load( islot_mod &slot, const JsonObject &jo, const std::string &src );
-        void load( islot_gun &slot, const JsonObject &jo, const std::string &src );
-        void load( islot_gunmod &slot, const JsonObject &jo, const std::string &src );
-        void load( islot_magazine &slot, const JsonObject &jo, const std::string &src );
-        void load( islot_bionic &slot, const JsonObject &jo, const std::string &src );
-        void load( relic &slot, const JsonObject &jo, std::string_view src );
+        void load( islot_tool &slot, const JsonObject &jo, const std::string &src, const std::string & );
+        void load( islot_comestible &slot, const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load( islot_mod &slot, const JsonObject &jo, const std::string &src, const std::string & );
+        void load( islot_gun &slot, const JsonObject &jo, const std::string &src, const std::string & );
+        void load( islot_gunmod &slot, const JsonObject &jo, const std::string &src, const std::string & );
+        void load( islot_magazine &slot, const JsonObject &jo, const std::string &src, const std::string & );
+        void load( islot_bionic &slot, const JsonObject &jo, const std::string &src, const std::string & );
+        void load( relic &slot, const JsonObject &jo, std::string_view src, const std::string & );
 
         //json data handlers
         void emplace_usage( std::map<std::string, use_function> &container,

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -305,7 +305,7 @@ class Item_factory
          */
         template<typename SlotType>
         void load_slot( cata::value_ptr<SlotType> &slotptr, const JsonObject &jo,
-                        const std::string &src );
+                        const std::string &src, const std::string &second_src );
 
         /**
          * Load item the item slot if present in json.
@@ -314,7 +314,7 @@ class Item_factory
          */
         template<typename SlotType>
         void load_slot_optional( cata::value_ptr<SlotType> &slotptr, const JsonObject &jo,
-                                 std::string_view member, const std::string &src );
+                                 std::string_view member, const std::string &src, const std::string &second_src );
 
         void load( islot_tool &slot, const JsonObject &jo, const std::string &src );
         void load( islot_comestible &slot, const JsonObject &jo, const std::string &src );
@@ -331,12 +331,12 @@ class Item_factory
 
         void set_use_methods_from_json( const JsonObject &jo, const std::string &src,
                                         const std::string &member, std::map<std::string, use_function> &use_methods,
-                                        std::map<std::string, int> &ammo_scale );
+                                        std::map<std::string, int> &ammo_scale, const std::string &second_src );
 
         use_function usage_from_string( const std::string &type ) const;
 
         std::pair<std::string, use_function> usage_from_object( const JsonObject &obj,
-                const std::string & );
+                const std::string &, const std::string & );
 
         /**
          * Helper function for Item_group loading

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -176,22 +176,22 @@ class Item_factory
          * @throw JsonError if the json object contains invalid data.
          */
         /*@{*/
-        void load_ammo( const JsonObject &jo, const std::string &src );
-        void load_gun( const JsonObject &jo, const std::string &src );
-        void load_armor( const JsonObject &jo, const std::string &src );
-        void load_pet_armor( const JsonObject &jo, const std::string &src );
-        void load_tool( const JsonObject &jo, const std::string &src );
-        void load_toolmod( const JsonObject &jo, const std::string &src );
-        void load_tool_armor( const JsonObject &jo, const std::string &src );
-        void load_book( const JsonObject &jo, const std::string &src );
-        void load_comestible( const JsonObject &jo, const std::string &src );
-        void load_engine( const JsonObject &jo, const std::string &src );
-        void load_wheel( const JsonObject &jo, const std::string &src );
-        void load_gunmod( const JsonObject &jo, const std::string &src );
-        void load_magazine( const JsonObject &jo, const std::string &src );
-        void load_battery( const JsonObject &jo, const std::string &src );
-        void load_generic( const JsonObject &jo, const std::string &src );
-        void load_bionic( const JsonObject &jo, const std::string &src );
+        void load_ammo( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_gun( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_armor( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_pet_armor( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_tool( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_toolmod( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_tool_armor( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_book( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_comestible( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_engine( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_wheel( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_gunmod( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_magazine( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_battery( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_generic( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_bionic( const JsonObject &jo, const std::string &src, const std::string &second_src );
         /*@}*/
 
         /**
@@ -297,7 +297,7 @@ class Item_factory
          * Called before creating a new template and handles inheritance via copy-from
          * May defer instantiation of the template if depends on other objects not as-yet loaded
          */
-        bool load_definition( const JsonObject &jo, const std::string &src, itype &def );
+        bool load_definition( const JsonObject &jo, const std::string &src, itype &def, const std::string &second_src );
 
         /**
          * Load the data of the slot struct. It creates the slot object (of type SlotType) and
@@ -356,7 +356,7 @@ class Item_factory
         bool load_string( std::vector<std::string> &vec, const JsonObject &obj, std::string_view name );
         void add_entry( Item_group &ig, const JsonObject &obj, const std::string &context );
 
-        void load_basic_info( const JsonObject &jo, itype &def, const std::string &src );
+        void load_basic_info( const JsonObject &jo, itype &def, const std::string &src, const std::string &second_src );
         void set_qualities_from_json( const JsonObject &jo, const std::string &member, itype &def );
         void extend_qualities_from_json( const JsonObject &jo, std::string_view member, itype &def );
         void delete_qualities_from_json( const JsonObject &jo, std::string_view member, itype &def );

--- a/src/itype.h
+++ b/src/itype.h
@@ -1250,6 +1250,7 @@ struct itype {
         units::mass integral_weight = -1_gram;
 
         std::vector<std::pair<itype_id, mod_id>> src;
+        std::vector<std::pair<itype_id, mod_id>> second_src;
 
         // Potential variant items that exist of this type (same stats, different name and desc)
         std::vector<itype_variant_data> variants;

--- a/src/itype.h
+++ b/src/itype.h
@@ -1565,7 +1565,7 @@ struct itype {
         bool is_basic_component() const;
 };
 
-void load_charge_removal_blacklist( const JsonObject &jo, std::string_view src );
-void load_temperature_removal_blacklist( const JsonObject &jo, std::string_view src );
+void load_charge_removal_blacklist( const JsonObject &jo, std::string_view src, std::string_view );
+void load_temperature_removal_blacklist( const JsonObject &jo, std::string_view src, std::string_view );
 
 #endif // CATA_SRC_ITYPE_H

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -287,7 +287,7 @@ class iuse_actor
         int cost;
 
         virtual ~iuse_actor() = default;
-        virtual void load( const JsonObject &jo, const std::string &src ) = 0;
+        virtual void load( const JsonObject &jo, const std::string &src, const std::string &second_src ) = 0;
         virtual std::optional<int> use( Character *, item &, const tripoint & ) const = 0;
         virtual ret_val<void> can_use( const Character &, const item &, const tripoint & ) const;
         virtual void info( const item &, std::vector<iteminfo> & ) const {}

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -169,7 +169,7 @@ std::unique_ptr<iuse_actor> iuse_transform::clone() const
     return std::make_unique<iuse_transform>( *this );
 }
 
-void iuse_transform::load( const JsonObject &obj, const std::string & )
+void iuse_transform::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     obj.read( "target", target, true );
 
@@ -485,7 +485,7 @@ std::unique_ptr<iuse_actor> unpack_actor::clone() const
     return std::make_unique<unpack_actor>( *this );
 }
 
-void unpack_actor::load( const JsonObject &obj, const std::string & )
+void unpack_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     obj.read( "group", unpack_group );
     obj.read( "items_fit", items_fit );
@@ -538,7 +538,7 @@ std::unique_ptr<iuse_actor> message_iuse::clone() const
     return std::make_unique<message_iuse>( *this );
 }
 
-void message_iuse::load( const JsonObject &obj, const std::string & )
+void message_iuse::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     obj.read( "name", name );
     obj.read( "message", message );
@@ -571,7 +571,7 @@ std::unique_ptr<iuse_actor> sound_iuse::clone() const
     return std::make_unique<sound_iuse>( *this );
 }
 
-void sound_iuse::load( const JsonObject &obj, const std::string & )
+void sound_iuse::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     obj.read( "name", name );
     obj.read( "sound_message", sound_message );
@@ -626,7 +626,7 @@ static std::vector<tripoint> points_for_gas_cloud( const tripoint &center, int r
     return result;
 }
 
-void explosion_iuse::load( const JsonObject &obj, const std::string & )
+void explosion_iuse::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     if( obj.has_object( "explosion" ) ) {
         JsonObject expl = obj.get_object( "explosion" );
@@ -718,7 +718,7 @@ static effect_data load_effect_data( const JsonObject &e )
                         bodypart_id( e.get_string( "bp", "bp_null" ) ), e.get_bool( "permanent", false ) );
 }
 
-void consume_drug_iuse::load( const JsonObject &obj, const std::string & )
+void consume_drug_iuse::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     obj.read( "activation_message", activation_message );
     obj.read( "charges_needed", charges_needed );
@@ -856,9 +856,9 @@ std::unique_ptr<iuse_actor> delayed_transform_iuse::clone() const
     return std::make_unique<delayed_transform_iuse>( *this );
 }
 
-void delayed_transform_iuse::load( const JsonObject &obj, const std::string &src )
+void delayed_transform_iuse::load( const JsonObject &obj, const std::string &src, const std::string & )
 {
-    iuse_transform::load( obj, src );
+    iuse_transform::load( obj, src, "" );
     obj.get_member( "not_ready_msg" ).read( not_ready_msg );
     transform_age = obj.get_int( "transform_age" );
 }
@@ -884,7 +884,7 @@ std::unique_ptr<iuse_actor> place_monster_iuse::clone() const
     return std::make_unique<place_monster_iuse>( *this );
 }
 
-void place_monster_iuse::load( const JsonObject &obj, const std::string & )
+void place_monster_iuse::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     mtypeid = mtype_id( obj.get_string( "monster_id" ) );
     obj.read( "friendly_msg", friendly_msg );
@@ -990,7 +990,7 @@ std::unique_ptr<iuse_actor> place_npc_iuse::clone() const
     return std::make_unique<place_npc_iuse>( *this );
 }
 
-void place_npc_iuse::load( const JsonObject &obj, const std::string & )
+void place_npc_iuse::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     npc_class_id = string_id<npc_template>( obj.get_string( "npc_class_id" ) );
     obj.read( "summon_msg", summon_msg );
@@ -1070,7 +1070,7 @@ void deploy_furn_actor::info( const item &, std::vector<iteminfo> &dump ) const
     }
 }
 
-void deploy_furn_actor::load( const JsonObject &obj, const std::string & )
+void deploy_furn_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     furn_type = furn_str_id( obj.get_string( "furn_type" ) );
 }
@@ -1171,7 +1171,7 @@ void deploy_appliance_actor::info( const item &, std::vector<iteminfo> &dump ) c
                                       vpart_appliance_from_item( appliance_base )->name() ) );
 }
 
-void deploy_appliance_actor::load( const JsonObject &obj, const std::string & )
+void deploy_appliance_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     mandatory( obj, false, "base", appliance_base );
 }
@@ -1195,7 +1195,7 @@ std::unique_ptr<iuse_actor> reveal_map_actor::clone() const
     return std::make_unique<reveal_map_actor>( *this );
 }
 
-void reveal_map_actor::load( const JsonObject &obj, const std::string & )
+void reveal_map_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     radius = obj.get_int( "radius" );
     obj.get_member( "message" ).read( message );
@@ -1258,7 +1258,7 @@ std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint
     return 0;
 }
 
-void firestarter_actor::load( const JsonObject &obj, const std::string & )
+void firestarter_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     moves_cost_fast = obj.get_int( "moves", moves_cost_fast );
     moves_cost_slow = obj.get_int( "moves_slow", moves_cost_fast * 10 );
@@ -1458,7 +1458,7 @@ std::optional<int> firestarter_actor::use( Character *p, item &it,
     return 0;
 }
 
-void salvage_actor::load( const JsonObject &obj, const std::string & )
+void salvage_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     assign( obj, "cost", cost );
     assign( obj, "moves_per_part", moves_per_part );
@@ -1786,7 +1786,7 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
     }
 }
 
-void inscribe_actor::load( const JsonObject &obj, const std::string & )
+void inscribe_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     assign( obj, "cost", cost );
     assign( obj, "on_items", on_items );
@@ -1936,7 +1936,7 @@ std::optional<int> inscribe_actor::use( Character *p, item &it, const tripoint &
     return std::nullopt;
 }
 
-void fireweapon_off_actor::load( const JsonObject &obj, const std::string & )
+void fireweapon_off_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     obj.read( "target_id", target_id, true );
     obj.read( "success_message", success_message );
@@ -1992,7 +1992,7 @@ ret_val<void> fireweapon_off_actor::can_use( const Character &p, const item &it,
     return ret_val<void>::make_success();
 }
 
-void fireweapon_on_actor::load( const JsonObject &obj, const std::string & )
+void fireweapon_on_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     obj.read( "noise_message", noise_message );
     obj.get_member( "charges_extinguish_message" ).read( charges_extinguish_message );
@@ -2040,7 +2040,7 @@ std::optional<int> fireweapon_on_actor::use( Character *p, item &it,
     return 1;
 }
 
-void manualnoise_actor::load( const JsonObject &obj, const std::string & )
+void manualnoise_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     obj.get_member( "use_message" ).read( use_message );
     obj.read( "noise_message", noise_message );
@@ -2077,7 +2077,7 @@ ret_val<void> manualnoise_actor::can_use( const Character &p, const item &it,
     return ret_val<void>::make_success();
 }
 
-void play_instrument_iuse::load( const JsonObject &, const std::string & )
+void play_instrument_iuse::load( const JsonObject &, const std::string &, const std::string & )
 {
 }
 
@@ -2114,7 +2114,7 @@ std::unique_ptr<iuse_actor> musical_instrument_actor::clone() const
     return std::make_unique<musical_instrument_actor>( *this );
 }
 
-void musical_instrument_actor::load( const JsonObject &obj, const std::string & )
+void musical_instrument_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     speed_penalty = obj.get_int( "speed_penalty", 10 );
     volume = obj.get_int( "volume" );
@@ -2262,7 +2262,7 @@ std::unique_ptr<iuse_actor> learn_spell_actor::clone() const
     return std::make_unique<learn_spell_actor>( *this );
 }
 
-void learn_spell_actor::load( const JsonObject &obj, const std::string & )
+void learn_spell_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     spells = obj.get_string_array( "spells" );
 }
@@ -2403,7 +2403,7 @@ std::unique_ptr<iuse_actor> cast_spell_actor::clone() const
     return std::make_unique<cast_spell_actor>( *this );
 }
 
-void cast_spell_actor::load( const JsonObject &obj, const std::string & )
+void cast_spell_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     no_fail = obj.get_bool( "no_fail" );
     item_spell = spell_id( obj.get_string( "spell_id" ) );
@@ -2483,7 +2483,7 @@ std::unique_ptr<iuse_actor> holster_actor::clone() const
     return std::make_unique<holster_actor>( *this );
 }
 
-void holster_actor::load( const JsonObject &obj, const std::string & )
+void holster_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     obj.read( "holster_prompt", holster_prompt );
     obj.read( "holster_msg", holster_msg );
@@ -2638,7 +2638,7 @@ std::unique_ptr<iuse_actor> ammobelt_actor::clone() const
     return std::make_unique<ammobelt_actor>( *this );
 }
 
-void ammobelt_actor::load( const JsonObject &obj, const std::string & )
+void ammobelt_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     belt = itype_id( obj.get_string( "belt" ) );
 }
@@ -2670,7 +2670,7 @@ std::optional<int> ammobelt_actor::use( Character *p, item &, const tripoint & )
     return 0;
 }
 
-void repair_item_actor::load( const JsonObject &obj, const std::string & )
+void repair_item_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     // Mandatory:
     for( const std::string line : obj.get_array( "materials" ) ) {
@@ -3264,7 +3264,7 @@ std::string repair_item_actor::get_description() const
     return string_format( _( "Repair %s" ), mats );
 }
 
-void heal_actor::load( const JsonObject &obj, const std::string & )
+void heal_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     // Mandatory
     move_cost = obj.get_int( "move_cost" );
@@ -3775,7 +3775,7 @@ void place_trap_actor::data::load( const JsonObject &obj )
     assign( obj, "moves", moves );
 }
 
-void place_trap_actor::load( const JsonObject &obj, const std::string & )
+void place_trap_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     assign( obj, "allow_underwater", allow_underwater );
     assign( obj, "allow_under_player", allow_under_player );
@@ -3946,7 +3946,7 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
     return 1;
 }
 
-void emit_actor::load( const JsonObject &obj, const std::string & )
+void emit_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     assign( obj, "emits", emits );
     assign( obj, "scale_qty", scale_qty );
@@ -3986,7 +3986,7 @@ void emit_actor::finalize( const itype_id &my_item_type )
     }
 }
 
-void saw_barrel_actor::load( const JsonObject &jo, const std::string & )
+void saw_barrel_actor::load( const JsonObject &jo, const std::string &, const std::string & )
 {
     assign( jo, "cost", cost );
 }
@@ -4047,7 +4047,7 @@ std::unique_ptr<iuse_actor> saw_barrel_actor::clone() const
     return std::make_unique<saw_barrel_actor>( *this );
 }
 
-void saw_stock_actor::load( const JsonObject &jo, const std::string & )
+void saw_stock_actor::load( const JsonObject &jo, const std::string &, const std::string & )
 {
     assign( jo, "cost", cost );
 }
@@ -4122,7 +4122,7 @@ std::unique_ptr<iuse_actor> saw_stock_actor::clone() const
     return std::make_unique<saw_stock_actor>( *this );
 }
 
-void molle_attach_actor::load( const JsonObject &jo, const std::string & )
+void molle_attach_actor::load( const JsonObject &jo, const std::string &, const std::string & )
 {
     assign( jo, "size", size );
     assign( jo, "moves", moves );
@@ -4189,7 +4189,7 @@ std::unique_ptr<iuse_actor> molle_detach_actor::clone() const
     return std::make_unique<molle_detach_actor>( *this );
 }
 
-void molle_detach_actor::load( const JsonObject &jo, const std::string & )
+void molle_detach_actor::load( const JsonObject &jo, const std::string &, const std::string & )
 {
     assign( jo, "moves", moves );
 }
@@ -4432,7 +4432,7 @@ void modify_gunmods_actor::finalize( const itype_id &my_item_type )
     }
 }
 
-void link_up_actor::load( const JsonObject &jo, const std::string & )
+void link_up_actor::load( const JsonObject &jo, const std::string &, const std::string & )
 {
     jo.read( "cable_length", cable_length );
     jo.read( "charge_rate", charge_rate );
@@ -5157,7 +5157,7 @@ std::unique_ptr<iuse_actor> deploy_tent_actor::clone() const
     return std::make_unique<deploy_tent_actor>( *this );
 }
 
-void deploy_tent_actor::load( const JsonObject &obj, const std::string & )
+void deploy_tent_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     assign( obj, "radius", radius );
     assign( obj, "wall", wall );
@@ -5262,7 +5262,7 @@ std::optional<int> weigh_self_actor::use( Character *p, item &, const tripoint &
     return 0;
 }
 
-void weigh_self_actor::load( const JsonObject &jo, const std::string & )
+void weigh_self_actor::load( const JsonObject &jo, const std::string &, const std::string & )
 {
     assign( jo, "max_weight", max_weight );
 }
@@ -5272,7 +5272,7 @@ std::unique_ptr<iuse_actor> weigh_self_actor::clone() const
     return std::make_unique<weigh_self_actor>( *this );
 }
 
-void sew_advanced_actor::load( const JsonObject &obj, const std::string & )
+void sew_advanced_actor::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     // Mandatory:
     for( const std::string line : obj.get_array( "materials" ) ) {
@@ -5513,7 +5513,7 @@ std::unique_ptr<iuse_actor> sew_advanced_actor::clone() const
     return std::make_unique<sew_advanced_actor>( *this );
 }
 
-void change_scent_iuse::load( const JsonObject &obj, const std::string & )
+void change_scent_iuse::load( const JsonObject &obj, const std::string &, const std::string & )
 {
     scenttypeid = scenttype_id( obj.get_string( "scent_typeid" ) );
     if( !scenttypeid.is_valid() ) {
@@ -5559,12 +5559,12 @@ std::unique_ptr<iuse_actor> effect_on_conditons_actor::clone() const
     return std::make_unique<effect_on_conditons_actor>( *this );
 }
 
-void effect_on_conditons_actor::load( const JsonObject &obj, const std::string &src )
+void effect_on_conditons_actor::load( const JsonObject &obj, const std::string &src, const std::string &second_src )
 {
     obj.read( "description", description );
     obj.read( "menu_text", menu_text );
     for( JsonValue jv : obj.get_array( "effect_on_conditions" ) ) {
-        eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 }
 

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -109,7 +109,7 @@ class iuse_transform : public iuse_actor
         explicit iuse_transform( const std::string &type = "transform" ) : iuse_actor( type ) {}
 
         ~iuse_transform() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -138,7 +138,7 @@ class unpack_actor : public iuse_actor
         explicit unpack_actor( const std::string &type = "unpack" ) : iuse_actor( type ) {}
 
         ~unpack_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> &dump ) const override;
@@ -156,7 +156,7 @@ class message_iuse : public iuse_actor
         translation message;
 
         ~message_iuse() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
@@ -178,7 +178,7 @@ class sound_iuse : public iuse_actor
         std::string sound_variant = "default";
 
         ~sound_iuse() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
@@ -216,7 +216,7 @@ class explosion_iuse : public iuse_actor
         explicit explosion_iuse( const std::string &type = "explosion" ) : iuse_actor( type ) {}
 
         ~explosion_iuse() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -264,7 +264,7 @@ class consume_drug_iuse : public iuse_actor
         explicit consume_drug_iuse( const std::string &type = "consume_drug" ) : iuse_actor( type ) {}
 
         ~consume_drug_iuse() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -299,7 +299,7 @@ class delayed_transform_iuse : public iuse_transform
                 type ) {}
 
         ~delayed_transform_iuse() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -332,7 +332,7 @@ class place_monster_iuse : public iuse_actor
 
         place_monster_iuse() : iuse_actor( "place_monster" ) { }
         ~place_monster_iuse() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -360,7 +360,7 @@ class change_scent_iuse : public iuse_actor
 
         change_scent_iuse() : iuse_actor( "change_scent" ) { }
         ~change_scent_iuse() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -379,7 +379,7 @@ class place_npc_iuse : public iuse_actor
 
         place_npc_iuse() : iuse_actor( "place_npc" ) { }
         ~place_npc_iuse() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -398,7 +398,7 @@ class deploy_furn_actor : public iuse_actor
         deploy_furn_actor() : iuse_actor( "deploy_furn" ) {}
 
         ~deploy_furn_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -415,7 +415,7 @@ class deploy_appliance_actor : public iuse_actor
         deploy_appliance_actor() : iuse_actor( "deploy_appliance" ) {}
         ~deploy_appliance_actor() override = default;
 
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -451,7 +451,7 @@ class reveal_map_actor : public iuse_actor
         explicit reveal_map_actor( const std::string &type = "reveal_map" ) : iuse_actor( type ) {}
 
         ~reveal_map_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -488,7 +488,7 @@ class firestarter_actor : public iuse_actor
         explicit firestarter_actor( const std::string &type = "firestarter" ) : iuse_actor( type ) {}
 
         ~firestarter_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -510,7 +510,7 @@ class salvage_actor : public iuse_actor
         explicit salvage_actor( const std::string &type = "salvage" ) : iuse_actor( type ) {}
 
         ~salvage_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
     private:
@@ -553,7 +553,7 @@ class inscribe_actor : public iuse_actor
         explicit inscribe_actor( const std::string &type = "inscribe" ) : iuse_actor( type ) {}
 
         ~inscribe_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -576,7 +576,7 @@ class fireweapon_off_actor : public iuse_actor
         fireweapon_off_actor() : iuse_actor( "fireweapon_off" ) {}
 
         ~fireweapon_off_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -597,7 +597,7 @@ class fireweapon_on_actor : public iuse_actor
         explicit fireweapon_on_actor( const std::string &type = "fireweapon_on" ) : iuse_actor( type ) {}
 
         ~fireweapon_on_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -618,7 +618,7 @@ class manualnoise_actor : public iuse_actor
         explicit manualnoise_actor( const std::string &type = "manualnoise" ) : iuse_actor( type ) {}
 
         ~manualnoise_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -630,7 +630,7 @@ class play_instrument_iuse : public iuse_actor
         explicit play_instrument_iuse( const std::string &type = "play_instrument" ) : iuse_actor( type ) {}
 
         ~play_instrument_iuse() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -675,7 +675,7 @@ class musical_instrument_actor : public iuse_actor
                 type ) {}
 
         ~musical_instrument_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -693,7 +693,7 @@ class learn_spell_actor : public iuse_actor
         explicit learn_spell_actor( const std::string &type = "learn_spell" ) : iuse_actor( type ) {}
 
         ~learn_spell_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *p, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -720,7 +720,7 @@ class cast_spell_actor : public iuse_actor
         explicit cast_spell_actor( const std::string &type = "cast_spell" ) : iuse_actor( type ) {}
 
         ~cast_spell_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -747,7 +747,7 @@ class holster_actor : public iuse_actor
         explicit holster_actor( const std::string &type = "holster" ) : iuse_actor( type ) {}
 
         ~holster_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -761,7 +761,7 @@ class ammobelt_actor : public iuse_actor
         ammobelt_actor() : iuse_actor( "ammobelt" ) {}
 
         ~ammobelt_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -852,7 +852,7 @@ class repair_item_actor : public iuse_actor
         explicit repair_item_actor( const std::string &type = "repair_item" ) : iuse_actor( type ) {}
 
         ~repair_item_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
@@ -919,7 +919,7 @@ class heal_actor : public iuse_actor
         explicit heal_actor( const std::string &type = "heal" ) : iuse_actor( type ) {}
 
         ~heal_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -966,7 +966,7 @@ class place_trap_actor : public iuse_actor
 
         explicit place_trap_actor( const std::string &type = "place_trap" );
         ~place_trap_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -980,7 +980,7 @@ class emit_actor : public iuse_actor
 
         explicit emit_actor( const std::string &type = "emit_actor" ) : iuse_actor( type ) {}
         ~emit_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void finalize( const itype_id &my_item_type ) override;
@@ -991,7 +991,7 @@ class saw_barrel_actor : public iuse_actor
     public:
         explicit saw_barrel_actor( const std::string &type = "saw_barrel" ) : iuse_actor( type ) {}
 
-        void load( const JsonObject &jo, const std::string & ) override;
+        void load( const JsonObject &jo, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
@@ -1003,7 +1003,7 @@ class saw_stock_actor : public iuse_actor
     public:
         explicit saw_stock_actor( const std::string &type = "saw_stock" ) : iuse_actor( type ) {}
 
-        void load( const JsonObject &jo, const std::string & ) override;
+        void load( const JsonObject &jo, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
@@ -1019,7 +1019,7 @@ class molle_attach_actor : public iuse_actor
         int size;
         int moves;
 
-        void load( const JsonObject &jo, const std::string & ) override;
+        void load( const JsonObject &jo, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -1032,7 +1032,7 @@ class molle_detach_actor : public iuse_actor
 
         int moves;
 
-        void load( const JsonObject &jo, const std::string & ) override;
+        void load( const JsonObject &jo, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -1042,7 +1042,7 @@ class install_bionic_actor : public iuse_actor
     public:
         explicit install_bionic_actor( const std::string &type = "install_bionic" ) : iuse_actor( type ) {}
 
-        void load( const JsonObject &, const std::string & ) override {}
+        void load( const JsonObject &, const std::string &, const std::string & ) override {}
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         ret_val<void> can_use( const Character &, const item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -1054,7 +1054,7 @@ class detach_gunmods_actor : public iuse_actor
     public:
         explicit detach_gunmods_actor( const std::string &type = "detach_gunmods" ) : iuse_actor( type ) {}
 
-        void load( const JsonObject &, const std::string & ) override {}
+        void load( const JsonObject &, const std::string &, const std::string & ) override {}
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         ret_val<void> can_use( const Character &, const item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -1066,7 +1066,7 @@ class modify_gunmods_actor : public iuse_actor
     public:
         explicit modify_gunmods_actor( const std::string &type = "modify_gunmods" ) : iuse_actor( type ) {}
 
-        void load( const JsonObject &, const std::string & ) override {}
+        void load( const JsonObject &, const std::string &, const std::string & ) override {}
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         ret_val<void> can_use( const Character &, const item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -1098,7 +1098,7 @@ class link_up_actor : public iuse_actor
         link_up_actor() : iuse_actor( "link_up" ) {}
 
         ~link_up_actor() override = default;
-        void load( const JsonObject &jo, const std::string & ) override;
+        void load( const JsonObject &jo, const std::string &, const std::string & ) override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -1119,7 +1119,7 @@ class deploy_tent_actor : public iuse_actor
         deploy_tent_actor() : iuse_actor( "deploy_tent" ) {}
 
         ~deploy_tent_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
@@ -1138,7 +1138,7 @@ class weigh_self_actor : public iuse_actor
         explicit weigh_self_actor( const std::string &type = "weigh_self" ) : iuse_actor( type ) {}
 
         ~weigh_self_actor() override = default;
-        void load( const JsonObject &jo, const std::string & ) override;
+        void load( const JsonObject &jo, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *p, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -1160,7 +1160,7 @@ class sew_advanced_actor : public iuse_actor
         explicit sew_advanced_actor( const std::string &type = "sew_advanced" ) : iuse_actor( type ) {}
 
         ~sew_advanced_actor() override = default;
-        void load( const JsonObject &obj, const std::string & ) override;
+        void load( const JsonObject &obj, const std::string &, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -1178,7 +1178,7 @@ class effect_on_conditons_actor : public iuse_actor
                 type ) {}
 
         ~effect_on_conditons_actor() override = default;
-        void load( const JsonObject &obj, const std::string &src ) override;
+        void load( const JsonObject &obj, const std::string &src, const std::string &second_src ) override;
         std::optional<int> use( Character *p, item &it, const tripoint &point ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -270,9 +270,9 @@ bool string_id<spell_type>::is_valid() const
     return spell_factory.is_valid( *this );
 }
 
-void spell_type::load_spell( const JsonObject &jo, const std::string &src )
+void spell_type::load_spell( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    spell_factory.load( jo, src );
+    spell_factory.load( jo, src, second_src );
 }
 
 static std::string moves_to_string( const int moves )
@@ -284,7 +284,7 @@ static std::string moves_to_string( const int moves )
     }
 }
 
-void spell_type::load( const JsonObject &jo, const std::string_view src )
+void spell_type::load( const JsonObject &jo, const std::string_view src, const std::string_view )
 {
     src_mod = mod_id( src );
     mandatory( jo, was_loaded, "name", name );

--- a/src/magic.h
+++ b/src/magic.h
@@ -367,8 +367,8 @@ class spell_type
         // bitfield of -certain- string flags which are heavily checked
         enum_bitset<spell_flag> spell_tags; // NOLINT(cata-serialize)
 
-        static void load_spell( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, std::string_view src );
+        static void load_spell( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void serialize( JsonOut &json ) const;
         /**
          * All spells in the game.

--- a/src/magic.h
+++ b/src/magic.h
@@ -214,6 +214,7 @@ class spell_type
         spell_id id;
         // NOLINTNEXTLINE(cata-serialize)
         std::vector<std::pair<spell_id, mod_id>> src;
+        std::vector<std::pair<spell_id, mod_id>> second_src;
         mod_id src_mod;
         // spell name
         translation name;

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -228,9 +228,9 @@ bool string_id<enchantment>::is_valid() const
     return spell_factory.is_valid( *this );
 }
 
-void enchantment::load_enchantment( const JsonObject &jo, const std::string &src )
+void enchantment::load_enchantment( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    spell_factory.load( jo, src );
+    spell_factory.load( jo, src, second_src );
 }
 
 void enchantment::reset()
@@ -240,7 +240,7 @@ void enchantment::reset()
 
 enchantment_id enchantment::load_inline_enchantment( const JsonValue &jv,
         const std::string_view src,
-        std::string &inline_id )
+        std::string &inline_id, const std::string_view second_src )
 {
     if( jv.test_string() ) {
         return enchantment_id( jv.get_string() );

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -251,7 +251,7 @@ enchantment_id enchantment::load_inline_enchantment( const JsonValue &jv,
 
         enchantment inline_enchant;
         inline_enchant.load( jv.get_object(), src, inline_id );
-        mod_tracker::assign_src( inline_enchant, src );
+        mod_tracker::assign_src( inline_enchant, src, second_src );
         spell_factory.insert( inline_enchant );
         return enchantment_id( inline_id );
     } else {

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -205,7 +205,7 @@ class enchantment
             NUM_CONDITION
         };
 
-        static void load_enchantment( const JsonObject &jo, const std::string &src );
+        static void load_enchantment( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
         void load( const JsonObject &jo, std::string_view src = {},
                    const std::optional<std::string> &inline_id = std::nullopt, bool is_child = false );
@@ -213,7 +213,7 @@ class enchantment
         // Takes in a JsonValue which can be either a string or an enchantment object and returns the id of the enchantment the caller will use.
         // If the input is a string return it as an enchantment_id otherwise create an enchantment with id inline_id and return inline_id as an enchantment id
         static enchantment_id load_inline_enchantment( const JsonValue &jv, std::string_view src,
-                std::string &inline_id );
+                std::string &inline_id, const std::string_view second_src );
 
         // this enchantment has a valid condition and is in the right location
         bool is_active( const Character &guy, const item &parent ) const;

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -233,6 +233,7 @@ class enchantment
         enchantment_id id;
         // NOLINTNEXTLINE(cata-serialize)
         std::vector<std::pair<enchantment_id, mod_id>> src;
+        std::vector<std::pair<enchantment_id, mod_id>> second_src;
 
         bool was_loaded = false;
 

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -39,9 +39,9 @@ bool string_id<ter_furn_transform>::is_valid() const
     return ter_furn_transform_factory.is_valid( *this );
 }
 
-void ter_furn_transform::load_transform( const JsonObject &jo, const std::string &src )
+void ter_furn_transform::load_transform( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    ter_furn_transform_factory.load( jo, src );
+    ter_furn_transform_factory.load( jo, src, second_src );
 }
 
 void ter_furn_transform::reset_all()
@@ -83,7 +83,7 @@ void ter_furn_data<T>::load( const JsonObject &jo )
     message_good = jo.get_bool( "message_good", true );
 }
 
-void ter_furn_transform::load( const JsonObject &jo, const std::string_view )
+void ter_furn_transform::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     std::string input;
     mandatory( jo, was_loaded, "id", input );

--- a/src/magic_ter_furn_transform.h
+++ b/src/magic_ter_furn_transform.h
@@ -81,8 +81,8 @@ class ter_furn_transform
         void transform( map &m, const tripoint_bub_ms &location ) const;
 
         static void reset();
-        static void load_transform( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, std::string_view );
+        static void load_transform( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load( const JsonObject &jo, std::string_view, const std::string_view );
 
         static const std::vector<ter_furn_transform> &get_all();
         static void reset_all();

--- a/src/magic_ter_furn_transform.h
+++ b/src/magic_ter_furn_transform.h
@@ -76,6 +76,7 @@ class ter_furn_transform
 
         ter_furn_transform_id id;
         std::vector<std::pair<ter_furn_transform_id, mod_id>> src;
+        std::vector<std::pair<ter_furn_transform_id, mod_id>> second_src;
         bool was_loaded = false;
 
         void transform( map &m, const tripoint_bub_ms &location ) const;

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2288,9 +2288,9 @@ FunctionMap all_functions()
     return builtin_functions;
 }
 
-void load( const JsonObject &jo, const std::string &src )
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    extras.load( jo, src );
+    extras.load( jo, src, second_src );
 }
 
 void check_consistency()
@@ -2374,7 +2374,7 @@ bool map_extra::is_valid_for( const mapgendata &md ) const
     return true;
 }
 
-void map_extra::load( const JsonObject &jo, const std::string_view )
+void map_extra::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "description", description_ );

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -69,7 +69,7 @@ class map_extra
 
         // Used by generic_factory
         bool was_loaded = false;
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void check() const;
     private:
         translation name_;
@@ -90,7 +90,7 @@ void apply_function( const map_extra_id &id, map &m, const tripoint_abs_sm &abs_
 void apply_function( const map_extra_id &id, tinymap &m,
                      const tripoint_abs_omt &abs_omt );
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void check_consistency();
 
 void debug_spawn_test();

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -43,6 +43,7 @@ class map_extra
     public:
         map_extra_id id = string_id<map_extra>::NULL_ID();
         std::vector<std::pair<map_extra_id, mod_id>> src;
+        std::vector<std::pair<map_extra_id, mod_id>> second_src;
         std::string generator_id;
         map_extra_method generator_method = map_extra_method::null;
         bool autonote = false;

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -794,20 +794,20 @@ std::vector<std::string> map_data_common_t::extended_description() const
     return ret;
 }
 
-void load_furniture( const JsonObject &jo, const std::string &src )
+void load_furniture( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     if( furniture_data.empty() ) {
         furniture_data.insert( null_furniture_t() );
     }
-    furniture_data.load( jo, src );
+    furniture_data.load( jo, src, second_src );
 }
 
-void load_terrain( const JsonObject &jo, const std::string &src )
+void load_terrain( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     if( terrain_data.empty() ) { // TODO: This shouldn't live here
         terrain_data.insert( null_terrain_t() );
     }
-    terrain_data.load( jo, src );
+    terrain_data.load( jo, src, second_src );
 }
 
 void map_data_common_t::extraprocess_flags( const ter_furn_flag flag )
@@ -966,7 +966,7 @@ void init_mapdata()
     add_actor( std::make_unique<eoc_examine_actor>() );
 }
 
-void map_data_common_t::load( const JsonObject &jo, const std::string &src )
+void map_data_common_t::load( const JsonObject &jo, const std::string &src, const std::string_view )
 {
     if( jo.has_string( "examine_action" ) ) {
         examine_actor = nullptr;
@@ -1024,9 +1024,9 @@ bool ter_t::is_null() const
     return id == ter_str_id::NULL_ID();
 }
 
-void ter_t::load( const JsonObject &jo, const std::string &src )
+void ter_t::load( const JsonObject &jo, const std::string &src, const std::string_view )
 {
-    map_data_common_t::load( jo, src );
+    map_data_common_t::load( jo, src, "" );
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "move_cost", movecost );
     optional( jo, was_loaded, "coverage", coverage );
@@ -1204,9 +1204,9 @@ bool furn_t::is_movable() const
     return move_str_req >= 0;
 }
 
-void furn_t::load( const JsonObject &jo, const std::string &src )
+void furn_t::load( const JsonObject &jo, const std::string &src, const std::string_view )
 {
-    map_data_common_t::load( jo, src );
+    map_data_common_t::load( jo, src, "" );
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "move_cost_mod", movecost );
     optional( jo, was_loaded, "coverage", coverage );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -593,7 +593,7 @@ struct map_data_common_t {
                    has_flag( ter_furn_flag::TFLAG_FLAMMABLE_HARD );
         }
 
-        virtual void load( const JsonObject &jo, const std::string & );
+        virtual void load( const JsonObject &jo, const std::string &, const std::string_view );
         virtual void check() const {};
 };
 
@@ -634,7 +634,7 @@ struct ter_t : map_data_common_t {
 
     std::vector<std::string> extended_description() const override;
 
-    void load( const JsonObject &jo, const std::string &src ) override;
+    void load( const JsonObject &jo, const std::string &src, const std::string_view ) override;
     void check() const override;
 };
 
@@ -689,12 +689,12 @@ struct furn_t : map_data_common_t {
 
     std::vector<std::string> extended_description() const override;
 
-    void load( const JsonObject &jo, const std::string &src ) override;
+    void load( const JsonObject &jo, const std::string &src, const std::string_view ) override;
     void check() const override;
 };
 
-void load_furniture( const JsonObject &jo, const std::string &src );
-void load_terrain( const JsonObject &jo, const std::string &src );
+void load_furniture( const JsonObject &jo, const std::string &src, const std::string &second_src );
+void load_terrain( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
 void verify_furniture();
 void verify_terrain();

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -604,6 +604,7 @@ struct map_data_common_t {
 struct ter_t : map_data_common_t {
 
     std::vector<std::pair<ter_str_id, mod_id>> src;
+    std::vector<std::pair<ter_str_id, mod_id>> second_src;
 
     ter_str_id id;    // The terrain's ID. Must be set, must be unique.
     ter_str_id open;  // Open action: transform into terrain with matching id
@@ -649,6 +650,7 @@ void reset_furn_ter();
 struct furn_t : map_data_common_t {
 
     std::vector<std::pair<furn_str_id, mod_id>> src;
+    std::vector<std::pair<furn_str_id, mod_id>> second_src;
 
     furn_str_id id;
     furn_str_id open;  // Open action: transform into furniture with matching id

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4403,7 +4403,7 @@ mapgen_palette mapgen_palette::load_temp( const JsonObject &jo, const std::strin
     return load_internal( jo, src, context, false, true );
 }
 
-void mapgen_palette::load( const JsonObject &jo, const std::string_view src )
+void mapgen_palette::load( const JsonObject &jo, const std::string_view src, const std::string & )
 {
     mapgen_palette ret = load_internal( jo, src, "", true, false );
     if( ret.id.is_empty() ) {

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -343,7 +343,7 @@ class mapgen_palette
          * Load a palette object and adds it to the global set of palettes.
          * If "palette" field is specified, those palettes will be loaded recursively.
          */
-        static void load( const JsonObject &jo, std::string_view src );
+        static void load( const JsonObject &jo, std::string_view src, const std::string & );
 
         /**
          * Returns a palette with given id. If not found, debugmsg and returns a dummy.

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -261,7 +261,7 @@ void ma_requirements::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "weapon_damage_requirements", min_damage, ma_weapon_damage_reader {} );
 }
 
-void ma_technique::load( const JsonObject &jo, const std::string_view src, const std::string_view )
+void ma_technique::load( const JsonObject &jo, const std::string_view src, const std::string_view second_src )
 {
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "description", description, translation() );
@@ -305,7 +305,7 @@ void ma_technique::load( const JsonObject &jo, const std::string_view src, const
     optional( jo, was_loaded, "tech_effects", tech_effects, tech_effect_reader{} );
 
     for( JsonValue jv : jo.get_array( "eocs" ) ) {
-        eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 
     if( jo.has_member( "condition" ) ) {
@@ -405,7 +405,7 @@ class ma_buff_reader : public generic_typed_reader<ma_buff_reader>
         }
 };
 
-void martialart::load( const JsonObject &jo, const std::string_view src, const std::string_view )
+void martialart::load( const JsonObject &jo, const std::string_view src, const std::string_view second_src )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "description", description );
@@ -433,37 +433,37 @@ void martialart::load( const JsonObject &jo, const std::string_view src, const s
     optional( jo, was_loaded, "onkill_buffs", onkill_buffs, ma_buff_reader{} );
 
     for( JsonValue jv : jo.get_array( "static_eocs" ) ) {
-        static_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        static_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
     for( JsonValue jv : jo.get_array( "onmove_eocs" ) ) {
-        onmove_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        onmove_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
     for( JsonValue jv : jo.get_array( "onpause_eocs" ) ) {
-        onpause_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        onpause_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
     for( JsonValue jv : jo.get_array( "onhit_eocs" ) ) {
-        onhit_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        onhit_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
     for( JsonValue jv : jo.get_array( "onattack_eocs" ) ) {
-        onattack_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        onattack_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
     for( JsonValue jv : jo.get_array( "ondodge_eocs" ) ) {
-        ondodge_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        ondodge_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
     for( JsonValue jv : jo.get_array( "onblock_eocs" ) ) {
-        onblock_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        onblock_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
     for( JsonValue jv : jo.get_array( "ongethit_eocs" ) ) {
-        ongethit_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        ongethit_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
     for( JsonValue jv : jo.get_array( "onmiss_eocs" ) ) {
-        onmiss_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        onmiss_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
     for( JsonValue jv : jo.get_array( "oncrit_eocs" ) ) {
-        oncrit_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        oncrit_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
     for( JsonValue jv : jo.get_array( "onkill_eocs" ) ) {
-        onkill_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        onkill_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 
     optional( jo, was_loaded, "techniques", techniques, string_id_reader<::ma_technique> {} );

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -75,9 +75,9 @@ bool attack_vector_id::is_valid() const
     return attack_vector_factory.is_valid( *this );
 }
 
-void attack_vector::load_attack_vectors( const JsonObject &jo, const std::string &src )
+void attack_vector::load_attack_vectors( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    attack_vector_factory.load( jo, src );
+    attack_vector_factory.load( jo, src, second_src );
 }
 
 void attack_vector::reset()
@@ -85,7 +85,7 @@ void attack_vector::reset()
     attack_vector_factory.reset();
 }
 
-void attack_vector::load( const JsonObject &jo, const std::string_view )
+void attack_vector::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     optional( jo, was_loaded, "weapon", weapon, false );
@@ -113,9 +113,9 @@ bool weapon_category_id::is_valid() const
     return weapon_category_factory.is_valid( *this );
 }
 
-void weapon_category::load_weapon_categories( const JsonObject &jo, const std::string &src )
+void weapon_category::load_weapon_categories( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    weapon_category_factory.load( jo, src );
+    weapon_category_factory.load( jo, src, second_src );
 }
 
 void weapon_category::reset()
@@ -123,7 +123,7 @@ void weapon_category::reset()
     weapon_category_factory.reset();
 }
 
-void weapon_category::load( const JsonObject &jo, const std::string_view )
+void weapon_category::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     optional( jo, was_loaded, "proficiencies", proficiencies_ );
@@ -163,9 +163,9 @@ matype_id martial_art_learned_from( const itype &type )
     return type.book->martial_art;
 }
 
-void load_technique( const JsonObject &jo, const std::string &src )
+void load_technique( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    ma_techniques.load( jo, src );
+    ma_techniques.load( jo, src, second_src );
 }
 
 // To avoid adding empty entries
@@ -261,7 +261,7 @@ void ma_requirements::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "weapon_damage_requirements", min_damage, ma_weapon_damage_reader {} );
 }
 
-void ma_technique::load( const JsonObject &jo, const std::string_view src )
+void ma_technique::load( const JsonObject &jo, const std::string_view src, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "description", description, translation() );
@@ -348,7 +348,7 @@ bool string_id<ma_technique>::is_valid() const
     return ma_techniques.is_valid( *this );
 }
 
-void ma_buff::load( const JsonObject &jo, const std::string_view src )
+void ma_buff::load( const JsonObject &jo, const std::string_view src, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "description", description );
@@ -387,9 +387,9 @@ bool string_id<ma_buff>::is_valid() const
     return ma_buffs.is_valid( *this );
 }
 
-void load_martial_art( const JsonObject &jo, const std::string &src )
+void load_martial_art( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    martialarts.load( jo, src );
+    martialarts.load( jo, src, second_src );
 }
 
 class ma_buff_reader : public generic_typed_reader<ma_buff_reader>
@@ -400,12 +400,12 @@ class ma_buff_reader : public generic_typed_reader<ma_buff_reader>
                 return mabuff_id( jin.get_string() );
             }
             JsonObject jsobj = jin.get_object();
-            ma_buffs.load( jsobj, "" );
+            ma_buffs.load( jsobj, "", "" );
             return mabuff_id( jsobj.get_string( "id" ) );
         }
 };
 
-void martialart::load( const JsonObject &jo, const std::string_view src )
+void martialart::load( const JsonObject &jo, const std::string_view src, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "description", description );

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -59,6 +59,7 @@ class weapon_category
 
         weapon_category_id id;
         std::vector<std::pair<weapon_category_id, mod_id>> src;
+        std::vector<std::pair<weapon_category_id, mod_id>> second_src;
         std::vector<proficiency_id> proficiencies_;
         bool was_loaded = false;
 
@@ -164,12 +165,13 @@ class ma_technique
     public:
         ma_technique();
 
-        void load( const JsonObject &jo, std::string_view src, const std::string_view );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view second_src );
         static void verify_ma_techniques();
         void check() const;
 
         matec_id id;
         std::vector<std::pair<matec_id, mod_id>> src;
+        std::vector<std::pair<matec_id, mod_id>> second_src;
         bool was_loaded = false;
         translation name;
 
@@ -292,6 +294,7 @@ class ma_buff
 
         mabuff_id id;
         std::vector<std::pair<mabuff_id, mod_id>> src;
+        std::vector<std::pair<mabuff_id, mod_id>> second_src;
         bool was_loaded = false;
         translation name;
         translation description;
@@ -327,7 +330,7 @@ class martialart
     public:
         martialart();
 
-        void load( const JsonObject &jo, std::string_view src, const std::string_view );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view second_src );
 
         void remove_all_buffs( Character &u ) const;
 
@@ -392,6 +395,7 @@ class martialart
 
         matype_id id;
         std::vector<std::pair<matype_id, mod_id>> src;
+        std::vector<std::pair<matype_id, mod_id>> second_src;
         bool was_loaded = false;
         translation name;
         translation description;

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -32,11 +32,11 @@ const matec_id tec_none( "tec_none" );
 class weapon_category
 {
     public:
-        static void load_weapon_categories( const JsonObject &jo, const std::string &src );
+        static void load_weapon_categories( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void verify_weapon_categories();
         static void reset();
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void check() const;
 
         static const std::vector<weapon_category> &get_all();
@@ -94,9 +94,9 @@ struct attack_vector {
 
     bool was_loaded = false;
 
-    static void load_attack_vectors( const JsonObject &jo, const std::string &src );
+    static void load_attack_vectors( const JsonObject &jo, const std::string &src, const std::string &second_src );
     static void reset();
-    void load( const JsonObject &jo, std::string_view );
+    void load( const JsonObject &jo, std::string_view, const std::string_view );
 };
 
 struct ma_requirements {
@@ -164,7 +164,7 @@ class ma_technique
     public:
         ma_technique();
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         static void verify_ma_techniques();
         void check() const;
 
@@ -319,7 +319,7 @@ class ma_buff
         bool strictly_melee = false; // can we only use it with weapons?
         bool stealthy = false; // do we make less noise when moving?
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 };
 
 class martialart
@@ -327,7 +327,7 @@ class martialart
     public:
         martialart();
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
         void remove_all_buffs( Character &u ) const;
 
@@ -455,8 +455,8 @@ class ma_style_callback : public uilist_callback
 };
 
 tech_effect_data load_tech_effect_data( const JsonObject &e );
-void load_technique( const JsonObject &jo, const std::string &src );
-void load_martial_art( const JsonObject &jo, const std::string &src );
+void load_technique( const JsonObject &jo, const std::string &src, const std::string &second_src );
+void load_martial_art( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void check_martialarts();
 void clear_techniques_and_martial_arts();
 void finalize_martial_arts();

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -78,7 +78,7 @@ static mat_burn_data load_mat_burn_data( const JsonObject &jsobj )
     return bd;
 }
 
-void material_type::load( const JsonObject &jsobj, const std::string_view )
+void material_type::load( const JsonObject &jsobj, const std::string_view, const std::string_view )
 {
     mandatory( jsobj, was_loaded, "name", _name );
 
@@ -363,9 +363,9 @@ const mat_burn_products &material_type::burn_products() const
     return _burn_products;
 }
 
-void materials::load( const JsonObject &jo, const std::string &src )
+void materials::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    material_data.load( jo, src );
+    material_data.load( jo, src, second_src );
 }
 
 void materials::check()

--- a/src/material.h
+++ b/src/material.h
@@ -118,7 +118,7 @@ class material_type
     public:
         material_type();
 
-        void load( const JsonObject &jsobj, std::string_view src );
+        void load( const JsonObject &jsobj, std::string_view src, const std::string_view );
         static void finalize_all();
         void check() const;
 
@@ -175,7 +175,7 @@ class material_type
 namespace materials
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void check();
 void reset();
 

--- a/src/material.h
+++ b/src/material.h
@@ -72,6 +72,7 @@ class material_type
     public:
         material_id id;
         std::vector<std::pair<material_id, mod_id>> src;
+        std::vector<std::pair<material_id, mod_id>> second_src;
         bool was_loaded = false;
 
     private:

--- a/src/math_parser_jmath.cpp
+++ b/src/math_parser_jmath.cpp
@@ -42,12 +42,12 @@ std::vector<jmath_func> const &jmath_func::get_all()
     return get_all_jmath_func().get_all();
 }
 
-void jmath_func::load_func( const JsonObject &jo, std::string const &src )
+void jmath_func::load_func( const JsonObject &jo, std::string const &src, const std::string &second_src )
 {
-    get_all_jmath_func().load( jo, src );
+    get_all_jmath_func().load( jo, src, second_src );
 }
 
-void jmath_func::load( JsonObject const &jo, const std::string_view /*src*/ )
+void jmath_func::load( JsonObject const &jo, const std::string_view /*src*/, const std::string_view )
 {
     optional( jo, was_loaded, "num_args", num_params );
     optional( jo, was_loaded, "return", _str );

--- a/src/math_parser_jmath.h
+++ b/src/math_parser_jmath.h
@@ -15,6 +15,7 @@ struct dialogue;
 struct jmath_func {
     jmath_func_id id;
     std::vector<std::pair<jmath_func_id, mod_id>> src;
+    std::vector<std::pair<jmath_func_id, mod_id>> second_src;
     bool was_loaded = false;
     int num_params{};
 

--- a/src/math_parser_jmath.h
+++ b/src/math_parser_jmath.h
@@ -21,8 +21,8 @@ struct jmath_func {
     double eval( dialogue &d ) const;
     double eval( dialogue &d, std::vector<double> const &params ) const;
 
-    void load( const JsonObject &jo, std::string_view src );
-    static void load_func( const JsonObject &jo, std::string const &src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
+    static void load_func( const JsonObject &jo, std::string const &src, const std::string &second_src );
     static void finalize();
     static void reset();
     static const std::vector<jmath_func> &get_all();

--- a/src/mission.h
+++ b/src/mission.h
@@ -256,13 +256,13 @@ struct mission_type {
         bool test_goal_condition( struct dialogue &d ) const;
 
         static void reset();
-        static void load_mission_type( const JsonObject &jo, const std::string &src );
+        static void load_mission_type( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void finalize();
         static void check_consistency();
 
         bool parse_funcs( const JsonObject &jo, std::string_view src,
                           std::function<void( mission * )> &phase_func );
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
         /**
          * Returns the translated name

--- a/src/mission.h
+++ b/src/mission.h
@@ -180,6 +180,7 @@ struct mission_type {
         // Matches it to a mission_type_id above
         mission_type_id id = mission_type_id( "MISSION_NULL" );
         std::vector<std::pair<mission_type_id, mod_id>> src;
+        std::vector<std::pair<mission_type_id, mod_id>> second_src;
         bool was_loaded = false;
     private:
         // The untranslated name of the mission

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -283,9 +283,9 @@ bool string_id<mission_type>::is_valid() const
     return mission_type_factory.is_valid( *this );
 }
 
-void mission_type::load_mission_type( const JsonObject &jo, const std::string &src )
+void mission_type::load_mission_type( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    mission_type_factory.load( jo, src );
+    mission_type_factory.load( jo, src, second_src );
 }
 
 static DynamicDataLoader::deferred_json deferred;
@@ -293,8 +293,9 @@ static DynamicDataLoader::deferred_json deferred;
 void mission_type::reset()
 {
     mission_type_factory.reset();
-    for( std::pair<JsonObject, std::string> &deferred_json : deferred ) {
-        deferred_json.first.allow_omitted_members();
+    for( std::tuple<JsonObject, std::string, std::string> &deferred_json : deferred ) {
+        std::get<0>(deferred_json).allow_omitted_members();
+        // deferred_json.first.allow_omitted_members();
     }
     deferred.clear();
 }
@@ -313,7 +314,7 @@ void assign_function( const JsonObject &jo, const std::string &id, Fun &target,
     }
 }
 
-void mission_type::load( const JsonObject &jo, const std::string &src )
+void mission_type::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     const bool strict = src == "dda";
 
@@ -366,7 +367,7 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
         } else if( jo.has_member( phase ) ) {
             JsonObject j_start = jo.get_object( phase );
             if( !parse_funcs( j_start, src, phase_func ) ) {
-                deferred.emplace_back( jo, src );
+                deferred.emplace_back( jo, src, second_src );
                 jo.allow_omitted_members();
                 j_start.allow_omitted_members();
                 return false;

--- a/src/mod_tileset.cpp
+++ b/src/mod_tileset.cpp
@@ -8,7 +8,7 @@
 std::vector<mod_tileset> all_mod_tilesets;
 
 void load_mod_tileset( const JsonObject &jsobj, const std::string_view, const cata_path &base_path,
-                       const cata_path &full_path )
+                       const cata_path &full_path, const std::string_view )
 {
     // This function only checks whether mod tileset is compatible.
     // Actual sprites are loaded when the main tileset is loaded.

--- a/src/mod_tileset.h
+++ b/src/mod_tileset.h
@@ -13,7 +13,7 @@ class mod_tileset;
 extern std::vector<mod_tileset> all_mod_tilesets;
 
 void load_mod_tileset( const JsonObject &jsobj, std::string_view, const cata_path &base_path,
-                       const cata_path &full_path );
+                       const cata_path &full_path, std::string_view );
 void reset_mod_tileset();
 
 class mod_tileset

--- a/src/mod_tracker.h
+++ b/src/mod_tracker.h
@@ -42,15 +42,16 @@ struct has_src_member<T, std::void_t<decltype( std::declval<T &>().src.emplace_b
 
     /** Dummy function, for if those conditions are not satisfied */
     template < typename T, typename std::enable_if_t < !has_src_member<T>::value > * = nullptr >
-    static void assign_src( T &, const std::string_view ) {
+    static void assign_src( T &, const std::string_view, std::string_view ) {
     }
 
     /** If those conditions are satisfied, keep track of where this item has been modified */
     template<typename T, typename std::enable_if_t<has_src_member<T>::value > * = nullptr>
-    static void assign_src( T &def, const std::string_view src ) {
+    static void assign_src( T &def, const std::string_view src, const std::string_view second_src ) {
         // We need to make sure we're keeping where this entity has been loaded
         // If the id this was last loaded with is not this one, discard the history and start again
         if( !def.src.empty() && def.src.back().first != def.id ) {
+            debugmsg("TEST0: first != last  with first=%s and id=%s", def.src.back().first.str(), def.id.str() );
             def.src.clear();
         }
         def.src.emplace_back( def.id, mod_id( src ) );
@@ -75,9 +76,15 @@ struct has_src_member<T, std::void_t<decltype( std::declval<T &>().src.emplace_b
     static void check_duplicate_entries( const T &n, const T &o ) {
         // We need to make sure we're keeping where this entity has been loaded
         // If the id this was last loaded with is not this one, discard the history and start again
+        // if( n.src.back() == o.src.back() && n.second_src.back() == o.second_src.back() ) {
         if( n.src.back() == o.src.back() ) {
-            throw mod_error( string_format( "%s (%s) has two definitions from the same source (%s)!",
-                                            n.id.str(), demangle( typeid( T ).name() ), n.src.back().second.str() ) );
+            // if (n.second_src.back().second.str() == "" ) {
+                throw mod_error( string_format( "%s (%s) has two definitions from the same source (%s)!",
+                                                n.id.str(), demangle( typeid( T ).name() ), n.src.back().second.str() ) );
+            // } else {
+                // throw mod_error( string_format( "%s (%s) has two definitions from the same secondary source (%s)!",
+                //                                 n.id.str(), demangle( typeid( T ).name() ), n.second_src.back().second.str() ) );
+            // }
         }
     }
 

--- a/src/mod_tracker.h
+++ b/src/mod_tracker.h
@@ -51,10 +51,12 @@ struct has_src_member<T, std::void_t<decltype( std::declval<T &>().src.emplace_b
         // We need to make sure we're keeping where this entity has been loaded
         // If the id this was last loaded with is not this one, discard the history and start again
         if( !def.src.empty() && def.src.back().first != def.id ) {
-            debugmsg("TEST0: first != last  with first=%s and id=%s", def.src.back().first.str(), def.id.str() );
+            // debugmsg("TEST0: first != last  with first=%s and id=%s", def.src.back().first.str(), def.id.str() );
             def.src.clear();
+            def.second_src.clear();
         }
         def.src.emplace_back( def.id, mod_id( src ) );
+        def.second_src.emplace_back( def.id, mod_id( second_src ) );
     }
 
     /** Dummy function, for if those conditions are not satisfied */
@@ -77,7 +79,7 @@ struct has_src_member<T, std::void_t<decltype( std::declval<T &>().src.emplace_b
         // We need to make sure we're keeping where this entity has been loaded
         // If the id this was last loaded with is not this one, discard the history and start again
         // if( n.src.back() == o.src.back() && n.second_src.back() == o.second_src.back() ) {
-        if( n.src.back() == o.src.back() ) {
+        if( n.src.back() == o.src.back() && n.second_src.back() == o.second_src.back() ) {
             // if (n.second_src.back().second.str() == "" ) {
                 throw mod_error( string_format( "%s (%s) has two definitions from the same source (%s)!",
                                                 n.id.str(), demangle( typeid( T ).name() ), n.src.back().second.str() ) );

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -88,9 +88,9 @@ void monfactions::reset()
     faction_factory.reset();
 }
 
-void monfactions::load_monster_faction( const JsonObject &jo, const std::string &src )
+void monfactions::load_monster_faction( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    faction_factory.load( jo, src );
+    faction_factory.load( jo, src, second_src );
 }
 
 bool monfaction::detect_base_faction_cycle() const
@@ -182,7 +182,7 @@ void monfactions::finalize()
     }
 }
 
-void monfaction::load( const JsonObject &jo, const std::string_view )
+void monfaction::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     optional( jo, was_loaded, "base_faction", base_faction, mfaction_str_id() );
     optional( jo, was_loaded, "by_mood", _att_by_mood, string_id_reader<monfaction>() );

--- a/src/monfaction.h
+++ b/src/monfaction.h
@@ -42,7 +42,7 @@ namespace monfactions
 const std::vector<monfaction> &get_all();
 void reset();
 void finalize();
-void load_monster_faction( const JsonObject &jo, const std::string &src );
+void load_monster_faction( const JsonObject &jo, const std::string &src, const std::string &second_src );
 } // namespace monfactions
 
 class monfaction
@@ -91,7 +91,7 @@ class monfaction
         void populate_attitude_vec() const;
 
         /** Load from JSON */
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
         friend void monfactions::finalize();
         friend class generic_factory<monfaction>;

--- a/src/monfaction.h
+++ b/src/monfaction.h
@@ -58,6 +58,7 @@ class monfaction
 
         mfaction_str_id id = mfaction_str_id::NULL_ID();
         std::vector<std::pair<mfaction_str_id, mod_id>> src;
+        std::vector<std::pair<mfaction_str_id, mod_id>> second_src;
         mfaction_str_id base_faction = mfaction_str_id::NULL_ID();
 
     private:

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -692,9 +692,9 @@ void MonsterGenerator::validate_species_ids( mtype &mon )
     }
 }
 
-void MonsterGenerator::load_monster( const JsonObject &jo, const std::string &src )
+void MonsterGenerator::load_monster( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    mon_templates->load( jo, src );
+    mon_templates->load( jo, src, second_src );
 }
 
 mon_effect_data::mon_effect_data() :
@@ -738,7 +738,7 @@ void mon_effect_data::load( const JsonObject &jo )
     }
 }
 
-void mtype::load( const JsonObject &jo, const std::string &src )
+void mtype::load( const JsonObject &jo, const std::string &src, const std::string_view )
 {
     bool strict = src == "dda";
 
@@ -1311,12 +1311,12 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     }
 }
 
-void MonsterGenerator::load_species( const JsonObject &jo, const std::string &src )
+void MonsterGenerator::load_species( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    mon_species->load( jo, src );
+    mon_species->load( jo, src, second_src );
 }
 
-void species_type::load( const JsonObject &jo, const std::string_view )
+void species_type::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     optional( jo, was_loaded, "description", description );
     optional( jo, was_loaded, "footsteps", footsteps, to_translation( "footsteps." ) );
@@ -1373,12 +1373,12 @@ void species_type::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "bleeds", bleeds, string_id_reader<::field_type> {}, fd_null );
 }
 
-void mon_flag::load_mon_flags( const JsonObject &jo, const std::string &src )
+void mon_flag::load_mon_flags( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    mon_flags.load( jo, src );
+    mon_flags.load( jo, src, second_src );
 }
 
-void mon_flag::load( const JsonObject &jo, std::string_view )
+void mon_flag::load( const JsonObject &jo, std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
 }
@@ -1506,7 +1506,7 @@ void mattack_actor::load( const JsonObject &jo, const std::string &src )
     was_loaded = true;
 }
 
-void MonsterGenerator::load_monster_attack( const JsonObject &jo, const std::string &src )
+void MonsterGenerator::load_monster_attack( const JsonObject &jo, const std::string &src, const std::string & )
 {
     add_attack( create_actor( jo, src ) );
 }

--- a/src/monstergenerator.h
+++ b/src/monstergenerator.h
@@ -30,6 +30,7 @@ using mon_action_defend = void ( * )( monster &, Creature *, dealt_projectile_at
 struct species_type {
     species_id id;
     std::vector<std::pair<species_id, mod_id>> src;
+    std::vector<std::pair<species_id, mod_id>> second_src;
     bool was_loaded = false;
     translation description;
     translation footsteps;

--- a/src/monstergenerator.h
+++ b/src/monstergenerator.h
@@ -46,7 +46,7 @@ struct species_type {
 
     }
 
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
 };
 
 class MonsterGenerator
@@ -63,9 +63,9 @@ class MonsterGenerator
         void reset();
 
         // JSON loading functions
-        void load_monster( const JsonObject &jo, const std::string &src );
-        void load_species( const JsonObject &jo, const std::string &src );
-        void load_monster_attack( const JsonObject &jo, const std::string &src );
+        void load_monster( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_species( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load_monster_attack( const JsonObject &jo, const std::string &src, const std::string & );
 
         // combines mtype and species information, sets bitflags
         void finalize_mtypes();

--- a/src/mood_face.cpp
+++ b/src/mood_face.cpp
@@ -28,9 +28,9 @@ bool mood_face_id::is_valid() const
     return mood_face_factory.is_valid( *this );
 }
 
-void mood_face::load_mood_faces( const JsonObject &jo, const std::string &src )
+void mood_face::load_mood_faces( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    mood_face_factory.load( jo, src );
+    mood_face_factory.load( jo, src, second_src );
 }
 
 void mood_face::reset()
@@ -38,7 +38,7 @@ void mood_face::reset()
     mood_face_factory.reset();
 }
 
-void mood_face::load( const JsonObject &jo, const std::string_view )
+void mood_face::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "values", values_ );
     std::sort( values_.begin(), values_.end(),

--- a/src/mood_face.h
+++ b/src/mood_face.h
@@ -15,10 +15,10 @@ class mood_face_value;
 class mood_face
 {
     public:
-        static void load_mood_faces( const JsonObject &jo, const std::string &src );
+        static void load_mood_faces( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
         static const std::vector<mood_face> &get_all();
 

--- a/src/mood_face.h
+++ b/src/mood_face.h
@@ -36,6 +36,7 @@ class mood_face
 
         mood_face_id id;
         std::vector<std::pair<mood_face_id, mod_id>> src;
+        std::vector<std::pair<mood_face_id, mod_id>> second_src;
         bool was_loaded = false;
 
         // Always sorted with highest value first

--- a/src/morale_types.cpp
+++ b/src/morale_types.cpp
@@ -29,9 +29,9 @@ bool morale_type::is_valid() const
     return morale_data.is_valid( *this );
 }
 
-void morale_type_data::load_type( const JsonObject &jo, const std::string &src )
+void morale_type_data::load_type( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    morale_data.load( jo, src );
+    morale_data.load( jo, src, second_src );
 }
 
 void morale_type_data::check_all()
@@ -44,7 +44,7 @@ void morale_type_data::reset()
     morale_data.reset();
 }
 
-void morale_type_data::load( const JsonObject &jo, const std::string_view )
+void morale_type_data::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "text", text );

--- a/src/morale_types.h
+++ b/src/morale_types.h
@@ -28,10 +28,10 @@ class morale_type_data
             return permanent;
         }
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void check() const;
 
-        static void load_type( const JsonObject &jo, const std::string &src );
+        static void load_type( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void check_all();
         static void reset();
 };

--- a/src/morale_types.h
+++ b/src/morale_types.h
@@ -20,6 +20,7 @@ class morale_type_data
     public:
         morale_type id;
         std::vector<std::pair<morale_type, mod_id>> src;
+        std::vector<std::pair<morale_type, mod_id>> second_src;
         bool was_loaded = false;
 
         /** Describes this morale type, with item type to replace wildcard with. */

--- a/src/move_mode.cpp
+++ b/src/move_mode.cpp
@@ -42,12 +42,12 @@ static const std::unordered_map<std::string, move_mode_type> move_types {
     { "running",   move_mode_type::RUNNING }
 };
 
-void move_mode::load_move_mode( const JsonObject &jo, const std::string &src )
+void move_mode::load_move_mode( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    move_mode_factory.load( jo, src );
+    move_mode_factory.load( jo, src, second_src );
 }
 
-void move_mode::load( const JsonObject &jo, const std::string_view/*src*/ )
+void move_mode::load( const JsonObject &jo, const std::string_view/*src*/, const std::string_view )
 {
     mandatory( jo, was_loaded, "character", _letter, unicode_codepoint_from_symbol_reader );
     mandatory( jo, was_loaded, "name",  _name );

--- a/src/move_mode.h
+++ b/src/move_mode.h
@@ -39,6 +39,7 @@ class move_mode
         bool was_loaded = false;
         move_mode_id id;
         std::vector<std::pair<move_mode_id, mod_id>> src;
+        std::vector<std::pair<move_mode_id, mod_id>> second_src;
 
         std::map<steed_type, translation> change_messages_success;
         std::map<steed_type, translation> change_messages_fail;

--- a/src/move_mode.h
+++ b/src/move_mode.h
@@ -67,8 +67,8 @@ class move_mode
         translation _name;
 
     public:
-        static void load_move_mode( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, std::string_view src );
+        static void load_move_mode( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         static void finalize();
         static void reset();
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -68,8 +68,8 @@ struct mon_flag {
     mon_flag_str_id id = mon_flag_str_id::NULL_ID();
     bool was_loaded = false;
 
-    void load( const JsonObject &jo, std::string_view src );
-    static void load_mon_flags( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
+    static void load_mon_flags( const JsonObject &jo, const std::string &src, const std::string &second_src );
     static void reset();
     static const std::vector<mon_flag> &get_all();
 };
@@ -552,7 +552,7 @@ struct mtype {
         void faction_display( catacurses::window &w, const point &top_left, int width ) const;
 
         // Historically located in monstergenerator.cpp
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, const std::string &src, const std::string_view );
 
     private:
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -341,6 +341,7 @@ struct mtype {
 
         /** Mod origin */
         std::vector<std::pair<mtype_id, mod_id>> src;
+        std::vector<std::pair<mtype_id, mod_id>> second_src;
         weakpoint_families families;
     private:
         std::vector<weakpoints_id> weakpoints_deferred;

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -404,8 +404,8 @@ struct mutation_branch {
         // For init.cpp: reset (clear) the mutation data
         static void reset_all();
         // For init.cpp: load mutation data from json
-        void load( const JsonObject &jo, std::string_view src );
-        static void load_trait( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src, const std::string &second_src );
+        static void load_trait( const JsonObject &jo, const std::string &src, const std::string &second_src );
         // For init.cpp: check internal consistency (valid ids etc.) of all mutations
         static void check_consistency();
 

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -173,6 +173,7 @@ struct mutation_variant {
 struct mutation_branch {
         trait_id id;
         std::vector<std::pair<trait_id, mod_id>> src;
+        std::vector<std::pair<trait_id, mod_id>> second_src;
         bool was_loaded = false;
         // True if this is a valid mutation.
         bool valid = false;

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -192,9 +192,9 @@ static social_modifiers load_mutation_social_mods( const JsonObject &jo )
     return ret;
 }
 
-void mutation_branch::load_trait( const JsonObject &jo, const std::string &src )
+void mutation_branch::load_trait( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    trait_factory.load( jo, src );
+    trait_factory.load( jo, src, second_src );
 }
 
 mut_transform::mut_transform() = default;
@@ -300,7 +300,7 @@ void mutation_variant::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void mutation_branch::load( const JsonObject &jo, const std::string_view src )
+void mutation_branch::load( const JsonObject &jo, const std::string_view src, const std::string &second_src )
 {
     mandatory( jo, was_loaded, "name", raw_name );
     mandatory( jo, was_loaded, "description", raw_desc );
@@ -439,7 +439,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string_view src )
     int enchant_num = 0;
     for( JsonValue jv : jo.get_array( "enchantments" ) ) {
         std::string enchant_name = "INLINE_ENCH_" + id.str() + "_" + std::to_string( enchant_num++ );
-        enchantments.push_back( enchantment::load_inline_enchantment( jv, src, enchant_name ) );
+        enchantments.push_back( enchantment::load_inline_enchantment( jv, src, enchant_name, second_src ) );
     }
 
     optional( jo, was_loaded, "comfort", comfort );

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -423,15 +423,15 @@ void mutation_branch::load( const JsonObject &jo, const std::string_view src, co
     }
 
     for( JsonValue jv : jo.get_array( "activated_eocs" ) ) {
-        activated_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        activated_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 
     for( JsonValue jv : jo.get_array( "processed_eocs" ) ) {
-        processed_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        processed_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 
     for( JsonValue jv : jo.get_array( "deactivated_eocs" ) ) {
-        deactivated_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        deactivated_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 
     optional( jo, was_loaded, "activated_is_setup", activated_is_setup, false );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -451,7 +451,7 @@ void npc_template::load( const JsonObject &jsobj, const std::string_view src, co
         tem.personality->altruism = personality.get_int( "altruism" );
     }
     for( JsonValue jv : jsobj.get_array( "death_eocs" ) ) {
-        guy.death_eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+        guy.death_eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
     }
 
     npc_templates.emplace( guy.idz, std::move( tem ) );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -297,7 +297,7 @@ npc &npc::operator=( npc && ) noexcept( list_is_noexcept ) = default;
 
 static std::map<string_id<npc_template>, npc_template> npc_templates;
 
-void npc_template::load( const JsonObject &jsobj, const std::string_view src )
+void npc_template::load( const JsonObject &jsobj, const std::string_view src, const std::string &second_src )
 {
     npc_template tem;
     npc &guy = tem.guy;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1475,7 +1475,7 @@ class npc_template
         std::optional<int> per;
         std::optional<npc_personality> personality;
 
-        static void load( const JsonObject &jsobj, std::string_view src );
+        static void load( const JsonObject &jsobj, std::string_view src, const std::string &second_src );
         static void reset();
         static void check_consistency();
 };

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -43,9 +43,9 @@ npc_class::npc_class() : id( npc_class_id::NULL_ID() )
 {
 }
 
-void npc_class::load_npc_class( const JsonObject &jo, const std::string &src )
+void npc_class::load_npc_class( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    npc_class_factory.load( jo, src );
+    npc_class_factory.load( jo, src, second_src );
 }
 
 void npc_class::reset_npc_classes()
@@ -224,7 +224,7 @@ void shopkeeper_item_group::deserialize( const JsonObject &jo )
     }
 }
 
-void npc_class::load( const JsonObject &jo, const std::string_view )
+void npc_class::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "job_description", job_description );

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -141,11 +141,11 @@ class npc_class
 
         bool is_common() const;
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
         static const npc_class_id &random_common();
 
-        static void load_npc_class( const JsonObject &jo, const std::string &src );
+        static void load_npc_class( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
         static const std::vector<npc_class> &get_all();
 

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -101,6 +101,7 @@ class npc_class
     public:
         npc_class_id id;
         std::vector<std::pair<npc_class_id, mod_id>> src;
+        std::vector<std::pair<npc_class_id, mod_id>> second_src;
         bool was_loaded = false;
 
         // By default, NPCs will be open to trade anything in their inventory, including worn items. If this is set to false, they won't sell items that they're directly wearing or wielding. Items inside of pockets/bags/etc are still fair game.

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -280,10 +280,10 @@ static std::vector<effect_on_condition_id> load_eoc_vector( const JsonObject &jo
     std::vector<effect_on_condition_id> eocs;
     if( jo.has_array( member ) ) {
         for( JsonValue jv : jo.get_array( member ) ) {
-            eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+            eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, "" ) );
         }
     } else if( jo.has_member( member ) ) {
-        eocs.push_back( effect_on_conditions::load_inline_eoc( jo.get_member( member ), src ) );
+        eocs.push_back( effect_on_conditions::load_inline_eoc( jo.get_member( member ), src, "" ) );
     }
     return eocs;
 }
@@ -307,7 +307,7 @@ load_eoc_vector_id_and_var(
             }
         }
         if( !entry.var ) {
-            entry.id = effect_on_conditions::load_inline_eoc( jv, src );
+            entry.id = effect_on_conditions::load_inline_eoc( jv, src, "" );
         }
         eocs_entries.push_back( entry );
     };
@@ -5376,7 +5376,7 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
 talk_effect_fun_t::func f_run_eoc_until( const JsonObject &jo, std::string_view member,
         const std::string_view src )
 {
-    effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), src );
+    effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), src, "" );
     std::function<bool( dialogue & )> cond;
     read_condition( jo, "condition", cond, true ); // The default result of this condition is true
 
@@ -5567,7 +5567,7 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
 talk_effect_fun_t::func f_run_eoc_with( const JsonObject &jo, std::string_view member,
                                         const std::string_view src )
 {
-    effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), src );
+    effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), src, "" );
 
     std::unordered_map<std::string, str_translation_or_var> context;
     if( jo.has_object( "variables" ) ) {
@@ -5938,7 +5938,7 @@ talk_effect_fun_t::func f_queue_eocs( const JsonObject &jo, std::string_view mem
 talk_effect_fun_t::func f_queue_eoc_with( const JsonObject &jo, std::string_view member,
         const std::string_view src )
 {
-    effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), src );
+    effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), src, "" );
 
     std::unordered_map<std::string, str_translation_or_var> context;
     if( jo.has_object( "variables" ) ) {
@@ -5986,7 +5986,7 @@ talk_effect_fun_t::func f_weighted_list_eocs( const JsonObject &jo,
         } else {
             eoc_weight.min = get_dbl_or_var_part( ja.next_value(), member );
         }
-        eoc_pairs.emplace_back( effect_on_conditions::load_inline_eoc( eoc, src ),
+        eoc_pairs.emplace_back( effect_on_conditions::load_inline_eoc( eoc, src, "" ),
                                 eoc_weight );
     }
     return [eoc_pairs]( dialogue & d ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7753,7 +7753,7 @@ void unload_talk_topics()
     json_talk_topics.clear();
 }
 
-void load_talk_topic( const JsonObject &jo, const std::string_view src )
+void load_talk_topic( const JsonObject &jo, const std::string_view src, const std::string &second_src )
 {
     if( jo.has_array( "id" ) ) {
         for( auto &id : jo.get_string_array( "id" ) ) {

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -129,6 +129,7 @@ class overmap_land_use_code
     public:
         overmap_land_use_code_id id = overmap_land_use_code_id::NULL_ID();
         std::vector<std::pair<overmap_land_use_code_id, mod_id>> src;
+        std::vector<std::pair<overmap_land_use_code_id, mod_id>> second_src;
 
         int land_use_code = 0;
         translation name;
@@ -288,6 +289,7 @@ class oter_vision
         friend struct mod_tracker;
         oter_vision_id id;
         std::vector<std::pair<oter_vision_id, mod_id>> src;
+        std::vector<std::pair<oter_vision_id, mod_id>> second_src;
         bool was_loaded = false;
 
         std::vector<level> levels;
@@ -299,6 +301,7 @@ struct oter_type_t {
 
         string_id<oter_type_t> id;
         std::vector<std::pair<string_id<oter_type_t>, mod_id>> src;
+        std::vector<std::pair<string_id<oter_type_t>, mod_id>> second_src;
     private:
         friend struct oter_t;
         translation name;
@@ -403,6 +406,7 @@ struct oter_t {
     public:
         oter_str_id id;         // definitive identifier.
         std::vector < std::pair < oter_str_id, mod_id>> src;
+        std::vector < std::pair < oter_str_id, mod_id>> second_src;
 
         oter_t();
         explicit oter_t( const oter_type_t &type );
@@ -691,7 +695,7 @@ class overmap_special
 
         // Used by generic_factory
         bool was_loaded = false;
-        void load( const JsonObject &jo, const std::string &src, const std::string_view );
+        void load( const JsonObject &jo, const std::string &src, const std::string_view second_src );
         void finalize();
         void finalize_mapgen_parameters();
         void check() const;
@@ -727,6 +731,7 @@ struct overmap_special_migration {
         bool was_loaded = false;
         overmap_special_migration_id id;
         std::vector<std::pair<overmap_special_migration_id, mod_id>> src;
+        std::vector<std::pair<overmap_special_migration_id, mod_id>> second_src;
         overmap_special_id new_id;
         friend generic_factory<overmap_special_migration>;
         friend struct mod_tracker;

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -140,7 +140,7 @@ class overmap_land_use_code
 
         // Used by generic_factory
         bool was_loaded = false;
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, const std::string &src, const std::string_view );
         void finalize();
         void check() const;
 };
@@ -271,14 +271,14 @@ class oter_vision
         };
         const level *viewed( om_vision_level ) const;
 
-        static void load_oter_vision( const JsonObject &jo, const std::string &src );
+        static void load_oter_vision( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
         static void check_oter_vision();
         static const std::vector<oter_vision> &get_all();
 
         oter_vision_id get_id() const;
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void check() const;
 
         static blended_omt get_blended_omt_info( const tripoint_abs_omt &omp, om_vision_level vision );
@@ -357,7 +357,7 @@ struct oter_type_t {
             flags.set( flag, value );
         }
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, const std::string &src, const std::string_view );
         void check() const;
         void finalize();
 
@@ -691,7 +691,7 @@ class overmap_special
 
         // Used by generic_factory
         bool was_loaded = false;
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, const std::string &src, const std::string_view );
         void finalize();
         void finalize_mapgen_parameters();
         void check() const;
@@ -713,9 +713,9 @@ class overmap_special
 
 struct overmap_special_migration {
     public:
-        static void load_migrations( const JsonObject &jo, const std::string &src );
+        static void load_migrations( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         static void check();
         // Check if the given overmap special should be migrated
         static bool migrated( const overmap_special_id &os_id );
@@ -735,7 +735,7 @@ struct overmap_special_migration {
 namespace overmap_terrains
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void check_consistency();
 void finalize();
 void reset();
@@ -747,7 +747,7 @@ const std::vector<oter_t> &get_all();
 namespace overmap_land_use_codes
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void finalize();
 void check_consistency();
 void reset();
@@ -759,7 +759,7 @@ const std::vector<overmap_land_use_code> &get_all();
 namespace overmap_specials
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void finalize();
 void finalize_mapgen_parameters();
 void check_consistency();
@@ -778,7 +778,7 @@ overmap_special_id create_building_from( const string_id<oter_type_t> &base );
 namespace city_buildings
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
 } // namespace city_buildings
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -86,9 +86,9 @@ const std::vector<option_slider> &option_slider::get_all()
     return option_slider_factory.get_all();
 }
 
-void option_slider::load_option_sliders( const JsonObject &jo, const std::string &src )
+void option_slider::load_option_sliders( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    option_slider_factory.load( jo, src );
+    option_slider_factory.load( jo, src, second_src );
 }
 
 void option_slider::finalize_all()
@@ -106,7 +106,7 @@ void option_slider::check_consistency()
     }
 }
 
-void option_slider::load( const JsonObject &jo, const std::string_view )
+void option_slider::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     optional( jo, was_loaded, "default", _default_level, 0 );

--- a/src/options.h
+++ b/src/options.h
@@ -425,11 +425,11 @@ struct option_slider {
         option_slider_id id;
         bool was_loaded = false;
 
-        static void load_option_sliders( const JsonObject &jo, const std::string &src );
+        static void load_option_sliders( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
         static void finalize_all();
         static void check_consistency();
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void check() const;
         static const std::vector<option_slider> &get_all();
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2959,7 +2959,7 @@ mapgen_arguments overmap_special::get_args( const mapgendata &md ) const
     return mapgen_params_.get_args( md, mapgen_parameter_scope::overmap_special );
 }
 
-void overmap_special::load( const JsonObject &jo, const std::string &src, const std::string_view )
+void overmap_special::load( const JsonObject &jo, const std::string &src, const std::string_view second_src )
 {
     const bool strict = src == "dda";
     // city_building is just an alias of overmap_special
@@ -2969,7 +2969,7 @@ void overmap_special::load( const JsonObject &jo, const std::string &src, const 
     optional( jo, was_loaded, "subtype", subtype_, overmap_special_subtype::fixed );
     optional( jo, was_loaded, "locations", default_locations_ );
     if( jo.has_member( "eoc" ) ) {
-        eoc = effect_on_conditions::load_inline_eoc( jo.get_member( "eoc" ), src );
+        eoc = effect_on_conditions::load_inline_eoc( jo.get_member( "eoc" ), src, second_src );
         has_eoc_ = true;
     }
     switch( subtype_ ) {
@@ -7689,7 +7689,11 @@ overmap_special_id overmap_specials::create_building_from( const string_id<oter_
 
     overmap_special_id new_id( "FakeSpecial_" + base.str() );
     overmap_special new_special( new_id, ter );
-    mod_tracker::assign_src( new_special, base->src.back().second.str() );
+    if ( !base->second_src.empty() ) {
+        mod_tracker::assign_src( new_special, base->src.back().second.str(), base->second_src.back().second.str() );
+    } else {
+        mod_tracker::assign_src( new_special, base->src.back().second.str(), "" );
+    }
 
     return specials.insert( new_special ).id;
 }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -170,9 +170,9 @@ bool string_id<oter_vision>::is_valid() const
     return oter_vision_factory.is_valid( *this );
 }
 
-void oter_vision::load_oter_vision( const JsonObject &jo, const std::string &src )
+void oter_vision::load_oter_vision( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    oter_vision_factory.load( jo, src );
+    oter_vision_factory.load( jo, src, second_src );
 }
 
 void oter_vision::reset()
@@ -474,7 +474,7 @@ std::string overmap_land_use_code::get_symbol() const
     return utf32_to_utf8( symbol );
 }
 
-void overmap_land_use_code::load( const JsonObject &jo, const std::string &src )
+void overmap_land_use_code::load( const JsonObject &jo, const std::string &src, const std::string_view )
 {
     const bool strict = src == "dda";
     assign( jo, "land_use_code", land_use_code, strict );
@@ -502,9 +502,9 @@ void overmap_land_use_code::check() const
 
 }
 
-void overmap_land_use_codes::load( const JsonObject &jo, const std::string &src )
+void overmap_land_use_codes::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    land_use_codes.load( jo, src );
+    land_use_codes.load( jo, src, second_src );
 }
 
 void overmap_land_use_codes::finalize()
@@ -529,15 +529,15 @@ const std::vector<overmap_land_use_code> &overmap_land_use_codes::get_all()
     return land_use_codes.get_all();
 }
 
-void overmap_specials::load( const JsonObject &jo, const std::string &src )
+void overmap_specials::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    specials.load( jo, src );
+    specials.load( jo, src, second_src );
 }
 
-void city_buildings::load( const JsonObject &jo, const std::string &src )
+void city_buildings::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     // Just an alias
-    overmap_specials::load( jo, src );
+    overmap_specials::load( jo, src, second_src );
 }
 
 void overmap_specials::finalize()
@@ -836,7 +836,7 @@ oter_vision_id oter_vision::get_id() const
     return id;
 }
 
-void oter_vision::load( const JsonObject &jo, std::string_view )
+void oter_vision::load( const JsonObject &jo, std::string_view, const std::string_view )
 {
     if( id.str().find( '$' ) != std::string::npos ) {
         jo.throw_error( string_format( "id for vision level %s contains a '$'", id.str() ) );
@@ -874,7 +874,7 @@ void oter_vision::check() const
 }
 
 
-void oter_type_t::load( const JsonObject &jo, const std::string &src )
+void oter_type_t::load( const JsonObject &jo, const std::string &src, const std::string_view )
 {
     const bool strict = src == "dda";
 
@@ -1186,9 +1186,9 @@ bool oter_t::is_hardcoded() const
     return hardcoded_mapgen.find( get_mapgen_id() ) != hardcoded_mapgen.end();
 }
 
-void overmap_terrains::load( const JsonObject &jo, const std::string &src )
+void overmap_terrains::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    terrain_types.load( jo, src );
+    terrain_types.load( jo, src, second_src );
 }
 
 void overmap_terrains::check_consistency()
@@ -2959,7 +2959,7 @@ mapgen_arguments overmap_special::get_args( const mapgendata &md ) const
     return mapgen_params_.get_args( md, mapgen_parameter_scope::overmap_special );
 }
 
-void overmap_special::load( const JsonObject &jo, const std::string &src )
+void overmap_special::load( const JsonObject &jo, const std::string &src, const std::string_view )
 {
     const bool strict = src == "dda";
     // city_building is just an alias of overmap_special
@@ -7804,9 +7804,9 @@ std::string oter_get_rotation_string( const oter_id &oter )
     return "";
 }
 
-void overmap_special_migration::load_migrations( const JsonObject &jo, const std::string &src )
+void overmap_special_migration::load_migrations( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    migrations.load( jo, src );
+    migrations.load( jo, src, second_src );
 }
 
 void overmap_special_migration::reset()
@@ -7814,7 +7814,7 @@ void overmap_special_migration::reset()
     migrations.reset();
 }
 
-void overmap_special_migration::load( const JsonObject &jo, const std::string_view )
+void overmap_special_migration::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     optional( jo, was_loaded, "new_id", new_id, overmap_special_id() );

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -98,7 +98,7 @@ bool overmap_connection::has( const int_id<oter_t> &oter ) const
     } ) != subtypes.cend();
 }
 
-void overmap_connection::load( const JsonObject &jo, const std::string_view )
+void overmap_connection::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, false, "subtypes", subtypes );
 }
@@ -127,9 +127,9 @@ void overmap_connection::finalize()
     cached_subtypes.resize( overmap_terrains::get_all().size() );
 }
 
-void overmap_connections::load( const JsonObject &jo, const std::string &src )
+void overmap_connections::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    connections.load( jo, src );
+    connections.load( jo, src, second_src );
 }
 
 void overmap_connections::finalize()

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -48,7 +48,7 @@ class overmap_connection
         const subtype *pick_subtype_for( const int_id<oter_t> &ground ) const;
         bool has( const int_id<oter_t> &oter ) const;
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void check() const;
         void finalize();
 
@@ -72,7 +72,7 @@ class overmap_connection
 namespace overmap_connections
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void finalize();
 void check_consistency();
 void reset();

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -54,6 +54,7 @@ class overmap_connection
 
         string_id<overmap_connection> id;
         std::vector<std::pair<string_id<overmap_connection>, mod_id>> src;
+        std::vector<std::pair<string_id<overmap_connection>, mod_id>> second_src;
         bool was_loaded = false;
 
     private:

--- a/src/overmap_location.cpp
+++ b/src/overmap_location.cpp
@@ -40,7 +40,7 @@ oter_type_id overmap_location::get_random_terrain() const
     return random_entry( terrains );
 }
 
-void overmap_location::load( const JsonObject &jo, const std::string_view )
+void overmap_location::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     optional( jo, was_loaded, "flags", flags );
     optional( jo, was_loaded, "terrains", terrains );
@@ -81,9 +81,9 @@ void overmap_location::finalize()
     }
 }
 
-void overmap_locations::load( const JsonObject &jo, const std::string &src )
+void overmap_locations::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    locations.load( jo, src );
+    locations.load( jo, src, second_src );
 }
 
 void overmap_locations::check_consistency()

--- a/src/overmap_location.h
+++ b/src/overmap_location.h
@@ -15,7 +15,7 @@ struct overmap_location {
     public:
         using TerrColType = cata::flat_set<oter_type_str_id>;
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void check() const;
         void finalize();
 
@@ -37,7 +37,7 @@ struct overmap_location {
 namespace overmap_locations
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void check_consistency();
 void reset();
 void finalize();

--- a/src/overmap_location.h
+++ b/src/overmap_location.h
@@ -27,6 +27,7 @@ struct overmap_location {
         // Used by generic_factory
         string_id<overmap_location> id;
         std::vector<std::pair<string_id<overmap_location>, mod_id>> src;
+        std::vector<std::pair<string_id<overmap_location>, mod_id>> second_src;
         bool was_loaded = false;
 
     private:

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -86,12 +86,12 @@ bool string_id<profession>::is_valid() const
 static profession_blacklist prof_blacklist;
 
 void profession_blacklist::load_profession_blacklist( const JsonObject &jo,
-        const std::string_view src )
+        const std::string_view src, const std::string &second_src )
 {
-    prof_blacklist.load( jo, src );
+    prof_blacklist.load( jo, src, second_src );
 }
 
-void profession_blacklist::load( const JsonObject &jo, const std::string_view )
+void profession_blacklist::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     if( !professions.empty() ) {
         DebugLog( D_INFO, DC_ALL ) << "Loading profession black with one already loaded, resetting";
@@ -142,9 +142,9 @@ profession::profession()
 {
 }
 
-void profession::load_profession( const JsonObject &jo, const std::string &src )
+void profession::load_profession( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    all_profs.load( jo, src );
+    all_profs.load( jo, src, second_src );
 }
 
 class skilllevel_reader : public generic_typed_reader<skilllevel_reader>
@@ -201,7 +201,7 @@ class item_reader : public generic_typed_reader<item_reader>
         }
 };
 
-void profession::load( const JsonObject &jo, const std::string_view )
+void profession::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     //If the "name" is an object then we have to deal with gender-specific titles,
     if( jo.has_object( "name" ) ) {

--- a/src/profession.h
+++ b/src/profession.h
@@ -89,13 +89,13 @@ class profession
 
         void check_item_definitions( const itypedecvec &items ) const;
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
     public:
         //these three aren't meant for external use, but had to be made public regardless
         profession();
 
-        static void load_profession( const JsonObject &jo, const std::string &src );
+        static void load_profession( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void load_item_substitutions( const JsonObject &jo );
 
         // these should be the only ways used to get at professions
@@ -173,9 +173,9 @@ struct profession_blacklist {
     std::set<string_id<profession>> professions;
     bool whitelist = false;
 
-    static void load_profession_blacklist( const JsonObject &jo, std::string_view src );
+    static void load_profession_blacklist( const JsonObject &jo, std::string_view src, const std::string &second_src );
     static void reset();
-    void load( const JsonObject &jo, std::string_view );
+    void load( const JsonObject &jo, std::string_view, std::string_view );
     void check_consistency() const;
 };
 

--- a/src/profession.h
+++ b/src/profession.h
@@ -132,6 +132,7 @@ class profession
         int age_upper = 55;
 
         std::vector<std::pair<string_id<profession>, mod_id>> src;
+        std::vector<std::pair<string_id<profession>, mod_id>> second_src;
 
         std::optional<achievement_id> get_requirement() const;
 

--- a/src/profession_group.cpp
+++ b/src/profession_group.cpp
@@ -20,12 +20,12 @@ bool string_id<profession_group>::is_valid() const
     return profession_group_factory.is_valid( *this );
 }
 
-void profession_group::load_profession_group( const JsonObject &jo, const std::string &src )
+void profession_group::load_profession_group( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    profession_group_factory.load( jo, src );
+    profession_group_factory.load( jo, src, second_src );
 }
 
-void profession_group::load( const JsonObject &jo, const std::string_view & )
+void profession_group::load( const JsonObject &jo, const std::string_view &, const std::string_view )
 {
     assign( jo, "id", id );
     assign( jo, "professions", profession_list );

--- a/src/profession_group.h
+++ b/src/profession_group.h
@@ -7,8 +7,8 @@
 
 struct profession_group {
 
-        static void load_profession_group( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, const std::string_view & );
+        static void load_profession_group( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load( const JsonObject &jo, const std::string_view &, const std::string_view );
         static const std::vector<profession_group> &get_all();
         static void check_profession_group_consistency();
         bool was_loaded = false;

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -68,15 +68,15 @@ std::string enum_to_string<proficiency_bonus_type>( const proficiency_bonus_type
 }
 } // namespace io
 
-void proficiency::load_proficiencies( const JsonObject &jo, const std::string &src )
+void proficiency::load_proficiencies( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    proficiency_factory.load( jo, src );
+    proficiency_factory.load( jo, src, second_src );
 }
 
 void proficiency_category::load_proficiency_categories( const JsonObject &jo,
-        const std::string &src )
+        const std::string &src, const std::string &second_src )
 {
-    proficiency_category_factory.load( jo, src );
+    proficiency_category_factory.load( jo, src, second_src );
 }
 
 void proficiency_bonus::deserialize( const JsonObject &jo )
@@ -95,7 +95,7 @@ void proficiency_category::reset()
     proficiency_category_factory.reset();
 }
 
-void proficiency::load( const JsonObject &jo, const std::string_view )
+void proficiency::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "description", _description );
@@ -121,7 +121,7 @@ void proficiency::load( const JsonObject &jo, const std::string_view )
     }
 }
 
-void proficiency_category::load( const JsonObject &jo, const std::string_view )
+void proficiency_category::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "description", _description );

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -68,6 +68,7 @@ class proficiency
         proficiency_id id;
         proficiency_category_id _category;
         std::vector<std::pair<proficiency_id, mod_id>> src;
+        std::vector<std::pair<proficiency_id, mod_id>> second_src;
         bool was_loaded = false;
 
         bool _can_learn = false;

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -54,9 +54,9 @@ struct proficiency_category {
     translation _description;
     bool was_loaded = false;
 
-    static void load_proficiency_categories( const JsonObject &jo, const std::string &src );
+    static void load_proficiency_categories( const JsonObject &jo, const std::string &src, const std::string &second_src );
     static void reset();
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
     static const std::vector<proficiency_category> &get_all();
 };
 
@@ -89,9 +89,9 @@ class proficiency
         std::map<std::string, std::vector<proficiency_bonus>> _bonuses;
 
     public:
-        static void load_proficiencies( const JsonObject &jo, const std::string &src );
+        static void load_proficiencies( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
         static const std::vector<proficiency> &get_all();
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -148,7 +148,7 @@ bool recipe::has_flag( const std::string &flag_name ) const
     return flags.count( flag_name );
 }
 
-void recipe::load( const JsonObject &jo, const std::string &src )
+void recipe::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
     bool strict = src == "dda";
 
@@ -158,7 +158,7 @@ void recipe::load( const JsonObject &jo, const std::string &src )
     if( jo.has_member( "result_eocs" ) ) {
         result_eocs.clear();
         for( JsonValue jv : jo.get_array( "result_eocs" ) ) {
-            result_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
+            result_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src, second_src ) );
         }
     }
     if( abstract ) {

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -269,7 +269,7 @@ class recipe
             return reversible;
         }
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
         void finalize();
 
         /** Returns a non-empty string describing an inconsistency (if any) in the recipe. */
@@ -309,6 +309,7 @@ class recipe
 
         recipe_id id = recipe_id::NULL_ID();
         std::vector<std::pair<recipe_id, mod_id>> src;
+        std::vector<std::pair<recipe_id, mod_id>> second_src;
 
         /** Abstract recipes can be inherited from but are themselves disposed of at finalization */
         bool abstract = false;

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -400,28 +400,28 @@ const std::set<const recipe *> &recipe_subset::of_component( const itype_id &id 
     return iter != component.end() ? iter->second : null_match;
 }
 
-void recipe_dictionary::load_recipe( const JsonObject &jo, const std::string &src )
+void recipe_dictionary::load_recipe( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    load( jo, src, recipe_dict.recipes );
+    load( jo, src, recipe_dict.recipes, second_src );
 }
 
-void recipe_dictionary::load_uncraft( const JsonObject &jo, const std::string &src )
+void recipe_dictionary::load_uncraft( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    load( jo, src, recipe_dict.uncraft );
+    load( jo, src, recipe_dict.uncraft, second_src );
 }
 
-void recipe_dictionary::load_practice( const JsonObject &jo, const std::string &src )
+void recipe_dictionary::load_practice( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    load( jo, src, recipe_dict.recipes );
+    load( jo, src, recipe_dict.recipes, second_src );
 }
 
-void recipe_dictionary::load_nested_category( const JsonObject &jo, const std::string &src )
+void recipe_dictionary::load_nested_category( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    load( jo, src, recipe_dict.recipes );
+    load( jo, src, recipe_dict.recipes, second_src );
 }
 
 recipe &recipe_dictionary::load( const JsonObject &jo, const std::string &src,
-                                 std::map<recipe_id, recipe> &out )
+                                 std::map<recipe_id, recipe> &out, const std::string &second_src )
 {
     recipe r;
 
@@ -429,7 +429,7 @@ recipe &recipe_dictionary::load( const JsonObject &jo, const std::string &src,
     if( jo.has_string( "copy-from" ) ) {
         recipe_id base = recipe_id( jo.get_string( "copy-from" ) );
         if( !out.count( base ) ) {
-            deferred.emplace_back( jo, src );
+            deferred.emplace_back( jo, src, second_src );
             jo.allow_omitted_members();
             return null_recipe;
         }
@@ -721,8 +721,9 @@ void recipe_dictionary::reset()
     recipe_dict.recipes.clear();
     recipe_dict.uncraft.clear();
     recipe_dict.items_on_loops.clear();
-    for( std::pair<JsonObject, std::string> &deferred_json : deferred ) {
-        deferred_json.first.allow_omitted_members();
+    for( std::tuple<JsonObject, std::string, std::string> &deferred_json : deferred ) {
+        std::get<0>(deferred_json).allow_omitted_members();
+        // deferred_json.first.allow_omitted_members();
     }
     deferred.clear();
 }

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -436,8 +436,8 @@ recipe &recipe_dictionary::load( const JsonObject &jo, const std::string &src,
         r = out[ base ];
     }
 
-    r.load( jo, src );
-    mod_tracker::assign_src( r, src );
+    r.load( jo, src, second_src );
+    mod_tracker::assign_src( r, src, second_src );
     r.was_loaded = true;
 
     // Check for duplicate recipe_ids before assigning it to the map

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -53,10 +53,10 @@ class recipe_dictionary
         /** Returns crafting recipe (or null recipe if no match) */
         static const recipe &get_craft( const itype_id &id );
 
-        static void load_recipe( const JsonObject &jo, const std::string &src );
-        static void load_uncraft( const JsonObject &jo, const std::string &src );
-        static void load_practice( const JsonObject &jo, const std::string &src );
-        static void load_nested_category( const JsonObject &jo, const std::string &src );
+        static void load_recipe( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        static void load_uncraft( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        static void load_practice( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        static void load_nested_category( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
         static void finalize();
         static void check_consistency();
@@ -70,7 +70,7 @@ class recipe_dictionary
         static void delete_if( const std::function<bool( const recipe & )> &pred );
 
         static recipe &load( const JsonObject &jo, const std::string &src,
-                             std::map<recipe_id, recipe> &out );
+                             std::map<recipe_id, recipe> &out, const std::string &second_src );
 
     private:
         std::map<recipe_id, recipe> recipes;

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -35,7 +35,7 @@ struct recipe_group_data {
     std::map<recipe_id, std::vector<omt_types_parameters>> om_terrains;
     bool was_loaded = false;
 
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
     void check() const;
 };
 
@@ -43,7 +43,7 @@ generic_factory<recipe_group_data> recipe_groups_data( "recipe group type" );
 
 } // namespace
 
-void recipe_group_data::load( const JsonObject &jo, const std::string_view )
+void recipe_group_data::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     building_type = jo.get_string( "building_type" );
     for( JsonObject ordering : jo.get_array( "recipes" ) ) {
@@ -178,9 +178,9 @@ std::string recipe_group::get_building_of_recipe( const std::string &recipe )
     return "";
 }
 
-void recipe_group::load( const JsonObject &jo, const std::string &src )
+void recipe_group::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    recipe_groups_data.load( jo, src );
+    recipe_groups_data.load( jo, src, second_src );
 }
 
 void recipe_group::check()

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -30,6 +30,7 @@ struct omt_types_parameters {
 struct recipe_group_data {
     group_id id;
     std::vector<std::pair<group_id, mod_id>> src;
+    std::vector<std::pair<group_id, mod_id>> second_src;
     std::string building_type = "NONE";
     std::map<recipe_id, translation> recipes;
     std::map<recipe_id, std::vector<omt_types_parameters>> om_terrains;

--- a/src/recipe_groups.h
+++ b/src/recipe_groups.h
@@ -14,7 +14,7 @@ class translation;
 namespace recipe_group
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void check();
 void reset();
 

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -101,9 +101,9 @@ bool string_id<relic_procgen_data>::is_valid() const
     return relic_procgen_data_factory.is_valid( *this );
 }
 
-void relic_procgen_data::load_relic_procgen_data( const JsonObject &jo, const std::string &src )
+void relic_procgen_data::load_relic_procgen_data( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    relic_procgen_data_factory.load( jo, src );
+    relic_procgen_data_factory.load( jo, src, second_src );
 }
 
 void relic::add_active_effect( const fake_spell &sp )
@@ -164,7 +164,7 @@ void relic_procgen_data::enchantment_active::deserialize( const JsonObject &jobj
     load( jobj );
 }
 
-void relic_procgen_data::load( const JsonObject &jo, const std::string_view )
+void relic_procgen_data::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     for( const JsonObject jo_inner : jo.get_array( "passive_add_procgen_values" ) ) {
         int weight = 0;

--- a/src/relic.h
+++ b/src/relic.h
@@ -132,9 +132,9 @@ class relic_procgen_data
         bool was_loaded = false;
 
         static const std::vector<relic_procgen_data> &get_all();
-        static void load_relic_procgen_data( const JsonObject &jo, const std::string &src );
+        static void load_relic_procgen_data( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
-        void load( const JsonObject &jo, std::string_view = {} );
+        void load( const JsonObject &jo, std::string_view = {}, const std::string_view = {} );
         void deserialize( const JsonObject &jobj );
 };
 

--- a/src/relic.h
+++ b/src/relic.h
@@ -121,6 +121,7 @@ class relic_procgen_data
     public:
         relic_procgen_id id;
         std::vector<std::pair<relic_procgen_id, mod_id>> src;
+        std::vector<std::pair<relic_procgen_id, mod_id>> second_src;
 
         int power_level( const enchant_cache &ench ) const;
         // power level of the active spell

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -99,12 +99,12 @@ void quality::reset()
     quality_factory.reset();
 }
 
-void quality::load_static( const JsonObject &jo, const std::string &src )
+void quality::load_static( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    quality_factory.load( jo, src );
+    quality_factory.load( jo, src, second_src );
 }
 
-void quality::load( const JsonObject &jo, const std::string_view )
+void quality::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
 

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -49,10 +49,10 @@ struct quality {
 
     std::vector<std::pair<int, std::string>> usages;
 
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
     static void reset();
-    static void load_static( const JsonObject &jo, const std::string &src );
+    static void load_static( const JsonObject &jo, const std::string &src, const std::string &second_src );
 };
 
 struct component {

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -45,6 +45,7 @@ struct quality {
     bool was_loaded = false;
     quality_id id;
     std::vector<std::pair<quality_id, mod_id>> src;
+    std::vector<std::pair<quality_id, mod_id>> second_src;
     translation name;
 
     std::vector<std::pair<int, std::string>> usages;

--- a/src/rotatable_symbols.cpp
+++ b/src/rotatable_symbols.cpp
@@ -35,7 +35,7 @@ std::vector<rotatable_symbol> symbols;
 namespace rotatable_symbols
 {
 
-void load( const JsonObject &jo, const std::string &src )
+void load( const JsonObject &jo, const std::string &src, const std::string & )
 {
     const std::string tuple_key = "tuple";
     const bool strict = src == "dda";

--- a/src/rotatable_symbols.h
+++ b/src/rotatable_symbols.h
@@ -10,7 +10,7 @@ class JsonObject;
 namespace rotatable_symbols
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string & );
 void reset();
 
 // Rotate a symbol n times (clockwise).

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1652,7 +1652,7 @@ void global_variables::serialize( JsonOut &jsout ) const
     jsout.member( "global_vals", global_values );
 }
 
-void global_variables::load_migrations( const JsonObject &jo, const std::string_view & )
+void global_variables::load_migrations( const JsonObject &jo, const std::string_view &, const std::string_view & )
 {
     const std::string from( jo.get_string( "from" ) );
     const std::string to = jo.has_string( "to" )

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2750,7 +2750,7 @@ static void load_legacy_craft_data( io::JsonObjectOutputArchive &, T & )
 
 static std::set<itype_id> charge_removal_blacklist;
 
-void load_charge_removal_blacklist( const JsonObject &jo, const std::string_view/*src*/ )
+void load_charge_removal_blacklist( const JsonObject &jo, const std::string_view/*src*/, const std::string_view )
 {
     jo.allow_omitted_members();
     std::set<itype_id> new_blacklist;
@@ -2760,7 +2760,7 @@ void load_charge_removal_blacklist( const JsonObject &jo, const std::string_view
 
 static std::set<itype_id> temperature_removal_blacklist;
 
-void load_temperature_removal_blacklist( const JsonObject &jo, const std::string_view/*src*/ )
+void load_temperature_removal_blacklist( const JsonObject &jo, const std::string_view/*src*/, const std::string_view )
 {
     jo.allow_omitted_members();
     std::set<itype_id> new_blacklist;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -51,12 +51,12 @@ scenario::scenario()
 {
 }
 
-void scenario::load_scenario( const JsonObject &jo, const std::string &src )
+void scenario::load_scenario( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    all_scenarios.load( jo, src );
+    all_scenarios.load( jo, src, second_src );
 }
 
-void scenario::load( const JsonObject &jo, const std::string_view )
+void scenario::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     // TODO: pretty much the same as in profession::load, but different contexts for pgettext.
     // TODO: maybe combine somehow?
@@ -342,12 +342,12 @@ bool scenario::scen_is_blacklisted() const
     return sc_blacklist.scenarios.count( id ) != 0;
 }
 
-void scen_blacklist::load_scen_blacklist( const JsonObject &jo, const std::string_view src )
+void scen_blacklist::load_scen_blacklist( const JsonObject &jo, const std::string_view src, const std::string &second_src )
 {
-    sc_blacklist.load( jo, src );
+    sc_blacklist.load( jo, src, second_src );
 }
 
-void scen_blacklist::load( const JsonObject &jo, const std::string_view )
+void scen_blacklist::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     if( !scenarios.empty() ) {
         DebugLog( D_INFO, DC_ALL ) <<

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -71,13 +71,13 @@ class scenario
 
         std::vector<std::pair<mongroup_id, float>> _surround_groups;
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         bool scenario_traits_conflict_with_profession_traits( const profession &p ) const;
 
     public:
         //these three aren't meant for external use, but had to be made public regardless
         scenario();
-        static void load_scenario( const JsonObject &jo, const std::string &src );
+        static void load_scenario( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
         // these should be the only ways used to get at scenario
         static const scenario *generic(); // points to the generic, default profession
@@ -162,8 +162,8 @@ struct scen_blacklist {
     std::set<string_id<scenario>> scenarios;
     bool whitelist = false;
 
-    static void load_scen_blacklist( const JsonObject &jo, std::string_view src );
-    void load( const JsonObject &jo, std::string_view );
+    static void load_scen_blacklist( const JsonObject &jo, std::string_view src, const std::string &second_src );
+    void load( const JsonObject &jo, std::string_view, std::string_view );
     void finalize();
 };
 

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -156,6 +156,7 @@ class scenario
         const std::vector<std::pair<mongroup_id, float>> &surround_groups() const;
 
         std::vector<std::pair<string_id<scenario>, mod_id>> src;
+        std::vector<std::pair<string_id<scenario>, mod_id>> second_src;
 };
 
 struct scen_blacklist {

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -281,12 +281,12 @@ bool string_id<scent_type>::is_valid() const
     return scent_factory.is_valid( *this );
 }
 
-void scent_type::load_scent_type( const JsonObject &jo, const std::string &src )
+void scent_type::load_scent_type( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    scent_factory.load( jo, src );
+    scent_factory.load( jo, src, second_src );
 }
 
-void scent_type::load( const JsonObject &jo, const std::string_view )
+void scent_type::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     assign( jo, "id", id );
     assign( jo, "receptive_species", receptive_species );

--- a/src/scent_map.h
+++ b/src/scent_map.h
@@ -38,6 +38,7 @@ class scent_type
 
         scenttype_id id;
         std::vector<std::pair<scenttype_id, mod_id>> src;
+        std::vector<std::pair<scenttype_id, mod_id>> second_src;
         std::set<species_id> receptive_species;
         static void reset();
 };

--- a/src/scent_map.h
+++ b/src/scent_map.h
@@ -30,8 +30,8 @@ class window;
 class scent_type
 {
     public:
-        static void load_scent_type( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, std::string_view );
+        static void load_scent_type( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load( const JsonObject &jo, std::string_view, const std::string_view );
         static const std::vector<scent_type> &get_all();
         static void check_scent_consistency();
         bool was_loaded = false;

--- a/src/shop_cons_rate.cpp
+++ b/src/shop_cons_rate.cpp
@@ -81,14 +81,14 @@ std::vector<shopkeeper_cons_rates> const &shopkeeper_cons_rates::get_all()
     return shop_cons_rate_factory.get_all();
 }
 
-void shopkeeper_cons_rates::load_rate( const JsonObject &jo, std::string const &src )
+void shopkeeper_cons_rates::load_rate( const JsonObject &jo, std::string const &src, const std::string &second_src )
 {
-    shop_cons_rate_factory.load( jo, src );
+    shop_cons_rate_factory.load( jo, src, second_src );
 }
 
-void shopkeeper_blacklist::load_blacklist( const JsonObject &jo, std::string const &src )
+void shopkeeper_blacklist::load_blacklist( const JsonObject &jo, std::string const &src, const std::string &second_src )
 {
-    shop_blacklist_factory.load( jo, src );
+    shop_blacklist_factory.load( jo, src, second_src );
 }
 
 void shopkeeper_cons_rates::check_all()
@@ -131,12 +131,12 @@ bool shopkeeper_cons_rate_entry::operator==( shopkeeper_cons_rate_entry const &r
     return icg_entry::operator==( rhs ) && rate == rhs.rate;
 }
 
-void shopkeeper_blacklist::load( JsonObject const &jo, const std::string_view/*src*/ )
+void shopkeeper_blacklist::load( JsonObject const &jo, const std::string_view/*src*/, const std::string_view )
 {
     optional( jo, was_loaded, "entries", entries, icg_entry_reader {} );
 }
 
-void shopkeeper_cons_rates::load( JsonObject const &jo, const std::string_view/*src*/ )
+void shopkeeper_cons_rates::load( JsonObject const &jo, const std::string_view/*src*/, const std::string_view )
 {
     optional( jo, was_loaded, "default_rate", default_rate );
     optional( jo, was_loaded, "junk_threshold", junk_threshold, money_reader {}, 1_cent );

--- a/src/shop_cons_rate.h
+++ b/src/shop_cons_rate.h
@@ -53,9 +53,9 @@ struct shopkeeper_cons_rates {
 
     static void reset();
     static const std::vector<shopkeeper_cons_rates> &get_all();
-    static void load_rate( const JsonObject &jo, std::string const &src );
+    static void load_rate( const JsonObject &jo, std::string const &src, const std::string &second_src );
     static void check_all();
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
     void check() const;
 
     int get_rate( item const &it, npc const &beta ) const;
@@ -70,8 +70,8 @@ struct shopkeeper_blacklist {
 
     static void reset();
     static const std::vector<shopkeeper_blacklist> &get_all();
-    static void load_blacklist( const JsonObject &jo, std::string const &src );
-    void load( const JsonObject &jo, std::string_view src );
+    static void load_blacklist( const JsonObject &jo, std::string const &src, const std::string &second_src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
     icg_entry const *matches( item const &it, npc const &beta ) const;
 };
 

--- a/src/skill_boost.cpp
+++ b/src/skill_boost.cpp
@@ -29,12 +29,12 @@ std::optional<skill_boost> skill_boost::get( const std::string &stat_str )
     return std::nullopt;
 }
 
-void skill_boost::load_boost( const JsonObject &jo, const std::string &src )
+void skill_boost::load_boost( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    all_skill_boosts.load( jo, src );
+    all_skill_boosts.load( jo, src, second_src );
 }
 
-void skill_boost::load( const JsonObject &jo, const std::string_view )
+void skill_boost::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "skills", _skills );
     mandatory( jo, was_loaded, "skill_offset", _offset );

--- a/src/skill_boost.h
+++ b/src/skill_boost.h
@@ -33,6 +33,7 @@ class skill_boost
         friend struct mod_tracker;
         string_id<skill_boost> id;
         std::vector<std::pair<string_id<skill_boost>, mod_id>> src;
+        std::vector<std::pair<string_id<skill_boost>, mod_id>> second_src;
         bool was_loaded = false;
         std::vector<std::string> _skills;
         int _offset = 0;

--- a/src/skill_boost.h
+++ b/src/skill_boost.h
@@ -22,7 +22,7 @@ class skill_boost
         const std::vector<std::string> &skills() const;
         float calc_bonus( int skill_total ) const;
 
-        static void load_boost( const JsonObject &jo, const std::string &src );
+        static void load_boost( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
 
         static const std::vector<skill_boost> &get_all();
@@ -38,7 +38,7 @@ class skill_boost
         int _offset = 0;
         float _power = 0.0f;
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 };
 
 #endif // CATA_SRC_SKILL_BOOST_H

--- a/src/speed_description.cpp
+++ b/src/speed_description.cpp
@@ -22,9 +22,9 @@ bool speed_description_id::is_valid() const
     return speed_description_factory.is_valid( *this );
 }
 
-void speed_description::load_speed_descriptions( const JsonObject &jo, const std::string &src )
+void speed_description::load_speed_descriptions( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    speed_description_factory.load( jo, src );
+    speed_description_factory.load( jo, src, second_src );
 }
 
 void speed_description::reset()
@@ -32,7 +32,7 @@ void speed_description::reset()
     speed_description_factory.reset();
 }
 
-void speed_description::load( const JsonObject &jo, const std::string_view )
+void speed_description::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     optional( jo, was_loaded, "values", values_ );
     std::sort( values_.begin(), values_.end(),

--- a/src/speed_description.h
+++ b/src/speed_description.h
@@ -33,6 +33,7 @@ class speed_description
 
         speed_description_id id;
         std::vector<std::pair<speed_description_id, mod_id>> src;
+        std::vector<std::pair<speed_description_id, mod_id>> second_src;
         bool was_loaded = false;
 
         // Always sorted with highest value first

--- a/src/speed_description.h
+++ b/src/speed_description.h
@@ -16,10 +16,10 @@ class speed_description_value;
 class speed_description
 {
     public:
-        static void load_speed_descriptions( const JsonObject &jo, const std::string &src );
+        static void load_speed_descriptions( const JsonObject &jo, const std::string &src, const std::string &second_src );
         static void reset();
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
         static const std::vector<speed_description> &get_all();
 

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -110,7 +110,7 @@ const std::set<std::string> &start_location::flags() const
     return _flags;
 }
 
-void start_location::load( const JsonObject &jo, const std::string &src )
+void start_location::load( const JsonObject &jo, const std::string &src, const std::string_view )
 {
     const bool strict = src == "dda";
 
@@ -611,9 +611,9 @@ void start_location::surround_with_monsters(
     }
 }
 
-void start_locations::load( const JsonObject &jo, const std::string &src )
+void start_locations::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    all_start_locations.load( jo, src );
+    all_start_locations.load( jo, src, second_src );
 }
 
 void start_locations::finalize_all()

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -39,6 +39,7 @@ class start_location
     public:
         start_location_id id;
         std::vector<std::pair<start_location_id, mod_id>> src;
+        std::vector<std::pair<start_location_id, mod_id>> second_src;
         bool was_loaded = false;
         void load( const JsonObject &jo, const std::string &src, const std::string_view );
         void finalize();

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -40,7 +40,7 @@ class start_location
         start_location_id id;
         std::vector<std::pair<start_location_id, mod_id>> src;
         bool was_loaded = false;
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, const std::string &src, const std::string_view );
         void finalize();
         void check() const;
 
@@ -119,7 +119,7 @@ class start_location
 namespace start_locations
 {
 
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void finalize_all();
 void check_consistency();
 void reset();

--- a/src/subbodypart.cpp
+++ b/src/subbodypart.cpp
@@ -66,12 +66,12 @@ sub_bodypart_id string_id<sub_body_part_type>::id() const
 template<>
 int_id<sub_body_part_type>::int_id( const string_id<sub_body_part_type> &id ) : _id( id.id() ) {}
 
-void sub_body_part_type::load_bp( const JsonObject &jo, const std::string &src )
+void sub_body_part_type::load_bp( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    sub_body_part_factory.load( jo, src );
+    sub_body_part_factory.load( jo, src, second_src );
 }
 
-void sub_body_part_type::load( const JsonObject &jo, const std::string_view )
+void sub_body_part_type::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", name );

--- a/src/subbodypart.h
+++ b/src/subbodypart.h
@@ -43,6 +43,7 @@ struct sub_body_part_type {
 
     sub_bodypart_str_id id;
     std::vector<std::pair<sub_bodypart_str_id, mod_id>> src;
+    std::vector<std::pair<sub_bodypart_str_id, mod_id>> second_src;
     sub_bodypart_str_id opposite;
 
     bool was_loaded = false;

--- a/src/subbodypart.h
+++ b/src/subbodypart.h
@@ -79,9 +79,9 @@ struct sub_body_part_type {
     // Unarmed damage when this subpart is our contact area
     damage_instance unarmed_damage;
 
-    static void load_bp( const JsonObject &jo, const std::string &src );
+    static void load_bp( const JsonObject &jo, const std::string &src, const std::string &second_src );
 
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
     // combine matching body part strings together for printing
     static std::vector<translation> consolidate( std::vector<sub_bodypart_id> &covered );

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -107,12 +107,12 @@ size_t trap::count()
     return trap_factory.size();
 }
 
-void trap::load_trap( const JsonObject &jo, const std::string &src )
+void trap::load_trap( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    trap_factory.load( jo, src );
+    trap_factory.load( jo, src, second_src );
 }
 
-void trap::load( const JsonObject &jo, const std::string_view )
+void trap::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", name_ );

--- a/src/trap.h
+++ b/src/trap.h
@@ -326,7 +326,7 @@ struct trap {
         /**
          * Loads this specific trap.
          */
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
 
         std::string debug_describe() const;
 
@@ -366,7 +366,7 @@ struct trap {
          * Loads the trap and adds it to the trapmap, and the traplist.
          * @throw JsonError if the json is invalid as usual.
          */
-        static void load_trap( const JsonObject &jo, const std::string &src );
+        static void load_trap( const JsonObject &jo, const std::string &src, const std::string &second_src );
         /**
          * Releases the loaded trap objects in trapmap and traplist.
          */

--- a/src/trap.h
+++ b/src/trap.h
@@ -110,6 +110,7 @@ using trap_function = std::function<bool( const tripoint &, Creature *, item * )
 struct trap {
         trap_str_id id;
         std::vector<std::pair<trap_str_id, mod_id>> src;
+        std::vector<std::pair<trap_str_id, mod_id>> second_src;
         trap_id loadid;
 
         bool was_loaded = false;

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -233,9 +233,9 @@ static void parse_vp_control_reqs( const JsonObject &obj, const vpart_id &id,
     optional( src, false, "proficiencies", req.proficiencies );
 }
 
-void vehicles::parts::load( const JsonObject &jo, const std::string &src )
+void vehicles::parts::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    vpart_info_factory.load( jo, src );
+    vpart_info_factory.load( jo, src, second_src );
 }
 
 void vpart_info::handle_inheritance( const vpart_info &copy_from,
@@ -262,7 +262,7 @@ void vpart_info::handle_inheritance( const vpart_info &copy_from,
     }
 }
 
-void vpart_info::load( const JsonObject &jo, const std::string &src )
+void vpart_info::load( const JsonObject &jo, const std::string &src, const std::string_view )
 {
     const bool strict = src == "dda";
 
@@ -1240,9 +1240,9 @@ bool string_id<vehicle_prototype>::is_valid() const
     return vehicle_prototype_factory.is_valid( *this );
 }
 
-void vehicles::load_prototype( const JsonObject &jo, const std::string &src )
+void vehicles::load_prototype( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    vehicle_prototype_factory.load( jo, src );
+    vehicle_prototype_factory.load( jo, src, second_src );
 }
 
 const std::vector<vehicle_prototype> &vehicles::get_all_prototypes()
@@ -1263,7 +1263,7 @@ static std::pair<std::string, std::string> get_vpart_str_variant( const std::str
            : std::make_pair( vpid.substr( 0, loc ), vpid.substr( loc + 1 ) );
 }
 
-void vehicle_prototype::load( const JsonObject &jo, std::string_view )
+void vehicle_prototype::load( const JsonObject &jo, std::string_view, const std::string_view )
 {
     vgroups[vgroup_id( id.str() )].add_vehicle( id, 100 );
     optional( jo, was_loaded, "name", name );

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -37,14 +37,14 @@ namespace vehicles
 // if part 'id' or 'abstract' fields contain it an error is raised
 constexpr char variant_separator = '#';
 
-void load_prototype( const JsonObject &jo, const std::string &src );
+void load_prototype( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void reset_prototypes();
 void finalize_prototypes();
 const std::vector<vehicle_prototype> &get_all_prototypes();
 
 namespace parts
 {
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 void check();
 void reset();
 void finalize();
@@ -241,7 +241,7 @@ class vpart_info
     public:
         vpart_id id;
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, const std::string &src, const std::string_view );
         void check() const;
         void finalize();
         void handle_inheritance( const vpart_info &copy_from,
@@ -509,7 +509,7 @@ struct vehicle_prototype {
 
         shared_ptr_fast<vehicle> blueprint;
 
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         static void save_vehicle_as_prototype( const vehicle &veh, JsonOut &json );
     private:
         bool was_loaded = false; // used by generic_factory

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -459,6 +459,7 @@ class vpart_info
     private:
         bool was_loaded = false; // used by generic_factory
         std::vector<std::pair<vpart_id, mod_id>> src;
+        std::vector<std::pair<vpart_id, mod_id>> second_src;
         friend class generic_factory<vpart_info>;
         friend struct mod_tracker;
 };
@@ -506,6 +507,7 @@ struct vehicle_prototype {
         std::vector<vehicle_item_spawn> item_spawns;
         std::vector<zone_def> zone_defs;
         std::vector<std::pair<vproto_id, mod_id>> src;
+        std::vector<std::pair<vproto_id, mod_id>> second_src;
 
         shared_ptr_fast<vehicle> blueprint;
 

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -55,9 +55,9 @@ bool string_id<weakpoints>::is_valid() const
     return weakpoints_factory.is_valid( *this );
 }
 
-void weakpoints::load_weakpoint_sets( const JsonObject &jo, const std::string &src )
+void weakpoints::load_weakpoint_sets( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    weakpoints_factory.load( jo, src );
+    weakpoints_factory.load( jo, src, second_src );
 }
 
 void weakpoints::reset()
@@ -673,7 +673,7 @@ void weakpoints::remove( const JsonArray &ja )
     }
 }
 
-void weakpoints::load( const JsonObject &jo, const std::string_view )
+void weakpoints::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     load( jo.get_array( "weakpoints" ) );
 }

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -165,6 +165,7 @@ struct weakpoints {
     // id of this set of weakpoints (inline weakpoints have a null id)
     weakpoints_id id;
     std::vector<std::pair<weakpoints_id, mod_id>> src;
+    std::vector<std::pair<weakpoints_id, mod_id>> second_src;
     // List of weakpoints. Each weakpoint should have a unique id.
     std::vector<weakpoint> weakpoint_list;
     // Default weakpoint to return.

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -184,12 +184,12 @@ struct weakpoints {
 
     /********************* weakpoint_set handling ****************************/
     // load standalone JSON type
-    void load( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view src, const std::string_view );
     void add_from_set( const weakpoints_id &set_id, bool replace_id );
     void add_from_set( const weakpoints &set, bool replace_id );
     void del_from_set( const weakpoints_id &set_id );
     void del_from_set( const weakpoints &set );
-    static void load_weakpoint_sets( const JsonObject &jo, const std::string &src );
+    static void load_weakpoint_sets( const JsonObject &jo, const std::string &src, const std::string &second_src );
     static void reset();
     static void finalize_all();
     static const std::vector<weakpoints> &get_all();

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -98,7 +98,7 @@ void weather_type::check() const
     }
 }
 
-void weather_type::load( const JsonObject &jo, const std::string_view )
+void weather_type::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "id",  id );
@@ -170,7 +170,7 @@ void weather_types::check_consistency()
     weather_type_factory.check();
 }
 
-void weather_types::load( const JsonObject &jo, const std::string &src )
+void weather_types::load( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    weather_type_factory.load( jo, src );
+    weather_type_factory.load( jo, src, second_src );
 }

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -116,7 +116,7 @@ struct weather_type {
         time_duration duration_max = 0_turns;
         std::optional<std::string> debug_cause_eoc;
         std::optional<std::string> debug_leave_eoc;
-        void load( const JsonObject &jo, std::string_view src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         void finalize();
         void check() const;
         std::string get_symbol() const {
@@ -133,7 +133,7 @@ void finalize_all();
 /** Clear all loaded weather types (invalidating any pointers) */
 void reset();
 /** Load weather type from JSON definition */
-void load( const JsonObject &jo, const std::string &src );
+void load( const JsonObject &jo, const std::string &src, const std::string &second_src );
 /** Checks all loaded from JSON are valid */
 void check_consistency();
 } // namespace weather_types

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -77,6 +77,7 @@ struct weather_type {
         bool was_loaded = false;
         weather_type_id id;
         std::vector<std::pair<weather_type_id, mod_id>> src;
+        std::vector<std::pair<weather_type_id, mod_id>> second_src;
         // UI name of weather type.
         translation name;
         // UI color of weather type.

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -37,9 +37,9 @@ bool string_id<widget>::is_valid() const
     return widget_factory.is_valid( *this );
 }
 
-void widget::load_widget( const JsonObject &jo, const std::string &src )
+void widget::load_widget( const JsonObject &jo, const std::string &src, const std::string &second_src )
 {
-    widget_factory.load( jo, src );
+    widget_factory.load( jo, src, second_src );
 }
 
 void widget::reset()
@@ -385,7 +385,7 @@ nc_color widget_clause::get_color_for_id( const std::string &clause_id, const wi
     return wp == nullptr ? c_white : wp->color;
 }
 
-void widget::load( const JsonObject &jo, const std::string_view )
+void widget::load( const JsonObject &jo, const std::string_view, const std::string_view )
 {
     optional( jo, was_loaded, "width", _width, 0 );
     optional( jo, was_loaded, "height", _height_max, 1 );

--- a/src/widget.h
+++ b/src/widget.h
@@ -215,6 +215,7 @@ class widget
 
         widget_id id;
         std::vector<std::pair<widget_id, mod_id>> src;
+        std::vector<std::pair<widget_id, mod_id>> second_src;
         bool was_loaded = false;
         const widget_clause *get_clause( const std::string &clause_id = "" ) const;
         std::vector<const widget_clause *> get_clauses() const;

--- a/src/widget.h
+++ b/src/widget.h
@@ -290,8 +290,8 @@ class widget
         widget_alignment _label_align;
 
         // Load JSON data for a widget (uses generic factory widget_factory)
-        static void load_widget( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, std::string_view src );
+        static void load_widget( const JsonObject &jo, const std::string &src, const std::string &second_src );
+        void load( const JsonObject &jo, std::string_view src, const std::string_view );
         // Finalize anything that must wait until all widgets are loaded
         static void finalize();
         // Recursively derive _label_width for nested layouts in this widget

--- a/tests/magic_spell_effect_test.cpp
+++ b/tests/magic_spell_effect_test.cpp
@@ -53,7 +53,7 @@ TEST_CASE( "line_attack", "[magic]" )
                          "    \"flags\": [ \"VERBAL\", \"NO_HANDS\", \"NO_LEGS\" ]\n"
                          "  }\n" );
 
-    spell_type::load_spell( obj, "" );
+    spell_type::load_spell( obj, "", "" );
 
     spell sp( spell_test_line_spell );
 

--- a/tests/vehicle_export_test.cpp
+++ b/tests/vehicle_export_test.cpp
@@ -61,7 +61,7 @@ TEST_CASE( "export_vehicle_test" )
 
     // To check the exported prototype has up-to-date format and is correct.
     vehicle_prototype vpr;
-    vpr.load( jo, "" );
+    vpr.load( jo, "", "" );
     CHECK( vpr.item_spawns == ( *vehicle_prototype_veh_export_test ).item_spawns );
     CHECK( vpr.zone_defs == ( *vehicle_prototype_veh_export_test ).zone_defs );
     CHECK( vpr.parts == ( *vehicle_prototype_veh_export_test ).parts );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Mod Compatibility 2: Prevent Error from duplicate ids within mod_interactions folder"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow mods to redefine their own content within their own overall mod folder, removing the need for authors to edit other mods to add compatibility for their own
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
2k lines changed
Pass the secondary source through many separate paths to the ultimate check

The error preventing mods redefining their content occurs within the mod_tracker.h file.  This solution intends to pass the secondary source all the way to this check similar to the primary source.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Moving the check closer to file load?  Would reduce how many lines need changing potentially.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiles and with very barebones testing works
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Considering redoing the whole thing in a different way but putting this up in the meanwhile while I think of that

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
