### PR TITLE
Add Vitamin C Supplements

### DIFF
--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -336,6 +336,7 @@
       { "prob": 75, "group": "vitamins_bottle_plastic_pill_supplement_1_20" },
       { "item": "gummy_vitamins", "prob": 25, "count": [ 1, 10 ] },
       { "prob": 75, "group": "calcium_tablet_bottle_plastic_pill_supplement_1_20" },
+      { "prob": 40, "group": "vitc_tablet_bottle_plastic_pill_supplement_1_20" },
       { "prob": 85, "group": "bottle_otc_painkiller_1_20" },
       { "prob": 25, "group": "caffeine_bottle_plastic_pill_supplement_1_10" },
       { "prob": 15, "group": "pills_sleep_bottle_plastic_pill_prescription_1_10" },

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -603,6 +603,21 @@
   },
   {
     "type": "item_group",
+    "id": "vitc_tablet_bottle_plastic_pill_supplement_1_20",
+    "subtype": "collection",
+    "//": "This group was not created automatically but may still contain errors.",
+    "container-item": "bottle_plastic_pill_supplement",
+    "entries": [ { "item": "vitc_tablet", "count": [ 1, 20 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "vitc_tablet_bottle_full",
+    "subtype": "collection",
+    "container-item": "bottle_plastic_pill_supplement",
+    "entries": [ { "item": "vitc_tablet", "count": 20 } ]
+  },
+  {
+    "type": "item_group",
     "id": "caffeine_bottle_plastic_pill_supplement_1_10",
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",

--- a/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
+++ b/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
@@ -55,6 +55,7 @@
       { "group": "full_ifak", "prob": 15 },
       { "group": "vitamins_bottle_plastic_pill_supplement_20", "prob": 75 },
       { "group": "calcium_tablet_bottle_full", "prob": 75 },
+      { "group": "vitc_tablet_bottle_full", "prob": 75 },
       { "group": "aspirin_bottle_full", "prob": 45 },
       { "group": "ibuprofen_bottle_full", "prob": 45 },
       { "group": "naproxen_bottle_full", "prob": 45 },

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -1,8 +1,3 @@
-Cataclysm: Dark Days Ahead JSON Web Linting Tool
-This is a tool to help modders and editors of the open source game Cataclysm: Dark Days Ahead write JSON in the game's expected format.
-
-Paste some JSON into the field below and click "Lint" to run an autoformatter against it.
-
 [
   {
     "id": "SUS_silverware",
@@ -1221,4 +1216,3 @@ Paste some JSON into the field below and click "Lint" to run an autoformatter ag
     "entries": [ { "item": "tums", "container-item": "null", "count": [ 1, 20 ] } ]
   }
 ]
-

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -1,3 +1,8 @@
+Cataclysm: Dark Days Ahead JSON Web Linting Tool
+This is a tool to help modders and editors of the open source game Cataclysm: Dark Days Ahead write JSON in the game's expected format.
+
+Paste some JSON into the field below and click "Lint" to run an autoformatter against it.
+
 [
   {
     "id": "SUS_silverware",
@@ -903,6 +908,7 @@
             "container-item": "null",
             "entry-wrapper": "bottle_plastic_small"
           },
+          { "item": "vitc_tablet", "prob": 7, "count": [ 1, 30 ], "entry-wrapper": "bottle_plastic_small" },
           {
             "item": "calcium_tablet",
             "prob": 10,
@@ -1215,3 +1221,4 @@
     "entries": [ { "item": "tums", "container-item": "null", "count": [ 1, 20 ] } ]
   }
 ]
+

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1856,6 +1856,22 @@
     "vitamins": [ [ "meat_allergen", 1 ] ]
   },
   {
+    "id": "vitc_tablet",
+    "type": "COMESTIBLE",
+    "comestible_type": "MED",
+    "name": { "str": "vitamin C supplement" },
+    "description": "A small white tablet promising more vitamin C than a human can conceivably absorb.",
+    "material": [ "drug_filler" ],
+    "weight": "1 g",
+    "volume": "5 ml",
+    "price": "7 cent",
+    "price_postapoc": "15 cent",
+    "flags": [ "IRREPLACEABLE_CONSUMABLE", "EDIBLE_FROZEN" ],
+    "symbol": "!",
+    "color": "magenta",
+    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "vitC", 556 ] ] }
+  },
+  {
     "id": "gummy_vitamins",
     "copy-from": "vitamins",
     "type": "COMESTIBLE",

--- a/data/json/npcs/NC_DOCTOR.json
+++ b/data/json/npcs/NC_DOCTOR.json
@@ -90,6 +90,7 @@
       { "group": "box_of_contact_lens_any", "prob": 10 },
       { "prob": 75, "group": "vitamins_bottle_plastic_pill_supplement_20" },
       { "prob": 75, "group": "calcium_tablet_bottle_plastic_pill_supplement_20" },
+      { "prob": 75, "group": "vitc_tablet_bottle_full" },
       { "prob": 85, "group": "bottle_otc_painkiller_20" },
       { "prob": 25, "group": "caffeine_bottle_plastic_pill_supplement_10" },
       { "prob": 15, "group": "pills_sleep_bottle_plastic_pill_prescription_10" },


### PR DESCRIPTION
#### Summary
Content "Add Vitamin C Supplements"

#### Purpose of change
We did not have Vitamin C supplements, despite having both iron and calcium supplements.  So, we should have vit C as well, since they're the only three vitamins we track anyway.

#### Describe the solution
-Add Vit C supplement - I'll cover details/choices in the additional context segment
-Add Vit C spawn groups - Mimics other groups, a full bottle and random partially depleted bottle
-Add Vit C spawns - softdrugs itemgroup, vitamin_shop itemgroup, doctor NPC shopkeep inventory, SUS bathroom vitamin spawns

#### Describe alternatives you've considered
The main thing I considered is lowering the amount of Vit C given from a supplement (currently 556%).  This is much higher than our other vitamins, however, these supplements have ENORMOUS vit C content irl.  Most I saw recommended 4 pills a day at around 500% per pill.  And unlike calcium or iron, there's really not a complication from over consuming vit C so I left it at 500% ish per pill.  For comparison, this is like 6-7 oranges worth, in game, so it's not inconceivably high.

#### Testing
Tested the vitamins, that they aren't broken or ridiculous.
Tested each spawn itemgroup to ensure they spawn and in appropriate numbers.
Basic syntax stuff/linting/blah blah etc.

#### Additional context
Here's a bunch of random, probably rambling notes/thoughts I had as I worked on this, explaining various things:
<details>
<summary>Thoughts/choices on the tablets themselves</summary>
I chose to use a tablet rather than a gummy to avoid managing calories/sugar material, as such this pill is basically purely Vit C and filler.  Material left as drug_filler to accommodate this.

Abstracted pill size to 1g to match multivitamin/calcium tablet, could not find actual pill size listed.

Pill cost roughly 7 cents per pill for 100 pill bottle.  Guessed post_apoc at 15 cents.

Vit C per pill = 556% RDA, this is partly the problem with using the tablets instead of gummies.  This is definitely not balanced for our game, but I didn't want to make a completely made up item, I wanted to base it from a real item. For comparison, this is like eating 7 oranges in game. It's not an absurd or inconceivable amount, you could definitely get it from just eating, but it's way more than most of our vitamins.

Also I capitalized C in the item name, I know we typically do lower case unless proper nouns, but vitamin C is usually capitalized, I don't know if this matters.
</details>

<details>
<summary>The full spawn/partial depleted spawn groups</summary>
Set up a group for spawning Vitamin C bottles as full.
Set up a group for spawning Vitamin C bottles as partially depleted.

Most supplement bottles I saw online were 50-200 count, seeming like 100 is average.  However, this is pretty unbalanced for our game especially given how much vit C is in each pill.  Most of our supplements are set to 20 pills per bottle, so that is what I've done.
</details>

<details>
<summary>The itemgroups/spawn balance/why these groups</summary>
Added to softdrugs, a catchall for lots of drugs including other vitamins/supplements.

Added to NC_DOCTOR_misc which is for doctor shopkeepers. They sell full bottles, so I added the full bottle to the list, at the same rate as vitamins/calcium tabs.

Added to vitamin_shop_group, which is alongside other vitamins.  This group also spawns in pharmacies, so it takes care of that spawn which is the main place you'd expect to find supplements.

Added to SUS domestic bathroom group, to the distribution group for vitamins, specifically. Everything up until now was using 20 pill bottles, but I see the pills here spawn in larger amounts than the 1-20 groups I saw in the other itemgroups. So here I bumped their spawn to 1-30.  I also lowered calcium spawns in this group.  I had to rebalance the values to accommodate the new supplement, and it makes sense that both vit C and calcium tabs would be much less common than generic multivitamins.

If anyone cares the distribution in the SUS vitamin group used to be:
Vitamins - 66.6%
Gummy Vitamins - 22.2%
Calcium Tabs - 11.1%

And the new distribution is:

Vitamins - 65%
Gummy Vitamins - 21%
Calcium Tabs - 7%
Vitamin C Tabs - 7%
</details>

EDIT: Also forgot to mention it was based on this: https://www.amazon.com/Natures-Bounty-Vitamin-Supplement-Supports/dp/B0061GLR5O/