### PR TITLE
Fix cotton patch being unusable to stop bleeding

### DIFF
--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -140,7 +140,12 @@
     "qualities": [ [ "SIEVE", 1 ], [ "STRAIN", 2 ] ],
     "color": "white",
     "use_action": [
-      { "type": "heal", "move_cost": 200, "used_up_item": { "id": "cotton_patchwork", "quantity": 1, "flags": [ "FILTHY" ] } },
+      {
+        "type": "heal",
+        "move_cost": 200,
+        "bleed": 1,
+        "used_up_item": { "id": "cotton_patchwork", "quantity": 1, "flags": [ "FILTHY" ] }
+      },
       "WASH_HARD_ITEMS"
     ],
     "flags": [ "NO_SALVAGE" ]

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -165,7 +165,12 @@
     "symbol": ",",
     "color": "white",
     "use_action": [
-      { "type": "heal", "move_cost": 200, "used_up_item": { "id": "cotton_patchwork", "quantity": 1, "flags": [ "FILTHY" ] } },
+      {
+        "type": "heal",
+        "move_cost": 200,
+        "bleed": 1,
+        "used_up_item": { "id": "cotton_patchwork", "quantity": 1, "flags": [ "FILTHY" ] }
+      },
       "WASH_HARD_ITEMS"
     ],
     "flags": [ "NO_SALVAGE" ]

--- a/data/mods/innawood/items/tool_tailoring.json
+++ b/data/mods/innawood/items/tool_tailoring.json
@@ -139,6 +139,7 @@
       {
         "type": "heal",
         "move_cost": 200,
+        "bleed": 1,
         "used_up_item": { "id": "fibercloth_patchwork", "quantity": 1, "flags": [ "FILTHY" ] }
       },
       "WASH_HARD_ITEMS"

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3306,6 +3306,11 @@ void heal_actor::load( const JsonObject &obj, const std::string & )
         }
     }
 
+    if( !bandages_power && !disinfectant_power && !bleed && !bite && !infect &&
+        !obj.has_array( "effects" ) ) {
+        obj.throw_error( _( "Heal actor is missing any valid healing effect" ) );
+    }
+
     if( obj.has_string( "used_up_item" ) ) {
         obj.read( "used_up_item", used_up_item_id, true );
     } else if( obj.has_object( "used_up_item" ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Cotton patch can be used to stop bleeding"


#### Purpose of change
Uhhhhhhhhhhhhhhhhh apparently cotton patches have never been able to do this despite having the heal action defined

#### Describe the solution
Add some (anti-)bleed power, so it can actually stop bleeding. It still doesn't provide any bandaging power

Also add some safety to the heal actor so if you try to load a healing action without any healing ability in the future it yells at you

#### Describe alternatives you've considered


#### Testing
![image](https://github.com/user-attachments/assets/76fb110b-81f2-46f6-9bdd-8938a1a387fa)

![image](https://github.com/user-attachments/assets/b0c299ee-f914-434f-a3d2-e8aa60d1081c)

![image](https://github.com/user-attachments/assets/d031c6a4-8697-45e5-8df9-aba5fc123ca7)



#### Additional context
I don't know how much bleed stoppage is appropriate so I went with the smallest possible value of 1.