### PR TITLE
NPCs can funk out to music, too.

### DIFF
--- a/src/iuse.h
+++ b/src/iuse.h
@@ -224,7 +224,8 @@ std::optional<int> disassemble( Character *, item *, const tripoint & );
 
 // Helper functions for other iuse functions
 void cut_log_into_planks( Character & );
-void play_music( Character *p, const tripoint &source, int volume, int max_morale );
+void play_music( Character *p, const tripoint &source, int volume, int max_morale,
+                 bool play_sounds = true );
 std::optional<int> purify_water( Character *p, item *purifier, item_location &water );
 int towel_common( Character *, item *, bool );
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -137,7 +137,6 @@ static const itype_id itype_syringe( "syringe" );
 static const json_character_flag json_flag_BIONIC_LIMB( "BIONIC_LIMB" );
 static const json_character_flag json_flag_MANUAL_CBM_INSTALLATION( "MANUAL_CBM_INSTALLATION" );
 
-static const morale_type morale_music( "morale_music" );
 static const morale_type morale_pyromania_nofire( "morale_pyromania_nofire" );
 static const morale_type morale_pyromania_startfire( "morale_pyromania_startfire" );
 
@@ -2243,13 +2242,13 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
 
     if( !p->has_effect( effect_music ) && p->can_hear( p->pos(), volume ) ) {
         // Sound code doesn't describe noises at the player position
-        if( p->is_avatar() && desc != "music" ) {
-            add_msg( m_info, desc );
+        if( desc != "music" ) {
+            p->add_msg_if_player( m_info, desc );
         }
-        p->add_effect( effect_music, 1_turns );
-        const int sign = morale_effect > 0 ? 1 : -1;
-        p->add_morale( morale_music, sign, morale_effect, 5_minutes, 2_minutes, true );
     }
+
+    // We already played the sounds, just handle applying effects now
+    iuse::play_music( p, p->pos(), volume, morale_effect, /*play_sounds=*/false );
 
     return 0;
 }


### PR DESCRIPTION
#### Summary
Balance "NPCs can funk out to music, too."

#### Purpose of change

![friday_night](https://github.com/user-attachments/assets/d79cef2e-beee-4412-9427-af6978069d06)


...Also NPCs couldn't enjoy music played from vehicle/appliance stereos.

#### Describe the solution
Properly check for everyone that can hear the music, and make them **feel the groove**.

Pipe musical_instrument_actor::use through iuse::play_music to minimize code duplication

#### Describe alternatives you've considered
Ehhh maybe there's a way to do this without lambdas. I know a lot of people don't like lambdas, but I've gotten used to them and these are pretty simple.

vehicle::play_music() probably shouldn't assume the player character and pass it on as `Character *p`?

#### Testing
instrument played by the player

https://github.com/user-attachments/assets/b2c85ff7-d2ad-4a24-877a-8d7183c8dc3e

vehicle/appliance stereo

https://github.com/user-attachments/assets/bc000986-b397-4c04-a407-390404c42b9f



Apparently there may be some way for NPCs to play instruments and for you to listen, but I wasn't able to find out how. Still I structured my changes so that anything that previously worked should continue to work.


#### Additional context
