### PR TITLE
Create an external option for disabling zombify_into. Apply it to both Aftershock:Exoplanet and DDtD

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -506,7 +506,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "ZOMBIFY_INTO_ENABLED",
-    "info": "Enables the functionality of the \"zombifies_into\" JSON field in monster definitions.",
+    "info": "Enables the functionality of the \"zombify_into\" JSON field in monster definitions.",
     "stype": "bool",
     "value": true
   },

--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -505,6 +505,13 @@
   },
   {
     "type": "EXTERNAL_OPTION",
+    "name": "ZOMBIFY_INTO_ENABLED",
+    "info": "Enables the functionality of the \"zombifies_into\" JSON field in monster definitions.",
+    "stype": "bool",
+    "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
     "name": "DESCRIBE_MUSIC_FREQUENCY",
     "info": "Determines frequency (in minutes) of displaying music description in sidebar when listening to MP3-players and the like.",
     "stype": "int",

--- a/data/mods/aftershock_exoplanet/options.json
+++ b/data/mods/aftershock_exoplanet/options.json
@@ -2,7 +2,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "ZOMBIFY_INTO_ENABLED",
-    "info": "Enables the functionality of the \"zombifies_into\" JSON field in monster definitions.",
+    "info": "Enables the functionality of the \"zombify_into\" JSON field in monster definitions.",
     "stype": "bool",
     "value": false
   }

--- a/data/mods/aftershock_exoplanet/options.json
+++ b/data/mods/aftershock_exoplanet/options.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "ZOMBIFY_INTO_ENABLED",
+    "info": "Enables the functionality of the \"zombifies_into\" JSON field in monster definitions.",
+    "stype": "bool",
+    "value": false
+  }
+]

--- a/data/mods/classic_zombies/options.json
+++ b/data/mods/classic_zombies/options.json
@@ -2,7 +2,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "ZOMBIFY_INTO_ENABLED",
-    "info": "Enables the functionality of the \"zombifies_into\" JSON field in monster definitions.",
+    "info": "Enables the functionality of the \"zombify_into\" JSON field in monster definitions.",
     "stype": "bool",
     "value": false
   }

--- a/data/mods/classic_zombies/options.json
+++ b/data/mods/classic_zombies/options.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "ZOMBIFY_INTO_ENABLED",
+    "info": "Enables the functionality of the \"zombifies_into\" JSON field in monster definitions.",
+    "stype": "bool",
+    "value": false
+  }
+]

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -314,7 +314,7 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
     update_prefix_suffix_flags();
     if( has_flag( flag_CORPSE ) ) {
         corpse = &type->source_monster.obj();
-        if( !type->source_monster.is_null() && !type->source_monster->zombify_into.is_empty() ) {
+        if( !type->source_monster.is_null() && !type->source_monster->zombify_into.is_empty() && get_option<bool>( "ZOMBIFY_INTO_ENABLED" ) ) {
             set_var( "zombie_form", type->source_monster->zombify_into.c_str() );
         }
     }
@@ -626,8 +626,8 @@ item item::make_corpse( const mtype_id &mt, time_point turn, const std::string &
         }
         result.set_var( "upgrade_time", std::to_string( upgrade_time ) );
     }
-
-    if( !mt->zombify_into.is_empty() ) {
+ 
+    if( !mt->zombify_into.is_empty() && get_option<bool>( "ZOMBIFY_INTO_ENABLED" ) ) {
         result.set_var( "zombie_form", mt->zombify_into.c_str() );
     }
 
@@ -13265,7 +13265,7 @@ bool item::process_corpse( map &here, Character *carrier, const tripoint &pos )
     }
 
     // handle human corpses rising as zombies
-    if( corpse->id == mtype_id::NULL_ID() && !has_var( "zombie_form" ) &&
+    if( corpse->id == mtype_id::NULL_ID() && !has_var( "zombie_form" ) && get_option<bool>( "ZOMBIFY_INTO_ENABLED" ) &&
         !mon_human->zombify_into.is_empty() ) {
         set_var( "zombie_form", mon_human->zombify_into.c_str() );
     }
@@ -13551,7 +13551,7 @@ ret_val<void> item::link_to( const optional_vpart_position &first_linked_vp,
         return ret_val<void>::make_failure();
     }
     // Link up the second vehicle first so, if it's a tow cable, the first vehicle will tow the second.
-    ret_val<void> result = link_to( second_linked_vp->vehicle(), second_linked_vp->mount(), link_type );
+    ret_val<void> result = link_to( second_linked_vp->vehicle(), second_linked_vp->mount(), link_type ); 
     if( !result.success() ) {
         return result;
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -314,7 +314,8 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
     update_prefix_suffix_flags();
     if( has_flag( flag_CORPSE ) ) {
         corpse = &type->source_monster.obj();
-        if( !type->source_monster.is_null() && !type->source_monster->zombify_into.is_empty() && get_option<bool>( "ZOMBIFY_INTO_ENABLED" ) ) {
+        if( !type->source_monster.is_null() && !type->source_monster->zombify_into.is_empty() &&
+            get_option<bool>( "ZOMBIFY_INTO_ENABLED" ) ) {
             set_var( "zombie_form", type->source_monster->zombify_into.c_str() );
         }
     }
@@ -626,7 +627,7 @@ item item::make_corpse( const mtype_id &mt, time_point turn, const std::string &
         }
         result.set_var( "upgrade_time", std::to_string( upgrade_time ) );
     }
- 
+
     if( !mt->zombify_into.is_empty() && get_option<bool>( "ZOMBIFY_INTO_ENABLED" ) ) {
         result.set_var( "zombie_form", mt->zombify_into.c_str() );
     }
@@ -13265,7 +13266,8 @@ bool item::process_corpse( map &here, Character *carrier, const tripoint &pos )
     }
 
     // handle human corpses rising as zombies
-    if( corpse->id == mtype_id::NULL_ID() && !has_var( "zombie_form" ) && get_option<bool>( "ZOMBIFY_INTO_ENABLED" ) &&
+    if( corpse->id == mtype_id::NULL_ID() && !has_var( "zombie_form" ) &&
+        get_option<bool>( "ZOMBIFY_INTO_ENABLED" ) &&
         !mon_human->zombify_into.is_empty() ) {
         set_var( "zombie_form", mon_human->zombify_into.c_str() );
     }
@@ -13551,7 +13553,7 @@ ret_val<void> item::link_to( const optional_vpart_position &first_linked_vp,
         return ret_val<void>::make_failure();
     }
     // Link up the second vehicle first so, if it's a tow cable, the first vehicle will tow the second.
-    ret_val<void> result = link_to( second_linked_vp->vehicle(), second_linked_vp->mount(), link_type ); 
+    ret_val<void> result = link_to( second_linked_vp->vehicle(), second_linked_vp->mount(), link_type );
     if( !result.success() ) {
         return result;
     }


### PR DESCRIPTION

#### Summary
Mods "Create an external option for disabling zombify_into. Apply it to both Aftershock:Exoplanet and DDtD"

#### Purpose of change
I noticed while testing the Exoplanet that zombies could still spawn in the mod due to the zombify_into field several creatures have. This adds an option to disable this functionality without having to painstakingly track blacklists for monster additions.

#### Describe the solution
I have added this option to Aftershock:Exoplanet, where the zombie virus doesnt exist. The mox enemies dont currently use this feature and things becoming mox enemies is too complex a process for it to happen as a blanket feature.

I also added this to DDtD. While I do think a classic zombies mod can have animal zombies, I think those should happen from animals getting bitten and surviving the encounter, not just from any death like in vanilla DDA. @I-am-Erk can confirm.

#### Testing
Manually swapped the flag off.
