### PR TITLE
Added check for stealing prior to obtaining book to read

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1688,12 +1688,11 @@ static void read()
     avatar &player_character = get_avatar();
     // Can read items from inventory or within one tile (including in vehicles)
     item_location loc = game_menus::inv::read( player_character );
+    item the_book = *loc.get_item();
 
-    if( loc ) {
+    if( loc && avatar_action::check_stealing( get_player_character(), the_book ) ) {
         if( loc->type->can_use( "learn_spell" ) ) {
-            item spell_book = *loc.get_item();
-            spell_book.get_use( "learn_spell" )->call( &player_character, spell_book,
-                    player_character.pos() );
+            the_book.get_use( "learn_spell" )->call( &player_character, the_book, player_character.pos() );
         } else {
             loc = loc.obtain( player_character );
             player_character.read( loc );


### PR DESCRIPTION
#### Summary
Features "Added check for stealing prior to obtaining book to read"

#### Purpose of change
* Closes #37181.

#### Describe the solution
Added check for stealing prior to obtaining book to read.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned animal shelter with a veterinarian. Tried to read veterinarian's comic book. Got a warning about stealing. Answered yes, answered no.

#### Additional context
None.