### PR TITLE
Avatar death also sends character death/character kill character event pulses

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2803,6 +2803,12 @@ bool game::try_get_right_click_action( action_id &act, const tripoint_bub_ms &mo
 bool game::is_game_over()
 {
     if( uquit == QUIT_DIED || uquit == QUIT_WATCH ) {
+        Creature *player_killer = u.get_killer();
+        if( player_killer && player_killer->as_character() ) {
+            events().send<event_type::character_kills_character>(
+                player_killer->as_character()->getID(), u.getID(), u.get_name() );
+        }
+        events().send<event_type::character_dies>( u.getID() );
         events().send<event_type::avatar_dies>();
     }
     if( uquit == QUIT_WATCH ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I noticed that the `character_dies` and `character_kills_character` events could only be triggered inside npc::die() despite the fact that the avatar is a character

#### Describe the solution
Also trigger those events inside game::is_game_over(), right where the `avatar_dies` event triggers.

#### Describe alternatives you've considered
avatar_dies seems kind of redundant, but I guess having a specialization is fine

And of course, we could unify this into some sort of Character::die() but that sounds like a lot more work :^)

#### Testing
Died to some zombies. Debugger indicated that the character_dies event was sent but character_kills_character was not. Zombie is a *monster*, not a *Character*, so this is the expected behavior.

#### Additional context
