### PR TITLE
Mission deadlines supports dialogue variables

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -535,8 +535,7 @@
     "fail": { "effect": { "math": [ "faction_trust('exodii')", "-=", "20" ] } },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
-    "deadline_low": 20,
-    "deadline_high": 20,
+    "deadline": [ "20 days", "20 days" ],
     "//": "Dialogue for this mission is handled externally.",
     "dialogue": {
       "describe": ".",

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -40,8 +40,7 @@
     "value": 150000,
     "urgent": true,
     "origins": [ "ORIGIN_OPENER_NPC", "ORIGIN_ANY_NPC" ],
-    "deadline_low": 30,
-    "deadline_high": 48,
+    "deadline": [ "30 days", "48 days" ],
     "dialogue": {
       "describe": "I'm… short… of breath…",
       "offer": "I'm asthmatic.  I need you to get an inhaler for me…",
@@ -74,8 +73,7 @@
     "urgent": true,
     "goal_condition": { "or": [ { "u_has_item": "antibiotics" }, { "u_has_item": "strong_antibiotic" }, { "u_has_item": "panacea" } ] },
     "origins": [ "ORIGIN_OPENER_NPC" ],
-    "deadline_low": 24,
-    "deadline_high": 48,
+    "deadline": [ "24 days", "48 days" ],
     "dialogue": {
       "describe": "This infection is bad, <very> bad…",
       "offer": "I'm infected.  Badly.  I need you to get some good antibiotics for me…",
@@ -969,8 +967,7 @@
     "description": "You have some time left until you can transfer control to your companions, provided you have <color_yellow>established a Basecamp</color> and <color_yellow>have at least 1 NPC companion</color>.",
     "difficulty": 0,
     "value": 0,
-    "deadline_low": { "math": [ "time_between_succession" ] },
-    "deadline_high": { "math": [ "time_between_succession" ] },
+    "deadline": { "math": [ "time_between_succession" ] },
     "invisible_on_complete": true,
     "start": {
       "effect": [

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -969,6 +969,8 @@
     "description": "You have some time left until you can transfer control to your companions, provided you have <color_yellow>established a Basecamp</color> and <color_yellow>have at least 1 NPC companion</color>.",
     "difficulty": 0,
     "value": 0,
+    "deadline_low": { "math": [ "time_between_succession" ] },
+    "deadline_high": { "math": [ "time_between_succession" ] },
     "invisible_on_complete": true,
     "start": {
       "effect": [
@@ -982,7 +984,7 @@
     "id": "EOC_FACTION_SUCCESSION_CHECK",
     "recurrence": [ "5 minutes", "20 minutes" ],
     "global": true,
-    "condition": { "math": [ "time_since(u_timer_time_of_last_succession)", ">", "time('90 d')" ] },
+    "condition": { "math": [ "time_since(u_timer_time_of_last_succession)", ">", "time_between_succession" ] },
     "effect": [ { "remove_active_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" }, { "u_lose_var": "time_of_last_succession" } ],
     "deactivate_condition": { "not": { "compare_string": [ "yes", { "u_val": "time_of_last_succession" } ] } }
   },
@@ -1007,10 +1009,23 @@
     ]
   },
   {
+    "//": "DUMB HACK ALERT! We need to check during both game_start and game_begin, because game_start runs first. If we only listen during game_begin then EOC_FACTION_SUCCESSION_CHANGE_INIT finds the variable doesn't exist when it runs during game_start, substituting a value of 0 turns. Double assigning the same value is harmless, just stupid. It shouldn't be necessary to make two EOCs for this. Oh well, what can you do",
     "type": "effect_on_condition",
-    "id": "EOC_FACTION_SUCCESSION_COOLDOWN",
+    "id": "EOC_FACTION_SUCCESSION_COOLDOWN_GAMEBEGIN_CHECK",
     "eoc_type": "EVENT",
     "required_event": "game_begin",
+    "effect": [ { "run_eocs": "EOC_FACTION_SUCCESSION_COOLDOWN" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FACTION_SUCCESSION_COOLDOWN_GAMESTART_CHECK",
+    "eoc_type": "EVENT",
+    "required_event": "game_start",
+    "effect": [ { "run_eocs": "EOC_FACTION_SUCCESSION_COOLDOWN" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FACTION_SUCCESSION_COOLDOWN",
     "effect": [ { "math": [ "time_between_succession", "=", "time(' 3 d')" ] } ]
   },
   {

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -995,7 +995,10 @@
     "required_event": "game_start",
     "effect": [
       { "remove_active_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" },
-      { "assign_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" }
+      {
+        "assign_mission": "MISSION_CAMP_LEADERSHIP_CHANGE",
+        "deadline": { "math": [ "time('now') + time_between_succession" ] }
+      }
     ]
   },
   {
@@ -1005,7 +1008,10 @@
     "required_event": "game_avatar_new",
     "effect": [
       { "remove_active_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" },
-      { "assign_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" }
+      {
+        "assign_mission": "MISSION_CAMP_LEADERSHIP_CHANGE",
+        "deadline": { "math": [ "time('now') + time_between_succession" ] }
+      }
     ]
   },
   {

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -1087,8 +1087,7 @@
     "fail": { "effect": { "math": [ "faction_trust('robofac')", "-=", "20" ] } },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
-    "deadline_low": 20,
-    "deadline_high": 20,
+    "deadline": [ "20 days", "20 days" ],
     "//": "Dialogue for this mission is handled externally.",
     "dialogue": {
       "describe": ".",

--- a/data/mods/classic_zombies/missiondef.json
+++ b/data/mods/classic_zombies/missiondef.json
@@ -5,8 +5,7 @@
     "type": "mission_definition",
     "name": { "str": "Reach Refugee Center" },
     "goal": "MGOAL_NULL",
-    "deadline_low": "1s",
-    "deadline_high": "1s",
+    "deadline": "1 seconds",
     "difficulty": 0,
     "value": 0
   }

--- a/data/mods/innawood/npcs/missiondef.json
+++ b/data/mods/innawood/npcs/missiondef.json
@@ -9,8 +9,7 @@
     "value": 150000,
     "urgent": true,
     "origins": [ "ORIGIN_OPENER_NPC", "ORIGIN_ANY_NPC" ],
-    "deadline_low": 30,
-    "deadline_high": 48,
+    "deadline": [ "30 days", "48 days" ],
     "dialogue": {
       "describe": "I'm… short… of breath…",
       "offer": "I'm asthmatic.  I need you to get some kind of medicinal tea for me…",
@@ -45,8 +44,7 @@
     "urgent": true,
     "goal_condition": { "u_has_item": "cattail_jelly" },
     "origins": [ "ORIGIN_OPENER_NPC" ],
-    "deadline_low": 24,
-    "deadline_high": 48,
+    "deadline": [ "24 days", "48 days" ],
     "dialogue": {
       "describe": "This infection is bad, <very> bad…",
       "offer": "I'm infected.  Badly.  I need you to get something antiseptic for me…",

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1567,6 +1567,7 @@ Will assign mission to the player
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
 | "assign_mission" | **mandatory** | string or [variable object](#variable-object) | Mission that would be assigned to the player |
+| "deadline" | optional | string or [variable object](#variable-object) | Time point when mission will be failed automatically if not already complete |
 
 ##### Valid talkers:
 
@@ -1575,9 +1576,9 @@ Will assign mission to the player
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
-Assign you a `MISSION_REACH_FAKE_DAVE` mission
+Assign you a `MISSION_REACH_FAKE_DAVE` mission which must be completed within the next 17 hours
 ```json
-{ "assign_mission": "MISSION_REACH_FAKE_DAVE" }
+{ "assign_mission": "MISSION_REACH_FAKE_DAVE", "deadline": { "math": [ "time('now') + time(' 17 h')" ] } }
 ```
 
 #### `remove_active_mission`

--- a/doc/MISSIONS_JSON.md
+++ b/doc/MISSIONS_JSON.md
@@ -9,6 +9,7 @@ NPCs can assign missions to the player.  There is a fairly regular structure for
     "name": "Retrieve Black Box Transcript",
     "description": "Decrypt the contents of the black box using a terminal from a nearby lab.",
     "goal": "MGOAL_FIND_ITEM",
+    "deadline": [ "16 hours", "math": [ "time(' 16 h') * 2" ] ],
     "difficulty": 2,
     "value": 150000,
     "item": "black_box_transcript",
@@ -17,6 +18,14 @@ NPCs can assign missions to the player.  There is a fairly regular structure for
        "effect": { "u_buy_item": "black_box" },
        "assign_mission_target": { "om_terrain": "lab", "reveal_radius": 3 }
     },
+    "urgent": false,
+    "has_generic_rewards": true,
+    "item": "pencil",
+    "item_group": "pencil_box_with_pencil",
+    "count": 6,
+    "required_container": "pencil_box",
+    "remove_container": true,
+    "empty_container": "can_drink",
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_EXPLORE_SARCOPHAGUS",
     "dialogue": {
@@ -43,6 +52,11 @@ it with "MISSION" and to use a fairly descriptive name.
 ### name
 The name is also required, and is displayed to the user in the 'm'issions menu.
 
+### deadline
+How long after being assigned this mission before it will automatically fail (if not already completed). Can be a pair of values, in which case a random value between the two is picked. If only a single value is given, always uses that value.
+
+Supports variable objects and math expressions.
+
 ### description
 Not required, but it's strongly recommended that you summarize all relevant info for the mission.
 You may refer to mission end effects of the "u_buy_item" type, as long as they do not come at a
@@ -60,6 +74,9 @@ cost to the player. See the example below:
     }
 ```
 This system may be expanded in the future to allow referring to other mission parameters and effects.
+
+### urgent
+If true, the NPC giving this mission will refuse to speak on any other topics besides completing this mission while it is active.
 
 ### goal
 Must be included, and must be one of these strings:

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -62,10 +62,9 @@ mission mission_type::create( const character_id &npc_id ) const
 
     struct dialogue d( get_talker_for( get_player_character() ),
                        get_talker_for( g->find_npc( npc_id ) ) );
-    time_duration deadline_low_as_var = deadline_low.evaluate( d );
-    time_duration deadline_high_as_var = deadline_high.evaluate( d );
-    if( deadline_low_as_var != 0_turns || deadline_high_as_var != 0_turns ) {
-        ret.deadline = calendar::turn + rng( deadline_low_as_var, deadline_high_as_var );
+    time_duration deadline_as_var = deadline.evaluate( d );
+    if( deadline_as_var != 0_turns ) {
+        ret.deadline = calendar::turn + deadline_as_var;
     } else {
         ret.deadline = calendar::turn_zero;
     }
@@ -323,10 +322,9 @@ void mission::assign( avatar &u )
             kill_count_to_reach = kills.kill_count( monster_species ) + monster_kill_goal;
         }
         dialogue d( get_talker_for( u ), get_talker_for( g->find_npc( npc_id ) ) );
-        time_duration deadline_low = type->deadline_low.evaluate( d );
-        time_duration deadline_high = type->deadline_high.evaluate( d );
-        if( deadline_low != 0_turns || deadline_high != 0_turns ) {
-            deadline = calendar::turn + rng( deadline_low, deadline_high );
+        time_duration deadline_as_var = type->deadline.evaluate( d );
+        if( deadline_as_var != 0_turns ) {
+            deadline = calendar::turn + deadline_as_var;
         } else {
             deadline = calendar::turn_zero;
         }

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -16,6 +16,7 @@
 #include "colony.h"
 #include "creature.h"
 #include "debug.h"
+#include "dialogue.h"
 #include "dialogue_chatbin.h"
 #include "enum_conversions.h"
 #include "game.h"
@@ -59,8 +60,12 @@ mission mission_type::create( const character_id &npc_id ) const
     ret.monster_type = monster_type;
     ret.monster_kill_goal = monster_kill_goal;
 
-    if( deadline_low != 0_turns || deadline_high != 0_turns ) {
-        ret.deadline = calendar::turn + rng( deadline_low, deadline_high );
+    struct dialogue d( get_talker_for( get_player_character() ),
+                       get_talker_for( g->find_npc( npc_id ) ) );
+    time_duration deadline_low_as_var = deadline_low.evaluate( d );
+    time_duration deadline_high_as_var = deadline_high.evaluate( d );
+    if( deadline_low_as_var != 0_turns || deadline_high_as_var != 0_turns ) {
+        ret.deadline = calendar::turn + rng( deadline_low_as_var, deadline_high_as_var );
     } else {
         ret.deadline = calendar::turn_zero;
     }
@@ -317,8 +322,11 @@ void mission::assign( avatar &u )
         } else if( type->goal == MGOAL_KILL_MONSTER_SPEC ) {
             kill_count_to_reach = kills.kill_count( monster_species ) + monster_kill_goal;
         }
-        if( type->deadline_low != 0_turns || type->deadline_high != 0_turns ) {
-            deadline = calendar::turn + rng( type->deadline_low, type->deadline_high );
+        dialogue d( get_talker_for( u ), get_talker_for( g->find_npc( npc_id ) ) );
+        time_duration deadline_low = type->deadline_low.evaluate( d );
+        time_duration deadline_high = type->deadline_high.evaluate( d );
+        if( deadline_low != 0_turns || deadline_high != 0_turns ) {
+            deadline = calendar::turn + rng( deadline_low, deadline_high );
         } else {
             deadline = calendar::turn_zero;
         }
@@ -781,6 +789,11 @@ const talk_effect_fun_t::likely_rewards_t &mission::get_likely_rewards() const
 bool mission::has_generic_rewards() const
 {
     return type->has_generic_rewards;
+}
+
+void mission::set_deadline( time_point new_deadline )
+{
+    deadline = new_deadline;
 }
 
 void mission::set_target( const tripoint_abs_omt &p )

--- a/src/mission.h
+++ b/src/mission.h
@@ -180,7 +180,6 @@ struct mission_type {
         // Matches it to a mission_type_id above
         mission_type_id id = mission_type_id( "MISSION_NULL" );
         std::vector<std::pair<mission_type_id, mod_id>> src;
-        bool was_loaded = false;
     private:
         // The untranslated name of the mission
         translation name = to_translation( "Bugged mission type" );
@@ -199,6 +198,8 @@ struct mission_type {
         bool urgent = false;
         // If the mission has generic rewards, so that the completion dialogue knows whether to offer them.
         bool has_generic_rewards = true;
+
+        bool was_loaded = false;
 
         // A limited subset of the talk_effects on the mission
         talk_effect_fun_t::likely_rewards_t likely_rewards;

--- a/src/mission.h
+++ b/src/mission.h
@@ -193,8 +193,8 @@ struct mission_type {
         // Value; determines rewards and such
         int value = 0;
         // Low and high deadlines
-        time_duration deadline_low = 0_turns;
-        time_duration deadline_high = 0_turns;
+        duration_or_var deadline_low;
+        duration_or_var deadline_high;
         // If true, the NPC will press this mission!
         bool urgent = false;
         // If the mission has generic rewards, so that the completion dialogue knows whether to offer them.
@@ -370,6 +370,7 @@ class mission
         /**
          * Simple setters, no checking if the values is performed. */
         /*@{*/
+        void set_deadline( time_point new_deadline );
         void set_target( const tripoint_abs_omt &p );
         void set_target_npc_id( const character_id &npc_id );
         void set_assigned_player_id( const character_id &char_id );

--- a/src/mission.h
+++ b/src/mission.h
@@ -192,9 +192,9 @@ struct mission_type {
         int difficulty = 0;
         // Value; determines rewards and such
         int value = 0;
-        // Low and high deadlines
-        duration_or_var deadline_low;
-        duration_or_var deadline_high;
+        // When this mission will auto-fail, if ever. Can be pair of values or just one
+        // If loaded as a pair, automatically calls rng(min, max) when evaluated, standard stuff
+        duration_or_var deadline;
         // If true, the NPC will press this mission!
         bool urgent = false;
         // If the mission has generic rewards, so that the completion dialogue knows whether to offer them.

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -384,8 +384,7 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
         return;
     }
 
-    deadline_low = get_duration_or_var( jo, "deadline_low", false );
-    deadline_high = get_duration_or_var( jo, "deadline_high", false );
+    deadline = get_duration_or_var( jo, "deadline", false );
 
     if( jo.has_member( "followup" ) ) {
         follow_up = mission_type_id( jo.get_string( "followup" ) );

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -384,8 +384,8 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
         return;
     }
 
-    assign( jo, "deadline_low", deadline_low, false, 1_days );
-    assign( jo, "deadline_high", deadline_high, false, 1_days );
+    deadline_low = get_duration_or_var( jo, "deadline_low", false );
+    deadline_high = get_duration_or_var( jo, "deadline_high", false );
 
     if( jo.has_member( "followup" ) ) {
         follow_up = mission_type_id( jo.get_string( "followup" ) );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5087,12 +5087,19 @@ talk_effect_fun_t::func f_assign_mission( const JsonObject &jo, std::string_view
         const std::string_view )
 {
     str_or_var mission_name = get_str_or_var( jo.get_member( member ), member, true );
-    return [mission_name]( dialogue const & d ) {
+    dbl_or_var deadline = get_dbl_or_var( jo, "deadline", false );
+    return [mission_name, deadline]( dialogue & d ) {
         avatar &player_character = get_avatar();
 
         const mission_type_id &mission_type = mission_type_id( mission_name.evaluate( d ) );
         mission *new_mission = mission::reserve_new( mission_type, character_id() );
         new_mission->assign( player_character );
+        // mission::assign assigns the type's deadline (which is often 0!), so if we want our specific
+        // deadline to be kept, it must always be done after assignment
+        const double deadline_dbl = deadline.evaluate( d );
+        if( deadline_dbl ) {
+            new_mission->set_deadline( calendar::turn_zero + time_duration::from_turns( deadline_dbl ) );
+        }
     };
 }
 


### PR DESCRIPTION
#### Summary
Features "Mission deadlines supports dialogue variables"

#### Purpose of change
Mission deadlines are almost unused, despite being one of the most obvious things any good 'quest' should have. 

Also the whole point of giving out the "faction succession" mission was to show the cooldown before you can do it again. There wasn't a way to actually *put in the cooldown*. This PR lets us put in the cooldown, and display the timer appropriately.

#### Describe the solution
load the deadline as a dur_or_var, ~~which means that existing durations can be loaded seamlessly while also supporting newly loaded dialogue variables~~ which supports times, integers, math expressions, and variable objects. This did end up taking out the old deadline_low and deadline_high, as previous code assumed their values were days.

Add a kwarg( /optional argument?) to assign_mission allowing access to mission::set_deadline

...Also a fix for EOC_FACTION_SUCCESSION_CHECK which still had a coded value of checking against the old 90-day cooldown, instead of the npctalkvar `time_between_succession`

#### Describe alternatives you've considered
the game_start and game_begin events require some really, really stupid piping. I'd strongly consider reversing their order so game_begin always runs first if it could be done easily.


#### Testing


https://github.com/user-attachments/assets/5b61f9e9-1d09-4e09-a6b1-7cabcf85b940




#### Additional context

