### PR TITLE
Eliminate faction camp storage zones cache

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -704,21 +704,18 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
                 60, get_owner() );
         // Find the nearest unsorted zone to dump objects at
         if( !zones.empty() ) {
-            if( zones != storage_zones ) {
-                std::unordered_set<tripoint_abs_ms> src_set;
-                for( const zone_data *zone : zones ) {
-                    for( const tripoint_abs_ms &p : tripoint_range<tripoint_abs_ms>(
-                             zone->get_start_point(), zone->get_end_point() ) ) {
-                        src_set.emplace( p );
-                    }
+            std::unordered_set<tripoint_abs_ms> src_set;
+            for( const zone_data *zone : zones ) {
+                for( const tripoint_abs_ms &p : tripoint_range<tripoint_abs_ms>(
+                         zone->get_start_point(), zone->get_end_point() ) ) {
+                    src_set.emplace( p );
                 }
-                set_storage_tiles( src_set );
             }
+            set_storage_tiles( src_set );
             src_loc = here.bub_from_abs( zones.front()->get_center_point() );
-            set_storage_zone( zones );
         }
         map &here = get_map();
-        for( const zone_data *zone : storage_zones ) {
+        for( const zone_data *zone : zones ) {
             if( zone->get_type() == zone_type_CAMP_STORAGE ) {
                 for( const tripoint_abs_ms &p : tripoint_range<tripoint_abs_ms>(
                          zone->get_start_point(), zone->get_end_point() ) ) {

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -467,17 +467,9 @@ class basecamp
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &data );
         void load_data( const std::string &data );
-        inline const std::vector<const zone_data * > &get_storage_zone() const {
-            return storage_zones;
-        }
-        // dumping spot in absolute co-ords
-        inline void set_storage_zone( const std::vector<const zone_data *> &zones ) {
-            storage_zones = zones;
-        }
         inline const std::unordered_set<tripoint_abs_ms> &get_storage_tiles() const {
             return src_set;
         }
-        // dumping spot in absolute co-ords
         inline void set_storage_tiles( const std::unordered_set<tripoint_abs_ms> &tiles ) {
             src_set = tiles;
         }
@@ -504,10 +496,10 @@ class basecamp
         std::map<point, expansion_data> expansions;
         comp_list camp_workers; // NOLINT(cata-serialize)
         basecamp_map camp_map; // NOLINT(cata-serialize)
+        // dumping spot in absolute co-ords
         tripoint_abs_ms dumping_spot;
         // Tiles inside STORAGE-type zones that have LIQUIDCONT terrain
         std::vector<tripoint_abs_ms> liquid_dumping_spots;
-        std::vector<const zone_data *> storage_zones; // NOLINT(cata-serialize)
         std::unordered_set<tripoint_abs_ms> src_set; // NOLINT(cata-serialize)
         std::set<itype_id> fuel_types; // NOLINT(cata-serialize)
         std::vector<basecamp_fuel> fuels; // NOLINT(cata-serialize)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Faction camp storage zone effective after editing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
`basecamp.storage_zones` is a cached vector of pointers to storage zones. If you create or delete zones then when your zones are enumerated they won't match and the storage_tiles/src_sec vector of locations will get updated. However, if you *edit* a storage zone, the check breaks and thinks the location vector doesn't need updating. This results in the game proceeding to use your old storage zone area even when no zone is pointing at it.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
I got rid of the storage_zones cache. The cost for creating it is low, and it's not in any hot path. The src_set cache of individual tiles still exists and is used much more often.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
1. Implement a vector<tripoint_range> type that src_set could use. This would be much faster to populate, and not much slower to iterate.
2. Keep track of when storage zones get dirtied and use that when determining whether to update the src_set.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Played with this for a few hours. Ran automated tests.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
