### PR TITLE
Kill loadscreen on tutorial start

### DIFF
--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -11,6 +11,7 @@
 #include "debug.h"
 #include "game.h"
 #include "item.h"
+#include "loading_ui.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "mapdata.h"
@@ -132,6 +133,7 @@ std::string enum_to_string<tut_lesson>( tut_lesson data )
 
 bool tutorial_game::init()
 {
+    loading_ui::done();
     // TODO: clean up old tutorial
 
     // Start at noon at the end of the spring and set a fixed temperature of 20 degrees to prevent freezing


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The loading screen was also stuck on the tutorial

#### Describe the solution
Kill it there too, when the tutorial starts

#### Describe alternatives you've considered
There's probably some place in game.cpp where we could put this, like a game_start(), but putting the kill in the tutorial start works just as well

#### Testing
I loaded the tutorial and there wasn't an image stuck on the screen

#### Additional context
