### PR TITLE
Fix: Allow tools with charged batteries to be modded

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5369,7 +5369,9 @@ std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint 
     }
 
     if( loc->ammo_remaining() ) {
-        if( !p->unload( loc ) ) {
+        if (loc->has_flag(flag_NO_UNLOAD)) {
+            p->add_msg_if_player( m_info, _("Attaching the mod...") );
+        } else if( !p->unload( loc ) ) {
             p->add_msg_if_player( m_info, _( "You cancel unloading the tool." ) );
             return std::nullopt;
         }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5370,7 +5370,7 @@ std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint 
 
     if( loc->ammo_remaining() ) {
         if( loc->has_flag( flag_NO_UNLOAD ) ) {
-            p->add_msg_if_player( m_info, _( "Attaching the mod..." ) );
+            p->add_msg_if_player( m_info, _( "Attaching the mod.." ) );
         } else if( !p->unload( loc ) ) {
             p->add_msg_if_player( m_info, _( "You cancel unloading the tool." ) );
             return std::nullopt;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5369,8 +5369,8 @@ std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint 
     }
 
     if( loc->ammo_remaining() ) {
-        if (loc->has_flag(flag_NO_UNLOAD)) {
-            p->add_msg_if_player( m_info, _("Attaching the mod...") );
+        if( loc->has_flag( flag_NO_UNLOAD ) ) {
+            p->add_msg_if_player( m_info, _( "Attaching the mod..." ) );
         } else if( !p->unload( loc ) ) {
             p->add_msg_if_player( m_info, _( "You cancel unloading the tool." ) );
             return std::nullopt;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Simply makes it possible to attach mods to tools. fixes #76717

#### Testing
Compiled the game and tested - attaching the mod to a tool works perfectly.
