### PR TITLE
Re-implement #73588 damaged appliances track damage when transformed to item and back

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1185,7 +1185,11 @@ std::optional<int> deploy_appliance_actor::use( Character *p, item &it, const tr
     }
 
     it.spill_contents( suitable.value() );
-    place_appliance( tripoint_bub_ms( suitable.value() ), vpart_appliance_from_item( appliance_base ), it );
+    if( !place_appliance( tripoint_bub_ms( suitable.value() ),
+                          vpart_appliance_from_item( appliance_base ), it ) ) {
+        // failed to place somehow, cancel!!
+        return 0;
+    }
     p->mod_moves( -to_moves<int>( 2_seconds ) );
     return 1;
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1185,7 +1185,7 @@ std::optional<int> deploy_appliance_actor::use( Character *p, item &it, const tr
     }
 
     it.spill_contents( suitable.value() );
-    place_appliance( tripoint_bub_ms( suitable.value() ), vpart_appliance_from_item( appliance_base ) );
+    place_appliance( tripoint_bub_ms( suitable.value() ), vpart_appliance_from_item( appliance_base ), it );
     p->mod_moves( -to_moves<int>( 2_seconds ) );
     return 1;
 }

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -72,6 +72,10 @@ void place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
     int partnum = -1;
     if( base ) {
         item copied = *base;
+        if( vpinfo.base_item != copied.typeId() ) {
+            // transform the deploying item into what it *should* be before storing it
+            copied.convert( vpinfo.base_item );
+        }
         partnum = veh->install_part( point_zero, vpart, std::move( copied ) );
     } else {
         partnum = veh->install_part( point_zero, vpart );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -54,7 +54,7 @@ vpart_id vpart_appliance_from_item( const itype_id &item_id )
     return vpart_ap_standing_lamp;
 }
 
-void place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
+bool place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
                       const std::optional<item> &base )
 {
 
@@ -64,7 +64,7 @@ void place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
 
     if( !veh ) {
         debugmsg( "error constructing vehicle" );
-        return;
+        return false;
     }
 
     veh->add_tag( flag_APPLIANCE );
@@ -79,6 +79,11 @@ void place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
         partnum = veh->install_part( point_zero, vpart, std::move( copied ) );
     } else {
         partnum = veh->install_part( point_zero, vpart );
+    }
+    if( partnum == -1 ) {
+        // unrecoverable, failed to be installed somehow
+        here.destroy_vehicle( veh );
+        return false;
     }
     veh->name = vpart->name();
 
@@ -118,6 +123,7 @@ void place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
     if( vpinfo.has_flag( flag_HALF_CIRCLE_LIGHT ) && partnum != -1 ) {
         orient_part( veh, vpinfo, partnum );
     }
+    return true;
 }
 
 player_activity veh_app_interact::run( vehicle &veh, const point &p )

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -9,7 +9,7 @@ class vehicle;
 class ui_adaptor;
 
 vpart_id vpart_appliance_from_item( const itype_id &item_id );
-void place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
+bool place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
                       const std::optional<item> &base = std::nullopt );
 
 /**

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1489,6 +1489,10 @@ int vehicle::install_part( const point &dp, const vpart_id &type, item &&base,
 
 int vehicle::install_part( const point &dp, vehicle_part &&vp )
 {
+    if( vp.base.is_null() ) {
+        debugmsg( "Part to be installed is missing base item, did the constructor fail to set_base?" );
+        return -1;
+    }
     const vpart_info &vpi = vp.info();
     const ret_val<void> valid_mount = can_mount( dp, vpi );
     if( !valid_mount.success() ) {

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -104,6 +104,7 @@ void vehicle_part::set_base( item &&new_base )
     if( new_base.typeId() != info().base_item ) {
         debugmsg( "new base '%s' doesn't match part type '%s', this is a bug",
                   new_base.typeId().str(), info().id.str() );
+        base = null_item_reference();
         return;
     }
     base = std::move( new_base );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
In #75397 PatrikLundell accidentally reverted  #73588 while fixing a pretty nasty bug with place_appliance where it could spawn a phantom vehicle.

#### Describe the solution
Reimplement, and build some proper guardrails so this can't happen again.

Once again we pass the deploying item along to place_appliance so values like the item's damage/burnt can be copied. However, we now **convert** its type to the appliance's base item to prevent the vehicle_part constructor from freaking out.

To ensure phantom parts are never installed vehicle::install_part() returns `-1` (invalid index position) in cases where the base hasn't been set.

place_appliance reads the returned part index and properly aborts if it's invalid.

The deploy actor also aborts in this case, not consuming the item activated.

#### Describe alternatives you've considered


#### Testing

#75366 does not occur in any circumstance

Installing and dragging around a damaged solar suitcase produces no errors while giving back a damaged item when taken down

https://github.com/user-attachments/assets/88862f89-1935-485e-b56f-569e9836f641

(Reintroduced the error for this test) If the guardrails DO get hit in the future, they fail gracefully without creating phantom vehicles:

https://github.com/user-attachments/assets/7f977bf3-f3a8-4c06-95d5-08ee9f370b39

#### Additional context
@PatrikLundell - courtesy notification.

@GuardianDll - courtesy notification.
