### PR TITLE
Refactor repeated map.ter .furn .*_at calls

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1356,8 +1356,7 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
         }
 
         moves_before_quality = to_moves<int>( furn_type->hacksaw->duration() );
-    } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->hacksaw->valid() ) {
             if( !testing ) {
                 debugmsg( "%s hacksaw is invalid", ter_type.id().str() );
@@ -1486,8 +1485,7 @@ void hacksaw_activity_actor::finish( player_activity &act, Character &who )
 
         data = static_cast<const activity_data_common *>( &*furn_type->hacksaw );
         here.furn_set( target, new_furn );
-    } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->hacksaw->valid() ) {
             if( !testing ) {
                 debugmsg( "%s hacksaw is invalid", ter_type.id().str() );
@@ -2621,8 +2619,7 @@ void boltcutting_activity_actor::start( player_activity &act, Character &/*who*/
         }
 
         act.moves_total = to_moves<int>( furn_type->boltcut->duration() );
-    } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->boltcut->valid() ) {
             if( !testing ) {
                 debugmsg( "%s boltcut is invalid", ter_type.id().str() );
@@ -2684,8 +2681,7 @@ void boltcutting_activity_actor::finish( player_activity &act, Character &who )
 
         data = static_cast<const activity_data_common *>( &*furn_type->boltcut );
         here.furn_set( target, new_furn );
-    } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->boltcut->valid() ) {
             if( !testing ) {
                 debugmsg( "%s boltcut is invalid", ter_type.id().str() );
@@ -5408,8 +5404,7 @@ void oxytorch_activity_actor::start( player_activity &act, Character &/*who*/ )
         }
 
         act.moves_total = to_moves<int>( furn_type->oxytorch->duration() );
-    } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->oxytorch->valid() ) {
             if( !testing ) {
                 debugmsg( "%s oxytorch is invalid", ter_type.id().str() );
@@ -5475,8 +5470,7 @@ void oxytorch_activity_actor::finish( player_activity &act, Character &who )
 
         data = static_cast<const activity_data_common *>( &*furn_type->oxytorch );
         here.furn_set( target, new_furn );
-    } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->oxytorch->valid() ) {
             if( !testing ) {
                 debugmsg( "%s oxytorch is invalid", ter_type.id().str() );
@@ -5866,8 +5860,7 @@ void prying_activity_actor::start( player_activity &act, Character &who )
         prying_nails = furn_type->prying->prying_data().prying_nails;
         act.moves_total = to_moves<int>(
                               prying_time( *furn_type->prying, tool, who ) );
-    } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->prying->valid() ) {
             if( !testing ) {
                 debugmsg( "%s prying is invalid", ter_type.id().str() );
@@ -5988,8 +5981,7 @@ void prying_activity_actor::handle_prying( Character &who )
         }
 
         here.furn_set( target, new_furn );
-    } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->prying->valid() ) {
             if( !testing ) {
                 debugmsg( "%s prying is invalid", ter_type.id().str() );
@@ -6073,8 +6065,7 @@ void prying_activity_actor::handle_prying_nails( Character &who )
 
         data = static_cast<const activity_data_common *>( &*furn_type->prying );
         here.furn_set( target, new_furn );
-    } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->prying->valid() ) {
             if( !testing ) {
                 debugmsg( "%s prying is invalid", ter_type.id().str() );
@@ -6429,11 +6420,12 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
     int log_quan;
     int stick_quan;
     int splint_quan;
-    if( here.ter( pos ) == ter_t_trunk ) {
+    const ter_id &t = here.ter( pos );
+    if( t == ter_t_trunk ) {
         log_quan = rng( 2, 3 );
         stick_quan = rng( 0, 3 );
         splint_quan = 0;
-    } else if( here.ter( pos ) == ter_t_stump ) {
+    } else if( t == ter_t_stump ) {
         log_quan = rng( 0, 2 );
         stick_quan = 0;
         splint_quan = rng( 5, 15 );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1346,7 +1346,7 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
     int moves_before_quality;
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const furn_id &furn_type = here.furn( target );
         if( !furn_type->hacksaw->valid() ) {
             if( !testing ) {
                 debugmsg( "%s hacksaw is invalid", furn_type.id().str() );
@@ -1356,7 +1356,7 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
         }
 
         moves_before_quality = to_moves<int>( furn_type->hacksaw->duration() );
-    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
+    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->hacksaw->valid() ) {
             if( !testing ) {
                 debugmsg( "%s hacksaw is invalid", ter_type.id().str() );
@@ -1465,7 +1465,7 @@ void hacksaw_activity_actor::finish( player_activity &act, Character &who )
     const activity_data_common *data;
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const furn_id &furn_type = here.furn( target );
         if( !furn_type->hacksaw->valid() ) {
             if( !testing ) {
                 debugmsg( "%s hacksaw is invalid", furn_type.id().str() );
@@ -1485,7 +1485,7 @@ void hacksaw_activity_actor::finish( player_activity &act, Character &who )
 
         data = static_cast<const activity_data_common *>( &*furn_type->hacksaw );
         here.furn_set( target, new_furn );
-    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
+    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->hacksaw->valid() ) {
             if( !testing ) {
                 debugmsg( "%s hacksaw is invalid", ter_type.id().str() );
@@ -2609,7 +2609,7 @@ void boltcutting_activity_actor::start( player_activity &act, Character &/*who*/
     const map &here = get_map();
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const furn_id &furn_type = here.furn( target );
         if( !furn_type->boltcut->valid() ) {
             if( !testing ) {
                 debugmsg( "%s boltcut is invalid", furn_type.id().str() );
@@ -2619,7 +2619,7 @@ void boltcutting_activity_actor::start( player_activity &act, Character &/*who*/
         }
 
         act.moves_total = to_moves<int>( furn_type->boltcut->duration() );
-    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
+    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->boltcut->valid() ) {
             if( !testing ) {
                 debugmsg( "%s boltcut is invalid", ter_type.id().str() );
@@ -2661,7 +2661,7 @@ void boltcutting_activity_actor::finish( player_activity &act, Character &who )
     const activity_data_common *data;
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const furn_id &furn_type = here.furn( target );
         if( !furn_type->boltcut->valid() ) {
             if( !testing ) {
                 debugmsg( "%s boltcut is invalid", furn_type.id().str() );
@@ -2681,7 +2681,7 @@ void boltcutting_activity_actor::finish( player_activity &act, Character &who )
 
         data = static_cast<const activity_data_common *>( &*furn_type->boltcut );
         here.furn_set( target, new_furn );
-    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
+    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->boltcut->valid() ) {
             if( !testing ) {
                 debugmsg( "%s boltcut is invalid", ter_type.id().str() );
@@ -2808,8 +2808,8 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
 
     map &here = get_map();
     const tripoint_bub_ms target = here.bub_from_abs( this->target );
-    const ter_id ter_type = here.ter( target );
-    const furn_id furn_type = here.furn( target );
+    const ter_id &ter_type = here.ter( target );
+    const furn_id &furn_type = here.furn( target );
     optional_vpart_position const veh = here.veh_at( target );
     int locked_part = -1;
     ter_id new_ter_type;
@@ -2977,7 +2977,7 @@ std::optional<tripoint_bub_ms> lockpick_activity_actor::select_location( avatar 
         return target;
     }
 
-    const ter_id terr_type = get_map().ter( *target );
+    const ter_id &terr_type = get_map().ter( *target );
     if( *target == you.pos_bub() ) {
         you.add_msg_if_player( m_info, _( "You pick your nose and your sinuses swing open." ) );
     } else if( get_creature_tracker().creature_at<npc>( *target ) ) {
@@ -4323,7 +4323,7 @@ void harvest_activity_actor::start( player_activity &act, Character &who )
     map &here = get_map();
 
     if( here.has_furn( target ) ) {
-        const furn_id furn = here.furn( target );
+        const furn_id &furn = here.furn( target );
 
         if( furn->has_examine( iexamine::harvest_furn ) ) {
             // TODO: Should be generified as a harvest field
@@ -5394,7 +5394,7 @@ void oxytorch_activity_actor::start( player_activity &act, Character &/*who*/ )
     const map &here = get_map();
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const furn_id &furn_type = here.furn( target );
         if( !furn_type->oxytorch->valid() ) {
             if( !testing ) {
                 debugmsg( "%s oxytorch is invalid", furn_type.id().str() );
@@ -5404,7 +5404,7 @@ void oxytorch_activity_actor::start( player_activity &act, Character &/*who*/ )
         }
 
         act.moves_total = to_moves<int>( furn_type->oxytorch->duration() );
-    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
+    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->oxytorch->valid() ) {
             if( !testing ) {
                 debugmsg( "%s oxytorch is invalid", ter_type.id().str() );
@@ -5450,7 +5450,7 @@ void oxytorch_activity_actor::finish( player_activity &act, Character &who )
     const activity_data_common *data;
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const furn_id &furn_type = here.furn( target );
         if( !furn_type->oxytorch->valid() ) {
             if( !testing ) {
                 debugmsg( "%s oxytorch is invalid", furn_type.id().str() );
@@ -5470,7 +5470,7 @@ void oxytorch_activity_actor::finish( player_activity &act, Character &who )
 
         data = static_cast<const activity_data_common *>( &*furn_type->oxytorch );
         here.furn_set( target, new_furn );
-    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
+    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->oxytorch->valid() ) {
             if( !testing ) {
                 debugmsg( "%s oxytorch is invalid", ter_type.id().str() );
@@ -5848,7 +5848,7 @@ void prying_activity_actor::start( player_activity &act, Character &who )
     const map &here = get_map();
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const furn_id &furn_type = here.furn( target );
         if( !furn_type->prying->valid() ) {
             if( !testing ) {
                 debugmsg( "%s prying is invalid", furn_type.id().str() );
@@ -5860,7 +5860,7 @@ void prying_activity_actor::start( player_activity &act, Character &who )
         prying_nails = furn_type->prying->prying_data().prying_nails;
         act.moves_total = to_moves<int>(
                               prying_time( *furn_type->prying, tool, who ) );
-    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
+    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->prying->valid() ) {
             if( !testing ) {
                 debugmsg( "%s prying is invalid", ter_type.id().str() );
@@ -5958,7 +5958,7 @@ void prying_activity_actor::handle_prying( Character &who )
     };
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const furn_id &furn_type = here.furn( target );
         if( !furn_type->prying->valid() ) {
             if( !testing ) {
                 debugmsg( "%s prying is invalid", furn_type.id().str() );
@@ -5981,7 +5981,7 @@ void prying_activity_actor::handle_prying( Character &who )
         }
 
         here.furn_set( target, new_furn );
-    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
+    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->prying->valid() ) {
             if( !testing ) {
                 debugmsg( "%s prying is invalid", ter_type.id().str() );
@@ -6047,7 +6047,7 @@ void prying_activity_actor::handle_prying_nails( Character &who )
     const activity_data_common *data;
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const furn_id &furn_type = here.furn( target );
         if( !furn_type->prying->valid() ) {
             if( !testing ) {
                 debugmsg( "%s prying is invalid", furn_type.id().str() );
@@ -6065,7 +6065,7 @@ void prying_activity_actor::handle_prying_nails( Character &who )
 
         data = static_cast<const activity_data_common *>( &*furn_type->prying );
         here.furn_set( target, new_furn );
-    } else if( const ter_id ter_type = here.ter( target ); !ter_type->is_null() ) {
+    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
         if( !ter_type->prying->valid() ) {
             if( !testing ) {
                 debugmsg( "%s prying is invalid", ter_type.id().str() );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1724,23 +1724,23 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
                     if( here.ter( source_pos )->has_examine( iexamine::gaspump ) ) {
                         add_msg( _( "With a clang and a shudder, the %s pump goes silent." ),
                                  liquid.type_name( 1 ) );
-                    } else if( here.furn( source_pos )->has_examine( iexamine::fvat_full ) ) {
+                    } else if( const furn_id &f = here.furn( source_pos ); f->has_examine( iexamine::fvat_full ) ) {
                         add_msg( _( "You squeeze the last drops of %s from the vat." ),
                                  liquid.type_name( 1 ) );
                         map_stack items_here = here.i_at( source_pos );
                         if( items_here.empty() ) {
-                            if( here.furn( source_pos ) == furn_f_fvat_wood_full ) {
+                            if( f == furn_f_fvat_wood_full ) {
                                 here.furn_set( source_pos, furn_f_fvat_wood_empty );
                             } else {
                                 here.furn_set( source_pos, furn_f_fvat_empty );
                             }
                         }
-                    } else if( here.furn( source_pos )->has_examine( iexamine::compost_full ) ) {
+                    } else if( f->has_examine( iexamine::compost_full ) ) {
                         add_msg( _( "You squeeze the last drops of %s from the tank." ),
                                  liquid.type_name( 1 ) );
                         map_stack items_here = here.i_at( source_pos );
                         if( items_here.empty() ) {
-                            if( here.furn( source_pos ) == furn_f_compost_full ) {
+                            if( f == furn_f_compost_full ) {
                                 here.furn_set( source_pos, furn_f_compost_empty );
                             }
                         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -836,8 +836,8 @@ construction const *_find_prereq( tripoint_bub_ms const &loc, construction_id co
 bool already_done( construction const &build, tripoint_bub_ms const &loc )
 {
     map &here = get_map();
-    const furn_id furn = here.furn( loc );
-    const ter_id ter = here.ter( loc );
+    const furn_id &furn = here.furn( loc );
+    const ter_id &ter = here.ter( loc );
     return !build.post_terrain.empty() &&
            ( ( !build.post_is_furniture && ter_id( build.post_terrain ) == ter ) ||
              ( build.post_is_furniture && furn_id( build.post_terrain ) == furn ) );
@@ -2470,7 +2470,7 @@ static bool chop_tree_activity( Character &you, const tripoint_bub_ms &src_loc )
         you.consume_charges( best_qual, best_qual.type->charges_to_use() );
     }
     map &here = get_map();
-    const ter_id ter = here.ter( src_loc );
+    const ter_id &ter = here.ter( src_loc );
     if( here.has_flag( ter_furn_flag::TFLAG_TREE, src_loc ) ) {
         you.assign_activity( chop_tree_activity_actor( moves, item_location( you, &best_qual ) ) );
         you.activity.placement = here.getglobal( src_loc );
@@ -2666,7 +2666,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
             continue;
         }
         if( act_id == ACT_MULTIPLE_FISH ) {
-            const ter_id terrain_id = here.ter( set_pt );
+            const ter_id &terrain_id = here.ter( set_pt );
             if( !terrain_id.obj().has_flag( ter_furn_flag::TFLAG_DEEP_WATER ) ) {
                 it2 = src_set.erase( it2 );
             } else {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1179,8 +1179,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
         }
     }
     if( act == ACT_MULTIPLE_CHOP_TREES ) {
-        if( here.has_flag( ter_furn_flag::TFLAG_TREE, src_loc ) || here.ter( src_loc ) == ter_t_trunk ||
-            here.ter( src_loc ) == ter_t_stump ) {
+        const ter_id &t = here.ter( src_loc );
+        if( t == ter_t_trunk || t == ter_t_stump || here.has_flag( ter_furn_flag::TFLAG_TREE, src_loc ) ) {
             if( you.has_quality( qual_AXE ) ) {
                 return activity_reason_info::ok( do_activity_reason::NEEDS_TREE_CHOPPING );
             } else {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -561,10 +561,10 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         if( waste_moves ) {
             you.mod_moves( -you.get_speed() );
         }
-    } else if( m.ter( dest_loc ) == ter_t_door_bar_locked ) {
+    } else if( const ter_id &t = m.ter( dest_loc ); t == ter_t_door_bar_locked ) {
         add_msg( _( "You rattle the bars but the door is locked!" ) );
     } else if( const std::unordered_set<ter_str_id> locked_doors = { ter_t_door_locked, ter_t_door_locked_peep, ter_t_door_locked_alarm, ter_t_door_locked_interior };
-               locked_doors.find( m.ter( dest_loc ).id() ) != locked_doors.end() ) {
+               locked_doors.find( t.id() ) != locked_doors.end() ) {
         // Don't drain move points for learning something you could learn just by looking
         add_msg( _( "That door is locked!" ) );
     }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2415,8 +2415,9 @@ float Character::env_surgery_bonus( int radius ) const
     float bonus = 1.0f;
     map &here = get_map();
     for( const tripoint_bub_ms &cell : here.points_in_radius( pos_bub(), radius ) ) {
-        if( here.furn( cell )->surgery_skill_multiplier ) {
-            bonus = std::max( bonus, *here.furn( cell )->surgery_skill_multiplier );
+        const furn_id &f = here.furn( cell );
+        if( f->surgery_skill_multiplier ) {
+            bonus = std::max( bonus, *f->surgery_skill_multiplier );
         }
     }
     return bonus;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3596,15 +3596,16 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
     const auto fld_override = field_override.find( tripoint_bub_ms( p ) );
     const bool fld_overridden = fld_override != field_override.end();
     map &here = get_map();
+    const field &f = here.field_at( p );
     const field_type_id &fld = fld_overridden ?
-                               fld_override->second : here.field_at( p ).displayed_field_type();
+                               fld_override->second : f.displayed_field_type();
     bool ret_draw_field = false;
     bool ret_draw_items = false;
     // go through each field and draw it
     if( !fld_overridden ) {
         const maptile &tile = here.maptile_at( p );
 
-        for( const std::pair<const field_type_id, field_entry> &fd_pr : here.field_at( p ) ) {
+        for( const std::pair<const field_type_id, field_entry> &fd_pr : f ) {
             const field_type_id &fld = fd_pr.first;
             if( !invisible[0] && fld.obj().display_field ) {
                 const lit_level lit = ll;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4990,7 +4990,7 @@ void cata_tiles::get_terrain_orientation( const tripoint_bub_ms &p, int &rota, i
     };
 
     // get terrain at x,y
-    const ter_id tid = ter( p, invisible[0] );
+    const ter_id &tid = ter( p, invisible[0] );
     if( tid == ter_str_id::NULL_ID() ) {
         subtile = 0;
         rota = 0;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1421,18 +1421,22 @@ bool Character::sight_impaired() const
 bool Character::has_alarm_clock() const
 {
     map &here = get_map();
-    return cache_has_item_with_flag( flag_ALARMCLOCK, true ) ||
-           ( here.veh_at( pos_bub() ) &&
-             !empty( here.veh_at( pos_bub() )->vehicle().get_avail_parts( "ALARMCLOCK" ) ) ) ||
+    if( cache_has_item_with_flag( flag_ALARMCLOCK, true ) ) {
+        return true;
+    }
+    const optional_vpart_position &vp = here.veh_at( pos_bub() );
+    return ( vp && !empty( vp->vehicle().get_avail_parts( "ALARMCLOCK" ) ) ) ||
            has_flag( json_flag_ALARMCLOCK );
 }
 
 bool Character::has_watch() const
 {
     map &here = get_map();
-    return cache_has_item_with_flag( flag_WATCH, true ) ||
-           ( here.veh_at( pos_bub() ) &&
-             !empty( here.veh_at( pos_bub() )->vehicle().get_avail_parts( "WATCH" ) ) ) ||
+    if( cache_has_item_with_flag( flag_WATCH, true ) ) {
+        return true;
+    }
+    const optional_vpart_position &vp = here.veh_at( pos_bub() );
+    return ( vp && !empty( vp->vehicle().get_avail_parts( "WATCH" ) ) ) ||
            has_flag( json_flag_WATCH );
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9146,8 +9146,8 @@ units::temperature_delta Character::floor_bedding_warmth( const tripoint &pos )
 {
     map &here = get_map();
     const trap &trap_at_pos = here.tr_at( pos );
-    const ter_id ter_at_pos = here.ter( pos );
-    const furn_id furn_at_pos = here.furn( pos );
+    const ter_id &ter_at_pos = here.ter( pos );
+    const furn_id &furn_at_pos = here.furn( pos );
 
     const optional_vpart_position vp = here.veh_at( pos );
     const std::optional<vpart_reference> boardable = vp.part_with_feature( "BOARDABLE", true );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -472,7 +472,7 @@ void Character::update_bodytemp()
     const int climate_control_heat = climate_control.first;
     const int climate_control_chill = climate_control.second;
     const bool use_floor_warmth = can_use_floor_warmth();
-    const furn_id furn_at_pos = here.furn( pos_bub() );
+    const furn_id &furn_at_pos = here.furn( pos_bub() );
     const std::optional<vpart_reference> boardable = vp.part_with_feature( "BOARDABLE", true );
     // This means which temperature is comfortable for a naked person
     // Ambient normal temperature is lower while asleep

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1161,8 +1161,8 @@ bool can_construct_furn_ter( const construction &con, furn_id const &f, ter_id c
 bool can_construct( const construction &con, const tripoint_bub_ms &p )
 {
     const map &here = get_map();
-    const furn_id f = here.furn( p );
-    const ter_id t = here.ter( p );
+    const furn_id &f = here.furn( p );
+    const ter_id &t = here.ter( p );
     if( con.pre_specials.size() > 1 ) { // pre-functions
         for( const auto &special : con.pre_specials ) {
             if( !special( p ) ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2001,9 +2001,10 @@ void construct::done_extract_maybe_revert_to_dirt( const tripoint_bub_ms &p, Cha
         here.ter_set( p, ter_t_dirt );
     }
 
-    if( here.ter( p ) == ter_t_clay ) {
+    const ter_id &t = here.ter( p );
+    if( t == ter_t_clay ) {
         add_msg( _( "You gather some clay." ) );
-    } else if( here.ter( p ) == ter_t_sand ) {
+    } else if( t == ter_t_sand ) {
         add_msg( _( "You gather some sand." ) );
     } else {
         // Fall through to an undefined material.
@@ -2053,10 +2054,11 @@ void construct::remove_above( const tripoint_bub_ms &p, Character &/*who*/ )
 void construct::add_roof( const tripoint_bub_ms &p, Character &/*who*/ )
 {
     map &here = get_map();
-    ter_id roof = here.ter( p ).obj().roof;
+    const ter_id &t = here.ter( p );
+    const ter_id &roof = t.obj().roof;
     if( !roof ) {
         debugmsg( "add_roof post_ter called on terrain lacking roof definition, %s.",
-                  here.ter( p ).id().c_str() );
+                  t.id().c_str() );
     }
     here.ter_set( p + tripoint_above, roof );
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -271,18 +271,17 @@ float Character::workbench_crafting_speed_multiplier( const item &craft,
             debugmsg( "part '%S' with WORKBENCH flag has no workbench info", vp->part().name() );
             return 0.0f;
         }
-    } else if( here.furn( *loc ).obj().workbench ) {
+    } else if( const auto &fw = here.furn( *loc ).obj().workbench ) {
         // Furniture workbench
-        const furn_t &f = here.furn( *loc ).obj();
-        multiplier = f.workbench->multiplier;
-        allowed_mass = f.workbench->allowed_mass;
-        allowed_volume = f.workbench->allowed_volume;
+        multiplier = fw->multiplier;
+        allowed_mass = fw->allowed_mass;
+        allowed_volume = fw->allowed_volume;
     } else {
         // Ground
-        const furn_t &f = furn_f_ground_crafting_spot.obj();
-        multiplier = f.workbench->multiplier;
-        allowed_mass = f.workbench->allowed_mass;
-        allowed_volume = f.workbench->allowed_volume;
+        const auto &fg = furn_f_ground_crafting_spot.obj().workbench;
+        multiplier = fg->multiplier;
+        allowed_mass = fg->allowed_mass;
+        allowed_volume = fg->allowed_volume;
     }
 
     const units::mass &craft_mass = craft.weight();

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -230,8 +230,9 @@ void editmap_hilight::draw( editmap &em, bool update )
                 char t_sym = terrain.symbol();
                 nc_color t_col = terrain.color();
 
-                if( here.furn( p ).to_i() > 0 ) {
-                    const furn_t &furniture_type = here.furn( p ).obj();
+                const furn_id &f = here.furn( p );
+                if( f.to_i() > 0 ) {
+                    const furn_t &furniture_type = f.obj();
                     t_sym = furniture_type.symbol();
                     t_col = furniture_type.color();
                 }
@@ -722,7 +723,8 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
         veh_msg = pgettext( "vehicle", "out" );
     }
 
-    const ter_t &terrain_type = here.ter( target ).obj();
+    const ter_id &t = here.ter( target );
+    const ter_t &terrain_type = t.obj();
     const furn_t &furniture_type = here.furn( target ).obj();
 
     int off = 1;
@@ -732,15 +734,16 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
                target.z() );
 
     mvwputch( w_info, point( 2, off ), terrain_type.color(), terrain_type.symbol() );
-    mvwprintw( w_info, point( 4, off ), _( "%d: %s; move cost %d" ), here.ter( target ).to_i(),
+    mvwprintw( w_info, point( 4, off ), _( "%d: %s; move cost %d" ), t.to_i(),
                static_cast<std::string>( terrain_type.id ),
                terrain_type.movecost
              );
     off++; // 2
-    if( here.furn( target ).to_i() > 0 ) {
+    const furn_id &f = here.furn( target );
+    if( f.to_i() > 0 ) {
         mvwputch( w_info, point( 2, off ), furniture_type.color(), furniture_type.symbol() );
         mvwprintw( w_info, point( 4, off ), _( "%d: %s; move cost %d movestr %d" ),
-                   here.furn( target ).to_i(),
+                   f.to_i(),
                    static_cast<std::string>( furniture_type.id ),
                    furniture_type.movecost,
                    furniture_type.move_str_req

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1022,7 +1022,7 @@ void apply<ter_t>( const ter_t &t, const shapetype editshape, const tripoint_bub
     ter_id teralt = undefined_ter_id;
     int alta = -1;
     int altb = -1;
-    const ter_id sel_ter = t.id.id();
+    const ter_id &sel_ter = t.id.id();
     if( editshape == editmap_rect ) {
         if( t.symbol() == LINE_XOXO || t.symbol() == '|' ) {
             isvert = true;
@@ -1059,7 +1059,7 @@ template<>
 void apply<furn_t>( const furn_t &t, const shapetype, const tripoint_bub_ms &,
                     const tripoint_bub_ms &, const std::vector<tripoint_bub_ms> &target_list )
 {
-    const furn_id sel_frn = t.id.id();
+    const furn_id &sel_frn = t.id.id();
     map &here = get_map();
     for( const tripoint_bub_ms &elem : target_list ) {
         here.furn_set( elem, sel_frn );

--- a/src/event_field_transformations.cpp
+++ b/src/event_field_transformations.cpp
@@ -46,7 +46,7 @@ static std::vector<cata_variant> is_mounted( const cata_variant &v )
 
 static std::vector<cata_variant> is_swimming_terrain( const cata_variant &v )
 {
-    const ter_id ter = v.get<ter_id>();
+    const ter_id &ter = v.get<ter_id>();
     const bool swimming = ter->has_flag( ter_furn_flag::TFLAG_DEEP_WATER ) &&
                           ter->has_flag( ter_furn_flag::TFLAG_SWIMMABLE );
     std::vector<cata_variant> result = { cata_variant( swimming ) };

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -707,8 +707,9 @@ void emp_blast( const tripoint &p )
         return;
     }
     // TODO: More terrain effects.
-    if( here.ter( p ) == ter_t_card_science || here.ter( p ) == ter_t_card_military ||
-        here.ter( p ) == ter_t_card_industrial ) {
+    const ter_id &t = here.ter( p );
+    if( t == ter_t_card_science || t == ter_t_card_military ||
+        t == ter_t_card_industrial ) {
         int rn = rng( 1, 100 );
         if( rn > 92 || rn < 40 ) {
             if( sight ) {
@@ -720,11 +721,9 @@ void emp_blast( const tripoint &p )
             if( sight ) {
                 add_msg( _( "The nearby doors slide open!" ) );
             }
-            for( int i = -3; i <= 3; i++ ) {
-                for( int j = -3; j <= 3; j++ ) {
-                    if( here.ter( p + tripoint( i, j, 0 ) ) == ter_t_door_metal_locked ) {
-                        here.ter_set( p + tripoint( i, j, 0 ), ter_t_floor );
-                    }
+            for( const tripoint &pos : here.points_in_radius( p, 3 ) ) {
+                if( here.ter( pos ) == ter_t_door_metal_locked ) {
+                    here.ter_set( pos, ter_t_floor );
                 }
             }
         }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2206,12 +2206,13 @@ void basecamp::scan_pseudo_items()
         const tripoint_omt_ms mapmin{ 0, 0, omt_pos.z() };
         const tripoint_omt_ms mapmax{ 2 * SEEX - 1, 2 * SEEY - 1, omt_pos.z() };
         for( const tripoint_omt_ms &pos : expansion_map.points_in_rectangle( mapmin, mapmax ) ) {
-            if( expansion_map.furn( pos ) != furn_str_id::NULL_ID() &&
-                expansion_map.furn( pos ).obj().crafting_pseudo_item.is_valid() &&
-                expansion_map.furn( pos ).obj().crafting_pseudo_item.obj().has_flag( flag_ALLOWS_REMOTE_USE ) ) {
+            const furn_id &f = expansion_map.furn( pos );
+            if( f != furn_str_id::NULL_ID() &&
+                f.obj().crafting_pseudo_item.is_valid() &&
+                f.obj().crafting_pseudo_item.obj().has_flag( flag_ALLOWS_REMOTE_USE ) ) {
                 bool found = false;
                 for( itype_id &element : expansion.second.available_pseudo_items ) {
-                    if( element == expansion_map.furn( pos ).obj().crafting_pseudo_item ) {
+                    if( element == f.obj().crafting_pseudo_item ) {
                         found = true;
                         break;
                     }
@@ -2222,9 +2223,10 @@ void basecamp::scan_pseudo_items()
                 }
             }
 
-            if( expansion_map.veh_at( pos ).has_value() &&
-                expansion_map.veh_at( pos )->vehicle().is_appliance() ) {
-                for( const auto &[tool, discard_] : expansion_map.veh_at( pos )->get_tools() ) {
+            const optional_vpart_position &vp = expansion_map.veh_at( pos );
+            if( vp.has_value() &&
+                vp->vehicle().is_appliance() ) {
+                for( const auto &[tool, discard_] : vp->get_tools() ) {
                     if( tool.has_flag( flag_PSEUDO ) &&
                         tool.has_flag( flag_ALLOWS_REMOTE_USE ) ) {
                         bool found = false;
@@ -4921,7 +4923,8 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
     }
     // having cut down the trees, cut the trunks into logs
     for( const tripoint_omt_ms &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
-        if( target_bay.ter( p ) == ter_t_trunk || target_bay.ter( p ) == ter_t_stump ) {
+        const ter_id &t = target_bay.ter( p );
+        if( t == ter_t_trunk || t == ter_t_stump ) {
             target_bay.ter_set( p, ter_t_dirt );
             target_bay.spawn_item( p, itype_log, rng( 2, 3 ), 0, calendar::turn );
             harvested++;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6499,7 +6499,8 @@ void game::print_furniture_info( const tripoint &lp, const catacurses::window &w
     mvwprintz( w_look, point( column, line++ ), c_white, desc );
 
     // Print each line of furniture description in gray
-    desc = string_format( m.furn( lp ).obj().description );
+    const furn_id &f = m.furn( lp );
+    desc = string_format( f.obj().description );
     std::vector<std::string> lines = foldstring( desc, max_width );
     int numlines = lines.size();
     for( int i = 0; i < numlines; i++ ) {
@@ -6507,9 +6508,9 @@ void game::print_furniture_info( const tripoint &lp, const catacurses::window &w
     }
 
     // If this furniture has a crafting pseudo item, check for tool qualities and print them
-    if( !m.furn( lp )->crafting_pseudo_item.is_empty() ) {
+    if( !f->crafting_pseudo_item.is_empty() ) {
         // Make a pseudo item instance so we can use qualities_info later
-        const item pseudo( m.furn( lp )->crafting_pseudo_item );
+        const item pseudo( f->crafting_pseudo_item );
         // Set up iteminfo query to show qualities
         std::vector<iteminfo_parts> quality_part = { iteminfo_parts::QUALITIES };
         const iteminfo_query quality_query( quality_part );
@@ -10526,9 +10527,9 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
             return false;
         }
     }
-    const optional_vpart_position vp_here = m.veh_at( u.pos_bub() );
-    const optional_vpart_position vp_there = m.veh_at( dest_loc );
-    const optional_vpart_position vp_grab = m.veh_at( u.pos_bub() + u.grab_point );
+    const optional_vpart_position &vp_here = m.veh_at( u.pos_bub() );
+    const optional_vpart_position &vp_there = m.veh_at( dest_loc );
+    const optional_vpart_position &vp_grab = m.veh_at( u.pos_bub() + u.grab_point );
     const vehicle *grabbed_vehicle = veh_pointer_or_null( vp_grab );
 
     bool pushing = false; // moving -into- grabbed tile; skip check for move_cost > 0
@@ -11135,13 +11136,14 @@ point game::place_player( const tripoint &dest_loc, bool quick )
     if( !quick && !m.has_flag( ter_furn_flag::TFLAG_SEALED, u.pos_bub() ) ) {
         if( get_option<bool>( "NO_AUTO_PICKUP_ZONES_LIST_ITEMS" ) ||
             !check_zone( zone_type_NO_AUTO_PICKUP, u.pos() ) ) {
-            if( u.is_blind() && !m.i_at( u.pos_bub() ).empty() ) {
+            const map_stack &ms = m.i_at( u.pos_bub() );
+            if( u.is_blind() && !ms.empty() ) {
                 add_msg( _( "There's something here, but you can't see what it is." ) );
             } else if( m.has_items( u.pos_bub() ) ) {
                 std::vector<std::string> names;
                 std::vector<size_t> counts;
                 std::vector<item> items;
-                for( item &tmpitem : m.i_at( u.pos_bub() ) ) {
+                for( const item &tmpitem : ms ) {
 
                     std::string next_tname = tmpitem.tname();
                     std::string next_dname = tmpitem.display_name();
@@ -11426,10 +11428,11 @@ int game::grabbed_furn_move_time( const tripoint &dp )
 
     const bool canmove = can_move_furniture( fdest.raw(), dp );
     const furn_t &furntype = m.furn( fpos ).obj();
-    const int dst_items = m.i_at( fdest ).size();
+    const map_stack &ms = m.i_at( fdest );
+    const int dst_items = ms.size();
 
-    const bool only_liquid_items = std::all_of( m.i_at( fdest ).begin(), m.i_at( fdest ).end(),
-    [&]( item & liquid_item ) {
+    const bool only_liquid_items = std::all_of( ms.begin(), ms.end(),
+    [&]( const item & liquid_item ) {
         return liquid_item.made_of_from_type( phase_id::LIQUID );
     } );
 
@@ -11437,9 +11440,10 @@ int game::grabbed_furn_move_time( const tripoint &dp )
                              !m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, fdest ) &&
                              !m.has_flag( ter_furn_flag::TFLAG_DESTROY_ITEM, fdest ) &&
                              only_liquid_items;
-    const bool src_item_ok = m.furn( fpos ).obj().has_flag( ter_furn_flag::TFLAG_CONTAINER ) ||
-                             m.furn( fpos ).obj().has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER ) ||
-                             m.furn( fpos ).obj().has_flag( ter_furn_flag::TFLAG_SEALED );
+    const furn_t &fo = m.furn( fpos ).obj();
+    const bool src_item_ok = fo.has_flag( ter_furn_flag::TFLAG_CONTAINER ) ||
+                             fo.has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER ) ||
+                             fo.has_flag( ter_furn_flag::TFLAG_SEALED );
 
     int str_req = furntype.move_str_req;
     // Factor in weight of items contained in the furniture.
@@ -11516,10 +11520,11 @@ bool game::grabbed_furn_move( const tripoint &dp )
 
     const furn_t furntype = m.furn( fpos ).obj();
     const int src_items = m.i_at( fpos ).size();
-    const int dst_items = m.i_at( fdest ).size();
+    const map_stack &dst_ms = m.i_at( fdest );
+    const int dst_items = dst_ms.size();
 
-    const bool only_liquid_items = std::all_of( m.i_at( fdest ).begin(), m.i_at( fdest ).end(),
-    [&]( item & liquid_item ) {
+    const bool only_liquid_items = std::all_of( dst_ms.begin(), dst_ms.end(),
+    [&]( const item & liquid_item ) {
         return liquid_item.made_of_from_type( phase_id::LIQUID );
     } );
 
@@ -11527,9 +11532,10 @@ bool game::grabbed_furn_move( const tripoint &dp )
                              !m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, fdest ) &&
                              !m.has_flag( ter_furn_flag::TFLAG_DESTROY_ITEM, fdest );
 
-    const bool src_item_ok = m.furn( fpos ).obj().has_flag( ter_furn_flag::TFLAG_CONTAINER ) ||
-                             m.furn( fpos ).obj().has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER ) ||
-                             m.furn( fpos ).obj().has_flag( ter_furn_flag::TFLAG_SEALED );
+    const furn_t &fo = m.furn( fpos ).obj();
+    const bool src_item_ok = fo.has_flag( ter_furn_flag::TFLAG_CONTAINER ) ||
+                             fo.has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER ) ||
+                             fo.has_flag( ter_furn_flag::TFLAG_SEALED );
 
     const int fire_intensity = m.get_field_intensity( fpos, fd_fire );
     time_duration fire_age = m.get_field_age( fpos, fd_fire );
@@ -11620,16 +11626,17 @@ bool game::grabbed_furn_move( const tripoint &dp )
         if( dst_item_ok && src_item_ok ) {
             // Assume contents of both cells are legal, so we can just swap contents.
             std::list<item> temp;
-            std::move( m.i_at( fpos ).begin(), m.i_at( fpos ).end(),
+            map_stack ms = m.i_at( fpos );
+            std::move( ms.begin(), ms.end(),
                        std::back_inserter( temp ) );
             m.i_clear( fpos );
-            for( auto item_iter = m.i_at( fdest ).begin();
-                 item_iter != m.i_at( fdest ).end(); ++item_iter ) {
-                m.i_at( fpos ).insert( *item_iter );
+            for( auto item_iter = ms.begin();
+                 item_iter != ms.end(); ++item_iter ) {
+                ms.insert( *item_iter );
             }
             m.i_clear( fdest );
             for( item &cur_item : temp ) {
-                m.i_at( fdest ).insert( cur_item );
+                ms.insert( cur_item );
             }
         } else {
             add_msg( _( "Stuff spills from the %s!" ), furntype.name() );

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -233,25 +233,26 @@ void tutorial_game::per_turn()
     }
 
     for( const tripoint_bub_ms &p : here.points_in_radius( player_character.pos_bub(), 1 ) ) {
-        if( here.ter( p ) == ter_t_door_c ) {
+        const ter_id &t = here.ter( p );
+        if( t == ter_t_door_c ) {
             add_message( tut_lesson::LESSON_OPEN );
             break;
-        } else if( here.ter( p ) == ter_t_door_o ) {
+        } else if( t == ter_t_door_o ) {
             add_message( tut_lesson::LESSON_CLOSE );
             break;
-        } else if( here.ter( p ) == ter_t_door_locked_interior ) {
+        } else if( t == ter_t_door_locked_interior ) {
             add_message( tut_lesson::LESSON_LOCKED_DOOR );
             break;
-        } else if( here.ter( p ) == ter_t_window ) {
+        } else if( t == ter_t_window ) {
             add_message( tut_lesson::LESSON_WINDOW );
             break;
         } else if( here.furn( p ) == furn_f_rack ) {
             add_message( tut_lesson::LESSON_EXAMINE );
             break;
-        } else if( here.ter( p ) == ter_t_stairs_down ) {
+        } else if( t == ter_t_stairs_down ) {
             add_message( tut_lesson::LESSON_STAIRS );
             break;
-        } else if( here.ter( p ) == ter_t_water_dispenser ) {
+        } else if( t == ter_t_water_dispenser ) {
             add_message( tut_lesson::LESSON_PICKUP_WATER );
             break;
         } else if( here.tr_at( p ).id == tr_bubblewrap ) {
@@ -264,37 +265,38 @@ void tutorial_game::per_turn()
         add_message( tut_lesson::LESSON_PICKUP );
     }
 
-    if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_1 ) {
+    const auto &tr = here.tr_at( player_character.pos_bub() );
+    if( tr == tr_tutorial_1 ) {
         add_message( tut_lesson::LESSON_LOOK );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_2 ) {
+    } else if( tr == tr_tutorial_2 ) {
         add_message( tut_lesson::LESSON_MOVEMENT_MODES );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_3 ) {
+    } else if( tr == tr_tutorial_3 ) {
         add_message( tut_lesson::LESSON_MONSTER_SIGHTED );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_4 ) {
+    } else if( tr == tr_tutorial_4 ) {
         add_message( tut_lesson::LESSON_REACH_ATTACK );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_5 ) {
+    } else if( tr == tr_tutorial_5 ) {
         add_message( tut_lesson::LESSON_HOLSTERS_WEAR );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_6 ) {
+    } else if( tr == tr_tutorial_6 ) {
         add_message( tut_lesson::LESSON_GUN_LOAD );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_7 ) {
+    } else if( tr == tr_tutorial_7 ) {
         add_message( tut_lesson::LESSON_INVENTORY );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_8 ) {
+    } else if( tr == tr_tutorial_8 ) {
         add_message( tut_lesson::LESSON_FLASHLIGHT );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_9 ) {
+    } else if( tr == tr_tutorial_9 ) {
         add_message( tut_lesson::LESSON_INTERACT );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_10 ) {
+    } else if( tr == tr_tutorial_10 ) {
         add_message( tut_lesson::LESSON_REMOTE_USE );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_11 ) {
+    } else if( tr == tr_tutorial_11 ) {
         player_character.set_hunger( 100 );
         player_character.stomach.empty();
         add_message( tut_lesson::LESSON_CRAFTING_FOOD );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_12 ) {
+    } else if( tr == tr_tutorial_12 ) {
         add_message( tut_lesson::LESSON_CONSTRUCTION );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_13 ) {
+    } else if( tr == tr_tutorial_13 ) {
         player_character.set_pain( 20 );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_14 ) {
+    } else if( tr == tr_tutorial_14 ) {
         add_message( tut_lesson::LESSON_THROWING );
-    } else if( here.tr_at( player_character.pos_bub() ) == tr_tutorial_15 ) {
+    } else if( tr == tr_tutorial_15 ) {
         add_message( tut_lesson::LESSON_FINALE );
     }
 }

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -265,7 +265,7 @@ void tutorial_game::per_turn()
         add_message( tut_lesson::LESSON_PICKUP );
     }
 
-    const auto &tr = here.tr_at( player_character.pos_bub() );
+    const trap &tr = here.tr_at( player_character.pos_bub() );
     if( tr == tr_tutorial_1 ) {
         add_message( tut_lesson::LESSON_LOOK );
     } else if( tr == tr_tutorial_2 ) {

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -498,11 +498,12 @@ bool doors::lock_door( map &m, Creature &who, const tripoint_bub_ms &lockp )
 {
     bool didit = false;
 
-    if( optional_vpart_position vp = m.veh_at( lockp ) ) {
+    if( const optional_vpart_position &vp = m.veh_at( lockp ) ) {
         vehicle *const veh = &vp->vehicle();
         const int vpart = vp->part_index();
-        const bool inside_vehicle = m.veh_at( who.pos_bub() ) &&
-                                    &vp->vehicle() == &m.veh_at( who.pos_bub() )->vehicle();
+        const optional_vpart_position &veh_here = m.veh_at( who.pos_bub() );
+        const bool inside_vehicle = veh_here &&
+                                    &vp->vehicle() == &veh_here->vehicle();
         const int lockable = veh->next_part_to_lock( vpart, !inside_vehicle );
         const int inside_lockable = veh->next_part_to_lock( vpart );
         const int already_locked_part = veh->next_part_to_unlock( vpart );
@@ -538,8 +539,9 @@ bool doors::can_lock_door( const map &m, const Creature &who, const tripoint_bub
     int lockable = -1;
     if( const optional_vpart_position vp = m.veh_at( lockp ) ) {
         const vehicle *const veh = &vp->vehicle();
-        const bool inside_vehicle = m.veh_at( who.pos_bub() ) &&
-                                    &vp->vehicle() == &m.veh_at( who.pos_bub() )->vehicle();
+        const optional_vpart_position &vp_here = m.veh_at( who.pos_bub() );
+        const bool inside_vehicle = vp_here &&
+                                    &vp->vehicle() == &vp_here->vehicle();
         const int vpart = vp->part_index();
         lockable = veh->next_part_to_lock( vpart, !inside_vehicle );
     }
@@ -551,11 +553,12 @@ bool doors::unlock_door( map &m, Creature &who, const tripoint_bub_ms &lockp )
 {
     bool didit = false;
 
-    if( optional_vpart_position vp = m.veh_at( lockp ) ) {
+    if( const optional_vpart_position &vp = m.veh_at( lockp ) ) {
         vehicle *const veh = &vp->vehicle();
         const int vpart = vp->part_index();
-        const bool inside_vehicle = m.veh_at( who.pos_bub() ) &&
-                                    &vp->vehicle() == &m.veh_at( who.pos_bub() )->vehicle();
+        const optional_vpart_position &vp_here = m.veh_at( who.pos_bub() );
+        const bool inside_vehicle = vp_here &&
+                                    &vp->vehicle() == &vp_here->vehicle();
         const int already_unlocked_part = veh->next_part_to_lock( vpart );
         const int inside_unlockable = veh->next_part_to_unlock( vpart );
         const int unlockable = veh->next_part_to_unlock( vpart, !inside_vehicle );
@@ -592,8 +595,9 @@ bool doors::can_unlock_door( const map &m, const Creature &who, const tripoint_b
     int unlockable = -1;
     if( const optional_vpart_position vp = m.veh_at( lockp ) ) {
         const vehicle *const veh = &vp->vehicle();
-        const bool inside_vehicle = m.veh_at( who.pos_bub() ) &&
-                                    &vp->vehicle() == &m.veh_at( who.pos_bub() )->vehicle();
+        const optional_vpart_position &vp_here = m.veh_at( who.pos_bub() );
+        const bool inside_vehicle = vp_here &&
+                                    &vp->vehicle() == &vp_here->vehicle();
         const int vpart = vp->part_index();
         unlockable = veh->next_part_to_unlock( vpart, !inside_vehicle );
     }

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -132,7 +132,7 @@ void gate_data::check() const
 
 bool gate_data::is_suitable_wall( const tripoint_bub_ms &pos ) const
 {
-    const ter_id wid = get_map().ter( pos );
+    const ter_id &wid = get_map().ter( pos );
     if( walls.empty() ) {
         return wid->has_flag( "WALL" );
     }
@@ -218,7 +218,7 @@ void gates::open_gate( const tripoint_bub_ms &pos )
             if( !close ) { // Opening the gate...
                 tripoint_bub_ms cur_pos = gate_pos;
                 while( true ) {
-                    const ter_id ter = here.ter( cur_pos );
+                    const ter_id &ter = here.ter( cur_pos );
 
                     if( ter == gate.door.id() ) {
                         here.ter_set( cur_pos, gate.floor.id() );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -723,8 +723,9 @@ static void grab()
         return;
     }
 
+    const optional_vpart_position &vp = here.veh_at( grabp );
     // Object might not be on the same z level if on a ramp.
-    if( !( here.veh_at( grabp ) || here.has_furn( grabp ) ) ) {
+    if( !( vp || here.has_furn( grabp ) ) ) {
         if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, grabp ) ||
             here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, you.pos_bub() ) ) {
             grabp.z() += 1;
@@ -734,7 +735,7 @@ static void grab()
         }
     }
 
-    if( const optional_vpart_position vp = here.veh_at( grabp ) ) {
+    if( vp ) {
         std::string veh_name = vp->vehicle().name;
         if( !vp->vehicle().handle_potential_theft( you ) ) {
             return;
@@ -752,7 +753,7 @@ static void grab()
             }
             get_player_character().pause();
             vp->vehicle().separate_from_grid( vp.value().mount() );
-            if( const optional_vpart_position split_vp = here.veh_at( grabp ) ) {
+            if( const optional_vpart_position &split_vp = here.veh_at( grabp ) ) {
                 veh_name = split_vp->vehicle().name;
             } else {
                 debugmsg( "Lost the part to drag after splitting power grid!" );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1456,7 +1456,8 @@ void iexamine::cardreader_foodplace( Character &you, const tripoint_bub_ms &exam
             add_msg( _( "The nearby doors are already unlocked." ) );
             if( query_yn( _( "Lock doors?" ) ) ) {
                 for( const tripoint_bub_ms &tmp : here.points_in_radius( tripoint_bub_ms( examp ), 3 ) ) {
-                    if( here.ter( tmp ) == ter_t_door_metal_o || here.ter( tmp ) == ter_t_door_metal_c ) {
+                    const ter_id &t = here.ter( tmp );
+                    if( t == ter_t_door_metal_o || t == ter_t_door_metal_c ) {
                         if( you.pos_bub() == tmp ) {
                             you.add_msg_if_player( m_bad, _( "You are in the way of the door, move before trying again." ) );
                         } else {
@@ -1640,22 +1641,24 @@ void iexamine::deployed_furniture( Character &you, const tripoint_bub_ms &pos )
 
     tripoint_bub_ms drop_pos = pos;
 
+    const furn_t &fo = here.furn( pos ).obj();
+    const std::string &name = fo.name();
     if( you.pos_bub().z() != pos.z() ) {
         drop_pos = you.pos_bub();
-        if( !you.query_yn( _( "Pull up the %s?" ), here.furn( pos ).obj().name() ) ) {
+        if( !you.query_yn( _( "Pull up the %s?" ), name ) ) {
             return;
         }
         you.add_msg_if_player( m_info, _( "You pull up the %s." ),
-                               here.furn( pos ).obj().name() );
+                               name );
     } else {
-        if( !you.query_yn( _( "Take down the %s?" ), here.furn( pos ).obj().name() ) ) {
+        if( !you.query_yn( _( "Take down the %s?" ), name ) ) {
             return;
         }
         you.add_msg_if_player( m_info, _( "You take down the %s." ),
-                               here.furn( pos ).obj().name() );
+                               name );
     }
 
-    const itype_id furn_item = here.furn( pos ).obj().deployed_item;
+    const itype_id &furn_item = fo.deployed_item;
     here.add_item_or_charges( drop_pos, item( furn_item, calendar::turn ) );
     here.furn_set( pos, furn_str_id::NULL_ID() );
 }
@@ -2766,7 +2769,8 @@ void iexamine::harvest_plant( Character &you, const tripoint_bub_ms &examp, bool
             int skillLevel = round( you.get_skill_level( skill_survival ) );
             ///\EFFECT_SURVIVAL increases number of plants harvested from a seed
             int plant_count = rng( skillLevel / 2, skillLevel );
-            plant_count *= here.furn( examp )->plant->harvest_multiplier;
+            const auto &fp = here.furn( examp )->plant;
+            plant_count *= fp->harvest_multiplier;
             plant_count = std::min( std::max( plant_count, 1 ), 12 );
             int seedCount = std::max( 1, rng( plant_count / 4, plant_count / 2 ) );
             for( item &i : get_harvest_items( type, plant_count, seedCount, true ) ) {
@@ -2775,7 +2779,7 @@ void iexamine::harvest_plant( Character &you, const tripoint_bub_ms &examp, bool
                 }
                 here.add_item_or_charges( you.pos_bub(), i );
             }
-            here.furn_set( examp, furn_str_id( here.furn( examp )->plant->base ) );
+            here.furn_set( examp, furn_str_id( fp->base ) );
             you.add_msg_if_player( m_neutral, _( "You harvest the plant." ) );
         }
     }
@@ -2922,7 +2926,7 @@ void iexamine::aggie_plant( Character &you, const tripoint_bub_ms &examp )
 void iexamine::kiln_empty( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    furn_id cur_kiln_type = here.furn( examp );
+    const furn_id &cur_kiln_type = here.furn( examp );
     furn_id next_kiln_type = furn_str_id::NULL_ID();
     if( cur_kiln_type == furn_f_kiln_empty ) {
         next_kiln_type = furn_f_kiln_full;
@@ -2930,7 +2934,7 @@ void iexamine::kiln_empty( Character &you, const tripoint_bub_ms &examp )
         next_kiln_type = furn_f_kiln_metal_full;
     } else {
         debugmsg( "Examined furniture has action kiln_empty, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_kiln_type.id().c_str() );
         return;
     }
 
@@ -3015,7 +3019,7 @@ void iexamine::kiln_empty( Character &you, const tripoint_bub_ms &examp )
 void iexamine::kiln_full( Character &, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    furn_id cur_kiln_type = here.furn( examp );
+    const furn_id &cur_kiln_type = here.furn( examp );
     furn_id next_kiln_type = furn_str_id::NULL_ID();
     if( cur_kiln_type == furn_f_kiln_full ) {
         next_kiln_type = furn_f_kiln_empty;
@@ -3023,7 +3027,7 @@ void iexamine::kiln_full( Character &, const tripoint_bub_ms &examp )
         next_kiln_type = furn_f_kiln_metal_empty;
     } else {
         debugmsg( "Examined furniture has action kiln_full, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_kiln_type.id().c_str() );
         return;
     }
     map_stack items = here.i_at( examp );
@@ -3075,13 +3079,13 @@ void iexamine::kiln_full( Character &, const tripoint_bub_ms &examp )
 void iexamine::arcfurnace_empty( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    furn_id cur_arcfurnace_type = here.furn( examp );
+    const furn_id &cur_arcfurnace_type = here.furn( examp );
     furn_id next_arcfurnace_type = furn_str_id::NULL_ID();
     if( cur_arcfurnace_type == furn_f_arcfurnace_empty ) {
         next_arcfurnace_type = furn_f_arcfurnace_full;
     } else {
         debugmsg( "Examined furniture has action arcfurnace_empty, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_arcfurnace_type.id().c_str() );
         return;
     }
 
@@ -3148,13 +3152,13 @@ void iexamine::arcfurnace_empty( Character &you, const tripoint_bub_ms &examp )
 void iexamine::arcfurnace_full( Character &, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    furn_id cur_arcfurnace_type = here.furn( examp );
+    const furn_id &cur_arcfurnace_type = here.furn( examp );
     furn_id next_arcfurnace_type = furn_str_id::NULL_ID();
     if( cur_arcfurnace_type == furn_f_arcfurnace_full ) {
         next_arcfurnace_type = furn_f_arcfurnace_empty;
     } else {
         debugmsg( "Examined furniture has action arcfurnace_full, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_arcfurnace_type.id().c_str() );
         return;
     }
 
@@ -3207,13 +3211,13 @@ void iexamine::arcfurnace_full( Character &, const tripoint_bub_ms &examp )
 void iexamine::stook_empty( Character &, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    furn_id cur_stook_type = here.furn( examp );
+    const furn_id &cur_stook_type = here.furn( examp );
     furn_id next_stook_type = furn_str_id::NULL_ID();
     if( cur_stook_type == furn_f_stook_empty ) {
         next_stook_type = furn_f_stook_full;
     } else {
         debugmsg( "Examined furniture has action stook_empty, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_stook_type.id().c_str() );
         return;
     }
 
@@ -3249,13 +3253,13 @@ void iexamine::stook_empty( Character &, const tripoint_bub_ms &examp )
 void iexamine::stook_full( Character &, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    furn_id cur_stook_type = here.furn( examp );
+    const furn_id &cur_stook_type = here.furn( examp );
     furn_id next_stook_type = furn_str_id::NULL_ID();
     if( cur_stook_type == furn_f_stook_full ) {
         next_stook_type = furn_str_id::NULL_ID();
     } else {
         debugmsg( "Examined furniture has action stook_full, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_stook_type.id().c_str() );
         return;
     }
     map_stack items = here.i_at( examp );
@@ -3296,13 +3300,13 @@ void iexamine::stook_full( Character &, const tripoint_bub_ms &examp )
 void iexamine::autoclave_empty( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    furn_id cur_autoclave_type = here.furn( examp );
+    const furn_id &cur_autoclave_type = here.furn( examp );
     furn_id next_autoclave_type = furn_str_id::NULL_ID();
     if( cur_autoclave_type == furn_id( "f_autoclave" ) ) {
         next_autoclave_type = furn_id( "f_autoclave_full" );
     } else {
         debugmsg( "Examined furniture has action autoclave_empty, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_autoclave_type.id().c_str() );
         return;
     }
 
@@ -3356,13 +3360,13 @@ void iexamine::autoclave_empty( Character &you, const tripoint_bub_ms &examp )
 void iexamine::autoclave_full( Character &, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    furn_id cur_autoclave_type = here.furn( examp );
+    const furn_id &cur_autoclave_type = here.furn( examp );
     furn_id next_autoclave_type = furn_str_id::NULL_ID();
     if( cur_autoclave_type == furn_id( "f_autoclave_full" ) ) {
         next_autoclave_type = furn_id( "f_autoclave" );
     } else {
         debugmsg( "Examined furniture has action autoclave_full, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_autoclave_type.id().c_str() );
         return;
     }
 
@@ -4953,8 +4957,9 @@ void iexamine::curtains( Character &you, const tripoint_bub_ms &examp )
         you.add_msg_if_player( _( "You carefully peek through the curtains." ) );
     } else if( choice == 1 ) {
         // Mr. Gorbachev, tear down those curtains!
-        if( here.ter( examp )->has_curtains() ) {
-            here.ter_set( examp, here.ter( examp )->curtain_transform );
+        const ter_id &t = here.ter( examp );
+        if( t->has_curtains() ) {
+            here.ter_set( examp, t->curtain_transform );
         }
 
         here.spawn_item( you.pos_bub(), itype_nail, 1, 4, calendar::turn );
@@ -6130,7 +6135,7 @@ static bool is_non_rotten_crafting_component( const item &it )
 static void mill_activate( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    const furn_id cur_mill_type = here.furn( examp );
+    const furn_id &cur_mill_type = here.furn( examp );
     furn_id next_mill_type = furn_str_id::NULL_ID();
     if( cur_mill_type == furn_f_wind_mill ) {
         next_mill_type = furn_f_wind_mill_active;
@@ -6138,7 +6143,7 @@ static void mill_activate( Character &you, const tripoint_bub_ms &examp )
         next_mill_type = furn_f_water_mill_active;
     } else {
         debugmsg( "Examined furniture has action mill_activate, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_mill_type.id().c_str() );
         return;
     }
     bool food_present = false;
@@ -6297,17 +6302,17 @@ static void mill_activate( Character &you, const tripoint_bub_ms &examp )
 static void smoker_activate( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    furn_id cur_smoker_type = here.furn( examp );
+    const furn_id &cur_smoker_type = here.furn( examp );
     furn_id next_smoker_type = furn_str_id::NULL_ID();
-    const bool portable = here.furn( examp ) == furn_f_metal_smoking_rack ||
-                          here.furn( examp ) == furn_f_metal_smoking_rack_active;
+    const bool portable = cur_smoker_type == furn_f_metal_smoking_rack ||
+                          cur_smoker_type == furn_f_metal_smoking_rack_active;
     if( cur_smoker_type == furn_f_smoking_rack ) {
         next_smoker_type = furn_f_smoking_rack_active;
     } else if( cur_smoker_type == furn_f_metal_smoking_rack ) {
         next_smoker_type = furn_f_metal_smoking_rack_active;
     } else {
         debugmsg( "Examined furniture has action smoker_activate, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_smoker_type.id().c_str() );
         return;
     }
     bool food_present = false;
@@ -6411,7 +6416,7 @@ static void smoker_activate( Character &you, const tripoint_bub_ms &examp )
 void iexamine::mill_finalize( Character &, const tripoint &examp )
 {
     map &here = get_map();
-    const furn_id cur_mill_type = here.furn( examp );
+    const furn_id &cur_mill_type = here.furn( examp );
     furn_id next_mill_type = furn_str_id::NULL_ID();
     if( cur_mill_type == furn_f_wind_mill_active ) {
         next_mill_type = furn_f_wind_mill;
@@ -6419,7 +6424,7 @@ void iexamine::mill_finalize( Character &, const tripoint &examp )
         next_mill_type = furn_f_water_mill;
     } else {
         debugmsg( "Furniture executed action mill_finalize, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_mill_type.id().c_str() );
         return;
     }
 
@@ -6527,7 +6532,7 @@ void iexamine::mill_finalize( Character &, const tripoint &examp )
 static void smoker_finalize( Character &, const tripoint &examp, const time_point &start_time )
 {
     map &here = get_map();
-    furn_id cur_smoker_type = here.furn( examp );
+    const furn_id &cur_smoker_type = here.furn( examp );
     furn_id next_smoker_type = furn_str_id::NULL_ID();
     if( cur_smoker_type == furn_f_smoking_rack_active ) {
         next_smoker_type = furn_f_smoking_rack;
@@ -6535,7 +6540,7 @@ static void smoker_finalize( Character &, const tripoint &examp, const time_poin
         next_smoker_type = furn_f_metal_smoking_rack;
     } else {
         debugmsg( "Furniture executed action smoker_finalize, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  cur_smoker_type.id().c_str() );
         return;
     }
 
@@ -6587,13 +6592,13 @@ static void smoker_load_food( Character &you, const tripoint_bub_ms &examp,
                               const units::volume &remaining_capacity )
 {
     map &here = get_map();
-    if( here.furn( examp ) == furn_f_smoking_rack_active ||
-        here.furn( examp ) == furn_f_metal_smoking_rack_active ) {
+    const furn_id &rack = here.furn( examp );
+    if( rack == furn_f_smoking_rack_active ||
+        rack == furn_f_metal_smoking_rack_active ) {
         you.add_msg_if_player( _( "You can't place more food while it's smoking." ) );
         return;
     }
 
-    furn_id rack = here.furn( examp );
     units::volume total_capacity = rack == furn_f_metal_smoking_rack ?
                                    sm_rack::MAX_FOOD_VOLUME_PORTABLE :
                                    sm_rack::MAX_FOOD_VOLUME;
@@ -6634,8 +6639,9 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
 {
     std::vector<item_comp> comps;
     map &here = get_map();
-    if( here.furn( examp ) == furn_f_wind_mill_active ||
-        here.furn( examp ) == furn_f_water_mill_active ) {
+    const furn_id &f = here.furn( examp );
+    if( f == furn_f_wind_mill_active ||
+        f == furn_f_water_mill_active ) {
         you.add_msg_if_player( _( "You can't place more food while it's milling." ) );
         return;
     }
@@ -6768,9 +6774,9 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
 
 void iexamine::on_smoke_out( const tripoint &examp, const time_point &start_time )
 {
-    map &here = get_map();
-    if( here.furn( examp ) == furn_f_smoking_rack_active ||
-        here.furn( examp ) == furn_f_metal_smoking_rack_active ) {
+    const furn_id &f = get_map().furn( examp );
+    if( f == furn_f_smoking_rack_active ||
+        f == furn_f_metal_smoking_rack_active ) {
         smoker_finalize( get_avatar(), examp, start_time );
     }
 }
@@ -6778,28 +6784,29 @@ void iexamine::on_smoke_out( const tripoint &examp, const time_point &start_time
 void iexamine::quern_examine( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    if( here.furn( examp ) == furn_f_water_mill ) {
+    const furn_id &f = here.furn( examp );
+    if( f == furn_f_water_mill ) {
         if( !here.is_water_shallow_current( examp ) ) {
             add_msg( _( "The water mill needs to be over shallow flowing water to work." ) );
             return;
         }
     }
-    if( here.furn( examp ) == furn_f_wind_mill ) {
+    if( f == furn_f_wind_mill ) {
         if( g->is_sheltered( examp ) ) {
             add_msg( _( "The wind mill needs to be outside in the wind to work." ) );
             return;
         }
     }
 
-    const bool active = here.furn( examp ) == furn_f_water_mill_active ||
-                        here.furn( examp ) == furn_f_wind_mill_active;
+    const bool active = f == furn_f_water_mill_active ||
+                        f == furn_f_wind_mill_active;
     map_stack items_here = here.i_at( examp );
 
     if( items_here.empty() && active ) {
         debugmsg( "active mill was empty!" );
-        if( here.furn( examp ) == furn_f_water_mill_active ) {
+        if( f == furn_f_water_mill_active ) {
             here.furn_set( examp, furn_f_water_mill );
-        } else if( here.furn( examp ) == furn_f_wind_mill_active ) {
+        } else if( f == furn_f_wind_mill_active ) {
             here.furn_set( examp, furn_f_wind_mill );
         }
         return;
@@ -6807,9 +6814,9 @@ void iexamine::quern_examine( Character &you, const tripoint_bub_ms &examp )
 
     if( items_here.size() == 1 && items_here.begin()->typeId() == itype_fake_milling_item ) {
         debugmsg( "f_mill_active was empty, and had fake_milling_item!" );
-        if( here.furn( examp ) == furn_f_water_mill_active ) {
+        if( f == furn_f_water_mill_active ) {
             here.furn_set( examp, furn_f_water_mill );
-        } else if( here.furn( examp ) == furn_f_wind_mill_active ) {
+        } else if( f == furn_f_wind_mill_active ) {
             here.furn_set( examp, furn_f_wind_mill );
         }
         items_here.erase( items_here.begin() );
@@ -6921,9 +6928,10 @@ void iexamine::quern_examine( Character &you, const tripoint_bub_ms &examp )
                 }
             }
             if( active ) {
-                if( here.furn( examp ) == furn_f_water_mill_active ) {
+                const furn_id &f = here.furn( examp );
+                if( f == furn_f_water_mill_active ) {
                     here.furn_set( examp, furn_f_water_mill );
-                } else if( here.furn( examp ) == furn_f_wind_mill_active ) {
+                } else if( f == furn_f_wind_mill_active ) {
                     here.furn_set( examp, furn_f_wind_mill );
                 }
                 add_msg( m_info, _( "You stop the milling process." ) );
@@ -6933,9 +6941,10 @@ void iexamine::quern_examine( Character &you, const tripoint_bub_ms &examp )
             add_msg( m_info, _( "Never mind." ) );
             break;
         case 4:
-            if( here.furn( examp ) == furn_f_water_mill_active ) {
+            const furn_id &f = here.furn( examp );
+            if( f == furn_f_water_mill_active ) {
                 here.furn_set( examp, furn_f_water_mill );
-            } else if( here.furn( examp ) == furn_f_wind_mill_active ) {
+            } else if( f == furn_f_wind_mill_active ) {
                 here.furn_set( examp, furn_f_wind_mill );
             }
             for( map_stack::iterator it = items_here.begin(); it != items_here.end(); ) {
@@ -6953,10 +6962,11 @@ void iexamine::quern_examine( Character &you, const tripoint_bub_ms &examp )
 void iexamine::smoker_options( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
-    const bool active = here.furn( examp ) == furn_f_smoking_rack_active ||
-                        here.furn( examp ) == furn_f_metal_smoking_rack_active;
-    const bool portable = here.furn( examp ) == furn_f_metal_smoking_rack ||
-                          here.furn( examp ) == furn_f_metal_smoking_rack_active;
+    const furn_id &f = here.furn( examp );
+    const bool active = f == furn_f_smoking_rack_active ||
+                        f == furn_f_metal_smoking_rack_active;
+    const bool portable = f == furn_f_metal_smoking_rack ||
+                          f == furn_f_metal_smoking_rack_active;
     map_stack items_here = here.i_at( examp );
 
     if( portable && items_here.empty() && active ) {
@@ -6999,9 +7009,9 @@ void iexamine::smoker_options( Character &you, const tripoint_bub_ms &examp )
         }
     }
 
-    const furn_t &f = here.furn( examp ).obj();
-    const itype *type = f.crafting_pseudo_item_type();
-    std::vector<const itype *> ammo_list = f.crafting_ammo_item_types();
+    const furn_t &fo = f.obj();
+    const itype *type = fo.crafting_pseudo_item_type();
+    std::vector<const itype *> ammo_list = fo.crafting_ammo_item_types();
     const bool empty = f_volume == 0_ml;
     const bool full = f_volume >= sm_rack::MAX_FOOD_VOLUME;
     const bool full_portable = f_volume >= sm_rack::MAX_FOOD_VOLUME_PORTABLE;
@@ -7216,8 +7226,9 @@ void iexamine::workbench_internal( Character &you, const tripoint_bub_ms &examp,
             }
         }
     } else {
-        name = here.furn( examp ).obj().name();
-        if( item::type_is_defined( here.furn( examp ).obj().deployed_item ) ) {
+        const furn_t &fo = here.furn( examp ).obj();
+        name = fo.name();
+        if( item::type_is_defined( fo.deployed_item ) ) {
             is_undeployable = true;
         }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2139,7 +2139,7 @@ void iexamine::fswitch( Character &you, const tripoint_bub_ms &examp )
         none( you, examp );
         return;
     }
-    ter_id terid = here.ter( examp );
+    const ter_id &terid = here.ter( examp );
     you.mod_moves( -to_moves<int>( 1_seconds ) );
     tripoint_bub_ms tmp;
     tmp.z() = examp.z();
@@ -2843,7 +2843,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint_bub_ms &tile,
     // The plant furniture has the NOITEM token which prevents adding items on that square,
     // spawned items are moved to an adjacent field instead, but the fertilizer token
     // must be on the square of the plant, therefore this hack:
-    const furn_id old_furn = here.furn( tile );
+    const furn_id &old_furn = here.furn( tile );
     here.furn_set( tile, furn_str_id::NULL_ID() );
     here.spawn_item( tile, itype_fertilizer, 1, 1, calendar::turn );
     here.furn_set( tile, old_furn );
@@ -3550,7 +3550,7 @@ void iexamine::fireplace( Character &you, const tripoint_bub_ms &examp )
 static void fvat_set_empty( const tripoint_bub_ms &pos )
 {
     map &here = get_map();
-    furn_id furn = here.furn( pos );
+    const furn_id &furn = here.furn( pos );
     if( furn == furn_f_fvat_wood_empty || furn == furn_f_fvat_wood_full ) {
         here.furn_set( pos, furn_f_fvat_wood_empty );
     } else {
@@ -3561,7 +3561,7 @@ static void fvat_set_empty( const tripoint_bub_ms &pos )
 static void fvat_set_full( const tripoint_bub_ms &pos )
 {
     map &here = get_map();
-    furn_id furn = here.furn( pos );
+    const furn_id &furn = here.furn( pos );
     if( furn == furn_f_fvat_wood_empty || furn == furn_f_fvat_wood_full ) {
         here.furn_set( pos, furn_f_fvat_wood_full );
     } else {
@@ -3783,7 +3783,7 @@ void iexamine::fvat_full( Character &you, const tripoint_bub_ms &examp )
 static void compost_set_empty( const tripoint_bub_ms &pos )
 {
     map &here = get_map();
-    furn_id furn = here.furn( pos );
+    const furn_id &furn = here.furn( pos );
     if( furn == furn_f_compost_empty || furn == furn_f_compost_full ) {
         here.furn_set( pos, furn_f_compost_empty );
     }
@@ -3792,7 +3792,7 @@ static void compost_set_empty( const tripoint_bub_ms &pos )
 static void compost_set_full( const tripoint_bub_ms &pos )
 {
     map &here = get_map();
-    furn_id furn = here.furn( pos );
+    const furn_id &furn = here.furn( pos );
     if( furn == furn_f_compost_empty || furn == furn_f_compost_full ) {
         here.furn_set( pos, furn_f_compost_full );
     }
@@ -4080,7 +4080,7 @@ static void displace_items_except_one_liquid( const tripoint_bub_ms &examp )
 {
     map &here = get_map();
     // Temporarily replace the real furniture with a fake furniture with NOITEM
-    const furn_id previous_furn = here.furn( examp );
+    const furn_id &previous_furn = here.furn( examp );
     here.furn_set( examp, furn_id( "f_no_item" ) );
 
     bool liquid_present = false;
@@ -4940,7 +4940,7 @@ void iexamine::curtains( Character &you, const tripoint_bub_ms &examp )
         return;
     }
 
-    const ter_id ter = here.ter( examp );
+    const ter_id &ter = here.ter( examp );
 
     // Peek through the curtains, or tear them down.
     uilist window_menu;
@@ -5032,7 +5032,7 @@ static int getNearPumpCount( const tripoint_bub_ms &p, fuel_station_fuel_type &f
     int result = 0;
     map &here = get_map();
     for( const tripoint_bub_ms &tmp : here.points_in_radius( p, 12 ) ) {
-        const ter_id t = here.ter( tmp );
+        const ter_id &t = here.ter( tmp );
         if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
             result++;
             fuel_type = FUEL_TYPE_GASOLINE;
@@ -5055,7 +5055,7 @@ std::optional<tripoint_bub_ms> iexamine::getNearFilledGasTank( const tripoint_bu
     map &here = get_map();
     for( const tripoint_bub_ms &tmp : here.points_in_radius( center, SEEX * 2 ) ) {
 
-        furn_id check_for_fuel_tank = here.furn( tmp );
+        const furn_id &check_for_fuel_tank = here.furn( tmp );
 
         if( ( fuel_type == FUEL_TYPE_GASOLINE && check_for_fuel_tank != furn_f_gas_tank ) ||
             ( fuel_type == FUEL_TYPE_DIESEL && check_for_fuel_tank != furn_f_diesel_tank ) ) {
@@ -5158,7 +5158,7 @@ std::optional<tripoint_bub_ms> iexamine::getGasPumpByNumber( const tripoint_bub_
     int k = 0;
     map &here = get_map();
     for( const tripoint_bub_ms &tmp : here.points_in_radius( p, 12 ) ) {
-        const ter_id t = here.ter( tmp );
+        const ter_id &t = here.ter( tmp );
         if( ( t == ter_t_gas_pump || t == ter_t_gas_pump_a
               || t == ter_t_diesel_pump || t == ter_t_diesel_pump_a ) && number == k++ ) {
             return tmp;
@@ -5205,8 +5205,8 @@ static int fromPumpFuel( const tripoint_bub_ms &dst, const tripoint_bub_ms &src 
             item liq_d( item_it->type, calendar::turn, amount );
 
             // add the charges to the destination
-            const ter_id backup_ter = here.ter( dst );
-            const furn_id backup_furn = here.furn( dst );
+            const ter_id &backup_ter = here.ter( dst );
+            const furn_id &backup_furn = here.furn( dst );
             here.ter_set( dst, ter_str_id::NULL_ID() );
             here.furn_set( dst, furn_str_id::NULL_ID() );
             here.add_item_or_charges( dst, liq_d );
@@ -5227,7 +5227,7 @@ static void turnOnSelectedPump( const tripoint_bub_ms &p, int number,
     int k = 0;
     map &here = get_map();
     for( const tripoint_bub_ms &tmp : here.points_in_radius( p, 12 ) ) {
-        const ter_id t = here.ter( tmp );
+        const ter_id &t = here.ter( tmp );
         if( fuel_type == FUEL_TYPE_GASOLINE ) {
             if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
                 if( number == k++ ) {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -524,21 +524,23 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
     provisioned_pseudo_tools.clear();
 
     for( const tripoint &p : pts ) {
+        const ter_id &t = m.ter( p );
         // a temporary hack while trees are terrain
-        if( m.ter( p )->has_flag( ter_furn_flag::TFLAG_TREE ) ) {
+        if( t->has_flag( ter_furn_flag::TFLAG_TREE ) ) {
             provide_pseudo_item( itype_butchery_tree_pseudo );
         }
         // Another terrible hack, as terrain can't provide pseudo items, and construction can't do multi-step furniture
         ter_id brick_oven( "t_brick_oven" );
-        if( m.ter( p ) == brick_oven ) {
+        if( t == brick_oven ) {
             provide_pseudo_item( itype_brick_oven_pseudo );
         }
-        const furn_t &f = m.furn( p ).obj();
-        if( item *furn_item = provide_pseudo_item( f.crafting_pseudo_item ) ) {
-            for( const itype *ammo : f.crafting_ammo_item_types() ) {
+        const furn_id &f = m.furn( p );
+        const furn_t &fo = f.obj();
+        if( item *furn_item = provide_pseudo_item( fo.crafting_pseudo_item ) ) {
+            for( const itype *ammo : fo.crafting_ammo_item_types() ) {
                 if( furn_item->has_pocket_type( pocket_type::MAGAZINE ) ) {
                     // NOTE: This only works if the pseudo item has a MAGAZINE pocket, not a MAGAZINE_WELL!
-                    const bool using_ammotype = f.has_flag( ter_furn_flag::TFLAG_AMMOTYPE_RELOAD );
+                    const bool using_ammotype = fo.has_flag( ter_furn_flag::TFLAG_AMMOTYPE_RELOAD );
                     int amount = 0;
                     itype_id ammo_id = ammo->get_id();
                     // Some furniture can consume more than one item type.
@@ -584,7 +586,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
         }
 
         // keg-kludge
-        if( m.furn( p )->has_examine( iexamine::keg ) ) {
+        if( f->has_examine( iexamine::keg ) ) {
             map_stack liq_contained = m.i_at( p );
             for( item &i : liq_contained ) {
                 if( i.made_of( phase_id::LIQUID ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13325,8 +13325,9 @@ bool item::process_corpse( map &here, Character *carrier, const tripoint &pos )
 
 bool item::process_fake_mill( map &here, Character * /*carrier*/, const tripoint &pos )
 {
-    if( here.furn( pos ) != furn_f_wind_mill_active &&
-        here.furn( pos ) != furn_f_water_mill_active ) {
+    const furn_id &f = here.furn( pos );
+    if( f != furn_f_wind_mill_active &&
+        f != furn_f_water_mill_active ) {
         item_counter = 0;
         return true; //destroy fake mill
     }
@@ -13340,8 +13341,9 @@ bool item::process_fake_mill( map &here, Character * /*carrier*/, const tripoint
 
 bool item::process_fake_smoke( map &here, Character * /*carrier*/, const tripoint &pos )
 {
-    if( here.furn( pos ) != furn_f_smoking_rack_active &&
-        here.furn( pos ) != furn_f_metal_smoking_rack_active ) {
+    const furn_id &f = here.furn( pos );
+    if( f != furn_f_smoking_rack_active &&
+        f != furn_f_metal_smoking_rack_active ) {
         item_counter = 0;
         return true; //destroy fake smoke
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2808,8 +2808,8 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint &pos )
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->prying->valid();
-        } else if( !here.ter( pnt )->is_null() ) {
-            return here.ter( pnt )->prying->valid();
+        } else if( const ter_id &t = here.ter( pnt ); !t->is_null() ) {
+            return t->prying->valid();
         }
         return false;
     };
@@ -4740,8 +4740,8 @@ std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint & )
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->oxytorch->valid();
-        } else if( !here.ter( pnt )->is_null() ) {
-            return here.ter( pnt )->oxytorch->valid();
+        } else if( const ter_id &t = here.ter( pnt ); !t->is_null() ) {
+            return t->oxytorch->valid();
         }
         return false;
     };
@@ -4784,8 +4784,8 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint &it_pnt
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->hacksaw->valid();
-        } else if( !here.ter( pnt )->is_null() ) {
-            return here.ter( pnt )->hacksaw->valid();
+        } else if( const ter_id &t = here.ter( pnt ); !t->is_null() ) {
+            return t->hacksaw->valid();
         }
         return false;
     };
@@ -4827,8 +4827,8 @@ std::optional<int> iuse::boltcutters( Character *p, item *it, const tripoint & )
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->boltcut->valid();
-        } else if( !here.ter( pnt )->is_null() ) {
-            return here.ter( pnt )->boltcut->valid();
+        } else if( const ter_id &t = here.ter( pnt ); !t->is_null() ) {
+            return t->boltcut->valid();
         }
         return false;
     };

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4692,7 +4692,7 @@ std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint & )
     };
     map &here = get_map();
     const std::function<bool( const tripoint & )> f = [&allowed_ter_id, &here]( const tripoint & pnt ) {
-        const ter_id type = here.ter( pnt );
+        const ter_id &type = here.ter( pnt );
         const bool is_allowed_terrain = allowed_ter_id.find( type.id() ) != allowed_ter_id.end();
         return is_allowed_terrain;
     };
@@ -5877,7 +5877,7 @@ static std::string colorized_ter_name_flags_at( const tripoint &point,
         const std::vector<std::string> &flags, const std::vector<ter_str_id> &ter_whitelist )
 {
     map &here = get_map();
-    const ter_id ter = here.ter( point );
+    const ter_id &ter = here.ter( point );
     std::string name = colorize( ter->name(), ter->color() );
     const std::string &graffiti_message = here.graffiti_at( point );
 
@@ -5913,7 +5913,7 @@ static std::string colorized_feature_description_at( const tripoint &center_poin
 {
     item_found = false;
     map &here = get_map();
-    const furn_id furn = here.furn( center_point );
+    const furn_id &furn = here.furn( center_point );
     if( furn != furn_str_id::NULL_ID() && furn.is_valid() ) {
         std::string furn_str = colorize( furn->name(), c_yellow );
         std::string sign_message = here.get_signage( center_point );
@@ -6334,8 +6334,8 @@ static item::extended_photo_def photo_def_for_camera_point( const tripoint &aim_
         found_item_aim_point = !item.is_null();
     }
 
-    const ter_id ter_aim = here.ter( aim_point );
-    const furn_id furn_aim = here.furn( aim_point );
+    const ter_id &ter_aim = here.ter( aim_point );
+    const furn_id &furn_aim = here.furn( aim_point );
 
     if( !description_figures_status.empty() ) {
         std::string names = enumerate_as_string( description_figures_status.begin(),

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5258,7 +5258,7 @@ bool deploy_tent_actor::check_intact( const tripoint_bub_ms &center ) const
 {
     map &here = get_map();
     for( const tripoint_bub_ms &dest : here.points_in_radius( center, radius ) ) {
-        const furn_id fid = here.furn( dest );
+        const furn_id &fid = here.furn( dest );
         if( dest == center && floor_center ) {
             if( fid != *floor_center ) {
                 return false;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -486,11 +486,11 @@ void map::generate_lightmap( const int zlev )
                         add_light_from_items( p, i_at( p ) );
                     }
 
-                    const ter_id terrain = cur_submap->get_ter( { sx, sy } );
+                    const ter_id &terrain = cur_submap->get_ter( { sx, sy } );
                     if( terrain->light_emitted > 0 ) {
                         add_light_source( p, terrain->light_emitted );
                     }
-                    const furn_id furniture = cur_submap->get_furn( {sx, sy } );
+                    const furn_id &furniture = cur_submap->get_furn( {sx, sy } );
                     if( furniture->light_emitted > 0 ) {
                         add_light_source( p, furniture->light_emitted );
                     }

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -216,10 +216,10 @@ std::optional<std::pair<trap_str_id, std::pair<translation, bool>>> ter_furn_tra
 void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) const
 {
     avatar &you = get_avatar();
-    const ter_id ter_at_loc = m.ter( location );
+    const ter_id &ter_at_loc = m.ter( location );
     std::optional<std::pair<ter_str_id, std::pair<translation, bool>>> ter_potential = next_ter(
                 ter_at_loc->id );
-    const furn_id furn_at_loc = m.furn( location );
+    const furn_id &furn_at_loc = m.furn( location );
     std::optional<std::pair<furn_str_id, std::pair<translation, bool>>> furn_potential = next_furn(
                 furn_at_loc->id );
     const trap_str_id trap_at_loc = m.maptile_at( location ).get_trap().id();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1796,9 +1796,9 @@ bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, cons
         debugmsg( "Tried to set furniture at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return false;
     }
-    const furn_id new_target_furniture = new_furniture == furn_f_clear ? furn_str_id::NULL_ID() :
-                                         new_furniture;
-    const furn_id old_id = current_submap->get_furn( l );
+    const furn_id &new_target_furniture = new_furniture == furn_f_clear ? furn_str_id::NULL_ID() :
+                                          new_furniture;
+    const furn_id &old_id = current_submap->get_furn( l );
     if( old_id == new_target_furniture ) {
         // Nothing changed
         return true;
@@ -1817,7 +1817,7 @@ bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, cons
         !new_f.has_flag( ter_furn_flag::TFLAG_ALLOW_ON_OPEN_AIR ) &&
         !new_f.has_flag( ter_furn_flag::TFLAG_FLOATS_IN_AIR ) &&
         new_target_furniture != furn_str_id::NULL_ID() ) {
-        const ter_id current_ter = current_submap->get_ter( l );
+        const ter_id &current_ter = current_submap->get_ter( l );
         debugmsg( "Setting furniture %s at %s where terrain is %s (which is_open_air)\n"
                   "If this is intentional, set the ALLOW_ON_OPEN_AIR flag on the furniture",
                   new_target_furniture.id().str(), p.to_string(), current_ter.id().str() );
@@ -2220,7 +2220,7 @@ uint8_t map::get_known_rotates_to_f( const tripoint_bub_ms &p,
  */
 const harvest_id &map::get_harvest( const tripoint_bub_ms &pos ) const
 {
-    const furn_id furn_here = furn( pos );
+    const furn_id &furn_here = furn( pos );
     if( !furn_here->has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
         const harvest_id &harvest = furn_here->get_harvest();
         if( !harvest.is_null() ) {
@@ -2228,7 +2228,7 @@ const harvest_id &map::get_harvest( const tripoint_bub_ms &pos ) const
         }
     }
 
-    const ter_id ter_here = ter( pos );
+    const ter_id &ter_here = ter( pos );
     if( ter_here->has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
         return harvest_id::NULL_ID();
     }
@@ -2244,7 +2244,7 @@ const std::set<std::string> &map::get_harvest_names( const tripoint &pos ) const
 const std::set<std::string> &map::get_harvest_names( const tripoint_bub_ms &pos ) const
 {
     static const std::set<std::string> null_harvest_names = {};
-    const furn_id furn_here = furn( pos );
+    const furn_id &furn_here = furn( pos );
     if( furn_here->can_examine( pos ) ) {
         if( furn_here->has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
             return null_harvest_names;
@@ -2253,7 +2253,7 @@ const std::set<std::string> &map::get_harvest_names( const tripoint_bub_ms &pos 
         return furn_here->get_harvest_names();
     }
 
-    const ter_id ter_here = ter( pos );
+    const ter_id &ter_here = ter( pos );
     if( ter_here->has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
         return null_harvest_names;
     }
@@ -2315,7 +2315,7 @@ bool map::ter_set( const tripoint_bub_ms &p, const ter_id &new_terrain, bool avo
         debugmsg( "Tried to set terrain at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return true;
     }
-    const ter_id old_id = current_submap->get_ter( l );
+    const ter_id &old_id = current_submap->get_ter( l );
     if( old_id == new_terrain ) {
         // Nothing changed
         return false;
@@ -2833,7 +2833,7 @@ bool map::supports_above( const tripoint_bub_ms &p ) const
         return true;
     }
 
-    const furn_id frn_id = tile.get_furn();
+    const furn_id &frn_id = tile.get_furn();
     if( frn_id != furn_str_id::NULL_ID() ) {
         const furn_t &frn = frn_id.obj();
         if( frn.movecost < 0 ) {
@@ -2880,7 +2880,7 @@ void map::drop_everything( const tripoint_bub_ms &p )
 
 void map::drop_furniture( const tripoint_bub_ms &p )
 {
-    const furn_id frn = furn( p );
+    const furn_id &frn = furn( p );
     if( frn == furn_str_id::NULL_ID() || frn->has_flag( ter_furn_flag::TFLAG_FLOATS_IN_AIR ) ) {
         return;
     }
@@ -2908,7 +2908,7 @@ void map::drop_furniture( const tripoint_bub_ms &p )
             return SS_GOOD_SUPPORT;
         }
 
-        const furn_id frn_id = furn( below_dest );
+        const furn_id &frn_id = furn( below_dest );
         if( frn_id != furn_str_id::NULL_ID() ) {
             const furn_t &frn = frn_id.obj();
             // Allow crushing tiny/nocollide furniture
@@ -4406,7 +4406,7 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
             // Take the tent down
             const int rad = tentp->second.obj().bash.collapse_radius;
             for( const tripoint_bub_ms &pt : points_in_radius( tentp->first, rad ) ) {
-                const furn_id frn = furn( pt );
+                const furn_id &frn = furn( pt );
                 if( frn == furn_str_id::NULL_ID() ) {
                     continue;
                 }
@@ -4769,8 +4769,8 @@ void map::shoot( const tripoint_bub_ms &p, projectile &proj, const bool hit_item
         return false;
     };
 
-    furn_id furniture = furn( p );
-    ter_id terrain = ter( p );
+    const furn_id &furniture = furn( p );
+    const ter_id &terrain = ter( p );
     bool hit_something = false;
 
     // shoot through furniture or terrain and see if we hit something
@@ -4846,7 +4846,7 @@ bool map::hit_with_acid( const tripoint_bub_ms &p )
     if( passable( p ) ) {
         return false;    // Didn't hit the tile!
     }
-    const ter_id t = ter( p );
+    const ter_id &t = ter( p );
     if( t == ter_t_wall_glass || t == ter_t_wall_glass_alarm ||
         t == ter_t_vat ) {
         ter_set( p, ter_t_floor );
@@ -7782,7 +7782,7 @@ int map::obstacle_coverage( const tripoint_bub_ms &loc1, const tripoint_bub_ms &
         obstaclepos = new_point;
         return false;
     } );
-    if( const furn_id obstacle_f = furn( tripoint_bub_ms( obstaclepos ) ) ) {
+    if( const furn_id &obstacle_f = furn( tripoint_bub_ms( obstaclepos ) ) ) {
         return obstacle_f->coverage;
     }
     if( const optional_vpart_position vp = veh_at( tripoint_bub_ms( obstaclepos ) ) ) {
@@ -7831,7 +7831,7 @@ int map::ledge_coverage( const Creature &viewer, const tripoint_bub_ms &target_p
         }
     }
     // Viewer eye level is higher when standing on furniture
-    const furn_id viewer_furn = furn( viewer_p );
+    const furn_id &viewer_furn = furn( viewer_p );
     if( viewer_furn.obj().id ) {
         eye_level += viewer_furn->coverage * 0.01f;
     }
@@ -7889,7 +7889,7 @@ int map::ledge_coverage( const tripoint_bub_ms &viewer_p, const tripoint_bub_ms 
         return 0;
     }
     // Target has a coverage penalty when standing on furniture
-    const furn_id target_furn = furn( target_p );
+    const furn_id &target_furn = furn( target_p );
     if( target_furn ) {
         ledge_coverage -= target_furn->coverage;
     }
@@ -7904,7 +7904,7 @@ int map::coverage( const tripoint &p ) const
 
 int map::coverage( const tripoint_bub_ms &p ) const
 {
-    if( const furn_id obstacle_f = furn( p ) ) {
+    if( const furn_id &obstacle_f = furn( p ) ) {
         return obstacle_f->coverage;
     }
     if( const optional_vpart_position vp = veh_at( p ) ) {
@@ -8970,7 +8970,7 @@ void map::rad_scorch( const tripoint_bub_ms &p, const time_duration &time_since_
         furn_set( p, furn_str_id::NULL_ID() );
     }
 
-    const ter_id tid = ter( p );
+    const ter_id &tid = ter( p );
     // TODO: De-hardcode this
     static const std::map<ter_id, ter_str_id> dies_into {{
             {ter_t_grass, ter_t_dirt},
@@ -9109,7 +9109,7 @@ void map::add_tree_tops( const tripoint_rel_sm &grid )
 
     for( int x = 0; x < SEEX; x++ ) {
         for( int y = 0; y < SEEY; y++ ) {
-            const ter_id ter_here = sub_here->get_ter( { x, y } );
+            const ter_id &ter_here = sub_here->get_ter( { x, y } );
             if( !ter_here.id()->has_flag( "EMPTY_SPACE" ) ) {
                 continue;
             }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1538,8 +1538,9 @@ static bool mx_reed( map &m, const tripoint &abs_sub )
             if( p == loc ) {
                 continue;
             }
-            if( m.ter( p ) == ter_t_water_moving_sh || m.ter( p ) == ter_t_water_sh ||
-                m.ter( p ) == ter_t_water_moving_dp || m.ter( p ) == ter_t_water_dp ) {
+            const ter_id &t = m.ter( p );
+            if( t == ter_t_water_moving_sh || t == ter_t_water_sh ||
+                t == ter_t_water_moving_dp || t == ter_t_water_dp ) {
                 return true;
             }
         }
@@ -2122,7 +2123,8 @@ static bool mx_city_trap( map &/*m*/, const tripoint &abs_sub )
 
     //Then find an empty 3x3 pavement square (no other traps, furniture, or vehicles)
     for( const tripoint_omt_ms &p : points_in_radius( trap_center, 1 ) ) {
-        if( ( compmap.ter( p ) == ter_t_pavement || compmap.ter( p ) == ter_t_pavement_y ) &&
+        const ter_id &t = compmap.ter( p );
+        if( ( t == ter_t_pavement || t == ter_t_pavement_y ) &&
             compmap.tr_at( p ).is_null() &&
             compmap.furn( p ) == furn_str_id::NULL_ID() &&
             !compmap.veh_at( p ) ) {

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -272,7 +272,7 @@ static void dead_vegetation_parser( map &m, const tripoint &loc )
         m.spawn_item( loc, itype_withered );
     }
     // terrain specific conversions
-    const ter_id tid = m.ter( loc );
+    const ter_id &tid = m.ter( loc );
     static const std::map<ter_id, ter_str_id> dies_into {{
             {ter_t_grass, ter_t_grass_dead},
             {ter_t_grass_long, ter_t_grass_dead},
@@ -1342,7 +1342,7 @@ static bool mx_clay_deposit( map &m, const tripoint &abs_sub )
 static void burned_ground_parser( map &m, const tripoint &loc )
 {
     const furn_t &fid = m.furn( loc ).obj();
-    const ter_id tid = m.ter( loc );
+    const ter_id &tid = m.ter( loc );
     const ter_t &tr = tid.obj();
 
     VehicleList vehs = m.get_vehicles();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1853,13 +1853,27 @@ void mapgen_parameters::check_and_merge( const mapgen_parameters &other,
     }
 }
 
+ret_val<void> jmapgen_piece_with_has_vehicle_collision::has_vehicle_collision(
+    const mapgendata &dat,
+    const tripoint_rel_ms &p ) const
+{
+    const optional_vpart_position &vp = dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
+                                        dat.zlevel() + p.z() ) );
+    if( vp.has_value() ) {
+        return ret_val<void>::make_failure( vp.value().vehicle().disp_name() );
+    } else {
+        return ret_val<void>::make_success();
+    }
+}
+
+
 /**
  * This is a generic mapgen piece, the template parameter PieceType should be another specific
  * type of jmapgen_piece. This class contains a vector of those objects and will chose one of
  * it at random.
  */
 template<typename PieceType>
-class jmapgen_alternatively : public jmapgen_piece
+class jmapgen_alternatively : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         // Note: this bypasses virtual function system, all items in this vector are of type
@@ -1891,15 +1905,6 @@ class jmapgen_alternatively : public jmapgen_piece
                     const std::string &context ) const override {
             if( const auto chosen = random_entry_opt( alternatives ) ) {
                 chosen->get().apply( dat, x, y, z, context );
-            }
-        }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
             }
         }
 };
@@ -2088,7 +2093,7 @@ class jmapgen_faction : public jmapgen_piece
  * Place a sign with some text.
  * "signage": the text on the sign.
  */
-class jmapgen_sign : public jmapgen_piece
+class jmapgen_sign : public jmapgen_piece_with_has_vehicle_collision
 {
     private:
         furn_id sign_furniture;
@@ -2136,15 +2141,6 @@ class jmapgen_sign : public jmapgen_piece
             signtext = SNIPPET.expand( signtext );
             replace_city_tag( signtext, cityname );
             return signtext;
-        }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
-            }
         }
 };
 /**
@@ -2198,7 +2194,7 @@ class jmapgen_graffiti : public jmapgen_piece
  * Place a vending machine with content.
  * "item_group": the item group that is used to generate the content of the vending machine.
  */
-class jmapgen_vending_machine : public jmapgen_piece
+class jmapgen_vending_machine : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         bool reinforced;
@@ -2225,15 +2221,6 @@ class jmapgen_vending_machine : public jmapgen_piece
             }
             dat.m.place_vending( r, chosen_id, reinforced, lootable, powered );
         }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
-            }
-        }
 
         void check( const std::string &oter_name, const mapgen_parameters &parameters,
                     const jmapgen_int &/*x*/, const jmapgen_int &/*y*/, const jmapgen_int &/*z*/
@@ -2245,7 +2232,7 @@ class jmapgen_vending_machine : public jmapgen_piece
  * Place a toilet with (dirty) water in it.
  * "amount": number of water charges to place.
  */
-class jmapgen_toilet : public jmapgen_piece
+class jmapgen_toilet : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         jmapgen_int amount;
@@ -2266,21 +2253,12 @@ class jmapgen_toilet : public jmapgen_piece
                 dat.m.place_toilet( r, charges );
             }
         }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
-            }
-        }
 };
 /**
  * Place a gas pump with fuel in it.
  * "amount": number of fuel charges to place.
  */
-class jmapgen_gaspump : public jmapgen_piece
+class jmapgen_gaspump : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         jmapgen_int amount;
@@ -2320,15 +2298,6 @@ class jmapgen_gaspump : public jmapgen_piece
                 dat.m.place_gas_pump( r, charges );
             } else {
                 dat.m.place_gas_pump( r, charges, chosen_fuel );
-            }
-        }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
             }
         }
 };
@@ -2734,7 +2703,7 @@ static inclusive_rectangle<point> vehicle_bounds( const vehicle_prototype &vp )
  * "fuel": fuel status of the vehicle, see @ref vehicle::vehicle
  * "status": overall (damage) status of the vehicle, see @ref vehicle::vehicle
  */
-class jmapgen_vehicle : public jmapgen_piece
+class jmapgen_vehicle : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         mapgen_value<vgroup_id> type;
@@ -2779,15 +2748,6 @@ class jmapgen_vehicle : public jmapgen_piece
             }
             if( get_map().inbounds( dat.m.getglobal( dst ) ) ) {
                 dat.m.queue_main_cleanup();
-            }
-        }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
             }
         }
 
@@ -2980,7 +2940,7 @@ class jmapgen_spawn_item : public jmapgen_piece
  * Place a trap.
  * "trap": id of the trap.
  */
-class jmapgen_trap : public jmapgen_piece
+class jmapgen_trap : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         mapgen_value<trap_id> id;
@@ -3015,15 +2975,6 @@ class jmapgen_trap : public jmapgen_piece
                 dat.m.trap_set( actual_loc, chosen_id );
             }
         }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
-            }
-        }
 
         void check( const std::string &oter_name, const mapgen_parameters &parameters,
                     const jmapgen_int &/*x*/, const jmapgen_int &/*y*/, const jmapgen_int &/*z*/
@@ -3039,7 +2990,7 @@ class jmapgen_trap : public jmapgen_piece
  * Place a furniture.
  * "furn": id of the furniture.
  */
-class jmapgen_furniture : public jmapgen_piece
+class jmapgen_furniture : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         mapgen_value<furn_id> id;
@@ -3059,15 +3010,6 @@ class jmapgen_furniture : public jmapgen_piece
                 debugmsg( "Problem setting furniture in %s", context );
             }
         }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
-            }
-        }
 
         void check( const std::string &oter_name, const mapgen_parameters &parameters,
                     const jmapgen_int &/*x*/, const jmapgen_int &/*y*/, const jmapgen_int &/*z*/
@@ -3079,7 +3021,7 @@ class jmapgen_furniture : public jmapgen_piece
  * Place terrain.
  * "ter": id of the terrain.
  */
-class jmapgen_terrain : public jmapgen_piece
+class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
 {
     private:
         enum apply_action {
@@ -3233,15 +3175,6 @@ class jmapgen_terrain : public jmapgen_piece
             }
             dat.m.ter_set( p, chosen_id );
         }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
-            }
-        }
 
         void check( const std::string &oter_name, const mapgen_parameters &parameters,
                     const jmapgen_int &/*x*/, const jmapgen_int &/*y*/, const jmapgen_int &/*z*/
@@ -3328,7 +3261,7 @@ class jmapgen_make_rubble : public jmapgen_piece
  * @param options Array of @ref computer_option
  * @param failures Array of failure effects (see @ref computer_failure)
  */
-class jmapgen_computer : public jmapgen_piece
+class jmapgen_computer : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         translation name;
@@ -3392,15 +3325,6 @@ class jmapgen_computer : public jmapgen_piece
                 cpu->set_access_denied_msg( access_denied.translated() );
             }
         }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
-            }
-        }
 };
 
 /**
@@ -3409,7 +3333,7 @@ class jmapgen_computer : public jmapgen_piece
  * "items": item group to spawn (object with usual parameters).
  * "furniture": furniture to create around it.
  */
-class jmapgen_sealed_item : public jmapgen_piece
+class jmapgen_sealed_item : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         mapgen_value<furn_id> furniture;
@@ -3534,15 +3458,6 @@ class jmapgen_sealed_item : public jmapgen_piece
             }
             furn_id chosen_furn = furniture.get( dat );
             dat.m.furn_set( tripoint_bub_ms( x.get(), y.get(), dat.zlevel() + z.get() ), chosen_furn );
-        }
-        ret_val<void> has_vehicle_collision( const mapgendata &dat,
-                                             const tripoint_rel_ms &p ) const override {
-            if( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value() ) {
-                return ret_val<void>::make_failure( dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(),
-                                                    dat.zlevel() + p.z() ) ).value().vehicle().disp_name() );
-            } else {
-                return ret_val<void>::make_success();
-            }
         }
 };
 
@@ -5362,8 +5277,9 @@ ret_val<void> jmapgen_setmap::has_vehicle_collision( const mapgendata &dat,
             return ret_val<void>::make_success();
     }
     for( const tripoint_bub_ms &p : dat.m.points_in_rectangle( start, end ) ) {
-        if( dat.m.veh_at( p ) ) {
-            return ret_val<void>::make_failure( dat.m.veh_at( p ).value().vehicle().disp_name() );
+        const optional_vpart_position &vp = dat.m.veh_at( p );
+        if( vp ) {
+            return ret_val<void>::make_failure( vp.value().vehicle().disp_name() );
         }
     }
     return ret_val<void>::make_success();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3002,7 +3002,7 @@ class jmapgen_furniture : public jmapgen_piece_with_has_vehicle_collision
         }
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
                     const std::string &context ) const override {
-            furn_id chosen_id = id.get( dat );
+            const furn_id &chosen_id = id.get( dat );
             if( chosen_id.id().is_null() ) {
                 return;
             }
@@ -3042,13 +3042,13 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
 
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
                     const std::string &context ) const override {
-            ter_id chosen_id = id.get( dat );
+            const ter_id &chosen_id = id.get( dat );
             if( chosen_id.id().is_null() ) {
                 return;
             }
             tripoint_bub_ms p( x.get(), y.get(), dat.zlevel() + z.get() );
 
-            ter_id terrain_here = dat.m.ter( p );
+            const ter_id &terrain_here = dat.m.ter( p );
             const ter_t &chosen_ter = *chosen_id;
             const bool is_wall = chosen_ter.has_flag( ter_furn_flag::TFLAG_WALL );
             const bool place_item = chosen_ter.has_flag( ter_furn_flag::TFLAG_PLACE_ITEM );
@@ -3235,7 +3235,7 @@ class jmapgen_make_rubble : public jmapgen_piece
         }
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
                     const std::string &/*context*/ ) const override {
-            furn_id chosen_rubble_type = rubble_type.get( dat );
+            const furn_id &chosen_rubble_type = rubble_type.get( dat );
             ter_id chosen_floor_type = floor_type.get( dat );
             if( chosen_rubble_type.id().is_null() ) {
                 return;
@@ -3456,7 +3456,7 @@ class jmapgen_sealed_item : public jmapgen_piece_with_has_vehicle_collision
             if( item_group_spawner ) {
                 item_group_spawner->apply( dat, x, y, z,  context );
             }
-            furn_id chosen_furn = furniture.get( dat );
+            const furn_id &chosen_furn = furniture.get( dat );
             dat.m.furn_set( tripoint_bub_ms( x.get(), y.get(), dat.zlevel() + z.get() ), chosen_furn );
         }
 };
@@ -6067,7 +6067,7 @@ void map::draw_lab( mapgendata &dat )
                         // liquid floors.
                         break;
                     }
-                    ter_id fluid_type = one_in( 3 ) ? ter_t_sewage : ter_t_water_sh;
+                    const ter_id &fluid_type = one_in( 3 ) ? ter_t_sewage : ter_t_water_sh;
                     for( int i = 0; i < EAST_EDGE; i++ ) {
                         for( int j = 0; j < SOUTH_EDGE; j++ ) {
                             // We spare some terrain to make it look better visually.
@@ -6095,7 +6095,7 @@ void map::draw_lab( mapgendata &dat )
                         // liquid floors.
                         break;
                     }
-                    ter_id fluid_type = one_in( 3 ) ? ter_t_sewage : ter_t_water_sh;
+                    const ter_id &fluid_type = one_in( 3 ) ? ter_t_sewage : ter_t_water_sh;
                     for( int i = 0; i < 2; ++i ) {
                         draw_rough_circle( [this, fluid_type]( const point & p ) {
                             const ter_id &maybe_flood_ter = ter( p );
@@ -8208,12 +8208,12 @@ std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_up
     if( update_function->second.funcs()[0]->update_map( fake_md ).success() ) {
         for( int z = -OVERMAP_DEPTH; z <= OVERMAP_DEPTH; z++ ) {
             for( const tripoint_omt_ms &pos : tmp_map.points_on_zlevel( z ) ) {
-                ter_id ter_at_pos = tmp_map.ter( pos );
+                const ter_id &ter_at_pos = tmp_map.ter( pos );
                 if( ter_at_pos != base_ter ) {
                     terrains[ter_at_pos] += 1;
                 }
                 if( tmp_map.has_furn( pos ) ) {
-                    furn_id furn_at_pos = tmp_map.furn( pos );
+                    const furn_id &furn_at_pos = tmp_map.furn( pos );
                     furnitures[furn_at_pos] += 1;
                 }
             }

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -250,6 +250,14 @@ class jmapgen_piece
         }
 };
 
+class jmapgen_piece_with_has_vehicle_collision : public jmapgen_piece
+{
+    public:
+        ret_val<void> has_vehicle_collision( const mapgendata &dat,
+                                             const tripoint_rel_ms &p ) const override;
+};
+
+
 /**
  * Where to place something on a map.
  */

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -2264,13 +2264,13 @@ void mremove_fields( map *m, const tripoint_bub_ms &p )
 void resolve_regional_terrain_and_furniture( const mapgendata &dat )
 {
     for( const tripoint_bub_ms &p : dat.m.points_on_zlevel() ) {
-        const ter_id tid_before = dat.m.ter( p );
-        const ter_id tid_after = dat.region.region_terrain_and_furniture.resolve( tid_before );
+        const ter_id &tid_before = dat.m.ter( p );
+        const ter_id &tid_after = dat.region.region_terrain_and_furniture.resolve( tid_before );
         if( tid_after != tid_before ) {
             dat.m.ter_set( p, tid_after );
         }
-        const furn_id fid_before = dat.m.furn( p );
-        const furn_id fid_after = dat.region.region_terrain_and_furniture.resolve( fid_before );
+        const furn_id &fid_before = dat.m.furn( p );
+        const furn_id &fid_after = dat.region.region_terrain_and_furniture.resolve( fid_before );
         if( fid_after != fid_before ) {
             dat.m.furn_set( p, fid_after );
         }

--- a/src/mapgenformat.cpp
+++ b/src/mapgenformat.cpp
@@ -21,8 +21,8 @@ void formatted_set_simple( map *m, const point &start, const char *cstr,
             p2.y++;
             p2.x = start.x;
         } else {
-            const ter_id ter = ter_b.translate( *p );
-            const furn_id furn = furn_b.translate( *p );
+            const ter_id &ter = ter_b.translate( *p );
+            const furn_id &furn = furn_b.translate( *p );
             if( ter != ter_str_id::NULL_ID() ) {
                 m->ter_set( p2, ter );
             }

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2799,16 +2799,17 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
     creature_tracker &creatures = get_creature_tracker();
     std::set<item> return_items;
     for( const tripoint_omt_ms &p : bay.points_on_zlevel() ) {
-        const ter_id t = bay.ter( p );
+        const ter_id &t = bay.ter( p );
+        const ter_t &to = t.obj();
         //Open all the doors, doesn't need to be exhaustive
         const std::unordered_set<ter_str_id> openable_doors = {ter_t_door_c, ter_t_door_c_peep, ter_t_door_b, ter_t_door_boarded, ter_t_door_boarded_damaged, ter_t_rdoor_boarded, ter_t_rdoor_boarded_damaged, ter_t_door_boarded_peep, ter_t_door_boarded_damaged_peep };
         if( openable_doors.find( t.id() ) != openable_doors.end() ) {
             bay.ter_set( p, ter_t_door_o );
         } else if( t == ter_t_door_locked || t == ter_t_door_locked_peep || t == ter_t_door_locked_alarm ) {
-            const map_bash_info &bash = bay.ter( p ).obj().bash;
+            const map_bash_info &bash = to.bash;
             bay.ter_set( p, bash.ter_set );
             // Bash doors twice
-            const map_bash_info &bash_again = bay.ter( p ).obj().bash;
+            const map_bash_info &bash_again = to.bash;
             bay.ter_set( p, bash_again.ter_set );
             bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
             bay.spawn_items( p, item_group::items_from( bash_again.drop_group, calendar::turn ) );
@@ -2818,7 +2819,7 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
         } else if( t == ter_t_door_glass_c ) {
             bay.ter_set( p, ter_t_door_glass_o );
         } else if( t == ter_t_wall && one_in( 25 ) ) {
-            const map_bash_info &bash = bay.ter( p ).obj().bash;
+            const map_bash_info &bash = to.bash;
             bay.ter_set( p, bash.ter_set );
             bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
             bay.collapse_at( p, false );
@@ -2826,15 +2827,15 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
         //Smash easily breakable stuff
         else if( const std::unordered_set<ter_str_id> weak_window_ters = {ter_t_window, ter_t_window_taped, ter_t_window_domestic, ter_t_window_boarded_noglass, ter_t_window_domestic_taped, ter_t_window_alarm_taped, ter_t_window_boarded, ter_t_curtains, ter_t_window_alarm, ter_t_window_no_curtains, ter_t_window_no_curtains_taped };
                  weak_window_ters.find( t.id() ) != weak_window_ters.end() && one_in( 4 ) ) {
-            const map_bash_info &bash = bay.ter( p ).obj().bash;
+            const map_bash_info &bash = to.bash;
             bay.ter_set( p, bash.ter_set );
             bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
         } else if( ( t == ter_t_wall_glass || t == ter_t_wall_glass_alarm ) && one_in( 3 ) ) {
-            const map_bash_info &bash = bay.ter( p ).obj().bash;
+            const map_bash_info &bash = to.bash;
             bay.ter_set( p, bash.ter_set );
             bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
-        } else if( bay.has_furn( p ) && bay.furn( p ).obj().bash.str_max != -1 && one_in( 10 ) ) {
-            const map_bash_info &bash = bay.furn( p ).obj().bash;
+        } else if( bay.has_furn( p ) && to.bash.str_max != -1 && one_in( 10 ) ) {
+            const map_bash_info &bash = to.bash;
             bay.furn_set( p, bash.furn_set );
             bay.delete_signage( p );
             bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -98,12 +98,14 @@ static tripoint_omt_ms find_potential_computer_point( const tinymap &compmap )
     std::vector<tripoint_omt_ms> potential;
     std::vector<tripoint_omt_ms> last_resort;
     for( const tripoint_omt_ms &p : compmap.points_on_zlevel() ) {
-        if( compmap.furn( p ) == furn_f_console_broken ) {
+        const furn_id &f = compmap.furn( p );
+        if( f == furn_f_console_broken ) {
             broken.emplace_back( p );
         } else if( broken.empty() && compmap.ter( p ) == ter_t_floor &&
-                   compmap.furn( p ) == furn_str_id::NULL_ID() ) {
+                   f == furn_str_id::NULL_ID() ) {
             for( const tripoint_omt_ms &p2 : compmap.points_in_radius( p, 1 ) ) {
-                if( compmap.furn( p2 ) == furn_f_bed || compmap.furn( p2 ) == furn_f_dresser ) {
+                const furn_id &f = compmap.furn( p2 );
+                if( f == furn_f_bed || f == furn_f_dresser ) {
                     potential.emplace_back( p );
                     break;
                 }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1411,7 +1411,7 @@ bool mattack::growplants( monster *z )
         return true;
     }
     for( const tripoint_bub_ms &p : here.points_in_radius( z->pos_bub(), 5 ) ) {
-        const ter_id ter = here.ter( p );
+        const ter_id &ter = here.ter( p );
         if( ter != ter_t_tree_young && ter != ter_t_underbrush ) {
             // Skip as soon as possible to avoid all the checks
             continue;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -197,7 +197,7 @@ bool monster::know_danger_at( const tripoint &p ) const
     // before hitting simple or complex but this is more explicit
     if( avoid_fire || avoid_fall || avoid_simple ||
         avoid_traps || avoid_dangerous_fields || avoid_sharp ) {
-        const ter_id target = here.ter( p );
+        const ter_id &target = here.ter( p );
         if( !here.has_vehicle_floor( p ) ) {
             // Don't enter lava if we have any concept of heat being bad
             if( avoid_fire && target == ter_t_lava ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2854,7 +2854,7 @@ void monster::process_turn()
                 if( zap != pos_bub() ) {
                     explosion_handler::emp_blast( zap.raw() ); // Fries electronics due to the intensity of the field
                 }
-                const ter_id t = here.ter( zap );
+                const ter_id &t = here.ter( zap );
                 if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
                     if( one_in( 4 ) ) {
                         explosion_handler::explosion( this, pos(), 40, 0.8, true );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4111,8 +4111,9 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
                         break;
                     }
                 } else if( search_type.value() == "furniture" ) {
-                    if( here.furn( search_loc ).id().c_str() == cur_search_target ||
-                        ( !here.furn( search_loc ).id().is_null() && cur_search_target.empty() ) ) {
+                    const furn_str_id &fi = here.furn( search_loc ).id();
+                    if( fi.c_str() == cur_search_target ||
+                        ( !fi.is_null() && cur_search_target.empty() ) ) {
                         target_pos = here.getglobal( search_loc );
                         found = true;
                         break;
@@ -4125,8 +4126,9 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
                         break;
                     }
                 } else if( search_type.value() == "trap" ) {
-                    if( here.tr_at( search_loc ).id.c_str() == cur_search_target ||
-                        ( !here.tr_at( search_loc ).is_null() &&
+                    const trap &tr = here.tr_at( search_loc );
+                    if( tr.id.c_str() == cur_search_target ||
+                        ( !tr.is_null() &&
                           cur_search_target.empty() ) ) {
                         target_pos = here.getglobal( search_loc );
                         found = true;

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -90,9 +90,10 @@ void add_fallback_zone( npc &guy )
     std::vector<tripoint_abs_ms> points;
     for( tripoint_abs_ms const &t : closest_points_first( loc, PICKUP_RANGE ) ) {
         tripoint_bub_ms const t_here = here.bub_from_abs( t );
-        if( here.has_furn( t_here ) &&
-            ( here.furn( t_here )->max_volume > ter_t_floor->max_volume ||
-              here.furn( t_here )->has_flag( ter_furn_flag::TFLAG_CONTAINER ) ) &&
+        const furn_id &f = here.furn( t_here );
+        if( f != furn_str_id::NULL_ID() &&
+            ( f->max_volume > ter_t_floor->max_volume ||
+              f->has_flag( ter_furn_flag::TFLAG_CONTAINER ) ) &&
             here.can_put_items_ter_furn( t_here ) &&
             !here.route( guy.pos_bub(), t_here, guy.get_pathfinding_settings(),
                          guy.get_path_avoid() )

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -91,7 +91,7 @@ SDL_Color get_map_color_at( const tripoint &p )
         return curses_color_to_SDL( vd.color );
     }
 
-    if( const furn_id furn_id = here.furn( p ) ) {
+    if( const furn_id &furn_id = here.furn( p ) ) {
         return curses_color_to_SDL( furn_id->color() );
     }
 

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -59,7 +59,7 @@ int comfort_data::human_comfort_at( const tripoint &p )
 {
     const map &here = get_map();
     const optional_vpart_position vp = here.veh_at( p );
-    const furn_id furn = here.furn( p );
+    const furn_id &furn = here.furn( p );
     const trap &trap = here.tr_at( p );
 
     if( vp ) {
@@ -259,9 +259,9 @@ void comfort_data::response::add_try_msgs( const Character &guy ) const
             }
         } else {
             std::string name;
-            const furn_id furn = here.furn( last_position );
+            const furn_id &furn = here.furn( last_position );
             const trap &trap = here.tr_at( last_position );
-            const ter_id ter = here.ter( last_position );
+            const ter_id &ter = here.ter( last_position );
             if( furn != furn_str_id::NULL_ID() ) {
                 name = furn->name();
             } else if( !trap.is_null() ) {

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -220,9 +220,10 @@ static void board_up( tinymap &m, const tripoint_range<tripoint> &range )
         // If the furniture is movable and the character can move it, use it to barricade
         //  is workable here as NPCs by definition are not starting the game.  (Let's hope.)
         ///\EFFECT_STR determines what furniture might be used as a starting area barricade
-        if( m.furn( p ).obj().is_movable() &&
-            m.furn( p ).obj().move_str_req < get_player_character().get_str() ) {
-            if( m.furn( p ).obj().movecost == 0 ) {
+        const furn_t &fo = m.furn( p ).obj();
+        if( fo.is_movable() &&
+            fo.move_str_req < get_player_character().get_str() ) {
+            if( fo.movecost == 0 ) {
                 // Obstacles are better, prefer them
                 furnitures1.push_back( p );
             } else {

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -183,7 +183,7 @@ static void board_up( tinymap &m, const tripoint_range<tripoint> &range )
     std::vector<tripoint> boardables;
     for( const tripoint &p : range ) {
         bool must_board_around = false;
-        const ter_id t = m.ter( p );
+        const ter_id &t = m.ter( p );
         if( t == ter_t_window_domestic || t == ter_t_window || t == ter_t_window_no_curtains ) {
             // Windows are always to the outside and must be boarded
             must_board_around = true;

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -196,7 +196,7 @@ bool submap::contains_vehicle( vehicle *veh )
 
 bool submap::is_open_air( const point_sm_ms &p ) const
 {
-    ter_id t = get_ter( p );
+    const ter_id &t = get_ter( p );
     return t->trap == tr_ledge;
 }
 

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -226,7 +226,8 @@ void timed_event::actualize()
                 } else if( here.ter( p ) == ter_t_rock_floor ) {
                     bool flood = false;
                     for( const tripoint_bub_ms &w : points_in_radius( p, 1 ) ) {
-                        if( here.ter( w ) == ter_t_water_dp || here.ter( w ) == ter_t_water_sh ) {
+                        const ter_id &t = here.ter( w );
+                        if( t == ter_t_water_dp || t == ter_t_water_sh ) {
                             flood = true;
                             break;
                         }

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1472,28 +1472,29 @@ bool trapfunc::temple_toggle( const tripoint &p, Creature *c, item * )
     if( c->is_avatar() ) {
         add_msg( _( "You hear the grinding of shifting rock." ) );
         map &here = get_map();
-        const ter_id type = here.ter( p );
+        const ter_id &type = here.ter( p );
         tripoint tmp = p;
         int &i = tmp.x;
         int &j = tmp.y;
         for( i = 0; i < MAPSIZE_X; i++ ) {
             for( j = 0; j < MAPSIZE_Y; j++ ) {
+                const ter_id &t = here.ter( tmp );
                 if( type == ter_t_floor_red ) {
-                    if( here.ter( tmp ) == ter_t_rock_green ) {
+                    if( t == ter_t_rock_green ) {
                         here.ter_set( tmp, ter_t_floor_green );
-                    } else if( here.ter( tmp ) == ter_t_floor_green ) {
+                    } else if( t == ter_t_floor_green ) {
                         here.ter_set( tmp, ter_t_rock_green );
                     }
                 } else if( type == ter_t_floor_green ) {
-                    if( here.ter( tmp ) == ter_t_rock_blue ) {
+                    if( t == ter_t_rock_blue ) {
                         here.ter_set( tmp, ter_t_floor_blue );
-                    } else if( here.ter( tmp ) == ter_t_floor_blue ) {
+                    } else if( t == ter_t_floor_blue ) {
                         here.ter_set( tmp, ter_t_rock_blue );
                     }
                 } else if( type == ter_t_floor_blue ) {
-                    if( here.ter( tmp ) == ter_t_rock_red ) {
+                    if( t == ter_t_rock_red ) {
                         here.ter_set( tmp, ter_t_floor_red );
-                    } else if( here.ter( tmp ) == ter_t_floor_red ) {
+                    } else if( t == ter_t_floor_red ) {
                         here.ter_set( tmp, ter_t_rock_red );
                     }
                 }
@@ -1510,18 +1511,20 @@ bool trapfunc::temple_toggle( const tripoint &p, Creature *c, item * )
 
         if( blocked_tiles.size() == 8 ) {
             for( int i = 7; i >= 0 ; --i ) {
-                if( here.ter( blocked_tiles.at( i ) ) != ter_t_rock_red &&
-                    here.ter( blocked_tiles.at( i ) ) != ter_t_rock_green &&
-                    here.ter( blocked_tiles.at( i ) ) != ter_t_rock_blue ) {
+                const ter_id &t = here.ter( blocked_tiles.at( i ) );
+                if( t != ter_t_rock_red &&
+                    t != ter_t_rock_green &&
+                    t != ter_t_rock_blue ) {
                     blocked_tiles.erase( blocked_tiles.begin() + i );
                 }
             }
             const tripoint &pnt = random_entry( blocked_tiles );
-            if( here.ter( pnt ) == ter_t_rock_red ) {
+            const ter_id &t = here.ter( pnt );
+            if( t == ter_t_rock_red ) {
                 here.ter_set( pnt, ter_t_floor_red );
-            } else if( here.ter( pnt ) == ter_t_rock_green ) {
+            } else if( t == ter_t_rock_green ) {
                 here.ter_set( pnt, ter_t_floor_green );
-            } else if( here.ter( pnt ) == ter_t_rock_blue ) {
+            } else if( t == ter_t_rock_blue ) {
                 here.ter_set( pnt, ter_t_floor_blue );
             }
         }

--- a/src/ui_extended_description.cpp
+++ b/src/ui_extended_description.cpp
@@ -94,15 +94,15 @@ extended_description_window::extended_description_window( tripoint_bub_ms &p ) :
         creature_description = critter->extended_description();
     }
     bool sees = get_player_character().sees( p );
-    furn_id furn = get_map().furn( p );
+    const furn_id &furn = get_map().furn( p );
     if( sees && furn ) {
         furniture_description = furn->extended_description();
     }
-    ter_id ter = get_map().ter( p );
+    const ter_id &ter = get_map().ter( p );
     if( sees && ter ) {
         terrain_description = ter->extended_description();
     }
-    const optional_vpart_position vp = get_map().veh_at( p );
+    const optional_vpart_position &vp = get_map().veh_at( p );
     if( sees && vp ) {
         veh_app_description = vp.extended_description();
     }

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -747,12 +747,12 @@ bool vehicle::autodrive_controller::check_drivable( const tripoint_bub_ms &pt ) 
 
     // check for furniture that hinders movement; furniture with 0 move cost
     // can be driven on
-    const furn_id furniture = here.furn( pt );
+    const furn_id &furniture = here.furn( pt );
     if( furniture != furn_str_id::NULL_ID() && furniture.obj().movecost != 0 ) {
         return false;
     }
 
-    const ter_id terrain = here.ter( pt );
+    const ter_id &terrain = here.ter( pt );
     if( terrain == ter_str_id::NULL_ID() ) {
         return false;
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1074,11 +1074,12 @@ void vehicle::operate_planter()
         vehicle_stack v = get_items( vp.part() );
         for( auto i = v.begin(); i != v.end(); i++ ) {
             if( i->is_seed() ) {
+                const ter_id &t = here.ter( loc );
                 // If it is an "advanced model" then it will avoid damaging itself or becoming damaged. It's a real feature.
-                if( here.ter( loc ) != ter_t_dirtmound && vp.has_feature( "ADVANCED_PLANTER" ) ) {
+                if( t != ter_t_dirtmound && vp.has_feature( "ADVANCED_PLANTER" ) ) {
                     //then don't put the item there.
                     break;
-                } else if( here.ter( loc ) == ter_t_dirtmound ) {
+                } else if( t == ter_t_dirtmound ) {
                     here.set( loc, ter_t_dirt, furn_f_plant_seed );
                 } else if( !here.has_flag( ter_furn_flag::TFLAG_PLOWABLE, loc ) ) {
                     //If it isn't plowable terrain, then it will most likely be damaged.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
A lot of places in the code call the same lookup functions for map data repeatedly. This makes some of those sections hard to read if the parameters are not short. It also results in lack of optimization in some cases

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Repeated calls to the map methods in question are replaced with one call and mostly const mostly references. A lot of existing calls that get copied to local vars are are converted to const references.

A dozen mapgen functions with identical `has_vehicle_collision` have been refactors to inherit from a new class that provides that method.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Caching more results in the map classes is an option but would be much more complex.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Automated tests pass. I've played for a while with the changes, and continue to do so.

#### Additional context
I skipped a few places where the repeated calls appear in the middle of a series of conditions so it would be more complex to break them out without changing the order of execution.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
