### PR TITLE
Wrap run_eocs properly

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1668,7 +1668,7 @@ Runs another EoC. It can be a separate EoC, or an inline EoC inside `run_eocs` e
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
 | "run_eocs" | **mandatory** | string (eoc id or inline eoc) or [variable object](#variable-object)) or array of eocs | EoC or EoCS that would be run |
-| "repeat" | optional | int or [variable object](#variable-object)) | if used, all eocs in run_eocs would be repeated this amount of times. Default 1 |
+| "repeat" | optional | int or [variable object](#variable-object)) | if used, all eocs in run_eocs would be repeated this amount of times. Eocs are repeated in order; having `"run_eocs": [ "A", "B" ], "repeat": 3` would look like `A, B, A, B, A, B`. Default 1 |
 
 
 ##### Valid talkers:

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5360,15 +5360,14 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
     return [eocs_entries, repeat]( dialogue & d ) {
         int i = 0;
         int repeat_amount = repeat.evaluate( d );
-
-        for( const eoc_entry &entry : eocs_entries ) {
-            effect_on_condition_id eoc_id =
-                entry.var ? effect_on_condition_id( entry.var->evaluate( d ) ) : entry.id;
-            dialogue newDialog( d );
-            while( i < repeat_amount ) {
+        while( i < repeat_amount ) {
+            for( const eoc_entry &entry : eocs_entries ) {
+                effect_on_condition_id eoc_id =
+                    entry.var ? effect_on_condition_id( entry.var->evaluate( d ) ) : entry.id;
+                dialogue newDialog( d );
                 eoc_id->activate( newDialog );
-                ++i;
             };
+            ++i;
         }
     };
 }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #76958
#### Describe the solution
When `repeat` field was added, i had some problems wrapping it around all the code, which i failed to resolve at that time, so i picked the second best option: wrap only final `eoc_id->activate( newDialog )`

Apparently it resulted in only first eoc being run, skipping the rest
#### Describe alternatives you've considered
Wrap loop properly, so all fields are repeated properly
Reflect it in docs
#### Testing

<details>
  <summary>Repeat 11 times</summary>
 
```json

{
    "type": "effect_on_condition",
    "id": "AAAAAAAAAAAA",
    "effect": [ { "run_eocs": [ "BBBBBBBBBB", "CCCCCCCCCC" ], "repeat": 11 } ]
  },
  {
    "type": "effect_on_condition",
    "id": "BBBBBBBBBB",
    "effect": [ { "u_message": "Yes" } ]
  },
  {
    "type": "effect_on_condition",
    "id": "CCCCCCCCCC",
    "effect": [ { "u_message": "No" } ]
  },

```
  
</details>

![image](https://github.com/user-attachments/assets/4963f4e3-7b34-46f9-bc5b-e9d0813fef58)

<details>
  <summary>Do not repeat at all</summary>
 
{
    "type": "effect_on_condition",
    "id": "AAAAAAAAAAAA",
    "effect": [ { "run_eocs": [ "BBBBBBBBBB", "CCCCCCCCCC" ] } ]
  },
  {
    "type": "effect_on_condition",
    "id": "BBBBBBBBBB",
    "effect": [ { "u_message": "Yes" } ]
  },
  {
    "type": "effect_on_condition",
    "id": "CCCCCCCCCC",
    "effect": [ { "u_message": "No" } ]
  },
  
</details>

![image](https://github.com/user-attachments/assets/d7a46ce0-9ed4-46b2-bf4d-c21c7ee4f81c)