### PR TITLE
`Burst-fire wielded weapon` now actually sets wielded weapon to burst or auto firing modes

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -134,6 +134,7 @@ static const efftype_id effect_stunned( "stunned" );
 static const flag_id json_flag_MOP( "MOP" );
 
 static const gun_mode_id gun_mode_AUTO( "AUTO" );
+static const gun_mode_id gun_mode_BURST( "BURST" );
 
 static const itype_id fuel_type_animal( "animal" );
 static const itype_id itype_radiocontrol( "radiocontrol" );
@@ -2597,10 +2598,8 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_FIRE_BURST: {
             if( weapon ) {
-                gun_mode_id original_mode = weapon->gun_get_mode_id();
-                if( weapon->gun_set_mode( gun_mode_AUTO ) ) {
+                if( weapon->gun_set_mode( gun_mode_BURST ) || weapon->gun_set_mode( gun_mode_AUTO ) ) {
                     avatar_action::fire_wielded_weapon( player_character );
-                    weapon->gun_set_mode( original_mode );
                 }
             }
             break;


### PR DESCRIPTION
#### Summary
Bugfixes "'Burst-fire wielded weapon' now actually sets wielded weapon to burst or auto firing modes"

#### Purpose of change
* Closes #53863.

#### Describe the solution
- Added burst firing mode to the check and gave it more priority over auto firing mode.
- Removed "remember current fire mode -> set firing mode to burst/auto -> open firing menu -> set firing mode to remembered one" logic since for some unknown reason "set firing mode to remembered one" action is executed _before_ the "open firing menu" action, so original firing mode is immediately reset.

#### Describe alternatives you've considered
None.

#### Testing
Got M16A4. Checked that current fire mode is semi-auto. Pressed pre-binded "Burst-fire wielded weapon" hotkey. Game opened firing menu, the gun's firing mode was set to burst.
Got M4A1. Checked that current fire mode is semi-auto. Pressed pre-binded "Burst-fire wielded weapon" hotkey. Game opened firing menu, the gun's firing mode was set to auto.

#### Additional context
None.