### PR TITLE
some devil and angel costume accessories

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -4195,6 +4195,7 @@
       { "item": "felinesuit", "prob": 3 },
       { "item": "dragonsuit", "prob": 1 },
       { "item": "wool_suit", "prob": 40 },
+      { "item": "wool_suit_devil", "prob": 15 },
       { "item": "unitard", "prob": 60 },
       { "item": "zentai", "prob": 5 },
       { "item": "wetsuit", "prob": 2 },

--- a/data/json/itemgroups/Clothing_Gear/costumes.json
+++ b/data/json/itemgroups/Clothing_Gear/costumes.json
@@ -206,7 +206,9 @@
       { "item": "bandana_head", "prob": 5 },
       { "item": "fedora", "prob": 10 },
       { "item": "porkpie", "prob": 10 },
-      { "item": "nun_wimple", "prob": 12 }
+      { "item": "nun_wimple", "prob": 12 },
+      { "item": "devil_horn_headband", "prob": 15 },
+      { "item": "angel_halo_headband", "prob": 15 }
     ]
   },
   {

--- a/data/json/itemgroups/Clothing_Gear/costumes.json
+++ b/data/json/itemgroups/Clothing_Gear/costumes.json
@@ -339,6 +339,7 @@
       { "item": "dragonsuit", "prob": 10 },
       { "item": "felinesuit", "prob": 10 },
       { "item": "bondage_suit", "prob": 15 },
+      { "item": "wool_suit_devil", "prob": 15 },
       { "item": "dinosuit", "prob": 10 },
       { "item": "sharksuit", "prob": 10 },
       { "item": "beekeeping_suit", "prob": 5 },

--- a/data/json/itemgroups/Clothing_Gear/costumes.json
+++ b/data/json/itemgroups/Clothing_Gear/costumes.json
@@ -75,7 +75,9 @@
       { "item": "gartersheath1", "prob": 25 },
       { "item": "gartersheath2", "prob": 10 },
       { "item": "eyepatch_leather", "prob": 20 },
-      { "item": "hakama", "prob": 1 }
+      { "item": "hakama", "prob": 1 },
+      { "item": "devil_tail", "prob": 15 },
+      { "item": "angel_wings", "prob": 15 }
     ]
   },
   {

--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -4925,6 +4925,6 @@
     "warmth": 6,
     "material_thickness": 2,
     "flags": [ "BELTED", "NO_WEAR_EFFECT" ],
-    "armor": [ { "encumbrance": [ 15 ], "coverage": 60, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
+    "armor": [ { "encumbrance": 15, "coverage": 60, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   }
 ]

--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -4893,5 +4893,38 @@
     "symbol": "^",
     "color": "yellow",
     "flags": [ "NO_WEAR_EFFECT" ]
+  },
+  {
+    "id": "devil_tail",
+    "type": "ARMOR",
+    "name": { "str": "devil tail" },
+    "description": "A slick and long red tail that ends in a pointy spade.",
+    "weight": "250 g",
+    "volume": "250 ml",
+    "price": "10 USD",
+    "price_postapoc": "10 cent",
+    "material": [ "plastic" ],
+    "symbol": "s",
+    "color": "red",
+    "flags": [ "NO_WEAR_EFFECT" ]
+  },
+  {
+    "id": "angel_wings",
+    "type": "ARMOR",
+    "name": { "str": "pair of angel wings", "str_pl": "pairs of angel wings" },
+    "description": "A rather impressive pair of white wings.  While they may not give you the ability to fly, they make you look angelic.",
+    "weight": "633 g",
+    "volume": "2 L",
+    "longest_side": "106 cm",
+    "price": "39 USD",
+    "price_postapoc": "5 USD",
+    "material": [ "nylon" ],
+    "symbol": "[",
+    "looks_like": "ragpouch",
+    "color": "light_gray",
+    "warmth": 6,
+    "material_thickness": 2,
+    "flags": [ "BELTED", "NO_WEAR_EFFECT" ],
+    "armor": [ { "encumbrance": [ 15 ], "coverage": 60, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   }
 ]

--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -4865,5 +4865,33 @@
         "append": true
       }
     ]
+  },
+  {
+    "id": "devil_horn_headband",
+    "type": "ARMOR",
+    "name": { "str": "pair of devil horns", "str_pl": "pairs of devil horns" },
+    "description": "A red plastic headband adorned with a pair of cartoonish devil horns.  Delightfully devillish.",
+    "weight": "100 g",
+    "volume": "100 ml",
+    "price": "15 USD",
+    "price_postapoc": "10 cent",
+    "material": [ "plastic" ],
+    "symbol": "^",
+    "color": "red",
+    "flags": [ "NO_WEAR_EFFECT" ]
+  },
+  {
+    "id": "angel_halo_headband",
+    "type": "ARMOR",
+    "name": { "str": "angel halo" },
+    "description": "A plastic headband adorned with a fluffy halo.",
+    "weight": "100 g",
+    "volume": "100 ml",
+    "price": "15 USD",
+    "price_postapoc": "10 cent",
+    "material": [ "plastic", "faux_fur" ],
+    "symbol": "^",
+    "color": "yellow",
+    "flags": [ "NO_WEAR_EFFECT" ]
   }
 ]

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -904,7 +904,6 @@
     "volume": "3 L",
     "price": "80 USD",
     "price_postapoc": "3 USD 50 cent",
-    "to_hit": -1,
     "material": [ "wool" ],
     "symbol": "[",
     "looks_like": "touring_suit",

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -896,6 +896,30 @@
     "flags": [ "VARSIZE" ]
   },
   {
+    "id": "wool_suit_devil",
+    "type": "ARMOR",
+    "name": { "str": "devil onesie" },
+    "description": "An encumbering red wool suit with a hood adorned with cartoonish devil horns and a devil's tail on the back.  It's for those who want to feel devilishly warm in their sleep.",
+    "weight": "883 g",
+    "volume": "3 L",
+    "price": "80 USD",
+    "price_postapoc": "3 USD 50 cent",
+    "to_hit": -1,
+    "material": [ "wool" ],
+    "symbol": "[",
+    "looks_like": "touring_suit",
+    "color": "red",
+    "armor": [
+      { "covers": [ "torso", "leg_l", "leg_r" ], "coverage": 100, "encumbrance": 20 },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 20 },
+      { "covers": [ "head" ], "coverage": 80, "encumbrance": 15 },
+      { "covers": [ "foot_l", "foot_r" ], "coverage": 100, "encumbrance": 15 }
+    ],
+    "warmth": 50,
+    "material_thickness": 1,
+    "flags": [ "VARSIZE", "HOOD" ]
+  },
+  {
     "id": "zentai",
     "type": "ARMOR",
     "name": { "str": "zentai" },


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Y'know, it's spooky month right now and im ina mood to put some costumes into the game, like this devil and angel thing for example.

#### Describe the solution

Adds:
- devil onesie
- devil horns headband
- devil tail
- angel halo
- angel wing
- Itemgroups for the items above

#### Describe alternatives you've considered

Keeping it to myself.

Add some other costume jsons i have lying around maybe.

#### Testing

![Screenshot_20241017_182453](https://github.com/user-attachments/assets/01572e10-4fed-4680-b6ba-ea5a38b138eb)


#### Additional context




<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
