### PR TITLE
magus.json description change for the Slow spell

### DIFF
--- a/data/mods/Magiclysm/Spells/magus.json
+++ b/data/mods/Magiclysm/Spells/magus.json
@@ -206,7 +206,7 @@
     "id": "magus_slow",
     "type": "SPELL",
     "name": "Slow",
-    "description": "This spell gives you an enormous boost of speed lasting a short period of time.",
+    "description": "This spell weakens your target, resulting in a decrease of speed lasting a short period of time.",
     "valid_targets": [ "ally", "hostile" ],
     "flags": [ "ENERVATION_SPELL", "LOUD", "VERBAL", "SOMATIC", "NO_PROJECTILE" ],
     "extra_effects": [ { "id": "eoc_enervation_setup", "hit_self": true } ],


### PR DESCRIPTION
#### Summary
Mods "Magus spell Slow Description Change"

#### Purpose of change

This is my first contribution/change. I apologize if it isn't formatted or done correctly.

I noticed that magus_slow had the same description as magus_haste.

Slow should indicate that it slows the target's speed.

#### Describe the solution

Made a rewrite. Tried to keep it similar to Haste, but opposite.

#### Describe alternatives you've considered

Ignore it and wait for someone else.

#### Testing

Description Change. This is all new, so I don't really know how to get the code compiled or whatever makes it game-ready, but I am fairly confident in a description change.

I did make the change on my running version and it seemed to come up fine. 

#### Additional context
Hope I did everything alright!