### PR TITLE
No repeatedly lighting fires on same tile

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -928,7 +928,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         add_msg_if_player( m_info, _( "You can now run faster, assisted by joint servomotors." ) );
     } else if( bio.id == bio_lighter ) {
         const std::optional<tripoint> pnt = choose_adjacent( _( "Start a fire where?" ) );
-        if( pnt && here.is_flammable( *pnt ) ) {
+        if( pnt && here.is_flammable( *pnt ) && !here.get_field( *pnt, fd_fire ) ) {
             add_msg_activate();
             here.add_field( *pnt, fd_fire, 1 );
             if( has_trait( trait_PYROMANIA ) ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Kill an exploit

#### Describe the solution
You can't light a tile that's already on fire

#### Describe alternatives you've considered


#### Testing
![image](https://github.com/user-attachments/assets/1a8067e5-542b-49cb-abcc-08dbbd0d3098)


#### Additional context
