### PR TITLE
Forbid starting fires on water tiles

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1921,7 +1921,12 @@ void activity_handlers::start_fire_do_turn( player_activity *act, Character *you
     if( !here.is_flammable( where ) ) {
         try_fuel_fire( *act, *you, true );
         if( !here.is_flammable( where ) ) {
-            you->add_msg_if_player( m_info, _( "There's nothing to light there." ) );
+            if( here.has_flag_ter( ter_furn_flag::TFLAG_DEEP_WATER, where ) ||
+                here.has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, where ) ) {
+                you->add_msg_if_player( m_info, _( "You can't light a fire on water." ) );
+            } else {
+                you->add_msg_if_player( m_info, _( "There's nothing to light there." ) );
+            }
             you->cancel_activity();
             return;
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3681,6 +3681,12 @@ bool map::is_flammable( const tripoint &p )
 
 bool map::is_flammable( const tripoint_bub_ms &p )
 {
+    // No fires on water tiles regardless of other factors
+    if( has_flag_ter( ter_furn_flag::TFLAG_DEEP_WATER, p ) ||
+        has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, p ) ) {
+        return false;
+    }
+
     if( has_flag( ter_furn_flag::TFLAG_FLAMMABLE, p ) ) {
         return true;
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Forbid starting fires (using firestarters) on water tiles"

#### Purpose of change
* Closes #59066. Since I can't confirm `If you start fire in water no matter shallow or deep - it will burn and cannot be extinguished` statement from that issue on latest experimental as of 22 October 2024, I suppose not allowing to start a fire with help of firestarters on water tile is enough to close the issue.

#### Describe the solution
Forbid starting fires (using firestarters) on water tiles. Also added a separate message for trying to start a fire on water.

#### Describe alternatives you've considered
Also forbid creating fire fields on water tiles through other means, for example flamethrowers, molotovs and magic?

#### Testing
Got a lighter and some splintered wood. Put the wood on tiles with shallow and deep water. Tried to light a fire on those tiles.

#### Additional context
None.