### PR TITLE
[MoM] Spread Electron Overflow charge value out over the number of items it's charging

### DIFF
--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -370,7 +370,7 @@
             "condition": { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
             "effect": [
               {
-                "if": { "math": [ "u_electrokin_personal_battery_count", ">=", "0" ] },
+                "if": { "math": [ "u_electrokin_personal_battery_count", ">", "0" ] },
                 "then": {
                   "math": [
                     "n_val('power')",

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -375,7 +375,7 @@
                   "math": [
                     "n_electrokin_charging_value_counter",
                     "+=",
-                    "( ( (u_spell_level('electrokinetic_personal_battery') / 3) + 2) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling) / u_electrokin_personal_battery_count"
+                    "( ( (u_spell_level('electrokinetic_personal_battery') / 5) + 1) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling) / u_electrokin_personal_battery_count"
                   ]
                 }
               }
@@ -387,38 +387,23 @@
             "effect": [
               {
                 "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "5" ] },
-                "then": [ 
-                  { "math": [ "n_val('power')", "+=", "5" ] },
-                  { "math": [ "n_electrokin_charging_value_counter", "-=", "5" ] }
-                ],
+                "then": [ { "math": [ "n_val('power')", "+=", "5" ] }, { "math": [ "n_electrokin_charging_value_counter", "-=", "5" ] } ],
                 "else": [
                   {
                     "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "4" ] },
-                    "then": [ 
-                      { "math": [ "n_val('power')", "+=", "4" ] },
-                      { "math": [ "n_electrokin_charging_value_counter", "-=", "4" ] }
-                    ],
+                    "then": [ { "math": [ "n_val('power')", "+=", "4" ] }, { "math": [ "n_electrokin_charging_value_counter", "-=", "4" ] } ],
                     "else": [
                       {
                         "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "3" ] },
-                        "then": [ 
-                          { "math": [ "n_val('power')", "+=", "3" ] },
-                          { "math": [ "n_electrokin_charging_value_counter", "-=", "3" ] }
-                        ],
+                        "then": [ { "math": [ "n_val('power')", "+=", "3" ] }, { "math": [ "n_electrokin_charging_value_counter", "-=", "3" ] } ],
                         "else": [
                           {
                             "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "2" ] },
-                            "then": [ 
-                              { "math": [ "n_val('power')", "+=", "2" ] },
-                              { "math": [ "n_electrokin_charging_value_counter", "-=", "2" ] }
-                            ],
+                            "then": [ { "math": [ "n_val('power')", "+=", "2" ] }, { "math": [ "n_electrokin_charging_value_counter", "-=", "2" ] } ],
                             "else": [
                               {
                                 "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "1" ] },
-                                "then": [ 
-                                  { "math": [ "n_val('power')", "+=", "1" ] },
-                                  { "math": [ "n_electrokin_charging_value_counter", "-=", "1" ] }
-                                ]
+                                "then": [ { "math": [ "n_val('power')", "+=", "1" ] }, { "math": [ "n_electrokin_charging_value_counter", "-=", "1" ] } ]
                               }
                             ]
                           }

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -366,18 +366,67 @@
         ],
         "true_eocs": [
           {
-            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_CHARGER",
+            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_VALUE_ADDED",
             "condition": { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
             "effect": [
               {
                 "if": { "math": [ "u_electrokin_personal_battery_count", ">", "0" ] },
                 "then": {
                   "math": [
-                    "n_val('power')",
+                    "n_electrokin_charging_value_counter",
                     "+=",
-                    "(1 + (u_spell_level('electrokinetic_personal_battery') * scaling_factor(u_val('intelligence') * u_nether_attunement_power_scaling) )) / u_electrokin_personal_battery_count"
+                    "( ( (u_spell_level('electrokinetic_personal_battery') / 3) + 2) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling) / u_electrokin_personal_battery_count"
                   ]
                 }
+              }
+            ]
+          },
+          {
+            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_CHARGER",
+            "condition": { "math": [ "n_electrokin_charging_value_counter", ">=", "1" ] },
+            "effect": [
+              {
+                "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "5" ] },
+                "then": [ 
+                  { "math": [ "n_val('power')", "+=", "5" ] },
+                  { "math": [ "n_electrokin_charging_value_counter", "-=", "5" ] }
+                ],
+                "else": [
+                  {
+                    "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "4" ] },
+                    "then": [ 
+                      { "math": [ "n_val('power')", "+=", "4" ] },
+                      { "math": [ "n_electrokin_charging_value_counter", "-=", "4" ] }
+                    ],
+                    "else": [
+                      {
+                        "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "3" ] },
+                        "then": [ 
+                          { "math": [ "n_val('power')", "+=", "3" ] },
+                          { "math": [ "n_electrokin_charging_value_counter", "-=", "3" ] }
+                        ],
+                        "else": [
+                          {
+                            "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "2" ] },
+                            "then": [ 
+                              { "math": [ "n_val('power')", "+=", "2" ] },
+                              { "math": [ "n_electrokin_charging_value_counter", "-=", "2" ] }
+                            ],
+                            "else": [
+                              {
+                                "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "1" ] },
+                                "then": [ 
+                                  { "math": [ "n_val('power')", "+=", "1" ] },
+                                  { "math": [ "n_electrokin_charging_value_counter", "-=", "1" ] }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -330,6 +330,32 @@
           }
         ]
       },
+      { "math": [ "u_electrokin_personal_battery_count", "=", "0" ] },
+      {
+        "u_run_inv_eocs": "all",
+        "search_data": [
+          { "flags": [ "RECHARGE" ] },
+          { "flags": [ "ELECTRONIC" ] },
+          { "flags": [ "ELECTROKINETIC_CHARGEABLE" ] },
+          { "flags": [ "USE_UPS" ] }
+        ],
+        "true_eocs": [
+          {
+            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_COUNTER",
+            "condition": { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
+            "effect": [ { "math": [ "u_electrokin_personal_battery_count", "++" ] } ]
+          }
+        ]
+      },
+      { "queue_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_FINALIZATION", "time_in_future": 1 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_FINALIZATION",
+    "//": "The one that actually does the charging",
+    "condition": { "u_has_effect": "effect_electrokin_personal_battery" },
+    "effect": [
       {
         "u_run_inv_eocs": "all",
         "search_data": [
@@ -344,11 +370,14 @@
             "condition": { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
             "effect": [
               {
-                "math": [
-                  "n_val('power')",
-                  "+=",
-                  "1 + ((u_spell_level('electrokinetic_personal_battery') / 5) * scaling_factor(u_val('intelligence') * u_nether_attunement_power_scaling) )"
-                ]
+                "if": { "math": [ "u_electrokin_personal_battery_count", ">=", "0" ] },
+                "then": {
+                  "math": [
+                    "n_val('power')",
+                    "+=",
+                    "(1 + (u_spell_level('electrokinetic_personal_battery') * scaling_factor(u_val('intelligence') * u_nether_attunement_power_scaling) )) / u_electrokin_personal_battery_count"
+                  ]
+                }
               }
             ]
           }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Spread Electron Overflow charge value out over the number of items it's charging"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It doesn't really make sense that if you have one smartphone and use Electron Overflow, you charge it with X power, and if you pick up another smartphone you charge both of them with X power (2X) total.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implement another EoC. The first one now scans all applicable items and saves them in a variable, and the second one adds the actual power, divided by the number of items you have. 

Due to the struckthrough section, it does it using a janky-but-workable solution suggested by Guardian (and which I previously used for contemplation XP values lower than 1). Each cycle, it checks the power value and increments it as a variable on the item. Then it checks the variables and items with a variable greater than 1 have power restored. Repeat until the power is no longer maintained. Only items below maximum charge have their variable incremented, so there should be no overcharging. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

~~The counting and everything works, but the behavior makes it seem like `n_val('power')` doesn't actually work off any real unit, it works off battery charge, so the relative amount to be charged goes below 1 nothing charges (if you have 6 "charge units" and 7 items on you, for example), which is a problem. The docs say it works on mJ but it doesn't seem to in-game.~~

If you have one item, it charges relatively quickly. If you have a bunch of items, the charge is spread out across all of them.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
