### PR TITLE
Debug radiation on characters and map tiles

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2023,6 +2023,13 @@
   },
   {
     "type": "keybinding",
+    "id": "EDIT_RADS",
+    "category": "EDITMAP",
+    "name": "Edit radiation",
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "EDIT_TERRAIN",
     "category": "EDITMAP",
     "name": "Edit terrain",

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2249,7 +2249,7 @@ static void character_edit_menu()
     }
 
     enum {
-        D_DESC, D_SKILLS, D_THEORY, D_PROF, D_STATS, D_SPELLS, D_ITEMS, D_DELETE_ITEMS, D_DROP_ITEMS, D_ITEM_WORN,
+        D_DESC, D_SKILLS, D_THEORY, D_PROF, D_STATS, D_SPELLS, D_ITEMS, D_DELETE_ITEMS, D_DROP_ITEMS, D_ITEM_WORN, D_RADS,
         D_HP, D_STAMINA, D_MORALE, D_PAIN, D_NEEDS, D_NORMALIZE_BODY, D_HEALTHY, D_STATUS, D_MISSION_ADD, D_MISSION_EDIT,
         D_TELE, D_MUTATE, D_BIONICS, D_CLASS, D_ATTITUDE, D_OPINION, D_PERSONALITY, D_ADD_EFFECT, D_ASTHMA, D_PRINT_VARS,
         D_WRITE_EOCS, D_KILL_XP, D_CHECK_TEMP, D_EDIT_VARS, D_FACTION
@@ -2265,6 +2265,7 @@ static void character_edit_menu()
     nmenu.addentry( D_DELETE_ITEMS, true, 'd', "%s", _( "Delete (all) items" ) );
     nmenu.addentry( D_DROP_ITEMS, true, 'D', "%s", _( "Drop items" ) );
     nmenu.addentry( D_ITEM_WORN, true, 'w', "%s", _( "Wear/wield an item from player's inventory" ) );
+    nmenu.addentry( D_RADS, true, 'r', "%s", _( "Set radiation" ) );
     nmenu.addentry( D_HP, true, 'h', "%s", _( "Set hit points" ) );
     nmenu.addentry( D_STAMINA, true, 'S', "%s", _( "Set stamina" ) );
     nmenu.addentry( D_MORALE, true, 'o', "%s", _( "Set morale" ) );
@@ -2344,6 +2345,13 @@ static void character_edit_menu()
                 item_location loc = you.get_wielded_item();
                 cata::event e = cata::event::make<event_type::character_wields_item>( you.getID(), loc->typeId() );
                 get_event_bus().send_with_talker( &you, &loc, e );
+            }
+        }
+        break;
+        case D_RADS: {
+            int value;
+            if( query_int( value, _( "Set rads to?  Currently: %d" ), you.get_rad() ) ) {
+                you.set_rad( value );
             }
         }
         break;

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -359,6 +359,7 @@ std::optional<tripoint_bub_ms> editmap::edit()
     ctxt.register_action( "LEVEL_DOWN" );
     ctxt.register_action( "EDIT_TRAPS" );
     ctxt.register_action( "EDIT_FIELDS" );
+    ctxt.register_action( "EDIT_RADS" );
     ctxt.register_action( "EDIT_TERRAIN" );
     ctxt.register_action( "EDIT_FURNITURE" );
     ctxt.register_action( "EDIT_OVERMAP" );
@@ -393,9 +394,10 @@ std::optional<tripoint_bub_ms> editmap::edit()
 
         // \u00A0 is the non-breaking space
         info_txt_curr = string_format( pgettext( "keybinding descriptions",
-                                       "%s, %s, [%s,%s,%s,%s]\u00A0fast scroll, %s, %s, %s, %s, %s, %s" ),
+                                       "%s, %s, %s, [%s,%s,%s,%s]\u00A0fast scroll, %s, %s, %s, %s, %s, %s" ),
                                        ctxt.describe_key_and_name( "EDIT_TRAPS" ),
                                        ctxt.describe_key_and_name( "EDIT_FIELDS" ),
+                                       ctxt.describe_key_and_name( "EDIT_RADS" ),
                                        ctxt.get_desc( "LEFT_WIDE", 1 ), ctxt.get_desc( "RIGHT_WIDE", 1 ),
                                        ctxt.get_desc( "UP_WIDE", 1 ), ctxt.get_desc( "DOWN_WIDE", 1 ),
                                        ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ),
@@ -417,6 +419,8 @@ std::optional<tripoint_bub_ms> editmap::edit()
             edit_feature<furn_t>();
         } else if( action == "EDIT_FIELDS" ) {
             edit_fld();
+        } else if( action == "EDIT_RADS" ) {
+            edit_rads();
         } else if( action == "EDIT_ITEMS" ) {
             edit_itm();
         } else if( action == "EDIT_TRAPS" ) {
@@ -1208,6 +1212,15 @@ void editmap::setup_fmenu( uilist &fmenu )
     }
     if( sel_field >= 0 ) {
         fmenu.selected = sel_field;
+    }
+}
+
+void editmap::edit_rads() const
+{
+    map &here = get_map();
+    int value = 0;
+    if( query_int( value, _( "Set rads to?  Currently: %d" ), here.get_radiation( target ) ) ) {
+        here.set_radiation( target, value );
     }
 }
 

--- a/src/editmap.h
+++ b/src/editmap.h
@@ -58,6 +58,7 @@ class editmap
         template<typename T_t>
         void edit_feature();
         void edit_fld();
+        void edit_rads() const;
         void edit_itm();
         void edit_critter( Creature &critter );
         void edit_mapgen();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #77190

#### Describe the solution
Add an option to get/set character radiation

Add an option to get/set tile radiation in the map editor

#### Describe alternatives you've considered

#### Testing
Debugged lots radiation onto myself, became violently ill.

Debugged lots radiation onto tile. Stood nearby. Did not become violently ill. Stepped onto tile with radiation, waited a few minutes. Became violently ill.

#### Additional context