### PR TITLE
Clean up monster eating code, part 1/???

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -69,6 +69,7 @@
     ]
   },
   {
+    "//": "This effect is automatically applied in C++.",
     "type": "effect_type",
     "id": "critter_well_fed",
     "name": [ "Well Fed" ],
@@ -76,6 +77,7 @@
     "desc": [ { "str": "AI tag for when critter has had enough to eat.  This is a bug if you have it.", "//~": "NO_I18N" } ]
   },
   {
+    "//": "This effect is automatically applied in C++.",
     "type": "effect_type",
     "id": "critter_underfed",
     "name": [ "Underfed" ],

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -302,6 +302,7 @@ void monmove()
             }
             critter.try_biosignature();
             critter.try_reproduce();
+            critter.digest_food();
         }
         while( critter.get_moves() > 0 && !critter.is_dead() && !critter.has_effect( effect_ridden ) ) {
             critter.made_footstep = false;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -165,7 +165,6 @@ static const efftype_id effect_cig( "cig" );
 static const efftype_id effect_conjunctivitis( "conjunctivitis" );
 static const efftype_id effect_contacts( "contacts" );
 static const efftype_id effect_corroding( "corroding" );
-static const efftype_id effect_critter_well_fed( "critter_well_fed" );
 static const efftype_id effect_crushed( "crushed" );
 static const efftype_id effect_datura( "datura" );
 static const efftype_id effect_dazed( "dazed" );
@@ -1615,14 +1614,12 @@ std::optional<int> iuse::petfood( Character *p, item *it, const tripoint & )
         }
 
         p->add_msg_if_player( _( "You feed your %1$s to the %2$s." ), it->tname(), mon->get_name() );
-        if( mon->has_flag( mon_flag_EATS ) ) {
+        if( !mon->has_fully_eaten() && mon->has_flag( mon_flag_EATS ) ) {
             int kcal = it->get_comestible()->default_nutrition.kcal();
             mon->mod_amount_eaten( kcal );
             if( mon->has_fully_eaten() ) {
                 p->add_msg_if_player( _( "The %1$s seems full now." ), mon->get_name() );
             }
-        } else if( !mon->has_flag( mon_flag_EATS ) ) {
-            mon->add_effect( effect_critter_well_fed, 24_hours );
         }
 
         if( petfood.feed.empty() ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1617,8 +1617,8 @@ std::optional<int> iuse::petfood( Character *p, item *it, const tripoint & )
         p->add_msg_if_player( _( "You feed your %1$s to the %2$s." ), it->tname(), mon->get_name() );
         if( mon->has_flag( mon_flag_EATS ) ) {
             int kcal = it->get_comestible()->default_nutrition.kcal();
-            mon->amount_eaten += kcal;
-            if( mon->amount_eaten >= mon->stomach_size ) {
+            mon->mod_amount_eaten( kcal );
+            if( mon->has_fully_eaten() ) {
                 p->add_msg_if_player( _( "The %1$s seems full now." ), mon->get_name() );
             }
         } else if( !mon->has_flag( mon_flag_EATS ) ) {

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -319,11 +319,11 @@ bool mattack::eat_crop( monster *z )
             target = p;
         }
         if( target ) {
-            if( z->amount_eaten <= z->stomach_size ) {
+            if( !z->has_fully_eaten() ) {
                 add_msg_if_player_sees( *z, _( "The %1s eats the %2s." ), z->name(), here.furnname( p ) );
                 here.furn_set( *target, furn_str_id( here.furn( *target )->plant->base ) );
                 here.i_clear( *target );
-                z->amount_eaten += 350;
+                z->mod_amount_eaten( 350 );
                 return true;
             }
         }
@@ -337,18 +337,18 @@ bool mattack::eat_crop( monster *z )
                 !item.has_flag( flag_CATTLE ) ) {
                 continue;
             }
-            if( z->amount_eaten <= z->stomach_size ) {
+            if( !z->has_fully_eaten() ) {
                 //Check for stomach size 0 so as to not break creatures which haven't
                 //been given a stomach size yet.
                 int consumed = 1;
                 if( item.count_by_charges() ) {
                     int kcal = item.get_comestible()->default_nutrition.kcal();
-                    z->amount_eaten += kcal;
+                    z->mod_amount_eaten( kcal );
                     add_msg_if_player_sees( *z, _( "The %1s eats the %2s." ), z->name(), item.display_name() );
                     here.use_charges( p, 1, item.type->get_id(), consumed );
                 } else {
                     int kcal = item.get_comestible()->default_nutrition.kcal();
-                    z->amount_eaten += kcal;
+                    z->mod_amount_eaten( kcal );
                     add_msg_if_player_sees( *z, _( "The %1s gobbles up the %2s." ), z->name(), item.display_name() );
                     here.use_amount( p, 1, item.type->get_id(), consumed );
                 }
@@ -492,16 +492,16 @@ bool mattack::eat_food( monster *z )
                 continue;
             }
             //Don't eat own eggs
-            if( z->type->baby_type.baby_egg != item.type->get_id() && ( z->amount_eaten <= z->stomach_size ) ) {
+            if( z->type->baby_type.baby_egg != item.type->get_id() && ( !z->has_fully_eaten() ) ) {
                 int consumed = 1;
                 if( item.count_by_charges() ) {
                     int kcal = item.get_comestible()->default_nutrition.kcal();
-                    z->amount_eaten += kcal;
+                    z->mod_amount_eaten( kcal );
                     add_msg_if_player_sees( *z, _( "The %1s eats the %2s." ), z->name(), item.display_name() );
                     here.use_charges( p, 1, item.type->get_id(), consumed );
                 } else {
                     int kcal = item.get_comestible()->default_nutrition.kcal();
-                    z->amount_eaten += kcal;
+                    z->mod_amount_eaten( kcal );
                     add_msg_if_player_sees( *z, _( "The %1s gobbles up the %2s." ), z->name(), item.display_name() );
                     here.use_amount( p, 1, item.type->get_id(), consumed );
                 }
@@ -524,14 +524,14 @@ bool mattack::eat_carrion( monster *z )
         for( item &item : items ) {
             //TODO: Completely eaten corpses should leave bones and other inedibles.
             if( item.has_flag( flag_CORPSE ) && item.damage() < item.max_damage() &&
-                z->amount_eaten < z->stomach_size &&
+                !z->has_fully_eaten() &&
                 ( item.made_of( material_flesh ) || item.made_of( material_iflesh ) ||
                   item.made_of( material_hflesh ) || item.made_of( material_veggy ) ) ) {
                 item.mod_damage( 700 );
                 if( item.damage() >= item.max_damage() && item.can_revive() ) {
                     item.set_flag( flag_PULPED );
                 }
-                z->amount_eaten += 100;
+                z->mod_amount_eaten( 100 );
                 add_msg_if_player_sees( *z, _( "The %1s gnaws on the %2s." ), z->name(), item.display_name() );
                 return true;
             }
@@ -551,24 +551,24 @@ bool mattack::graze( monster *z )
         }
         if( here.has_flag( ter_furn_flag::TFLAG_FLOWER, p ) &&
             !here.has_flag( ter_furn_flag::TFLAG_GRAZER_INEDIBLE, p ) &&
-            ( z->amount_eaten <= z->stomach_size ) ) {
+            ( !z->has_fully_eaten() ) ) {
             here.furn_set( p, furn_str_id::NULL_ID() );
-            z->amount_eaten += 50;
+            z->mod_amount_eaten( 50 );
             //Calorie amount is based on the "small_plant" dummy item, as with the grazer mutation.
             return true;
         }
         if( here.has_flag( ter_furn_flag::TFLAG_SHRUB, p ) &&
             !here.has_flag( ter_furn_flag::TFLAG_GRAZER_INEDIBLE, p ) &&
-            ( z->amount_eaten <= z->stomach_size ) ) {
+            ( !z->has_fully_eaten() ) ) {
             add_msg_if_player_sees( *z, _( "The %1s eats the %2s." ), z->name(), here.tername( p ) );
             here.ter_set( p, ter_t_dirt );
-            z->amount_eaten += 174;
+            z->mod_amount_eaten( 174 );
             //Calorie amount is based on the "underbrush" dummy item, as with the grazer mutation.
             return true;
         }
-        if( here.has_flag( ter_furn_flag::TFLAG_GRAZABLE, p ) && z->amount_eaten < z->stomach_size ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_GRAZABLE, p ) && !z->has_fully_eaten() ) {
             here.ter_set( p, here.get_ter_transforms_into( p ) );
-            z->amount_eaten += 70;
+            z->mod_amount_eaten( 70 );
             //Calorie amount is based on the "grass" dummy item, as with the grazer mutation.
             return true;
         }
@@ -585,12 +585,12 @@ bool mattack::browse( monster *z )
         if( z->friendly && rl_dist( get_player_character().pos_bub(), p ) <= 2 ) {
             continue;
         }
-        if( here.has_flag( ter_furn_flag::TFLAG_BROWSABLE, p ) && ( z->amount_eaten <= z->stomach_size ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_BROWSABLE, p ) && ( !z->has_fully_eaten() ) ) {
             const harvest_id harvest = here.get_harvest( p );
             if( !harvest.is_null() || !harvest->empty() ) {
                 add_msg_if_player_sees( *z, _( "The %1s eats from the %2s." ), z->name(), here.tername( p ) );
                 here.ter_set( p, here.get_ter_transforms_into( p ) );
-                z->amount_eaten += 174;
+                z->mod_amount_eaten( 174 );
                 //Calorie amount is based on the "underbrush" dummy item, as with the grazer mutation.
                 return true;
             }

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -292,7 +292,7 @@ item_location make_mon_corpse( monster &z, int damageLvl )
     if( z.has_effect( effect_no_ammo ) ) {
         corpse.set_var( "no_ammo", "no_ammo" );
     }
-    if( z.has_effect( effect_critter_underfed ) ) {
+    if( !z.has_eaten_enough() ) {
         corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
     }
     return get_map().add_item_ret_loc( z.pos_bub(), corpse );

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -47,7 +47,6 @@
 #include "value_ptr.h"
 #include "viewer.h"
 
-static const efftype_id effect_critter_underfed( "critter_underfed" );
 static const efftype_id effect_no_ammo( "no_ammo" );
 
 static const harvest_drop_type_id harvest_drop_bone( "bone" );
@@ -202,7 +201,7 @@ item_location mdeath::splatter( monster &z )
         if( z.has_effect( effect_no_ammo ) ) {
             corpse.set_var( "no_ammo", "no_ammo" );
         }
-        if( z.has_effect( effect_critter_underfed ) ) {
+        if( !z.has_eaten_enough() ) {
             corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
         }
         return here.add_item_ret_loc( z.pos_bub(), corpse );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -44,7 +44,6 @@
 
 static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_controlled( "controlled" );
-static const efftype_id effect_critter_well_fed( "critter_well_fed" );
 static const efftype_id effect_harnessed( "harnessed" );
 static const efftype_id effect_has_bag( "has_bag" );
 static const efftype_id effect_leashed( "leashed" );
@@ -528,7 +527,7 @@ void milk_source( monster &source_mon )
         add_msg( _( "You milk the %s." ), source_mon.get_name() );
     } else {
         add_msg( _( "The %s has no more milk." ), source_mon.get_name() );
-        if( !source_mon.has_effect( effect_critter_well_fed ) ) {
+        if( !source_mon.has_eaten_enough() ) {
             add_msg( _( "It might not be getting enough to eat." ) );
         }
     }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -645,13 +645,9 @@ bool monexamine::pet_menu( monster &z )
     std::string pet_name = z.get_name();
 
     amenu.text = string_format( _( "What to do with your %s?" ), pet_name );
-    if( z.has_flag( mon_flag_EATS ) && ( z.amount_eaten < ( z.stomach_size / 10 ) ) ) {
-        amenu.text = string_format( _( "What to do with your %s?\n" "Hunger: Famished" ), pet_name );
-    } else if( z.has_flag( mon_flag_EATS ) && ( z.amount_eaten > ( z.stomach_size / 10 ) &&
-               z.amount_eaten < z.stomach_size ) ) {
-        amenu.text = string_format( _( "What to do with your %s?\n" "Hunger: Hungry" ), pet_name );
-    } else if( z.has_flag( mon_flag_EATS ) && z.amount_eaten >= z.stomach_size ) {
-        amenu.text = string_format( _( "What to do with your %s?\n" "Hunger: Full" ), pet_name );
+    if( z.has_flag( mon_flag_EATS ) ) {
+        amenu.text = string_format( _( "What to do with your %s?\n" "Fullness: %i%%" ), pet_name,
+                                    z.get_stomach_fullness_percent() );
     }
     amenu.addentry( swap_pos, true, 's', _( "Swap positions" ) );
     amenu.addentry( push_monster, true, 'p', _( "Push %s" ), pet_name );
@@ -978,13 +974,9 @@ bool monexamine::mfriend_menu( monster &z )
     const std::string pet_name = z.get_name();
 
     amenu.text = string_format( _( "What to do with your %s?" ), pet_name );
-    if( z.has_flag( mon_flag_EATS ) && ( z.amount_eaten < ( z.stomach_size / 10 ) ) ) {
-        amenu.text = string_format( _( "What to do with your %s?\n" "Hunger: Famished" ), pet_name );
-    } else if( z.has_flag( mon_flag_EATS ) && ( z.amount_eaten > ( z.stomach_size / 10 ) &&
-               z.amount_eaten < z.stomach_size ) ) {
-        amenu.text = string_format( _( "What to do with your %s?\n" "Hunger: Hungry" ), pet_name );
-    } else if( z.has_flag( mon_flag_EATS ) && z.amount_eaten >= z.stomach_size ) {
-        amenu.text = string_format( _( "What to do with your %s?\n" "Hunger: Full" ), pet_name );
+    if( z.has_flag( mon_flag_EATS ) ) {
+        amenu.text = string_format( _( "What to do with your %s?\n" "Fullness: %i%%" ), pet_name,
+                                    z.get_stomach_fullness_percent() );
     }
     amenu.addentry( swap_pos, true, 's', _( "Swap positions" ) );
     amenu.addentry( push_monster, true, 'p', _( "Push %s" ), pet_name );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -662,6 +662,20 @@ void monster::refill_udders()
     }
 }
 
+void monster::recheck_fed_status()
+{
+    remove_effect( effect_critter_underfed );
+    remove_effect( effect_critter_well_fed );
+    if( !has_flag( mon_flag_EATS ) ) {
+        return;
+    }
+    if( has_fully_eaten() ) {
+        add_effect( effect_critter_well_fed, 24_hours );
+    } else if( get_amount_eaten() == 0 ) {
+        add_effect( effect_critter_underfed, 24_hours );
+    }
+}
+
 void monster::set_amount_eaten( int new_amount )
 {
     amount_eaten = new_amount;
@@ -695,8 +709,7 @@ void monster::reset_digestion()
     if( calendar::turn - stomach_timer > 3_days ) {
         //If the player hasn't been around, assume critters have been operating at a subsistence level.
         //Otherwise everything will constantly be underfed. We only run this on load to prevent problems.
-        remove_effect( effect_critter_underfed );
-        remove_effect( effect_critter_well_fed );
+        recheck_fed_status();
         set_amount_eaten( 0 );
         stomach_timer = calendar::turn;
     }
@@ -705,11 +718,7 @@ void monster::reset_digestion()
 void monster::digest_food()
 {
     if( calendar::turn - stomach_timer > 1_days ) {
-        if( has_fully_eaten() && !has_effect( effect_critter_underfed ) ) {
-            add_effect( effect_critter_well_fed, 24_hours );
-        } else if( ( amount_eaten < ( stomach_size / 10 ) ) && !has_effect( effect_critter_well_fed ) ) {
-            add_effect( effect_critter_underfed, 24_hours );
-        }
+        recheck_fed_status();
         set_amount_eaten( 0 );
         stomach_timer = calendar::turn;
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -560,7 +560,7 @@ void monster::try_reproduce()
         return;
     }
 
-    if( !baby_timer && has_fully_eaten() ) {
+    if( !baby_timer && has_eaten_enough() ) {
         // Assume this is a freshly spawned monster (because baby_timer is not set yet), set the point when it reproduce to somewhere in the future.
         // Monsters need to have eaten eat to start their pregnancy timer, but that's all.
         baby_timer.emplace( calendar::turn + *type->baby_timer );
@@ -672,7 +672,7 @@ void monster::recheck_fed_status()
     }
     if( has_fully_eaten() ) {
         add_effect( effect_critter_well_fed, 24_hours );
-    } else if( get_amount_eaten() == 0 ) {
+    } else if( !has_eaten_enough() ) {
         add_effect( effect_critter_underfed, 24_hours );
     }
 }
@@ -680,11 +680,13 @@ void monster::recheck_fed_status()
 void monster::set_amount_eaten( int new_amount )
 {
     amount_eaten = new_amount;
+    recheck_fed_status();
 }
 
 void monster::mod_amount_eaten( int amount_to_add )
 {
     amount_eaten += amount_to_add;
+    recheck_fed_status();
 }
 
 int monster::get_amount_eaten() const

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3422,29 +3422,8 @@ void monster::process_effects()
         }
     }
 
-    if( has_effect( effect_critter_well_fed ) && one_in( 90 ) ) {
-        heal( 1 );
-    }
-
-    //We already check these timers on_load, but adding a random chance for them to go off here
-    //will make it so that the player needn't leave the area and return for critters to poop,
-    //become hungry, evolve, have babies, or refill udders.
-    if( one_in( 30000 ) ) {
-        try_upgrade( false );
-        try_reproduce();
-        try_biosignature();
-
-        if( get_amount_eaten() > 0 ) {
-            if( has_flag( mon_flag_EATS ) ) {
-                digest_food();
-            } else {
-                set_amount_eaten( 0 );
-            }
-        }
-
-        if( has_flag( mon_flag_MILKABLE ) ) {
-            refill_udders();
-        }
+    if( calendar::once_every( 24_hours ) ) {
+        digest_food();
     }
 
     //Monster will regen morale and aggression if it is at/above max HP

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -712,17 +712,6 @@ bool monster::has_fully_eaten() const
     return amount_eaten >= stomach_size;
 }
 
-void monster::reset_digestion()
-{
-    if( calendar::turn - stomach_timer > 3_days ) {
-        //If the player hasn't been around, assume critters have been operating at a subsistence level.
-        //Otherwise everything will constantly be underfed. We only run this on load to prevent problems.
-        recheck_fed_status();
-        set_amount_eaten( 0 );
-        stomach_timer = calendar::turn;
-    }
-}
-
 void monster::digest_food()
 {
     if( calendar::turn - stomach_timer > 1_days ) {
@@ -3964,7 +3953,6 @@ void monster::on_load()
     try_upgrade( false );
     try_reproduce();
     try_biosignature();
-    reset_digestion();
 
     if( has_flag( mon_flag_MILKABLE ) ) {
         refill_udders();

--- a/src/monster.h
+++ b/src/monster.h
@@ -540,8 +540,16 @@ class monster : public Creature
         int friendly = 0;
         int anger = 0;
         int morale = 0;
+    private:
         int stomach_size = 0;
         int amount_eaten = 0;
+    public:
+        void set_amount_eaten( int new_amount );
+        void mod_amount_eaten( int amount_to_add );
+        int get_amount_eaten() const;
+        // Truncates to integer for ease of use
+        int get_stomach_fullness_percent() const;
+        bool has_fully_eaten() const;
         // Our faction (species, for most monsters)
         mfaction_id faction;
         // If we're related to a mission

--- a/src/monster.h
+++ b/src/monster.h
@@ -118,7 +118,6 @@ class monster : public Creature
         void try_biosignature();
         void refill_udders();
         void digest_food();
-        void reset_digestion();
         void spawn( const tripoint &p );
         void spawn( const tripoint_abs_ms &loc );
         std::vector<material_id> get_absorb_material() const;

--- a/src/monster.h
+++ b/src/monster.h
@@ -550,6 +550,10 @@ class monster : public Creature
         int get_amount_eaten() const;
         // Truncates to integer for ease of use
         int get_stomach_fullness_percent() const;
+        // Whether the monster has eaten enough to reproduce/make milk/get by normally
+        bool has_eaten_enough() const;
+        // Whether their stomach is completely full or more
+        // TODO: Find out why can we even exceed stomach size??
         bool has_fully_eaten() const;
         // Our faction (species, for most monsters)
         mfaction_id faction;

--- a/src/monster.h
+++ b/src/monster.h
@@ -543,6 +543,7 @@ class monster : public Creature
     private:
         int stomach_size = 0;
         int amount_eaten = 0;
+        void recheck_fed_status();
     public:
         void set_amount_eaten( int new_amount );
         void mod_amount_eaten( int amount_to_add );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Housekeeping

#### Describe the solution
Move monster stomach/digestion stats to private members

Make them only accessible through proper setters and getters (and mod)

Centralize the various calls to checking stomach/have eaten enough in functions monster::has_eaten_enough()/monster::has_fully_eaten() etc

Remove a truly inexplicable call to monster::try_upgrade() inside of monster::process_effects, and all that similar logic from #69249. These are already processed in monmove() with proper rate-limiting. The sole exception is try_upgrade, which had *no reason* to be here in any case. Monsters should NEVER naturally evolve in sight of the player.

Completely delete the reset_digestion() hack. All it did was hide issues with #69249's implementation, it did not actually help them in any way.


#### Describe alternatives you've considered
Revert #69249, honestly.

#### Testing
It compiles.

I expect that there will be many reports of people reporting wild animals being constantly and forever underfed. This was previously hidden by periodically removing the effect, and directly checking the stomach contents when it came time to reproduce/etc That means they were underfed, with all the follow-on effects, *but it simply wasn't displayed to the player*.

This is an issue with the original implementation. It may be handled in a followup PR, or maybe it won't be. Who knows

#### Additional context
