### PR TITLE
Add Brass Catchers Slots to HWP and Prototype Gun

### DIFF
--- a/data/json/items/gun/robofac_gun.json
+++ b/data/json/items/gun/robofac_gun.json
@@ -27,6 +27,7 @@
     "valid_mod_locations": [
       [ "underbarrel", 1 ],
       [ "rail", 1 ],
+      [ "brass catcher", 1 ],
       [ "sling", 1 ],
       [ "grip", 1 ],
       [ "bore", 1 ],
@@ -80,6 +81,7 @@
     "valid_mod_locations": [
       [ "underbarrel", 1 ],
       [ "rail", 1 ],
+      [ "brass catcher", 1 ],
       [ "sling", 1 ],
       [ "grip", 1 ],
       [ "bore", 1 ],


### PR DESCRIPTION
#### Summary
Features "Adds Brass Catcher Slots to HWP and Prototype Gun"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Both the HWP and Prototype gun lacked a slot for brass catchers, which honestly doesn't make sense given the triviality of adding a bag to a gun.  GuardianDLL checked for me, and there was no comment about the lack of the slot, so we assumed it was simply an oversight.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a slot for brass catcher to each gun.  Easy, simple.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not adding a mod slot to these guns, because they're too high tech or something.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Booted the game up with changes, worked just fine.  Spawned a HWP and Prototype gun, added a bore mod to each (as mod slots are invisible without these), and found a slot.  Spawned two brass catchers and attached one to each gun.
Tested on the following version and settings
- OS: Windows
    - OS Version: 10.0.19045.4894 (22H2)
- Game Version: cdda-experimental-2024-10-21-2303 7fc0414 [64-bit]
- Graphics Version: Tiles
- Game Language: System language []
- Mods loaded: [
    Dark Days Ahead [dda],
    Disable NPC Needs [no_npc_food],
    Portal Storms Ignore NPCs [personal_portal_storms],
    Slowdown Fungal Growth [no_fungal_growth]
]

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![image](https://github.com/user-attachments/assets/13d6e65d-ef7f-4fc9-9e35-6e0fef5c8cf7)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
