### PR TITLE
add new event of monster taking damage/dying

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1356,7 +1356,8 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | character_ranged_attacks_monster | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim_type", `mtype_id` }, | character / monster |
 | character_smashes_tile | | { "character", `character_id` },<br/> { "terrain", `ter_str_id` },  { "furniture", `furn_str_id` }, | character / NONE |
 | character_starts_activity | Triggered when character starts or resumes activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "resume", `bool` } | character / NONE |
-| character_takes_damage | triggers when character gets any damage from any creature | { "character", `character_id` },<br/> { "damage", `int` }, | character / attackerm if exists, otherwise NONE(character or monster) | use `has_beta` conditon before interacting with beta talker
+| character_takes_damage | triggers when character gets any damage from any creature | { "character", `character_id` },<br/> { "damage", `int` }, | character / attacker if exists, otherwise NONE(character or monster) | use `has_beta` conditon before interacting with beta talker
+| monster_takes_damage | triggers when monster gets any damage from any creature. Includes damages from effects like bleeding | { "damage", `int` },<br/> { "dies", `bool` }, | monster / attacker if exists, otherwise NONE(character or monster) | use `has_beta` conditon before interacting with beta talker
 | character_triggers_trap | | { "character", `character_id` },<br/> { "trap", `trap_str_id` }, | character / NONE |
 | character_wakes_up | triggers in the moment player lost it's sleep effect and wakes up | { "character", `character_id` }, | character / NONE |
 | character_attempt_to_fall_asleep | triggers in the moment character tries to fall asleep, after confirming and setting an alarm, but before "you lie down" | { "character", `character_id` }, | character / NONE |

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -51,6 +51,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::character_smashes_tile: return "character_smashes_tile";
         case event_type::character_starts_activity: return "character_starts_activity";
         case event_type::character_takes_damage: return "character_takes_damage";
+        case event_type::monster_takes_damage: return "monster_takes_damage";
         case event_type::character_triggers_trap: return "character_triggers_trap";
         case event_type::character_falls_asleep: return "character_falls_asleep";
         case event_type::character_attempt_to_fall_asleep: return "character_attempt_to_fall_asleep";
@@ -143,7 +144,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 104,
+static_assert( static_cast<int>( event_type::num_event_types ) == 105,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );
@@ -178,6 +179,7 @@ DEFINE_EVENT_FIELDS( character_ranged_attacks_monster )
 DEFINE_EVENT_FIELDS( character_smashes_tile )
 DEFINE_EVENT_FIELDS( character_starts_activity )
 DEFINE_EVENT_FIELDS( character_takes_damage )
+DEFINE_EVENT_FIELDS( monster_takes_damage )
 DEFINE_EVENT_FIELDS( character_triggers_trap )
 DEFINE_EVENT_FIELDS( character_falls_asleep )
 DEFINE_EVENT_FIELDS( character_attempt_to_fall_asleep )

--- a/src/event.h
+++ b/src/event.h
@@ -475,7 +475,7 @@ struct event_spec<event_type::character_takes_damage> {
 
 template<>
 struct event_spec<event_type::monster_takes_damage> {
-    static constexpr std::array<std::pair<const char*, cata_variant_type>, 2> fields = { {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = { {
             { "damage", cata_variant_type::int_ },
             { "dies", cata_variant_type::bool_ },
         }

--- a/src/event.h
+++ b/src/event.h
@@ -59,6 +59,7 @@ enum class event_type : int {
     character_smashes_tile,
     character_starts_activity,
     character_takes_damage,
+    monster_takes_damage,
     character_triggers_trap,
     character_attempt_to_fall_asleep,
     character_falls_asleep,
@@ -188,7 +189,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 104,
+static_assert( static_cast<int>( event_type::num_event_types ) == 105,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -468,6 +469,15 @@ struct event_spec<event_type::character_takes_damage> {
     static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "damage", cata_variant_type::int_ },
+        }
+    };
+};
+
+template<>
+struct event_spec<event_type::monster_takes_damage> {
+    static constexpr std::array<std::pair<const char*, cata_variant_type>, 2> fields = { {
+            { "damage", cata_variant_type::int_ },
+            { "dies", cata_variant_type::bool_ },
         }
     };
 };

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -1128,6 +1128,7 @@ void memorial_logger::notify( const cata::event &e )
         case event_type::character_smashes_tile:
         case event_type::character_starts_activity:
         case event_type::character_takes_damage:
+        case event_type::monster_takes_damage:
         case event_type::character_wakes_up:
         case event_type::character_attempt_to_fall_asleep:
         case event_type::character_falls_asleep:

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2291,6 +2291,14 @@ void monster::apply_damage( Creature *source, bodypart_id /*bp*/, int dam,
     // Ensure we can try to get at what hit us.
     reset_pathfinding_cd();
     hp -= dam;
+
+    cata::event e = cata::event::make<event_type::monster_takes_damage>( dam, hp < 1 );
+    if( source ) {
+        get_event_bus().send_with_talker( this, source, e );
+    } else {
+        get_event_bus().send( e );
+    }
+
     if( hp < 1 ) {
         set_killer( source );
     } else if( dam > 0 ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Close #76875
#### Describe the solution
Add new event, that runs every time monster takes damage, and send damage value and bool if monster dies from attack or not
#### Testing
```json

  {
    "type": "effect_on_condition",
    "id": "AAAAAAAA",
    "eoc_type": "EVENT",
    "required_event": "monster_takes_damage",
    "effect": [ { "message": "alpha: <u_name>, beta: <npc_name>, damage: <context_val:damage>, dies: <context_val:dies> (0 is false, 1 is true)" } ]
  },

```
![image](https://github.com/user-attachments/assets/9dec99ce-9721-42ed-8e3a-a170e071642a)
