### PR TITLE
Fix food calcs for items with non-food components

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -322,8 +322,9 @@ nutrients Character::compute_effective_nutrients( const item &comest ) const
         return {};
     }
 
-    // if item has components, will derive calories from that instead.
-    if( !comest.components.empty() && !comest.has_flag( flag_NUTRIENT_OVERRIDE ) ) {
+    // if item has food components, will derive calories from that instead.
+    if( !comest.components.empty() && !comest.has_flag( flag_NUTRIENT_OVERRIDE ) &&
+        comest.made_of_any_food_components( true ) ) {
         nutrients tally{};
         if( comest.recipe_charges == 0 ) {
             // Avoid division by zero

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8663,6 +8663,29 @@ bool item::is_maybe_melee_weapon() const
            my_cat_id == item_category_tools;
 }
 
+bool item::made_of_any_food_components( bool deep_search ) const
+{
+    if( components.empty() || !get_comestible() ) {
+        return false;
+    }
+
+    for( const std::pair<itype_id, std::vector<item>> pair : components ) {
+        for( const item &it : pair.second ) {
+            nutrients &maybe_food = it.get_comestible()->default_nutrition;
+            bool must_be_food = maybe_food.kcal() > 0 || maybe_food.vitamins().empty();
+            bool has_food_component = false;
+            if( deep_search && !it.components.empty() ) {
+                // make true if any component has food values, even if some don't
+                has_food_component |= it.made_of_any_food_components( deep_search );
+            }
+            if( must_be_food || has_food_component ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 bool item::has_edged_damage() const
 {
     for( const damage_type &dt : damage_type::get_all() ) {

--- a/src/item.h
+++ b/src/item.h
@@ -368,6 +368,12 @@ class item : public visitable
         bool is_ebook_storage() const;
 
         /**
+         * Checks whether the item's components (and sub-components if deep_search) are food items
+         * Used for calculating nutrients of crafted food
+         */
+        bool made_of_any_food_components( bool deep_search = false ) const;
+
+        /**
          * A heuristic on whether it's a good idea to use this as a melee weapon.
          * Used for nicer messages only.
          */


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
#76999

#### Describe the solution
Ignore the food's components when the components are ENTIRELY non-food and act as if it was default nutrition.

If the food is made of ANY food, acts like before where it calculates the total calories+vitamins from components.

If the food is not made of anything (no components), acts like before and uses default nutrition.

#### Describe alternatives you've considered
Don't let food be made out of non-food?

#### Testing
@Karol1223 told me this works and if it doesn't they are wholly to blame. I take no responsibility whatsoever!

#### Additional context
