### PR TITLE
Heating elements no longer drop from smashing the fume hood

### DIFF
--- a/data/json/furniture_and_terrain/furniture-medical.json
+++ b/data/json/furniture_and_terrain/furniture-medical.json
@@ -282,7 +282,6 @@
         { "item": "steel_chunk", "count": [ 4, 8 ] },
         { "item": "sheet_metal_small", "count": [ 8, 12 ] },
         { "item": "sheet_metal", "count": [ 1, 4 ] },
-        { "item": "element", "count": [ 1, 3 ] },
         { "item": "plastic_chunk", "count": [ 30, 50 ] },
         { "item": "pipe", "count": 1 },
         { "item": "glass_shard", "count": [ 25, 100 ] },


### PR DESCRIPTION
#### Summary
Bugfixes "Heating elements no longer drop from smashing the fume hood"

#### Purpose of change
* Closes #53784.

#### Describe the solution
Removed heating elements drop from smashing the fume hood.

#### Describe alternatives you've considered
None.

#### Testing
None, obvious json change.

#### Additional context
None.