### PR TITLE
Deduplicate origin string generation

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2400,10 +2400,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                        bool /* debug */ ) const
 {
     if( parts->test( iteminfo_parts::BASE_MOD_SRC ) ) {
-        info.emplace_back( "BASE", string_format( _( "Origin: %s" ), enumerate_as_string( type->src,
-        []( const std::pair<itype_id, mod_id> &source ) {
-            return string_format( "'%s'", source.second->name() );
-        }, enumeration_conjunction::arrow ) ) );
+        info.emplace_back( "BASE", get_origin( type->src ) );
         insert_separation_line( info );
     }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -885,12 +885,7 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
     const int max_width = getmaxx( w ) - column - 1;
     std::ostringstream oss;
 
-    oss << get_tag_from_color( c_white ) << _( "Origin: " );
-    oss << enumerate_as_string( type->src.begin(),
-    type->src.end(), []( const std::pair<mtype_id, mod_id> &source ) {
-        return string_format( "'%s'", source.second->name() );
-    }, enumeration_conjunction::arrow );
-    oss << "</color>" << "\n";
+    oss << get_tag_from_color( c_white ) << get_origin( type->src ) << "</color>" << "\n";
 
     if( debug_mode ) {
         oss << colorize( type->id.str(), c_white );
@@ -975,15 +970,7 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
 
 void monster::print_info_imgui() const
 {
-    ImGui::TextUnformatted( _( "Origin: " ) );
-    std::string mods = enumerate_as_string( type->src.begin(),
-                                            type->src.end(),
-    []( const std::pair<mtype_id, mod_id> &source ) {
-        return string_format( "'%s'", source.second->name() );
-    },
-    enumeration_conjunction::arrow );
-    ImGui::SameLine( 0, 0 );
-    ImGui::TextUnformatted( mods.c_str() );
+    ImGui::TextUnformatted( get_origin( type->src ).c_str() );
 
     if( debug_mode ) {
         ImGui::TextUnformatted( type->id.c_str() );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2136,14 +2136,7 @@ static struct {
 static std::string assemble_profession_details( const avatar &u, const input_context &ctxt,
         const std::vector<string_id<profession>> &sorted_profs, const int cur_id, const std::string &notes )
 {
-    std::string assembled;
-
-    // Display Origin
-    const std::string mod_src = enumerate_as_string( sorted_profs[cur_id]->src, [](
-    const std::pair<profession_id, mod_id> &source ) {
-        return string_format( "'%s'", source.second->name() );
-    }, enumeration_conjunction::arrow );
-    assembled += string_format( _( "Origin: %s" ), mod_src ) + "\n";
+    std::string assembled = get_origin( sorted_profs[cur_id]->src ) + "\n";
 
     std::string profession_name = sorted_profs[cur_id]->gender_appropriate_name( u.male );
     if( get_option<bool>( "SCREEN_READER_MODE" ) && !notes.empty() ) {
@@ -3349,13 +3342,7 @@ static struct {
 static std::string assemble_scenario_details( const avatar &u, const input_context &ctxt,
         const scenario *current_scenario, const std::string &notes )
 {
-    std::string assembled;
-    // Display Origin
-    const std::string mod_src = enumerate_as_string( current_scenario->src,
-    []( const std::pair<string_id<scenario>, mod_id> &source ) {
-        return string_format( "'%s'", source.second->name() );
-    }, enumeration_conjunction::arrow );
-    assembled += string_format( _( "Origin: %s" ), mod_src ) + "\n";
+    std::string assembled = get_origin( current_scenario->src ) + "\n";
 
     std::string scenario_name = current_scenario->gender_appropriate_name( !u.male );
     if( get_option<bool>( "SCREEN_READER_MODE" ) && !notes.empty() ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1572,12 +1572,7 @@ std::string overmapbuffer::get_description_at( const tripoint_abs_sm &where )
         }
     }
 
-    // Display Origin
-    const std::string mod_src = enumerate_as_string( oter->get_type_id().obj().src,
-    []( const std::pair<oter_type_str_id, mod_id> &source ) {
-        return string_format( "'%s'", source.second->name() );
-    }, enumeration_conjunction::arrow );
-    format_string += "\n" + string_format( _( "Origin: %s" ), mod_src );
+    format_string += "\n" + get_origin( oter->get_type_id()->src );
 
     return string_format( format_string, ter_name, dir_name, closest_city_name );
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Remove duplicated code to generate origin string"

#### Purpose of change/Describe the solution
There's a templated function to do this, so use it instead of scattering the same snippet of code around in all the places that do this.
See https://github.com/CleverRaven/Cataclysm-DDA/pull/76983

#### Testing
![image](https://github.com/user-attachments/assets/02807dbd-6e01-4d35-b531-aee83aa88396)  ![image](https://github.com/user-attachments/assets/4827e43d-42d0-46db-aa9f-1f9a2e4c0d8c)  ![image](https://github.com/user-attachments/assets/22368ef8-1e26-49f8-8f17-12c01988a136)  ![image](https://github.com/user-attachments/assets/c345e3b2-5ec3-4e64-b837-25ef275bdbc9) ![image](https://github.com/user-attachments/assets/5abe1d56-6b3e-428c-819b-e01f4fc23dc2)




