### PR TITLE
Allow debug revealing any OM

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1243,6 +1243,13 @@
   },
   {
     "type": "keybinding",
+    "id": "REVEAL_MAP",
+    "category": "OVERMAP",
+    "name": "Reveal map",
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "MODIFY_HORDE",
     "category": "OVERMAP",
     "name": "Modify existing horde or place new one",

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -182,7 +182,6 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::WISH: return "WISH";
         case debug_menu::debug_menu_index::SHORT_TELEPORT: return "SHORT_TELEPORT";
         case debug_menu::debug_menu_index::LONG_TELEPORT: return "LONG_TELEPORT";
-        case debug_menu::debug_menu_index::REVEAL_MAP: return "REVEAL_MAP";
         case debug_menu::debug_menu_index::SPAWN_NPC: return "SPAWN_NPC";
         case debug_menu::debug_menu_index::SPAWN_NAMED_NPC: return "SPAWN_NAMED_NPC";
         case debug_menu::debug_menu_index::SPAWN_OM_NPC: return "SPAWN_OM_NPC";
@@ -460,30 +459,33 @@ bool is_debug_character()
            debug_names.count( first_word( world_generator->active_world->world_name ) );
 }
 
-static void prompt_or_do_map_reveal( int reveal_level = 0 )
+void prompt_map_reveal( const std::optional<tripoint_abs_omt> &p )
 {
-    if( reveal_level == 0 ) {
-        uilist vis_sel;
-        vis_sel.text = _( "Reveal at which vision level?" );
-        for( int i = static_cast<int>( om_vision_level::unseen );
-             i < static_cast<int>( om_vision_level::last ); ++i ) {
-            vis_sel.addentry( i, true, std::nullopt, io::enum_to_string( static_cast<om_vision_level>( i ) ) );
-        }
-        vis_sel.query();
-        reveal_level = vis_sel.ret;
-        if( reveal_level == UILIST_CANCEL ) {
-            return;
-        }
+    uilist vis_sel;
+    vis_sel.text = _( "Reveal at which vision level?" );
+    for( int i = static_cast<int>( om_vision_level::full );
+         i >= static_cast<int>( om_vision_level::unseen ); --i ) {
+        vis_sel.addentry( i, true, std::nullopt, io::enum_to_string( static_cast<om_vision_level>( i ) ) );
     }
-    overmap &cur_om = g->get_cur_om();
+    vis_sel.query();
+    if( vis_sel.ret == UILIST_CANCEL ) {
+        return;
+    }
+    map_reveal( vis_sel.ret, p );
+}
+
+void map_reveal( int reveal_level_int, const std::optional<tripoint_abs_omt> &p )
+{
+    const om_vision_level reveal_level = static_cast<om_vision_level>( reveal_level_int );
+    overmap &om = !p ? g->get_cur_om() : overmap_buffer.get( project_to<coords::om>( *p ).xy() );
     for( int i = 0; i < OMAPX; i++ ) {
         for( int j = 0; j < OMAPY; j++ ) {
             for( int k = -OVERMAP_DEPTH; k <= OVERMAP_HEIGHT; k++ ) {
-                cur_om.set_seen( { i, j, k }, static_cast<om_vision_level>( reveal_level ), true );
+                om.set_seen( { i, j, k }, reveal_level, true );
             }
         }
     }
-    add_msg( m_good, _( "Current overmap revealed." ) );
+    add_msg( m_good, !p ? _( "Current overmap revealed." ) : _( "Overmap revealed." ) );
 }
 
 static int player_uilist()
@@ -878,7 +880,6 @@ static int spawning_uilist()
 static int map_uilist()
 {
     const std::vector<uilist_entry> uilist_initializer = {
-        { uilist_entry( debug_menu_index::REVEAL_MAP, true, 'r', _( "Reveal map" ) ) },
         { uilist_entry( debug_menu_index::KILL_AREA, true, 'a', _( "Kill in Area" ) ) },
         { uilist_entry( debug_menu_index::KILL_NPCS, true, 'k', _( "Kill NPCs" ) ) },
         { uilist_entry( debug_menu_index::MAP_EDITOR, true, 'M', _( "Map editor" ) ) },
@@ -3743,7 +3744,7 @@ void do_debug_quick_setup()
     for( const std::pair<const skill_id, SkillLevel> &pair : u.get_all_skills() ) {
         u.set_skill_level( pair.first, 10 );
     }
-    prompt_or_do_map_reveal( static_cast<int>( om_vision_level::full ) );
+    map_reveal( static_cast<int>( om_vision_level::full ) );
 }
 
 void debug()
@@ -3801,11 +3802,6 @@ void debug()
         case debug_menu_index::LONG_TELEPORT:
             debug_menu::teleport_long();
             break;
-
-        case debug_menu_index::REVEAL_MAP: {
-            prompt_or_do_map_reveal();
-        }
-        break;
 
         case debug_menu_index::SPAWN_NPC:
             spawn_npc();

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -8,12 +8,11 @@
 #include <string>
 #include <string_view>
 
-#include "coords_fwd.h"
+#include "coordinates.h"
 
 class Character;
 class Creature;
 struct mongroup;
-struct tripoint;
 
 template <typename E> struct enum_traits;
 
@@ -24,7 +23,6 @@ enum class debug_menu_index : int {
     WISH,
     SHORT_TELEPORT,
     LONG_TELEPORT,
-    REVEAL_MAP,
     SPAWN_NPC,
     SPAWN_NAMED_NPC,
     SPAWN_OM_NPC,
@@ -164,6 +162,8 @@ Container string_to_iterable( const std::string_view str, const std::string_view
 }
 
 bool is_debug_character();
+void prompt_map_reveal( const std::optional<tripoint_abs_omt> &p = std::nullopt );
+void map_reveal( int reveal_level_int, const std::optional<tripoint_abs_omt> &p = std::nullopt );
 
 /* Merges iterable elements into std::string with
  * @param delimiter between them

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1153,6 +1153,7 @@ static void draw_om_sidebar( ui_adaptor &ui,
         print_hint( "SET_SPECIAL_ARGS", c_light_blue );
         print_hint( "LONG_TELEPORT", c_light_blue );
         print_hint( "MODIFY_HORDE", c_light_blue );
+        print_hint( "REVEAL_MAP", c_light_blue );
         ++y;
     }
 
@@ -1910,6 +1911,7 @@ static tripoint_abs_omt display()
         ictxt.register_action( "SET_SPECIAL_ARGS" );
         ictxt.register_action( "LONG_TELEPORT" );
         ictxt.register_action( "MODIFY_HORDE" );
+        ictxt.register_action( "REVEAL_MAP" );
     }
     ictxt.register_action( "QUIT" );
     std::string action;
@@ -2126,7 +2128,8 @@ static tripoint_abs_omt display()
             action = "QUIT";
         } else if( action == "MODIFY_HORDE" ) {
             modify_horde_func( curs );
-            action = "QUIT";
+        } else if( action == "REVEAL_MAP" ) {
+            debug_menu::prompt_map_reveal( curs );
         } else if( action == "MISSIONS" ) {
             g->list_missions();
         }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1148,12 +1148,12 @@ static void draw_om_sidebar( ui_adaptor &ui,
     };
 
     if( data.debug_editor ) {
-        print_hint( "PLACE_TERRAIN", c_light_blue );
-        print_hint( "PLACE_SPECIAL", c_light_blue );
-        print_hint( "SET_SPECIAL_ARGS", c_light_blue );
-        print_hint( "LONG_TELEPORT", c_light_blue );
-        print_hint( "MODIFY_HORDE", c_light_blue );
         print_hint( "REVEAL_MAP", c_light_blue );
+        print_hint( "LONG_TELEPORT", c_light_blue );
+        print_hint( "PLACE_SPECIAL", c_light_blue );
+        print_hint( "PLACE_TERRAIN", c_light_blue );
+        print_hint( "SET_SPECIAL_ARGS", c_light_blue );
+        print_hint( "MODIFY_HORDE", c_light_blue );
         ++y;
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Debug reveal map moved to overmap editor, can reveal any overmap"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Testing anything overmap related is a PITA currently bc you reveal the overmap, open debug long teleport to see the map and then tele to the next map to reveal it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Moves reveal map to the overmap editor where it reveals based on cursor position now rather than where the player is. This lets you immediately see the results and reveal more overmaps or teleport around without going through menus
Reverses the order of the vision levels in the reveal prompt to put "full", the option you'll almost always want, to the top

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Doing this sooner
Leaving the reveal map option where it is too but imo this is just an upgrade regardless of what you're doing and leaving it there would just mean fewer peeps would find this
Moving the Map category into similar binds on the Map editor and making the Map and Overmap editors top level debug options
Making it so once you've opened the overmap editor once in a session the `m`ap just opens the overmap editor
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Revealed existing and new overmaps at the different vision levels with expected results
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
