### PR TITLE
Fix bad Boolean logic example

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -248,7 +248,7 @@ Checks you are **not** close to refugee center (at least 4 overmap tiles afar)
 Checks you don't have any traits from the list
 ```json
 "condition": {
-  "or": [
+  "and": [
     { "not": { "u_has_trait": "HUMAN_ARMS" } },
     { "not": { "u_has_trait": "HUMAN_SKIN" } },
     { "not": { "u_has_trait": "HUMAN_EYES" } },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The example documentation incorrectly states that performing an OR operation over a set of inverted Boolean values is equivalent to inverting the output of an OR operation over a set of values that were not inverted.

#### Describe the solution

Change the `or` to an `and`.

#### Describe alternatives you've considered

N/A

#### Testing

N/A

#### Additional context