### PR TITLE
correct height when a uilist has desired_bounds not including height

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -746,9 +746,10 @@ void uilist::calc_data()
     calculated_menu_size.x += calculated_hotkey_width + padding;
     calculated_menu_size.x += calculated_label_width + padding;
     calculated_menu_size.x += calculated_secondary_width + padding;
-    float max_avail_height = ImGui::GetMainViewport()->Size.y;
-    if( desired_bounds.has_value() ) {
-        max_avail_height = desired_bounds.value().h;
+    float max_avail_height = 0.9 * ImGui::GetMainViewport()->Size.y;
+    float desired_height;
+    if( desired_bounds.has_value() && ( desired_height = desired_bounds.value().h != -1 ) ) {
+        max_avail_height = std::min( max_avail_height, desired_height );
     }
     calculated_menu_size.y = std::min( max_avail_height - additional_height +
                                        ( s.FramePadding.y * 2.0 ),

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -747,9 +747,11 @@ void uilist::calc_data()
     calculated_menu_size.x += calculated_label_width + padding;
     calculated_menu_size.x += calculated_secondary_width + padding;
     float max_avail_height = 0.9 * ImGui::GetMainViewport()->Size.y;
-    float desired_height;
-    if( desired_bounds.has_value() && ( desired_height = desired_bounds.value().h != -1 ) ) {
-        max_avail_height = std::min( max_avail_height, desired_height );
+    if( desired_bounds.has_value() ) {
+        float desired_height = desired_bounds.value().h;
+        if( desired_height != -1 ) {
+            max_avail_height = std::min( max_avail_height, desired_height );
+        }
     }
     calculated_menu_size.y = std::min( max_avail_height - additional_height +
                                        ( s.FramePadding.y * 2.0 ),


### PR DESCRIPTION
#### Summary
Bugfixes "calculate correct height when a uilist has desired_bounds not including a height"

#### Purpose of change
Fixes #77191

#### Describe the solution
When the desired bounds doesn't include a height, use the screen height instead of -1 as the desired height.


https://github.com/user-attachments/assets/20d472fa-0ec6-4199-a7ce-df57b3148620

