### PR TITLE
DinoMod for Tropicata

### DIFF
--- a/data/mods/DinoMod/mod_interactions/tropicata/monstergroups/dinosaur.json
+++ b/data/mods/DinoMod/mod_interactions/tropicata/monstergroups/dinosaur.json
@@ -1,0 +1,190 @@
+[
+  {
+    "//": "These groups are called by the exhibit, zoo, and science basements, and NPC missions",
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR",
+    "monsters": [
+      { "group": "GROUP_WILDERNESS_FOREST_DINO", "weight": 250 },
+      { "group": "GROUP_DINOSAUR_SAUROPODS_WILDERNESS", "weight": 150 },
+      { "group": "GROUP_DINOSAUR_HADROSAURS_WILDERNESS", "weight": 150 },
+      { "group": "GROUP_DINOSAUR_PREDATOR_STREAM", "weight": 150 },
+      { "group": "GROUP_DINOSAUR_PREDATOR_SWAMP", "weight": 150 },
+      { "group": "GROUP_DINOSAUR_CAVE", "weight": 150 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_SOUTH_AMERICA",
+    "monsters": [
+      { "monster": "mon_eoraptor", "weight": 20, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_giganotosaurus", "weight": 10, "cost_multiplier": 40, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_amargasaurus", "weight": 5, "cost_multiplier": 25, "pack_size": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_ASIA",
+    "monsters": [
+      { "monster": "mon_qianzhousaurus", "weight": 200, "cost_multiplier": 40, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_therizinosaurus", "weight": 200, "cost_multiplier": 30, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_velociraptor", "weight": 200, "cost_multiplier": 10, "pack_size": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_EUROPE",
+    "monsters": [
+      { "monster": "mon_compsognathus", "weight": 100, "cost_multiplier": 40, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_iguanodon", "weight": 100, "pack_size": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_HARMLESS",
+    "monsters": [
+      { "monster": "mon_albertonykus", "weight": 20, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_eoraptor", "weight": 20, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_sarahsaurus", "weight": 20, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_scutellosaurus", "weight": 20, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_tenontosaurus", "weight": 100, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_aquilops", "weight": 25, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_nanosaurus", "weight": 20, "pack_size": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_DANGEROUS",
+    "monsters": [
+      { "monster": "mon_tawa", "weight": 200, "cost_multiplier": 5, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_coelophysis", "weight": 200, "cost_multiplier": 5, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_stenonychosaurus", "weight": 5, "cost_multiplier": 30, "pack_size": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_HARMLESS_HATCHLING",
+    "monsters": [
+      { "monster": "mon_eoraptor_hatchling", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_sarahsaurus_hatchling", "weight": 10, "cost_multiplier": 25, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_amargasaurus_hatchling", "weight": 10, "cost_multiplier": 25, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_scutellosaurus_hatchling", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_stegosaurus_hatchling", "weight": 10, "cost_multiplier": 20, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_tenontosaurus_hatchling", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_DANGEROUS_HATCHLING",
+    "monsters": [
+      { "monster": "mon_tawa_hatchling", "weight": 4, "cost_multiplier": 5, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_coelophysis_hatchling", "weight": 4, "cost_multiplier": 5, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_spinosaurus_hatchling", "cost_multiplier": 40, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_acrocanthosaurus_hatchling", "weight": 8, "cost_multiplier": 40, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_giganotosaurus_hatchling", "weight": 8, "cost_multiplier": 40, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_stenonychosaurus_hatchling", "weight": 5, "cost_multiplier": 30, "pack_size": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_HARMLESS_JUVENILE",
+    "monsters": [
+      { "monster": "mon_sarahsaurus_juvenile", "weight": 50, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_tenontosaurus_juvenile", "weight": 50, "cost_multiplier": 0, "pack_size": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_DANGEROUS_JUVENILE",
+    "monsters": [
+      { "monster": "mon_giganotosaurus_juvenile", "cost_multiplier": 30, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_spinosaurus_juvenile", "cost_multiplier": 40, "pack_size": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_MEGA_HERBIVORE",
+    "monsters": [ { "monster": "mon_amargasaurus", "weight": 5, "cost_multiplier": 25, "pack_size": [ 1, 2 ] } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_MEGA_CARNIVORE",
+    "monsters": [ { "monster": "mon_giganotosaurus", "weight": 200, "cost_multiplier": 40 } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_FLY",
+    "monsters": [
+      { "monster": "mon_dimorphodon", "weight": 10, "cost_multiplier": 0, "pack_size": [ 2, 4 ] },
+      { "monster": "mon_pteranodon", "weight": 935, "cost_multiplier": 0 },
+      { "monster": "mon_pteranodon", "weight": 50, "cost_multiplier": 0, "pack_size": [ 2, 4 ] },
+      { "monster": "mon_quetzalcoatlus", "weight": 5, "cost_multiplier": 0, "pack_size": [ 2, 4 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_SWIM",
+    "monsters": [
+      { "monster": "mon_mosasaurus", "weight": 4, "cost_multiplier": 60 },
+      { "monster": "mon_spinosaurus", "weight": 4, "cost_multiplier": 40 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_PREDATOR_STREAM",
+    "monsters": [
+      { "monster": "mon_tawa", "pack_size": [ 4, 8 ] },
+      { "monster": "mon_coelophysis", "pack_size": [ 4, 8 ] },
+      { "monster": "mon_acrocanthosaurus", "weight": 1, "pack_size": [ 4, 8 ], "cost_multiplier": 40 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_PREDATOR_SWAMP",
+    "monsters": [
+      { "monster": "mon_giganotosaurus", "weight": 2, "cost_multiplier": 40 },
+      { "monster": "mon_stenonychosaurus", "weight": 5, "cost_multiplier": 30, "pack_size": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_ZREDATOR_STREAM",
+    "monsters": [ { "monster": "mon_zacrocanthosaurus", "cost_multiplier": 45 } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_ZREDATOR_SWAMP",
+    "monsters": [ { "monster": "mon_ziganotosaurus", "cost_multiplier": 80 } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_SAUROPODS_WILDERNESS",
+    "monsters": [
+      { "monster": "mon_sarahsaurus", "weight": 10, "cost_multiplier": 10, "pack_size": [ 4, 12 ] },
+      { "monster": "mon_amargasaurus", "weight": 10, "cost_multiplier": 10, "pack_size": [ 4, 12 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_ZAUROPODS_WILDERNESS",
+    "monsters": [ { "monster": "mon_zamargasaurus", "weight": 10, "cost_multiplier": 30, "pack_size": [ 4, 12 ] } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_HADROSAURS_WILDERNESS",
+    "monsters": [ { "monster": "mon_tenontosaurus", "weight": 20, "pack_size": [ 4, 12 ] } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_ZADROSAURS_WILDERNESS",
+    "monsters": [  ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOSAUR_CAVE",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_eoraptor", "weight": 400, "pack_size": [ 1, 22 ] },
+      { "monster": "mon_dimorphodon", "weight": 500, "pack_size": [ 2, 4 ] }
+    ]
+  }
+]

--- a/data/mods/DinoMod/mod_interactions/tropicata/monstergroups/wilderness.json
+++ b/data/mods/DinoMod/mod_interactions/tropicata/monstergroups/wilderness.json
@@ -1,0 +1,170 @@
+[
+  {
+    "type": "monstergroup",
+    "name": "GROUP_FOREST",
+    "is_animal": true,
+    "monsters": [
+      { "group": "GROUP_WILDERNESS_FOREST_DINO", "weight": 150 },
+      { "group": "GROUP_WILDERNESS_FOREST_SAUROPODS", "weight": 15, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FOREST_DINO",
+    "is_animal": true,
+    "monsters": [ { "monster": "mon_eoraptor", "weight": 20, "pack_size": [ 1, 2 ] } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FOREST_SAUROPODS",
+    "is_animal": true,
+    "monsters": [ { "monster": "mon_amargasaurus_juvenile", "weight": 4, "pack_size": [ 4, 12 ] } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_RIVER",
+    "monsters": [
+      { "monster": "mon_pteranodon", "weight": 25, "cost_multiplier": 20, "pack_size": [ 2, 4 ] },
+      { "monster": "mon_quetzalcoatlus", "weight": 4, "cost_multiplier": 30, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_mosasaurus", "weight": 1, "cost_multiplier": 25, "starts": "3 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "7 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "14 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "28 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "90 days" },
+      { "monster": "mon_plesiosaurus", "weight": 1, "cost_multiplier": 25, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "7 days" },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "14 days" },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "28 days" },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "90 days" }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_STREAM",
+    "monsters": [
+      { "group": "GROUP_DINOSAUR_PREDATOR_STREAM", "weight": 10, "starts": "3 days" },
+      { "group": "GROUP_DINOSAUR_PREDATOR_STREAM", "weight": 20, "starts": "3 days", "ends": "7 days" },
+      { "group": "GROUP_DINOSAUR_PREDATOR_STREAM", "weight": 20, "starts": "3 days", "ends": "28 days" },
+      { "group": "GROUP_DINOSAUR_PREDATOR_STREAM", "weight": 20, "starts": "3 days", "ends": "90 days" },
+      { "group": "GROUP_DINOSAUR_ZREDATOR_STREAM", "weight": 25, "starts": "7 days" },
+      { "group": "GROUP_DINOSAUR_ZREDATOR_STREAM", "weight": 25, "starts": "28 days" },
+      { "group": "GROUP_DINOSAUR_ZREDATOR_STREAM", "weight": 25, "starts": "90 days" },
+      { "group": "GROUP_DINOSAUR_SAUROPODS_WILDERNESS", "weight": 25, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      {
+        "group": "GROUP_DINOSAUR_SAUROPODS_WILDERNESS",
+        "weight": 25,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "3 days"
+      },
+      {
+        "group": "GROUP_DINOSAUR_SAUROPODS_WILDERNESS",
+        "weight": 25,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "7 days"
+      },
+      {
+        "group": "GROUP_DINOSAUR_SAUROPODS_WILDERNESS",
+        "weight": 25,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "group": "GROUP_DINOSAUR_SAUROPODS_WILDERNESS",
+        "weight": 25,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "90 days"
+      },
+      { "group": "GROUP_DINOSAUR_ZAUROPODS_WILDERNESS", "weight": 25, "starts": "3 days" },
+      { "group": "GROUP_DINOSAUR_ZAUROPODS_WILDERNESS", "weight": 25, "starts": "7 days" },
+      { "group": "GROUP_DINOSAUR_ZAUROPODS_WILDERNESS", "weight": 25, "starts": "28 days" },
+      { "group": "GROUP_DINOSAUR_ZAUROPODS_WILDERNESS", "weight": 25, "starts": "90 days" }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_OCEAN_SHORE",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_mosasaurus", "weight": 2, "cost_multiplier": 25, "starts": "3 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "7 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "14 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "28 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "90 days" },
+      { "monster": "mon_plesiosaurus", "weight": 4, "cost_multiplier": 25, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "7 days" },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "14 days" },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "28 days" },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "90 days" }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_OCEAN_DEEP",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_mosasaurus", "weight": 2, "cost_multiplier": 25, "starts": "3 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "7 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "14 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "28 days" },
+      { "monster": "mon_zosasaurus", "cost_multiplier": 25, "starts": "90 days" },
+      { "monster": "mon_plesiosaurus", "weight": 4, "cost_multiplier": 25, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "7 days" },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "14 days" },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "28 days" },
+      { "monster": "mon_zlesiosaurus", "cost_multiplier": 25, "starts": "90 days" }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_SWAMP",
+    "monsters": [
+      { "group": "GROUP_DINOSAUR_PREDATOR_SWAMP", "weight": 20, "starts": "3 days" },
+      { "group": "GROUP_DINOSAUR_PREDATOR_SWAMP", "weight": 20, "starts": "3 days", "ends": "7 days" },
+      { "group": "GROUP_DINOSAUR_PREDATOR_SWAMP", "weight": 20, "starts": "3 days", "ends": "28 days" },
+      { "group": "GROUP_DINOSAUR_PREDATOR_SWAMP", "weight": 20, "starts": "3 days", "ends": "90 days" },
+      { "group": "GROUP_DINOSAUR_ZREDATOR_SWAMP", "weight": 25, "starts": "7 days" },
+      { "group": "GROUP_DINOSAUR_ZREDATOR_SWAMP", "weight": 25, "starts": "28 days" },
+      { "group": "GROUP_DINOSAUR_ZREDATOR_SWAMP", "weight": 25, "starts": "90 days" },
+      { "group": "GROUP_DINOSAUR_HADROSAURS_WILDERNESS", "weight": 25 },
+      { "group": "GROUP_DINOSAUR_HADROSAURS_WILDERNESS", "weight": 25, "ends": "3 days" },
+      { "group": "GROUP_DINOSAUR_HADROSAURS_WILDERNESS", "weight": 25, "ends": "7 days" },
+      { "group": "GROUP_DINOSAUR_HADROSAURS_WILDERNESS", "weight": 25, "ends": "28 days" },
+      { "group": "GROUP_DINOSAUR_HADROSAURS_WILDERNESS", "weight": 25, "ends": "90 days" },
+      { "group": "GROUP_DINOSAUR_ZADROSAURS_WILDERNESS", "weight": 25, "starts": "3 days" },
+      { "group": "GROUP_DINOSAUR_ZADROSAURS_WILDERNESS", "weight": 25, "starts": "7 days" },
+      { "group": "GROUP_DINOSAUR_ZADROSAURS_WILDERNESS", "weight": 25, "starts": "28 days" },
+      { "group": "GROUP_DINOSAUR_ZADROSAURS_WILDERNESS", "weight": 25, "starts": "90 days" }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_PARK_ANIMAL",
+    "is_animal": true,
+    "monsters": [ { "monster": "mon_dimorphodon", "weight": 50, "cost_multiplier": 0, "pack_size": [ 2, 4 ], "conditions": [ "DAY" ] } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_POND_BIRD",
+    "is_animal": true,
+    "monsters": [ { "monster": "mon_dimorphodon", "weight": 50, "cost_multiplier": 0, "pack_size": [ 2, 4 ] } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_CAVE",
+    "is_animal": true,
+    "monsters": [ { "group": "GROUP_DINOSAUR_CAVE", "weight": 200 } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ROOF_ANIMAL",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_eoraptor", "weight": 25, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_dimorphodon", "weight": 25, "pack_size": [ 2, 4 ] },
+      { "monster": "mon_pteranodon", "weight": 25, "cost_multiplier": 20, "pack_size": [ 2, 4 ] },
+      { "monster": "mon_quetzalcoatlus", "weight": 25, "cost_multiplier": 30, "pack_size": [ 1, 2 ] }
+    ]
+  }
+]

--- a/data/mods/DinoMod/mod_interactions/tropicata/monstergroups/wilderness.json
+++ b/data/mods/DinoMod/mod_interactions/tropicata/monstergroups/wilderness.json
@@ -12,7 +12,11 @@
     "type": "monstergroup",
     "name": "GROUP_WILDERNESS_FOREST_DINO",
     "is_animal": true,
-    "monsters": [ { "monster": "mon_eoraptor", "weight": 20, "pack_size": [ 1, 2 ] } ]
+    "monsters": [
+      { "monster": "mon_eoraptor", "weight": 20, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_scutellosaurus", "weight": 10, "pack_size": [ 2, 4 ] },
+      { "monster": "mon_stegosaurus", "weight": 10, "pack_size": [ 2, 4 ] }
+    ]
   },
   {
     "type": "monstergroup",


### PR DESCRIPTION
#### Summary
Mods "DinoMod for Tropicata"

#### Purpose of change

Implement mod compatibility with Tropicata

#### Describe the solution

Creates new variants of DinoMod monstergroups files rebalanced for tropical Central and South America and Africa (Gondwana in dino times). Puts that in the new mod_interactions folder

#### Describe alternatives you've considered

Wait until more little South American dinos are in to make this a little more alive.

#### Testing

Game loads no errors. Tropicata monsters appear as intended but currently this is not working at all.

#### Additional context

Balance inspired by https://unews.utah.edu/why-big-dinosaurs-steered-clear-of-the-tropics/ "Our data suggest it was not a fun place"