### PR TITLE
Give bone skewers calories

### DIFF
--- a/data/json/items/resources/bone.json
+++ b/data/json/items/resources/bone.json
@@ -121,7 +121,7 @@
     "abstract": "skull_abstract",
     "name": { "str": "abstract skull", "//~": "NO_I18N" },
     "description": { "str": "This is a dummy item.  If you see it something went wrong.", "//~": "NO_I18N" },
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID"],
     "category": "other",
     "weight": "1 kg",
     "volume": "1400 ml",
@@ -148,26 +148,32 @@
     "snippet_category": "skull_human_tainted_desc"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
     "id": "skull_canis_small",
     "name": { "str": "tiny canine skull" },
     "description": "The skull of a tiny canine, likely a Chihuahua or another similarly sized dog breed.",
+    "flags": [ "TRADER_AVOID", "RAW", "INEDIBLE" ],
     "copy-from": "skull_abstract",
     "weight": "35 g",
     "volume": "270 ml",
     "longest_side": "7 cm",
-    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_2_1" }
+    "calories": 21,
+    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_2_1" },
+    "comestible_type": "FOOD"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
     "id": "skull_canis_medium",
     "name": { "str": "small canine skull" },
     "description": "The skull of a small canine, likely a small dog breed.",
+    "flags": [ "TRADER_AVOID", "RAW", "INEDIBLE" ],
     "copy-from": "skull_abstract",
     "weight": "65 g",
     "volume": "500 ml",
     "longest_side": "12 cm",
-    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_1_1" }
+    "calories": 38,
+    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_1_1" },
+    "comestible_type": "FOOD"
   },
   {
     "type": "GENERIC",
@@ -187,26 +193,32 @@
     "copy-from": "skull_canis"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
     "id": "skull_feline_small",
     "name": { "str": "small feline skull" },
     "description": "The skull of a small feline, likely a house cat.",
+    "flags": [ "TRADER_AVOID", "RAW", "INEDIBLE" ],
     "copy-from": "skull_abstract",
     "weight": "40 g",
     "volume": "300 ml",
     "longest_side": "10 cm",
-    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_2_1" }
+    "calories": 23,
+    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_2_1" },
+    "comestible_type": "FOOD"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
     "id": "skull_feline_medium",
     "name": { "str": "medium feline skull" },
     "description": "The skull of a medium-sized feline, likely a bobcat.",
+    "flags": [ "TRADER_AVOID", "RAW", "INEDIBLE" ],
     "copy-from": "skull_abstract",
     "weight": "65 g",
     "volume": "500 ml",
     "longest_side": "13 cm",
-    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_1_1" }
+    "calories": 38,
+    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_1_1" },
+    "comestible_type": "FOOD"
   },
   {
     "type": "GENERIC",
@@ -219,15 +231,18 @@
     "longest_side": "21 cm"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
     "id": "skull_raccoon",
     "name": { "str": "raccoon skull" },
     "description": "The skull of a raccoon.",
+    "flags": [ "TRADER_AVOID", "RAW", "INEDIBLE" ],
     "copy-from": "skull_abstract",
     "weight": "75 g",
     "volume": "575 ml",
     "longest_side": "12 cm",
-    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_1_1" }
+    "calories": 44,
+    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_1_1" },
+    "comestible_type": "FOOD"
   },
   {
     "type": "GENERIC",
@@ -240,48 +255,60 @@
     "longest_side": "30 cm"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
     "id": "skull_opossum",
     "name": { "str": "opossum skull" },
     "description": "The skull of an opossum.",
+    "flags": [ "TRADER_AVOID", "RAW", "INEDIBLE" ],
     "copy-from": "skull_abstract",
     "weight": "45 g",
     "volume": "275 ml",
     "longest_side": "11 cm",
-    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_2_1" }
+    "calories": 26,
+    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_2_1" },
+    "comestible_type": "FOOD"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
     "id": "skull_skunk",
     "name": { "str": "skunk skull" },
     "description": "The skull of a skunk.",
+    "flags": [ "TRADER_AVOID", "RAW", "INEDIBLE" ],
     "copy-from": "skull_abstract",
     "weight": "56 g",
     "volume": "300 ml",
     "longest_side": "8 cm",
-    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_2_1" }
+    "calories": 33,
+    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_2_1" },
+    "comestible_type": "FOOD"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
     "id": "skull_rodent",
     "name": { "str": "rodent skull" },
     "description": "The skull of a small rodent, most likely a rat.",
+    "flags": [ "TRADER_AVOID", "RAW", "INEDIBLE" ],
     "copy-from": "skull_abstract",
     "weight": "3 g",
     "volume": "20 ml",
     "longest_side": "5 cm",
-    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_20_1" }
+    "calories": 2,
+    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_20_1" },
+    "comestible_type": "FOOD"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
     "id": "skull_rabbit",
     "name": { "str": "rabbit skull" },
     "description": "The skull of a rabbit or a hare.",
+    "flags": [ "TRADER_AVOID", "RAW", "INEDIBLE" ],
     "copy-from": "skull_abstract",
     "weight": "90 g",
     "volume": "450 ml",
     "longest_side": "10 cm",
-    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_1_1" }
+    "calories": 52,
+    "milling": { "into": "meal_bone", "recipe": "meal_bone_mill_1_1" },
+    "comestible_type": "FOOD"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/resources/bone.json
+++ b/data/json/items/resources/bone.json
@@ -111,6 +111,7 @@
     "weight": "10 g",
     "volume": "25 ml",
     "milling": { "into": "meal_bone_tainted", "recipe": "meal_bone_tainted_mill_6_1" },
+    "calories": 6,
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ]
   },

--- a/data/json/items/resources/bone.json
+++ b/data/json/items/resources/bone.json
@@ -99,7 +99,7 @@
     "price_postapoc": "1 cent"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
     "id": "skewer_bone",
     "symbol": ",",
     "color": "white",
@@ -107,7 +107,8 @@
     "description": "A thin skewer carved from bone.  Sadly, it won't make squirrel on a stick taste better.",
     "category": "other",
     "material": [ "bone" ],
-    "flags": [ "TRADER_AVOID" ],
+    "comestible_type": "FOOD",
+    "flags": [ "TRADER_AVOID", "RAW", "INEDIBLE" ],
     "weight": "10 g",
     "volume": "25 ml",
     "milling": { "into": "meal_bone_tainted", "recipe": "meal_bone_tainted_mill_6_1" },


### PR DESCRIPTION
#### Summary

Bugfixes "Give bone skewers calories"

#### Purpose of change

Noticed that bone skewers had no calories while helping unicorn work out the issues in #76999, which causes tainted bone meal crafted from them to have 0 calories. This made the game literally unplayable, so needed immediate resolution.

#### Describe the solution

I gave them 6 calories, resulting in tainted bone meal with 36 calories when crafted from them. This is one more than normal bone meal, but I don't think you can give an item fractional calories so this is the best I could do.

#### Describe alternatives you've considered

Leaving the game in an unplayable state, where tainted bone meal crafted from bone skewers had no calories. D:

#### Testing

![image](https://github.com/user-attachments/assets/1eb70cda-1ea5-4c68-aceb-07e66ed826a4)
resultant item from milling bone skewers
#### Additional context
