### PR TITLE
Add controlling_vehicle EOC condition

### DIFF
--- a/data/json/ui/structured/structured_speed_vehicle.json
+++ b/data/json/ui/structured/structured_speed_vehicle.json
@@ -36,11 +36,15 @@
     "width": 27,
     "clauses": [
       {
-        "id": "not_driving",
+        "id": "not_controlling_vehicle",
         "widgets": [ "structured_wield_simple", "structured_speed_layout" ],
-        "condition": { "not": "u_driving" }
+        "condition": { "not": "u_controlling_vehicle" }
       },
-      { "id": "driving", "widgets": [ "structured_fuel", "structured_vehicle_speed" ], "condition": "u_driving" }
+      {
+        "id": "controlling_vehicle",
+        "widgets": [ "structured_fuel", "structured_vehicle_speed" ],
+        "condition": "u_controlling_vehicle"
+      }
     ]
   },
   {

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -875,9 +875,30 @@ You don't wield anything
 { "not": "u_has_weapon" }
 ```
 
+### `u_controlling_vehicle`, `npc_controlling_vehicle`
+- type: simple string
+- return true if alpha or beta talker control a vehicle; Nota bene: NPCs cannot currently operate vehicles
+
+#### Valid talkers:
+
+| Avatar | Character | NPC | Monster |  Furniture | Item |
+| ------ | --------- | --------- | ---- | ------- | --- | 
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+
+#### Examples
+
+```json
+"u_controlling_vehicle"
+```
+
+true if you do not drive
+```json
+{ "not": "u_controlling_vehicle" }
+```
+
 ### `u_driving`, `npc_driving`
 - type: simple string
-- return true if alpha or beta talker operate a vehicles; Nota bene: NPCs cannot currently operate vehicles
+- return true if alpha or beta talker operate a moving vehicle; Nota bene: NPCs cannot currently operate vehicles
 
 #### Valid talkers:
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1558,11 +1558,22 @@ conditional_t::func f_has_weapon( bool is_npc )
     };
 }
 
+conditional_t::func f_is_controlling_vehicle( bool is_npc )
+{
+    return [is_npc]( dialogue const & d ) {
+        const talker *actor = d.actor( is_npc );
+        if( const optional_vpart_position &vp = get_map().veh_at( actor->pos() ) ) {
+            return actor->is_in_control_of( vp->vehicle() );
+        }
+        return false;
+    };
+}
+
 conditional_t::func f_is_driving( bool is_npc )
 {
     return [is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
-        if( const optional_vpart_position vp = get_map().veh_at( actor->pos() ) ) {
+        if( const optional_vpart_position &vp = get_map().veh_at( actor->pos() ) ) {
             return vp->vehicle().is_moving() && actor->is_in_control_of( vp->vehicle() );
         }
         return false;
@@ -2609,6 +2620,7 @@ parsers_simple = {
     {"u_can_stow_weapon", "npc_can_stow_weapon", &conditional_fun::f_can_stow_weapon },
     {"u_can_drop_weapon", "npc_can_drop_weapon", &conditional_fun::f_can_drop_weapon },
     {"u_has_weapon", "npc_has_weapon", &conditional_fun::f_has_weapon },
+    {"u_controlling_vehicle", "npc_controlling_vehicle", &conditional_fun::f_is_controlling_vehicle },
     {"u_driving", "npc_driving", &conditional_fun::f_is_driving },
     {"u_has_activity", "npc_has_activity", &conditional_fun::f_has_activity },
     {"u_is_riding", "npc_is_riding", &conditional_fun::f_is_riding },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Add controlling_vehicle EOC condition"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The driving condition only applies to vehicles in motion. When it's used by the structured sidebar to control display of vehicle speed, that means the player can't see their throttle setting when starting to drive a vehicle until it has already started moving.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Add a new condition `u_controlling_vehicle` that includes stationary vehicles, and use that condition in the sidebar.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I looked through various other uses of u_driving and npc_driving and a few might make sense to change but I didn't want to presume.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Playing with this change and the structured sidebar now and it works as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
