### PR TITLE
Adjust Raw Butter recipes, Adds raw butter to recipes that use butter.

### DIFF
--- a/data/json/recipes/food/bread.json
+++ b/data/json/recipes/food/bread.json
@@ -227,6 +227,6 @@
     "activity_level": "LIGHT_EXERCISE",
     "result": "PBJ_Toast",
     "copy-from": "buttered_toast",
-    "components": [ [ [ "jam_fruit", 1 ] ], [ [ "butter", 1 ] ], [ [ "any_peanutbutter", 1, "LIST" ] ], [ [ "toast", 1 ] ] ]
+    "components": [ [ [ "jam_fruit", 1 ] ], [ [ "butter", 1 ], [ "raw_butter", 1 ] ], [ [ "any_peanutbutter", 1, "LIST" ] ], [ [ "toast", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/food/dairy_products.json
+++ b/data/json/recipes/food/dairy_products.json
@@ -30,7 +30,7 @@
     "//": "Book Things to do with milk.  Add curdled milk and cheese recipes to the book.  Also consider adding to brewing json Airag from this book.",
     "tools": [ [ [ "jar_glass_sealed", -1 ] ] ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "milk_cream", 3 ] ], [ [ "salt", 1 ] ] ],
-    "charges": 9
+    "charges": 13
   },
   {
     "type": "recipe",

--- a/data/json/recipes/food/dairy_products.json
+++ b/data/json/recipes/food/dairy_products.json
@@ -12,8 +12,8 @@
     "qualities": [ { "id": "CHURN", "level": 1 } ],
     "book_learn": [ [ "dairy_book", 3 ] ],
     "//": "Book Things to do with milk.  Add curdled milk and cheese recipes to the book.  Also consider adding to brewing json Airag from this book.",
-    "components": [ [ [ "milk_cream", 5 ] ] ],
-    "charges": 99
+    "components": [ [ [ "milk_cream", 5 ] ], [ [ "salt", 1 ] ] ],
+    "charges": 22
   },
   {
     "type": "recipe",
@@ -29,8 +29,8 @@
     "book_learn": [ [ "dairy_book", 3 ] ],
     "//": "Book Things to do with milk.  Add curdled milk and cheese recipes to the book.  Also consider adding to brewing json Airag from this book.",
     "tools": [ [ [ "jar_glass_sealed", -1 ] ] ],
-    "components": [ [ [ "water_clean", 1 ] ], [ [ "milk_cream", 3 ] ] ],
-    "charges": 33
+    "components": [ [ [ "water_clean", 1 ] ], [ [ "milk_cream", 3 ] ], [ [ "salt", 1 ] ] ],
+    "charges": 9
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -6730,7 +6730,7 @@
         [ "honey_mustard", 1 ],
         [ "mustard", 1 ],
         [ "butter", 1 ],
-        [ "raw_butter" ],
+        [ "raw_butter", 1 ],
         [ "horseradish", 1 ],
         [ "mayonnaise", 1 ],
         [ "bacon", 1 ],

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -6730,6 +6730,7 @@
         [ "honey_mustard", 1 ],
         [ "mustard", 1 ],
         [ "butter", 1 ],
+        [ "raw_butter"],
         [ "horseradish", 1 ],
         [ "mayonnaise", 1 ],
         [ "bacon", 1 ],
@@ -9677,7 +9678,7 @@
         [ "wild_garlic", 1 ],
         [ "garlic_powder", 1 ]
       ],
-      [ [ "butter", 1 ] ],
+      [ [ "butter", 1 ], [ "raw_butter", 1 ] ],
       [ [ "wild_herbs", 6 ] ]
     ],
     "charges": 6

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -6730,7 +6730,7 @@
         [ "honey_mustard", 1 ],
         [ "mustard", 1 ],
         [ "butter", 1 ],
-        [ "raw_butter"],
+        [ "raw_butter" ],
         [ "horseradish", 1 ],
         [ "mayonnaise", 1 ],
         [ "bacon", 1 ],

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -43,7 +43,7 @@
     "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_carving" } ],
     "tools": [ [ [ "char_smoker", 100 ] ] ],
-    "components": [ [ [ "log", 1 ] ], [ [ "butter", 30 ], [ "edible_lard", 4, "LIST" ] ] ]
+    "components": [ [ [ "log", 1 ] ], [ [ "butter", 30 ], [ "raw_butter", 30 ], [ "edible_lard", 4, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -1034,7 +1034,8 @@
         [ "honey_mustard", 1 ],
         [ "horseradish", 1 ],
         [ "sauerkraut", 1 ],
-        [ "butter", 1 ]
+        [ "butter", 1 ],
+        [ "raw_butter"]
       ]
     ]
   },

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -1035,7 +1035,7 @@
         [ "horseradish", 1 ],
         [ "sauerkraut", 1 ],
         [ "butter", 1 ],
-        [ "raw_butter" ]
+        [ "raw_butter", 1 ]
       ]
     ]
   },

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -1035,7 +1035,7 @@
         [ "horseradish", 1 ],
         [ "sauerkraut", 1 ],
         [ "butter", 1 ],
-        [ "raw_butter"]
+        [ "raw_butter" ]
       ]
     ]
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Fix raw butter calories, add salt to raw butter recipes, Add raw butter as option to recipes that use butter"


#### Purpose of change
Fixes #77224, or at least, as much as I'm able to.
Raw butter before was making super low calorie versions of butter, some recipes that used butter did not allow for using raw butter.   Salt was added to raw butter recipes for two reasons, first as raw butter is used as a drop in replacement for butter it should match it vaguely in terms of taste.  Secondly, when looking up homemade butter recipes, all four I examined had a line recommending adding salt to taste.


#### Describe the solution
From a few resources, like FDA definition of butter, and several recipes for homemade butter, I determined that homemade butter should be approximately 80-85% milkfat, and found that the current listing for raw butter at ~109 calories was more or less accurate.
This adjusts the output charges of raw butter from the churn from 99 to 22, resulting in raw butter with 111 calories per serving, and reduces the output of the shake method of raw butter from 33 to 13, resulting in raw butter with 113 calories per serving.
This PR also adds raw butter to recipes that seemingly lack it as an oversight, as they use butter.  This particular facet of the PR may be considered over-reach and I'm happy to split it off if desired.  The recipes changed for this facet are the condiment list, shillelagh, escargot, pbj toast, and lobster roll.
The PR also adds the requirement of 1 unit of salt per crafting operation of raw butter.


#### Describe alternatives you've considered
1: Remove Raw Butter entirely, make all current recipes craft regular butter instead.  This means that crafted butter would last longer on average by a few days, but that seems reasonable.  In the desire to not change more than necessary, I opted to not do this unless it's broadly desired.
2: Rename raw butter to homemade butter.  I feel like the name raw implies a state that's better or more refined.
3: Add nutrient_override to raw butter, so we don't run into this mess of juggling calories.  It would also allow for fixing the side issue of the buttermilk being magic calories.  That said, given that seems to be part of a broader crafting issue, I opted not to do so.
4: Splitting this PR into several, as I worry this might be considered scope creep between the charge adjustments, adding the raw butter to recipes that use butter, and adding salt to the recipes.


#### Testing
Tested on:
 - OS: Windows
    - OS Version: 10.0.19045.4894 (22H2)
- Game Version: cdda-experimental-2024-10-21-2303 7fc0414 [64-bit]
- Graphics Version: Tiles
- Game Language: System language []
- Mods loaded: [
    Dark Days Ahead [dda],
    Disable NPC Needs [no_npc_food],
    Portal Storms Ignore NPCs [personal_portal_storms],
    Slowdown Fungal Growth [no_fungal_growth]
]

I started a new game using these changes, encountered some errors, fixed them, loaded into the world, set skills to 10, spawned the "things to do with milk" book, several containers, tools etc, and turned milk jars into heavy cream.  Next, I crafted one craft of raw butter using the churn method, observed the 111 calories that match calculation.  Next, I crafted the shake method, encountered an issue where the calories in did not match calories out, meaning we have magic calories in this, as well as other recipes that use food and byproducts.  That seems outside the scope of this issue, so for now I'm accepting the buttermilk being free calories.  I adjusted the recipe again and found it to make raw butter with 113 calories, which is within the 5% difference I set for myself as a metric.
If one wishes to test the byproduct issue, spawn 2 units of chunk of fat, notice they have 1923 calories each, then craft lard, and notice you have 6 units of lard at 641, and one unit of cracklins at 270.  This means that you have 3846 calories in, and 3846+270 calories out.  Assuming this is correct and I'm not making an error, I believe this warrants a bug report.

#### Additional context
Please let me know if my changes need adjustment, or split up.  I'm still trying to understand what degree of scope expanse would warrant making multiple PRs.  I want to make clean edits, but I don't want to annoy reviewers with 3 different PRs if that's unnecessary.
