### PR TITLE
Introduced untyped coordinate operations to typed ones

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -160,7 +160,7 @@ void active_item_cache::rotate_locations( int turns, const point_rel_ms &dim )
     for( std::pair<const int, std::list<item_reference>> &pair : active_items ) {
         for( item_reference &ir : pair.second ) {
             // Should 'rotate' be propaged up to the typed coordinates?
-            ir.location = point_rel_ms( ir.location.raw().rotate( turns, dim.raw() ) );
+            ir.location = ir.location.rotate( turns, dim.raw() );
         }
     }
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11359,14 +11359,14 @@ action_id Character::get_next_auto_move_direction()
 
     if( next_expected_position ) {
         // Difference between where the character is and where we expect them to be after last auto-move.
-        tripoint diff = ( pos_bub() - *next_expected_position ).raw().abs();
+        tripoint_rel_ms diff = ( pos_bub() - *next_expected_position ).abs();
         // This might differ by 1 (in z-direction), since the character might have crossed a ramp,
         // which teleported them a tile up or down. If the error is in x or y direction, we might as well
         // give them a turn to recover, as the move still might be vaild.
         // We cut off at 1 since 2 definitely results in an invalid move.
         // If the character is still stumbling or stuck,
         // they will cancel the auto-move on the next cycle (as the distance increases).
-        if( std::max( { diff.x, diff.y, diff.z } ) > 1 ) {
+        if( std::max( { diff.x(), diff.y(), diff.z()} ) > 1 ) {
             // We're off course, possibly stumbling or stuck, cancel auto move
             return ACTION_NULL;
         }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1497,15 +1497,15 @@ void _rotate_zone( map &target_map, zone_data &zone, int turns )
             z_start.x() + z_end.x() == a_end.x() ) {
             return;
         }
-        point z_l_start = z_start.xy().raw().rotate( turns, dim );
-        point z_l_end = z_end.xy().raw().rotate( turns, dim );
+        point_bub_ms z_l_start = z_start.xy().rotate( turns, dim );
+        point_bub_ms z_l_end = z_end.xy().rotate( turns, dim );
         tripoint_abs_ms first =
-            target_map.getglobal( tripoint_bub_ms( std::min( z_l_start.x, z_l_end.x ),
-                                  std::min( z_l_start.y, z_l_end.y ),
+            target_map.getglobal( tripoint_bub_ms( std::min( z_l_start.x(), z_l_end.x() ),
+                                  std::min( z_l_start.y(), z_l_end.y() ),
                                   z_start.z() ) );
         tripoint_abs_ms second =
-            target_map.getglobal( tripoint_bub_ms( std::max( z_l_start.x, z_l_end.x ),
-                                  std::max( z_l_start.y, z_l_end.y ),
+            target_map.getglobal( tripoint_bub_ms( std::max( z_l_start.x(), z_l_end.x() ),
+                                  std::max( z_l_start.y(), z_l_end.y() ),
                                   z_end.z() ) );
         zone.set_position( std::make_pair( first.raw(), second.raw() ), false, true, false, true );
     }

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -214,7 +214,7 @@ class coord_point_ob : public
             return coord_point_ob( this->raw().abs() );
         }
 
-        constexpr auto rotate( int turns, const point &dim = { 1, 1 } ) const {
+        constexpr auto rotate( int turns, const point &dim = point_south_east ) const {
             return coord_point_ob( this->raw().rotate( turns, dim ) );
         }
 

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -210,6 +210,14 @@ class coord_point_ob : public
             return this_as_point( this->raw().xy() );
         }
 
+        constexpr auto abs() const {
+            return coord_point_ob( this->raw().abs() );
+        }
+
+        constexpr auto rotate( int turns, const point &dim = { 1, 1 } ) const {
+            return coord_point_ob( this->raw().rotate( turns, dim ) );
+        }
+
         friend inline this_as_ob operator+( const coord_point_ob &l, const point &r ) {
             return this_as_ob( l.raw() + r );
         }
@@ -404,6 +412,14 @@ constexpr inline auto operator-(
 {
     using PointResult = decltype( PointL() + PointR() );
     return coord_point_ob<PointResult, origin::relative, Scale>( l.raw() - r.raw() );
+}
+
+template<typename Point, origin Origin, scale Scale>
+constexpr inline auto operator-(
+    const coord_point_ob<Point, Origin, Scale> &l )
+{
+    using PointResult = decltype( Point() );
+    return coord_point_ob<PointResult, Origin, Scale>( - l.raw() );
 }
 
 // Only relative points can be multiplied by a constant

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11366,8 +11366,7 @@ bool game::phasing_move_enchant( const tripoint &dest_loc, const int phase_dista
 
 bool game::can_move_furniture( tripoint fdest, const tripoint &dp )
 {
-    // TODO: Fix when unary operation available
-    const bool pulling_furniture = dp.xy() == ( point_rel_ms_zero - u.grab_point.xy() ).raw();
+    const bool pulling_furniture = dp.xy() == -u.grab_point.xy().raw();
     const bool has_floor = m.has_floor_or_water( fdest );
     creature_tracker &creatures = get_creature_tracker();
     bool is_ramp_or_road = m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fdest ) ||
@@ -12790,8 +12789,8 @@ void game::update_overmap_seen()
             continue;
         }
         // If circular distances are enabled, scale overmap distances by the diagonality of the sight line.
-        point abs_delta = delta.raw().abs();
-        int max_delta = std::max( abs_delta.x, abs_delta.y );
+        point_rel_omt abs_delta = delta.abs();
+        int max_delta = std::max( abs_delta.x(), abs_delta.y() );
         const float multiplier = trigdist ? std::sqrt( h_squared ) / max_delta : 1;
         const std::vector<tripoint_abs_omt> line = line_to( ompos, p );
         float sight_points = dist;

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -40,13 +40,11 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     }
     const vehicle *veh_under_player = veh_pointer_or_null( m.veh_at( u.pos_bub() ) );
     if( grabbed_vehicle == veh_under_player ) {
-        // TODO: Fix when unary operation available
-        u.grab_point = tripoint_rel_ms_zero - dp;
+        u.grab_point = - dp;
         return false;
     }
 
-    // TODO: Fix when unary operation available
-    tripoint_rel_ms dp_veh = tripoint_rel_ms_zero - u.grab_point;
+    tripoint_rel_ms dp_veh = - u.grab_point;
     const tripoint_rel_ms prev_grab = u.grab_point;
     tripoint_rel_ms next_grab = u.grab_point;
     const tileray initial_veh_face = grabbed_vehicle->face;
@@ -63,8 +61,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         pushing = true;
     } else if( std::abs( dp.x() + dp_veh.x() ) != 2 && std::abs( dp.y() + dp_veh.y() ) != 2 ) {
         // Not actually moving the vehicle, don't do the checks
-        // TODO: Fix when unary operation available
-        u.grab_point = tripoint_rel_ms_zero - ( dp + dp_veh );
+        u.grab_point = - ( dp + dp_veh );
         return false;
     } else if( ( dp.x() == prev_grab.x() || dp.y() == prev_grab.y() ) &&
                next_grab.x() != 0 && next_grab.y() != 0 ) {
@@ -73,13 +70,11 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         dp_veh.x() = dp.x() == -dp_veh.x() ? 0 : dp_veh.x();
         dp_veh.y() = dp.y() == -dp_veh.y() ? 0 : dp_veh.y();
 
-        // TODO: Fix when unary operation available
-        next_grab = tripoint_rel_ms_zero - dp_veh;
+        next_grab = - dp_veh;
         zigzag = true;
     } else {
         // We are pulling the vehicle
-        // TODO: Fix when unary operation available
-        next_grab = tripoint_rel_ms_zero - dp;
+        next_grab = - dp;
         pulling = true;
     }
 
@@ -276,10 +271,8 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     // Try to place the vehicle in the position player just left rather than "flattening" the zig-zag
     tripoint_rel_ms final_dp_veh = get_move_dir( dp_veh, next_grab );
     if( final_dp_veh == tripoint_rel_ms_min && zigzag ) {
-        // TODO: Fix when unary operation available
-        final_dp_veh = get_move_dir( tripoint_rel_ms_zero - prev_grab, tripoint_rel_ms_zero - dp );
-        // TODO: Fix when unary operation available
-        next_grab = tripoint_rel_ms_zero - dp;
+        final_dp_veh = get_move_dir( - prev_grab, - dp );
+        next_grab = - dp;
     }
 
     if( final_dp_veh == tripoint_rel_ms_min ) {

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -30,11 +30,11 @@ void bresenham( const point_bub_ms &p1, const point_bub_ms &p2, int t,
     // Signs of slope values.
     const point s( ( d.x() == 0 ) ? 0 : sgn( d.x() ), ( d.y() == 0 ) ? 0 : sgn( d.y() ) );
     // Absolute values of slopes x2 to avoid rounding errors.
-    const point a = d.raw().abs() * 2;
+    const point_rel_ms a = d.abs() * 2;
 
     point_bub_ms cur = p1;
 
-    if( a.x == a.y ) {
+    if( a.x() == a.y() ) {
         while( cur.x() != p2.x() ) {
             cur.y() += s.y;
             cur.x() += s.x;
@@ -42,14 +42,14 @@ void bresenham( const point_bub_ms &p1, const point_bub_ms &p2, int t,
                 break;
             }
         }
-    } else if( a.x > a.y ) {
+    } else if( a.x() > a.y() ) {
         while( cur.x() != p2.x() ) {
             if( t > 0 ) {
                 cur.y() += s.y;
-                t -= a.x;
+                t -= a.x();
             }
             cur.x() += s.x;
-            t += a.y;
+            t += a.y();
             if( !interact( cur ) ) {
                 break;
             }
@@ -58,10 +58,10 @@ void bresenham( const point_bub_ms &p1, const point_bub_ms &p2, int t,
         while( cur.y() != p2.y() ) {
             if( t > 0 ) {
                 cur.x() += s.x;
-                t -= a.y;
+                t -= a.y();
             }
             cur.y() += s.y;
-            t += a.x;
+            t += a.x();
             if( !interact( cur ) ) {
                 break;
             }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7237,7 +7237,7 @@ void map::rotate( int turns )
         // Translate bubble -> global -> current map.
         const point_bub_ms old( bub_from_abs( get_map().getglobal( np.pos_bub() ).xy() ) );
 
-        const point_bub_ms new_pos( old.raw().rotate( turns, {SEEX * 2, SEEY * 2} ) );
+        const point_bub_ms new_pos( old.rotate( turns, {SEEX * 2, SEEY * 2} ) );
         np.spawn_at_precise( getglobal( tripoint_bub_ms( new_pos, sq.z() ) ) );
     }
 
@@ -7326,7 +7326,7 @@ void map::rotate( int turns )
             if( queued_point_sm.y() % 2 != 0 ) {
                 old.y() += SEEY;
             }
-            const point_bub_ms new_pos( old.raw().rotate( turns, {SEEX * 2, SEEY * 2} ) );
+            const point_bub_ms new_pos( old.rotate( turns, {SEEX * 2, SEEY * 2} ) );
             queued_points[queued_point.first] = getglobal( tripoint_bub_ms( new_pos,
                                                 queued_point.second.z() ) );
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2567,7 +2567,7 @@ bool vehicle::split_vehicles( map &here,
             new_vehicle->refresh();
         } else {
             // include refresh
-            new_vehicle->shift_parts( here, point_zero - mnt_offset );
+            new_vehicle->shift_parts( here, - mnt_offset );
         }
 
         // update the precalc points

--- a/tests/submap_test.cpp
+++ b/tests/submap_test.cpp
@@ -108,7 +108,7 @@ TEST_CASE( "submap_rotation2", "[submap]" )
     for( int x = 0; x < SEEX; x++ ) {
         for( int y = 0; y < SEEY; y++ ) {
             point_sm_ms p( x, y );
-            point_sm_ms p_after_rotation = point_sm_ms( p.raw().rotate( rotation_turns, {SEEX, SEEY} ) );
+            point_sm_ms p_after_rotation = p.rotate( rotation_turns, {SEEX, SEEY} );
 
             CAPTURE( p, p_after_rotation );
             CHECK( sm.get_radiation( p_after_rotation ) == sm_copy.get_radiation( p ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #74721 (unary "-" missing for typed coordinates) + adding "abs" and "rotate".
Also converted usages.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Copy template of binary "-" operation and guess how to hack it into being unary. Once it compiled, converted usages, which also compiled.
- (skipping failures)
- Introduce "abs" and "rotate" operations into the coord_point_ob template class.
- Converted usages of these operations to no longer use an untyped conversion work around.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Try to do the same with the point only distance operations. Don't know how to restrict the operations to two dimensional points only.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded save, walked up ramp, jumped into a car, drove through some hay bales (which turned out to be sturdier than the last time, as the vehicle took damage in several such collisions), ran over a zombie corpse with inventory, ran into and over a turkey, and finally smashed into a stationary vehicle.
Nothing odd seen (apart from the reinforced hay bales).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Would benefit from review by someone competent. Apart from general template wrangling, there's also the issue of ib vs ob, as unary minus and abs don't really make sense for ib coordinates, and should definitely produce ob results. I think it does produce ob results with the current code.

I don't think there's an easy way to get the rotate operation take a corresponding relative point parameter, so it remains untyped (and even if there is an easy one, it's beyond my capabilities).

There's some rather odd "unary" minus usage in map.cpp operation map::points_on_zlevel in the form of `tripoint_bub_ms_zero - tripoint_rel_ms_above` for a fallback case. As far as I can tell -tripoint_rel_ms_above equals tripoint_rel_ms_below, but I've left this mess untouched.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
