### PR TITLE
[MoM] Feral psion updates with copy-from

### DIFF
--- a/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
@@ -4,7 +4,7 @@
     "type": "MONSTER",
     "name": { "str": "Dr. Brain" },
     "description": "An ordinary-looking scientist lost amid the carnage, were it not for the bloodshot eyes, the enlarged cranium, and the fact that the zombies ignore them.  Bits of paper and chemistry equipment lazily float in the air near them.",
-    "copy-from": "mon_feral_psion_default"
+    "copy-from": "mon_feral_psion_default",
     "//": "This is supposed to be a rare boss kind of monster, with both telepathic and telekinetic abililites, but no tougher than a normal zombie.",
     "default_faction": "science",
     "species": [ "FERAL", "TELEKIN_PUSHPULL_NULL" ],
@@ -43,13 +43,13 @@
           "dodgeable": false,
           "uncanny_dodgeable": true,
           "blockable": false,
-          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },      
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
           "hit_dmg_u": "%1$s stares at you and your %2$s is hammered with psionic force!",
-          "hit_dmg_npc": "%1$s stares at <npcname> and their %2$s is hammered with psionic force!",      
+          "hit_dmg_npc": "%1$s stares at <npcname> and their %2$s is hammered with psionic force!",
           "miss_msg_u": "%1$s stares at you and you narrowly avoid an unseen attack!",
           "miss_msg_npc": "%1$s stares and <npcname> narrowly avoids an unseen attack!",
           "no_dmg_msg_u": "%1$s stares at you, but the telekinetic attack rebounds off your armor.",
-          "no_dmg_msg_npc": "%1$s stares at <npcname>, but the telekinetic attack rebounds off their armor."    
+          "no_dmg_msg_npc": "%1$s stares at <npcname>, but the telekinetic attack rebounds off their armor."
         },
         {
           "id": "smash",
@@ -63,16 +63,16 @@
           "dodgeable": false,
           "uncanny_dodgeable": true,
           "blockable": false,
-          "effects_require_dmg": false,     
+          "effects_require_dmg": false,
           "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
           "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
-          "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",         
+          "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
           "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
-          "miss_msg_npc": "%s stares at <npcname> but nothing happens!"  
+          "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
         },
         {
-          "id": "psi_drbrain_momentum_alteration",    
-          "type": "spell",   
+          "id": "psi_drbrain_momentum_alteration",
+          "type": "spell",
           "spell_data": { "id": "telekinetic_momentum_monster" },
           "cooldown": 1,
           "condition": {
@@ -100,7 +100,7 @@
     "type": "MONSTER",
     "name": "feral security guard, Ψ Division",
     "description": "A security guard gone feral, or so you thought.  As you look closer, you notice the relatively-normal appearance, the clear eyes, and the patch on their uniform with a Ψ shape in front of the logo of XEDRA.  The zombies around them ignore them as they move smoothly and purposefully through the ruins.",
-    "copy-from": "mon_feral_psion_default"
+    "copy-from": "mon_feral_psion_default",
     "default_faction": "science",
     "proportional": { "speed": 1.1 },
     "relative": { "melee_skill": 3, "melee_dice": 1, "dodge": 4 },

--- a/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
@@ -4,204 +4,147 @@
     "type": "MONSTER",
     "name": { "str": "Dr. Brain" },
     "description": "An ordinary-looking scientist lost amid the carnage, were it not for the bloodshot eyes, the enlarged cranium, and the fact that the zombies ignore them.  Bits of paper and chemistry equipment lazily float in the air near them.",
+    "copy-from": "mon_feral_psion_default"
     "//": "This is supposed to be a rare boss kind of monster, with both telepathic and telekinetic abililites, but no tougher than a normal zombie.",
     "default_faction": "science",
-    "looks_like": "chud",
-    "bodytype": "human",
     "species": [ "FERAL", "TELEKIN_PUSHPULL_NULL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
     "symbol": "@",
     "color": "magenta",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 4,
-    "melee_dice": 1,
-    "melee_dice_sides": 3,
-    "melee_damage": [ { "damage_type": "cut", "amount": 2 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 2,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "path_settings": { "max_dist": 30, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "vision_day": 50,
-    "vision_night": 3,
     "death_drops": "feral_scientists_death_drops_psychic",
     "zombify_into": "mon_zombie_scientist",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "PLAYER_CLOSE" ],
-    "special_attacks": [
-      [ "PARROT_AT_DANGER", 15 ],
-      {
-        "id": "psi_drbrain_flashbang",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_confusion_monster", "min_level": 5 },
-        "cooldown": { "math": [ "6 + rand(12)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
-      },
-      {
-        "id": "psi_drbrain_blast",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_blast_monster", "min_level": 4 },
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s stares at %3$s!"
-      },
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "mon_telekinetic_mindhammer",
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "move_cost": 80,
-        "range": 6,
-        "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 25 } ],
-        "dodgeable": false,
-        "uncanny_dodgeable": true,
-        "blockable": false,
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s stares at you and your %2$s is hammered with psionic force!",
-        "hit_dmg_npc": "%1$s stares at <npcname> and their %2$s is hammered with psionic force!",
-        "miss_msg_u": "%1$s stares at you and you narrowly avoid an unseen attack!",
-        "miss_msg_npc": "%1$s stares and <npcname> narrowly avoids an unseen attack!",
-        "no_dmg_msg_u": "%1$s stares at you, but the telekinetic attack rebounds off your armor.",
-        "no_dmg_msg_npc": "%1$s stares at <npcname>, but the telekinetic attack rebounds off their armor."
-      },
-      {
-        "id": "smash",
-        "move_cost": 80,
-        "cooldown": { "math": [ "4 + rand(8)" ] },
-        "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 20, "armor_penetration": 10 } ],
-        "hitsize_min": 12,
-        "range": 8,
-        "throw_strength": 70,
-        "dodgeable": false,
-        "uncanny_dodgeable": true,
-        "blockable": false,
-        "effects_require_dmg": false,
-        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
-        "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
-        "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
-        "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
-        "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
-      },
-      {
-        "id": "psi_drbrain_momentum_alteration",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_momentum_monster" },
-        "cooldown": 1,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
+    "extend": {
+      "special_attacks": [
+        [ "PARROT_AT_DANGER", 15 ],
+        {
+          "id": "psi_drbrain_flashbang",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_confusion_monster", "min_level": 5 },
+          "cooldown": { "math": [ "6 + rand(12)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
         },
-        "monster_message": "The air around %1$s wavers."
-      },
-      {
-        "id": "psi_drbrain_inertial_barrier",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_barrier_monster" },
-        "cooldown": 1,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
+        {
+          "id": "psi_drbrain_blast",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_blast_monster", "min_level": 4 },
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s stares at %3$s!"
         },
-        "monster_message": "The air around %1$s distorts."
-      },
-      [ "PULL_METAL_WEAPON", 8 ]
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "TEEP_IMMUNE"
-    ]
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "mon_telekinetic_mindhammer",
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "move_cost": 80,
+          "accuracy": 7,
+          "range": 6,
+          "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 25 } ],
+          "dodgeable": false,
+          "uncanny_dodgeable": true,
+          "blockable": false,
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },      
+          "hit_dmg_u": "%1$s stares at you and your %2$s is hammered with psionic force!",
+          "hit_dmg_npc": "%1$s stares at <npcname> and their %2$s is hammered with psionic force!",      
+          "miss_msg_u": "%1$s stares at you and you narrowly avoid an unseen attack!",
+          "miss_msg_npc": "%1$s stares and <npcname> narrowly avoids an unseen attack!",
+          "no_dmg_msg_u": "%1$s stares at you, but the telekinetic attack rebounds off your armor.",
+          "no_dmg_msg_npc": "%1$s stares at <npcname>, but the telekinetic attack rebounds off their armor."    
+        },
+        {
+          "id": "smash",
+          "move_cost": 80,
+          "cooldown": { "math": [ "4 + rand(8)" ] },
+          "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 20, "armor_penetration": 10 } ],
+          "hitsize_min": 12,
+          "accuracy": 7,
+          "range": 8,
+          "throw_strength": 70,
+          "dodgeable": false,
+          "uncanny_dodgeable": true,
+          "blockable": false,
+          "effects_require_dmg": false,     
+          "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+          "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
+          "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",         
+          "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
+          "miss_msg_npc": "%s stares at <npcname> but nothing happens!"  
+        },
+        {
+          "id": "psi_drbrain_momentum_alteration",    
+          "type": "spell",   
+          "spell_data": { "id": "telekinetic_momentum_monster" },
+          "cooldown": 1,
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
+          },
+          "monster_message": "The air around %1$s wavers."
+        },
+        {
+          "id": "psi_drbrain_inertial_barrier",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_barrier_monster" },
+          "cooldown": 1,
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
+          },
+          "monster_message": "The air around %1$s distorts."
+        },
+        [ "PULL_METAL_WEAPON", 8 ]
+      ],
+      "flags": [ "TEEP_IMMUNE", "PUSH_MON" ]
+    }
   },
   {
     "id": "mon_feral_security_psychic",
     "type": "MONSTER",
     "name": "feral security guard, Ψ Division",
     "description": "A security guard gone feral, or so you thought.  As you look closer, you notice the relatively-normal appearance, the clear eyes, and the patch on their uniform with a Ψ shape in front of the logo of XEDRA.  The zombies around them ignore them as they move smoothly and purposefully through the ruins.",
+    "copy-from": "mon_feral_psion_default"
     "default_faction": "science",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 110,
-    "material": [ "flesh" ],
+    "proportional": { "speed": 1.1 },
+    "relative": { "melee_skill": 3, "melee_dice": 1, "dodge": 4 },
     "color": "pink",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 6,
-    "melee_dice": 2,
-    "melee_dice_sides": 5,
-    "melee_damage": [ { "damage_type": "bash", "amount": 6 } ],
+    "melee_damage": [ { "damage_type": "bash", "amount": 3 } ],
     "attack_cost": 85,
     "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 5,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 35,
-    "vision_night": 7,
-    "path_settings": { "max_dist": 30, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_security_death_drops_psychic",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "special_attacks": [
-      [ "PARROT_AT_DANGER", 15 ],
-      {
-        "id": "smash",
-        "attack_upper": true,
-        "throw_strength": 50,
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
-      },
-      [ "BIO_OP_DISARM", 15 ],
-      {
-        "id": "bio_op_takedown",
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
-      },
-      {
-        "id": "psi_biokin_guard_hardened_skin",
-        "type": "spell",
-        "spell_data": { "id": "biokinetic_hardened_skin_monster" },
-        "cooldown": 120,
-        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ] },
-        "monster_message": "%1$s's skin takes on a slightly waxen appearance."
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PATH_AVOID_FIRE",
-      "PRIORITIZE_TARGETS",
-      "STUN_IMMUNE"
-    ]
+    "extend": {
+      "special_attacks": [
+        [ "PARROT_AT_DANGER", 15 ],
+        {
+          "id": "smash",
+          "attack_upper": true,
+          "throw_strength": 50,
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
+        },
+        [ "BIO_OP_DISARM", 15 ],
+        {
+          "id": "bio_op_takedown",
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
+        },
+        {
+          "id": "psi_biokin_guard_hardened_skin",
+          "type": "spell",
+          "spell_data": { "id": "biokinetic_hardened_skin_monster" },
+          "cooldown": 120,
+          "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ] },
+          "monster_message": "%1$s's skin takes on a slightly waxen appearance."
+        }
+      ],
+      "flags": [ "STUN_IMMUNE" ]
+    }
   },
   {
     "id": "mon_feral_security_captain_psychic",
     "type": "MONSTER",
     "copy-from": "mon_feral_human_bio3",
     "name": "feral security captain, Ψ Division",
-    "looks_like": "chud",
+    "default_faction": "science",
     "description": "A feral security guard with a military-style uniform, bearing the XEDRA logo and some kind of rank insignia.  Their movements are precise, controlled, and inhumanly smooth, and while their eyes are still bloodshot, they have a spark lacking in most ferals you've seen.",
     "death_drops": "feral_security_captain_death_drops_psychic"
   }

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -2,12 +2,9 @@
   {
     "id": "mon_feral_psion_default",
     "type": "MONSTER",
-    "copy-from": "mon_feral_human_pipe"
-    "//": "interstitial copy-from to edit flags and special attacks appropriately"
-    "special_attacks": [
-      [ "BROWSE", 100 ],
-      [ "EAT_FOOD", 100 ]
-    ],
+    "copy-from": "mon_feral_human_pipe",
+    "//": "interstitial copy-from to edit flags and special attacks appropriately",
+    "special_attacks": [ [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "flags": [
       "SEES",
       "HEARS",
@@ -172,7 +169,7 @@
           "no_dmg_msg_u": "%1$s blurs as they explode into motion!",
           "no_dmg_msg_npc": "%1$s blurs as they explode into motion!"
         }
-       ],
+      ],
       "flags": [ "STUN_IMMUNE", "NO_BREATHE" ]
     }
   },
@@ -182,16 +179,13 @@
     "name": "feral seer",
     "description": "This feral human completely lacks the crazed look most of their compatriots have.  Instead, they fix their bloodshot eyes straight at you, seeming to gaze right into your soul, and raise their weapon.",
     "copy-from": "mon_feral_psion_default",
-    "relative": { "melee_skill": 1, "dodge": 4,"vision_night": 7 },
+    "relative": { "melee_skill": 1, "dodge": 4, "vision_night": 7 },
     "color": "dark_gray",
     "symbol": "@",
     "death_drops": "feral_humans_death_drops_clair",
     "zombify_into": "mon_zombie_survivor",
     "upgrades": { "half_life": 45, "into": "mon_feral_human_clair2" },
-    "extend": {
-      "special_attacks": [ { "id": "feral_weapon_pipe" } ],
-      "flags": [ "GOODHEARING", "HARDTOSHOOT", "WIELDED_WEAPON" ]
-    }
+    "extend": { "special_attacks": [ { "id": "feral_weapon_pipe" } ], "flags": [ "GOODHEARING", "HARDTOSHOOT", "WIELDED_WEAPON" ] }
   },
   {
     "id": "mon_feral_human_clair2",
@@ -742,7 +736,7 @@
     "type": "MONSTER",
     "name": "feral PKer",
     "description": "Though they still have a maniacal expression, this feral human is distinguished by the rocks floating in the around around them.",
-    "copy-from": "mon_feral_psion_default",   
+    "copy-from": "mon_feral_psion_default",
     "color": "yellow",
     "symbol": "@",
     "death_drops": "feral_humans_death_drops_telekin",
@@ -816,7 +810,7 @@
     "type": "MONSTER",
     "name": "feral mindhand",
     "description": "This feral human moves quickly across uneven terrain and, when you look more closely, you see that they are floating just above the ground.  The air around them is distorted strangely, like looking through the surface of water.",
-    "copy-from": "mon_feral_psion_default",   
+    "copy-from": "mon_feral_psion_default",
     "species": [ "FERAL", "TELEKIN_PUSHPULL_NULL" ],
     "color": "yellow",
     "symbol": "@",
@@ -899,13 +893,14 @@
         [ "PULL_METAL_WEAPON", 10 ]
       ],
       "flags": [ "CLIMBS", "PUSH_VEH", "PUSH_MON" ]
+    }
   },
   {
     "id": "mon_feral_human_telekin3",
     "type": "MONSTER",
     "name": "unstoppable force",
     "description": "Hovering half a meter off the ground, this feral human is surrounded by a whirling cloud of rock, dust, splintered wood, and various household objects.  As they move, the ground occasionally shakes.",
-    "copy-from": "mon_feral_psion_default",   
+    "copy-from": "mon_feral_psion_default",
     "species": [ "FERAL", "TELEKIN_PUSHPULL_NULL" ],
     "color": "yellow",
     "symbol": "@",
@@ -932,7 +927,7 @@
           "id": "mon_telekinetic3_mindhammer",
           "cooldown": { "math": [ "6 + rand(12)" ] },
           "move_cost": 80,
-          "accuracy": 9
+          "accuracy": 9,
           "range": 11,
           "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 35 } ],
           "dodgeable": false,
@@ -946,14 +941,14 @@
           "no_dmg_msg_u": "%1$s stares at you, but the telekinetic attack rebounds off your armor.",
           "no_dmg_msg_npc": "%1$s stares at <npcname>, but the telekinetic attack rebounds off their armor."
         },
-        { 
+        {
           "id": "smash",
           "move_cost": 80,
           "cooldown": { "math": [ "4 + rand(8)" ] },
           "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 25, "armor_penetration": 10 } ],
           "hitsize_min": 12,
-          "accuracy": 9
-          "range": 11,    
+          "accuracy": 9,
+          "range": 11,
           "throw_strength": 50,
           "dodgeable": false,
           "uncanny_dodgeable": true,
@@ -1001,7 +996,7 @@
           "spell_data": { "id": "telekinetic_earthshaker_monster", "min_level": 5 },
           "cooldown": { "math": [ "15 + rand(30)" ] },
           "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-          "monster_message": "%1$s closes their eyes and the ground shakes!" 
+          "monster_message": "%1$s closes their eyes and the ground shakes!"
         },
         [ "PULL_METAL_WEAPON", 5 ]
       ],
@@ -1013,7 +1008,7 @@
     "type": "MONSTER",
     "name": "feral esper",
     "description": "This feral human lacks the crazed look most of their kind have.  Instead, their gaze is unfocused, as though listening to voices only they can hear.",
-    "copy-from": "mon_feral_psion_default", 
+    "copy-from": "mon_feral_psion_default",
     "relative": { "dodge": 2 },
     "//": "Additional dodge due to reading the player's mind",
     "color": "white",
@@ -1069,10 +1064,10 @@
         {
           "id": "psi_telepath2_scream",
           "type": "spell",
-          "spell_data": { "id": "telepathic_confusion_monster", "min_level": 3 }, 
+          "spell_data": { "id": "telepathic_confusion_monster", "min_level": 3 },
           "cooldown": { "math": [ "8 + rand(16)" ] },
           "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-          "monster_message": "A roar fills %3$s's mind and the world is blotted out!"  
+          "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
         },
         {
           "id": "psi_telepath2_blast",
@@ -1099,7 +1094,7 @@
     "type": "MONSTER",
     "name": { "str": "instiller of nightmares", "str_pl": "instillers of nightmares" },
     "description": "Just another feral, with the typical bloodshot eyes and intense expression.  You have only a moment to think that before your heart starts racing in your chest and the hair stands up on the back of your neck as every instinct screams at you to run.",
-    "copy-from": "mon_feral_psion_default", 
+    "copy-from": "mon_feral_psion_default",
     "relative": { "dodge": 4 },
     "color": "white",
     "symbol": "@",
@@ -1155,7 +1150,7 @@
     "type": "MONSTER",
     "name": "feral jumper",
     "description": "What was once empty air suddenly contains this feral human.  They have the same crazed expression as their fellows, but their gaze is focused on more distant locations.",
-    "copy-from": "mon_feral_psion_default", 
+    "copy-from": "mon_feral_psion_default",
     "relative": { "dodge": 2 },
     "color": "blue",
     "symbol": "@",
@@ -1190,7 +1185,7 @@
     "type": "MONSTER",
     "name": "feral slider",
     "description": "Every time you blink, this feral human is in a different place.  They are always in motion without actually crossing the intervening space.",
-    "copy-from": "mon_feral_psion_default", 
+    "copy-from": "mon_feral_psion_default",
     "relative": { "dodge": 4 },
     "color": "blue",
     "symbol": "@",
@@ -1231,7 +1226,7 @@
           "max_range": 12,
           "message": "%1$s vanishes and reappears elsewhere!",
           "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
-        }      
+        }
       ],
       "flags": [ "CLIMBS", "HARDTOSHOOT", "TELEPORT_IMMUNE" ]
     }
@@ -1241,7 +1236,7 @@
     "type": "MONSTER",
     "name": "ephemeral riftwalker",
     "description": "This feral barely seems to exist in the real world.  They constantly vanish and reappear, weird light and strange mist following in their wake.",
-    "copy-from": "mon_feral_psion_default", 
+    "copy-from": "mon_feral_psion_default",
     "relative": { "dodge": 6 },
     "color": "blue",
     "symbol": "@",
@@ -1306,7 +1301,7 @@
     "type": "MONSTER",
     "name": "feral mender",
     "description": "Other than the intense expression, this feral human looks to be the picture of health.  They could have starred in a healthcare advertisement before the Cataclysm.  Only the jagged bit of wood clutched like a club indicates something is wrong.",
-    "copy-from": "mon_feral_psion_default", 
+    "copy-from": "mon_feral_psion_default",
     "proportional": { "hp": 1.2 },
     "//": "HP and regeneration due to vitakinetic powers",
     "material": [ "flesh" ],
@@ -1351,7 +1346,7 @@
     "type": "MONSTER",
     "name": "feral regenerator",
     "description": "This feral human doesn't even have bloodshot eyes.  Their skin positively glows, and as you watch them brush past a jagged chunk of wood to get to you, the wound they receive immediately stops bleeding and rapidly begins to close.",
-    "copy-from": "mon_feral_psion_default", 
+    "copy-from": "mon_feral_psion_default",
     "proportional": { "hp": 1.45 },
     "color": "green",
     "symbol": "@",

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -1,120 +1,12 @@
 [
   {
-    "id": "mon_feral_human_bio",
+    "id": "mon_feral_psion_default",
     "type": "MONSTER",
-    "name": "feral adept",
-    "description": "This feral human moves with a disturbing fluid grace.  Despite that, they bear the same crazed expression as all the others.",
-    "//": "Additional HP, speed, armor, and vision distance due to biokinetic powers",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 110,
-    "material": [ "flesh" ],
-    "symbol": "@",
-    "color": "pink",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 5,
-    "melee_dice": 2,
-    "melee_dice_sides": 4,
-    "melee_damage": [ { "damage_type": "bash", "amount": 3 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 48,
-    "vision_night": 4,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
-    "death_drops": "feral_humans_death_drops_bio",
-    "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "upgrades": { "half_life": 45, "into": "mon_feral_human_bio2" },
+    "copy-from": "mon_feral_human_pipe"
+    "//": "interstitial copy-from to edit flags and special attacks appropriately"
     "special_attacks": [
-      {
-        "id": "smash",
-        "attack_upper": true,
-        "throw_strength": 30,
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
-      },
-      [ "BIO_OP_DISARM", 10 ]
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PATH_AVOID_FIRE",
-      "PRIORITIZE_TARGETS"
-    ]
-  },
-  {
-    "id": "mon_feral_human_bio2",
-    "type": "MONSTER",
-    "name": { "str": "feral dervish", "str_pl": "feral dervishes" },
-    "description": "Despite their appearance, this creature moves too quickly and smoothly to be truly human.  Bloodshot eyes are the only indicator that they are not some kind of perfectly precise android.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 125,
-    "material": [ "flesh" ],
-    "color": "pink",
-    "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 8,
-    "melee_dice": 2,
-    "melee_dice_sides": 6,
-    "melee_damage": [ { "damage_type": "bash", "amount": 6 } ],
-    "attack_cost": 80,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 5,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 50,
-    "vision_night": 7,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
-    "death_drops": "feral_humans_death_drops_bio",
-    "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "upgrades": { "half_life": 45, "into": "mon_feral_human_bio3" },
-    "special_attacks": [
-      {
-        "id": "smash",
-        "attack_upper": true,
-        "throw_strength": 50,
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
-      },
-      [ "BIO_OP_DISARM", 10 ],
-      {
-        "id": "bio_op_takedown",
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
-      },
-      {
-        "id": "psi_biokin2_hardened_skin",
-        "type": "spell",
-        "spell_data": { "id": "biokinetic_hardened_skin_monster" },
-        "cooldown": 1,
-        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ] },
-        "monster_message": "%1$s's skin takes on a slightly waxen appearance."
-      }
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
     ],
     "flags": [
       "SEES",
@@ -128,8 +20,77 @@
       "PATH_AVOID_DANGER",
       "PATH_AVOID_FIRE",
       "PRIORITIZE_TARGETS",
-      "STUN_IMMUNE"
+      "EATS"
     ]
+  },
+  {
+    "id": "mon_feral_human_bio",
+    "type": "MONSTER",
+    "name": "feral adept",
+    "description": "This feral human moves with a disturbing fluid grace.  Despite that, they bear the same crazed expression as all the others.",
+    "copy-from": "mon_feral_psion_default",
+    "proportional": { "speed": 1.1 },
+    "relative": { "melee_skill": 2, "melee_dice": 1, "melee_dice_sides": -2, "dodge": 2 },
+    "symbol": "@",
+    "color": "pink",
+    "melee_damage": [ { "damage_type": "bash", "amount": 3 } ],
+    "death_drops": "feral_humans_death_drops_bio",
+    "zombify_into": "mon_zombie_survivor",
+    "upgrades": { "half_life": 45, "into": "mon_feral_human_bio2" },
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "smash",
+          "attack_upper": true,
+          "throw_strength": 30,
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
+        },
+        [ "BIO_OP_DISARM", 10 ]
+      ]
+    }
+  },
+  {
+    "id": "mon_feral_human_bio2",
+    "type": "MONSTER",
+    "name": { "str": "feral dervish", "str_pl": "feral dervishes" },
+    "description": "Despite their appearance, this creature moves too quickly and smoothly to be truly human.  Bloodshot eyes are the only indicator that they are not some kind of perfectly precise android.",
+    "copy-from": "mon_feral_psion_default",
+    "proportional": { "speed": 1.25 },
+    "relative": { "melee_skill": 4, "melee_dice": 1, "dodge": 4 },
+    "color": "pink",
+    "symbol": "@",
+    "melee_damage": [ { "damage_type": "bash", "amount": 6 } ],
+    "attack_cost": 80,
+    "death_drops": "feral_humans_death_drops_bio",
+    "zombify_into": "mon_zombie_survivor",
+    "upgrades": { "half_life": 45, "into": "mon_feral_human_bio3" },
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "smash",
+          "attack_upper": true,
+          "throw_strength": 50,
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
+        },
+        [ "BIO_OP_DISARM", 10 ],
+        {
+          "id": "bio_op_takedown",
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
+        },
+        {
+          "id": "psi_biokin2_hardened_skin",
+          "type": "spell",
+          "spell_data": { "id": "biokinetic_hardened_skin_monster" },
+          "cooldown": 1,
+          "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ] },
+          "monster_message": "%1$s's skin takes on a slightly waxen appearance."
+        }
+      ],
+      "flags": [ "STUN_IMMUNE" ]
+    }
   },
   {
     "id": "mon_feral_human_bio3",
@@ -137,2095 +98,1326 @@
     "name": "human whirlwind",
     "description": "With inhumanly precise movements, this feral moves toward you.  They are clearly still alive, but their mouth is closed and their chest does not rise or fall.  As you watch, they suddenly blur into rapid motion.",
     "//": "NO_BREATHE here is due to the biokinetic Sealed System power.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 135,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",
+    "proportional": { "speed": 1.35 },
+    "relative": { "melee_skill": 6, "melee_dice": 1, "dodge": 6 },
     "color": "pink",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 8,
-    "melee_dice": 2,
-    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "bash", "amount": 8 } ],
     "attack_cost": 75,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 5,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 55,
-    "vision_night": 7,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_bio",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "special_attacks": [
-      [ "PARROT_AT_DANGER", 10 ],
-      {
-        "id": "smash",
-        "attack_upper": true,
-        "throw_strength": 50,
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_psi_biokin3_hurricane_blows" } } ]
+    "extend": {
+      "special_attacks": [
+        [ "PARROT_AT_DANGER", 10 ],
+        {
+          "id": "smash",
+          "attack_upper": true,
+          "throw_strength": 50,
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_psi_biokin3_hurricane_blows" } } ]
+          }
+        },
+        {
+          "type": "leap",
+          "cooldown": { "math": [ "2 + rand(5)" ] },
+          "move_cost": 50,
+          "allow_no_target": true,
+          "max_range": 5,
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_psi_biokin3_hurricane_blows" } } ]
+          },
+          "message": "%1$s moves so quickly your eyes can barely follow them!"
+        },
+        [ "BIO_OP_DISARM", 10 ],
+        {
+          "id": "bio_op_takedown",
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_psi_biokin3_hurricane_blows" } } ]
+          }
+        },
+        {
+          "id": "psi_biokin3_hardened_skin",
+          "type": "spell",
+          "spell_data": { "id": "biokinetic_hardened_skin_monster" },
+          "cooldown": 1,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "NO_PSIONICS" } },
+              { "not": { "u_has_effect": "effect_monster_hardened_skin" } },
+              { "not": { "u_has_effect": "effect_psi_biokin3_hurricane_blows" } }
+            ]
+          },
+          "monster_message": "%1$s's skin takes on a slightly waxen appearance."
+        },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "psi_biokin3_hurricane_blows_probe",
+          "cooldown": { "math": [ "15 + rand(30)" ] },
+          "move_cost": 100,
+          "damage_max_instance": [ { "damage_type": "bash", "amount": 0 } ],
+          "self_effects_always": [ { "id": "effect_psi_biokin3_hurricane_blows", "duration": 0 } ],
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_psi_biokin3_hurricane_blows" } } ]
+          },
+          "dodgeable": false,
+          "blockable": false,
+          "hit_dmg_u": "%1$s blurs as they explode into motion!",
+          "hit_dmg_npc": "%1$s blurs as they explode into motion!",
+          "miss_msg_u": "%1$s blurs as they explode into motion!",
+          "miss_msg_npc": "%1$s blurs as they explode into motion!",
+          "no_dmg_msg_u": "%1$s blurs as they explode into motion!",
+          "no_dmg_msg_npc": "%1$s blurs as they explode into motion!"
         }
-      },
-      {
-        "type": "leap",
-        "cooldown": { "math": [ "2 + rand(5)" ] },
-        "move_cost": 50,
-        "allow_no_target": true,
-        "max_range": 5,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_psi_biokin3_hurricane_blows" } } ]
-        },
-        "message": "%1$s moves so quickly your eyes can barely follow them!"
-      },
-      [ "BIO_OP_DISARM", 10 ],
-      {
-        "id": "bio_op_takedown",
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_psi_biokin3_hurricane_blows" } } ]
-        }
-      },
-      {
-        "id": "psi_biokin3_hardened_skin",
-        "type": "spell",
-        "spell_data": { "id": "biokinetic_hardened_skin_monster" },
-        "cooldown": 1,
-        "condition": {
-          "and": [
-            { "not": { "u_has_flag": "NO_PSIONICS" } },
-            { "not": { "u_has_effect": "effect_monster_hardened_skin" } },
-            { "not": { "u_has_effect": "effect_psi_biokin3_hurricane_blows" } }
-          ]
-        },
-        "monster_message": "%1$s's skin takes on a slightly waxen appearance."
-      },
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "psi_biokin3_hurricane_blows_probe",
-        "cooldown": { "math": [ "15 + rand(30)" ] },
-        "move_cost": 100,
-        "damage_max_instance": [ { "damage_type": "bash", "amount": 0 } ],
-        "self_effects_always": [ { "id": "effect_psi_biokin3_hurricane_blows", "duration": 0 } ],
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_psi_biokin3_hurricane_blows" } } ]
-        },
-        "dodgeable": false,
-        "blockable": false,
-        "hit_dmg_u": "%1$s blurs as they explode into motion!",
-        "hit_dmg_npc": "%1$s blurs as they explode into motion!",
-        "miss_msg_u": "%1$s blurs as they explode into motion!",
-        "miss_msg_npc": "%1$s blurs as they explode into motion!",
-        "no_dmg_msg_u": "%1$s blurs as they explode into motion!",
-        "no_dmg_msg_npc": "%1$s blurs as they explode into motion!"
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PATH_AVOID_FIRE",
-      "PRIORITIZE_TARGETS",
-      "NO_BREATHE",
-      "STUN_IMMUNE"
-    ]
+       ],
+      "flags": [ "STUN_IMMUNE", "NO_BREATHE" ]
+    }
   },
   {
     "id": "mon_feral_human_clair",
     "type": "MONSTER",
     "name": "feral seer",
     "description": "This feral human completely lacks the crazed look most of their compatriots have.  Instead, they fix their bloodshot eyes straight at you, seeming to gaze right into your soul, and raise their weapon.",
-    "//": "Speed bonus here, like HARDTOSHOOT below, does not represent faster physical movement but rather foreseeing the player's actions",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 105,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",
+    "relative": { "melee_skill": 1, "dodge": 4,"vision_night": 7 },
     "color": "dark_gray",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 4,
-    "melee_dice": 2,
-    "melee_dice_sides": 3,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 5,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 45,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "death_drops": "feral_humans_death_drops_clair",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "special_attacks": [ { "id": "feral_weapon_pipe" } ],
     "upgrades": { "half_life": 45, "into": "mon_feral_human_clair2" },
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "GOODHEARING",
-      "HARDTOSHOOT"
-    ]
+    "extend": {
+      "special_attacks": [ { "id": "feral_weapon_pipe" } ],
+      "flags": [ "GOODHEARING", "HARDTOSHOOT", "WIELDED_WEAPON" ]
+    }
   },
   {
     "id": "mon_feral_human_clair2",
     "type": "MONSTER",
     "name": { "str": "feral visionary", "str_pl": "feral visionaries" },
     "description": "By the time you see this feral, they have already noticed you.  They stare straight at you, regardless of obstruction or any obstacle in between, clutching a weapon in one hand.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",
+    "relative": { "melee_skill": 3, "dodge": 7, "vision_day": 5, "vision_night": 12 },
     "color": "dark_gray",
     "symbol": "@",
-    "aggression": 30,
     "morale": 110,
-    "melee_skill": 6,
-    "melee_dice": 3,
-    "melee_dice_sides": 3,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 8,
     "armor": { "bullet": 20 },
     "//": "Armor here represents knowing where the enemy is going to shoot and not being there, not being literally immune to bullets.",
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 50,
-    "vision_night": 50,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "death_drops": "feral_humans_death_drops_clair",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "special_attacks": [
-      {
-        "type": "gun",
-        "cooldown": { "math": [ "2 + rand(4)" ] },
-        "move_cost": 150,
-        "gun_type": "feral_clair_thrown_rock",
-        "ammo_type": "rock",
-        "no_ammo_sound": "",
-        "fake_skills": [ [ "throw", 5 ] ],
-        "fake_str": 8,
-        "condition": { "not": { "u_has_effect": "maimed_arm" } },
-        "require_targeting_player": false,
-        "ranges": [ [ 2, 7, "DEFAULT" ] ],
-        "description": "The feral visionary throws a rock!"
-      },
-      { "id": "feral_weapon_pipe" }
-    ],
     "starting_ammo": { "rock": 6 },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_clair3" },
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "DROPS_AMMO",
-      "WIELDED_WEAPON",
-      "GOODHEARING",
-      "HARDTOSHOOT",
-      "ALL_SEEING"
-    ]
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": { "math": [ "2 + rand(4)" ] },
+          "move_cost": 150,
+          "gun_type": "feral_clair_thrown_rock",
+          "ammo_type": "rock",
+          "no_ammo_sound": "",
+          "fake_skills": [ [ "throw", 5 ] ],
+          "fake_str": 8,
+          "condition": { "not": { "u_has_effect": "maimed_arm" } },
+          "require_targeting_player": false,
+          "ranges": [ [ 2, 7, "DEFAULT" ] ],
+          "description": "The feral visionary throws a rock!"
+        },
+        { "id": "feral_weapon_pipe" }
+      ],
+      "flags": [ "GOODHEARING", "HARDTOSHOOT", "WIELDED_WEAPON", "DROPS_AMMO", "ALL_SEEING" ]
+    }
   },
   {
     "id": "mon_feral_human_clair3",
     "type": "MONSTER",
     "name": "pattern screamer",
     "description": "This feral's eyes are closed, but they move with no hesitation, effortlessly avoiding all obstacles in their path, and clutching a large rock in one hand and a long bit of debris in the other.  When you look at them, you hear a static crackling, just on the threshold of inaudibility.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",
+    "relative": { "melee_skill": 3, "melee_dice": 2, "melee_dice_sides": -3, "dodge": 11, "vision_day": 10, "vision_night": 22 },
     "color": "dark_gray",
     "symbol": "@",
-    "aggression": 40,
     "morale": 110,
-    "melee_skill": 6,
-    "melee_dice": 3,
-    "melee_dice_sides": 3,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 12,
     "armor": { "bullet": 40 },
     "//": "Armor here represents knowing where the enemy is going to shoot and not being there, not being literally immune to bullets.",
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 55,
-    "vision_night": 55,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "death_drops": "feral_humans_death_drops_clair",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "special_attacks": [
-      {
-        "type": "gun",
-        "cooldown": { "math": [ "2 + rand(4)" ] },
-        "move_cost": 150,
-        "gun_type": "pattern_screamer_thrown_rock",
-        "ammo_type": "rock",
-        "no_ammo_sound": "",
-        "fake_skills": [ [ "throw", 9 ] ],
-        "fake_str": 10,
-        "condition": { "not": { "u_has_effect": "maimed_arm" } },
-        "require_targeting_player": false,
-        "ranges": [ [ 2, 10, "DEFAULT" ] ],
-        "description": "With inhuman accuracy, the pattern screamer throws a rock!"
-      },
-      { "id": "feral_weapon_pipe" },
-      {
-        "id": "psi_pattern_scream",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_shrieking_monster", "min_level": 3 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "Static fills your hearing for a moment, blotting out all other sounds!"
-      }
-    ],
     "starting_ammo": { "rock": 6 },
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "DROPS_AMMO",
-      "WIELDED_WEAPON",
-      "GOODHEARING",
-      "HARDTOSHOOT",
-      "ALL_SEEING"
-    ]
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": { "math": [ "2 + rand(4)" ] },
+          "move_cost": 150,
+          "gun_type": "pattern_screamer_thrown_rock",
+          "ammo_type": "rock",
+          "no_ammo_sound": "",
+          "fake_skills": [ [ "throw", 9 ] ],
+          "fake_str": 10,
+          "condition": { "not": { "u_has_effect": "maimed_arm" } },
+          "require_targeting_player": false,
+          "ranges": [ [ 2, 10, "DEFAULT" ] ],
+          "description": "With inhuman accuracy, the pattern screamer throws a rock!"
+        },
+        { "id": "feral_weapon_pipe" },
+        {
+          "id": "psi_pattern_scream",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_shrieking_monster", "min_level": 3 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "Static fills your hearing for a moment, blotting out all other sounds!"
+        }
+      ]
+    }
   },
   {
     "id": "mon_feral_human_electrokin",
     "type": "MONSTER",
     "name": "feral sparker",
     "description": "This feral has the standard bloodshot eyes and erratic movements, but in addition, some of their gestures unleash a shower of sparks.  They seem totally unphased by the light or the crackling sounds.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",
     "color": "cyan",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "electric", "amount": 4 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_electromagnetics" ],
-    "dodge": 2,
     "armor": { "electric": 15 },
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_electro",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "upgrades": { "half_life": 45, "into": "mon_feral_human_electrokin2" },
-    "special_attacks": [
-      {
-        "id": "psi_electrokin_dazehit",
-        "type": "spell",
-        "spell_data": { "id": "electrokinetic_shock_touch_monster", "min_level": 3 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's touches %3$s with a jolt!"
-      }
-    ],
-    "special_when_hit": [ "ZAPBACK", 50 ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS"
-    ]
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "psi_electrokin_dazehit",
+          "type": "spell",
+          "spell_data": { "id": "electrokinetic_shock_touch_monster", "min_level": 3 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's touches %3$s with a jolt!"
+        }
+      ]
+    },
+    "special_when_hit": [ "ZAPBACK", 50 ]
   },
   {
     "id": "mon_feral_human_electrokin2",
     "type": "MONSTER",
     "name": "feral dynamo",
     "description": "Lightning crackles across this feral's skin, occasionally discharging into the surrounding environment.  Their bloodshot eyes have an eerie blue glow.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",
     "color": "cyan",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "electric", "amount": 7 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_electromagnetics" ],
-    "dodge": 2,
     "armor": { "electric": 15 },
-    "harvest": "human",
     "emit_fields": [ { "emit_id": "emit_shock_cloud", "delay": "15 s" } ],
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_electro",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "upgrades": { "half_life": 45, "into": "mon_feral_human_electrokin3" },
-    "special_attacks": [
-      {
-        "id": "psi_electrokin2_dazehit",
-        "type": "spell",
-        "spell_data": { "id": "electrokinetic_shock_touch_monster", "min_level": 3 },
-        "cooldown": { "math": [ "4 + rand(8)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's touches %3$s with a jolt!"
-      },
-      {
-        "id": "psi_electrokin2_lightning_bolt",
-        "type": "spell",
-        "spell_data": { "id": "electrokinetic_lightning_bolt_monster", "min_level": 4 },
-        "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's unleashes a bolt of lightning!"
-      },
-      {
-        "id": "psi_electrokin2_paralyze",
-        "type": "spell",
-        "spell_data": { "id": "electrokinetic_paralysis_monster", "min_level": 5 },
-        "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's waves a hand at %3$s and sparks crackle over their skin!"
-      }
-    ],
     "special_when_hit": [ "ZAPBACK", 80 ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "ELECTRIC"
-    ]
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "psi_electrokin2_dazehit",
+          "type": "spell",
+          "spell_data": { "id": "electrokinetic_shock_touch_monster", "min_level": 3 },
+          "cooldown": { "math": [ "4 + rand(8)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's touches %3$s with a jolt!"
+        },
+        {
+          "id": "psi_electrokin2_lightning_bolt",
+          "type": "spell",
+          "spell_data": { "id": "electrokinetic_lightning_bolt_monster", "min_level": 4 },
+          "cooldown": { "math": [ "10 + rand(20)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's unleashes a bolt of lightning!"
+        },
+        {
+          "id": "psi_electrokin2_paralyze",
+          "type": "spell",
+          "spell_data": { "id": "electrokinetic_paralysis_monster", "min_level": 5 },
+          "cooldown": { "math": [ "15 + rand(30)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's waves a hand at %3$s and sparks crackle over their skin!"
+        }
+      ],
+      "flags": [ "ELECTRIC" ]
+    }
   },
   {
     "id": "mon_feral_human_electrokin3",
     "type": "MONSTER",
     "name": "avatar of the storm",
     "description": "This feral is barely visible, their body constantly wreathed in bolts of lightning.  A harsh actinic glow casts their surroundings into sharp relief while leaving their own features concealed.  Crackling lightning nearly-constantly explodes from their body and grounds itself nearby.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 110,
+    "copy-from": "mon_feral_psion_default",
+    "proportional": { "speed": 1.1 },
+    "relative": { "dodge": 1 },
     "//": "Speed due to Neuro-acceleration",
-    "material": [ "flesh" ],
     "color": "cyan",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "electric", "amount": 10 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_electromagnetics" ],
-    "dodge": 2,
-    "harvest": "human",
     "emit_fields": [ { "emit_id": "emit_shock_cloud", "delay": "2 s" } ],
     "luminance": 30,
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_electro",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "special_attacks": [
-      {
-        "id": "psi_electrokin3_dazehit",
-        "type": "spell",
-        "spell_data": { "id": "electrokinetic_shock_touch_monster", "min_level": 5 },
-        "cooldown": { "math": [ "4 + rand(8)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's touches %3$s with a jolt!"
-      },
-      {
-        "id": "psi_electrokin3_lightning_bolt",
-        "type": "spell",
-        "spell_data": { "id": "electrokinetic_lightning_blast_monster", "min_level": 8 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's unleashes a bolt of lightning!"
-      },
-      {
-        "id": "psi_electrokin3_paralyze",
-        "type": "spell",
-        "spell_data": { "id": "electrokinetic_paralysis_monster", "min_level": 8 },
-        "cooldown": { "math": [ "12 + rand(24)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's waves a hand at %3$s and sparks crackle over their skin!"
-      },
-      {
-        "id": "psi_electrokin3_revive",
-        "type": "spell",
-        "spell_data": { "id": "electrokinetic_revive_monster", "min_level": 5 },
-        "cooldown": { "math": [ "25 + rand(50)" ] },
-        "allow_no_target": true,
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's gestures and lighting crackles around them!"
-      }
-    ],
     "special_when_hit": [ "ZAPBACK", 95 ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "ELECTRIC_FIELD"
-    ]
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "psi_electrokin3_dazehit",
+          "type": "spell",
+          "spell_data": { "id": "electrokinetic_shock_touch_monster", "min_level": 5 },
+          "cooldown": { "math": [ "4 + rand(8)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's touches %3$s with a jolt!"
+        },
+        {
+          "id": "psi_electrokin3_lightning_bolt",
+          "type": "spell",
+          "spell_data": { "id": "electrokinetic_lightning_blast_monster", "min_level": 8 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's unleashes a bolt of lightning!"
+        },
+        {
+          "id": "psi_electrokin3_paralyze",
+          "type": "spell",
+          "spell_data": { "id": "electrokinetic_paralysis_monster", "min_level": 8 },
+          "cooldown": { "math": [ "12 + rand(24)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's waves a hand at %3$s and sparks crackle over their skin!"
+        },
+        {
+          "id": "psi_electrokin3_revive",
+          "type": "spell",
+          "spell_data": { "id": "electrokinetic_revive_monster", "min_level": 5 },
+          "cooldown": { "math": [ "25 + rand(50)" ] },
+          "allow_no_target": true,
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's gestures and lighting crackles around them!"
+        }
+      ],
+      "flags": [ "ELECTRIC_FIELD" ]
+    }
   },
   {
     "id": "mon_feral_human_photokin",
     "type": "MONSTER",
     "name": "feral radiant",
     "description": "This feral's skin has some sort of radiance.  Their eyes are bright with light and there's a slight shimmer around their form.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",
     "color": "yellow",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "melee_damage": [ { "damage_type": "bash", "amount": 4 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_photo",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": { "effect": { "id": "death_blind_oneineight", "hit_self": true } },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_photokin2" },
-    "special_attacks": [
-      {
-        "id": "psi_photokin1_lightdodge",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_light_dodge_monster", "min_level": 3 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's form is shifting with illusions!"
-      },
-      {
-        "id": "psi_photokin1_lightbeam",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 2 },
-        "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s fires a photon beam!"
-      },
-      {
-        "id": "psi_photokin1_illuminate",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_illumination_monster", "min_level": 5 },
-        "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's looks at you for a moment."
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS"
-    ]
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "psi_photokin1_lightdodge",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_light_dodge_monster", "min_level": 3 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's form is shifting with illusions!"
+        },
+        {
+          "id": "psi_photokin1_lightbeam",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 2 },
+          "cooldown": { "math": [ "10 + rand(20)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s fires a photon beam!"
+        },
+        {
+          "id": "psi_photokin1_illuminate",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_illumination_monster", "min_level": 5 },
+          "cooldown": { "math": [ "15 + rand(30)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's looks at you for a moment."
+        }
+      ]
+    }
   },
   {
     "id": "mon_feral_human_photokin2",
     "type": "MONSTER",
     "name": "feral beacon",
     "description": "Almost blinding light radiates from this feral's skin.  They seem to have greater control over their powers than most ferals, but they are still clearly insane.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",
     "color": "yellow",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 4,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "melee_damage": [ { "damage_type": "bash", "amount": 4 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 4,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_photo",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": { "effect": { "id": "death_blind_oneinfour", "hit_self": true } },
     "luminance": 50,
     "upgrades": { "half_life": 45, "into": "mon_feral_human_photokin3" },
-    "special_attacks": [
-      [ "PARROT_AT_DANGER", 10 ],
-      {
-        "id": "psi_photokin2_lightdodge",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_light_dodge_monster", "min_level": 6 },
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's form is shifting with illusions!"
-      },
-      {
-        "id": "psi_photokin2_lightbeam",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 5 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s fires a photon beam!"
-      },
-      {
-        "id": "psi_photokin2_lightflash",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_light_flash_monster", "min_level": 4 },
-        "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s concentrates and unleashes a super-luminous flash!"
-      },
-      {
-        "id": "psi_photokin2_radiation_blast",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_radiation_attack_monster", "min_level": 7 },
-        "cooldown": { "math": [ "12 + rand(24)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s stares at %3$s and %3$s is enveloped in an eerie glow!"
-      },
-      {
-        "id": "psi_photokin2_illuminate",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_illumination_monster", "min_level": 10 },
-        "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's looks at you for a moment."
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "PHOTOKIN_MONSTER_IMMUNE"
-    ]
+    "extend": {
+      "special_attacks": [
+        [ "PARROT_AT_DANGER", 10 ],
+        {
+          "id": "psi_photokin2_lightdodge",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_light_dodge_monster", "min_level": 6 },
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's form is shifting with illusions!"
+        },
+        {
+          "id": "psi_photokin2_lightbeam",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 5 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s fires a photon beam!"
+        },
+        {
+          "id": "psi_photokin2_lightflash",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_light_flash_monster", "min_level": 4 },
+          "cooldown": { "math": [ "10 + rand(20)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s concentrates and unleashes a super-luminous flash!"
+        },
+        {
+          "id": "psi_photokin2_radiation_blast",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_radiation_attack_monster", "min_level": 7 },
+          "cooldown": { "math": [ "12 + rand(24)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s stares at %3$s and %3$s is enveloped in an eerie glow!"
+        },
+        {
+          "id": "psi_photokin2_illuminate",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_illumination_monster", "min_level": 10 },
+          "cooldown": { "math": [ "15 + rand(30)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's looks at you for a moment."
+        }
+      ],
+      "flags": [ "PHOTOKIN_MONSTER_IMMUNE" ]
+    }
   },
   {
     "id": "mon_feral_human_photokin3",
     "type": "MONSTER",
     "name": "atom splitter",
     "description": "This feral glows brighter than streetlamp, casting their surroundings into sharp relief amid the glow.  They are clearly still lucid but their expression is blank and their eyes are unfocused.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 105,
-    "speed": 100,
+    "copy-from": "mon_feral_psion_default",
     "material": [ "flesh" ],
     "color": "yellow",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 4,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "melee_damage": [ { "damage_type": "bash", "amount": 4 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 4,
-    "regenerates": 8,
-    "regeneration_modifiers": [ [ "effect_vitakin_hurt", -4 ], [ "effect_psi_null", -8 ] ],
-    "bleed_rate": 0,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_photo",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
       "effect": { "id": "death_blindness", "hit_self": true },
       "message": "%1$s shrieks and unleashes a powerful blinding flash!"
     },
     "luminance": 200,
-    "special_attacks": [
-      [ "PARROT_AT_DANGER", 10 ],
-      {
-        "id": "psi_photokin3_lightdodge",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_light_dodge_monster", "min_level": 7 },
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's form is shifting with illusions!"
-      },
-      {
-        "id": "psi_photokin3_lightbeam",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 6 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s fires a photon beam!"
-      },
-      {
-        "id": "psi_photokin3_lightflash",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_light_flash_monster", "min_level": 6 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s concentrates and unleashes a super-luminous flash!"
-      },
-      {
-        "id": "psi_photokin3_radiation_blast",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_radiation_attack_monster", "min_level": 10 },
-        "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s stares at you and you are enveloped in an eerie glow!"
-      },
-      {
-        "id": "psi_photokin3_illuminate",
-        "type": "spell",
-        "spell_data": { "id": "photokinetic_illumination_monster", "min_level": 15 },
-        "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s's looks at you for a moment."
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "PHOTOKIN_MONSTER_IMMUNE"
-    ]
+    "extend": {
+      "special_attacks": [
+        [ "PARROT_AT_DANGER", 10 ],
+        {
+          "id": "psi_photokin3_lightdodge",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_light_dodge_monster", "min_level": 7 },
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's form is shifting with illusions!"
+        },
+        {
+          "id": "psi_photokin3_lightbeam",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 6 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s fires a photon beam!"
+        },
+        {
+          "id": "psi_photokin3_lightflash",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_light_flash_monster", "min_level": 6 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s concentrates and unleashes a super-luminous flash!"
+        },
+        {
+          "id": "psi_photokin3_radiation_blast",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_radiation_attack_monster", "min_level": 10 },
+          "cooldown": { "math": [ "10 + rand(20)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s stares at you and you are enveloped in an eerie glow!"
+        },
+        {
+          "id": "psi_photokin3_illuminate",
+          "type": "spell",
+          "spell_data": { "id": "photokinetic_illumination_monster", "min_level": 15 },
+          "cooldown": { "math": [ "15 + rand(30)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s's looks at you for a moment."
+        }
+      ],
+      "flags": [ "PHOTOKIN_MONSTER_IMMUNE" ]
+    }
   },
   {
     "id": "mon_feral_human_pyrokin",
     "type": "MONSTER",
     "name": "feral burner",
     "description": "This feral human looks a little more composed than most, but only a little.  Their clothes are singed and the air around them shimmers like a summer heat haze.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",
     "color": "red",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "heat", "amount": 4 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 2,
     "armor": { "heat": 15 },
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_pyro",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": { "effect": { "id": "death_explosion_oneineight", "hit_self": true } },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_pyrokin2" },
-    "special_attacks": [
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "mon_fountain_of_flames",
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "move_cost": 80,
-        "damage_max_instance": [ { "damage_type": "heat", "amount": 20 } ],
-        "dodgeable": true,
-        "blockable": false,
-        "effects": [ { "id": "onfire", "duration": 60, "chance": 25, "affect_hit_bp": true } ],
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s gestures and your %2$s is engulfed in flames!",
-        "hit_dmg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames!",
-        "miss_msg_u": "%1$s gestures and you narrowly avoid a burst of flame!",
-        "miss_msg_npc": "%1$s gestures and <npcname> narrowly avoids a burst of flame!",
-        "no_dmg_msg_u": "%1$s gestures and your %2$s is engulfed in flames, but they do not burn you.",
-        "no_dmg_msg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames, but it does not burn them."
-      },
-      {
-        "id": "psi_pyrokin1_flashbang",
-        "type": "spell",
-        "spell_data": { "id": "pyrokinetic_flash_monster", "min_level": 1 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "The air erupts into an eye-searing flash!"
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "FIREPROOF"
-    ]
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "mon_fountain_of_flames",
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "accuracy": 4,
+          "move_cost": 80,
+          "damage_max_instance": [ { "damage_type": "heat", "amount": 20 } ],
+          "dodgeable": true,
+          "blockable": false,
+          "effects": [ { "id": "onfire", "duration": 60, "chance": 25, "affect_hit_bp": true } ],
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "hit_dmg_u": "%1$s gestures and your %2$s is engulfed in flames!",
+          "hit_dmg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames!",
+          "miss_msg_u": "%1$s gestures and you narrowly avoid a burst of flame!",
+          "miss_msg_npc": "%1$s gestures and <npcname> narrowly avoids a burst of flame!",
+          "no_dmg_msg_u": "%1$s gestures and your %2$s is engulfed in flames, but they do not burn you.",
+          "no_dmg_msg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames, but it does not burn them."
+        },
+        {
+          "id": "psi_pyrokin1_flashbang",
+          "type": "spell",
+          "spell_data": { "id": "pyrokinetic_flash_monster", "min_level": 1 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "The air erupts into an eye-searing flash!"
+        }
+      ],
+      "flags": [ "FIREPROOF" ]
+    }
   },
   {
     "id": "mon_feral_human_pyrokin2",
     "type": "MONSTER",
     "name": "feral inferno",
     "description": "Through a cloud of smoke and fire, you can see a human form.  Their body is barely visible through the flames.",
+    "copy-from": "mon_feral_psion_default",
     "//": "I kind of want them to emit flames as well as smoke, but testing shows that leads to basically everything burning uncontrollable and entire hordes of zombies dying.  Their pyrokinesis already causes enough havoc.  Change once fire is no longer the most deadly post-Cataclysm weapon.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
     "color": "red",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 4,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "heat", "amount": 8 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
     "armor": { "heat": 30 },
-    "harvest": "human",
     "emit_fields": [ { "emit_id": "emit_smoke_stream", "delay": "8 s" } ],
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_pyro",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": { "effect": { "id": "death_explosion_oneinfour", "hit_self": true } },
     "luminance": 50,
     "upgrades": { "half_life": 45, "into": "mon_feral_human_pyrokin3" },
-    "special_attacks": [
-      [ "PARROT_AT_DANGER", 10 ],
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "mon_fountain_of_flames",
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "move_cost": 80,
-        "range": 2,
-        "damage_max_instance": [ { "damage_type": "heat", "amount": 25 } ],
-        "dodgeable": true,
-        "blockable": false,
-        "effects": [ { "id": "onfire", "duration": 60, "chance": 50, "affect_hit_bp": true } ],
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s gestures and your %2$s is engulfed in flames!",
-        "hit_dmg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames!",
-        "miss_msg_u": "%1$s gestures and you narrowly avoid a burst of flame!",
-        "miss_msg_npc": "%1$s gestures and <npcname> narrowly avoids a burst of flame!",
-        "no_dmg_msg_u": "%1$s gestures and your %2$s is engulfed in flames, but they do not burn you.",
-        "no_dmg_msg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames, but it does not burn them."
-      },
-      {
-        "id": "psi_pyrokin2_flashbang",
-        "type": "spell",
-        "spell_data": { "id": "pyrokinetic_flash_monster", "min_level": 4 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "The air erupts into an eye-searing flash!"
-      },
-      {
-        "id": "psi_pyrokin2_flamebomb",
-        "type": "spell",
-        "spell_data": { "id": "pyrokinetic_blast_monster", "min_level": 4 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s gestures and summons a conflagration!"
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "FIREY"
-    ]
+    "extend": {
+      "special_attacks": [
+        [ "PARROT_AT_DANGER", 10 ],
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "mon_fountain_of_flames",
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "accuracy": 6,
+          "move_cost": 80,
+          "range": 2,
+          "damage_max_instance": [ { "damage_type": "heat", "amount": 25 } ],
+          "dodgeable": true,
+          "blockable": false,
+          "effects": [ { "id": "onfire", "duration": 60, "chance": 50, "affect_hit_bp": true } ],
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "hit_dmg_u": "%1$s gestures and your %2$s is engulfed in flames!",
+          "hit_dmg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames!",
+          "miss_msg_u": "%1$s gestures and you narrowly avoid a burst of flame!",
+          "miss_msg_npc": "%1$s gestures and <npcname> narrowly avoids a burst of flame!",
+          "no_dmg_msg_u": "%1$s gestures and your %2$s is engulfed in flames, but they do not burn you.",
+          "no_dmg_msg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames, but it does not burn them."
+        },
+        {
+          "id": "psi_pyrokin2_flashbang",
+          "type": "spell",
+          "spell_data": { "id": "pyrokinetic_flash_monster", "min_level": 4 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "The air erupts into an eye-searing flash!"
+        },
+        {
+          "id": "psi_pyrokin2_flamebomb",
+          "type": "spell",
+          "spell_data": { "id": "pyrokinetic_blast_monster", "min_level": 4 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s gestures and summons a conflagration!"
+        }
+      ],
+      "flags": [ "FIREY" ]
+    }
   },
   {
     "id": "mon_feral_human_pyrokin3",
     "type": "MONSTER",
     "name": "unending conflagration",
     "description": "Occasionally through the fire and smoke, you can see a human form.  Their flesh blackens and withers in the heat, then the burns retreat and healthy skin replaces it, over and over again.",
+    "copy-from": "mon_feral_psion_default",
     "//": "No ballistic armor because the temperature to melt a bullet after being fired but before it hits you is apparently over 100 million degrees.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 105,
-    "speed": 100,
-    "material": [ "flesh" ],
     "color": "red",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 4,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "heat", "amount": 10 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
     "armor": { "heat": 50 },
     "bleed_rate": 0,
     "harvest": "human",
     "emit_fields": [ { "emit_id": "emit_pyrokinetic_aura_7", "delay": "2 s" } ],
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_pyro",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
       "effect": { "id": "death_conflagration", "hit_self": true },
       "message": "%1$s screams and the flames around them burst outward!"
     },
     "luminance": 200,
-    "special_attacks": [
-      [ "PARROT_AT_DANGER", 10 ],
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "mon_fountain_of_flames",
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "move_cost": 80,
-        "range": 3,
-        "damage_max_instance": [ { "damage_type": "heat", "amount": 35 } ],
-        "dodgeable": true,
-        "blockable": false,
-        "effects": [ { "id": "onfire", "duration": 60, "chance": 75, "affect_hit_bp": true } ],
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s gestures and your %2$s is engulfed in flames!",
-        "hit_dmg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames!",
-        "miss_msg_u": "%1$s gestures and you narrowly avoid a burst of flame!",
-        "miss_msg_npc": "%1$s gestures and <npcname> narrowly avoids a burst of flame!",
-        "no_dmg_msg_u": "%1$s gestures and your %2$s is engulfed in flames, but they do not burn you.",
-        "no_dmg_msg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames, but it does not burn them."
-      },
-      {
-        "id": "psi_pyrokin3_flashbang",
-        "type": "spell",
-        "spell_data": { "id": "pyrokinetic_flash_monster", "min_level": 5 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "The air erupts into an eye-searing flash!"
-      },
-      {
-        "id": "psi_pyrokin3_flamebomb",
-        "type": "spell",
-        "spell_data": { "id": "pyrokinetic_blast_monster", "min_level": 6 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s gestures and summons a conflagration!"
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "FIREY"
-    ]
+    "extend": {
+      "special_attacks": [
+        [ "PARROT_AT_DANGER", 10 ],
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "mon_fountain_of_flames",
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "accuracy": 8,
+          "move_cost": 80,
+          "range": 3,
+          "damage_max_instance": [ { "damage_type": "heat", "amount": 35 } ],
+          "dodgeable": true,
+          "blockable": false,
+          "effects": [ { "id": "onfire", "duration": 60, "chance": 75, "affect_hit_bp": true } ],
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "hit_dmg_u": "%1$s gestures and your %2$s is engulfed in flames!",
+          "hit_dmg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames!",
+          "miss_msg_u": "%1$s gestures and you narrowly avoid a burst of flame!",
+          "miss_msg_npc": "%1$s gestures and <npcname> narrowly avoids a burst of flame!",
+          "no_dmg_msg_u": "%1$s gestures and your %2$s is engulfed in flames, but they do not burn you.",
+          "no_dmg_msg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames, but it does not burn them."
+        },
+        {
+          "id": "psi_pyrokin3_flashbang",
+          "type": "spell",
+          "spell_data": { "id": "pyrokinetic_flash_monster", "min_level": 5 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "The air erupts into an eye-searing flash!"
+        },
+        {
+          "id": "psi_pyrokin3_flamebomb",
+          "type": "spell",
+          "spell_data": { "id": "pyrokinetic_blast_monster", "min_level": 6 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s gestures and summons a conflagration!"
+        }
+      ],
+      "flags": [ "FIREY" ]
+    },
+    "delete": { "flags": [ "PATH_AVOID_FIRE" ] }
   },
   {
     "id": "mon_feral_human_telekin",
     "type": "MONSTER",
     "name": "feral PKer",
     "description": "Though they still have a maniacal expression, this feral human is distinguished by the rocks floating in the around around them.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL", "TELEKIN_PUSHPULL_NULL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",   
     "color": "yellow",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 4,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
-    "armor": { "bash": 8, "cut": 5, "stab": 3, "bullet": 15, "psi_telekinetic_damage": 10 },
     "death_drops": "feral_humans_death_drops_telekin",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
       "effect": { "id": "death_telekeinetic_hit_oneinfive", "hit_self": true },
       "message": "As the %1$s dies, a wave of force explodes outward!"
     },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_telekin2" },
     "starting_ammo": { "rock": 6 },
-    "special_attacks": [
-      {
-        "id": "psi_telekin1_telegrab",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_pull_monster", "min_level": 2 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
-        "monster_message": "%1$s stares at %3$s and %3$s is lifted up and pulled towards them!"
-      },
-      {
-        "type": "gun",
-        "cooldown": { "math": [ "2 + rand(4)" ] },
-        "move_cost": 50,
-        "gun_type": "feral_human_thrown_rock",
-        "ammo_type": "rock",
-        "no_ammo_sound": "",
-        "fake_skills": [ [ "throw", 6 ] ],
-        "fake_str": 11,
-        "require_targeting_player": false,
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "ranges": [ [ 2, 10, "DEFAULT" ] ],
-        "description": "%1$s makes a throwing motion and one of the rocks around them suddenly launches like a bullet!"
-      },
-      {
-        "id": "smash",
-        "move_cost": 80,
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 15, "armor_penetration": 10 } ],
-        "hitsize_min": 12,
-        "range": 6,
-        "throw_strength": 20,
-        "dodgeable": false,
-        "uncanny_dodgeable": true,
-        "blockable": false,
-        "effects_require_dmg": false,
-        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
-        "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
-        "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
-        "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
-        "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
-      },
-      {
-        "id": "psi_telekin1_momentum_alteration",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_momentum_monster" },
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "psi_telekin1_telegrab",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_pull_monster", "min_level": 2 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+          "monster_message": "%1$s stares at %3$s and %3$s is lifted up and pulled towards them!"
         },
-        "monster_message": "The air around %1$s wavers."
-      },
-      [ "PULL_METAL_WEAPON", 15 ]
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PATH_AVOID_FIRE",
-      "PRIORITIZE_TARGETS",
-      "PUSH_VEH",
-      "PUSH_MON"
-    ]
+        {
+          "type": "gun",
+          "cooldown": { "math": [ "2 + rand(4)" ] },
+          "move_cost": 50,
+          "gun_type": "feral_human_thrown_rock",
+          "ammo_type": "rock",
+          "no_ammo_sound": "",
+          "fake_skills": [ [ "throw", 6 ] ],
+          "fake_str": 11,
+          "require_targeting_player": false,
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "ranges": [ [ 2, 10, "DEFAULT" ] ],
+          "description": "%1$s makes a throwing motion and one of the rocks around them suddenly launches like a bullet!"
+        },
+        {
+          "id": "smash",
+          "move_cost": 80,
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 15, "armor_penetration": 10 } ],
+          "hitsize_min": 12,
+          "accuracy": 4,
+          "range": 6,
+          "throw_strength": 20,
+          "dodgeable": false,
+          "uncanny_dodgeable": true,
+          "blockable": false,
+          "effects_require_dmg": false,
+          "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+          "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
+          "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
+          "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
+          "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
+        },
+        {
+          "id": "psi_telekin1_momentum_alteration",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_momentum_monster" },
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
+          },
+          "monster_message": "The air around %1$s wavers."
+        },
+        [ "PULL_METAL_WEAPON", 15 ]
+      ],
+      "flags": [ "PUSH_MON" ]
+    }
   },
   {
     "id": "mon_feral_human_telekin2",
     "type": "MONSTER",
     "name": "feral mindhand",
     "description": "This feral human moves quickly across uneven terrain and, when you look more closely, you see that they are floating just above the ground.  The air around them is distorted strangely, like looking through the surface of water.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
+    "copy-from": "mon_feral_psion_default",   
     "species": [ "FERAL", "TELEKIN_PUSHPULL_NULL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
     "color": "yellow",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 6,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "bash", "amount": 4 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_telekin",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
       "effect": { "id": "death_telekeinetic_hit_oneinthree", "hit_self": true },
       "message": "As the %1$s dies, a wave of force explodes outward!"
     },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_telekin3" },
-    "special_attacks": [
-      {
-        "id": "psi_telekin2_telegrab",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_pull_monster", "min_level": 3 },
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
-        "monster_message": "%1$s stares at %3$s and %3$s is lifted up and pulled towards them!"
-      },
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "mon_telekinetic_mindhammer",
-        "cooldown": { "math": [ "6 + rand(12)" ] },
-        "move_cost": 80,
-        "range": 8,
-        "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 20 } ],
-        "dodgeable": false,
-        "uncanny_dodgeable": true,
-        "blockable": false,
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s stares at you and your %2$s is hammered with psionic force!",
-        "hit_dmg_npc": "%1$s stares at <npcname> and their %2$s is hammered with psionic force!",
-        "miss_msg_u": "%1$s stares at you and you narrowly avoid an unseen attack!",
-        "miss_msg_npc": "%1$s stares and <npcname> narrowly avoids an unseen attack!",
-        "no_dmg_msg_u": "%1$s stares at you, but the telekinetic attack rebounds off your armor.",
-        "no_dmg_msg_npc": "%1$s stares at <npcname>, but the telekinetic attack rebounds off their armor."
-      },
-      {
-        "id": "smash",
-        "move_cost": 80,
-        "cooldown": { "math": [ "4 + rand(8)" ] },
-        "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 25, "armor_penetration": 10 } ],
-        "hitsize_min": 12,
-        "range": 8,
-        "throw_strength": 50,
-        "dodgeable": false,
-        "uncanny_dodgeable": true,
-        "blockable": false,
-        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
-        "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
-        "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
-        "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
-        "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
-      },
-      {
-        "id": "psi_telekin2_momentum_alteration",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_momentum_monster" },
-        "cooldown": 1,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "psi_telekin2_telegrab",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_pull_monster", "min_level": 3 },
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+          "monster_message": "%1$s stares at %3$s and %3$s is lifted up and pulled towards them!"
         },
-        "monster_message": "The air around %1$s wavers."
-      },
-      {
-        "id": "psi_telekin2_inertial_barrier",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_barrier_monster" },
-        "cooldown": 1,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "mon_telekinetic_mindhammer",
+          "cooldown": { "math": [ "6 + rand(12)" ] },
+          "move_cost": 80,
+          "accuracy": 6,
+          "range": 8,
+          "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 20 } ],
+          "dodgeable": false,
+          "uncanny_dodgeable": true,
+          "blockable": false,
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "hit_dmg_u": "%1$s stares at you and your %2$s is hammered with psionic force!",
+          "hit_dmg_npc": "%1$s stares at <npcname> and their %2$s is hammered with psionic force!",
+          "miss_msg_u": "%1$s stares at you and you narrowly avoid an unseen attack!",
+          "miss_msg_npc": "%1$s stares and <npcname> narrowly avoids an unseen attack!",
+          "no_dmg_msg_u": "%1$s stares at you, but the telekinetic attack rebounds off your armor.",
+          "no_dmg_msg_npc": "%1$s stares at <npcname>, but the telekinetic attack rebounds off their armor."
         },
-        "monster_message": "The air around %1$s distorts."
-      },
-      [ "PULL_METAL_WEAPON", 10 ]
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PATH_AVOID_FIRE",
-      "PRIORITIZE_TARGETS",
-      "CLIMBS",
-      "PUSH_VEH",
-      "PUSH_MON",
-      "TELEKIN_IMMUNE"
-    ]
+        {
+          "id": "smash",
+          "move_cost": 80,
+          "cooldown": { "math": [ "4 + rand(8)" ] },
+          "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 25, "armor_penetration": 10 } ],
+          "hitsize_min": 12,
+          "accuracy": 6,
+          "range": 8,
+          "throw_strength": 50,
+          "dodgeable": false,
+          "uncanny_dodgeable": true,
+          "blockable": false,
+          "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+          "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
+          "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
+          "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
+          "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
+        },
+        {
+          "id": "psi_telekin2_momentum_alteration",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_momentum_monster" },
+          "cooldown": 1,
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
+          },
+          "monster_message": "The air around %1$s wavers."
+        },
+        {
+          "id": "psi_telekin2_inertial_barrier",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_barrier_monster" },
+          "cooldown": 1,
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
+          },
+          "monster_message": "The air around %1$s distorts."
+        },
+        [ "PULL_METAL_WEAPON", 10 ]
+      ],
+      "flags": [ "CLIMBS", "PUSH_VEH", "PUSH_MON" ]
   },
   {
     "id": "mon_feral_human_telekin3",
     "type": "MONSTER",
     "name": "unstoppable force",
     "description": "Hovering half a meter off the ground, this feral human is surrounded by a whirling cloud of rock, dust, splintered wood, and various household objects.  As they move, the ground occasionally shakes.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
+    "copy-from": "mon_feral_psion_default",   
     "species": [ "FERAL", "TELEKIN_PUSHPULL_NULL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
     "color": "yellow",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 7,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "bash", "amount": 8 } ],
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_telekin",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
       "effect": { "id": "death_telekeinetic_hit_oneinthree", "hit_self": true },
       "message": "As the %1$s dies, a wave of force explodes outward!"
     },
-    "special_attacks": [
-      {
-        "id": "psi_telekin3_telegrab",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_pull_monster", "min_level": 6 },
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
-        "monster_message": "%1$s stares at %3$s and %3$s is lifted up and pulled towards them!"
-      },
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "mon_telekinetic3_mindhammer",
-        "cooldown": { "math": [ "6 + rand(12)" ] },
-        "move_cost": 80,
-        "range": 11,
-        "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 35 } ],
-        "dodgeable": false,
-        "uncanny_dodgeable": true,
-        "blockable": false,
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s stares at you and your %2$s is hammered with psionic force!",
-        "hit_dmg_npc": "%1$s stares at <npcname> and their %2$s is hammered with psionic force!",
-        "miss_msg_u": "%1$s stares at you and you narrowly avoid an unseen attack!",
-        "miss_msg_npc": "%1$s stares and <npcname> narrowly avoids an unseen attack!",
-        "no_dmg_msg_u": "%1$s stares at you, but the telekinetic attack rebounds off your armor.",
-        "no_dmg_msg_npc": "%1$s stares at <npcname>, but the telekinetic attack rebounds off their armor."
-      },
-      {
-        "id": "smash",
-        "move_cost": 80,
-        "cooldown": { "math": [ "4 + rand(8)" ] },
-        "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 25, "armor_penetration": 10 } ],
-        "hitsize_min": 12,
-        "range": 11,
-        "throw_strength": 50,
-        "dodgeable": false,
-        "uncanny_dodgeable": true,
-        "blockable": false,
-        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
-        "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
-        "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
-        "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
-        "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
-      },
-      {
-        "id": "psi_telekin3_momentum_alteration",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_momentum_monster" },
-        "cooldown": 1,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "psi_telekin3_telegrab",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_pull_monster", "min_level": 6 },
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+          "monster_message": "%1$s stares at %3$s and %3$s is lifted up and pulled towards them!"
         },
-        "monster_message": "The air around %1$s wavers."
-      },
-      {
-        "id": "psi_telekin3_inertial_barrier",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_barrier_monster_improved" },
-        "cooldown": 1,
-        "condition": {
-          "and": [
-            { "not": { "u_has_flag": "NO_PSIONICS" } },
-            { "not": { "u_has_effect": "effect_monster_inertial_barrier_improved" } }
-          ]
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "mon_telekinetic3_mindhammer",
+          "cooldown": { "math": [ "6 + rand(12)" ] },
+          "move_cost": 80,
+          "accuracy": 9
+          "range": 11,
+          "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 35 } ],
+          "dodgeable": false,
+          "uncanny_dodgeable": true,
+          "blockable": false,
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "hit_dmg_u": "%1$s stares at you and your %2$s is hammered with psionic force!",
+          "hit_dmg_npc": "%1$s stares at <npcname> and their %2$s is hammered with psionic force!",
+          "miss_msg_u": "%1$s stares at you and you narrowly avoid an unseen attack!",
+          "miss_msg_npc": "%1$s stares and <npcname> narrowly avoids an unseen attack!",
+          "no_dmg_msg_u": "%1$s stares at you, but the telekinetic attack rebounds off your armor.",
+          "no_dmg_msg_npc": "%1$s stares at <npcname>, but the telekinetic attack rebounds off their armor."
         },
-        "monster_message": "The air around %1$s distorts."
-      },
-      {
-        "id": "psi_telekin3_wreckingball",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_explosion_monster", "min_level": 8 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s gestures and the ground burst apart!"
-      },
-      {
-        "id": "psi_telekin3_earthshake",
-        "type": "spell",
-        "spell_data": { "id": "telekinetic_earthshaker_monster", "min_level": 5 },
-        "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s closes their eyes and the ground shakes!"
-      },
-      [ "PULL_METAL_WEAPON", 5 ]
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PATH_AVOID_FIRE",
-      "PRIORITIZE_TARGETS",
-      "FLIES",
-      "PUSH_VEH",
-      "PUSH_MON",
-      "TELEKIN_IMMUNE"
-    ]
+        { 
+          "id": "smash",
+          "move_cost": 80,
+          "cooldown": { "math": [ "4 + rand(8)" ] },
+          "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 25, "armor_penetration": 10 } ],
+          "hitsize_min": 12,
+          "accuracy": 9
+          "range": 11,    
+          "throw_strength": 50,
+          "dodgeable": false,
+          "uncanny_dodgeable": true,
+          "blockable": false,
+          "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+          "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
+          "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
+          "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
+          "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
+        },
+        {
+          "id": "psi_telekin3_momentum_alteration",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_momentum_monster" },
+          "cooldown": 1,
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
+          },
+          "monster_message": "The air around %1$s wavers."
+        },
+        {
+          "id": "psi_telekin3_inertial_barrier",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_barrier_monster_improved" },
+          "cooldown": 1,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "NO_PSIONICS" } },
+              { "not": { "u_has_effect": "effect_monster_inertial_barrier_improved" } }
+            ]
+          },
+          "monster_message": "The air around %1$s distorts."
+        },
+        {
+          "id": "psi_telekin3_wreckingball",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_explosion_monster", "min_level": 8 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s gestures and the ground bursts apart!"
+        },
+        {
+          "id": "psi_telekin3_earthshake",
+          "type": "spell",
+          "spell_data": { "id": "telekinetic_earthshaker_monster", "min_level": 5 },
+          "cooldown": { "math": [ "15 + rand(30)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s closes their eyes and the ground shakes!" 
+        },
+        [ "PULL_METAL_WEAPON", 5 ]
+      ],
+      "flags": [ "FLIES", "PUSH_VEH", "PUSH_MON" ]
+    }
   },
   {
     "id": "mon_feral_human_teep",
     "type": "MONSTER",
     "name": "feral esper",
     "description": "This feral human lacks the crazed look most of their kind have.  Instead, their gaze is unfocused, as though listening to voices only they can hear.",
+    "copy-from": "mon_feral_psion_default", 
+    "relative": { "dodge": 2 },
     "//": "Additional dodge due to reading the player's mind",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
     "color": "white",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
     "armor": { "psi_telepathic_damage": 20 },
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "death_drops": "feral_humans_death_drops_teep",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
       "effect": { "id": "death_psychic_scream", "hit_self": true, "min_level": 5 },
       "message": "As the %1$s dies, a scream fills your mind!"
     },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_teep2" },
-    "special_attacks": [
-      {
-        "id": "psi_telepath1_scream",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_confusion_monster", "min_level": 3 },
-        "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
-      },
-      {
-        "id": "psi_telepath1_blast",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_blast_monster", "min_level": 1 },
-        "cooldown": { "math": [ "9 + rand(18)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s stares at %3$s!"
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS"
-    ]
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "psi_telepath1_scream",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_confusion_monster", "min_level": 3 },
+          "cooldown": { "math": [ "10 + rand(20)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
+        },
+        {
+          "id": "psi_telepath1_blast",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_blast_monster", "min_level": 1 },
+          "cooldown": { "math": [ "9 + rand(18)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s stares at %3$s!"
+        }
+      ]
+    }
   },
   {
     "id": "mon_feral_human_teep2",
     "type": "MONSTER",
     "name": "feral brainburner",
     "description": "Before you see them, you can feel it--a sensation like spiders crawling along your brain.  As you shudder, this feral human looks at you and smiles slightly.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default",
+    "relative": { "dodge": 3 },
     "color": "white",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "death_drops": "feral_humans_death_drops_teep",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
       "effect": { "id": "death_psychic_scream", "hit_self": true, "min_level": 10 },
       "message": "As the %1$s dies, a scream fills your mind!"
     },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_teep3" },
-    "special_attacks": [
-      [ "PARROT_AT_DANGER", 10 ],
-      {
-        "id": "psi_telepath2_scream",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_confusion_monster", "min_level": 3 },
-        "cooldown": { "math": [ "8 + rand(16)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
-      },
-      {
-        "id": "psi_telepath2_blast",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_blast_monster", "min_level": 2 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s stares at %3$s!"
-      },
-      {
-        "id": "psi_telepath2_horror",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_horror_monster", "min_level": 4 },
-        "cooldown": { "math": [ "12 + rand(24)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s stares at %3$s!"
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "TEEP_IMMUNE"
-    ]
+    "extend": {
+      "special_attacks": [
+        [ "PARROT_AT_DANGER", 10 ],
+        {
+          "id": "psi_telepath2_scream",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_confusion_monster", "min_level": 3 }, 
+          "cooldown": { "math": [ "8 + rand(16)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "A roar fills %3$s's mind and the world is blotted out!"  
+        },
+        {
+          "id": "psi_telepath2_blast",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_blast_monster", "min_level": 2 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s stares at %3$s!"
+        },
+        {
+          "id": "psi_telepath2_horror",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_horror_monster", "min_level": 4 },
+          "cooldown": { "math": [ "12 + rand(24)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s stares at %3$s!"
+        }
+      ],
+      "flags": [ "TEEP_IMMUNE" ]
+    }
   },
   {
     "id": "mon_feral_human_teep3",
     "type": "MONSTER",
     "name": { "str": "instiller of nightmares", "str_pl": "instillers of nightmares" },
     "description": "Just another feral, with the typical bloodshot eyes and intense expression.  You have only a moment to think that before your heart starts racing in your chest and the hair stands up on the back of your neck as every instinct screams at you to run.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default", 
+    "relative": { "dodge": 4 },
     "color": "white",
     "symbol": "@",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "death_drops": "feral_humans_death_drops_teep",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
       "effect": { "id": "death_psychic_scream", "hit_self": true, "min_level": 15 },
       "message": "As the %1$s dies, a scream fills your mind!"
     },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_teep3" },
-    "special_attacks": [
-      [ "PARROT_AT_DANGER", 10 ],
-      {
-        "id": "psi_telepath3_scream",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_confusion_monster", "min_level": 5 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
-      },
-      {
-        "id": "psi_telepath3_blast",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_blast_monster", "min_level": 5 },
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s stares at %3$s!"
-      },
-      {
-        "id": "psi_telepath3_horror_aoe",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_horror_aoe_monster", "min_level": 15 },
-        "allow_no_target": true,
-        "cooldown": { "math": [ "12 + rand(24)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s eyes suddenly go wide!"
-      },
-      {
-        "id": "psi_telepath3_freeze",
-        "type": "spell",
-        "spell_data": { "id": "telepathic_primal_fear_monster", "min_level": 5 },
-        "cooldown": { "math": [ "17 + rand(34)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s stares at %3$s and they freeze like a frightened rabbit!"
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "TEEP_IMMUNE"
-    ]
+    "extend": {
+      "special_attacks": [
+        [ "PARROT_AT_DANGER", 10 ],
+        {
+          "id": "psi_telepath3_scream",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_confusion_monster", "min_level": 5 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
+        },
+        {
+          "id": "psi_telepath3_blast",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_blast_monster", "min_level": 5 },
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s stares at %3$s!"
+        },
+        {
+          "id": "psi_telepath3_horror_aoe",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_horror_aoe_monster", "min_level": 15 },
+          "allow_no_target": true,
+          "cooldown": { "math": [ "12 + rand(24)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s eyes suddenly go wide!"
+        },
+        {
+          "id": "psi_telepath3_freeze",
+          "type": "spell",
+          "spell_data": { "id": "telepathic_primal_fear_monster", "min_level": 5 },
+          "cooldown": { "math": [ "17 + rand(34)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s stares at %3$s and they freeze like a frightened rabbit!"
+        }
+      ],
+      "flags": [ "TEEP_IMMUNE" ]
+    }
   },
   {
     "id": "mon_feral_human_porter",
     "type": "MONSTER",
     "name": "feral jumper",
     "description": "What was once empty air suddenly contains this feral human.  They have the same crazed expression as their fellows, but their gaze is focused on more distant locations.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default", 
+    "relative": { "dodge": 2 },
     "color": "blue",
     "symbol": "@",
-    "aggression": 30,
     "morale": 25,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "death_drops": "feral_humans_death_drops_porter",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "upgrades": { "half_life": 45, "into": "mon_feral_human_porter2" },
-    "special_attacks": [
-      {
-        "id": "psi_teleport1_slow",
-        "type": "spell",
-        "spell_data": { "id": "teleport_slow_monster", "min_level": 2 },
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s looks at %3$s and the world lurches."
-      },
-      {
-        "type": "leap",
-        "cooldown": { "math": [ "4 + rand(8)" ] },
-        "allow_no_target": true,
-        "max_range": 8,
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "message": "%1$s vanishes and reappears elsewhere!"
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "CLIMBS",
-      "HARDTOSHOOT",
-      "TELEPORT_IMMUNE"
-    ]
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "psi_teleport1_slow",
+          "type": "spell",
+          "spell_data": { "id": "teleport_slow_monster", "min_level": 2 },
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s looks at %3$s and the world lurches."
+        },
+        {
+          "type": "leap",
+          "cooldown": { "math": [ "4 + rand(8)" ] },
+          "allow_no_target": true,
+          "max_range": 8,
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "message": "%1$s vanishes and reappears elsewhere!"
+        }
+      ],
+      "flags": [ "CLIMBS", "HARDTOSHOOT", "TELEPORT_IMMUNE" ]
+    }
   },
   {
     "id": "mon_feral_human_porter2",
     "type": "MONSTER",
     "name": "feral slider",
     "description": "Every time you blink, this feral human is in a different place.  They are always in motion without actually crossing the intervening space.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default", 
+    "relative": { "dodge": 4 },
     "color": "blue",
     "symbol": "@",
-    "aggression": 30,
     "morale": 25,
-    "melee_skill": 4,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "death_drops": "feral_humans_death_drops_porter",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "upgrades": { "half_life": 45, "into": "mon_feral_human_porter3" },
-    "special_attacks": [
-      {
-        "id": "psi_teleport2_slow",
-        "type": "spell",
-        "spell_data": { "id": "teleport_slow_monster", "min_level": 4 },
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s glances at %3$s and the world lurches."
-      },
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "teleport_touch",
-        "move_cost": 80,
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "accuracy": 5,
-        "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
-        "blockable": false,
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s touches you and the world shifts around you!",
-        "hit_dmg_npc": "%1$s touches <npcname> and the world shifts around them!",
-        "miss_msg_u": "%s reaches for you but you avoid their touch!",
-        "miss_msg_npc": "%s reaches for <npcname> but they dodge!"
-      },
-      {
-        "type": "leap",
-        "cooldown": { "math": [ "1 + rand(2)" ] },
-        "move_cost": 50,
-        "allow_no_target": true,
-        "max_range": 12,
-        "message": "%1$s vanishes and reappears elsewhere!",
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "CLIMBS",
-      "HARDTOSHOOT",
-      "TELEPORT_IMMUNE"
-    ]
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "psi_teleport2_slow",
+          "type": "spell",
+          "spell_data": { "id": "teleport_slow_monster", "min_level": 4 },
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s glances at %3$s and the world lurches."
+        },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "teleport_touch",
+          "move_cost": 80,
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "accuracy": 5,
+          "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
+          "blockable": false,
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "hit_dmg_u": "%1$s touches you and the world shifts around you!",
+          "hit_dmg_npc": "%1$s touches <npcname> and the world shifts around them!",
+          "miss_msg_u": "%s reaches for you but you avoid their touch!",
+          "miss_msg_npc": "%s reaches for <npcname> but they dodge!"
+        },
+        {
+          "type": "leap",
+          "cooldown": { "math": [ "1 + rand(2)" ] },
+          "move_cost": 50,
+          "allow_no_target": true,
+          "max_range": 12,
+          "message": "%1$s vanishes and reappears elsewhere!",
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
+        }      
+      ],
+      "flags": [ "CLIMBS", "HARDTOSHOOT", "TELEPORT_IMMUNE" ]
+    }
   },
   {
     "id": "mon_feral_human_porter3",
     "type": "MONSTER",
     "name": "ephemeral riftwalker",
     "description": "This feral barely seems to exist in the real world.  They constantly vanish and reappear, weird light and strange mist following in their wake.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default", 
+    "relative": { "dodge": 6 },
     "color": "blue",
     "symbol": "@",
-    "aggression": 30,
     "morale": 25,
-    "melee_skill": 4,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
-    "harvest": "human",
     "emit_fields": [ { "emit_id": "emit_plasma", "delay": "1 s" } ],
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "death_drops": "feral_humans_death_drops_porter",
     "death_function": {
       "effect": { "id": "teleport_summon_monster", "hit_self": true },
       "message": "As the %1$s dies, the air warps around them!"
     },
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "luminance": 25,
-    "special_attacks": [
-      [ "PARROT_AT_DANGER", 10 ],
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "teleport_touch",
-        "move_cost": 65,
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "accuracy": 6,
-        "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
-        "blockable": false,
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s touches you and the world warps around you!",
-        "hit_dmg_npc": "%1$s touches <npcname> and the world warps around them!",
-        "miss_msg_u": "%s reaches for you but you avoid their touch!",
-        "miss_msg_npc": "%s reaches for <npcname> but they dodge!"
-      },
-      {
-        "id": "psi_teleport3_slow",
-        "type": "spell",
-        "spell_data": { "id": "teleport_slow_monster", "min_level": 6 },
-        "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s glances at %3$s and the world lurches."
-      },
-      {
-        "id": "psi_teleport3_instability",
-        "type": "spell",
-        "spell_data": { "id": "teleport_blink_attack_monster", "min_level": 4 },
-        "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s touches %3$s and the world around %3$s wavers."
-      },
-      {
-        "type": "leap",
-        "cooldown": 1,
-        "move_cost": 50,
-        "allow_no_target": true,
-        "max_range": 16,
-        "message": "%1$s vanishes and reappears elsewhere!",
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PRIORITIZE_TARGETS",
-      "CLIMBS",
-      "HARDTOSHOOT",
-      "TELEPORT_IMMUNE"
-    ]
+    "extend": {
+      "special_attacks": [
+        [ "PARROT_AT_DANGER", 10 ],
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "teleport_touch",
+          "move_cost": 65,
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "accuracy": 6,
+          "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
+          "blockable": false,
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "hit_dmg_u": "%1$s touches you and the world warps around you!",
+          "hit_dmg_npc": "%1$s touches <npcname> and the world warps around them!",
+          "miss_msg_u": "%s reaches for you but you avoid their touch!",
+          "miss_msg_npc": "%s reaches for <npcname> but they dodge!"
+        },
+        {
+          "id": "psi_teleport3_slow",
+          "type": "spell",
+          "spell_data": { "id": "teleport_slow_monster", "min_level": 6 },
+          "cooldown": { "math": [ "5 + rand(10)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s glances at %3$s and the world lurches."
+        },
+        {
+          "id": "psi_teleport3_instability",
+          "type": "spell",
+          "spell_data": { "id": "teleport_blink_attack_monster", "min_level": 4 },
+          "cooldown": { "math": [ "10 + rand(20)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s touches %3$s and the world around %3$s wavers."
+        },
+        {
+          "type": "leap",
+          "cooldown": 1,
+          "move_cost": 50,
+          "allow_no_target": true,
+          "max_range": 16,
+          "message": "%1$s vanishes and reappears elsewhere!",
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
+        }
+      ],
+      "flags": [ "CLIMBS", "HARDTOSHOOT", "TELEPORT_IMMUNE" ]
+    }
   },
   {
     "id": "mon_feral_human_vita",
     "type": "MONSTER",
     "name": "feral mender",
     "description": "Other than the intense expression, this feral human looks to be the picture of health.  They could have starred in a healthcare advertisement before the Cataclysm.  Only the jagged bit of wood clutched like a club indicates something is wrong.",
+    "copy-from": "mon_feral_psion_default", 
+    "proportional": { "hp": 1.2 },
     "//": "HP and regeneration due to vitakinetic powers",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 125,
-    "speed": 100,
     "material": [ "flesh" ],
     "color": "green",
     "symbol": "@",
-    "aggression": 30,
     "morale": 45,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
     "regen_morale": true,
-    "armor": { "bash": 5, "cut": 3, "stab": 3, "bullet": 5 },
-    "regenerates": 5,
-    "regeneration_modifiers": [ [ "effect_vitakin_hurt", -2 ], [ "effect_psi_null", -5 ] ],
+    "regenerates": 2,
+    "regeneration_modifiers": [ [ "effect_vitakin_hurt", -1 ], [ "effect_psi_null", -2 ] ],
     "bleed_rate": 0,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_vita",
     "zombify_into": "mon_zombie_survivor",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "upgrades": { "half_life": 45, "into": "mon_feral_human_vita2" },
-    "special_attacks": [
-      { "id": "feral_weapon_pipe" },
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "mon_vitakinetic_weakness",
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "move_cost": 60,
-        "damage_max_instance": [ { "damage_type": "biological", "amount": 0 } ],
-        "dodgeable": true,
-        "blockable": true,
-        "effects": [ { "id": "effect_vitakinetic_health_down", "duration": [ 620000, 1620000 ] } ],
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s touches you and you feel weaker!",
-        "hit_dmg_npc": "%1$s touches <npcname> and they flinch!",
-        "miss_msg_u": "%1$s tries to touch you, but you dodge!",
-        "miss_msg_npc": "%1$s tries to touch <npcname>, but they dodge!",
-        "no_dmg_msg_u": "%1$s touches you but only hits your armor.",
-        "no_dmg_msg_npc": "%1$s touches <npcname> but only hits their armor."
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PATH_AVOID_FIRE",
-      "PRIORITIZE_TARGETS",
-      "NO_FUNG_DMG"
-    ]
+    "extend": {
+      "special_attacks": [
+        { "id": "feral_weapon_pipe" },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "mon_vitakinetic_weakness",
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "accuracy": 4,
+          "move_cost": 60,
+          "damage_max_instance": [ { "damage_type": "biological", "amount": 0 } ],
+          "dodgeable": true,
+          "blockable": true,
+          "effects": [ { "id": "effect_vitakinetic_health_down", "duration": [ 620000, 1620000 ] } ],
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "hit_dmg_u": "%1$s touches you and you feel weaker!",
+          "hit_dmg_npc": "%1$s touches <npcname> and they flinch!",
+          "miss_msg_u": "%1$s tries to touch you, but you dodge!",
+          "miss_msg_npc": "%1$s tries to touch <npcname>, but they dodge!",
+          "no_dmg_msg_u": "%1$s touches you but only hits your armor.",
+          "no_dmg_msg_npc": "%1$s touches <npcname> but only hits their armor."
+        }
+      ],
+      "flags": [ "NO_FUNG_DMG", "WIELDED_WEAPON" ]
+    }
   },
   {
     "id": "mon_feral_human_vita2",
     "type": "MONSTER",
     "name": "feral regenerator",
     "description": "This feral human doesn't even have bloodshot eyes.  Their skin positively glows, and as you watch them brush past a jagged chunk of wood to get to you, the wound they receive immediately stops bleeding and rapidly begins to close.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 150,
-    "speed": 100,
-    "material": [ "flesh" ],
+    "copy-from": "mon_feral_psion_default", 
+    "proportional": { "hp": 1.45 },
     "color": "green",
     "symbol": "@",
-    "aggression": 30,
     "morale": 45,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 3,
     "regen_morale": true,
-    "armor": { "bash": 5, "cut": 3, "stab": 3, "bullet": 5 },
     "regenerates": 5,
     "regeneration_modifiers": [ [ "effect_vitakin_hurt", -2 ], [ "effect_psi_null", -5 ], [ "effect_feral_regeneration", 5 ] ],
     "bleed_rate": 0,
-    "harvest": "human",
-    "dissect": "dissect_human_sample_single",
-    "vision_day": 45,
-    "vision_night": 3,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_vita",
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "special_attacks": [
-      { "id": "feral_weapon_pipe" },
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "mon_vitakinetic_laceration",
-        "cooldown": { "math": [ "6 + rand(12)" ] },
-        "move_cost": 60,
-        "damage_max_instance": [ { "damage_type": "biological", "amount": 15 } ],
-        "effects": [
-          { "id": "bleed", "duration": [ 60, 120 ], "intensity": [ 1, 10 ], "chance": 50, "affect_hit_bp": true },
-          { "id": "psi_vitakinetic_degeneration", "duration": [ 600, 2400 ] }
-        ],
-        "dodgeable": true,
-        "blockable": true,
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s touches you and wounds open on your flesh!",
-        "hit_dmg_npc": "%1$s touches <npcname> and wounds open on their flesh!",
-        "miss_msg_u": "%1$s tries to touch you, but you dodge!",
-        "miss_msg_npc": "%1$s tries to touch <npcname>, but they dodge!",
-        "no_dmg_msg_u": "%1$s touches you but only hits your armor.",
-        "no_dmg_msg_npc": "%1$s touches <npcname> but only hits their armor."
-      },
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "mon_vitakinetic_weakness_2",
-        "cooldown": { "math": [ "7 + rand(14)" ] },
-        "move_cost": 60,
-        "damage_max_instance": [ { "damage_type": "biological", "amount": 0 } ],
-        "dodgeable": true,
-        "blockable": true,
-        "effects": [ { "id": "effect_vitakinetic_healing_down", "duration": [ 920000, 2120000 ] } ],
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "hit_dmg_u": "%1$s touches you and you feel weaker!",
-        "hit_dmg_npc": "%1$s touches <npcname> and they flinch!",
-        "miss_msg_u": "%1$s tries to touch you, but you dodge!",
-        "miss_msg_npc": "%1$s tries to touch <npcname>, but they dodge!",
-        "no_dmg_msg_u": "%1$s touches you but only hits your armor.",
-        "no_dmg_msg_npc": "%1$s touches <npcname> but only hits their armor."
-      },
-      {
-        "id": "psi_vitakin2_regeneration",
-        "type": "spell",
-        "spell_data": { "id": "vitakinetic_regeneration_monster" },
-        "cooldown": { "math": [ "10 + rand(20)" ] },
-        "allow_no_target": true,
-        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$s closes their eyes and their wounds begin healing at a rapid pace!"
-      }
-    ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER",
-      "PATH_AVOID_FIRE",
-      "PRIORITIZE_TARGETS",
-      "NO_FUNG_DMG"
-    ]
+    "extend": {
+      "special_attacks": [
+        { "id": "feral_weapon_pipe" },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "mon_vitakinetic_laceration",
+          "cooldown": { "math": [ "6 + rand(12)" ] },
+          "accuracy": 6,
+          "move_cost": 60,
+          "damage_max_instance": [ { "damage_type": "biological", "amount": 15 } ],
+          "effects": [
+            { "id": "bleed", "duration": [ 60, 120 ], "intensity": [ 1, 10 ], "chance": 50, "affect_hit_bp": true },
+            { "id": "psi_vitakinetic_degeneration", "duration": [ 600, 2400 ] }
+          ],
+          "dodgeable": true,
+          "blockable": true,
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "hit_dmg_u": "%1$s touches you and wounds open on your flesh!",
+          "hit_dmg_npc": "%1$s touches <npcname> and wounds open on their flesh!",
+          "miss_msg_u": "%1$s tries to touch you, but you dodge!",
+          "miss_msg_npc": "%1$s tries to touch <npcname>, but they dodge!",
+          "no_dmg_msg_u": "%1$s touches you but only hits your armor.",
+          "no_dmg_msg_npc": "%1$s touches <npcname> but only hits their armor."
+        },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "mon_vitakinetic_weakness_2",
+          "cooldown": { "math": [ "7 + rand(14)" ] },
+          "accuracy": 6,
+          "move_cost": 60,
+          "damage_max_instance": [ { "damage_type": "biological", "amount": 0 } ],
+          "dodgeable": true,
+          "blockable": true,
+          "effects": [ { "id": "effect_vitakinetic_healing_down", "duration": [ 920000, 2120000 ] } ],
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "hit_dmg_u": "%1$s touches you and you feel weaker!",
+          "hit_dmg_npc": "%1$s touches <npcname> and they flinch!",
+          "miss_msg_u": "%1$s tries to touch you, but you dodge!",
+          "miss_msg_npc": "%1$s tries to touch <npcname>, but they dodge!",
+          "no_dmg_msg_u": "%1$s touches you but only hits your armor.",
+          "no_dmg_msg_npc": "%1$s touches <npcname> but only hits their armor."
+        },
+        {
+          "id": "psi_vitakin2_regeneration",
+          "type": "spell",
+          "spell_data": { "id": "vitakinetic_regeneration_monster" },
+          "cooldown": { "math": [ "10 + rand(20)" ] },
+          "allow_no_target": true,
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s closes their eyes and their wounds begin healing at a rapid pace!"
+        }
+      ],
+      "flags": [ "NO_FUNG_DMG", "WIELDED_WEAPON" ]
+    }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Feral psion updates with copy-from"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Copy-from makes sure that it's easier to keep monsters that are supposed to be similar up to date, preventing idiosyncrasies. For example, a lot of feral psions had dodge 3 (feral default is 1), weird vision ranges (feral security guard, Ψ Division had vision 35, better than the 30 that ferals used to have but worse than the 45 they have now), armor they shouldn't have (feral telekinetics still had their innate armor even though they get Momentum Alteration and some get Inertial Barrier now), and so on. If ferals are even further changed, this will keep feral psions in sync. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Copy-from chain all feral psions to `mon_feral_psion_default`, which itself is copy-from `mon_feral_human_pipe` (one remove done to set base flags and special attacks once instead of per-monster, since many feral psions don't use weapons or throw rocks). Delete all redundant lines, use proportional and relative when necessary.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a bunch of feral psions and checked the message logs while they fought mi-go. No errors and they had appropriate stats (it came down to three mi-go attacking a `feral visionary` who kept sidestepping every one of their attacks a split second before they would attack).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Feral electrokinetics and biokinetics still have their speed boosts. It's out of scope for this PR, but they should get Heightened Reflexes/Neuro-Acceleration as appropriate, so you can lead them toward blanks to cancel their buffs (or use a null grenade once I add those).
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
