### PR TITLE
add a tab bar to the uilist showing categories, if there are any

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2077,9 +2077,9 @@ void query_destination_callback::draw_squares( const uilist *menu )
     ImGui::NewLine();
     cata_assert( menu->entries.size() >= 9 );
     int sel = 0;
-    if( menu->hovered >= 0 && static_cast<size_t>( menu->hovered ) < menu->entries.size() ) {
+    if( menu->previewing >= 0 && static_cast<size_t>( menu->previewing ) < menu->entries.size() ) {
         sel = _adv_inv.screen_relative_location(
-                  static_cast <aim_location>( menu->hovered + 1 ) );
+                  static_cast <aim_location>( menu->previewing + 1 ) );
     }
     for( int i = 1; i < 10; i++ ) {
         aim_location loc = _adv_inv.screen_relative_location( static_cast <aim_location>( i ) );

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -89,7 +89,7 @@ void pocket_favorite_callback::refresh( uilist *menu )
             continue;
         }
 
-        if( i == menu->hovered ) {
+        if( i == menu->previewing ) {
             selected_pocket = pocket;
             pocket_num = std::get<1>( pocket_val ) + 1;
             break;

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2944,7 +2944,7 @@ spell &known_magic::select_spell( Character &guy )
         -1.0,
             -1.0,
             std::max( 80, TERMX * 3 / 8 ) *ImGui::CalcTextSize( "X" ).x,
-            clamp( static_cast<int>( known_spells_sorted.size() ), 24, TERMY * 9 / 10 ) *ImGui::GetTextLineHeightWithSpacing(),
+            clamp( static_cast<int>( known_spells_sorted.size() ), 24, TERMY * 9 / 10 ) *ImGui::GetTextLineHeight(),
         };
 
     spell_menu.title = _( "Choose a Spell" );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2530,8 +2530,8 @@ class spellcasting_callback : public uilist_callback
             ImGui::NewLine();
             if( ImGui::BeginChild( "spell info", { desired_extra_space_right( ), 0 }, false,
                                    ImGuiWindowFlags_AlwaysAutoResize ) ) {
-                if( menu->hovered >= 0 && static_cast<size_t>( menu->hovered ) < known_spells.size() ) {
-                    display_spell_info( menu->hovered );
+                if( menu->previewing >= 0 && static_cast<size_t>( menu->previewing ) < known_spells.size() ) {
+                    display_spell_info( menu->previewing );
                 }
             }
             ImGui::EndChild();

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -171,7 +171,7 @@ class teleporter_callback : public uilist_callback
         }
         void refresh( uilist *menu ) override {
             ImGui::TableSetColumnIndex( 2 );
-            const int entnum = menu->hovered;
+            const int entnum = menu->previewing;
             if( entnum >= 0 && static_cast<size_t>( entnum ) < index_pairs.size() ) {
                 avatar &player_character = get_avatar();
                 int dist = rl_dist( player_character.global_omt_location(), index_pairs[entnum] );

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -150,7 +150,7 @@ void uilist_impl::draw_controls()
                         }
                         if( ImGui::Selectable( "##s", is_selected, flags ) ) {
                             parent.fselected = i;
-                            parent.selected = parent.hovered = parent.fentries[ parent.fselected ];
+                            parent.selected = parent.previewing = parent.fentries[ parent.fselected ];
                             // We are going to return now that the user clicked on something, so scrolling seems
                             // unnecessary. However, the debug spawn item function reuses the same menu to let the
                             // user spawn multiple items and it’s weird if the correct item isn’t scrolled into view
@@ -163,7 +163,7 @@ void uilist_impl::draw_controls()
                                            ImGui::GetCurrentContext()->HoveredIdPreviousFrame;
                         if( is_hovered && mouse_moved ) {
                             // this row is hovered and the hover state just changed, show context for it
-                            parent.hovered = parent.fentries[ i ];
+                            parent.previewing = parent.fentries[ i ];
                         }
 
                         // Force the spacing to be set to the padding value.
@@ -212,7 +212,7 @@ void uilist_impl::draw_controls()
         if( !parent.footer_text.empty() ) {
             description = parent.footer_text;
         } else {
-            description = parent.entries[parent.hovered].desc;
+            description = parent.entries[parent.previewing].desc;
         }
         cataimgui::draw_colored_text( description );
     }
@@ -464,7 +464,7 @@ void uilist::init()
     ret_evt = input_event(); // last input event
     keymap.clear();        // keymap[input_event] == index, for entries[index]
     selected = 0;          // current highlight, for entries[index]
-    hovered = 0;           // current mouse highlight, for entries[index]
+    previewing = 0;           // current mouse highlight, for entries[index]
     entries.clear();       // uilist_entry(int returnval, bool enabled, int keycode, std::string text, ... TODO: submenu stuff)
     started = false;       // set to true when width and key calculations are done, and window is generated.
     desc_enabled = false;  // don't show option description by default
@@ -606,12 +606,12 @@ void uilist::filterlist()
         if( fentries.empty() ) {
             selected = -1;
         } else {
-            hovered = selected = fentries [ 0 ];
+            previewing = selected = fentries [ 0 ];
         }
     } else if( fselected < static_cast<int>( fentries.size() ) ) {
-        hovered = selected = fentries[fselected];
+        previewing = selected = fentries[fselected];
     } else {
-        hovered = fselected = selected = -1;
+        previewing = fselected = selected = -1;
     }
     // scroll to top of screen if all remaining entries fit the screen.
     if( static_cast<int>( fentries.size() ) <= vmax ) {
@@ -862,7 +862,7 @@ bool uilist::scrollby( const int scrollby )
         }
     }
     if( static_cast<size_t>( fselected ) < fentries.size() ) {
-        selected = hovered = fentries [ fselected ];
+        selected = previewing = fentries [ fselected ];
         if( callback != nullptr ) {
             callback->select( this );
         }
@@ -1112,7 +1112,7 @@ void uilist::settext( const std::string &str )
 
 void uilist::set_selected( int index )
 {
-    selected = hovered = std::clamp( index, 0, static_cast<int>( entries.size() - 1 ) );
+    selected = previewing = std::clamp( index, 0, static_cast<int>( entries.size() - 1 ) );
 }
 
 void uilist::add_category( const std::string &key, const std::string &name )
@@ -1180,7 +1180,7 @@ void uimenu::finalize_addentries()
 
 void uimenu::set_selected( int index )
 {
-    menu.selected = menu.hovered = index;
+    menu.selected = menu.previewing = index;
 }
 
 void uimenu::set_title( const std::string &title )

--- a/src/ui.h
+++ b/src/ui.h
@@ -187,8 +187,8 @@ struct uilist_entry {
  *     }
  *   }
  *   void refresh( uilist *menu ) {
- *       if( menu->hovered >= 0 && static_cast<size_t>( menu->hovered ) < game_z.size() ) {
- *           ImGui::TextColored( c_red, "( %s )", game_z[menu->hovered]->name() );
+ *       if( menu->previewing >= 0 && static_cast<size_t>( menu->previewing ) < game_z.size() ) {
+ *           ImGui::TextColored( c_red, "( %s )", game_z[menu->previewing]->name() );
  *       }
  *   }
  * }
@@ -496,7 +496,7 @@ class uilist // NOLINT(cata-xy)
         input_event ret_evt;
         int ret = 0;
         int selected = 0;
-        int hovered = 0;
+        int previewing = 0;
 
         void set_selected( int index );
 };

--- a/src/ui.h
+++ b/src/ui.h
@@ -486,7 +486,8 @@ class uilist // NOLINT(cata-xy)
         bool need_to_scroll = false;
         std::vector<std::pair<std::string, std::string>> categories;
         std::function<bool( const uilist_entry &, const std::string & )> category_filter;
-        int current_category = 0;
+        size_t current_category = 0;
+        size_t switch_to_category = 0;
 
     public:
         // Results

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -178,8 +178,8 @@ class wish_mutate_callback: public uilist_callback
 
             ImGui::TableSetColumnIndex( 2 );
 
-            if( menu->hovered >= 0 && static_cast<size_t>( menu->hovered ) < vTraits.size() ) {
-                const mutation_branch &mdata = vTraits[menu->hovered].obj();
+            if( menu->previewing >= 0 && static_cast<size_t>( menu->previewing ) < vTraits.size() ) {
+                const mutation_branch &mdata = vTraits[menu->previewing].obj();
 
                 ImGui::TextUnformatted( mdata.valid ? _( "Valid" ) : _( "Nonvalid" ) );
                 ImGui::NewLine();
@@ -677,7 +677,7 @@ class wish_monster_callback: public uilist_callback
             info_size.x = desired_extra_space_right( );
             ImGui::TableSetColumnIndex( 2 );
             if( ImGui::BeginChild( "monster info", info_size ) ) {
-                const int entnum = menu->hovered;
+                const int entnum = menu->previewing;
                 const bool valid_entnum = entnum >= 0 && static_cast<size_t>( entnum ) < mtypes.size();
                 if( entnum != lastent ) {
                     lastent = entnum;
@@ -998,7 +998,7 @@ class wish_item_callback: public uilist_callback
             info_size.x = desired_extra_space_right( );
             ImGui::TableSetColumnIndex( 2 );
             if( ImGui::BeginChild( "monster info", info_size ) ) {
-                const int entnum = menu->hovered;
+                const int entnum = menu->previewing;
                 if( entnum >= 0 && static_cast<size_t>( entnum ) < standard_itype_ids.size() ) {
                     item tmp = wishitem_produce( *standard_itype_ids[entnum], flags, false );
 


### PR DESCRIPTION
#### Summary
Interface "uilist menus that have categories now include a tabbar to allow the user to select a category"
#### Purpose of change

* Fixes #75666
* Fixes #76746

#### Describe the solution

Allows the user to select a category using the mouse, in addition to the existing key bindings.

Also tweaks how the size of the uilist is computed a bit, to keep the calculated_menu_size correct even when the caller specifies desired_bounds.

#### Testing

Start a game with Magiclysm, use the debug menu to edit your character, add some spells. Then check the spellcasting menu to see if it looks right. Then go back and add every spell (default key binding is `t`). Check the spellcasting menu again to make sure it still looks right.

#### Additional context

![Screenshot from 2024-10-18 03-28-34](https://github.com/user-attachments/assets/b06257bb-3509-4b91-8e45-c3496fd2e36d)
![Screenshot from 2024-10-18 03-25-33](https://github.com/user-attachments/assets/7dd000f8-8077-4cdc-9385-d5c05f89ea72)
