### PR TITLE
Fix sling staff

### DIFF
--- a/data/json/items/gunmod/conversions.json
+++ b/data/json/items/gunmod/conversions.json
@@ -1084,6 +1084,7 @@
     "location": "bore",
     "mod_targets": [ "staff_sling" ],
     "install_time": "1 m",
-    "ammo_modifier": [ "sling-ready_grenade" ]
+    "ammo_modifier": [ "sling-ready_grenade" ],
+    "pocket_mods": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "sling-ready_grenade": 1 }, "open_container": true } ]
   }
 ]

--- a/data/json/items/ranged/slings.json
+++ b/data/json/items/ranged/slings.json
@@ -89,7 +89,7 @@
     "clip_size": 1,
     "valid_mod_locations": [ [ "bore", 1 ] ],
     "reload": 50,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "rock": 1, "sling-ready_grenade": 1 }, "open_container": true } ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "rock": 1 }, "open_container": true } ],
     "melee_damage": { "bash": 16 }
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix conflict between `ammo` and `ammo_restriction` in sling staff"
#### Purpose of change
Fix #77007 
#### Describe the solution
Remove `"sling-ready_grenade": 1` from `ammo_restriction` of sling staff, and add `"pocket_mods": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "sling-ready_grenade": 1 }, "open_container": true } ]` to the grenade cradle.
#### Describe alternatives you've considered
Only allow `RELOAD_AND_SHOOT` weapons to be reloaded with ammo type both defined in `ammo` and `ammo_restriction`.
#### Testing
1. Wield a sling staff, and carry a rock and a sling-ready grenade.
2. Press `f` and see that the sling staff ignores the sling-ready grenade.
3. Attach the grenade cradle for staff sling to the staff sling, press `f` and see that the rock is ignored.
#### Additional context
Should also apply this patch to 0.H RC.