### PR TITLE
add PRESERVE_SPAWN_OMT for smartphones

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -620,7 +620,17 @@
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
-    "flags": [ "WATCH", "ALARMCLOCK", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "CALORIES_INTAKE", "ELECTRONIC" ],
+    "flags": [
+      "WATCH",
+      "ALARMCLOCK",
+      "USE_UPS",
+      "NO_UNLOAD",
+      "NO_RELOAD",
+      "WATER_BREAK",
+      "CALORIES_INTAKE",
+      "ELECTRONIC",
+      "PRESERVE_SPAWN_OMT"
+    ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 56 } },
       {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Google maps feature was intended to work with spawn_location_omt variable; and i forgot to add flag that stores variable in item on spawn
#### Describe the solution
Add PRESERVE_SPAWN_OMT flag 