### PR TITLE
Colored crop tops

### DIFF
--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -2084,7 +2084,7 @@
     "variants": [
       {
         "id": "generic_tshirt",
-        "name": { "str": "t-shirt" },
+        "name": { "str": "crop top" },
         "description": "A short-sleeved cotton shirt, cropped to expose the stomach.",
         "weight": 1
       },

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -2079,6 +2079,87 @@
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ]
       },
       { "coverage": 50, "covers": [ "arm_l", "arm_r" ], "specifically_covers": [ "arm_upper_l", "arm_upper_r" ] }
+    ],
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "generic_tshirt",
+        "name": { "str": "t-shirt" },
+        "description": "A short-sleeved cotton shirt, cropped to expose the stomach.",
+        "weight": 1
+      },
+      {
+        "id": "red_tshirt",
+        "name": { "str": "red crop top" },
+        "description": "This one is colored red.",
+        "color": "red",
+        "append": true,
+        "weight": 1
+      },
+      {
+        "id": "blue_tshirt",
+        "name": { "str": "blue crop top" },
+        "color": "blue",
+        "description": "This one is colored blue.",
+        "append": true,
+        "weight": 1
+      },
+      {
+        "id": "yellow_tshirt",
+        "name": { "str": "yellow crop top" },
+        "color": "yellow",
+        "description": "This one is colored yellow.",
+        "append": true,
+        "weight": 1
+      },
+      {
+        "id": "green_tshirt",
+        "name": { "str": "green crop top" },
+        "color": "green",
+        "description": "This one is colored green.",
+        "append": true,
+        "weight": 1
+      },
+      {
+        "id": "purple_tshirt",
+        "name": { "str": "purple crop top" },
+        "color": "magenta",
+        "description": "This one is colored purple.",
+        "append": true,
+        "weight": 1
+      },
+      {
+        "id": "pink_tshirt",
+        "name": { "str": "pink crop top" },
+        "color": "magenta",
+        "description": "This one is colored pink.",
+        "append": true,
+        "weight": 1
+      },
+      {
+        "id": "cyan_tshirt",
+        "name": { "str": "cyan crop top" },
+        "color": "cyan",
+        "description": "This one is colored cyan.",
+        "append": true,
+        "weight": 1
+      },
+      {
+        "id": "black_tshirt",
+        "name": { "str": "black crop top" },
+        "color": "dark_gray",
+        "description": "This one is colored black.",
+        "append": true,
+        "weight": 1
+      },
+      {
+        "id": "brown_tshirt",
+        "name": { "str": "brown crop top" },
+        "color": "brown",
+        "description": "This one is colored brown.",
+        "append": true,
+        "weight": 1
+      }
     ]
   },
   {


### PR DESCRIPTION

#### Summary
None


#### Purpose of change

Adds colored crop tops.

#### Describe the solution

Give crop top color variants.

#### Describe alternatives you've considered

Keeping it to myself.

#### Testing

![Screenshot_20241013_132414_1](https://github.com/user-attachments/assets/bc3fbd28-61eb-443c-9e86-ae4f66757fa5)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
