### PR TITLE
Debugging new population horde actually sets population

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1674,6 +1674,7 @@ static void modify_horde_func( tripoint_abs_omt &curs )
     tripoint_abs_omt horde_destination = tripoint_abs_omt_zero;
     switch( smenu.ret ) {
         case 0:
+            new_value = chosen_group.interest;
             query_int( new_value, _( "Set interest to what value?  Currently %d" ), chosen_group.interest );
             chosen_group.set_interest( new_value );
             break;
@@ -1686,6 +1687,7 @@ static void modify_horde_func( tripoint_abs_omt &curs )
             chosen_group.target = project_to<coords::sm>( horde_destination ).xy();
             break;
         case 2:
+            new_value = chosen_group.population;
             query_int( new_value, _( "Set population to what value?  Currently %d" ), chosen_group.population );
             chosen_group.population = new_value;
             break;
@@ -1693,6 +1695,7 @@ static void modify_horde_func( tripoint_abs_omt &curs )
             debug_menu::wishmonstergroup_mon_selection( chosen_group );
             break;
         case 4:
+            new_value = static_cast<int>( chosen_group.behaviour );
             // Screw it we hardcode a popup, if you really want to use this you're welcome to improve it
             popup( _( "Set behavior to which enum value?  Currently %d.  \nAccepted values:\n0 = none,\n1 = city,\n2=roam,\n3=nemesis" ),
                    static_cast<int>( chosen_group.behaviour ) );

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -760,8 +760,9 @@ void debug_menu::wishmonstergroup( tripoint_abs_omt &loc )
         }
         const mongroup_id selected_group( possible_groups[selected] );
         new_group.type = selected_group;
-        int new_value = 0;
+        int new_value = new_group.population; // default value if query declined
         query_int( new_value, _( "Set population to what value?  Currently %d" ), new_group.population );
+        new_group.population = new_value;
         overmap &there = overmap_buffer.get( project_to<coords::om>( loc ).xy() );
         there.debug_force_add_group( new_group );
         return; // Don't go to adding individual monsters, they'll override the values we just set


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Made an oops. When making a new population horde it asks what the population should be, but that value was discarded without being used.

#### Describe the solution
Actually use the value, set the population to whatever value the player gives

Also add some safety to the queries added in that PR. If the player exits the query, instead of changing the value to 0, always keep the value the same.


#### Describe alternatives you've considered
since query_int has a boolean return type I considered e.g.
```c++
            if( query_int( new_value, _( "Set population to what value?  Currently %d" ),
                           chosen_group.population ) ) {
                chosen_group.population = new_value;
            }
            break;
```

But that query_int creates a line that's too long and must be broken into two lines for astyle, which IMO harms readability


#### Testing
Population was set to the value I gave it when spawning new hordes

#### Additional context
