### PR TITLE
Enable Giant Pincer Mutation

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3454,7 +3454,6 @@
     "visibility": 10,
     "ugliness": 9,
     "description": "Instead of your right hand, you now have a giant claw resembling ones found on crabs.  It encumbers you greatly, but you can use it in melee combat to deal massive damage.",
-    "valid": true,
     "cancels": [ "NAILS", "CLAWS", "TALONS", "WEBBED", "ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8" ],
     "prereqs": [ "CRUSTACEAN_CARAPACE" ],
     "integrated_armor": [ "integrated_giant_pincer" ],

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3454,7 +3454,7 @@
     "visibility": 10,
     "ugliness": 9,
     "description": "Instead of your right hand, you now have a giant claw resembling ones found on crabs.  It encumbers you greatly, but you can use it in melee combat to deal massive damage.",
-    "valid": false,
+    "valid": true,
     "cancels": [ "NAILS", "CLAWS", "TALONS", "WEBBED", "ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8" ],
     "prereqs": [ "CRUSTACEAN_CARAPACE" ],
     "integrated_armor": [ "integrated_giant_pincer" ],


### PR DESCRIPTION
#### Summary
Bugfixes "Enable Giant Pincer Mutation"

#### Purpose of change
#76672 pointed out that the Giant Pincer Mutation was unobtainable.  It was marked as not being obtainable except as a starting trait, but appeared in no character creation except for a mod.

#### Describe the solution
Changed "valid" to true, making it obtainable through regular mutation.

#### Describe alternatives you've considered
Leaving it in case I was wrong, but I looked into it and it's been unchanged since implemented, and I think it's just an oversight.

#### Testing
Enabling it allows it to be mutated, as expected.

#### Additional context
Did not appear in any starting scenarios/etc. that would enable it to be selected at start.  Trait prevented it from being obtained via catalyst.  Did not make sense.

Does not appear to have been disabled by WIP limb stuff (it's referenced there, but only as being replaced when losing an arm/etc).  Does not appear to have been modified since being added.  Does not appear obtainable.  Appears to be an oversight.

If I missed something, let me know.  There's some discussion in the linked issue.

closes #76672
