### PR TITLE
"Center view" centers to player's current z-level

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2064,6 +2064,7 @@ static void do_deathcam_action( const action_id &act, avatar &player_character )
         case ACTION_CENTER:
             player_character.view_offset.x() = g->driving_view_offset.x;
             player_character.view_offset.y() = g->driving_view_offset.y;
+            player_character.view_offset.z() = 0;
             break;
 
         case ACTION_SHIFT_N:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Related to #76974, pressing the center view button doesn't reset the z-level offset

#### Describe the solution
Reset the z-level offset when that command is sent.

Technically speaking we don't have any method to permanently offset the player's view across z-levels, so this should never be necessary. But it's free and setting a z-level offset could be implemented. 

This just makes it work as you'd expect it to work - instead of never modifying the z-level offset, it just *centers* it! 'Cause you told the game to "center view"!

#### Describe alternatives you've considered


#### Testing


https://github.com/user-attachments/assets/590057b5-a83e-4bc2-94a5-3ff01622a6c9



#### Additional context

