### PR TITLE
Add Low-Grade Methamphetamine recipe

### DIFF
--- a/data/json/recipes/chem/drugs.json
+++ b/data/json/recipes/chem/drugs.json
@@ -57,6 +57,32 @@
   },
   {
     "type": "recipe",
+    "result": "meth",
+    "id_suffix": "from_phosporous_iodine",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_DRUGS",
+    "skill_used": "chemistry",
+    "difficulty": 4,
+    "time": "6 h",
+    "book_learn": [ [ "recipe_labchem", 6 ] ],
+    "batch_time_factors": [ 30, 5 ],
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" }
+    ],
+    "qualities": [ { "id": "CHEM", "level": 3 }, { "id": "SEPARATE", "level": 1 } ],
+    "components": [
+      [ [ "dayquil", 25 ], [ "nyquil", 25 ] ],
+      [ [ "iodine_crystal", 7 ] ],
+      [ [ "red_phosphorous", 2 ], [ "red_phosphorous_small", 200 ] ],
+      [ [ "chem_acetone", 1 ] ],
+      [ [ "chem_methanol", 2 ] ],
+      [ [ "lye_powder", 5 ], [ "chem_potassium_hydroxide", 25 ], [ "lye", 1 ], [ "lye_potassium", 1 ] ]
+    ],
+    "charges": 6
+  },
+  {
+    "type": "recipe",
     "result": "pure_meth",
     "id_suffix": "from_phosporous_iodine",
     "activity_level": "NO_EXERCISE",

--- a/data/json/recipes/chem/drugs.json
+++ b/data/json/recipes/chem/drugs.json
@@ -67,9 +67,7 @@
     "time": "6 h",
     "book_learn": [ [ "recipe_labchem", 6 ] ],
     "batch_time_factors": [ 30, 5 ],
-    "proficiencies": [
-      { "proficiency": "prof_intro_chemistry" }
-    ],
+    "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],
     "qualities": [ { "id": "CHEM", "level": 3 }, { "id": "SEPARATE", "level": 1 } ],
     "components": [
       [ [ "dayquil", 25 ], [ "nyquil", 25 ] ],


### PR DESCRIPTION
Added recipe for low-grade meth

#### Summary
Content "Added a Low-Grade Methamphetamine recipe"

#### Purpose of change

High-Grade Methamphetamine is eventually producible by the player if they reach the latter tiers of chemistry, but Low-Grade has always been relegated to the sidelines. I added the recipe to entice a new playstyle and allow for more storytelling aspects in a more roleplaying aspect.

#### Describe the solution

It adds a recipe very similar to High-Grade Methamphetamine, but instead relies on more cough syrup in exchange for the other ingredients as Low-Grade Methamphetamine is largely less pure than it's High-Grade counterpart.

I've dropped the chemistry skill required to 4, half-ing what is needed for High-Grade. Removed most proficiencies since Low-Grade is typically (from my understanding) made by more inexperienced/rushed/equipment lacking chemists.

I've kept the tools required with CHEM 3 and SEPERATION 1 largely due to a Hot Plate being required in CHEM 3 tools and a Separation Flask for SEPERATION 1 still required for the chemistry.

I've dropped most ingredients needed from High-Grade to fit Low-Grade in exchange for higher amounts of Pseudo (Cough-Syrup) which I have also added the ability to use both drowsy and non-drowsy, since I'm assuming the drowsy variant is less pure and purity isn't something the player making Low-Grade would concern themselves with.

Lye and it's alternatives in the recipe have largely stayed the same, mostly because Lye and Potassium Lye already being at 1 singular and I don't know what I could do to drop it further.

#### Describe alternatives you've considered

None, just wanted to add the recipe

#### Testing

I have a testing version of CDDA I do the JSON changes to to test contributions and it works.

#### Additional context

Was thinking of making a journal that can teach this to the player early on, maybe one that could be left in a overworld junkie house/drug lab


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
