### PR TITLE
hide fullscreen option to emscripten builds

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2616,7 +2616,7 @@ void options_manager::add_options_graphics()
              display_list.front().first, COPT_CURSES_HIDE );
 #endif
 
-#if !defined(__ANDROID__) // Android is always fullscreen
+#if !defined(__ANDROID__) || !defined(__EMSCRIPTEN__) // Android and Emscripten are always fullscreen
         add( "FULLSCREEN", page_id, to_translation( "Fullscreen" ),
              to_translation( "Starts Cataclysm in one of the fullscreen modes.  Requires restart." ),
         { { "no", to_translation( "No" ) }, { "maximized", to_translation( "Maximized" ) }, { "fullscreen", to_translation( "Fullscreen" ) }, { "windowedbl", to_translation( "Windowed borderless" ) } },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fullscreen modes don't (and shouldn't) work for players playing on the browser

#### Describe the solution
Hide the option

#### Describe alternatives you've considered
NONE

#### Testing
Should work

#### Additional context
NONE
