### PR TITLE
Flamethrowers count as firestarters for lighting up bombs

### DIFF
--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -49,7 +49,8 @@
     "reload": 4,
     "flags": [ "NEVER_JAMS", "FIRESTARTER" ],
     "ammo_to_fire": 100,
-    "faults": [  ]
+    "faults": [  ],
+    "use_action": { "type": "firestarter" }
   },
   {
     "abstract": "launcher_base",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12461,7 +12461,7 @@ bool item::use_charges( const itype_id &what, int &qty, std::list<item> &used,
             return VisitResponse::NEXT;
         }
 
-        if( e->is_tool() ) {
+        if( e->is_tool() || e->is_gun() ) {
             if( e->typeId() == what || ( in_tools && e->ammo_current() == what ) ) {
                 int n;
                 if( carrier ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Flamethrowers count as firestarters for lighting up bombs"

#### Purpose of change
* Closes #61143.

#### Describe the solution
- Added `firestarter` `use_action` to `flamethrower_base`.
- In `use_charges` allowed checking for `GUN` type of items.

#### Describe alternatives you've considered
None.

#### Testing
Got dynamite and a flamethrower. Wielded dynamite and activated it. Dynamite was lit, flamethrower lost 1 charge of napalm.

#### Additional context
AFAIK currently there's no underbarrel flamethrowers in vanilla or built-in mods, but if some modder wants to add such a thing to his mod, I suppose this gunmod won't work. Should I also add a check for `GUNMOD` type of items?