### PR TITLE
OMT description fixes

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1030,8 +1030,8 @@ static void draw_om_sidebar( ui_adaptor &ui,
                         vision_level_string = _( "This is a bug!" );
                         break;
                 }
-                lines = fold_and_print( wbar, point( 3, lines + 1 ), getmaxx( wbar ) - 3, c_light_gray,
-                                        vision_level_string );
+                lines += fold_and_print( wbar, point( 3, lines + 1 ), getmaxx( wbar ) - 3, c_light_gray,
+                                         vision_level_string );
             }
         }
     } else {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1534,7 +1534,7 @@ std::string overmapbuffer::get_description_at( const tripoint_abs_sm &where )
     const city_reference closest_cref = closest_known_city( where );
 
     if( !closest_cref ) {
-        return ter_name;
+        return ter_name + "\n" + get_origin( oter->get_type_id()->src );
     }
 
     const struct city &closest_city = *closest_cref.city;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #77111.

#### Describe the solution
Show origin of the content even if there's no cities in the vicinity.

Also. while I'm here, I fixed vision level description overlapping the `Distance to current objective` text.

#### Describe alternatives you've considered
None.

#### Testing
Created world with no cities, opened map, checked that `Origin:` text is shown.

Took mission, looked at vaguely seen OMTs, checked that text ain't overlapped.

#### Additional context
World with no cities
![изображение](https://github.com/user-attachments/assets/2b88d232-f4af-4fa6-b4cf-35ec6ef54ff2)

Before:
![изображение](https://github.com/user-attachments/assets/45edec71-e752-4c34-825b-824e98b011eb)

After:
![изображение](https://github.com/user-attachments/assets/c53b940e-4cca-4ef4-ac93-64785766d205)

Also I want to mention that for the same reason the `Origin:` text won't be shown if we're on any z-level other than 0, e.g. on the roof or in the cellar. I might fix that too, but honestly I don't understand why does this check even exist. Climbing to the roof of starting evac shelter suddenly makes us lose orientation?