### PR TITLE
Added check for stealing prior to activating items

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1087,6 +1087,11 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
         }
     }
 
+    item thing = *loc.get_item();
+    if( !avatar_action::check_stealing( get_player_character(), thing ) ) {
+        return;
+    }
+
     loc.overflow();
 
     if( loc->is_comestible() && loc->is_frozen_liquid() ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1087,8 +1087,7 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
         }
     }
 
-    item thing = *loc.get_item();
-    if( !avatar_action::check_stealing( get_player_character(), thing ) ) {
+    if( !avatar_action::check_stealing( get_player_character(), *loc.get_item() ) ) {
         return;
     }
 
@@ -1100,7 +1099,7 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
     }
 
     if( loc->wetness && loc->has_flag( flag_WATER_BREAK_ACTIVE ) ) {
-        if( query_yn( _( "This item is still wet and it will break if you turn it on. Proceed?" ) ) ) {
+        if( query_yn( _( "This item is still wet and it will break if you turn it on.  Proceed?" ) ) ) {
             loc->deactivate();
             loc.get_item()->set_fault( faults::random_of_type( "wet" ) );
             // An electronic item in water is also shorted.


### PR DESCRIPTION
#### Summary
Features "Added check for stealing prior to activating items"

#### Purpose of change
* Closes #61294.

#### Describe the solution
Added `check_stealing` prior to activating items in `avatar_action::use_item`.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned animal shelter with a veterinarian. Tried to activate veterinarian's lighter (lying on one of the shelves). Got a warning about stealing. Answered yes, answered no.

#### Additional context
None.