### PR TITLE
Track kills through grenades and other explosives

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1714,7 +1714,7 @@ stacking_info item::stacks_with( const item &rhs, bool check_components, bool co
     bits.set( tname::segments::UPS, _stacks_ups( *this, rhs ) );
     // Guns that differ only by dirt/shot_counter can still stack,
     // but other item_vars such as label/note will prevent stacking
-    static const std::set<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location_omt", "ethereal" };
+    static const std::set<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location_omt", "ethereal", "last_act_by_char_id" };
     bits.set( tname::segments::VARS, map_equal_ignoring_keys( item_vars, rhs.item_vars, ignore_keys ) );
     bits.set( tname::segments::ETHEREAL, _stacks_ethereal( *this, rhs ) );
     bits.set( tname::segments::LOCATION_HINT, _stacks_location_hint( *this, rhs ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -241,6 +241,8 @@ std::optional<int> iuse_transform::use( Character *p, item &it, const tripoint &
         return std::nullopt;
     }
 
+    it.set_var( "last_act_by_char_id", p->getID().get_value() );
+
     int result = 0;
 
     if( need_fire ) {
@@ -652,10 +654,19 @@ void explosion_iuse::load( const JsonObject &obj, const std::string & )
     obj.read( "scrambler_blast_radius", scrambler_blast_radius );
 }
 
-std::optional<int> explosion_iuse::use( Character *p, item &, const tripoint &pos ) const
+std::optional<int> explosion_iuse::use( Character *p, item &it, const tripoint &pos ) const
 {
     if( explosion.power >= 0.0f ) {
-        explosion_handler::explosion( p, pos, explosion );
+        Character *source = p;
+        if( it.has_var( "last_act_by_char_id" ) ) {
+            character_id thrower( it.get_var( "last_act_by_char_id", 0 ) );
+            if( thrower == get_player_character().getID() ) {
+                source = &get_player_character();
+            } else {
+                source = g->find_npc( thrower );
+            }
+        }
+        explosion_handler::explosion( source, pos, explosion );
     }
 
     if( draw_explosion_radius >= 0 ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1416,6 +1416,7 @@ dealt_projectile_attack Character::throw_item( const tripoint_bub_ms &target, co
 {
     // Copy the item, we may alter it before throwing
     item thrown = to_throw;
+    thrown.set_var( "last_act_by_char_id", getID().get_value() );
 
     const int move_cost = throw_cost( *this, to_throw );
     mod_moves( -move_cost );


### PR DESCRIPTION
#### Summary
Bugfixes "Kills from explosive devices are properly tracked"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/71742
The source of the explosion for grenades was being passed as the character they were (potentially) on, because no other character was available to be responsible at that point. 

#### Describe the solution
To make a character available, whenever an item is activated or thrown, set an item var with the last character to do so on it. Then, use that to find the explosion source.

Also, ignore the var in checking if an item stacks with another.

#### Testing
![image](https://github.com/user-attachments/assets/acd766bc-16e7-4825-b8db-4d0558645ee7)
![image](https://github.com/user-attachments/assets/ed7294d4-602a-43bc-a6c3-652af891e6ce)
![image](https://github.com/user-attachments/assets/9b18f51d-53ca-4478-99ea-f79c6d597ced)
![image](https://github.com/user-attachments/assets/5ba2182b-866f-404d-aa5c-09cbc17fe054)

Throwing a grenade, then saving and loading still attributes kills correctly.

#### Additional context
I don't think there exists a place where the throwing case will hit something the activation case doesn't, but I figured it was best to cover it.