### PR TITLE
private resort no longer flushes weird legals

### DIFF
--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -84,6 +84,28 @@
   },
   {
     "type": "item_group",
+    "id": "stash_drugs_illegals",
+    "items": [
+      { "prob": 4, "group": "oxycodone_bottle_plastic_pill_prescription_1_10" },
+      { "item": "morphine", "prob": 4, "count": [ 1, 4 ] },
+      { "prob": 10, "group": "xanax_bottle_plastic_pill_prescription_1_10" },
+      { "prob": 10, "group": "adderall_bottle_plastic_pill_prescription_1_10" },
+      [ "pipe_tobacco", 2 ],
+      { "prob": 2, "group": "tobacco_bag_plastic_1_20" },
+      [ "seed_tobacco", 15 ],
+      [ "rolling_paper", 9 ],
+      [ "pipe_glass", 17 ],
+      { "prob": 8, "group": "coke_bag_zipper_1_8" },
+      { "prob": 2, "group": "meth_bag_zipper_1_6" },
+      { "prob": 1, "group": "heroin_bag_zipper_1_4" },
+      { "prob": 4, "group": "crack_bag_zipper_1_4" },
+      [ "crackpipe", 7 ],
+      { "prob": 1, "group": "diazepam_bottle_plastic_pill_prescription_1_10" },
+      { "item": "lsd", "prob": 6, "count": [ 1, 5 ] }
+    ]
+  },
+  {
+    "type": "item_group",
     "id": "bugout_bag",
     "subtype": "distribution",
     "//": "randomized assortment of possible bugout bags people would have as the apocalypse ramped up",

--- a/data/json/mapgen_palettes/private_resort.json
+++ b/data/json/mapgen_palettes/private_resort.json
@@ -44,7 +44,7 @@
     },
     "toilets": { "$": {  } },
     "items": {
-      "$": { "item": "stash_drugs", "chance": 75 },
+      "$": { "item": "stash_drugs_illegals", "chance": 75 },
       "Y": { "item": "mansion_safe_nogun", "chance": 100, "repeat": [ 3, 8 ] },
       "l": { "item": "trash", "chance": 66, "repeat": [ 1, 3 ] },
       "e": { "item": "SUS_office_desk", "chance": 50 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Due to a massive skill issue with git, I'm doing a second take of my own #77086

![image](https://github.com/user-attachments/assets/b04af801-812c-4910-8440-3ade04ed9db5)
mr harakka suggested this, and I chose to pick it up. After further deliberation, it turned into removing stuff that didn't make sense to hide
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
New "stash_drugs_illegals" itemgroup for use in private resort toilets. I am keeping in tobacco pipes and glass pipes (bongs) because I guess they would be able to be crushed and flushed, and the party people didn't want the police to find traces.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added various debug items to the itemgroup in question to know that the private resort toilets (like in picture) are the ones currently being changed, then removed said debug items along with all other nonsensical items after making sure by seeing. Then did a non-exhaustive test to see that weird legals aren't spawning.
![image](https://github.com/user-attachments/assets/ca456a31-3c34-40e4-82c4-7f278e4d7e47)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Please correct me on missing illegal stuff and potentially kept legal stuff, I only made very shallow searches.

Also as to not forget relevant things said (in case it matters):
![image](https://github.com/user-attachments/assets/f25f2287-0601-4879-a40c-beb3dc785556)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
