### PR TITLE
Fix set of clothes crash

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5641,6 +5641,15 @@ std::unique_ptr<activity_actor> reel_cable_activity_actor::deserialize( JsonValu
 
 void outfit_swap_actor::start( player_activity &act, Character &who )
 {
+    if( !who.is_wielding( *outfit_item ) && !who.wield( *outfit_item ) ) {
+        who.add_msg_if_player( m_warning,
+                               _( "You'll need the outfit in your hands before you can change outfits." ) );
+        act.set_to_null();
+        return;
+    }
+    if( !outfit_item ) { // if we wielded it in the last if, it's invalidated and reacquired here
+        outfit_item = who.get_wielded_item();
+    }
     item fake_storage( outfit_item->typeId() );
     for( const item_location &worn_item : who.get_visible_worn_items() ) {
         act.moves_total += who.item_handling_cost( *worn_item ); // Cost of taking it off


### PR DESCRIPTION
#### Summary
Bugfixes "Fixed a crash when using the 'set of clothes' item"

#### Purpose of change
* Fixes #75543
* Fixes #76931

#### Describe the solution
The crash happened because when activating the item it could be inside some of the clothes we were taking off. If activating it from the ground, it was picked up... and **sometimes**(not always!) put into a pocket. That we were taking off. And deleting.

Thus, it crashes between taking off our items(copying them to the newly spawned copy) and putting on the new ones, which are supposed to come out of the *deleted set of clothes*.

By forcing the wield we ensure it is not in a pocket and remains in existence as a valid item_location through the entire activity.

#### Describe alternatives you've considered
I looked into how grenades force wielding, but that only works with iuse_transforms so I had to make my own implementation.


#### Testing
Wear a backpack, activate set of clothes. Either forcibly wields the item or cancels if you refuse the selection of what to do with your current wielded item. Doesn't crash in any circumstance


#### Additional context
