### PR TITLE
Prompt if you really want to crash the game

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -4070,8 +4070,12 @@ void debug()
             debugmsg( "Test debugmsg" );
             break;
         case debug_menu_index::CRASH_GAME:
-            static_cast<void>( raise( SIGSEGV ) );
-            break;
+            if( query_yn( _( "Are you sure you wan't to crash the game?" ) ) ) {
+                if( query_yn( _( "Are you REALLY sure you wan't to crash the game?" ) ) ) {
+                    static_cast<void>( raise( SIGSEGV ) );
+                    break;
+                };
+            }
         case debug_menu_index::ACTIVATE_EOC: {
             run_eoc_menu();
         }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -4070,8 +4070,8 @@ void debug()
             debugmsg( "Test debugmsg" );
             break;
         case debug_menu_index::CRASH_GAME:
-            if( query_yn( _( "Are you sure you wan't to crash the game?" ) ) ) {
-                if( query_yn( _( "Are you REALLY sure you wan't to crash the game?" ) ) ) {
+            if( query_yn( _( "Are you sure you want to crash the game?" ) ) ) {
+                if( query_yn( _( "Are you REALLY sure you want to crash the game?" ) ) ) {
                     static_cast<void>( raise( SIGSEGV ) );
                     break;
                 };


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I work a lot with EoC
`Crash game (test crashing handling)` button happens to be right above `Activate EOC` button
I got tired
#### Describe the solution
Prompt do you really want to crash the game
#### Testing
![image](https://github.com/user-attachments/assets/48c9132e-f9a3-4ec0-9dde-e4ed0cad5b68)
![image](https://github.com/user-attachments/assets/b5b7d6c3-1050-4679-a72a-55f00655c7c1)
![image](https://github.com/user-attachments/assets/4ad25c6b-cd3e-4ef3-a01b-e3184662b2c3)