### PR TITLE
[CR] Allow Fruit Sugar refining using Potassium Hydroxide

### DIFF
--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -6281,7 +6281,7 @@
         [ "honeycomb", 1 ],
         [ "can_corn", 3 ]
       ],
-      [ [ "lye_powder", 20 ] ],
+      [ [ "lye_powder", 20 ], [ "chem_potassium_hydroxide", 28 ] ],
       [ [ "water_clean", 1 ] ]
     ]
   },
@@ -6385,7 +6385,7 @@
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "BOIL", "level": 2 }, { "id": "CHEM", "level": 1 } ],
     "tools": [ [ [ "water_boiling_heat", 8, "LIST" ] ] ],
     "//1": "1u base + 1u ingredient + 6u evaporation",
-    "components": [ [ [ "sugar_beet", 3 ] ], [ [ "water_clean", 1 ], [ "water", 1 ] ], [ [ "lye_powder", 20 ] ] ]
+    "components": [ [ [ "sugar_beet", 3 ] ], [ [ "water_clean", 1 ], [ "water", 1 ] ], [ [ "lye_powder", 20 ], [ "chem_potassium_hydroxide", 28 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -6385,7 +6385,11 @@
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "BOIL", "level": 2 }, { "id": "CHEM", "level": 1 } ],
     "tools": [ [ [ "water_boiling_heat", 8, "LIST" ] ] ],
     "//1": "1u base + 1u ingredient + 6u evaporation",
-    "components": [ [ [ "sugar_beet", 3 ] ], [ [ "water_clean", 1 ], [ "water", 1 ] ], [ [ "lye_powder", 20 ], [ "chem_potassium_hydroxide", 28 ] ] ]
+    "components": [
+      [ [ "sugar_beet", 3 ] ],
+      [ [ "water_clean", 1 ], [ "water", 1 ] ],
+      [ [ "lye_powder", 20 ], [ "chem_potassium_hydroxide", 28 ] ]
+    ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Balance "Add Potassium Hydroxide alternative to produce sugar" 

#### Purpose of change
Based on the #74547 suggestion
#### Describe the solution
fixes #74547
It simply adds the possibility for the player to use the sodium hydroxide lye powder OR the potassium hydroxide powder to refine sugar. The logic of the production value requirement is the following: 
Based on the molecular weight difference between KOH and NaOH(56 g/mol for KOH and 40 g/mol for NaOH), about 1.4 times(maths: 56/40 = 1.4) more KOH is required to achieve the same chemical reaction. The base recipe uses 20 u of the sodium hydroxide lye powder, so 20 * 1.4 = 24 u. 
The sources used for this adjustment include:
https://araxchemi.com/en/potassium-hydroxide-vs-sodium-hydroxide/
https://patents.google.com/patent/US3098045A/en ("The alkali metal hydroxide we employ may be NaOH, KOH or LiOI-l. For reasons of economy NaOH is preferred.")


#### Testing
Compiled the game and checked the recipe, the player can now use the sodium hydroxide lye powder OR the potassium hydroxide powder to refine sugar

