### PR TITLE
fix spells segfaulting from wrong creature

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1067,7 +1067,7 @@ bool spell::can_learn( const Character &guy ) const
     return guy.has_trait( type->spell_class );
 }
 
-int spell::get_amount_of_projectiles( const Character &guy ) const
+int spell::get_amount_of_projectiles( const Creature &guy ) const
 {
     dialogue d( get_talker_for( guy ), nullptr );
     return type->multiple_projectiles.evaluate( d );

--- a/src/magic.h
+++ b/src/magic.h
@@ -554,7 +554,8 @@ class spell
         bool can_cast( const Character &guy ) const;
         // can the Character learn this spell?
         bool can_learn( const Character &guy ) const;
-        int get_amount_of_projectiles( const Character &guy ) const;
+        // if spell shoots more than one projectile
+        int get_amount_of_projectiles( const Creature &guy ) const;
         // is this spell valid
         bool is_valid() const;
         int bps_affected() const;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -567,7 +567,7 @@ static void damage_targets( const spell &sp, Creature &caster,
                 val.amount *= damage_mitigation_multiplier;
             }
             if( cr->as_character() != nullptr ) {
-                int multishot = sp.get_amount_of_projectiles( *caster.as_character() );
+                int multishot = sp.get_amount_of_projectiles( caster );
                 std::vector<bodypart_id> target_bdpts = cr->get_all_body_parts( get_body_part_flags::only_main );
 
                 if( sp.bps_affected() > 0 ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
For some reason author of #76818 made the code assuming there can't be a situation when monster casts spell on character
What a dumbass
#### Describe the solution
Apply suggestion by Renech, which is simply use proper creature (that is, creature, and not a character)
#### Testing
used this save by Storm
[Colony-TEST_MOM-trimmed.tar.gz](https://github.com/user-attachments/files/17343908/Colony-TEST_MOM-trimmed.tar.gz)
before changes it constantly segfaulted the game
after fix, no segfaults, and character died in very expected manner
![image](https://github.com/user-attachments/assets/d9f33ee0-97e0-49db-8f7d-3b4f7b534d5f)