### PR TITLE
Missions track when they were completed/failed

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -334,6 +334,8 @@ void mission::fail()
     if( player_character.getID() == player_id ) {
         player_character.on_mission_finished( *this );
     }
+    // Tracks completion/failure
+    deadline = calendar::turn;
 
     type->fail( this );
 }
@@ -459,6 +461,9 @@ void mission::wrap_up()
             //Suppress warnings
             break;
     }
+
+    // Tracks completion/failure
+    deadline = calendar::turn;
 
     type->end( this );
 }

--- a/src/mission.h
+++ b/src/mission.h
@@ -316,6 +316,8 @@ class mission
         int monster_kill_goal = 0;
         // The kill count you need to reach to complete mission
         int kill_count_to_reach = 0;
+        // When this mission will auto-fail if not already completed/failed
+        // Also overloaded to track when the mission was completed/loaded
         time_point deadline;
         // ID of a related npc
         character_id npc_id;

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -284,10 +284,8 @@ void mission_ui_impl::draw_selected_description( std::vector<mission *> missions
     cataimgui::draw_colored_text( parsed_description, c_unset, table_column_width * 1.15 );
     if( miss->has_deadline() ) {
         const time_point deadline = miss->get_deadline();
-        ImGui::Text( _( "Deadline: %s" ), to_string( deadline ).c_str() );
         if( selected_tab == mission_ui_tab_enum::ACTIVE ) {
-            // There's no point in displaying this for a completed/failed mission.
-            // @ TODO: But displaying when you completed it would be useful.
+            ImGui::TextWrapped( _( "Deadline: %s" ), to_string( deadline ).c_str() );
             const time_duration remaining = deadline - calendar::turn;
             std::string remaining_time;
             if( remaining <= 0_turns ) {
@@ -298,6 +296,24 @@ void mission_ui_impl::draw_selected_description( std::vector<mission *> missions
                 remaining_time = to_string_approx( remaining );
             }
             ImGui::TextWrapped( _( "Time remaining: %s" ), remaining_time.c_str() );
+        } else {
+            const time_duration time_in_past = calendar::turn - deadline;
+            std::string time_in_past_string;
+            if( get_player_character().has_watch() ) {
+                time_in_past_string = to_string( time_in_past );
+            } else {
+                time_in_past_string = to_string_approx( time_in_past );
+            }
+            if( deadline != calendar::turn_zero ) {
+                if( selected_tab == mission_ui_tab_enum::COMPLETED ) {
+                    cataimgui::draw_colored_text( string_format( _( "Completed: %s" ),
+                                                  to_string( deadline ) ), c_green );
+                } else if( selected_tab == mission_ui_tab_enum::FAILED ) {
+                    cataimgui::draw_colored_text( string_format( _( "Failed at: %s" ),
+                                                  to_string( deadline ).c_str() ), c_red );
+                }
+                cataimgui::draw_colored_text( string_format( _( "%s ago" ), time_in_past_string ), c_unset );
+            }
         }
     }
     if( miss->has_target() ) {


### PR DESCRIPTION
#### Summary
Interface "Missions track when they were completed/failed"

#### Purpose of change
Squash a TODO in the mission UI

Let our characters remember the great moments when they succeeded - and failed...

#### Describe the solution
Overload the `deadline` time_point for missions. If it's an active mission, the deadline is when it will fail. If it's a completed or failed mission, the deadline is when we completed or failed it (respectively).

Add the extra mission_ui code to handle displaying this for completed or failed missions

#### Describe alternatives you've considered


#### Testing

https://github.com/user-attachments/assets/de132939-016c-4db5-a18f-3e805d6a3df2


#### Additional context
