### PR TITLE
math: improve diag_value constructors

### DIFF
--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -204,7 +204,7 @@ constexpr void _validate_operand( thingie const &thing, std::string_view symbol 
 
 void _validate_unused_kwargs( diag_kwargs const &kwargs )
 {
-    for( diag_kwargs::value_type const &v : kwargs ) {
+    for( diag_kwargs::impl_t::value_type const &v : kwargs.kwargs ) {
         if( !v.second.was_used() ) {
             throw std::invalid_argument( string_format( R"(Unused kwarg "%s")", v.first ) );
         }
@@ -605,7 +605,7 @@ void math_exp::math_exp_impl::new_func()
                     "All positional arguments must precede keyword-value pairs" );
             }
             kwarg &kw = std::get<kwarg>( output.top().data );
-            kwargs.emplace( kw.key, _get_diag_value( *kw.val ) );
+            kwargs.kwargs.emplace( kw.key, _get_diag_value( *kw.val ) );
             output.pop();
         }
         for( std::vector<thingie>::size_type i = 0; i < nparams; i++ ) {

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -31,10 +31,7 @@ The typical parsing function takes the form:
 std::function<double( dialogue & )> myfunction_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value myval;
-    if( kwargs.count( "mykwarg" ) != 0 ) {
-        myval = *kwargs.at( "mykwarg" );
-    }
+    diag_value myval = kwargs.kwarg_or( "mykwarg", "default-value" );
 
     ...parse-time code...
 
@@ -198,10 +195,7 @@ std::function<double( dialogue & )> damage_level_eval( char scope,
 std::function<double( dialogue & )> effect_intensity_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value bp_val;
-    if( kwargs.count( "bodypart" ) != 0 ) {
-        bp_val = *kwargs.at( "bodypart" );
-    }
+    diag_value bp_val = kwargs.kwarg_or( "bodypart" );
     return[effect_id = params[0], bp_val, beta = is_beta( scope )]( dialogue const & d ) {
         std::string const bp_str = bp_val.str( d );
         bodypart_id const bp = bp_str.empty() ? bodypart_str_id::NULL_ID() : bodypart_id( bp_str );
@@ -349,8 +343,10 @@ std::function<double( dialogue & )> field_strength_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
     std::optional<var_info> loc_var;
-    if( kwargs.count( "location" ) != 0 ) {
-        loc_var = kwargs.at( "location" )->var();
+    diag_value loc_val = kwargs.kwarg_or( "location" );
+
+    if( !loc_val.is_empty() ) {
+        loc_var = loc_val.var();
     } else if( scope == 'g' ) {
         throw std::invalid_argument( string_format(
                                          R"("field_strength" needs either an actor scope (u/n) or a 'location' kwarg)" ) );
@@ -402,10 +398,7 @@ std::function<double( dialogue & )> sum_traits_of_category_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
 
-    diag_value type( "ALL" );
-    if( kwargs.count( "type" ) != 0 ) {
-        type = *kwargs.at( "type" );
-    }
+    diag_value type = kwargs.kwarg_or( "type", "ALL" );
 
     return [beta = is_beta( scope ), category = params[0], type]( dialogue const & d ) {
 
@@ -432,10 +425,7 @@ std::function<double( dialogue & )> sum_traits_of_category_char_has_eval( char s
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
 
-    diag_value type( "ALL" );
-    if( kwargs.count( "type" ) != 0 ) {
-        type = *kwargs.at( "type" );
-    }
+    diag_value type = kwargs.kwarg_or( "type", "ALL" );
 
     return [beta = is_beta( scope ), category = params[0], type]( dialogue const & d ) {
 
@@ -541,27 +531,18 @@ std::function<void( dialogue &, double )> spellcasting_adjustment_ass( char scop
     };
     diag_value filter;
     spell_scope spellsearch_scope;
-    if( kwargs.count( "mod" ) != 0 ) {
-        filter = *kwargs.at( "mod" );
+    if( filter = kwargs.kwarg_or( "mod" ); !filter.is_empty() ) {
         spellsearch_scope = scope_mod;
-    } else if( kwargs.count( "school" ) != 0 ) {
-        filter = *kwargs.at( "school" );
+    } else if( filter = kwargs.kwarg_or( "school" ); !filter.is_empty() ) {
         spellsearch_scope = scope_school;
-    } else if( kwargs.count( "spell" ) != 0 ) {
-        filter = *kwargs.at( "spell" );
+    } else if( filter = kwargs.kwarg_or( "spell" ); !filter.is_empty() ) {
         spellsearch_scope = scope_spell;
     } else {
         spellsearch_scope = scope_all;
     }
 
-    diag_value whitelist;
-    diag_value blacklist;
-    if( kwargs.count( "flag_whitelist" ) != 0 ) {
-        whitelist = *kwargs.at( "flag_whitelist" );
-    }
-    if( kwargs.count( "flag_blacklist" ) != 0 ) {
-        blacklist = *kwargs.at( "flag_blacklist" );
-    }
+    diag_value whitelist = kwargs.kwarg_or( "flag_whitelist" );
+    diag_value blacklist = kwargs.kwarg_or( "flag_blacklist" );
 
     return[beta = is_beta( scope ),
                 spellcasting_property = params[0], whitelist, blacklist, spellsearch_scope,
@@ -629,10 +610,7 @@ std::function<double( dialogue & )> item_count_eval( char scope,
 std::function<double( dialogue & )> item_rad_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value agg_val( "min" );
-    if( kwargs.count( "aggregate" ) != 0 ) {
-        agg_val = *kwargs.at( "aggregate" );
-    }
+    diag_value agg_val  = kwargs.kwarg_or( "aggregate", "min" );
 
     return [beta = is_beta( scope ), flag = params[0], agg_val]( dialogue const & d ) {
         std::optional<aggregate_type> const agg =
@@ -745,21 +723,14 @@ bool _filter_character( Character const *beta, Character const &guy, int radius,
 std::function<double( dialogue & )> _characters_nearby_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value radius_val( 1000 );
-    diag_value filter_val( "any" );
-    diag_value allow_hallucinations_val;
+    diag_value radius_val = kwargs.kwarg_or( "radius", 1000 );
+    diag_value filter_val = kwargs.kwarg_or( "attitude", "any" );
+    diag_value allow_hallucinations_val = kwargs.kwarg_or( "allow_hallucinations" );
     std::optional<var_info> loc_var;
-    if( kwargs.count( "radius" ) != 0 ) {
-        radius_val = *kwargs.at( "radius" );
-    }
-    if( kwargs.count( "attitude" ) != 0 ) {
-        filter_val = *kwargs.at( "attitude" );
-    }
-    if( kwargs.count( "allow_hallucinations" ) != 0 ) {
-        allow_hallucinations_val = *kwargs.at( "allow_hallucinations" );
-    }
-    if( kwargs.count( "location" ) != 0 ) {
-        loc_var = kwargs.at( "location" )->var();
+    diag_value loc_val = kwargs.kwarg_or( "location" );
+
+    if( !loc_val.is_empty() ) {
+        loc_var = loc_val.var();
     } else if( scope == 'g' ) {
         throw std::invalid_argument( string_format(
                                          R"("characters_nearby" needs either an actor scope (u/n) or a 'location' kwarg)" ) );
@@ -868,17 +839,13 @@ template<class ID>
 std::function<double( dialogue & )> _monsters_nearby_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs, f_monster_match<ID> f )
 {
-    diag_value radius_val( 1000 );
-    diag_value filter_val( "hostile" );
+    diag_value radius_val = kwargs.kwarg_or( "radius", 1000 );
+    diag_value filter_val = kwargs.kwarg_or( "attitude", "hostile" );
+    diag_value loc_val =  kwargs.kwarg_or( "location" );
     std::optional<var_info> loc_var;
-    if( kwargs.count( "radius" ) != 0 ) {
-        radius_val = *kwargs.at( "radius" );
-    }
-    if( kwargs.count( "attitude" ) != 0 ) {
-        filter_val = *kwargs.at( "attitude" );
-    }
-    if( kwargs.count( "location" ) != 0 ) {
-        loc_var = kwargs.at( "location" )->var();
+
+    if( !loc_val.is_empty() ) {
+        loc_var = loc_val.var();
     } else if( scope == 'g' ) {
         throw std::invalid_argument( string_format(
                                          R"("monsters_nearby" needs either an actor scope (u/n) or a 'location' kwarg)" ) );
@@ -945,10 +912,8 @@ std::function<double( dialogue & )> moon_phase_eval( char /* scope */,
 std::function<double( dialogue & )> pain_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value format_value( "raw" );
-    if( kwargs.count( "type" ) != 0 ) {
-        format_value = *kwargs.at( "type" );
-    }
+    diag_value format_value = kwargs.kwarg_or( "type", "raw" );
+
     return [format_value, beta = is_beta( scope )]( dialogue const & d ) {
         std::string format = format_value.str( d );
         if( format == "perceived" ) {
@@ -965,10 +930,7 @@ std::function<double( dialogue & )> pain_eval( char scope,
 std::function<void( dialogue &, double )> pain_ass( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value format_value( std::string( "raw" ) );
-    if( kwargs.count( "type" ) != 0 ) {
-        format_value = *kwargs.at( "type" );
-    }
+    diag_value format_value = kwargs.kwarg_or( "type", "raw" );
 
     return [beta = is_beta( scope ), format_value]( dialogue const & d, double val ) {
 
@@ -1040,16 +1002,8 @@ std::function<void( dialogue &, double )> school_level_adjustment_ass( char scop
 std::function<double( dialogue & )> get_daily_calories( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value type_val( "total" );
-    diag_value day_val;
-
-    if( kwargs.count( "day" ) != 0 ) {
-        day_val = *kwargs.at( "day" );
-    }
-
-    if( kwargs.count( "type" ) != 0 ) {
-        type_val = *kwargs.at( "type" );
-    }
+    diag_value type_val = kwargs.kwarg_or( "type", "total" );
+    diag_value day_val = kwargs.kwarg_or( "day" );
 
     return[beta = is_beta( scope ), day_val, type_val ]( dialogue const & d ) {
         std::string type = type_val.str( d );
@@ -1082,10 +1036,7 @@ std::function<void( dialogue &, double )> skill_ass( char scope,
 std::function<double( dialogue & )> skill_exp_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value format_value( "percentage" );
-    if( kwargs.count( "format" ) != 0 ) {
-        format_value = *kwargs.at( "format" );
-    }
+    diag_value format_value = kwargs.kwarg_or( "format", "percentage" );
 
     return[skill_value = params[0], format_value, beta = is_beta( scope )]( dialogue const & d ) {
         skill_id skill( skill_value.str( d ) );
@@ -1101,10 +1052,7 @@ std::function<double( dialogue & )> skill_exp_eval( char scope,
 std::function<void( dialogue &, double )> skill_exp_ass( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value format_value( "percentage" );
-    if( kwargs.count( "format" ) != 0 ) {
-        format_value = *kwargs.at( "format" );
-    }
+    diag_value format_value = kwargs.kwarg_or( "format", "percentage" );
 
     return [skill_value = params[0], format_value, beta = is_beta( scope ) ]( dialogue const & d,
     double val ) {
@@ -1121,10 +1069,8 @@ std::function<void( dialogue &, double )> skill_exp_ass( char scope,
 std::function<double( dialogue & )> spell_count_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value school_value;
-    if( kwargs.count( "school" ) != 0 ) {
-        school_value = *kwargs.at( "school" );
-    }
+    diag_value school_value = kwargs.kwarg_or( "school" );
+
     return[beta = is_beta( scope ), school_value]( dialogue const & d ) {
         std::string school_str = school_value.str( d );
         const trait_id scid = school_str.empty() ? trait_id::NULL_ID() : trait_id( school_str );
@@ -1135,16 +1081,8 @@ std::function<double( dialogue & )> spell_count_eval( char scope,
 std::function<double( dialogue & )> spell_sum_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value school_value;
-    diag_value min_level;
-
-    if( kwargs.count( "school" ) != 0 ) {
-        school_value = *kwargs.at( "school" );
-    }
-
-    if( kwargs.count( "level" ) != 0 ) {
-        min_level = *kwargs.at( "level" );
-    }
+    diag_value school_value = kwargs.kwarg_or( "school" );
+    diag_value min_level = kwargs.kwarg_or( "level" );
 
     return[beta = is_beta( scope ), school_value, min_level]( dialogue const & d ) {
         std::string school_str = school_value.str( d );
@@ -1269,10 +1207,7 @@ double _time_in_unit( double time, std::string_view unit )
 std::function<double( dialogue & )> time_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value unit_val;
-    if( kwargs.count( "unit" ) != 0 ) {
-        unit_val = *kwargs.at( "unit" );
-    }
+    diag_value unit_val = kwargs.kwarg_or( "unit" );
 
     return [val = params[0], unit_val]( dialogue const & d ) {
         std::string const val_str = val.str( d );
@@ -1307,10 +1242,7 @@ std::function<void( dialogue &, double )> time_ass( char /* scope */,
 std::function<double( dialogue & )> time_since_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value unit_val;
-    if( kwargs.count( "unit" ) != 0 ) {
-        unit_val = *kwargs.at( "unit" );
-    }
+    diag_value unit_val = kwargs.kwarg_or( "unit" );
 
     return [val = params[0], unit_val]( dialogue const & d ) {
         double ret{};
@@ -1333,10 +1265,7 @@ std::function<double( dialogue & )> time_since_eval( char /* scope */,
 std::function<double( dialogue & )> time_until_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value unit_val;
-    if( kwargs.count( "unit" ) != 0 ) {
-        unit_val = *kwargs.at( "unit" );
-    }
+    diag_value unit_val = kwargs.kwarg_or( "unit" );
 
     return [val = params[0], unit_val]( dialogue const & d ) {
         double ret{};
@@ -1369,10 +1298,7 @@ std::function<double( dialogue & )> time_until_eval( char /* scope */,
 std::function<double( dialogue & )> time_until_eoc_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value unit_val;
-    if( kwargs.count( "unit" ) != 0 ) {
-        unit_val = *kwargs.at( "unit" );
-    }
+    diag_value unit_val = kwargs.kwarg_or( "unit" );
 
     return [eoc_val = params[0], unit_val]( dialogue const & d ) -> double {
         effect_on_condition_id eoc_id( eoc_val.str( d ) );
@@ -1389,15 +1315,8 @@ std::function<double( dialogue & )> time_until_eoc_eval( char /* scope */,
 std::function<double( dialogue & )> effect_duration_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value bp_val;
-    if( kwargs.count( "bodypart" ) != 0 ) {
-        bp_val = *kwargs.at( "bodypart" );
-    }
-
-    diag_value unit_val;
-    if( kwargs.count( "unit" ) != 0 ) {
-        unit_val = *kwargs.at( "unit" );
-    }
+    diag_value bp_val = kwargs.kwarg_or( "bodypart" );
+    diag_value unit_val = kwargs.kwarg_or( "unit" );
 
     return[effect_id = params[0], bp_val, unit_val, beta = is_beta( scope )]( dialogue const & d ) {
         std::string const bp_str = bp_val.str( d );
@@ -1411,10 +1330,8 @@ std::function<double( dialogue & )> effect_duration_eval( char scope,
 std::function<double( dialogue & )> proficiency_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value fmt_val( std::string{"time_spent"} );
-    if( kwargs.count( "format" ) != 0 ) {
-        fmt_val = *kwargs.at( "format" );
-    }
+    diag_value fmt_val = kwargs.kwarg_or( "format", "time_spent" );
+
     return [beta = is_beta( scope ), prof_value = params[0], fmt_val]( dialogue const & d ) {
         proficiency_id prof( prof_value.str( d ) );
         time_duration raw = d.actor( beta )->proficiency_practiced_time( prof );
@@ -1439,14 +1356,9 @@ std::function<double( dialogue & )> proficiency_eval( char scope,
 std::function<void( dialogue &, double )> proficiency_ass( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value fmt_val( "time_spent" );
-    diag_value direct_val;
-    if( kwargs.count( "format" ) != 0 ) {
-        fmt_val = *kwargs.at( "format" );
-    }
-    if( kwargs.count( "direct" ) != 0 ) {
-        direct_val = *kwargs.at( "direct" );
-    }
+    diag_value fmt_val = kwargs.kwarg_or( "format", "time_spent" );
+    diag_value direct_val = kwargs.kwarg_or( "direct" );
+
     return [prof_value = params[0], fmt_val, direct_val, beta = is_beta( scope )]( dialogue const & d,
     double val ) {
         proficiency_id prof( prof_value.str( d ) );
@@ -1508,7 +1420,7 @@ std::function<double( dialogue & )> _test_func( std::vector<diag_value> const &p
         double ( *f )( diag_value const &v, dialogue const &d ) )
 {
     std::vector<diag_value> all_params( params );
-    for( diag_kwargs::value_type const &v : kwargs ) {
+    for( diag_kwargs::impl_t::value_type const &v : kwargs.kwargs ) {
         if( v.first != "test_unused_kwarg" ) {
             all_params.emplace_back( *v.second );
         }
@@ -1648,16 +1560,9 @@ std::function<void( dialogue &, double )> npc_trust_ass( char scope,
 std::function<double( dialogue & )> calories_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value format_value( "raw" );
-    if( kwargs.count( "format" ) != 0 ) {
-        format_value = *kwargs.at( "format" );
-    }
-
+    diag_value format_value = kwargs.kwarg_or( "format", "raw" );
     // dummy kwarg, intentionally discarded!
-    diag_value ignore_weariness_val;
-    if( kwargs.count( "dont_affect_weariness" ) != 0 ) {
-        ignore_weariness_val = *kwargs.at( "dont_affect_weariness" );
-    }
+    diag_value ignore_weariness_val = kwargs.kwarg_or( "dont_affect_weariness" );
 
     return[format_value, beta = is_beta( scope )]( dialogue const & d ) -> double {
         std::string format = format_value.str( d );
@@ -1700,10 +1605,8 @@ std::function<double( dialogue & )> calories_eval( char scope,
 std::function<void( dialogue &, double )> calories_ass( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value ignore_weariness_val;
-    if( kwargs.count( "dont_affect_weariness" ) != 0 ) {
-        ignore_weariness_val = *kwargs.at( "dont_affect_weariness" );
-    }
+    diag_value ignore_weariness_val = kwargs.kwarg_or( "dont_affect_weariness" );
+
     return[ignore_weariness_val, beta = is_beta( scope ) ]( dialogue const & d, double val ) {
         const bool ignore_weariness = is_true( ignore_weariness_val.dbl( d ) );
         int current_kcal = d.actor( beta )->get_stored_kcal();

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -402,7 +402,7 @@ std::function<double( dialogue & )> sum_traits_of_category_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
 
-    diag_value type( std::string{ "ALL" } );
+    diag_value type( "ALL" );
     if( kwargs.count( "type" ) != 0 ) {
         type = *kwargs.at( "type" );
     }
@@ -432,7 +432,7 @@ std::function<double( dialogue & )> sum_traits_of_category_char_has_eval( char s
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
 
-    diag_value type( std::string{ "ALL" } );
+    diag_value type( "ALL" );
     if( kwargs.count( "type" ) != 0 ) {
         type = *kwargs.at( "type" );
     }
@@ -629,7 +629,7 @@ std::function<double( dialogue & )> item_count_eval( char scope,
 std::function<double( dialogue & )> item_rad_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value agg_val( std::string{ "min" } );
+    diag_value agg_val( "min" );
     if( kwargs.count( "aggregate" ) != 0 ) {
         agg_val = *kwargs.at( "aggregate" );
     }
@@ -745,9 +745,9 @@ bool _filter_character( Character const *beta, Character const &guy, int radius,
 std::function<double( dialogue & )> _characters_nearby_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value radius_val( 1000.0 );
-    diag_value filter_val( std::string{ "any" } );
-    diag_value allow_hallucinations_val( 0.0 );
+    diag_value radius_val( 1000 );
+    diag_value filter_val( "any" );
+    diag_value allow_hallucinations_val( 0 );
     std::optional<var_info> loc_var;
     if( kwargs.count( "radius" ) != 0 ) {
         radius_val = *kwargs.at( "radius" );
@@ -868,8 +868,8 @@ template<class ID>
 std::function<double( dialogue & )> _monsters_nearby_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs, f_monster_match<ID> f )
 {
-    diag_value radius_val( 1000.0 );
-    diag_value filter_val( std::string{ "hostile" } );
+    diag_value radius_val( 1000 );
+    diag_value filter_val( "hostile" );
     std::optional<var_info> loc_var;
     if( kwargs.count( "radius" ) != 0 ) {
         radius_val = *kwargs.at( "radius" );
@@ -945,7 +945,7 @@ std::function<double( dialogue & )> moon_phase_eval( char /* scope */,
 std::function<double( dialogue & )> pain_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value format_value( std::string( "raw" ) );
+    diag_value format_value( "raw" );
     if( kwargs.count( "type" ) != 0 ) {
         format_value = *kwargs.at( "type" );
     }
@@ -1040,8 +1040,8 @@ std::function<void( dialogue &, double )> school_level_adjustment_ass( char scop
 std::function<double( dialogue & )> get_daily_calories( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value type_val( std::string( "total" ) );
-    diag_value day_val( 0.0 );
+    diag_value type_val( "total" );
+    diag_value day_val( 0 );
 
     if( kwargs.count( "day" ) != 0 ) {
         day_val = *kwargs.at( "day" );
@@ -1082,7 +1082,7 @@ std::function<void( dialogue &, double )> skill_ass( char scope,
 std::function<double( dialogue & )> skill_exp_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value format_value( std::string( "percentage" ) );
+    diag_value format_value( "percentage" );
     if( kwargs.count( "format" ) != 0 ) {
         format_value = *kwargs.at( "format" );
     }
@@ -1101,7 +1101,7 @@ std::function<double( dialogue & )> skill_exp_eval( char scope,
 std::function<void( dialogue &, double )> skill_exp_ass( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value format_value( std::string( "percentage" ) );
+    diag_value format_value( "percentage" );
     if( kwargs.count( "format" ) != 0 ) {
         format_value = *kwargs.at( "format" );
     }
@@ -1136,7 +1136,7 @@ std::function<double( dialogue & )> spell_sum_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
     diag_value school_value( std::string{} );
-    diag_value min_level( 0.0 );
+    diag_value min_level( 0 );
 
     if( kwargs.count( "school" ) != 0 ) {
         school_value = *kwargs.at( "school" );
@@ -1439,8 +1439,8 @@ std::function<double( dialogue & )> proficiency_eval( char scope,
 std::function<void( dialogue &, double )> proficiency_ass( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value fmt_val( std::string{"time_spent"} );
-    diag_value direct_val( 0.0 );
+    diag_value fmt_val( "time_spent" );
+    diag_value direct_val( 0 );
     if( kwargs.count( "format" ) != 0 ) {
         fmt_val = *kwargs.at( "format" );
     }
@@ -1648,13 +1648,13 @@ std::function<void( dialogue &, double )> npc_trust_ass( char scope,
 std::function<double( dialogue & )> calories_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value format_value( std::string( "raw" ) );
+    diag_value format_value( "raw" );
     if( kwargs.count( "format" ) != 0 ) {
         format_value = *kwargs.at( "format" );
     }
 
     // dummy kwarg, intentionally discarded!
-    diag_value ignore_weariness_val( 0.0 );
+    diag_value ignore_weariness_val( 0 );
     if( kwargs.count( "dont_affect_weariness" ) != 0 ) {
         ignore_weariness_val = *kwargs.at( "dont_affect_weariness" );
     }
@@ -1700,7 +1700,7 @@ std::function<double( dialogue & )> calories_eval( char scope,
 std::function<void( dialogue &, double )> calories_ass( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value ignore_weariness_val( 0.0 );
+    diag_value ignore_weariness_val( 0 );
     if( kwargs.count( "dont_affect_weariness" ) != 0 ) {
         ignore_weariness_val = *kwargs.at( "dont_affect_weariness" );
     }

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -31,7 +31,7 @@ The typical parsing function takes the form:
 std::function<double( dialogue & )> myfunction_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value myval( std::string{} );
+    diag_value myval;
     if( kwargs.count( "mykwarg" ) != 0 ) {
         myval = *kwargs.at( "mykwarg" );
     }
@@ -198,7 +198,7 @@ std::function<double( dialogue & )> damage_level_eval( char scope,
 std::function<double( dialogue & )> effect_intensity_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value bp_val( std::string{} );
+    diag_value bp_val;
     if( kwargs.count( "bodypart" ) != 0 ) {
         bp_val = *kwargs.at( "bodypart" );
     }
@@ -539,7 +539,7 @@ std::function<void( dialogue &, double )> spellcasting_adjustment_ass( char scop
         scope_school,
         scope_spell
     };
-    diag_value filter( std::string{} );
+    diag_value filter;
     spell_scope spellsearch_scope;
     if( kwargs.count( "mod" ) != 0 ) {
         filter = *kwargs.at( "mod" );
@@ -554,8 +554,8 @@ std::function<void( dialogue &, double )> spellcasting_adjustment_ass( char scop
         spellsearch_scope = scope_all;
     }
 
-    diag_value whitelist( std::string{} );
-    diag_value blacklist( std::string{} );
+    diag_value whitelist;
+    diag_value blacklist;
     if( kwargs.count( "flag_whitelist" ) != 0 ) {
         whitelist = *kwargs.at( "flag_whitelist" );
     }
@@ -747,7 +747,7 @@ std::function<double( dialogue & )> _characters_nearby_eval( char scope,
 {
     diag_value radius_val( 1000 );
     diag_value filter_val( "any" );
-    diag_value allow_hallucinations_val( 0 );
+    diag_value allow_hallucinations_val;
     std::optional<var_info> loc_var;
     if( kwargs.count( "radius" ) != 0 ) {
         radius_val = *kwargs.at( "radius" );
@@ -1041,7 +1041,7 @@ std::function<double( dialogue & )> get_daily_calories( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
     diag_value type_val( "total" );
-    diag_value day_val( 0 );
+    diag_value day_val;
 
     if( kwargs.count( "day" ) != 0 ) {
         day_val = *kwargs.at( "day" );
@@ -1121,7 +1121,7 @@ std::function<void( dialogue &, double )> skill_exp_ass( char scope,
 std::function<double( dialogue & )> spell_count_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value school_value( std::string{} );
+    diag_value school_value;
     if( kwargs.count( "school" ) != 0 ) {
         school_value = *kwargs.at( "school" );
     }
@@ -1135,8 +1135,8 @@ std::function<double( dialogue & )> spell_count_eval( char scope,
 std::function<double( dialogue & )> spell_sum_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value school_value( std::string{} );
-    diag_value min_level( 0 );
+    diag_value school_value;
+    diag_value min_level;
 
     if( kwargs.count( "school" ) != 0 ) {
         school_value = *kwargs.at( "school" );
@@ -1269,7 +1269,7 @@ double _time_in_unit( double time, std::string_view unit )
 std::function<double( dialogue & )> time_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value unit_val( std::string{} );
+    diag_value unit_val;
     if( kwargs.count( "unit" ) != 0 ) {
         unit_val = *kwargs.at( "unit" );
     }
@@ -1307,7 +1307,7 @@ std::function<void( dialogue &, double )> time_ass( char /* scope */,
 std::function<double( dialogue & )> time_since_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value unit_val( std::string{} );
+    diag_value unit_val;
     if( kwargs.count( "unit" ) != 0 ) {
         unit_val = *kwargs.at( "unit" );
     }
@@ -1333,7 +1333,7 @@ std::function<double( dialogue & )> time_since_eval( char /* scope */,
 std::function<double( dialogue & )> time_until_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value unit_val( std::string{} );
+    diag_value unit_val;
     if( kwargs.count( "unit" ) != 0 ) {
         unit_val = *kwargs.at( "unit" );
     }
@@ -1369,7 +1369,7 @@ std::function<double( dialogue & )> time_until_eval( char /* scope */,
 std::function<double( dialogue & )> time_until_eoc_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value unit_val( std::string{} );
+    diag_value unit_val;
     if( kwargs.count( "unit" ) != 0 ) {
         unit_val = *kwargs.at( "unit" );
     }
@@ -1389,12 +1389,12 @@ std::function<double( dialogue & )> time_until_eoc_eval( char /* scope */,
 std::function<double( dialogue & )> effect_duration_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    diag_value bp_val( std::string{} );
+    diag_value bp_val;
     if( kwargs.count( "bodypart" ) != 0 ) {
         bp_val = *kwargs.at( "bodypart" );
     }
 
-    diag_value unit_val( std::string{} );
+    diag_value unit_val;
     if( kwargs.count( "unit" ) != 0 ) {
         unit_val = *kwargs.at( "unit" );
     }
@@ -1440,7 +1440,7 @@ std::function<void( dialogue &, double )> proficiency_ass( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
     diag_value fmt_val( "time_spent" );
-    diag_value direct_val( 0 );
+    diag_value direct_val;
     if( kwargs.count( "format" ) != 0 ) {
         fmt_val = *kwargs.at( "format" );
     }
@@ -1654,7 +1654,7 @@ std::function<double( dialogue & )> calories_eval( char scope,
     }
 
     // dummy kwarg, intentionally discarded!
-    diag_value ignore_weariness_val( 0 );
+    diag_value ignore_weariness_val;
     if( kwargs.count( "dont_affect_weariness" ) != 0 ) {
         ignore_weariness_val = *kwargs.at( "dont_affect_weariness" );
     }
@@ -1700,7 +1700,7 @@ std::function<double( dialogue & )> calories_eval( char scope,
 std::function<void( dialogue &, double )> calories_ass( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
 {
-    diag_value ignore_weariness_val( 0 );
+    diag_value ignore_weariness_val;
     if( kwargs.count( "dont_affect_weariness" ) != 0 ) {
         ignore_weariness_val = *kwargs.at( "dont_affect_weariness" );
     }

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -8,9 +8,21 @@
 #include <string_view>
 #include <vector>
 
-struct diag_value;
-struct deref_diag_value;
-using diag_kwargs = std::map<std::string, deref_diag_value>;
+#include "math_parser_diag_value.h"
+
+struct diag_kwargs {
+    using impl_t = std::map<std::string, deref_diag_value>;
+
+    impl_t kwargs;
+
+    template<typename T = std::monostate>
+    diag_value kwarg_or( std::string const &key, T const &default_value = {} ) const {
+        if( auto it = kwargs.find( key ); it != kwargs.end() ) {
+            return *( it->second );
+        }
+        return diag_value{ default_value };
+    }
+};
 
 struct dialogue;
 struct dialogue_func {

--- a/src/math_parser_diag_value.cpp
+++ b/src/math_parser_diag_value.cpp
@@ -33,6 +33,11 @@ template<class C, class R = C, bool at_runtime = false>
 constexpr R _diag_value_at_parse_time( diag_value::impl_t const &data )
 {
     return std::visit( overloaded{
+        []( std::monostate const &/* std */ ) -> R
+        {
+            static R null_R{};
+            return null_R;
+        },
         []( C const & v ) -> R
         {
             return v;
@@ -69,6 +74,10 @@ double diag_value::dbl() const
 double diag_value::dbl( dialogue const &d ) const
 {
     return std::visit( overloaded{
+        []( std::monostate const &/* std */ )
+        {
+            return 0.0;
+        },
         []( double v )
         {
             return v;
@@ -117,6 +126,10 @@ std::string_view diag_value::str() const
 std::string diag_value::str( dialogue const &d ) const
 {
     return std::visit( overloaded{
+        []( std::monostate const &/* std */ )
+        {
+            return std::string{};
+        },
         []( double v )
         {
             // NOLINTNEXTLINE(cata-translate-string-literal)

--- a/src/math_parser_diag_value.cpp
+++ b/src/math_parser_diag_value.cpp
@@ -177,6 +177,11 @@ bool diag_value::is_array() const
     return std::holds_alternative<diag_array>( data );
 }
 
+bool diag_value::is_empty() const
+{
+    return std::holds_alternative<std::monostate>( data );
+}
+
 diag_array const &diag_value::array() const
 {
     return _diag_value_at_parse_time<diag_array, diag_array const &>( data );

--- a/src/math_parser_diag_value.cpp
+++ b/src/math_parser_diag_value.cpp
@@ -154,6 +154,11 @@ var_info diag_value::var() const
     return _diag_value_at_parse_time<var_info>( data );
 }
 
+var_info diag_value::var( dialogue const &/* d */ ) const
+{
+    return _diag_value_at_parse_time<var_info, var_info const &, true>( data );
+}
+
 bool diag_value::is_array() const
 {
     return std::holds_alternative<diag_array>( data );

--- a/src/math_parser_diag_value.h
+++ b/src/math_parser_diag_value.h
@@ -28,7 +28,7 @@ using is_variant_type = is_one_of<T, V>;
 // *INDENT-ON*
 
 struct diag_value {
-    using impl_t = std::variant<double, std::string, var_info, math_exp, diag_array>;
+    using impl_t = std::variant<std::monostate, double, std::string, var_info, math_exp, diag_array>;
 
     diag_value() = default;
 

--- a/src/math_parser_diag_value.h
+++ b/src/math_parser_diag_value.h
@@ -15,31 +15,63 @@ class math_exp;
 struct dialogue;
 struct diag_value;
 using diag_array = std::vector<diag_value>;
+
+// https://stackoverflow.com/a/45896101
+// *INDENT-OFF*
+template <class T, class U>
+struct is_one_of;
+template <class T, class... Ts>
+// NOLINTNEXTLINE(cata-avoid-alternative-tokens) broken check
+struct is_one_of<T, std::variant<Ts...>> : std::bool_constant<( std::is_same_v<T, Ts> || ... )> {};
+template <class T, class V>
+using is_variant_type = is_one_of<T, V>;
+// *INDENT-ON*
+
 struct diag_value {
+    using impl_t = std::variant<double, std::string, var_info, math_exp, diag_array>;
+
     diag_value() = default;
-    template <class U>
+
+    // *INDENT-OFF* astyle formatting isn't stable here
+    template <typename D,
+              std::enable_if_t<!is_variant_type<D, impl_t>{} && std::is_arithmetic_v<D>, int> = 0>
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    diag_value( D d ) : data( std::in_place_type<double>, std::forward<D>( d ) ) {}
+
+    template <typename S,
+              std::enable_if_t<
+                  !is_variant_type<S, impl_t>{} && std::is_convertible_v<S, std::string>, int> = 0>
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    diag_value( S s ) : data( std::in_place_type<std::string>, std::forward<S>( s ) ) {}
+
+    template <class U, std::enable_if_t<is_variant_type<U, impl_t>{}, int> = 0>
     explicit diag_value( U u ) : data( std::in_place_type<U>, std::forward<U>( u ) ) {}
+    // *INDENT-ON*
+
     template <class T, class... Args>
     explicit diag_value( std::in_place_type_t<T> /*t*/, Args &&...args )
         : data( std::in_place_type<T>, std::forward<Args>( args )... ) {}
 
-    // these functions can be used at parse time if the parameter needs to be of exactly this type
-    // with no conversion. These throw so they should *NOT* be used at runtime.
     bool is_dbl() const;
-    double dbl() const;
     bool is_str() const;
-    std::string_view str() const;
     bool is_var() const;
-    var_info var() const;
     bool is_array() const;
-    diag_array const &array() const;
 
-    // evaluate and possibly convert the parameter to this type
+    // these functions can be used at parse time if the parameter needs
+    // to be of exactly this type with no conversion.
+    // These throw so they should *NOT* be used at runtime.
+    double dbl() const;
+    std::string_view str() const;
+    diag_array const &array() const;
+    var_info var() const;
+
+    // evaluate and possibly convert the parameter to this type.
+    // These do not throw and they're meant to be used at runtime
     double dbl( dialogue const &d ) const;
     std::string str( dialogue const &d ) const;
+    var_info var( dialogue const &/* d */ ) const;
     diag_array const &array( dialogue const &/* d */ ) const;
 
-    using impl_t = std::variant<double, std::string, var_info, math_exp, diag_array>;
     impl_t data;
 };
 

--- a/src/math_parser_diag_value.h
+++ b/src/math_parser_diag_value.h
@@ -56,6 +56,7 @@ struct diag_value {
     bool is_str() const;
     bool is_var() const;
     bool is_array() const;
+    bool is_empty() const;
 
     // these functions can be used at parse time if the parameter needs
     // to be of exactly this type with no conversion.

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -12,6 +12,7 @@
 #include "cata_utility.h"
 #include "debug.h"
 #include "dialogue_helpers.h"
+#include "type_id.h"
 #include "math_parser_diag.h"
 #include "math_parser_func.h"
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change
`diag_value` and `diag_kwargs` are a little awkward to use

#### Describe the solution
<details>
<summary>Add more constructors so you can use arithmetic values and string literals directly</summary>

Instead of
```cpp
    diag_value type( std::string{ "ALL" } );
```
you can now write
```cpp
    diag_value type( "ALL" );
```

Instead of
```cpp
    diag_value type( static_cast<double>( PICKUP_RANGE ) );
```
you can now write
```cpp
    diag_value type( PICKUP_RANGE );
```

Instead of
```cpp
    diag_value str_val( std::string{} );
    diag_value art_val( 0.0 );
```
you can now write
```cpp
    diag_value str_val;
    diag_value art_val;
```
and they are treated as zero/null values as needed.

You can also easily construct arrays now
```cpp
    diag_value val( diag_array{ 1, 2, "three" } );
```

</details>

<details>
<summary>Add a `kwarg_or()` helper function</summary>

Instead of
```cpp
    diag_value type( std::string{ "ALL" } );
    if( kwargs.count( "type" ) != 0 ) {
        type = *kwargs.at( "type" );
    }
```
you can now write
```cpp
    diag_value type = kwargs.kwarg_or( "type", "ALL" );
```

Works with empty values too
```cpp
    diag_value type = kwargs.kwarg_or( "type" );
```

</details>

#### Describe alternatives you've considered

N/A

#### Testing
Existing test units

#### Additional context
GuardianDll take a look please and let me know if this is clear.