### PR TITLE
Backport 77159 Bump Android API level to 34

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -54,7 +54,7 @@ version_header_path=./../src/version.h
 
 # This property controls which compileSdkVersion should be used
 # You can override this from the command line by passing "-Poverride_compileSdkVersion=#"
-override_compileSdkVersion=33
+override_compileSdkVersion=34
 
 # This property controls which minSdkVersion should be used
 # You can override this from the command line by passing "-Poverride_minSdkVersion=#"
@@ -62,7 +62,7 @@ override_minSdkVersion=21
 
 # This property controls which targetSdkVersion should be used
 # You can override this from the command line by passing "-Poverride_targetSdkVersion=#"
-override_targetSdkVersion=33
+override_targetSdkVersion=34
 
 # This property controls which ndkBuildAppPlatform should be used
 # You can override this from the command line by passing "-Poverride_ndkBuildAppPlatform=#"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Build AAB for Cataclysm app update on Play Store

#### Describe the solution

Backport #77159

#### Testing

APK/AAB builds successfully.