### PR TITLE
Don't inform player they're wounded if they're actually just plain dead

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -1021,8 +1021,11 @@
     "//1": "Only run EOC if character is currently on succession cooldown!",
     "condition": {
       "and": [
+        "u_is_avatar",
         { "math": [ "has_var(u_timer_time_of_last_succession)" ] },
-        { "math": [ "time_since(u_timer_time_of_last_succession)", "<", "time_between_succession" ] }
+        { "math": [ "time_since(u_timer_time_of_last_succession)", "<", "time_between_succession" ] },
+        { "math": [ "u_hp('torso')", "!=", "0" ] },
+        { "math": [ "u_hp('head')", "!=", "0" ] }
       ]
     },
     "//2": "Remove the mission tracking that you can't change char, push the timer back by [cooldown length] so changing is immediately available.",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Whenever any one of your limbs break and you're off-cooldown for succession, it'll tell you that you've been wounded and should consider letting someone else lead for a bit.

This is not a helpful message if you've just been vaporized by a nuclear explosion.

#### Describe the solution
Check head and torso HP is not 0 before sending the message. If either is 0 we must be dead, and the message should not be sent

Also added a safety check so this only ever runs for the avatar. Right now it's only possible for the broken limb event to be sent for the avatar, but that seems like a bug.

https://github.com/CleverRaven/Cataclysm-DDA/blob/2e5b3cfe9ad582fb031dc7b1b5a2f11f84e45f9a/src/creature.cpp#L2522-L2529

#### Describe alternatives you've considered
I tried using the `u_is_alive` condition, but setting the character as 'dead' happens after limb breaking, so that does not work.

I considered shuffling around the order that those happen in so that `u_is_alive` would work, but that seemed unnecessary.

I *also* considered implementing an overload of u_hp that returned a summed value of all vital parts, but that was a lot of effort.

#### Testing

Dying without getting the message:

https://github.com/user-attachments/assets/76c08b51-aca3-4423-834c-856f99e870ca


I also manually broke a limb to ensure that it still ran
![image](https://github.com/user-attachments/assets/2e491ffb-623e-4cb8-9fad-275999697082)

I did not test this EOC's interaction with characters that do not have a head/torso. I presume the returned HP value is -1 and it would still be bugged for them. But it would've been bugged for them previously, so 🤷


#### Additional context

