### PR TITLE
move volume and weight vals to math

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -109,8 +109,8 @@
     "type": "effect_on_condition",
     "id": "EOC_variable_weight_volume_test1",
     "effect": [
-      { "math": [ "u_weight_test", "=", "u_val('weight')" ] },
-      { "math": [ "u_volume_test", "=", "u_val('volume')" ] },
+      { "math": [ "u_weight_test", "=", "u_weight()" ] },
+      { "math": [ "u_volume_test", "=", "u_volume()" ] },
       { "u_message": "<u_name> weight: <u_val:weight_test> volume: <u_val:volume_test>" }
     ]
   },
@@ -118,8 +118,8 @@
     "type": "effect_on_condition",
     "id": "EOC_variable_weight_volume_test2",
     "effect": [
-      { "math": [ "u_weight_test", "=", "n_val('weight')" ] },
-      { "math": [ "u_volume_test", "=", "n_val('volume')" ] },
+      { "math": [ "u_weight_test", "=", "n_weight()" ] },
+      { "math": [ "u_volume_test", "=", "n_volume()" ] },
       { "u_message": "<npc_name> weight: <u_val:weight_test> volume: <u_val:volume_test>" }
     ]
   },

--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -50,7 +50,7 @@
         "math": [
           "u_weight_ratio",
           "=",
-          "(((u_telekinesis_power_level * 25) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 10) / (u_val('weight') / 1000000)"
+          "(((u_telekinesis_power_level * 25) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 10) / (u_weight() / 1000000)"
         ]
       },
       { "math": [ "u_telekinesis_shove_spell_level", "=", "clamp(((u_weight_ratio - 1) * 2), 0, 30)" ] },
@@ -90,7 +90,7 @@
         "math": [
           "u_weight_ratio",
           "=",
-          "(((u_telekinesis_power_level * 25) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 10) / (u_val('weight') / 1000000)"
+          "(((u_telekinesis_power_level * 25) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 10) / (u_weight() / 1000000)"
         ]
       },
       { "math": [ "u_telekinesis_pull_spell_level", "=", "clamp(((u_weight_ratio - 1) * 2), 0, 30)" ] },
@@ -150,7 +150,7 @@
         "math": [
           "u_weight_ratio",
           "=",
-          "(((u_telekinesis_power_level * 150) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 100) / (u_val('weight') / 1000000)"
+          "(((u_telekinesis_power_level * 150) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 100) / (u_weight() / 1000000)"
         ]
       },
       { "math": [ "u_telekinesis_shove_spell_level", "=", "clamp(((u_weight_ratio - 1) * 2), 0, 20)" ] },
@@ -180,7 +180,7 @@
         "math": [
           "u_weight_ratio",
           "=",
-          "(((u_telekinesis_power_level * 150) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 100) / (u_val('weight') / 1000000)"
+          "(((u_telekinesis_power_level * 150) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 100) / (u_weight() / 1000000)"
         ]
       },
       { "math": [ "u_telekinesis_pull_spell_level", "=", "clamp(((u_weight_ratio - 1) * 2), 0, 20)" ] },

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1393,6 +1393,8 @@ _some functions support array arguments or kwargs, denoted with square brackets 
 | npc_fear()    |  ✅   |  ✅   | u, n  | Return NPC fear toward opposite talker. <br/><br/>Example:<br/> `{ "math": [ "n_npc_fear()", "<", "2" ] }`|
 | npc_trust()    |  ✅   |  ✅   | u, n  | Return NPC trust toward opposite talker. <br/><br/>Example:<br/> `{ "math": [ "n_npc_trust()", "=", "2" ] }`|
 | npc_value()    |  ✅   |  ✅   | u, n  | Return NPC value toward opposite talker. <br/><br/>Example:<br/> `{ "math": [ "n_npc_value()", "+=", "2" ] }`|
+| weight()    |  ✅   |  ❌   | u, n  | Return creature or item weight, in miligrams. <br/><br/>Example:<br/> `{ "math": [ "u_weight()", "<", "1000000" ] }`|
+| volume()    |  ✅   |  ❌   | u, n  | Return creature or item volume, in mililiters. <br/><br/>Example:<br/> `{ "math": [ "u_volume()", "<", "1000" ] }`|
 | vitamin(`s`/`v`)    |  ✅   |   ✅  | u, n  | Return or set the characters vitamin level.<br/>Argument is vitamin ID.<br/><br/>Example:<br/>`{ "math": [ "u_vitamin('mutagen')", "=", "0" ] }`|
 | warmth(`s`/`v`)    |  ✅   |   ❌  | u, n  | Return the characters warmth on a body part.<br/>Argument is bodypart ID.<br/><br/>Example:<br/> The value displayed in-game is calculated as follows.<br/> `"{ "math": [ "u_warmth_in_game", "=", "(u_warmth('torso') / 100) * 2 - 100"] }`|
 | vision_range()    |  ✅   |   ❌  | u, n  | Return the character's or monsters visual range, adjusted by their mutations, effects, and other issues.<br/><br/>Example:<br/> `"{ "math": [ "n_vision_range()", "<", "30"] }`|

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2210,8 +2210,6 @@ std::unordered_map<std::string_view, int ( talker::* )() const> const f_get_vals
     { "strength_bonus", &talker::get_str_bonus },
     { "strength", &talker::str_cur },
     { "thirst", &talker::get_thirst },
-    { "volume", &talker::get_volume },
-    { "weight", &talker::get_weight },
     { "count", &talker::get_count }
 };
 } // namespace

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1698,6 +1698,38 @@ std::function<void( dialogue &, double )> calories_ass( char scope,
     };
 }
 
+std::function<double( dialogue & )> weight_eval( char scope,
+        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+{
+    return[beta = is_beta( scope )]( dialogue const & d ) {
+        if( d.actor( beta )->get_character() || d.actor( beta )->get_monster() ) {
+            return d.actor( beta )->get_weight();
+        }
+        item_location const *it = static_cast<talker const *>( d.actor( beta ) )->get_item();
+        if( it && *it ) {
+            return static_cast<int>( to_milligram( it->get_item()->weight() ) );
+        }
+        debugmsg( "For weight(), talker is not character nor item" );
+        return 0;
+    };
+}
+
+std::function<double( dialogue & )> volume_eval( char scope,
+        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+{
+    return[beta = is_beta( scope )]( dialogue const & d ) {
+        if( d.actor( beta )->get_character() || d.actor( beta )->get_monster() ) {
+            return d.actor( beta )->get_volume();
+        }
+        item_location const *it = static_cast<talker const *>( d.actor( beta ) )->get_item();
+        if( it && *it ) {
+            return to_milliliter( it->get_item()->volume() );
+        }
+        debugmsg( "For volume(), talker is not character nor item" );
+        return 0;
+    };
+}
+
 std::function<double( dialogue & )> vitamin_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
@@ -1879,6 +1911,8 @@ std::map<std::string_view, dialogue_func_eval> const dialogue_eval_f{
     { "vision_range", { "un", 0, vision_range_eval } },
     { "vitamin", { "un", 1, vitamin_eval } },
     { "calories", { "un", 0, calories_eval } },
+    { "weight", { "un", 0, weight_eval } },
+    { "volume", { "un", 0, volume_eval } },
     { "warmth", { "un", 1, warmth_eval } },
     { "weather", { "g", 1, weather_eval } },
     { "climate_control_str_heat", { "un", 0, climate_control_str_heat_eval } },

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -1009,6 +1009,11 @@ int talker_character_const::get_weight() const
     return units::to_milligram( me_chr_const->get_weight() );
 }
 
+int talker_character_const::get_volume() const
+{
+    return units::to_milliliter( me_chr_const->get_total_volume() );
+}
+
 void talker_character::set_height( int amount )
 {
     me_chr->set_base_height( amount );

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -194,6 +194,7 @@ class talker_character_const: public talker_cloner<talker_character_const>
         int get_height() const override;
         int get_bmi_permil() const override;
         int get_weight() const override;
+        int get_volume() const override;
         const move_mode_id &get_move_mode() const override;
         int get_fine_detail_vision_mod() const override;
         int get_health() const override;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Since #76892 allow to use math evaluation on items, that means we can just add math function that allow us to directly check whatever we need, in all possible ways
#### Describe the solution
This PR replaces old `u_val('weight')` and `u_val('volume')` with math syntax, that allow to be used on items. For volume it also adds abiltiy to read character volume

#### Testing

<details>
  <summary>test json</summary>
 
```json
  {
    "type": "effect_on_condition",
    "id": "AAAAAAAA",
    "effect": [
      {
        "u_run_inv_eocs": "manual_mult",
        "true_eocs": [
          {
            "id": "EOC_WHATEVER_0",
            "effect": [
              { "math": [ "_u", "=", "u_weight()" ] },
              { "math": [ "_n", "=", "n_weight()" ] },
              {
                "u_message": "alpha: <u_name>, weight <context_val:u> mg, beta: <npc_name>, weight <context_val:n> mg"
              }
            ]
          }
        ]
      }
    ]
  },
  {
    "type": "effect_on_condition",
    "id": "BBBBBBBB",
    "effect": [
      {
        "u_run_inv_eocs": "manual_mult",
        "true_eocs": [
          {
            "id": "EOC_WHATEVER_1",
            "effect": [
              { "math": [ "_u", "=", "u_volume()" ] },
              { "math": [ "_n", "=", "n_volume()" ] },
              {
                "u_message": "alpha: <u_name>, volume <context_val:u> ml, beta: <npc_name>, volume <context_val:n> ml"
              }
            ]
          }
        ]
      }
    ]
  },
  ```
  
</details>

![image](https://github.com/user-attachments/assets/0a222fa2-ad39-41c6-9bac-712d1f4fd96c)

#### Additional context
i would really like to also add the field similar to `time()` funciton, but #70996 uses some magic i am not familiar with