### PR TITLE
Unload zone properly clears auto whitelists

### DIFF
--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -585,6 +585,10 @@ std::list<item> item::remove_items_with( const std::function<bool( const item &e
     // but no way to determine where something got removed here
     update_modified_pockets();
 
+    if( !res.empty() ) {
+        on_contents_changed();
+    }
+
     return res;
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Unload zone properly clears auto whitelists"

#### Purpose of change
* Fix #73216

#### Describe the solution
Basically apply Andrei's solution.

#### Describe alternatives you've considered
Embarrassingly, I was going to add more ad-hoc calls to item::on_contents_changed() before I read Andrei's post. Their idea was definitely better though

#### Testing


https://github.com/user-attachments/assets/26644496-c791-464f-9e47-f7e74bdadda8



#### Additional context

