### PR TITLE
Rejecting some area threats near 'safe' locations during overmap generation

### DIFF
--- a/data/json/overmap/multitile_city_buildings.json
+++ b/data/json/overmap/multitile_city_buildings.json
@@ -63,7 +63,7 @@
       { "point": [ 1, 1, 2 ], "overmap": "deserter_city_office_3fb_north" },
       { "point": [ 1, 1, 3 ], "overmap": "deserter_city_office_roofb_north" }
     ],
-    "flags": [ "GLOBALLY_UNIQUE" ]
+    "flags": [ "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "city_building",

--- a/data/json/overmap/overmap_mutable/farm_isherwood_mutable.json
+++ b/data/json/overmap/overmap_mutable/farm_isherwood_mutable.json
@@ -7,6 +7,7 @@
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 35, 100 ],
+    "priority": 1,
     "flags": [ "FARM", "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ],
     "check_for_locations_area": [ { "type": [ "land" ], "from": [ -10, 0, 0 ], "to": [ 7, 26, 0 ] } ],
     "joins": [

--- a/data/json/overmap/overmap_special/aircraft_carrier.json
+++ b/data/json/overmap/overmap_special/aircraft_carrier.json
@@ -203,6 +203,7 @@
     "city_distance": [ -1, 1000 ],
     "locations": [ "lake_surface" ],
     "occurrences": [ 75, 100 ],
-    "flags": [ "LAKE", "MAN_MADE", "GLOBALLY_UNIQUE", "MILITARY" ]
+    "priority": 1,
+    "flags": [ "LAKE", "MAN_MADE", "GLOBALLY_UNIQUE", "MILITARY", "SAFE_AT_WORLDGEN" ]
   }
 ]

--- a/data/json/overmap/overmap_special/alien.json
+++ b/data/json/overmap/overmap_special/alien.json
@@ -26,7 +26,8 @@
     "city_distance": [ 40, 90 ],
     "city_sizes": [ 0, 16 ],
     "occurrences": [ 2, 100 ],
-    "flags": [ "EXODII", "CBM", "GLOBALLY_UNIQUE" ]
+    "priority": 1,
+    "flags": [ "EXODII", "CBM", "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",
@@ -118,6 +119,6 @@
     "city_sizes": [ 1, 12 ],
     "occurrences": [ 1, 12 ],
     "priority": 1,
-    "flags": [ "GLOBALLY_UNIQUE", "EXODII" ]
+    "flags": [ "GLOBALLY_UNIQUE", "EXODII", "SAFE_AT_WORLDGEN" ]
   }
 ]

--- a/data/json/overmap/overmap_special/nuclear_plant.json
+++ b/data/json/overmap/overmap_special/nuclear_plant.json
@@ -605,6 +605,6 @@
     "city_sizes": [ 5, -1 ],
     "occurrences": [ 900, 1000 ],
     "priority": 1,
-    "flags": [ "CLASSIC", "MAN_MADE", "GLOBALLY_UNIQUE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN" ]
   }
 ]

--- a/data/json/overmap/overmap_special/overmap_special_vitrified.json
+++ b/data/json/overmap/overmap_special/overmap_special_vitrified.json
@@ -18,7 +18,8 @@
     ],
     "connections": [ { "point": [ 4, -2, 0 ], "terrain": "road", "connection": "local_road", "existing": true, "from": [ 3, -2, 0 ] } ],
     "occurrences": [ 10, 100 ],
-    "flags": [ "GLOBALLY_UNIQUE", "FARM", "MAN_MADE" ],
+    "priority": 1,
+    "flags": [ "GLOBALLY_UNIQUE", "FARM", "MAN_MADE", "SAFE_AT_WORLDGEN" ],
     "rotate": false
   }
 ]

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -5461,7 +5461,7 @@
   {
     "type": "overmap_special",
     "id": "Barry's Mi-Go Scout Tower",
-    "//": "This is a globally unqiue special used in the Isherwood rescue mission.",
+    "//": "This is a globally unqiue special used in the Isherwood rescue mission. However, it's also an area threat, and that means it should have a lower priority than 'normal' safe flagged specials.",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "barry_mi-go_scout_tower_1_north" },
       { "point": [ 0, 0, 1 ], "overmap": "barry_mi-go_scout_tower_2_north" },
@@ -5480,7 +5480,6 @@
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 0, 20 ],
     "occurrences": [ 70, 100 ],
-    "priority": 1,
     "connections": [ { "point": [ -2, 2, 0 ], "terrain": "road", "connection": "local_road" } ],
     "flags": [ "MI-GO", "WILDERNESS", "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN" ],
     "eoc": { "id": "EOC_ISHERWOOD_MIGO_SPAWN_EXCEPTIONS", "condition": { "not": { "mod_is_loaded": "innawood" } } },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -301,7 +301,8 @@
     "locations": [ "forest" ],
     "city_distance": [ 12, -1 ],
     "occurrences": [ 30, 100 ],
-    "flags": [ "CLASSIC", "FARM", "GLOBALLY_UNIQUE", "MAN_MADE" ]
+    "priority": 1,
+    "flags": [ "CLASSIC", "FARM", "GLOBALLY_UNIQUE", "MAN_MADE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",
@@ -373,7 +374,8 @@
     "city_distance": [ 25, -1 ],
     "city_sizes": [ 0, 12 ],
     "occurrences": [ 100, 100 ],
-    "flags": [ "CLASSIC", "MAN_MADE", "GLOBALLY_UNIQUE", "WILDERNESS" ]
+    "priority": 1,
+    "flags": [ "CLASSIC", "MAN_MADE", "GLOBALLY_UNIQUE", "WILDERNESS", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",
@@ -542,7 +544,8 @@
     "city_distance": [ 30, -1 ],
     "city_sizes": [ 0, 12 ],
     "occurrences": [ 10, 100 ],
-    "flags": [ "CLASSIC", "MAN_MADE", "GLOBALLY_UNIQUE" ]
+    "priority": 1,
+    "flags": [ "CLASSIC", "MAN_MADE", "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",
@@ -597,7 +600,8 @@
     ],
     "locations": [ "field", "forest_without_trail" ],
     "occurrences": [ 10, 100 ],
-    "flags": [ "CLASSIC", "GLOBALLY_UNIQUE", "MAN_MADE" ]
+    "priority": 1,
+    "flags": [ "CLASSIC", "GLOBALLY_UNIQUE", "MAN_MADE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",
@@ -748,7 +752,8 @@
     "occurrences": [ 75, 100 ],
     "connections": [ { "point": [ 0, 4, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 3, 0 ] } ],
     "rotate": false,
-    "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "MAN_MADE" ]
+    "priority": 1,
+    "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "MAN_MADE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",
@@ -2540,6 +2545,7 @@
     "locations": [ "forest" ],
     "city_distance": [ 20, -1 ],
     "occurrences": [ 80, 100 ],
+    "priority": 1,
     "flags": [ "CLASSIC", "WILDERNESS", "OVERMAP_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
   },
   {
@@ -2559,6 +2565,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 20, -1 ],
     "occurrences": [ 50, 100 ],
+    "priority": 1,
     "flags": [ "CLASSIC", "WILDERNESS", "OVERMAP_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
   },
   {
@@ -2571,6 +2578,7 @@
     "locations": [ "forest" ],
     "city_distance": [ 20, -1 ],
     "occurrences": [ 10, 100 ],
+    "priority": 1,
     "flags": [ "CLASSIC", "WILDERNESS", "SAFE_AT_WORLDGEN", "OVERMAP_UNIQUE", "MAN_MADE" ]
   },
   {
@@ -2592,6 +2600,7 @@
     "locations": [ "field" ],
     "city_distance": [ 20, -1 ],
     "occurrences": [ 10, 100 ],
+    "priority": 1,
     "flags": [ "CLASSIC", "WILDERNESS", "OVERMAP_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
   },
   {
@@ -2754,7 +2763,8 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "occurrences": [ 30, 100 ],
-    "flags": [ "OVERMAP_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE", "FARM" ]
+    "priority": 1,
+    "flags": [ "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE", "FARM" ]
   },
   {
     "type": "overmap_special",
@@ -3737,6 +3747,7 @@
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 1, 16 ],
     "occurrences": [ 33, 100 ],
+    "priority": 1,
     "rotate": false,
     "flags": [ "OVERMAP_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE", "GLOBALLY_UNIQUE" ]
   },
@@ -3763,6 +3774,7 @@
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 1, 16 ],
     "occurrences": [ 33, 100 ],
+    "priority": 1,
     "rotate": false,
     "flags": [ "SAFE_AT_WORLDGEN", "MAN_MADE", "GLOBALLY_UNIQUE" ]
   },
@@ -5468,8 +5480,9 @@
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 0, 20 ],
     "occurrences": [ 70, 100 ],
+    "priority": 1,
     "connections": [ { "point": [ -2, 2, 0 ], "terrain": "road", "connection": "local_road" } ],
-    "flags": [ "MI-GO", "WILDERNESS", "GLOBALLY_UNIQUE" ],
+    "flags": [ "MI-GO", "WILDERNESS", "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN" ],
     "eoc": { "id": "EOC_ISHERWOOD_MIGO_SPAWN_EXCEPTIONS", "condition": { "not": { "mod_is_loaded": "innawood" } } },
     "spawns": { "group": "GROUP_MI-GO_CAMP_OM", "population": [ 2, 5 ], "radius": [ 2, 30 ] }
   },
@@ -5982,9 +5995,10 @@
     "connections": [ { "point": [ 3, -2, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, -1, 0 ] } ],
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 4, -1 ],
+    "priority": 1,
     "occurrences": [ 45, 100 ],
     "//": "Inflated chance, in effect ~10%",
-    "flags": [ "MILITARY", "GLOBALLY_UNIQUE", "MAN_MADE" ]
+    "flags": [ "MILITARY", "GLOBALLY_UNIQUE", "MAN_MADE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",
@@ -6337,7 +6351,8 @@
     "connections": [ { "point": [ 3, 3, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, 2, 0 ] } ],
     "city_distance": [ 0, 20 ],
     "occurrences": [ 5, 100 ],
-    "flags": [ "GLOBALLY_UNIQUE", "RISK_EXTREME", "GENERIC_LOOT", "MAN_MADE" ]
+    "priority": 1,
+    "flags": [ "GLOBALLY_UNIQUE", "RISK_EXTREME", "GENERIC_LOOT", "MAN_MADE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",
@@ -6742,7 +6757,8 @@
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 75, 100 ],
-    "flags": [ "GLOBALLY_UNIQUE", "MAN_MADE" ]
+    "priority": 1,
+    "flags": [ "GLOBALLY_UNIQUE", "MAN_MADE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",
@@ -6776,8 +6792,9 @@
     "locations": [ "forest" ],
     "city_distance": [ 7, 15 ],
     "occurrences": [ 50, 100 ],
+    "priority": 1,
     "connections": [ { "point": [ 2, 4, 0 ], "terrain": "forest_trail", "connection": "forest_trail", "from": [ 2, 0, 0 ] } ],
-    "flags": [ "WILDERNESS", "GLOBALLY_UNIQUE", "MAN_MADE" ]
+    "flags": [ "WILDERNESS", "GLOBALLY_UNIQUE", "MAN_MADE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1278,7 +1278,7 @@ See [Character](#character)
 - ```LAKE``` Location is placed on a lake and will be ignored for placement if the overmap doesn't contain any lake terrain.
 - ```MAN_MADE``` For location, created by human.  Used by the Innawood mod.
 - ```MI-GO``` Location is related to mi-go.
-- ```SAFE_AT_WORLDGEN``` Location will not spawn overmap monster groups during worldgen (does not affect monsters spawned by mapgen).
+- ```SAFE_AT_WORLDGEN``` Location will not spawn overmap monster groups during worldgen (does not affect monsters spawned by mapgen).  It will also cause map specials (only) with a radius for creature spawns to not spawn within their maximum radius.
 - ```TRIFFID``` Location is related to triffids.  Used to classify location.
 - ```URBAN```
 - ```WILDERNESS``` Locations that have no road connection.

--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -454,7 +454,7 @@ original intersection.
 | `city_distance` | Min/max distance from a city edge that the special may be placed. Use -1 for unbounded.               |
 | `city_sizes`    | Min/max city size for a city that the special may be placed near. Use -1 for unbounded.               |
 | `occurrences`   | Min/max number of occurrences when placing the special. If UNIQUE flag is set, becomes X of Y chance. |
-| `priority`      | **Warning: Do not use this unnecessarily.** The generation process is executed in the order of specials with the highest value. Can be used when maps are difficult to generate. (large maps, maps that are or require dependencies etc) It is **strongly recommended** to set it to 1 (HIGH priority) or -1 (LOW priority) if used. (default = 0) |
+| `priority`      | **Warning: Do not use this unnecessarily.** The generation process is executed in the order of specials with the highest value. Can be used when maps are difficult to generate. (large maps, maps that are or require dependencies etc) It is **strongly recommended** to set it to 1 (HIGH priority) or -1 (LOW priority) if used. (default = 0).  It is adviced that map specials marked with the SAFE_AT_WORLDGEN are given a priority of 1 unless there are reasons not to, in order to exist when specials spawning monsters in an area are spawned, as that will cause the latter not to spawn that close. |
 | `flags`         | See `Overmap specials` in [JSON_FLAGS.md](JSON_FLAGS.md).                                             |
 | `rotate`        | Whether the special can rotate. True if not specified.                                                |
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6952,6 +6952,9 @@ std::vector<tripoint_om_omt> overmap::place_special(
 
     if( special.has_flag( "GLOBALLY_UNIQUE" ) ) {
         overmap_buffer.add_unique_special( special.id );
+        point_abs_omt location = coords::project_to<coords::omt>(this->pos()) + p.xy().raw();
+        DebugLog(DL_ALL, DC_ALL) << "Globally Unique " << special.id.c_str() << " added at " << location.to_string_writable();
+        add_msg("Globally Unique %s added at %s", special.id.c_str(), p.to_string_writable());
     } else if( special.has_flag( "OVERMAP_UNIQUE" ) ) {
         overmap_buffer.log_unique_special( special.id );
     }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6904,7 +6904,6 @@ bool overmap::can_place_special( const overmap_special &special, const tripoint_
         const point_abs_omt base = coords::project_to<coords::omt>( this->pos() );
         for( int x = p.x() - spawns.radius.max; x <= p.x() + spawns.radius.max; x++ ) {
             for( int y = p.y() - spawns.radius.max; y <= p.y() + spawns.radius.max; y++ ) {
-                const point_abs_omt source = base + p.xy().raw();
                 const tripoint_abs_omt target = tripoint_abs_omt{ base, p.z() } + point_rel_omt{ x, y };
                 if( overmap_buffer.get_existing( coords::project_to<coords::om>( target.xy() ) ) ) {
                     const std::optional<overmap_special_id> spec = overmap_buffer.overmap_special_at( target );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Note that this PR header has been updated to cover the final(?) implementation, which may place some of the comments beneat out of context.

Step towards protecting "safe" facilities from area threats overwhelming them.
Partially dealing with #77267, by making Tacoma farm globally unique.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Reject placement of map specials placing monsters in a radius around them if they can overlap with facilities supposed to be safe. The radius checked is the maximum for the area threat. The actual one is generated as placement. This typically provides a buffer around the facilities.
- Raised priority of all globally unique map specials to 1 (except gun_show, which remains at -1, and Barry's Mi-Go place, which is also an area threat) to ensure they're placed before area threats. Note that Deserter City cannot be given a priority as it's not a map special.
- Marked all globally unique map specials as SAFE_AT_WORLDGEN to block area threats from overlapping with them.
- Made Tacoma globally unique.
- Added some documentation of the priority dependencies.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Also check safe facilities against area threats. That involves a number of problems:
  - You'd have to check the maximum range any area threat can have to find them.
  - Protected facilities can be fairly large, and an offset of 14 or so from the anchor point in some random direction is quite a bit.
- Change the code that checks groups at safe facility placement to reject rather than remove groups. Would require restructuring of the code.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Printing locations of all globally unique facilities to the debug log so they can be checked for area threat collisions. Went through and checked all facilities, with no encroaching threats found.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This is one part of the equation. However, it relies on a number of assumptions:
- All map specials with a placement radius are hostile. That's probably true currently, at least.

Also, the implementation makes use of the maximum threat radius, not the one ultimately used. On the one hand, it provides a safety margin for most facilities, but on the other hand it restrict the placement. I can see two alternatives to this approach:
- Generate the maximum radius before the check and make use of the generated value if generation is approved.
- Modify the code to return a safe maximum radius for the radius generation RNG to be used instead of the JSON one.
The former should work, while the latter would be a bit messy. Most places calling the operation don't seem to care about radii.

It can be noted that the OVERMAP_UNIQUE bandit facilities are covered by the logic, and thus should be protected.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
