### PR TITLE
Make battery chargers work outside the reality bubble

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5831,7 +5831,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                     }
 
                     if( n.is_vehicle_battery() ) {
-                        n.mod_energy( units::from_kilojoule( charged ) );
+                        n.mod_energy( units::from_kilojoule( static_cast<std::int64_t>( charged ) ) );
                     } else {
                         n.ammo_set( itype_battery, n.ammo_remaining() + charged );
                     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5801,6 +5801,10 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
             dischargeable = ( dischargeable / 1000 ) + x_in_y( dischargeable % 1000, 1000 );
             for( item &n : cur_veh.get_items( vp ) ) {
 
+                if( dischargeable <= 0 ) {
+                    break;
+                }
+
                 if( !n.has_flag( flag_RECHARGE ) && !n.has_flag( flag_USE_UPS ) ) {
                     continue;
                 }
@@ -5834,10 +5838,6 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                         n.mod_energy( units::from_kilojoule( static_cast<std::int64_t>( charged ) ) );
                     } else {
                         n.ammo_set( itype_battery, n.ammo_remaining() + charged );
-                    }
-
-                    if( dischargeable <= 0 ) {
-                        break;
                     }
 
                 }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3198,6 +3198,7 @@ void vehicle_part::deserialize( const JsonObject &data )
     data.read( "ammo_pref", ammo_pref );
     data.read( "locked", locked );
     data.read( "last_disconnected", last_disconnected );
+    data.read( "last_charged", last_charged );
 
     if( migration != nullptr ) {
         for( const itype_id &it : migration->add_veh_tools ) {
@@ -3252,6 +3253,7 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "ammo_pref", ammo_pref );
     json.member( "locked", locked );
     json.member( "last_disconnected", last_disconnected );
+    json.member( "last_charged", last_charged );
     json.end_object();
 }
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -534,6 +534,8 @@ struct vehicle_part {
 
         time_point last_disconnected = calendar::before_time_starts;
 
+        time_point last_charged = calendar::turn;
+
     private:
         // part type definition
         // note: this could be a const& but doing so would require hassle with implementing


### PR DESCRIPTION
#### Summary
Bugfixes "Battery charger appliances now work when outside the reality bubble"

#### Purpose of change
Closes #42911.

The purpose is making appliances like the box battery charger work outside the reality bubble. Until now, if you put an empty battery in a box battery charger attached to a power source, you go outside the reality bubble, you wait, and you go back to check, the battery won't have charged at all.

#### Describe the solution

The solution I used is "catching up" when loading the charger after a while, by checking the last time the charger had an opportunity to charge. This is accomplished with a new member in `vehicle_part`. The code needs to consider the possibility of multiple batteries, of the power source depleting and of the batteries filling up.

#### Describe alternatives you've considered

I'm not sure, but maybe this could be rewrote to reuse the link system. I don't think that's necessary though.

For calculations I used integer kilojoules as much as possible, maybe it could be better to do everything in float and convert when needed.

#### Testing

I tried putting two discharged big tool batteries in a foot locker recharging station (connected to a very large grid battery), going away, waiting, and coming back.

Most of the time it works as intended: the batteries are charged, and the very large grid battery has been discharged a little more (because of the 85% inefficiency). In some tries, however, the batteries were charged less than they should have been given the time waited, but I'm not sure how to reproduce it. I will try to do more tests when I have the time.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

