### PR TITLE
"all" option for distraction manager

### DIFF
--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -21,6 +21,7 @@ struct configurable_distraction {
     bool *state;
     std::string name;
     std::string description;
+    bool is_toggle = false;
 };
 
 static const std::vector<configurable_distraction> &get_configurable_distractions()
@@ -41,6 +42,7 @@ static const std::vector<configurable_distraction> &get_configurable_distraction
         {&uistate.distraction_mutation,        translate_marker( "Mutation" ),                     translate_marker( "This distraction will interrupt your activity when you gain or lose a mutation." )},
         {&uistate.distraction_oxygen,          translate_marker( "Asphyxiation" ),                 translate_marker( "This distraction will interrupt your activity when you can't breathe." )},
         {&uistate.distraction_withdrawal,      translate_marker( "Withdrawal" ),                  translate_marker( "This distraction will interrupt your activity when you have withdrawals." )},
+        {&uistate.distraction_all,             translate_marker( "Toggle all" ),                   translate_marker( "Toggle all distractions" ), uistate.is_toggle = true }
     };
     return configurable_distractions;
 }
@@ -155,10 +157,29 @@ void distraction_manager_gui::show()
             break;
         }
 
+        bool toggle_state;
         if( navigate_ui_list( action, currentLine, 5, number_of_distractions, true ) ) {
         } else if( action == "CONFIRM" || action == "LEFT" || action == "RIGHT" ) {
             *( get_configurable_distractions()[currentLine].state ) ^= true;
-        }
+            if( get_configurable_distractions()[currentLine].is_toggle ) {
+                toggle_state = uistate.distraction_all;
+                uistate.distraction_noise = toggle_state;
+                uistate.distraction_pain = toggle_state;
+                uistate.distraction_attack = toggle_state;
+                uistate.distraction_hostile_close = toggle_state;
+                uistate.distraction_hostile_spotted = toggle_state;
+                uistate.distraction_conversation = toggle_state;
+                uistate.distraction_asthma = toggle_state;
+                uistate.distraction_dangerous_field = toggle_state;
+                uistate.distraction_weather_change = toggle_state;
+                uistate.distraction_hunger = toggle_state;
+                uistate.distraction_thirst = toggle_state;
+                uistate.distraction_temperature = toggle_state;
+                uistate.distraction_mutation = toggle_state;
+                uistate.distraction_oxygen = toggle_state;
+                uistate.distraction_withdrawal = toggle_state;
+           }
+        } 
     }
 }
 

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -178,8 +178,8 @@ void distraction_manager_gui::show()
                 uistate.distraction_mutation = toggle_state;
                 uistate.distraction_oxygen = toggle_state;
                 uistate.distraction_withdrawal = toggle_state;
-           }
-        } 
+            }
+        }
     }
 }
 

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -159,7 +159,9 @@ class uistatedata
         bool distraction_mutation = true;
         bool distraction_oxygen = true;
         bool distraction_withdrawal = true;
+        bool distraction_all = true;
         bool numpad_navigation = false;
+        bool is_toggle = false;
 
         // V Menu Stuff
         int list_item_sort = 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
[Kevin was saying](https://github.com/CleverRaven/Cataclysm-DDA/pull/77332#issuecomment-2438391673) that a separate option to disable all distractions would be okay, so I figure just adding a distraction menu option does that, but both ways.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added a new `distraction_all` option, marked it as special being `is_toggle`, then just adds a check if it's the current distraction menu option being selected and if so, manually (fixme) sets all other options to match it upon being updated.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
It works quite like how one would expect, the only thing I'm looking out for is having to write it to json when saving (but it hasn't presented an issue... I'm still wary of being a "it works on my machine", even if it shouldn't matter due to the nature of it only affecting anything when being activated as a menu option)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I don't think more types of distractions are being added anytime soon, but it would be a good idea to find a way to read and set all non-`is_toggle` distraction menu options automatically.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
