### PR TITLE
Option to start bash activity on partial bash

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -123,6 +123,14 @@
     "multi_activity": true
   },
   {
+    "id": "ACT_BASH",
+    "type": "activity_type",
+    "activity_level": "MODERATE_EXERCISE",
+    "verb": "bashing",
+    "can_resume": false,
+    "based_on": "neither"
+  },
+  {
     "id": "ACT_BIKERACK_RACKING",
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -142,6 +142,32 @@ class autodrive_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 };
 
+class bash_activity_actor : public activity_actor
+{
+    private:
+        tripoint_bub_ms target;
+
+    public:
+        explicit bash_activity_actor( const tripoint_bub_ms &where ) : target( where ) {}
+
+        activity_id get_type() const override {
+            return activity_id( "ACT_BASH" );
+        };
+
+        void start( player_activity &, Character & ) override {}
+        void canceled( player_activity &, Character & ) override {}
+        void finish( player_activity &, Character & ) override {}
+
+        void do_turn( player_activity &, Character & ) override;
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<bash_activity_actor>( *this );
+        }
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+};
+
 class gunmod_remove_activity_actor : public activity_actor
 {
     private:

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -235,6 +235,15 @@ class avatar : public Character
         bool has_seen_snippet( const snippet_id &snippet ) const;
         const std::set<snippet_id> &get_snippets();
 
+        /** smash a map feature */
+        struct smash_result {
+            int skill;
+            int resistance;
+            bool did_smash;
+            bool success;
+        };
+        smash_result smash( tripoint_bub_ms &smashp );
+
         /**
          * Opens the targeting menu to pull a nearby creature towards the character.
          * @param name Name of the implement used to pull the creature. */

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -904,27 +904,6 @@ static void haul_toggle()
 
 static void smash()
 {
-    avatar &player_character = get_avatar();
-    map &here = get_map();
-    if( player_character.is_mounted() ) {
-        auto *mons = player_character.mounted_creature.get();
-        if( mons->has_flag( mon_flag_RIDEABLE_MECH ) ) {
-            if( !mons->check_mech_powered() ) {
-                add_msg( m_bad, _( "Your %s refuses to move as its batteries have been drained." ),
-                         mons->get_name() );
-                return;
-            }
-        }
-    }
-    const int move_cost = !player_character.is_armed() ? 80 :
-                          player_character.get_wielded_item()->attack_time( player_character ) *
-                          0.8;
-    bool mech_smash = false;
-    int smashskill = player_character.smash_ability();
-    if( player_character.is_mounted() ) {
-        mech_smash = true;
-    }
-
     const bool allow_floor_bash = debug_mode; // Should later become "true"
     const std::optional<tripoint> smashp_ = choose_adjacent( _( "Smash where?" ), allow_floor_bash );
     if( !smashp_ ) {
@@ -936,20 +915,58 @@ static void smash()
         return; // player declined to smash faction's stuff
     }
 
+    avatar &player_character = get_avatar();
+    avatar::smash_result res = player_character.smash( smashp );
+    if( res.did_smash && !res.success &&
+        res.resistance > 0 && res.skill >= res.resistance &&
+        query_yn( _( "Keep smashing until destroyed?" ) ) ) {
+        player_character.assign_activity( bash_activity_actor( smashp ) );
+    }
+}
+
+avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
+{
+    avatar::smash_result ret;
+    ret.did_smash = false;
+    ret.success = false;
+    ret.skill = -1;
+    ret.resistance = -1;
+
+    map &here = get_map();
+    if( is_mounted() ) {
+        auto *mons = mounted_creature.get();
+        if( mons->has_flag( mon_flag_RIDEABLE_MECH ) ) {
+            if( !mons->check_mech_powered() ) {
+                add_msg( m_bad, _( "Your %s refuses to move as its batteries have been drained." ),
+                         mons->get_name() );
+                return ret;
+            }
+        }
+    }
+    const int move_cost = !is_armed() ? 80 :
+                          get_wielded_item()->attack_time( *this ) * 0.8;
+    bool mech_smash = false;
+    int smashskill = smash_ability();
+    ret.skill = smashskill;
+    if( is_mounted() ) {
+        mech_smash = true;
+    }
+
     bool smash_floor = false;
-    if( smashp.z() != player_character.posz() ) {
-        if( smashp.z() > player_character.posz() ) {
+    if( smashp.z() != posz() ) {
+        if( smashp.z() > posz() ) {
             // TODO: Knock on the ceiling
-            return;
+            return ret;
         }
 
-        smashp.z() = player_character.posz();
+        smashp.z() = posz();
         smash_floor = true;
     }
+
     get_event_bus().send<event_type::character_smashes_tile>(
-        player_character.getID(), here.ter( smashp ).id(), here.furn( smashp ).id() );
-    if( player_character.is_mounted() ) {
-        monster *crit = player_character.mounted_creature.get();
+        getID(), here.ter( smashp ).id(), here.furn( smashp ).id() );
+    if( is_mounted() ) {
+        monster *crit = mounted_creature.get();
         if( crit->has_flag( mon_flag_RIDEABLE_MECH ) ) {
             crit->use_mech_power( 3_kJ );
         }
@@ -961,20 +978,26 @@ static void smash()
         }
         if( smashskill < bash_info.str_min && one_in( 10 ) ) {
             add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), fd_to_smsh.first->get_name() );
-            return;
+            ret.did_smash = true;
+            return ret;
         } else if( smashskill >= rng( bash_info.str_min, bash_info.str_max ) ) {
             sounds::sound( smashp, bash_info.sound_vol, sounds::sound_t::combat, bash_info.sound, true, "smash",
                            "field" );
             here.remove_field( smashp, fd_to_smsh.first );
             here.spawn_items( smashp, item_group::items_from( bash_info.drop_group, calendar::turn ) );
-            player_character.mod_moves( - bash_info.fd_bash_move_cost );
+            mod_moves( - bash_info.fd_bash_move_cost );
             add_msg( m_info, bash_info.field_bash_msg_success.translated() );
-            return;
+            ret.did_smash = true;
+            ret.success = true;
+            return ret;
         } else {
             sounds::sound( smashp, bash_info.sound_fail_vol, sounds::sound_t::combat, bash_info.sound_fail,
                            true, "smash",
                            "field" );
-            return;
+
+            ret.resistance = bash_info.str_min;
+            ret.did_smash = true;
+            return ret;
         }
     }
 
@@ -983,9 +1006,9 @@ static void smash()
         if( maybe_corpse.is_corpse() && maybe_corpse.damage() < maybe_corpse.max_damage() &&
             maybe_corpse.can_revive() ) {
             if( maybe_corpse.get_mtype()->bloodType()->has_acid &&
-                !player_character.is_immune_field( fd_acid ) ) {
+                !is_immune_field( fd_acid ) ) {
                 if( !query_yn( _( "Are you sure you want to pulp an acid filled corpse?" ) ) ) {
-                    return; // Player doesn't want an acid bath
+                    return ret; // Player doesn't want an acid bath
                 }
             }
             should_pulp = true; // There is at least one corpse to pulp
@@ -993,20 +1016,20 @@ static void smash()
     }
 
     if( should_pulp ) {
-        player_character.assign_activity( pulp_activity_actor( here.getglobal( smashp ), true ) );
-        return; // don't smash terrain if we've smashed a corpse
+        assign_activity( pulp_activity_actor( here.getglobal( smashp ), true ) );
+        return ret; // don't smash terrain if we've smashed a corpse
     }
 
     vehicle *veh = veh_pointer_or_null( here.veh_at( smashp ) );
     if( veh != nullptr ) {
-        if( !veh->handle_potential_theft( player_character ) ) {
-            return;
+        if( !veh->handle_potential_theft( *this ) ) {
+            return ret;
         }
     }
 
-    if( !player_character.has_weapon() ) {
+    if( !has_weapon() ) {
         const bodypart_id bp_null( "bp_null" );
-        std::pair<bodypart_id, int> best_part_to_smash = player_character.best_part_to_smash();
+        std::pair<bodypart_id, int> best_part_to_smash = this->best_part_to_smash();
         if( best_part_to_smash.first != bp_null && here.is_bashable( smashp ) ) {
             std::string name_to_bash = _( "thing" );
             if( here.is_bashable_furn( smashp ) ) {
@@ -1026,18 +1049,19 @@ static void smash()
     const bash_params bash_result = here.bash( smashp, smashskill, false, false, smash_floor );
     // Weariness scaling
     float weary_mult = 1.0f;
-    item_location weapon = player_character.used_weapon();
+    item_location weapon = used_weapon();
     if( bash_result.did_bash ) {
+        ret.did_smash = true;
         if( !mech_smash ) {
-            player_character.set_activity_level( MODERATE_EXERCISE );
-            player_character.handle_melee_wear( weapon );
-            weary_mult = 1.0f / player_character.exertion_adjusted_move_multiplier( MODERATE_EXERCISE );
+            set_activity_level( MODERATE_EXERCISE );
+            handle_melee_wear( weapon );
+            weary_mult = 1.0f / exertion_adjusted_move_multiplier( MODERATE_EXERCISE );
 
-            const int mod_sta = 2 * player_character.get_standard_stamina_cost();
-            player_character.burn_energy_arms( mod_sta );
+            const int mod_sta = 2 * get_standard_stamina_cost();
+            burn_energy_arms( mod_sta );
 
-            if( static_cast<int>( player_character.get_skill_level( skill_melee ) ) == 0 ) {
-                player_character.practice( skill_melee, rng( 0, 1 ) * rng( 0, 1 ) );
+            if( static_cast<int>( get_skill_level( skill_melee ) ) == 0 ) {
+                practice( skill_melee, rng( 0, 1 ) * rng( 0, 1 ) );
             }
             if( weapon ) {
                 const int glass_portion = weapon->made_of( material_glass );
@@ -1048,31 +1072,32 @@ static void smash()
                 const int vol = weapon->volume() * glass_fraction / units::legacy_volume_factor;
                 if( glass_portion && rng( 0, vol + 3 ) < vol ) {
                     add_msg( m_bad, _( "Your %s shatters!" ), weapon->tname() );
-                    weapon->spill_contents( player_character.pos() );
-                    sounds::sound( player_character.pos(), 24, sounds::sound_t::combat, "CRACK!", true, "smash",
+                    weapon->spill_contents( pos() );
+                    sounds::sound( pos(), 24, sounds::sound_t::combat, "CRACK!", true, "smash",
                                    "glass" );
-                    player_character.deal_damage( nullptr, bodypart_id( "hand_r" ), damage_instance( damage_cut,
-                                                  rng( 0,
-                                                       vol ) ) );
+                    deal_damage( nullptr, bodypart_id( "hand_r" ), damage_instance( damage_cut,
+                                 rng( 0,
+                                      vol ) ) );
                     if( vol > 20 ) {
                         // Hurt left arm too, if it was big
-                        player_character.deal_damage( nullptr, bodypart_id( "hand_l" ), damage_instance( damage_cut,
-                                                      rng( 0,
-                                                           static_cast<int>( vol * .5 ) ) ) );
+                        deal_damage( nullptr, bodypart_id( "hand_l" ), damage_instance( damage_cut,
+                                     rng( 0, static_cast<int>( vol * .5 ) ) ) );
                     }
-                    player_character.remove_weapon();
-                    player_character.check_dead_state();
+                    remove_weapon();
+                    check_dead_state();
                 }
             }
         }
-        player_character.mod_moves( -move_cost * weary_mult );
-        player_character.recoil = MAX_RECOIL;
+        mod_moves( -move_cost * weary_mult );
+        recoil = MAX_RECOIL;
 
         if( bash_result.success ) {
+            ret.success = true;
             // Bash results in destruction of target
             g->draw_async_anim( smashp, "bash_complete", "X", c_light_gray );
         } else if( smashskill >= here.bash_resistance( smashp ) ) {
             // Bash effective but target not yet destroyed
+            ret.resistance = here.bash_resistance( smashp );
             g->draw_async_anim( smashp, "bash_effective", "/", c_light_gray );
         } else {
             // Bash not effective
@@ -1091,6 +1116,8 @@ static void smash()
     } else {
         add_msg( _( "There's nothing there to smash!" ) );
     }
+
+    return ret;
 }
 
 static int try_set_alarm()

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4325,7 +4325,7 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
         // Gradually makes hard bashes easier
         int damage = get_map_damage( tripoint_bub_ms( p ) );
         add_msg_debug( debugmode::DF_MAP,
-                       "Bashing difficulty %d, threshold is %d. Strength is %d + %d, added damage %d", smax, smin,
+                       "Bashing difficulty %d, threshold is %d. Strength is %d + %d, added damage %f", smax, smin,
                        params.strength, damage, std::max( ( params.strength - smin ) * params.roll, 0.f ) );
         if( params.strength + damage >= smax ) {
             damage = 0;


### PR DESCRIPTION
#### Summary
Interface "Add activity to continually bash something until it's destroyed"

#### Purpose of change
When you can smash something, but it will be difficult, you need to repeatedly press 's' and then a direction key. This is tiresome, and there's no real reason for it - we can just ask the player if they want their character to keep smashing until it's gone.

#### Describe the solution
Move noninteractive bashing code for avatars into an avatar:: function, and return some info about how the bash went - if it didn't succeed but could with more effort, ask if they want to keep bashing until it does.

Especially annoying since https://github.com/CleverRaven/Cataclysm-DDA/pull/69219

#### Describe alternatives you've considered
Refactoring the code more, but this was fast and worked.

#### Testing
Grab a heavy sledgehammer and hit a tree.
![image](https://github.com/user-attachments/assets/6dbc09f5-9959-4999-9437-b299bf877b22)
![image](https://github.com/user-attachments/assets/1a39c464-1cb8-4e3b-b03f-605c370136d8)
The pauses are because the PC runs out of stamina and waits until it regenerates.
