### PR TITLE
no more duplicate teamster quests

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -180,10 +180,7 @@
         "text": "How do I get to that farm?",
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
         "condition": {
-          "and": [
-            { "math": [ "npc_randomize_dialogue_direction", "==", "1" ] },
-            { "not": { "compare_string": [ "isherwood", { "u_val": "teamster_mission_directions" } ] } }
-          ]
+          "and": [ { "math": [ "npc_randomize_dialogue_direction == 1" ] }, { "not": { "u_has_mission": "directions_isherwood" } } ]
         },
         "effect": { "assign_mission": "directions_isherwood" },
         "switch": true
@@ -192,10 +189,7 @@
         "text": "How do I get to that lab?",
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
         "condition": {
-          "and": [
-            { "math": [ "npc_randomize_dialogue_direction", "==", "2" ] },
-            { "not": { "compare_string": [ "hub01", { "u_val": "teamster_mission_directions" } ] } }
-          ]
+          "and": [ { "math": [ "npc_randomize_dialogue_direction == 2" ] }, { "not": { "u_has_mission": "directions_hub01" } } ]
         },
         "effect": { "assign_mission": "directions_hub01" },
         "switch": true
@@ -204,10 +198,7 @@
         "text": "How do I get to that castle?",
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
         "condition": {
-          "and": [
-            { "math": [ "npc_randomize_dialogue_direction", "==", "3" ] },
-            { "not": { "compare_string": [ "exodii", { "u_val": "teamster_mission_directions" } ] } }
-          ]
+          "and": [ { "math": [ "npc_randomize_dialogue_direction == 3" ] }, { "not": { "u_has_mission": "directions_exodii" } } ]
         },
         "effect": { "assign_mission": "directions_exodii" },
         "switch": true
@@ -216,10 +207,7 @@
         "text": "Where was that?",
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
         "condition": {
-          "and": [
-            { "math": [ "npc_randomize_dialogue_direction", "==", "4" ] },
-            { "not": { "compare_string": [ "artisans", { "u_val": "teamster_mission_directions" } ] } }
-          ]
+          "and": [ { "math": [ "npc_randomize_dialogue_direction == 4" ] }, { "not": { "u_has_mission": "directions_artisans" } } ]
         },
         "effect": { "assign_mission": "directions_artisans" },
         "switch": true


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Talking to the teamster and getting directions, occasionally it is possible to get multiple of the same quest.

Previous occurrences:
![image](https://github.com/user-attachments/assets/51269145-a34e-44bc-a754-7affad087803)
![repdouble](https://github.com/user-attachments/assets/07c54de1-9db7-4f2e-8c22-03ee80facdf7)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
By checking for the mission directly, I have not observed any repeats.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I talked a lot to the teamster. Showing a non-repeating quest list does not say a lot due to the teamster being random.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The Old Guard representative can still give you an identically named (not internally) quest to the teamster about the Exodii, without any regard for it being weird that you have two of the same quest name, but I don't care too much.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
