### PR TITLE
Numbered pockets in pocket description

### DIFF
--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -2810,26 +2810,41 @@ TEST_CASE( "pocket_info_for_a_multi-pocket_item", "[iteminfo][pocket][multiple]"
 {
     clear_avatar();
 
-    item test_belt( "test_tool_belt" );
+    item test_belt( "test_tool_belt_pocket_mix" );
     std::vector<iteminfo_parts> pockets = { iteminfo_parts::DESCRIPTION_POCKETS };
 
     override_option opt_vol( "VOLUME_UNITS", "l" );
     override_option opt_weight( "USE_METRIC_WEIGHTS", "kg" );
     override_option opt_dist( "DISTANCE_UNITS", "metric" );
 
-    // When two pockets have the same attributes, they are combined with a heading like:
+    // When multiple pockets have the same attributes, they are combined headings like:
     //
-    //  2 Pockets with capacity:
+    //  Pockets 1, 2, and 3
     //  Volume: ...  Weight: ...
     //
     // The "Total capacity" indicates the sum Volume/Weight capacity of all pockets.
     CHECK( item_info_str( test_belt, pockets ) ==
            "--\n"
            "<color_c_white>Total capacity</color>:\n"
-           "Volume: <color_c_yellow>6.00</color> L  Weight: <color_c_yellow>4.80</color> kg\n"
+           "Volume: <color_c_yellow>7.00</color> L  Weight: <color_c_yellow>9.00</color> kg\n"
            "--\n"
-           "<color_c_white>4 pockets</color> with capacity:\n"
-           "Volume: <color_c_yellow>1.50</color> L  Weight: <color_c_yellow>1.20</color> kg\n"
+           "<color_c_white>Pocket 1</color>\n"
+           "Volume: <color_c_yellow>1.00</color> L  Weight: <color_c_yellow>1.50</color> kg\n"
+           "Item length: <color_c_yellow>0</color> cm to <color_c_yellow>40</color> cm\n"
+           "Base moves to remove item: <color_c_yellow>100</color>\n"
+           "--\n"
+           "<color_c_white>Pockets 2 and 3</color>\n"
+           "Volume: <color_c_yellow>1.50</color> L  Weight: <color_c_yellow>1.50</color> kg\n"
+           "Item length: <color_c_yellow>0</color> cm to <color_c_yellow>70</color> cm\n"
+           "Minimum item volume: <color_c_yellow>0.050</color> L\n"
+           "Base moves to remove item: <color_c_yellow>50</color>\n"
+           "This is a <color_c_cyan>holster</color>, it only holds <color_c_cyan>one item at a time</color>.\n"
+           "<color_c_white>Restrictions</color>:\n"
+           "* Item must clip onto a belt loop\n"
+           "* <color_c_white>or</color> Item must fit in a sheath\n"
+           "--\n"
+           "<color_c_white>Pockets 4, 5, and 6</color>\n"
+           "Volume: <color_c_yellow>1.00</color> L  Weight: <color_c_yellow>1.50</color> kg\n"
            "Item length: <color_c_yellow>0</color> cm to <color_c_yellow>70</color> cm\n"
            "Minimum item volume: <color_c_yellow>0.050</color> L\n"
            "Base moves to remove item: <color_c_yellow>50</color>\n"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Show pocket numbers in pocket descriptions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
It is difficult to match pocket descriptions with pocket contents in the view where they are separate, especially when some pockets are duplicated.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Replace "Pocket ... 2 Pockets ...  Pocket ... 3 Pockets" with "Pocket 1 ... Pockets 2 and 3 ... Pocket 4 ... Pockets 5, 6, and 7" in the section of an item description where the pockets are described.
![image](https://github.com/user-attachments/assets/c06ad594-4878-4a53-8415-2a0017df6b7c)

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I would prefer to have two columns, one for descriptions and one for contents, but that's a much bigger change.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I'm playing with this change.

#### Additional context
This PR also makes the following changes:
* avoid emitting pocket contents descriptions that won't be used
* break out of the duplicate pocket matching loop as soon as a match is found


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
