### PR TITLE
Aftershock: Suit batteries

### DIFF
--- a/data/mods/Aftershock/itemgroups/clothing/winter_outfits.json
+++ b/data/mods/Aftershock/itemgroups/clothing/winter_outfits.json
@@ -32,7 +32,11 @@
     "type": "item_group",
     "//": "The matching frontier-cryosuit set. Includes suit, mask and possible future accessories",
     "subtype": "collection",
-    "entries": [ { "item": "afs_frontier_cryo" }, { "item": "afs_frontier_cryomask", "prob": 90 } ]
+    "entries": [
+      { "item": "afs_frontier_cryo" },
+      { "item": "afs_frontier_cryomask", "prob": 90 },
+      { "item": "afs_heavy_suit_battery_cell", "count": [ 1, 2 ], "prob": 25, "charges": [ 0, 1000 ] }
+    ]
   },
   {
     "id": "afs_cryopod_g",

--- a/data/mods/Aftershock/itemgroups/loot_corpse_groups.json
+++ b/data/mods/Aftershock/itemgroups/loot_corpse_groups.json
@@ -13,6 +13,7 @@
         ]
       },
       { "group": "afs_survivor_weapon_set", "prob": 80 },
+      { "item": "afs_heavy_suit_battery_cell", "count": [ 1, 2 ], "prob": 80, "charges": [ 100, 1000 ] },
       { "group": "afs_tools_scavenging", "prob": 30 },
       { "group": "tools_survival", "prob": 80, "count": [ 1, 3 ] },
       { "group": "afs_cheap_food", "prob": 30, "count": [ 2, 6 ] },

--- a/data/mods/Aftershock/items/armor/winter_suits.json
+++ b/data/mods/Aftershock/items/armor/winter_suits.json
@@ -104,8 +104,8 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM" ],
-        "default_magazine": "medium_battery_cell"
+        "flag_restriction": [ "BATTERY_HEAVY" ],
+        "default_magazine": "afs_heavy_suit_battery_cell"
       }
     ],
     "warmth": 20,
@@ -169,8 +169,8 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM" ],
-        "default_magazine": "medium_battery_cell"
+        "flag_restriction": [ "BATTERY_HEAVY" ],
+        "default_magazine": "afs_heavy_suit_battery_cell"
       }
     ],
     "warmth": 20,

--- a/data/mods/Aftershock/items/battery.json
+++ b/data/mods/Aftershock/items/battery.json
@@ -4,7 +4,7 @@
     "type": "MAGAZINE",
     "category": "tool_magazine",
     "name": { "str": "suit battery", "str_pl": "suit batteries" },
-    "description": "A heavy battery cell, compatible with most industrial equipment but purposefully designed to power EVA suits. It's a bit too big to fit in most portable tools.",
+    "description": "A heavy battery cell, compatible with most industrial equipment but purposefully designed to power EVA suits  It's a bit too big to fit in most portable tools.",
     "ascii_picture": "heavy_plus_battery_cell",
     "weight": "880 g",
     "volume": "900 ml",

--- a/data/mods/Aftershock/items/battery.json
+++ b/data/mods/Aftershock/items/battery.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "afs_heavy_suit_battery_cell",
+    "type": "MAGAZINE",
+    "category": "tool_magazine",
+    "name": { "str": "suit battery", "str_pl": "suit batteries" },
+    "description": "A heavy battery cell, compatible with most industrial equipment but purposefully designed to power EVA suits. It's a bit too big to fit in most portable tools.",
+    "ascii_picture": "heavy_plus_battery_cell",
+    "weight": "880 g",
+    "volume": "900 ml",
+    "longest_side": "113 mm",
+    "price": "200 USD",
+    "price_postapoc": "200 USD",
+    "material": [ { "type": "budget_steel", "portion": 99 }, { "type": "plastic", "portion": 1 } ],
+    "symbol": "=",
+    "color": "yellow",
+    "ammo_type": [ "battery" ],
+    "capacity": 1000,
+    "looks_like": "battery",
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "BATTERY_HEAVY" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1000 } } ]
+  }
+]

--- a/data/mods/Aftershock/items/tool_armor.json
+++ b/data/mods/Aftershock/items/tool_armor.json
@@ -20,8 +20,8 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM" ],
-        "default_magazine": "medium_battery_cell"
+        "flag_restriction": [ "BATTERY_HEAVY" ],
+        "default_magazine": "afs_heavy_suit_battery_cell"
       }
     ],
     "use_action": {

--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_tool_trader.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_tool_trader.json
@@ -36,6 +36,7 @@
       { "group": "afs_tools_scavenging", "count": [ 6, 12 ] },
       { "group": "afs_tools_pocket", "count": [ 5, 10 ] },
       { "item": "afs_40g_plasma_civ", "count": [ 2, 5 ] },
+      { "item": "afs_heavy_suit_battery_cell", "count": [ 2, 5 ] },
       { "group": "afs_tools_welding_consumable", "count": [ 6, 8 ] },
       { "group": "afs_augustmoon_batteries_disposable", "count": [ 5, 10 ] },
       { "group": "afs_augustmoon_batteries_rechargeable", "count": [ 2, 3 ], "prob": 20 }


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Add suit batteries for the winter suits."

#### Purpose of change
Suit operating time is balanced around batteries with a 1000 charges. This adds a common battery with these many charges in order to not reformulate the entire suit design.

#### Describe the solution
New Items, magazine updates and item groups.

#### Testing
Loaded and scavenged both a suit and a battery.
