### PR TITLE
Remove code for auto derivation of count-max

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1438,10 +1438,6 @@ void Item_factory::finalize()
             it->second.recipes.push_back( p.first );
         }
     }
-    for( auto &e : m_template_groups ) {
-        auto &isd = e.second;
-        isd->finalize( itype_id::NULL_ID() );
-    }
 }
 void item_blacklist_t::clear()
 {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -31,7 +31,6 @@
 #include "units.h"
 
 static const std::string null_item_id( "null" );
-static const itype_id itype_corpse( "corpse" );
 
 std::size_t Item_spawn_data::create( ItemList &list,
                                      const time_point &birthday, spawn_flags flags ) const

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -322,83 +322,18 @@ std::size_t Single_item_creator::create( ItemList &list,
     return list.size() - prev_list_size;
 }
 
-void Single_item_creator::finalize( const itype_id &container_ex )
-{
-    auto sanitize_count = [this]() {
-        if( modifier->count.first == -1 ) {
-            modifier->count.first = 1;
-        }
-        if( modifier->count.second == -1 ) {
-            modifier->count.second = 1;
-        }
-    };
-    itype_id cont;
-    if( container_item.has_value() ) {
-        cont = container_item.value();
-    } else {
-        cont = container_ex;
-    }
-    if( modifier.has_value() ) {
-        std::unique_ptr<item> content_final;
-        if( modifier->charges.first != -1 || modifier->charges.second != -1 ) {
-            if( type == S_ITEM ) {
-                content_final = std::make_unique<item>( itype_id( id ), calendar::turn_zero );
-                if( !modifier->ammo && !content_final->type->can_have_charges() && !content_final->is_tool() &&
-                    !content_final->is_gun() && !content_final->is_magazine() ) {
-                    debugmsg( "itemgroup entry for spawning item %s defined charges but can't have any", id );
-                    sanitize_count();
-                    return;
-                }
-            }
-        }
-        if( modifier->count.first != -1 && modifier->count.second == -1 ) {
-            if( type != S_ITEM ) {
-                debugmsg( "cannot auto derive count-max for spawning itemgroup %s", id );
-                sanitize_count();
-                return;
-            } else {
-                auto &count = modifier->count;
-                int max_capacity = -1;
-                if( !content_final ) {
-                    content_final = std::make_unique<item>( itype_id( id ), calendar::turn_zero );
-                }
-                item container_final( cont, calendar::turn_zero );
-                if( container_final.is_null() ) {
-                    debugmsg( "cannot auto derive count-max for itemgroup entry of spawning %s inside null container-item.",
-                              id, container_ex.str() );
-                    sanitize_count();
-                    return;
-                }
-                if( content_final->is_gun() || content_final->is_magazine() || content_final->is_tool() ) {
-                    debugmsg( "cannot auto derive count-max for itemgroup entry of spawning %s.", id );
-                    sanitize_count();
-                    return;
-                }
-                if( modifier->container && !modifier->container->has_item( itype_corpse ) &&
-                    !modifier->container->has_item( itype_id::NULL_ID() ) ) {
-                    debugmsg( "cannot auto derive count-max for itemgroup entry of spawning %s with container-item defined in entry.",
-                              id );
-                    sanitize_count();
-                    return;
-                }
-                if( content_final->type->weight == 0_gram ) {
-                    max_capacity = content_final->charges_per_volume( container_final.get_total_capacity() );
-                } else {
-                    max_capacity = std::min( content_final->charges_per_volume( container_final.get_total_capacity() ),
-                                             content_final->charges_per_weight( container_final.get_total_weight_capacity() ) );
-                }
-                count.second = std::max( count.first, max_capacity );
-            }
-        }
-        sanitize_count();
-    }
-}
-
 void Single_item_creator::check_consistency( bool actually_spawn ) const
 {
     if( type == S_ITEM ) {
         if( !item::type_is_defined( itype_id( id ) ) ) {
             debugmsg( "item id %s is unknown (in %s)", id, context() );
+        }
+        if( modifier && ( modifier->charges.first != -1 || modifier->charges.second != -1 ) ) {
+            itype_id content_final( id );
+            if( !modifier->ammo && !content_final->can_have_charges() && !content_final->tool &&
+                !content_final->gun && !content_final->magazine ) {
+                debugmsg( "itemgroup entry for spawning item %s defined charges but can't have any", id );
+            }
         }
     } else if( type == S_ITEM_GROUP ) {
         if( !item_group::group_is_defined( item_group_id( id ) ) ) {
@@ -544,7 +479,7 @@ void Single_item_creator::inherit_ammo_mag_chances( const int ammo, const int ma
 
 Item_modifier::Item_modifier()
     : damage( 0, 0 )
-    , count( -1, -1 )
+    , count( 1, 1 )
       // Dirt in guns is capped unless overwritten in the itemgroup
       // most guns should not be very dirty or dirty at all
     , dirt( 0, 500 )
@@ -873,19 +808,6 @@ void Item_group::add_entry( std::unique_ptr<Item_spawn_data> ptr )
         sic->inherit_ammo_mag_chances( with_ammo, with_magazine );
     }
     items.push_back( std::move( ptr ) );
-}
-
-void Item_group::finalize( const itype_id &container )
-{
-    itype_id cont;
-    if( container_item.has_value() ) {
-        cont = container_item.value();
-    } else {
-        cont = container;
-    }
-    for( auto &e : items ) {
-        e->finalize( cont );
-    }
 }
 
 std::size_t Item_group::create( Item_spawn_data::ItemList &list,

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -153,11 +153,6 @@ class Item_spawn_data
          */
         virtual std::size_t create( ItemList &list, const time_point &birthday, RecursionList &rec,
                                     spawn_flags = spawn_flags::none ) const = 0;
-        /**
-        * Instead of calculating at run-time, give a step to finalize those item_groups that has count-min but not count-max.
-        * The reason is
-        */
-        virtual void finalize( const itype_id & ) = 0;
         std::size_t create( ItemList &list, const time_point &birthday,
                             spawn_flags = spawn_flags::none ) const;
         /**
@@ -340,7 +335,6 @@ class Single_item_creator : public Item_spawn_data
 
         std::size_t create( ItemList &list, const time_point &birthday, RecursionList &rec,
                             spawn_flags ) const override;
-        void finalize( const itype_id &container = itype_id::NULL_ID() ) override;
         item create_single( const time_point &birthday, RecursionList &rec ) const override;
         item create_single_without_container( const time_point &birthday, RecursionList &rec ) const;
         void check_consistency( bool actually_spawn ) const override;
@@ -389,7 +383,6 @@ class Item_group : public Item_spawn_data
          * a Single_item_creator or Item_group to @ref items.
          */
         void add_entry( std::unique_ptr<Item_spawn_data> ptr );
-        void finalize( const itype_id &container = itype_id::NULL_ID() )override;
         std::size_t create( ItemList &list, const time_point &birthday, RecursionList &rec,
                             spawn_flags ) const override;
         item create_single( const time_point &birthday, RecursionList &rec ) const override;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2493,7 +2493,6 @@ class jmapgen_loot : public jmapgen_piece
             } else {
                 result_group.add_group_entry( group, 100 );
             }
-            result_group.finalize( itype_id::NULL_ID() );
         }
 
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,


### PR DESCRIPTION
Move charge check to check_consistency(), return default count to (1,1), remove Item_spawn_data::finalize()

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Item_spawn_data::finalize() was added in https://github.com/CleverRaven/Cataclysm-DDA/pull/67410/commits/22cbdde68b664ea1a9245abf34d6d9d19ea78cfd. The reason was to support auto derivation of count-max, and to check whether an itemgroup entry defines charges for items that cannot have it.

#76917 disabled support for x-min/x-max itemgroup fields, so there's no need to support auto derivation of count-max.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove Item_spawn_data::finalize().
Return the default value of `modifier->count` back to (1,1).
Move charge check to check_consistency().
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leave it alone.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
It compiles.
Go to the military base to confirm that #68220 doesn't happen.
Walk around and things seem normal.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
