### PR TITLE
math: improve error reporting

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -52,6 +52,7 @@
 #include "mapdata.h"
 #include "martialarts.h"
 #include "math_parser.h"
+#include "math_parser_type.h"
 #include "mission.h"
 #include "mtype.h"
 #include "mutation.h"
@@ -608,12 +609,12 @@ void finalize_conditions()
         deferred_math &math = dfr.front();
         try {
             math.exp->parse( math.str, false );
-            math._validate_type();
-        } catch( std::invalid_argument const &ex ) {
+        } catch( math::exception const &ex ) {
             JsonObject jo{ std::move( math.jo ) };
             clear_deferred_math();
             jo.throw_error_at( "math", ex.what() );
         }
+        math._validate_type();
         dfr.pop();
     }
 }
@@ -2344,7 +2345,7 @@ conditional_t::get_get_dbl( std::string_view checked_value, char scope )
 
     } else if( checked_value == "allies" ) {
         if( is_npc ) {
-            throw std::invalid_argument( "Can't get allies count for NPCs" );
+            throw math::syntax_error( "Can't get allies count for NPCs" );
         }
         return []( const_dialogue const & /* d */ ) {
             return static_cast<double>( g->allies().size() );
@@ -2390,7 +2391,7 @@ conditional_t::get_get_dbl( std::string_view checked_value, char scope )
         };
     }
 
-    throw std::invalid_argument( string_format( R"(Invalid aspect "%s" for val())", checked_value ) );
+    throw math::syntax_error( string_format( R"(Invalid aspect "%s" for val())", checked_value ) );
 }
 
 namespace
@@ -2474,18 +2475,17 @@ conditional_t::get_set_dbl( std::string_view checked_value, char scope )
             d.actor( is_npc )->set_mana_cur( ( d.actor( is_npc )->mana_max() * input ) / 100 );
         };
     }
-    throw std::invalid_argument( string_format( R"(Invalid aspect "%s" for val())", checked_value ) );
+    throw math::syntax_error( string_format( R"(Invalid aspect "%s" for val())", checked_value ) );
 }
 
 void deferred_math::_validate_type() const
 {
     math_type_t exp_type = exp->get_type();
     if( exp_type == math_type_t::assign && type != math_type_t::assign ) {
-        jo.throw_error(
-            R"(Assignment operators can't be used in this context.  Did you mean to use "=="? )" );
+        jo.throw_error_at( "math",
+                           R"(Assignment operators can't be used in this context.  Did you mean to use "=="? )" );
     } else if( exp_type != math_type_t::assign && type == math_type_t::assign ) {
-        jo.throw_error(
-            R"(Eval statement in assignment context has no effect)" );
+        jo.throw_error_at( "math", R"(Eval statement in assignment context has no effect)" );
     }
 }
 
@@ -2499,15 +2499,20 @@ void eoc_math::from_json( const JsonObject &jo, std::string_view member, math_ty
     exp = defer_math( jo, combined, type_ );
 }
 
-double eoc_math::act( dialogue &d ) const
+template<typename D>
+double eoc_math::act( D &d ) const
 {
-    return exp->eval( d );
+    try {
+        return exp->eval( d );
+    } catch( math::exception const &re ) {
+        debugmsg( "%s\n\n%s", re.what(), d.get_callstack() );
+    }
+
+    return 0;
 }
 
-double eoc_math::act( const_dialogue const &d ) const
-{
-    return exp->eval( d );
-}
+template double eoc_math::act( dialogue &d ) const;
+template double eoc_math::act( const_dialogue const &d ) const;
 
 static const
 std::vector<condition_parser>

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -104,8 +104,9 @@ struct eoc_math {
     std::shared_ptr<math_exp> exp;
 
     void from_json( const JsonObject &jo, std::string_view member, math_type_t type_ );
-    double act( dialogue &d ) const;
-    double act( const_dialogue const &d ) const;
+
+    template<typename D>
+    double act( D &d ) const;
 };
 
 struct dbl_or_var_part {

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -331,7 +331,13 @@ class math_exp::math_exp_impl
         }
 
     private:
-        std::stack<op_t> ops;
+        struct op_ctxt {
+            op_t op;
+            std::string_view pos;
+
+            op_ctxt( op_t op_, std::string_view pos_ ): op( op_ ), pos( pos_ ) {};
+        };
+        std::stack<op_ctxt> ops;
         std::stack<thingie> output;
         struct arity_t {
             enum class type_t {
@@ -355,20 +361,20 @@ class math_exp::math_exp_impl
         };
         std::stack<arity_t> arity;
         thingie tree{ 0.0 };
-        std::string_view last_token;
+        std::string_view parse_position;
         parse_state state;
         math_type_t type = math_type_t::ret;
 
         void _parse( std::string_view str );
         void parse_string( std::string_view token, std::string_view full );
-        void parse_bin_op( pbin_op const &op );
-        void parse_ass_op( pass_op const &op );
+        void parse_bin_op( pbin_op const &op, std::string_view pos );
+        void parse_ass_op( pass_op const &op, std::string_view pos );
         void parse_diag_f( std::string_view symbol, scoped_diag_proto const &token );
         void parse_comma();
-        void parse_lparen( arity_t::type_t type = arity_t::type_t::parens );
-        void parse_rparen();
-        void parse_lbracket();
-        void parse_rbracket();
+        void parse_lparen( std::string_view pos, arity_t::type_t type = arity_t::type_t::parens );
+        void parse_rparen( std::string_view pos );
+        void parse_lbracket( std::string_view pos );
+        void parse_rbracket( std::string_view pos );
         void new_func();
         void new_oper();
         void new_var( std::string_view str );
@@ -377,7 +383,7 @@ class math_exp::math_exp_impl
         void new_array();
         void maybe_first_argument();
         std::string error( std::string_view str, std::string_view what );
-        void validate_string( std::string_view str, std::string_view label, std::string_view badlist );
+        static void validate_string( std::string_view str, std::string_view badlist );
         static std::vector<diag_value> _get_diag_vals( thingie &thing );
         thingie _resolve_proto( thingie &thing, bool assignment = false,
                                 std::vector<diag_value> const *args_ = nullptr );
@@ -396,7 +402,7 @@ void math_exp::math_exp_impl::_parse( std::string_view str )
     constexpr std::string_view expression_separators = "+-*/^,()[]%':><=!?";
     state = {};
     for( std::string_view const token : tokenize( str, expression_separators ) ) {
-        last_token = token;
+        parse_position = token;
         if( state.instring || token == "'" ) {
             parse_string( token, str );
 
@@ -409,14 +415,14 @@ void math_exp::math_exp_impl::_parse( std::string_view str )
         } else if( std::optional<pmath_func> ftoken = get_function( token ); ftoken ) {
             state.validate( parse_state::expect::operand );
             maybe_first_argument();
-            ops.emplace( *ftoken );
+            ops.emplace( *ftoken, token );
             arity.emplace( ( *ftoken )->symbol, ( *ftoken )->num_params, arity_t::type_t::func );
             state.set( parse_state::expect::lparen );
 
         } else if( jmath_func_id jmfid( token ); jmfid.is_valid() ) {
             state.validate( parse_state::expect::operand );
             maybe_first_argument();
-            ops.emplace( jmfid );
+            ops.emplace( jmfid, token );
             arity.emplace( token, jmfid->num_params, arity_t::type_t::func );
             state.set( parse_state::expect::lparen );
 
@@ -425,29 +431,29 @@ void math_exp::math_exp_impl::_parse( std::string_view str )
 
         } else if( std::optional<punary_op> op = get_unary_op( token ); op && state.allows_prefix_unary ) {
             state.validate( parse_state::expect::operand );
-            ops.emplace( *op );
+            ops.emplace( *op, token );
             state.set( parse_state::expect::operand );
 
         } else if( std::optional<pbin_op> op = get_binary_op( token ); op ) {
-            parse_bin_op( *op );
+            parse_bin_op( *op, token );
 
         } else if( std::optional<pass_op> op = get_ass_op( token ); op ) {
-            parse_ass_op( *op );
+            parse_ass_op( *op, token );
 
         } else if( token == "," ) {
             parse_comma();
 
         } else if( token == "(" ) {
-            parse_lparen();
+            parse_lparen( token );
 
         } else if( token == ")" ) {
-            parse_rparen();
+            parse_rparen( token );
 
         } else if( token == "[" ) {
-            parse_lbracket();
+            parse_lbracket( token );
 
         } else if( token == "]" ) {
-            parse_rbracket();
+            parse_rbracket( token );
 
         } else {
             state.validate( parse_state::expect::operand );
@@ -458,10 +464,12 @@ void math_exp::math_exp_impl::_parse( std::string_view str )
     }
     state.validate( parse_state::expect::eof );
     while( !ops.empty() ) {
-        if( std::holds_alternative<paren>( ops.top() ) && std::get<paren>( ops.top() ) == paren::left ) {
+        op_t const &op = ops.top().op;
+        parse_position = ops.top().pos;
+        if( std::holds_alternative<paren>( op ) && std::get<paren>( op ) == paren::left ) {
             throw math::syntax_error( "Unterminated left paranthesis" );
         }
-        if( std::holds_alternative<paren>( ops.top() ) && std::get<paren>( ops.top() ) == paren::left_sq ) {
+        if( std::holds_alternative<paren>( op ) && std::get<paren>( op ) == paren::left_sq ) {
             throw math::syntax_error( "Unterminated left bracket" );
         }
         new_oper();
@@ -497,30 +505,30 @@ void math_exp::math_exp_impl::parse_string( std::string_view token, std::string_
     }
 }
 
-void math_exp::math_exp_impl::parse_bin_op( pbin_op const &op )
+void math_exp::math_exp_impl::parse_bin_op( pbin_op const &op, std::string_view pos )
 {
     if( op->symbol == ":" && !arity.empty() && arity.top().type == arity_t::type_t::ternary ) {
         // insert a pair of parens to help resolve nested ternaries like 0?0?-1:-2:1
-        parse_rparen();
+        parse_rparen( pos );
     }
     state.validate( parse_state::expect::oper );
-    while( !ops.empty() && ops.top() > *op ) {
+    while( !ops.empty() && ops.top().op > *op ) {
         new_oper();
     }
-    ops.emplace( op );
+    ops.emplace( op, pos );
     state.set( parse_state::expect::operand, true );
     if( op->symbol == "?" ) {
-        parse_lparen( arity_t::type_t::ternary );
+        parse_lparen( pos, arity_t::type_t::ternary );
     }
 }
 
-void math_exp::math_exp_impl::parse_ass_op( pass_op const &op )
+void math_exp::math_exp_impl::parse_ass_op( pass_op const &op, std::string_view pos )
 {
     state.validate( parse_state::expect::oper );
-    while( !ops.empty() && ops.top() > assignment_op ) {
+    while( !ops.empty() && ops.top().op > assignment_op ) {
         new_oper();
     }
-    ops.emplace( op );
+    ops.emplace( op, pos );
     if( op->unaryone ) {
         state.set( parse_state::expect::eof, true );
     } else {
@@ -532,7 +540,7 @@ void math_exp::math_exp_impl::parse_diag_f(
     std::string_view symbol, scoped_diag_proto const &token )
 {
     state.validate( parse_state::expect::operand );
-    ops.emplace( token );
+    ops.emplace( token, symbol );
     arity.emplace( symbol, token.df->num_params, arity_t::type_t::func, true );
     state.set( parse_state::expect::lparen, false );
 }
@@ -543,31 +551,32 @@ void math_exp::math_exp_impl::parse_comma()
     if( arity.empty() || !arity.top().allows_comma() ) {
         throw math::syntax_error( "Misplaced comma" );
     }
-    while( ops.top() > paren::left ) {
+    while( ops.top().op > paren::left ) {
         new_oper();
     }
     arity.top().current++;
     state.set( parse_state::expect::operand, true );
 }
 
-void math_exp::math_exp_impl::parse_lparen( arity_t::type_t type )
+void math_exp::math_exp_impl::parse_lparen( std::string_view pos, arity_t::type_t type )
 {
     state.validate( parse_state::expect::lparen );
-    if( ops.empty() || !is_function( ops.top() ) ) {
+    if( ops.empty() || !is_function( ops.top().op ) ) {
         arity.emplace( std::string_view{}, 0, type, !arity.empty() && arity.top().stringy );
     }
-    ops.emplace( paren::left );
+    ops.emplace( paren::left, pos );
     state.set( parse_state::expect::operand, true );
 }
 
-void math_exp::math_exp_impl::parse_rparen()
+void math_exp::math_exp_impl::parse_rparen( std::string_view pos )
 {
     state.validate( parse_state::expect::rparen );
-    while( !ops.empty() && ops.top() > paren::left ) {
+    while( !ops.empty() && ops.top().op > paren::left ) {
         new_oper();
     }
-    if( ops.empty() || !std::holds_alternative<paren>( ops.top() ) ||
-        std::get<paren>( ops.top() ) != paren::left ) {
+    if( ops.empty() || !std::holds_alternative<paren>( ops.top().op ) ||
+        std::get<paren>( ops.top().op ) != paren::left ) {
+        parse_position = pos;
         throw math::syntax_error( "Misplaced right parenthesis" );
     }
     ops.pop();
@@ -577,7 +586,7 @@ void math_exp::math_exp_impl::parse_rparen()
     state.set( parse_state::expect::oper, false );
 }
 
-void math_exp::math_exp_impl::parse_lbracket()
+void math_exp::math_exp_impl::parse_lbracket( std::string_view pos )
 {
     state.validate( parse_state::expect::lbracket );
     if( arity.empty() || !arity.top().stringy ) {
@@ -585,17 +594,18 @@ void math_exp::math_exp_impl::parse_lbracket()
     }
     arity.emplace( std::string_view{}, 0, arity_t::type_t::array,
                    !arity.empty() && arity.top().stringy );
-    ops.emplace( paren::left_sq );
+    ops.emplace( paren::left_sq, pos );
     state.set( parse_state::expect::operand, true );
 }
 
-void math_exp::math_exp_impl::parse_rbracket()
+void math_exp::math_exp_impl::parse_rbracket( std::string_view pos )
 {
     state.validate( parse_state::expect::rbracket );
     if( arity.empty() || arity.top().type != arity_t::type_t::array ) {
+        parse_position = pos;
         throw math::syntax_error( "Misplaced right bracket" );
     }
-    while( !ops.empty() && ops.top() > paren::left_sq ) {
+    while( !ops.empty() && ops.top().op > paren::left_sq ) {
         new_oper();
     }
     ops.pop();
@@ -612,7 +622,7 @@ thingie math_exp::math_exp_impl::_resolve_proto( thingie &thing, bool assignment
     if( std::holds_alternative<func_diag_proto>( thing.data ) ) {
         func_diag_proto &proto = std::get<func_diag_proto>( thing.data );
         std::vector<diag_value> const &args = args_ == nullptr ? _get_diag_vals( thing ) : *args_;
-        last_token = proto.token;
+        parse_position = proto.token;
 
         if( !assignment && proto.f->fe == nullptr ) {
             throw math::syntax_error( "Function prototype %s() cannot be evaluated", proto.token );
@@ -638,7 +648,7 @@ thingie math_exp::math_exp_impl::_resolve_proto( thingie &thing, bool assignment
 
 void math_exp::math_exp_impl::new_func()
 {
-    if( !ops.empty() && is_function( ops.top() ) ) {
+    if( !ops.empty() && is_function( ops.top().op ) ) {
         std::vector<thingie>::size_type const nparams = arity.top().current;
         if( arity.top().expected >= 0 ) {
             if( arity.top().current < arity.top().expected ) {
@@ -682,7 +692,7 @@ void math_exp::math_exp_impl::new_func()
                 throw math::internal_error( "Internal func error.  That's all we know." );
             },
         },
-        ops.top() );
+        ops.top().op );
         ops.pop();
     }
 }
@@ -772,23 +782,24 @@ void math_exp::math_exp_impl::new_array()
 
 void math_exp::math_exp_impl::new_oper()
 {
-    op_t op( ops.top() );
+    op_ctxt op( ops.top() );
     ops.pop();
     std::visit( overloaded{
-        [this]( pbin_op v )
+        [this, &op]( pbin_op v )
         {
             cata_assert( output.size() >= 2 );
             thingie rhs = _resolve_proto( output.top() );
             output.pop();
             thingie lhs = _resolve_proto( output.top() );
             output.pop();
+            parse_position = op.pos;
             if( v->symbol == "?" ) {
                 throw math::syntax_error( "Unterminated ternary" );
             }
             if( v->symbol == ":" ) {
                 std::string_view top_sym =
-                    !ops.empty() && std::holds_alternative<pbin_op>( ops.top() )
-                    ? std::get<pbin_op>( ops.top() )->symbol
+                    !ops.empty() && std::holds_alternative<pbin_op>( ops.top().op )
+                    ? std::get<pbin_op>( ops.top().op )->symbol
                     : std::string_view{};
 
                 if( !output.empty() && top_sym == "?" ) {
@@ -801,6 +812,7 @@ void math_exp::math_exp_impl::new_oper()
                     throw math::syntax_error( "Misplaced colon" );
                 }
             } else {
+                parse_position = op.pos;
                 _validate_operand( lhs, v->symbol );
                 _validate_operand( rhs, v->symbol );
                 if( output.empty() && arity.empty() ) {
@@ -809,15 +821,16 @@ void math_exp::math_exp_impl::new_oper()
                 output.emplace( std::in_place_type_t<oper>(), lhs, rhs, v->f );
             }
         },
-        [this]( punary_op v )
+        [this, &op]( punary_op v )
         {
             cata_assert( !output.empty() );
             thingie rhs = _resolve_proto( output.top() );
             output.pop();
+            parse_position = op.pos;
             _validate_operand( rhs, v->symbol );
             output.emplace( std::in_place_type_t<oper>(), thingie { 0.0 }, rhs, v->f );
         },
-        [this]( pass_op v )
+        [this, &op]( pass_op v )
         {
             thingie rhs{ 1.0 };
             if( !v->unaryone ) {
@@ -836,6 +849,7 @@ void math_exp::math_exp_impl::new_oper()
                 mhs = _resolve_proto( temp, false, &args );
             }
 
+            parse_position = op.pos;
             if( !is_assign_target( lhs ) ) {
                 throw math::syntax_error( "lhs of assignment operator must be an assign target" );
             }
@@ -851,7 +865,7 @@ void math_exp::math_exp_impl::new_oper()
             throw math::internal_error( "Internal oper error.  That's all we know." );
         }
     },
-    op );
+    op.op );
 }
 
 void math_exp::math_exp_impl::new_var( std::string_view str )
@@ -877,14 +891,14 @@ void math_exp::math_exp_impl::new_var( std::string_view str )
         type = var_type::context;
         scoped = scoped.substr( 1 );
     }
-    validate_string( scoped, "variable", " \'" );
+    validate_string( scoped, " \'" );
     output.emplace( std::in_place_type_t<var>(), type, std::string{ scoped } );
 }
 
 std::string math_exp::math_exp_impl::error( std::string_view str, std::string_view what )
 {
     std::ptrdiff_t offset =
-        std::max<std::ptrdiff_t>( 0, last_token.data() - str.data() );
+        std::max<std::ptrdiff_t>( 0, parse_position.data() - str.data() );
     // center the problematic token on screen if the expression is too long
     if( offset > 80 ) {
         str.remove_prefix( offset - 40 );
@@ -892,7 +906,7 @@ std::string math_exp::math_exp_impl::error( std::string_view str, std::string_vi
     }
     // NOLINTNEXTLINE(cata-translate-string-literal): debug message
     std::string mess = string_format( "Expression parsing failed: %s", what );
-    if( last_token == "(" && state.expected == parse_state::expect::oper &&
+    if( parse_position == "(" && state.expected == parse_state::expect::oper &&
         std::holds_alternative<var>( output.top().data ) ) {
         // NOLINTNEXTLINE(cata-translate-string-literal): debug message
         mess = string_format( "%s (or unknown function %s)", mess,
@@ -904,14 +918,12 @@ std::string math_exp::math_exp_impl::error( std::string_view str, std::string_vi
     return string_format( "\n%s\n\n%.80s\n%*s▲▲▲\n", mess, str, offset, " " );
 }
 
-void math_exp::math_exp_impl::validate_string( std::string_view str, std::string_view label,
-        std::string_view badlist )
+void math_exp::math_exp_impl::validate_string( std::string_view str, std::string_view badlist )
 {
     std::string_view::size_type const pos = str.find_first_of( badlist );
     if( pos != std::string_view::npos ) {
-        last_token.remove_prefix( pos + ( label == "string" ? 1 : 0 ) );
         // NOLINTNEXTLINE(cata-translate-string-literal): debug message
-        throw math::syntax_error( R"(Stray " %c " inside %s operand "%s")", str[pos], label, str );
+        throw math::syntax_error( R"(Stray " %c " inside %s operand "%s")", str[pos], str );
     }
 }
 

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -48,8 +48,8 @@ math_eval_dbl_f myfunction_eval( char scope,
   ex: school_level() split from spell_level() instead of spell_level('school':blorg)
 - Use parameter-less functions diag_value::str(), dbl(), and var() only at parse-time
 - Use conversion functions diag_value::str( d ) and dbl( d ) only at run-time
-- Always throw on errors at parse-time
-- Never throw at run-time. Use a debugmsg() and recover gracefully
+- throw math::syntax_error for parse-time errors
+- throw math::runtime_error for run-time errors
 */
 
 static const json_character_flag json_flag_MUTATION_THRESHOLD( "MUTATION_THRESHOLD" );
@@ -87,7 +87,8 @@ template<typename T>
 T _read_from_string( std::string_view s, const std::vector<std::pair<std::string, T>> &units )
 {
     auto const error = [s]( char const * suffix, size_t /* offset */ ) {
-        debugmsg( R"(Failed to convert "%s" to a %s value: %s)", s, _str_type_of<T>(), suffix );
+        throw math::runtime_error( R"(Failed to convert "%s" to a %s value: %s)", s, _str_type_of<T>(),
+                                   suffix );
     };
     return detail::read_from_json_string_common<T>( s, units, error );
 }
@@ -185,8 +186,7 @@ diag_eval_dbl_f damage_level_eval( char scope, std::vector<diag_value> const &pa
     return[params, beta = is_beta( scope )]( const_dialogue const & d ) {
         item_location const *it = d.const_actor( beta )->get_const_item();
         if( !it ) {
-            debugmsg( "subject of damage_level() must be an item" );
-            return 0;
+            throw math::runtime_error( "subject of damage_level() must be an item" );
         }
         return ( *it )->damage_level();
     };
@@ -348,8 +348,8 @@ diag_eval_dbl_f field_strength_eval( char scope, std::vector<diag_value> const &
     if( !loc_val.is_empty() ) {
         loc_var = loc_val.var();
     } else if( scope == 'g' ) {
-        throw std::invalid_argument( string_format(
-                                         R"("field_strength" needs either an actor scope (u/n) or a 'location' kwarg)" ) );
+        throw math::syntax_error(
+            R"("field_strength" needs either an actor scope (u/n) or a 'location' kwarg)" );
     }
 
     return [beta = is_beta( scope ), field_value = params[0], loc_var]( const_dialogue const & d ) {
@@ -374,8 +374,7 @@ diag_eval_dbl_f gun_damage_eval( char scope, std::vector<diag_value> const &para
         item_location const *it = d.const_actor( beta )->get_const_item();
         if( it == nullptr )
         {
-            debugmsg( "subject of gun_damage() must be an item" );
-            return 0;
+            throw math::runtime_error( "subject of gun_damage() must be an item" );
         }
         std::string const dt_str = dt_val.str( d );
         if( dt_str == "ALL" )
@@ -413,8 +412,7 @@ diag_eval_dbl_f sum_traits_of_category_eval( char scope, std::vector<diag_value>
         } else if( thing == "ALL" ) {
             count_type = mut_count_type::ALL;
         } else {
-            debugmsg( "Incorrect type '%s' in sum_traits_of_category", type.str() );
-            return 0;
+            throw math::runtime_error( "Incorrect type '%s' in sum_traits_of_category", type.str() );
         }
 
         return d.const_actor( beta )->get_total_in_category( cat, count_type );
@@ -440,8 +438,7 @@ diag_eval_dbl_f sum_traits_of_category_char_has_eval( char scope,
         } else if( thing == "ALL" ) {
             count_type = mut_count_type::ALL;
         } else {
-            debugmsg( "Incorrect type '%s' in sum_traits_of_category", type.str() );
-            return 0;
+            throw math::runtime_error( "Incorrect type '%s' in sum_traits_of_category", type.str() );
         }
 
         return d.const_actor( beta )->get_total_in_category_char_has( cat, count_type );
@@ -654,8 +651,7 @@ diag_eval_dbl_f melee_damage_eval( char scope, std::vector<diag_value> const &pa
     return[dt_val = params[0], beta = is_beta( scope )]( const_dialogue const & d ) {
         item_location const *it = d.const_actor( beta )->get_const_item();
         if( it == nullptr ) {
-            debugmsg( "subject of melee_damage() must be an item" );
-            return 0;
+            throw math::runtime_error( "subject of melee_damage() must be an item" );
         }
         std::string const dt_str = dt_val.str( d );
         if( dt_str == "ALL" ) {
@@ -732,8 +728,8 @@ diag_eval_dbl_f _characters_nearby_eval( char scope, std::vector<diag_value> con
     if( !loc_val.is_empty() ) {
         loc_var = loc_val.var();
     } else if( scope == 'g' ) {
-        throw std::invalid_argument( string_format(
-                                         R"("characters_nearby" needs either an actor scope (u/n) or a 'location' kwarg)" ) );
+        throw math::syntax_error(
+            R"("characters_nearby" needs either an actor scope (u/n) or a 'location' kwarg)" );
     }
 
     return [beta = is_beta( scope ), params, loc_var, filter_val, radius_val,
@@ -755,8 +751,8 @@ diag_eval_dbl_f _characters_nearby_eval( char scope, std::vector<diag_value> con
         } else if( filter_str == "hostile" ) {
             filter = character_filter::hostile;
         } else if( filter_str != "any" ) {
-            debugmsg( R"(Unknown attitude filter "%s" for characters_nearby(), counting all characters)",
-                      filter_str );
+            throw math::runtime_error(
+                R"(Unknown attitude filter "%s" for characters_nearby())", filter_str );
         }
         bool allow_hallucinations = false;
         int const hallucinations_int = static_cast<int>( allow_hallucinations_val.dbl( d ) );
@@ -847,8 +843,8 @@ diag_eval_dbl_f _monsters_nearby_eval( char scope, std::vector<diag_value> const
     if( !loc_val.is_empty() ) {
         loc_var = loc_val.var();
     } else if( scope == 'g' ) {
-        throw std::invalid_argument( string_format(
-                                         R"("monsters_nearby" needs either an actor scope (u/n) or a 'location' kwarg)" ) );
+        throw math::syntax_error(
+            R"("monsters_nearby" needs either an actor scope (u/n) or a 'location' kwarg)" );
     }
 
     return [beta = is_beta( scope ), params, loc_var, radius_val, filter_val,
@@ -873,7 +869,8 @@ diag_eval_dbl_f _monsters_nearby_eval( char scope, std::vector<diag_value> const
         } else if( filter_str == "friendly" ) {
             filter = mon_filter::friends;
         } else if( filter_str != "hostile" ) {
-            debugmsg( R"(Unknown attitude filter "%s" for monsters_nearby(), assuming "hostile")", filter_str );
+            throw math::runtime_error(
+                R"(Unknown attitude filter "%s" for monsters_nearby())", filter_str );
         }
 
         std::vector<Creature *> const targets = g->get_creatures_if( [&mids, &radius,
@@ -922,8 +919,7 @@ diag_eval_dbl_f pain_eval( char scope, std::vector<diag_value> const & /* params
         } else if( format == "raw" ) {
             return d.const_actor( beta )->pain_cur();
         } else {
-            debugmsg( R"(Unknown type "%s" for pain())", format );
-            return 0;
+            throw math::runtime_error( R"(Unknown type "%s" for pain())", format );
         }
     };
 }
@@ -941,7 +937,7 @@ diag_assign_dbl_f pain_ass( char scope, std::vector<diag_value> const & /* param
         } else if( format == "raw" ) {
             d.actor( beta )->set_pain( val );
         } else {
-            debugmsg( R"(Unknown assigning type "%s" for pain())", format );
+            throw math::runtime_error( R"(Unknown type "%s" for pain())", format );
         }
     };
 }
@@ -1009,8 +1005,7 @@ diag_eval_dbl_f get_daily_calories( char scope, std::vector<diag_value> const & 
         std::string type = type_val.str( d );
         int const day = day_val.dbl( d );
         if( day < 0 ) {
-            debugmsg( "get_daily_calories(): cannot access calorie diary from the future (day < 0)" );
-            return 0;
+            throw math::runtime_error( "get_daily_calories(): cannot access calorie diary from the future (day < 0)" );
         }
 
         return d.const_actor( beta )->get_daily_calories( day, type );
@@ -1042,7 +1037,7 @@ diag_eval_dbl_f skill_exp_eval( char scope, std::vector<diag_value> const &param
         skill_id skill( skill_value.str( d ) );
         std::string format = format_value.str( d );
         if( format != "raw" && format != "percentage" ) {
-            debugmsg( R"(Unknown format type "%s" for skill_exp, assumning "percentage")", format );
+            throw math::runtime_error( R"(Unknown format type "%s" for skill_exp")", format );
         }
         bool raw = format == "raw";
         return d.const_actor( beta )->get_skill_exp( skill, raw );
@@ -1059,7 +1054,7 @@ diag_assign_dbl_f skill_exp_ass( char scope, std::vector<diag_value> const &para
         skill_id skill( skill_value.str( d ) );
         std::string format = format_value.str( d );
         if( format != "raw" && format != "percentage" ) {
-            debugmsg( R"(Unknown format type "%s" for skill_exp, assumning "percentage")", format );
+            throw math::runtime_error( R"(Unknown format type "%s" for skill_exp)", format );
         }
         bool raw = format == "raw";
         return d.actor( beta )->set_skill_exp( skill, val, raw );
@@ -1133,9 +1128,10 @@ diag_assign_dbl_f spell_level_ass( char scope, std::vector<diag_value> const &pa
                                    diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope ), spell_value = params[0]]( dialogue const & d, double val ) {
-        const spell_id spell( spell_value.str( d ) );
+        std::string const spell_str = spell_value.str( d );
+        const spell_id spell( spell_str );
         if( spell == spell_id::NULL_ID() ) {
-            debugmsg( "Can't set spell level of %s", spell.str() );
+            throw math::runtime_error( R"("%s" is not a valid spell)", spell_str );
         } else {
             d.actor( beta )->set_spell_level( spell, val );
         }
@@ -1195,7 +1191,7 @@ double _time_in_unit( double time, std::string_view unit )
         } );
 
         if( iter == time_duration::units.end() ) {
-            debugmsg( R"(Unknown time unit "%s", assuming turns )", unit );
+            throw math::runtime_error( R"(Unknown time unit "%s")", unit );
         } else {
             return time / to_turns<double>( iter->second );
         }
@@ -1235,8 +1231,7 @@ diag_assign_dbl_f time_ass( char /* scope */, std::vector<diag_value> const &par
         };
     }
 
-    throw std::invalid_argument(
-        string_format( "Only time('now') is a valid time() assignment target" ) );
+    throw math::syntax_error( "Only time('now') is a valid time() assignment target" );
 }
 
 diag_eval_dbl_f time_since_eval( char /* scope */, std::vector<diag_value> const &params,
@@ -1347,7 +1342,7 @@ diag_eval_dbl_f proficiency_eval( char scope, std::vector<diag_value> const &par
             return to_turns<double>( prof->time_to_learn() - raw );
         } else {
             if( format != "time_spent" ) {
-                debugmsg( R"(Unknown format type "%s" for proficiency, assumning "time_spent")", format );
+                throw math::runtime_error( R"(Unknown format type "%s" for proficiency)", format );
             }
             return to_turns<double>( raw );
         }
@@ -1374,7 +1369,7 @@ diag_assign_dbl_f proficiency_ass( char scope, std::vector<diag_value> const &pa
             to_write = to_turns<int>( prof->time_to_learn() ) - val;
         } else {
             if( format != "time_spent" ) {
-                debugmsg( R"(Unknown format type "%s" for proficiency, assumning "time_spent")", format );
+                throw math::runtime_error( R"(Unknown format type "%s" for proficiency)", format );
             }
             to_write = val;
         }
@@ -1383,7 +1378,8 @@ diag_assign_dbl_f proficiency_ass( char scope, std::vector<diag_value> const &pa
         // Due to rounding errors, -1 can occur in normal situations. When that happens, ignore it
         if( !direct && learned < 1 ) {
             if( learned < -1 ) {
-                debugmsg( "For proficiency %s in dialogue, trying to learn negative without direct", prof.str() );
+                throw math::runtime_error( "For proficiency %s in dialogue, trying to learn negative without direct",
+                                           prof.str() );
             }
             return 0;
         }
@@ -1471,8 +1467,7 @@ diag_eval_dbl_f vision_range_eval( char scope, std::vector<diag_value> const & /
             tripoint_bub_ms tripoint = get_map().bub_from_abs( mon->get_location() );
             return mon->sight_range( here.ambient_light_at( tripoint ) );
         }
-        debugmsg( "Tried to access vision range of a non-Character talker" );
-        return 0;
+        throw math::runtime_error( "Tried to access vision range of a non-Character talker" );
     };
 }
 
@@ -1567,8 +1562,7 @@ diag_eval_dbl_f calories_eval( char scope, std::vector<diag_value> const & /* pa
         std::string format = format_value.str( d );
         if( format != "raw" && format != "percent" )
         {
-            debugmsg( R"(Unknown format type "%s" for calories, assumning "raw")", format );
-            format = "raw";
+            throw math::runtime_error( R"(Unknown format type "%s" for calories)", format );
         }
 
         if( format == "percent" )
@@ -1582,8 +1576,7 @@ diag_eval_dbl_f calories_eval( char scope, std::vector<diag_value> const & /* pa
                 }
                 return d.const_actor( beta )->get_stored_kcal() / divisor;
             } else {
-                debugmsg( "Percent can be used only with character" );
-                return 0;
+                throw math::runtime_error( "Percent can be used only with character" );
             }
         } else if( format == "raw" )
         {
@@ -1595,8 +1588,7 @@ diag_eval_dbl_f calories_eval( char scope, std::vector<diag_value> const & /* pa
                 return default_character_compute_effective_nutrients( *it->get_item() ).kcal();
             }
         }
-        debugmsg( "For calories(), talker is not character nor item" );
-        return 0;
+        throw math::runtime_error( "For calories(), talker is not character nor item" );
     };
 }
 
@@ -1624,8 +1616,7 @@ diag_eval_dbl_f weight_eval( char scope, std::vector<diag_value> const & /* para
         if( it && *it ) {
             return static_cast<int>( to_milligram( it->get_item()->weight() ) );
         }
-        debugmsg( "For weight(), talker is not character nor item" );
-        return 0;
+        throw math::runtime_error( "For weight(), talker is not character nor item" );
     };
 }
 
@@ -1640,8 +1631,7 @@ diag_eval_dbl_f volume_eval( char scope, std::vector<diag_value> const & /* para
         if( it && *it ) {
             return to_milliliter( it->get_item()->volume() );
         }
-        debugmsg( "For volume(), talker is not character nor item" );
-        return 0;
+        throw math::runtime_error( "For volume(), talker is not character nor item" );
     };
 }
 
@@ -1657,8 +1647,7 @@ diag_eval_dbl_f vitamin_eval( char scope, std::vector<diag_value> const &params,
             const nutrients &nutrient_data = default_character_compute_effective_nutrients( *itm->get_item() );
             return static_cast<int>( nutrient_data.vitamins().count( vitamin_id( id.str( d ) ) ) );
         }
-        debugmsg( "Tried to access vitamins of a non-Character/non-item talker" );
-        return 0;
+        throw math::runtime_error( "Tried to access vitamins of a non-Character/non-item talker" );
     };
 }
 
@@ -1709,7 +1698,7 @@ diag_eval_dbl_f weather_eval( char /* scope */, std::vector<diag_value> const &p
             return precip_mm_per_hour( get_weather().weather_id->precip );
         };
     }
-    throw std::invalid_argument( string_format( "Unknown weather aspect %s", params[0].str() ) );
+    throw math::syntax_error( "Unknown weather aspect %s", params[0].str() );
 }
 
 diag_assign_dbl_f weather_ass( char /* scope */, std::vector<diag_value> const &params,
@@ -1740,7 +1729,7 @@ diag_assign_dbl_f weather_ass( char /* scope */, std::vector<diag_value> const &
             get_weather().clear_temp_cache();
         };
     }
-    throw std::invalid_argument( string_format( "Unknown weather aspect %s", params[0].str() ) );
+    throw math::syntax_error( "Unknown weather aspect %s", params[0].str() );
 }
 
 diag_eval_dbl_f climate_control_str_heat_eval( char scope,

--- a/src/math_parser_diag_value.h
+++ b/src/math_parser_diag_value.h
@@ -58,16 +58,16 @@ struct diag_value {
     bool is_array() const;
     bool is_empty() const;
 
-    // these functions can be used at parse time if the parameter needs
+    // These functions can be used at parse time if the parameter needs
     // to be of exactly this type with no conversion.
-    // These throw so they should *NOT* be used at runtime.
+    // These throw a math::syntax_error for type mismatches
     double dbl() const;
     std::string_view str() const;
     diag_array const &array() const;
     var_info var() const;
 
-    // evaluate and possibly convert the parameter to this type.
-    // These do not throw and they're meant to be used at runtime
+    // Evaluate and possibly convert the parameter to this type.
+    // These throw a math::runtime_error for failed conversions
     double dbl( const_dialogue const &d ) const;
     std::string str( const_dialogue const &d ) const;
     var_info var( const_dialogue const &/* d */ ) const;

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -11,7 +11,6 @@
 
 #include "cata_utility.h"
 #include "condition.h"
-#include "debug.h"
 #include "dialogue.h"
 #include "dialogue_helpers.h"
 #include "math_parser_diag.h"
@@ -110,8 +109,7 @@ struct func_diag {
         if( fe ) {
             return fe( d );
         }
-        debugmsg( "Unexpected eval called on function that cannot evaluate" );
-        return 0;
+        throw math::internal_error( "math called eval() on unexpected function that cannot evaluate" );
     }
 
     void assign( dialogue &d, double val ) const {
@@ -119,7 +117,7 @@ struct func_diag {
             fa( d, val );
             return;
         }
-        debugmsg( "Unexpected assign called on function that cannot assign" );
+        throw math::internal_error( "math called assign() on unexpected function that cannot assign" );
     }
 
     eval_f fe;
@@ -207,7 +205,7 @@ constexpr double thingie::eval( const_dialogue const &d ) const
         },
         []( ass_oper const & /* v */ ) -> double
         {
-            debugmsg( "Cannot use assignment operators from eval context" );
+            throw math::runtime_error( "Cannot use assignment operators from eval context" );
             return 0.0;
         },
         [&d]( auto const & v ) -> double
@@ -217,7 +215,7 @@ constexpr double thingie::eval( const_dialogue const &d ) const
                 return v.eval( d );
             } else
             {
-                debugmsg( "math called eval() on unexpected node without eval()" );
+                throw math::internal_error( "math called eval() on unexpected node without eval()" );
                 return 0.0;
             }
         },

--- a/src/math_parser_type.h
+++ b/src/math_parser_type.h
@@ -2,10 +2,60 @@
 #ifndef CATA_SRC_MATH_PARSER_TYPE_H
 #define CATA_SRC_MATH_PARSER_TYPE_H
 
+#include <stdexcept>
+#include <string>
+
+#include "string_formatter.h"
+
 enum class math_type_t : int {
     ret = 0,
     compare,
     assign,
 };
+
+namespace math
+{
+
+template<int severity>
+constexpr std::string_view _severity_str();
+
+class exception: public std::runtime_error
+{
+    public:
+        explicit exception( std::string const &str ): std::runtime_error( str ) {}
+};
+
+template<int severity_>
+class math_exception_impl : public exception
+{
+    public:
+        static constexpr int severity = severity_;
+
+        template <typename... Args>
+        constexpr explicit math_exception_impl( Args &&...args )
+            : exception( string_format( "%s: %s", _severity_str<severity_>(),
+                                        string_format( std::forward<Args>( args )... ) ) ) {}
+};
+
+// syntax error in parsed expression
+using syntax_error = math_exception_impl<0>;
+// runtime error that can't be found at parse time, like bad variable types or values
+using runtime_error = math_exception_impl<5>;
+// math parser entered an unexpected state
+using internal_error = math_exception_impl<10>;
+
+template<int severity>
+constexpr std::string_view _severity_str()
+{
+    if constexpr( severity == syntax_error::severity ) {
+        return "Math syntax error";
+    } else if constexpr( severity == runtime_error::severity ) {
+        return "Math runtime error";
+    } else if constexpr( severity == internal_error::severity ) {
+        return "Fatal math error";
+    }
+    return "Math error";
+}
+} // namespace math
 
 #endif // CATA_SRC_MATH_PARSER_TYPE_H

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -243,7 +243,14 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
         CHECK_FALSE( testexp.parse( "_test_diag_(1?'a':1:'b':2)" ) ); // no kwargs in ternaries
         CHECK_FALSE( testexp.parse( "sin('1':'2')" ) ); // no kwargs in math functions (yet?)
         CHECK( testexp.parse( "_test_str_len_('fail')" ) );  // expected array at runtime
-        CHECK( testexp.eval( d ) == 0 );
+        bool expected_array = false;
+        try {
+            testexp.eval( d );
+        } catch( math::runtime_error const &ex ) {
+            std::string_view what( ex.what() );
+            expected_array = what.find( "Expected array" ) != std::string_view::npos;
+        }
+        CHECK( expected_array );
         CHECK_FALSE( testexp.parse( "'1':'2'" ) );
         CHECK_FALSE( testexp.parse( "2 2*2" ) ); // stray space inside variable name
         CHECK_FALSE( testexp.parse( "2+++2" ) );
@@ -260,10 +267,6 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
         CHECK_FALSE( testexp.parse( "_test_diag_('1':0=0?1:2)" ) );
         CHECK_FALSE( testexp.parse( "_test_diag_('1':a=2)" ) );
     } );
-
-    // make sure there were no bad error messages
-    CHECK( dmsg.find( "Unexpected" ) == std::string::npos );
-    CHECK( dmsg.find( "That's all we know" ) == std::string::npos );
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity): false positive


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The math parser points at the wrong token for complex  expressions with errors
Runtime math errors don't show any context and are hard to debug


~~- Depends on: #77238 and first commits are from there
this PR starts at 1ff5c4f35c92c65e289543aeae57f8ecafa786bf  `math: standardize error severity`~~

#### Describe the solution
- Standardize math errors by severity as syntax / runtime / internal. Syntax errors are caught by default, the others fall through in test units (but not in game) and should help with testing and fuzzing
- Track operator position while parsing instead of just using the last one
- Show EOC callstack for runtime errors


#### Describe alternatives you've considered

N/A

#### Testing
<details>
<summary>Before: the error message points at the wrong token</summary>

![parse-before](https://github.com/user-attachments/assets/c2e79743-de55-489b-9af5-6dc64273526d)

</details>

<details>
<summary>After: error message indicates correct token</summary>

![parse-after](https://github.com/user-attachments/assets/b20103d8-8c77-4339-b523-cfe449bd1f73)


</details>

<details>
<summary>Before: runtime variable error shows no context</summary>

![runtime before](https://github.com/user-attachments/assets/5ed43da8-d648-4729-89bf-eebbe47a8f39)

</details>

<details>
<summary>After: runtime error shows EOC callstack</summary>

![runtime-after](https://github.com/user-attachments/assets/6cc1db2e-7067-4922-9081-5bffecf93586)

</details>

#### Additional context
N/A