### PR TITLE
Added check for stealing prior to reloading items

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9888,6 +9888,9 @@ void game::reload( item_location &loc, bool prompt, bool empty )
     }
 
     if( !u.has_item( *loc ) && !loc->has_flag( flag_ALLOWS_REMOTE_USE ) ) {
+        if( !avatar_action::check_stealing( get_player_character(), *loc.get_item() ) ) {
+            return;
+        }
         loc = loc.obtain( u );
         if( !loc ) {
             add_msg( _( "Never mind." ) );


### PR DESCRIPTION
#### Summary
Features "Added check for stealing prior to reloading items"

#### Purpose of change
Bugfixes.

#### Describe the solution
Added `check_stealing` prior to activating items in `game::reload`.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned animal shelter with a veterinarian. Tried to reload veterinarian's lighter (lying on one of the shelves). Got a warning about stealing. Answered yes, answered no.

#### Additional context
None.