### PR TITLE
eoc: clean up run_eocs

### DIFF
--- a/data/mods/TEST_DATA/effect_on_condition.json
+++ b/data/mods/TEST_DATA/effect_on_condition.json
@@ -128,5 +128,40 @@
     "type": "effect_on_condition",
     "id": "EOC_N",
     "effect": [ { "set_string_var": { "context_val": "test_context_key_N" }, "target_var": { "global_val": "test_global_key_N" } } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "run_eocs_talker_mixes",
+    "effect": [
+      {
+        "run_eocs": [ "EOC_mixins_save_name" ],
+        "alpha_talker": { "context_val": "alpha_var" },
+        "beta_talker": { "context_val": "beta_var" },
+        "false_eocs": "EOC_mixes_fail"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "run_eocs_talker_mixes_loc",
+    "effect": [
+      { "run_eocs": [ "EOC_mixins_save_name" ], "alpha_loc": { "context_val": "alpha_var" }, "false_eocs": "EOC_mixes_fail" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_mixins_save_name",
+    "effect": [
+      { "set_string_var": "<u_name>", "target_var": { "global_val": "alpha_name" }, "parse_tags": true },
+      { "set_string_var": "<npc_name>", "target_var": { "global_val": "beta_name" }, "parse_tags": true }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_mixes_fail",
+    "effect": [
+      { "set_string_var": "mixin fail alpha", "target_var": { "global_val": "alpha_name" } },
+      { "set_string_var": "mixin fail beta", "target_var": { "global_val": "beta_name" } }
+    ]
   }
 ]

--- a/data/mods/TEST_DATA/effect_on_condition.json
+++ b/data/mods/TEST_DATA/effect_on_condition.json
@@ -92,22 +92,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "run_eocs_4",
-    "//": "in 2 seconds, run_eocs_4 should be 10 - we shove 10 eocs to run in two seconds",
-    "effect": [ { "run_eocs": [ "EOC_G", "EOC_H" ], "time_in_future": "2 seconds", "iterations": 5 } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_G",
-    "effect": [ { "math": [ "run_eocs_4", "++" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_H",
-    "effect": [ { "math": [ "run_eocs_4", "++" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "run_eocs_5",
     "//": "run_eocs_5 should be 4 - we run eocs until run_eocs_5 would be 4",
     "effect": [ { "run_eocs": [ "EOC_I", "EOC_J" ], "condition": { "math": [ "run_eocs_5 <= 3" ] } } ]
@@ -124,37 +108,13 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "run_eocs_6",
-    "//": "in 10 seconds, run_eocs_6 should be 10 - two eocs would be randomly fired for 10 seconds",
-    "effect": [
-      {
-        "run_eocs": [ "EOC_K", "EOC_L" ],
-        "time_in_future": [ "0 seconds", "10 seconds" ],
-        "randomize_time_in_future": true,
-        "iterations": 5
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_K",
-    "effect": [ { "math": [ "run_eocs_6", "++" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_L",
-    "effect": [ { "math": [ "run_eocs_6", "++" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "run_eocs_7",
-    "//": "in 10 seconds, run_eocs_7 should be 10, 'test_global_key_M' should contain 'test_context_value_M', and 'test_global_key_N' should contain 'test_context_value_N'",
+    "//": "in 10 seconds, 'test_global_key_M' should contain 'test_context_value_M', and 'test_global_key_N' should contain 'test_context_value_N'",
     "effect": [
       {
         "run_eocs": [ "EOC_M", "EOC_N" ],
         "time_in_future": [ "0 seconds", "10 seconds" ],
         "randomize_time_in_future": true,
-        "iterations": 5,
         "variables": { "test_context_key_M": "test_context_value_M", "test_context_key_N": "test_context_value_N" }
       }
     ]
@@ -162,23 +122,11 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_M",
-    "effect": [
-      { "math": [ "run_eocs_7", "++" ] },
-      {
-        "set_string_var": { "context_val": "test_context_key_M" },
-        "target_var": { "global_val": "test_global_key_M" }
-      }
-    ]
+    "effect": [ { "set_string_var": { "context_val": "test_context_key_M" }, "target_var": { "global_val": "test_global_key_M" } } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_N",
-    "effect": [
-      { "math": [ "run_eocs_7", "++" ] },
-      {
-        "set_string_var": { "context_val": "test_context_key_N" },
-        "target_var": { "global_val": "test_global_key_N" }
-      }
-    ]
+    "effect": [ { "set_string_var": { "context_val": "test_context_key_N" }, "target_var": { "global_val": "test_global_key_N" } } ]
   }
 ]

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -244,6 +244,7 @@ struct dialogue {
                   const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond,
                   const std::unordered_map<std::string, std::string> &ctx );
         talker *actor( bool is_beta ) const;
+        bool has_actor( bool is_beta ) const;
 
         mutable itype_id cur_item;
         mutable std::string reason;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -124,9 +124,7 @@ static const effect_on_condition_id effect_on_condition_EOC_try_kill( "EOC_try_k
 static const effect_on_condition_id effect_on_condition_run_eocs_1( "run_eocs_1" );
 static const effect_on_condition_id effect_on_condition_run_eocs_2( "run_eocs_2" );
 static const effect_on_condition_id effect_on_condition_run_eocs_3( "run_eocs_3" );
-static const effect_on_condition_id effect_on_condition_run_eocs_4( "run_eocs_4" );
 static const effect_on_condition_id effect_on_condition_run_eocs_5( "run_eocs_5" );
-static const effect_on_condition_id effect_on_condition_run_eocs_6( "run_eocs_6" );
 static const effect_on_condition_id effect_on_condition_run_eocs_7( "run_eocs_7" );
 
 static const flag_id json_flag_FILTHY( "FILTHY" );
@@ -1423,32 +1421,29 @@ TEST_CASE( "EOC_run_eocs", "[eoc]" )
     REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_1" ).empty() );
     REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_2" ).empty() );
     REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_3" ).empty() );
-    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_4" ).empty() );
     REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_5" ).empty() );
-    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_6" ).empty() );
-    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_7" ).empty() );
     REQUIRE( globvars.get_global_value( "npctalk_var_test_global_key_M" ).empty() );
     REQUIRE( globvars.get_global_value( "npctalk_var_test_global_key_N" ).empty() );
 
     CHECK( effect_on_condition_run_eocs_1->activate( d ) );
     CHECK( effect_on_condition_run_eocs_2->activate( d ) );
     CHECK( effect_on_condition_run_eocs_3->activate( d ) );
-    CHECK( effect_on_condition_run_eocs_4->activate( d ) );
     CHECK( effect_on_condition_run_eocs_5->activate( d ) );
-    CHECK( effect_on_condition_run_eocs_6->activate( d ) );
     CHECK( effect_on_condition_run_eocs_7->activate( d ) );
-
-    set_time( calendar::turn + 10_seconds );
-    effect_on_conditions::process_effect_on_conditions( get_avatar() );
 
     CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_1" ) ) == Approx( 2 ) );
     CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_2" ) ) == Approx( 20 ) );
-    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_3" ) ) == Approx( 2 ) );
-    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_4" ) ) == Approx( 10 ) );
     CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_5" ) ) == Approx( 4 ) );
-    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_6" ) ) == Approx( 10 ) );
-    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_7" ) ) == Approx( 10 ) );
 
+    set_time( calendar::turn + 1_seconds );
+    effect_on_conditions::process_effect_on_conditions( get_avatar() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_run_eocs_3" ).empty() );
+    set_time( calendar::turn + 1_seconds );
+    effect_on_conditions::process_effect_on_conditions( get_avatar() );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_run_eocs_3" ) ) == Approx( 2 ) );
+
+    set_time( calendar::turn + 8_seconds );
+    effect_on_conditions::process_effect_on_conditions( get_avatar() );
     CHECK( globvars.get_global_value( "npctalk_var_test_global_key_M" ) == "test_context_value_M" );
     CHECK( globvars.get_global_value( "npctalk_var_test_global_key_N" ) == "test_context_value_N" );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The `run_eocs` function has a few issues:
- the talker manipulation function always tries to get the underlying `Character` of a `talker` so it cannot work with other types, such as items
- numerous overlapping fallbacks hide JSON and code errors
- if `iterations` is set to 1 (manually or during the loop) and a `condition` is also defined, `iterations` is unexpectedly bumped up to 100
- the combination of `condition`/`iterations` + `time_in_future` does not work as intended: instead of queuing a loop, it queues multiple eoc runs. It's especially bad when also combined with `randomize_time_in_future` since you get a spread of one-runs instead of a loop at a random time
- the loop `condition` is only checked at queue time so it cannot end the loop on its own

#### Describe the solution

- clone the talkers instead of trying to hack it with base class accessor
- delete all fallbacks
- don't allow queuing a loop from one invocation. There is no infrastructure for serializing arbitrary conditions so this use case cannot be supported. But you can queue another EOC that runs a loop with no issues.

#### Describe alternatives you've considered
N/A

#### Testing

Extended existing test to cover talker manipulations.

#### Additional context
N/A
