### PR TITLE
Tutorial bugfixes and tweaks

### DIFF
--- a/data/json/snippets/tutorial.json
+++ b/data/json/snippets/tutorial.json
@@ -53,7 +53,7 @@
       },
       {
         "id": "LESSON_GOT_WEAPON",
-        "text": "The item you just picked up is a good weapon!  To wield a weapon, press <keybind:wield>, then pick what to wield.  To wield nothing, either drop your weapon with <keybind:drop>, or press <keybind:wield> to put it away.  A zombie has spawned nearby.  To attack it, simply move into it."
+        "text": "The item you just picked up is a good weapon!  To wield a weapon, press <keybind:wield>, then pick what to wield.  To wield nothing, either drop your weapon with <keybind:drop>, or press <keybind:wield> to put it away."
       },
       {
         "id": "LESSON_GOT_FOOD",

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -630,6 +630,7 @@ void Character::pick_up( const drop_locations &what )
         quantities.emplace_back( dl.second );
     }
 
+    last_item = item( *items.back() ).typeId();
     assign_activity( pickup_activity_actor( items, quantities, pos_bub(), false ) );
 }
 

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -152,6 +152,18 @@ bool tutorial_game::init()
     player_character.dex_cur = player_character.dex_max;
 
     player_character.set_all_parts_hp_to_max();
+    player_character.clear_effects();
+    player_character.clear_morale();
+    player_character.clear_vitamins();
+    player_character.set_sleepiness( 0 );
+    player_character.set_focus( 100 );
+    player_character.set_hunger( 0 );
+    player_character.set_pain( 0 );
+    player_character.set_rad( 0 );
+    player_character.set_sleep_deprivation( 0 );
+    player_character.set_stamina( player_character.get_stamina_max() );
+    player_character.set_stored_kcal( player_character.get_healthy_kcal() );
+    player_character.set_thirst( 0 );
 
     //~ default name for the tutorial
     player_character.name = _( "John Smith" );
@@ -355,7 +367,6 @@ void tutorial_game::post_action( action_id act )
         }
         break;
 
-        /* fallthrough */
         case ACTION_PICKUP: {
             item it( player_character.last_item, calendar::turn_zero );
             if( it.is_armor() ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #55276.
Also, while I'm here, I fixed the case of player character spawning famished at the start of the tutorial.

#### Describe the solution
- Set `last_item` at the end of process of picking up.
- Removed part about zombie spawning from one of tutorial snippets.
- Normalize all body stats at the start of the tutorial.

#### Describe alternatives you've considered
None.

#### Testing
Started tutorial. Checked that player character isn't famished.
Debug-spawned backpack, wore it to get some inventory space. Found a baseball bat, picked it up into my backpack. Got tutorial lesson "Got weapon". Checked that I get respective lessons for picking up food, guns, ammo, and tools.

#### Additional context
None.