### PR TITLE
Faulty guns don't lock your view

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -336,8 +336,8 @@ void aim_activity_actor::start( player_activity &act, Character &who )
     item &it = *weapon.get_item();
 
     if( !check_gun_ability_to_shoot( who, it ) ) {
-        aborted = true; // why doesn't interrupt?
-        act.set_to_null();
+        aborted = true;
+        finish( act, who );
     }
 
     // Time spent on aiming is determined on the go by the player


### PR DESCRIPTION
#### Summary
Bugfixes "Faulty guns don't lock your view"

#### Purpose of change
* Fixes #76557

#### Describe the solution
Properly finish the activity with an abort, even if the gun jammed. This calls aim_activity_actor::restore_view()

#### Describe alternatives you've considered
call aim_activity_actor::restore_view() directly?

#### Testing


https://github.com/user-attachments/assets/ee40bfb6-62e5-4e43-99fd-575271d8e2b9



#### Additional context
