### PR TITLE
Allow setting duration for all types of prying, not only for prying nails

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -5196,11 +5196,11 @@ oxytorch: {
 ```
 
 #### `prying`
-(Optional) Data for using with pyring tools
+(Optional) Data for using with prying tools
 ```cpp
 "prying": {
     "result": "furniture_id", // (optional) furniture it will become when done, defaults to f_null
-    "duration": "1 seconds", // (optional) time required for prying nails, default is 1 second
+    "duration": "1 seconds", // (optional) time required for prying, default is 1 second
     "message": "You finish prying the door.", // (optional) message that will be displayed when finished prying successfully
     "byproducts": [ // (optional) list of items that will be spawned when finished successfully
         {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5838,7 +5838,7 @@ time_duration prying_activity_actor::prying_time( const activity_data_common &da
         const item_location &tool, const Character &who )
 {
     const pry_data &pdata = data.prying_data();
-    if( pdata.prying_nails ) {
+    if( data.duration() != 1_seconds ) {
         return data.duration();
     }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5838,7 +5838,7 @@ time_duration prying_activity_actor::prying_time( const activity_data_common &da
         const item_location &tool, const Character &who )
 {
     const pry_data &pdata = data.prying_data();
-    if( data.duration() != 1_seconds ) {
+    if( data.duration() > 1_seconds ) {
         return data.duration();
     }
 

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1405,8 +1405,8 @@ TEST_CASE( "prying", "[activity][prying]" )
             const time_duration prying_time = prying_activity_actor::prying_time(
                                                   *ter_test_t_prying3->prying, prying_tool, dummy );
 
-            THEN( "prying time is 32 seconds" ) {
-                CHECK( prying_time == 32_seconds );
+            THEN( "prying time is 30 seconds" ) {
+                CHECK( prying_time == 30_seconds );
             }
         }
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Implement @LyranRenegade's suggestion from #59045.

#### Describe the solution
Previously one was able to set duration for prying, though he had to set `prying_nails: true` despite not even planning to actually pry nails. `duration` field name was confusing since it's not "duration of prying", but rather "duration of prying nails".

Now `duration` field works regardless of state of `prying_nails`, one only need to set `duration` to anything greater than 1 second.

#### Describe alternatives you've considered
Change field name from `duration` to something like `prying_nails_duration` to avoid confusion. But adding functionality is still better, I think.

#### Testing
Added `duration: 300 seconds` to locked wood door. Tried to pry it with a crowbar. Noticed that prying took 5 minutes instead of usual ~30 seconds for a default character.

#### Additional context
None.