### PR TITLE
Show `%s wounds are closing up!` message only if `message` field of healing spell is empty

### DIFF
--- a/data/mods/Magiclysm/Spells/animist.json
+++ b/data/mods/Magiclysm/Spells/animist.json
@@ -821,7 +821,7 @@
     "//": "added this min/max damage for player, so it will be visible how much hp would be healed.  ",
     "effect": "attack",
     "shape": "blast",
-    "message": "",
+    "message": "You regain health as you devour the life essence of your ally!",
     "min_damage": -1,
     "max_damage": -10,
     "damage_increment": -0.4,

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -617,8 +617,10 @@ static void damage_targets( const spell &sp, Creature &caster,
             }
         } else if( sp.damage( caster ) < 0 ) {
             sp.heal( target, caster );
-            add_msg_if_player_sees( cr->pos(), m_good, _( "%s wounds are closing up!" ),
-                                    cr->disp_name( true ) );
+            if( sp.message().empty() ) {
+                add_msg_if_player_sees( cr->pos(), m_good, _( "%s wounds are closing up!" ),
+                                        cr->disp_name( true, true ) );
+            }
         }
 
         // handling DOTs here


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #61977.

#### Describe the solution
Show `%s wounds are closing up!` message only if message field of healing spell is empty. Also, while I'm here, I added some flavor text when casting `Devour` spell.

#### Describe alternatives you've considered
None.

#### Testing
Created world with Magiclysm mod. Debug-learned the Devour spell to 25 level. Got an NPC ally. Cast Devour spell on ally. Checked that no `%s wounds are closing up!` message appears in message log, only my newly added flavor text.

#### Additional context
![изображение](https://github.com/user-attachments/assets/a1e7f46c-74d1-4090-8c1f-df61b80fa044)