### PR TITLE
Added check for stealing prior to unloading containers

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -4517,6 +4517,10 @@ std::pair<item_location, bool> unload_selector::execute()
         } else if( input.action == "CONFIRM" ) {
             const inventory_entry &highlighted = get_active_column().get_highlighted();
             if( highlighted && highlighted.is_selectable() ) {
+                item to_unload = *highlighted.any_item();
+                if( !avatar_action::check_stealing( get_player_character(), to_unload ) ) {
+                    return { item_location(), uistate.unload_auto_contain };
+                }
                 return { highlighted.any_item(), uistate.unload_auto_contain };
             }
         } else if( input.action == "CONTAIN_MODE" ) {


### PR DESCRIPTION
#### Summary
Features "Added check for stealing prior to unloading containers"

#### Purpose of change
* Closes #61296.

#### Describe the solution
Added `check_stealing` in `unload_selector::execute()`.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned animal shelter with a veterinarian. Tried to unload veterinarian's can of wet dog food. Got a warning about stealing. Answered yes, answered no.

#### Additional context
None.