### PR TITLE
Requirements warn if loading components as tools

### DIFF
--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -9,9 +9,9 @@
     "id": "shot_forming",
     "type": "requirement",
     "//": "Forming of shot from raw materials",
+    "components": [ [ [ "any_water", 1, "LIST" ] ] ],
     "tools": [
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ], [ "iron_pot", -1 ], [ "pan", -1 ], [ "pot_makeshift", -1 ] ],
-      [ [ "any_water", 1, "LIST" ] ],
       [
         [ "ladle", -1 ],
         [ "ceramic_mug", -1 ],

--- a/data/mods/Xedra_Evolved/requirements/spell_components.json
+++ b/data/mods/Xedra_Evolved/requirements/spell_components.json
@@ -15,11 +15,6 @@
     "components": [ [ [ "forged_dreamstuff_ingot", 1 ], [ "dreamdross_lump", 10 ], [ "scrap_dreamdross", 100 ] ] ]
   },
   {
-    "id": "spell_components_schematics",
-    "type": "requirement",
-    "components": [ [ [ "drawing_tool", 2, "LIST" ] ], [ [ "paper", 8 ] ] ]
-  },
-  {
     "id": "spell_components_dreamer_coin",
     "type": "requirement",
     "components": [

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -603,13 +603,20 @@ template<typename T>
 void requirement_data::check_consistency( const std::vector< std::vector<T> > &vec,
         const std::string &display_name )
 {
+
     for( const auto &list : vec ) {
+        bool requirement_was_empty = true;
         for( const auto &comp : list ) {
+            requirement_was_empty = false;
             if( comp.requirement ) {
                 debugmsg( "Finalization failed to inline %s in %s", comp.type.c_str(), display_name );
             }
 
             comp.check_consistency( display_name );
+        }
+        if( requirement_was_empty ) {
+            debugmsg( "Requirement %s is empty, recipes using it have no valid results.  Some input must be invalid.",
+                      display_name );
         }
     }
 }
@@ -716,6 +723,10 @@ void requirement_data::finalize()
         } );
         requirement_data::alter_tool_comp_vector &vec = r.second.tools;
         for( auto &list : vec ) {
+            if( list.empty() ) {
+                debugmsg( "Requirements data %s tools vector contains impossible requirements.  Recipes using this requirement set will be impossible to make.",
+                          r.first.c_str() );
+            }
             std::vector<tool_comp> new_list;
             for( tool_comp &comp : list ) {
                 const auto replacements = item_controller->subtype_replacement( comp.type );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fix #77136, hopefully for real this time

#### Describe the solution
Specifically check requirements data during finalizing data and consistency checking to see if we're missing *any* valid possibilities. If there's literally nothing then it will never work.

Unfortunately, there is no way to be more specific with our error messages than giving the requirements set ID. 

#### Describe alternatives you've considered
I would love to throw errors earlier and more fatally, during loading. But we don't *know* at that time if the requirements are actually valid or not. Expanding the requirements doesn't happen until inline_requirements, after all requirements have been loaded. At that point we've already lost where we were in json and there's no better information to provide, so we just have to give what we can.

#### Testing
shot_forming group properly throws errors with C++ changes applied

00 shot, reloaded can be crafted with json changes applied

#### Additional context
With this, I don't actually understand how #72801 worked or why it doesn't work here. It caught at least some of these errors in the past, but why not this one?
