### PR TITLE
Refugee center cleanups

### DIFF
--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -405,7 +405,8 @@
       "effect": [
         { "math": [ "dave_castle_stage", "++" ] },
         { "math": [ "u_counter_refugee_center_refugee_happiness", "++" ] },
-        { "mapgen_update": "refcenter_unlock_roofstairs", "om_terrain": "evac_center_13" }
+        { "mapgen_update": "refcenter_unlock_roofstairs", "om_terrain": "evac_center_13" },
+        { "mapgen_update": "beggar_2_remove_lobbycardboard", "om_terrain": "evac_center_18" }
       ]
     }
   },
@@ -477,5 +478,11 @@
         { "point": "terrain", "id": "t_door_metal_c", "x": 22, "y": 14 }
       ]
     }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "beggar_2_remove_lobbycardboard",
+    "method": "json",
+    "object": { "set": [ { "line": "furniture", "id": "f_clear", "x": 6, "y": 1, "x2": 8, "y2": 1 } ] }
   }
 ]

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -475,7 +475,7 @@
     "object": {
       "set": [
         { "point": "terrain", "id": "t_door_metal_c", "x": 1, "y": 14 },
-        { "point": "terrain", "id": "t_door_metal_c", "x": 22, "y": 14 }
+        { "point": "terrain", "id": "t_door_metal_c", "x": 21, "y": 14 }
       ]
     }
   },

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -240,6 +240,12 @@
     "id": "TALK_FREE_MERCHANTS_MERCHANT_BeggarsRecruited",
     "type": "talk_topic",
     "dynamic_line": "I appreciate it a lot, getting them somewhere safe.  I hope that's what you did, anyway.  In any case, having the lobby clear is a big help.  Even with the uh, cardboard guy still around, he's a lot easier to handle alone.",
+    "speaker_effect": {
+      "effect": [
+        { "mapgen_update": "shopkeep_lobby_cleanup1", "om_terrain": "evac_center_13" },
+        { "mapgen_update": "shopkeep_lobby_cleanup2", "om_terrain": "evac_center_18" }
+      ]
+    },
     "responses": [
       { "text": "I do believe we discussed a reward?", "topic": "TALK_FREE_MERCHANTS_MERCHANT_BeggarsRecruited_Reward" },
       { "text": "Just glad to help.", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" }
@@ -373,5 +379,17 @@
         ]
       }
     ]
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "shopkeep_lobby_cleanup1",
+    "method": "json",
+    "object": { "set": [ { "square": "item_remove", "x": 5, "y": 22, "x2": 18, "y2": 23 } ] }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "shopkeep_lobby_cleanup2",
+    "method": "json",
+    "object": { "set": [ { "square": "item_remove", "x": 5, "y": 0, "x2": 18, "y2": 2 } ] }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Even after clearing out the beggars in the refugee center, their blankets and pillows remained. Dave's cardboard fort lingered following his departure, to what seemed to me be erroneous. Also with Dave, one of the roof access doors was incorrectly placed, turning a brick wall into a door (with the original still locked).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Trigger mapgen updates to:
1. Remove blankets and pillows in the lobby (if Smokes was asked and convinced to pay regarding the beggars)
2. Remove Dave's lobby fort once he moves up to the roof

Also edits the coordinate of the roof access when Dave moves up
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<details>
  <summary>Broken doors</summary>
  
![brokeydoor](https://github.com/user-attachments/assets/43a83618-2db7-43fb-8932-16ef1056cbf5)
![wackydoor](https://github.com/user-attachments/assets/a37db056-b94b-4229-a134-7397656d0f65)
  
</details>

<details>
  <summary>Fixed doors</summary>
  
![doorgood](https://github.com/user-attachments/assets/e8513e0e-6bd2-45b0-9704-841736c4c702)
![postdoor](https://github.com/user-attachments/assets/018bfe1d-9b2b-4dbf-afe9-d610d82dccf8)

  
</details>

<details>
  <summary>Messy lobby</summary>
  

People gone, mess remained
![messy](https://github.com/user-attachments/assets/c4dfbe1a-f930-4feb-b81a-cc76642fc6b8)

Just a normal picture of how it looks when first visiting the lobby, for reference
![mess](https://github.com/user-attachments/assets/142dd320-2418-4365-a98b-d52b5b7de8e6)

  
</details>

<details>
  <summary>Clean lobby</summary>
  

People gone, mess cleaned up (after asking Smokes)
![daveclean](https://github.com/user-attachments/assets/8696ee37-1962-47cd-96ae-e5e19d3bf5d2)
![flawlesscleanliness](https://github.com/user-attachments/assets/f584a5b9-c839-485c-bf70-0358844a95f0)


Showcase of Dave having moved, but not his friends (notice the fort being gone)
![davemessgone](https://github.com/user-attachments/assets/970bf4c7-5703-4352-ae08-59c7e5b0bada)

  
</details>
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
