### PR TITLE
Unify all run_eocs in a single eoc function

### DIFF
--- a/data/mods/Perk_melee/EOC/shared_eocs.json
+++ b/data/mods/Perk_melee/EOC/shared_eocs.json
@@ -71,7 +71,7 @@
       {
         "run_eoc_until": "EOC_PERK_TRY_RETREAT",
         "condition": { "math": [ "u_monsters_nearby('radius': 1)", ">", "0" ] },
-        "iteration": 10
+        "iterations": 10
       }
     ]
   },

--- a/data/mods/Perk_melee/martial_arts.json
+++ b/data/mods/Perk_melee/martial_arts.json
@@ -72,7 +72,7 @@
           {
             "run_eoc_until": "EOC_PERK_TRY_RETREAT",
             "condition": { "math": [ "u_monsters_nearby('radius': 1)", ">", "0" ] },
-            "iteration": 10
+            "iterations": 10
           }
         ]
       }

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -203,7 +203,7 @@
       {
         "run_eoc_until": "EOC_until_nested",
         "condition": { "math": [ "u_context", "<", "10000" ] },
-        "iteration": 10000
+        "iterations": 10000
       }
     ]
   },

--- a/data/mods/TEST_DATA/effect_on_condition.json
+++ b/data/mods/TEST_DATA/effect_on_condition.json
@@ -41,5 +41,144 @@
     "type": "ter_furn_transform",
     "id": "test_dirt_transform",
     "terrain": [ { "result": [ "t_grass" ], "valid_terrain": [ "t_dirt" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "run_eocs_1",
+    "//": "run_eocs_1 should be 2",
+    "effect": [ { "run_eocs": [ "EOC_A", "EOC_B" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_A",
+    "effect": [ { "math": [ "run_eocs_1", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_B",
+    "effect": [ { "math": [ "run_eocs_1", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "run_eocs_2",
+    "//": "run_eocs_2 should be 20",
+    "effect": [ { "run_eocs": [ "EOC_C", "EOC_D" ], "iteration": 10 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_C",
+    "effect": [ { "math": [ "run_eocs_2", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_D",
+    "effect": [ { "math": [ "run_eocs_2", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "run_eocs_3",
+    "//": "in 5 seconds, run_eocs_3 should be 2 - 2 eocs would be fired in 2 seconds",
+    "effect": [ { "run_eocs": [ "EOC_E", "EOC_F" ], "time_in_future": "2 seconds" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_E",
+    "effect": [ { "math": [ "run_eocs_3", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_F",
+    "effect": [ { "math": [ "run_eocs_3", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "run_eocs_4",
+    "//": "in 2 seconds, run_eocs_4 should be 10 - we shove 10 eocs to run in two seconds",
+    "effect": [ { "run_eocs": [ "EOC_G", "EOC_H" ], "time_in_future": "2 seconds", "iteration": 5 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_G",
+    "effect": [ { "math": [ "run_eocs_4", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_H",
+    "effect": [ { "math": [ "run_eocs_4", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "run_eocs_5",
+    "//": "run_eocs_5 should be 4 - we run eocs until run_eocs_5 would be 4",
+    "effect": [ { "run_eocs": [ "EOC_I", "EOC_J" ], "condition": { "math": [ "run_eocs_5 =< 3" ] } } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_I",
+    "effect": [ { "math": [ "run_eocs_5", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_J",
+    "effect": [ { "math": [ "run_eocs_5", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "run_eocs_6",
+    "//": "in 10 seconds, run_eocs_6 should be 10 - two eocs would be randomly fired for 10 seconds",
+    "effect": [
+      {
+        "run_eocs": [ "EOC_K", "EOC_L" ],
+        "time_in_future": [ "0 seconds", "10 seconds" ],
+        "randomize_time_in_future": true,
+        "iteration": 5
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_K",
+    "effect": [ { "math": [ "run_eocs_6", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_L",
+    "effect": [ { "math": [ "run_eocs_6", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "run_eocs_7",
+    "//": "in 10 seconds, run_eocs_7 should be 10, 'test_global_key_M' should contain 'test_context_value_M', and 'test_global_key_N' should contain 'test_context_value_N'",
+    "effect": [
+      {
+        "run_eocs": [ "EOC_M", "EOC_N" ],
+        "time_in_future": [ "0 seconds", "10 seconds" ],
+        "randomize_time_in_future": true,
+        "iteration": 5,
+        "variables": { "test_context_key_M": "test_context_value_M", "test_context_key_N": "test_context_value_N" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_M",
+    "effect": [
+      { "math": [ "run_eocs_7", "++" ] },
+      {
+        "set_string_var": { "context_val": "test_context_key_M" },
+        "target_var": { "global_val": "test_global_key_M" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_N",
+    "effect": [
+      { "math": [ "run_eocs_7", "++" ] },
+      {
+        "set_string_var": { "context_val": "test_context_key_N" },
+        "target_var": { "global_val": "test_global_key_N" }
+      }
+    ]
   }
 ]

--- a/data/mods/TEST_DATA/effect_on_condition.json
+++ b/data/mods/TEST_DATA/effect_on_condition.json
@@ -110,7 +110,7 @@
     "type": "effect_on_condition",
     "id": "run_eocs_5",
     "//": "run_eocs_5 should be 4 - we run eocs until run_eocs_5 would be 4",
-    "effect": [ { "run_eocs": [ "EOC_I", "EOC_J" ], "condition": { "math": [ "run_eocs_5 =< 3" ] } } ]
+    "effect": [ { "run_eocs": [ "EOC_I", "EOC_J" ], "condition": { "math": [ "run_eocs_5 <= 3" ] } } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/TEST_DATA/effect_on_condition.json
+++ b/data/mods/TEST_DATA/effect_on_condition.json
@@ -62,7 +62,7 @@
     "type": "effect_on_condition",
     "id": "run_eocs_2",
     "//": "run_eocs_2 should be 20",
-    "effect": [ { "run_eocs": [ "EOC_C", "EOC_D" ], "iteration": 10 } ]
+    "effect": [ { "run_eocs": [ "EOC_C", "EOC_D" ], "iterations": 10 } ]
   },
   {
     "type": "effect_on_condition",
@@ -94,7 +94,7 @@
     "type": "effect_on_condition",
     "id": "run_eocs_4",
     "//": "in 2 seconds, run_eocs_4 should be 10 - we shove 10 eocs to run in two seconds",
-    "effect": [ { "run_eocs": [ "EOC_G", "EOC_H" ], "time_in_future": "2 seconds", "iteration": 5 } ]
+    "effect": [ { "run_eocs": [ "EOC_G", "EOC_H" ], "time_in_future": "2 seconds", "iterations": 5 } ]
   },
   {
     "type": "effect_on_condition",
@@ -131,7 +131,7 @@
         "run_eocs": [ "EOC_K", "EOC_L" ],
         "time_in_future": [ "0 seconds", "10 seconds" ],
         "randomize_time_in_future": true,
-        "iteration": 5
+        "iterations": 5
       }
     ]
   },
@@ -154,7 +154,7 @@
         "run_eocs": [ "EOC_M", "EOC_N" ],
         "time_in_future": [ "0 seconds", "10 seconds" ],
         "randomize_time_in_future": true,
-        "iteration": 5,
+        "iterations": 5,
         "variables": { "test_context_key_M": "test_context_value_M", "test_context_key_N": "test_context_value_N" }
       }
     ]

--- a/data/mods/Xedra_Evolved/eocs/spell_learning_eoc.json
+++ b/data/mods/Xedra_Evolved/eocs/spell_learning_eoc.json
@@ -60,11 +60,11 @@
     "effect": [
       {
         "if": { "math": [ "xe_eater_leveling", ">", "0" ] },
-        "then": [ { "run_eocs": "EOC_PICK_SPELL_EATER", "repeat": { "global_val": "xe_eater_leveling" } } ]
+        "then": [ { "run_eocs": "EOC_PICK_SPELL_EATER", "iterations": { "global_val": "xe_eater_leveling" } } ]
       },
       {
         "if": { "math": [ "xe_dreamer_leveling", ">", "0" ] },
-        "then": [ { "run_eocs": "EOC_PICK_SPELL_DREAMER", "repeat": { "global_val": "xe_dreamer_leveling" } } ]
+        "then": [ { "run_eocs": "EOC_PICK_SPELL_DREAMER", "iterations": { "global_val": "xe_dreamer_leveling" } } ]
       }
     ]
   },

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5364,8 +5364,8 @@ void process_eoc( const effect_on_condition_id &eoc, dialogue &d,
     }
 }
 
-void run_eoc_once( std::vector<eoc_entry> eocs, dialogue &d, dialogue newDialog,
-                   duration_or_var dov_time, bool random_time )
+void run_eoc_once( const std::vector<eoc_entry> &eocs, dialogue &d, dialogue newDialog,
+                   const duration_or_var &dov_time, bool random_time )
 {
     time_duration time_in_future = dov_time.evaluate( d );
 
@@ -5385,8 +5385,8 @@ void run_eoc_once( std::vector<eoc_entry> eocs, dialogue &d, dialogue newDialog,
 }
 
 dialogue generate_new_dialogue( dialogue &d, bool has_alpha_var, bool has_beta_var,
-                                str_or_var alpha_var, str_or_var beta_var, bool is_alpha_loc, bool is_beta_loc,
-                                std::vector<effect_on_condition_id> false_eocs )
+                                const str_or_var &alpha_var, const str_or_var &beta_var, bool is_alpha_loc, bool is_beta_loc,
+                                const std::vector<effect_on_condition_id> &false_eocs )
 {
     // to generate new dialogue from existing one, and possibly swap talkers
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5346,54 +5346,154 @@ talk_effect_fun_t::func f_make_sound( const JsonObject &jo, std::string_view mem
     };
 }
 
-
+void process_eoc( const effect_on_condition_id &eoc, dialogue &d,
+                  time_duration time_in_future )
+{
+    if( eoc->type == eoc_type::ACTIVATION ) {
+        Character *alpha = d.has_alpha ? d.actor( false )->get_character() : nullptr;
+        if( alpha ) {
+            effect_on_conditions::queue_effect_on_condition( time_in_future, eoc, *alpha, d.get_context() );
+        } else if( eoc->global ) {
+            effect_on_conditions::queue_effect_on_condition( time_in_future, eoc, get_player_character(),
+                    d.get_context() );
+        }
+        // If the target is a monster or item and the eoc is non global it won't be queued and will silently "fail"
+        // this is so monster attacks against other monsters won't give error messages.
+    } else {
+        debugmsg( "Cannot queue a non activation effect_on_condition.  %s", d.get_callstack() );
+    }
+}
 
 talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view member,
                                     const std::string_view src )
 {
-    std::vector<eoc_entry> eocs_entries = load_eoc_vector_id_and_var( jo, member, src );
-    dbl_or_var repeat = get_dbl_or_var( jo, "repeat", false, 1 );
-
-    if( eocs_entries.empty() ) {
+    std::vector<eoc_entry> eocs = load_eoc_vector_id_and_var( jo, member, src );
+    if( eocs.empty() ) {
         jo.throw_error( "Invalid input for run_eocs" );
     }
-    return [eocs_entries, repeat]( dialogue & d ) {
+
+    dbl_or_var iteration = get_dbl_or_var( jo, "iteration", false, -1 );
+    std::function<bool( dialogue & )> cond;
+    read_condition( jo, "condition", cond, true );
+    duration_or_var dov_time = get_duration_or_var( jo, "time_in_future", false, 0_seconds );
+    bool random_time = jo.get_bool( "randomize_time_in_future", false );
+
+    std::unordered_map<std::string, str_translation_or_var> context;
+    if( jo.has_object( "variables" ) ) {
+        const JsonObject &variables = jo.get_object( "variables" );
+        for( const JsonMember &jv : variables ) {
+            context["npctalk_var_" + jv.name()] = get_str_translation_or_var( jv, jv.name(), true );
+        }
+    }
+
+    str_or_var alpha_var;
+    str_or_var beta_var;
+    bool is_alpha_loc = false;
+    bool is_beta_loc = false;
+    bool has_alpha_var = true;
+    bool has_beta_var = true;
+
+    if( jo.has_member( "beta_loc" ) ) {
+        beta_var = get_str_or_var( jo.get_member( "beta_loc" ), "beta_loc", false, "npc" );
+        is_beta_loc = true;
+    } else if( jo.has_member( "beta_talker" ) ) {
+        beta_var = get_str_or_var( jo.get_member( "beta_talker" ), "beta_talker", false, "npc" );
+    } else {
+        beta_var.str_val = "npc";
+        has_beta_var = false;
+    }
+
+    if( jo.has_member( "alpha_loc" ) ) {
+        alpha_var = get_str_or_var( jo.get_member( "alpha_loc" ), "alpha_loc", has_beta_var,
+                                    "u" ); // alpha_talker is mandatory if beta_talker exists
+        is_alpha_loc = true;
+    } else if( jo.has_member( "alpha_talker" ) ) {
+        alpha_var = get_str_or_var( jo.get_member( "alpha_talker" ), "alpha_talker", false, "u" );
+    } else {
+        alpha_var.str_val = "u";
+        has_alpha_var = false;
+    }
+
+    std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs", src );
+
+    return [eocs, cond, iteration, dov_time, random_time, alpha_var, beta_var, is_alpha_loc,
+          is_beta_loc, has_alpha_var, has_beta_var, false_eocs, context]( dialogue & d ) {
+        dialogue newDialog( d );
+
+        // we probably can move it to it's own function?
+        if( has_alpha_var || has_beta_var ) {
+            bool alpha_invalid = false; // whether alpha talker exists in the game
+            bool beta_invalid = false; // whether beta talker exists in the game
+            auto get_talker = [&d]( const str_or_var & var, bool is_loc, bool & invalid ) {
+                Creature *guy;
+                std::string str = var.evaluate( d );
+                if( is_loc ) {
+                    tripoint_abs_ms pos = tripoint_abs_ms( tripoint::from_string( str ) );
+                    guy = get_creature_tracker().creature_at( pos );
+                    if( guy == nullptr ) {
+                        invalid = true;
+                    }
+                } else if( str.empty() ) {
+                    guy = nullptr;
+                } else if( str == "u" ) {
+                    guy = d.has_alpha ? d.actor( false )->get_creature() : nullptr;
+                } else if( str == "npc" ) {
+                    guy = d.has_beta ? d.actor( true )->get_creature() : nullptr;
+                } else if( str == "avatar" ) {
+                    guy = &get_avatar();
+                } else {
+                    guy = get_character_from_id( str, g.get() );
+                    if( guy == nullptr ) {
+                        invalid = true;
+                    }
+                }
+                return guy;
+            };
+
+            Creature *alpha_guy = get_talker( alpha_var, is_alpha_loc, alpha_invalid );
+            Creature *beta_guy = get_talker( beta_var, is_beta_loc, beta_invalid );
+            if( alpha_invalid || beta_invalid || ( alpha_guy == nullptr && beta_guy == nullptr ) ) {
+                run_eoc_vector( false_eocs, d );
+                return;
+            } else {
+                newDialog = dialogue(
+                                ( alpha_guy == nullptr ) ? nullptr : get_talker_for( alpha_guy ),
+                                ( beta_guy == nullptr ) ? nullptr : get_talker_for( beta_guy ),
+                                d.get_conditionals(),
+                                d.get_context()
+                            );
+            }
+        }
+
+        for( const auto &val : context ) {
+            newDialog.set_value( val.first, val.second.evaluate( d ) );
+        }
+
         int i = 0;
-        int repeat_amount = repeat.evaluate( d );
-        while( i < repeat_amount ) {
-            for( const eoc_entry &entry : eocs_entries ) {
+        int iteration_amount = iteration.evaluate( d );
+        time_duration time_in_future = dov_time.evaluate( d );
+
+        // there was 'd.amend_callstack( "EOC: " + eoc->id.str() )' in f_run_eoc_until
+        // but because i don't know it's purpose nor it's effect, i'll left it here as comment
+        while( cond( d ) ) {
+            for( const eoc_entry &entry : eocs ) {
                 effect_on_condition_id eoc_id =
                     entry.var ? effect_on_condition_id( entry.var->evaluate( d ) ) : entry.id;
-                dialogue newDialog( d );
-                eoc_id->activate( newDialog );
+
+                if( time_in_future == 0_seconds ) {
+                    eoc_id->activate( newDialog );
+                } else {
+                    if( random_time ) {
+                        process_eoc( eoc_id, newDialog, dov_time.evaluate( d ) );
+                    } else {
+                        process_eoc( eoc_id, newDialog, time_in_future );
+                    }
+                }
             };
             ++i;
-        }
-    };
-}
-
-talk_effect_fun_t::func f_run_eoc_until( const JsonObject &jo, std::string_view member,
-        const std::string_view src )
-{
-    effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), src );
-    std::function<bool( dialogue & )> cond;
-    read_condition( jo, "condition", cond, true ); // The default result of this condition is true
-
-    dbl_or_var iteration_count = get_dbl_or_var( jo, "iteration", false, 100 );
-
-    return [eoc, cond, iteration_count]( dialogue & d ) {
-        int max_iteration = iteration_count.evaluate( d );
-
-        int curr_iteration = 0;
-        // Amend the eoc to the callstack before the iteration.
-        // In the interation, the eoc doesn't need to be amended repeatedly in activate().
-        d.amend_callstack( "EOC: " + eoc->id.str() );
-        while( cond( d ) ) {
-            curr_iteration++;
-            if( curr_iteration > max_iteration ) {
+            if( i >= iteration_amount || iteration_amount == 0 ) {
                 break;
             }
-            eoc->activate( d, false );
         }
     };
 }
@@ -5559,105 +5659,6 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
             eocs[eoc_list.ret].var ? effect_on_condition_id( eocs[eoc_list.ret].var->evaluate(
                         d ) ) : eocs[eoc_list.ret].id;
         chosen_eoc_id->activate( newDialog );
-    };
-}
-
-
-talk_effect_fun_t::func f_run_eoc_with( const JsonObject &jo, std::string_view member,
-                                        const std::string_view src )
-{
-    effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), src );
-
-    std::unordered_map<std::string, str_translation_or_var> context;
-    if( jo.has_object( "variables" ) ) {
-        const JsonObject &variables = jo.get_object( "variables" );
-        for( const JsonMember &jv : variables ) {
-            context["npctalk_var_" + jv.name()] = get_str_translation_or_var( jv, jv.name(), true );
-        }
-    }
-
-    str_or_var alpha_var;
-    str_or_var beta_var;
-    bool is_alpha_loc = false;
-    bool is_beta_loc = false;
-    bool has_alpha_var = true;
-    bool has_beta_var = true;
-
-    if( jo.has_member( "beta_loc" ) ) {
-        beta_var = get_str_or_var( jo.get_member( "beta_loc" ), "beta_loc", false, "npc" );
-        is_beta_loc = true;
-    } else if( jo.has_member( "beta_talker" ) ) {
-        beta_var = get_str_or_var( jo.get_member( "beta_talker" ), "beta_talker", false, "npc" );
-    } else {
-        beta_var.str_val = "npc";
-        has_beta_var = false;
-    }
-
-    if( jo.has_member( "alpha_loc" ) ) {
-        alpha_var = get_str_or_var( jo.get_member( "alpha_loc" ), "alpha_loc", has_beta_var,
-                                    "u" ); // alpha_talker is mandatory if beta_talker exists
-        is_alpha_loc = true;
-    } else if( jo.has_member( "alpha_talker" ) ) {
-        alpha_var = get_str_or_var( jo.get_member( "alpha_talker" ), "alpha_talker", false, "u" );
-    } else {
-        alpha_var.str_val = "u";
-        has_alpha_var = false;
-    }
-
-    std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs", src );
-
-    return [eoc, context, alpha_var, beta_var, is_alpha_loc, is_beta_loc, has_alpha_var,
-         has_beta_var, false_eocs]( dialogue const & d ) {
-        dialogue newDialog( d );
-
-        if( has_alpha_var || has_beta_var ) {
-            bool alpha_invalid = false;// whether alpha talker exists in the game
-            bool beta_invalid = false;// whether beta talker exists in the game
-            auto get_talker = [&d]( const str_or_var & var, bool is_loc, bool & invalid ) {
-                Creature *guy;
-                std::string str = var.evaluate( d );
-                if( is_loc ) {
-                    tripoint_abs_ms pos = tripoint_abs_ms( tripoint::from_string( str ) );
-                    guy = get_creature_tracker().creature_at( pos );
-                    if( guy == nullptr ) {
-                        invalid = true;
-                    }
-                } else if( str.empty() ) {
-                    guy = nullptr;
-                } else if( str == "u" ) {
-                    guy = d.has_alpha ? d.actor( false )->get_creature() : nullptr;
-                } else if( str == "npc" ) {
-                    guy = d.has_beta ? d.actor( true )->get_creature() : nullptr;
-                } else if( str == "avatar" ) {
-                    guy = &get_avatar();
-                } else {
-                    guy = get_character_from_id( str, g.get() );
-                    if( guy == nullptr ) {
-                        invalid = true;
-                    }
-                }
-                return guy;
-            };
-
-            Creature *alpha_guy = get_talker( alpha_var, is_alpha_loc, alpha_invalid );
-            Creature *beta_guy = get_talker( beta_var, is_beta_loc, beta_invalid );
-            if( alpha_invalid || beta_invalid || ( alpha_guy == nullptr && beta_guy == nullptr ) ) {
-                run_eoc_vector( false_eocs, d );
-                return;
-            } else {
-                newDialog = dialogue(
-                                ( alpha_guy == nullptr ) ? nullptr : get_talker_for( alpha_guy ),
-                                ( beta_guy == nullptr ) ? nullptr : get_talker_for( beta_guy ),
-                                d.get_conditionals(),
-                                d.get_context()
-                            );
-            }
-        }
-        for( const auto &val : context ) {
-            newDialog.set_value( val.first, val.second.evaluate( d ) );
-        }
-
-        eoc->activate( newDialog );
     };
 }
 
@@ -5893,83 +5894,6 @@ talk_effect_fun_t::func f_set_talker( const JsonObject &jo, std::string_view mem
     return [is_npc, var, type, var_name]( dialogue & d ) {
         int id = d.actor( is_npc )->getID().get_value();
         write_var_value( type, var_name, &d, id );
-    };
-}
-
-void process_eoc( const effect_on_condition_id &eoc, dialogue &d,
-                  time_duration time_in_future )
-{
-    if( eoc->type == eoc_type::ACTIVATION ) {
-        Character *alpha = d.has_alpha ? d.actor( false )->get_character() : nullptr;
-        if( alpha ) {
-            effect_on_conditions::queue_effect_on_condition( time_in_future, eoc, *alpha, d.get_context() );
-        } else if( eoc->global ) {
-            effect_on_conditions::queue_effect_on_condition( time_in_future, eoc, get_player_character(),
-                    d.get_context() );
-        }
-        // If the target is a monster or item and the eoc is non global it won't be queued and will silently "fail"
-        // this is so monster attacks against other monsters won't give error messages.
-    } else {
-        debugmsg( "Cannot queue a non activation effect_on_condition.  %s", d.get_callstack() );
-    }
-}
-
-talk_effect_fun_t::func f_queue_eocs( const JsonObject &jo, std::string_view member,
-                                      const std::string_view src )
-{
-    std::vector<eoc_entry> eocs_entries = load_eoc_vector_id_and_var( jo, member, src );
-    if( eocs_entries.empty() ) {
-        jo.throw_error( "Invalid input for queue_eocs" );
-    }
-
-    duration_or_var dov_time_in_future = get_duration_or_var( jo, "time_in_future", false,
-                                         0_seconds );
-    return [dov_time_in_future, eocs_entries]( dialogue & d ) {
-        time_duration time_in_future = dov_time_in_future.evaluate( d );
-        for( const eoc_entry &entry : eocs_entries ) {
-            effect_on_condition_id eoc_id =
-                entry.var ? effect_on_condition_id( entry.var->evaluate( d ) ) : entry.id;
-            process_eoc( eoc_id, d, time_in_future );
-        };
-    };
-}
-
-talk_effect_fun_t::func f_queue_eoc_with( const JsonObject &jo, std::string_view member,
-        const std::string_view src )
-{
-    effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), src );
-
-    std::unordered_map<std::string, str_translation_or_var> context;
-    if( jo.has_object( "variables" ) ) {
-        const JsonObject &variables = jo.get_object( "variables" );
-        for( const JsonMember &jv : variables ) {
-            context["npctalk_var_" + jv.name()] = get_str_translation_or_var( jv, jv.name(), true );
-        }
-    }
-
-    duration_or_var dov_time_in_future = get_duration_or_var( jo, "time_in_future", false,
-                                         0_seconds );
-    return [dov_time_in_future, eoc, context]( dialogue & d ) {
-        time_duration time_in_future = dov_time_in_future.evaluate( d );
-        if( eoc->type == eoc_type::ACTIVATION ) {
-
-            std::unordered_map<std::string, std::string> passed_variables;
-            for( const auto &val : context ) {
-                passed_variables[val.first] = val.second.evaluate( d );
-            }
-
-            Character *alpha = d.has_alpha ? d.actor( false )->get_character() : nullptr;
-            if( alpha ) {
-                effect_on_conditions::queue_effect_on_condition( time_in_future, eoc, *alpha, passed_variables );
-            } else if( eoc->global ) {
-                effect_on_conditions::queue_effect_on_condition( time_in_future, eoc, get_player_character(),
-                        passed_variables );
-            }
-            // If the target is a monster or item and the eoc is non global it won't be queued and will silently "fail"
-            // this is so monster attacks against other monsters won't give error messages.
-        } else {
-            debugmsg( "Cannot queue a non activation effect_on_condition.  %s", d.get_callstack() );
-        }
     };
 }
 
@@ -6961,11 +6885,11 @@ parsers = {
     { "remove_active_mission", jarg::member, &talk_effect_fun::f_remove_active_mission },
     { "offer_mission", jarg::array | jarg::string, &talk_effect_fun::f_offer_mission },
     { "run_eocs", jarg::member | jarg::array, &talk_effect_fun::f_run_eocs },
-    { "run_eoc_until", jarg::member, &talk_effect_fun::f_run_eoc_until },
-    { "run_eoc_with", jarg::member, &talk_effect_fun::f_run_eoc_with },
+    { "run_eoc_until", jarg::member, &talk_effect_fun::f_run_eocs },
+    { "run_eoc_with", jarg::member, &talk_effect_fun::f_run_eocs },
     { "run_eoc_selector", jarg::member, &talk_effect_fun::f_run_eoc_selector },
-    { "queue_eocs", jarg::member | jarg::array, &talk_effect_fun::f_queue_eocs },
-    { "queue_eoc_with", jarg::member, &talk_effect_fun::f_queue_eoc_with },
+    { "queue_eocs", jarg::member | jarg::array, &talk_effect_fun::f_run_eocs },
+    { "queue_eoc_with", jarg::member, &talk_effect_fun::f_run_eocs },
     { "weighted_list_eocs", jarg::array, &talk_effect_fun::f_weighted_list_eocs },
     { "if", jarg::member, &talk_effect_fun::f_if },
     { "switch", jarg::member, &talk_effect_fun::f_switch },

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5523,8 +5523,9 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
                 }
             }
         } else {
-            while( i >= iteration_amount ) {
+            while( i < iteration_amount ) {
                 run_eoc_once( eocs, d, newDialog, dov_time, random_time );
+                ++i;
             }
         }
     };

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5425,14 +5425,14 @@ dialogue generate_new_dialogue( dialogue &d, bool has_alpha_var, bool has_beta_v
         Creature *beta_guy = get_talker( beta_var, is_beta_loc, beta_invalid );
         if( alpha_invalid || beta_invalid || ( alpha_guy == nullptr && beta_guy == nullptr ) ) {
             run_eoc_vector( false_eocs, d );
-            return newDialog;
         } else {
-            return newDialog = dialogue( ( alpha_guy == nullptr ) ? nullptr : get_talker_for( alpha_guy ),
-                                         ( beta_guy == nullptr ) ? nullptr : get_talker_for( beta_guy ),
-                                         d.get_conditionals(),
-                                         d.get_context() );
+            newDialog = dialogue( ( alpha_guy == nullptr ) ? nullptr : get_talker_for( alpha_guy ),
+                                  ( beta_guy == nullptr ) ? nullptr : get_talker_for( beta_guy ),
+                                  d.get_conditionals(),
+                                  d.get_context() );
         }
-    }
+    };
+    return newDialog;
 }
 
 talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view member,

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5443,7 +5443,7 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
         jo.throw_error( "Invalid input for run_eocs" );
     }
 
-    dbl_or_var iteration = get_dbl_or_var( jo, "iteration", false, 1 );
+    dbl_or_var iterations = get_dbl_or_var( jo, "iterations", false, 1 );
     bool has_cond = false;
     std::function<bool( dialogue & )> cond;
     if( jo.has_object( "condition" ) ) {
@@ -5494,7 +5494,7 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
 
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs", src );
 
-    return [eocs, cond, has_cond, iteration, dov_time, random_time, alpha_var, beta_var, is_alpha_loc,
+    return [eocs, cond, has_cond, iterations, dov_time, random_time, alpha_var, beta_var, is_alpha_loc,
           is_beta_loc, has_alpha_var, has_beta_var, false_eocs, context]( dialogue & d ) {
 
         dialogue newDialog = generate_new_dialogue( d, has_alpha_var, has_beta_var, alpha_var, beta_var,
@@ -5505,25 +5505,25 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
         }
 
         int i = 0;
-        int iteration_amount = iteration.evaluate( d );
+        int iterations_amount = iterations.evaluate( d );
 
         // there was 'd.amend_callstack( "EOC: " + eoc->id.str() )' in f_run_eoc_until
         // but because i don't know it's purpose nor it's effect, i'll left it here as comment
 
         if( has_cond ) {
-            // if it's a loop, we will use iteration_amount as limit to amount of loops allowed
+            // if it's a loop, we will use iterations_amount as limit to amount of loops allowed
             // and bump it to 100 as default value
-            iteration_amount = iteration_amount == 1 ? 100 : iteration_amount;
+            iterations_amount = iterations_amount == 1 ? 100 : iterations_amount;
 
             while( cond( d ) ) {
                 run_eoc_once( eocs, d, newDialog, dov_time, random_time );
                 ++i;
-                if( i >= iteration_amount ) {
+                if( i >= iterations_amount ) {
                     break;
                 }
             }
         } else {
-            while( i < iteration_amount ) {
+            while( i < iterations_amount ) {
                 run_eoc_once( eocs, d, newDialog, dov_time, random_time );
                 ++i;
             }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5373,8 +5373,15 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
     }
 
     dbl_or_var iteration = get_dbl_or_var( jo, "iteration", false, -1 );
+    bool has_cond = false;
     std::function<bool( dialogue & )> cond;
-    read_condition( jo, "condition", cond, true );
+    if( jo.has_object( "condition" ) ) {
+        read_condition( jo, "condition", cond, true );
+        has_cond = true;
+    } else {
+        read_condition( jo, "condition", cond, true );
+    }
+
     duration_or_var dov_time = get_duration_or_var( jo, "time_in_future", false, 0_seconds );
     bool random_time = jo.get_bool( "randomize_time_in_future", false );
 
@@ -5416,7 +5423,7 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
 
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs", src );
 
-    return [eocs, cond, iteration, dov_time, random_time, alpha_var, beta_var, is_alpha_loc,
+    return [eocs, cond, has_cond, iteration, dov_time, random_time, alpha_var, beta_var, is_alpha_loc,
           is_beta_loc, has_alpha_var, has_beta_var, false_eocs, context]( dialogue & d ) {
         dialogue newDialog( d );
 
@@ -5491,7 +5498,14 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
                 }
             };
             ++i;
-            if( i >= iteration_amount || iteration_amount == 0 ) {
+
+            // very smart boolean logic should be here, but you got me instead
+
+            if( iteration_amount == -1 || !has_cond ) {
+                break;
+            }
+
+            if( i >= iteration_amount || !has_cond ) {
                 break;
             }
         }

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -121,6 +121,13 @@ static const effect_on_condition_id effect_on_condition_EOC_teleport_test( "EOC_
 static const effect_on_condition_id
 effect_on_condition_EOC_test_weapon_damage( "EOC_test_weapon_damage" );
 static const effect_on_condition_id effect_on_condition_EOC_try_kill( "EOC_try_kill" );
+static const effect_on_condition_id effect_on_condition_run_eocs_1( "run_eocs_1" );
+static const effect_on_condition_id effect_on_condition_run_eocs_2( "run_eocs_2" );
+static const effect_on_condition_id effect_on_condition_run_eocs_3( "run_eocs_3" );
+static const effect_on_condition_id effect_on_condition_run_eocs_4( "run_eocs_4" );
+static const effect_on_condition_id effect_on_condition_run_eocs_5( "run_eocs_5" );
+static const effect_on_condition_id effect_on_condition_run_eocs_6( "run_eocs_6" );
+static const effect_on_condition_id effect_on_condition_run_eocs_7( "run_eocs_7" );
 
 static const flag_id json_flag_FILTHY( "FILTHY" );
 
@@ -1402,4 +1409,47 @@ TEST_CASE( "EOC_string_test", "[eoc]" )
     CHECK( get_avatar().get_value( "npctalk_var_key1" ) == "nest2" );
     CHECK( get_avatar().get_value( "npctalk_var_key2" ) == "nest3" );
     CHECK( get_avatar().get_value( "npctalk_var_key3" ) == "nest4" );
+}
+
+TEST_CASE( "EOC_run_eocs", "[eoc]" )
+{
+    clear_avatar();
+    clear_map();
+
+    dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+    global_variables &globvars = get_globals();
+    globvars.clear_global_values();
+
+    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_1" ).empty() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_2" ).empty() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_3" ).empty() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_4" ).empty() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_5" ).empty() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_6" ).empty() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_7" ).empty() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_test_global_key_M" ).empty() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_test_global_key_N" ).empty() );
+
+    CHECK( effect_on_condition_run_eocs_1->activate( d ) );
+    CHECK( effect_on_condition_run_eocs_2->activate( d ) );
+    CHECK( effect_on_condition_run_eocs_3->activate( d ) );
+    CHECK( effect_on_condition_run_eocs_4->activate( d ) );
+    CHECK( effect_on_condition_run_eocs_5->activate( d ) );
+    CHECK( effect_on_condition_run_eocs_6->activate( d ) );
+    CHECK( effect_on_condition_run_eocs_7->activate( d ) );
+
+    set_time( calendar::turn + 10_seconds );
+    effect_on_conditions::process_effect_on_conditions( get_avatar() );
+
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_1" ) ) == Approx( 2 ) );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_2" ) ) == Approx( 20 ) );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_3" ) ) == Approx( 2 ) );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_4" ) ) == Approx( 10 ) );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_5" ) ) == Approx( 4 ) );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_6" ) ) == Approx( 10 ) );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_7" ) ) == Approx( 10 ) );
+
+    CHECK( globvars.get_global_value( "npctalk_var_test_global_key_M" ) == "test_context_value_M" );
+    CHECK( globvars.get_global_value( "npctalk_var_test_global_key_N" ) == "test_context_value_N" );
+
 }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
We have five different functions (run_eocs, queue_eocs, run_eoc_with, queue_eoc_with, run_eoc_until), that do effectively the same, but their syntax is not shared, which sometimes can be tricky
#### Describe the solution
Concentrate all of them in a single function
- [x] Make test to prevent ~~me~~ breaking it again
-  ~~replace json syntax with run_eocs~~ i will do it in the separate PR
- [x] reflect changes in documentation
#### Describe alternatives you've considered
Not?
#### Testing
In the process
#### Additional context
Made draft only to grab fancy number 