### PR TITLE
Overhaul faction mission travel.

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -93,6 +93,7 @@ static const time_duration work_day_hours_time = work_day_hours * 1_hours;
 
 time_duration base_camps::to_workdays( const time_duration &work_time )
 {
+    // logic here is duplicated in reverse in basecamp::time_to_food
     if( work_time < ( work_day_hours + 1 ) * 1_hours ) {
         return work_time;
     }

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -249,8 +249,9 @@ class basecamp
         nutrients camp_food_supply( nutrients &change );
         /// Constructs a new nutrients struct in place and forwards it. Passed argument should be in kilocalories.
         nutrients camp_food_supply( int change );
-        /// Calculates raw kcal cost from duration of work and exercise, then forwards it to above
-        nutrients camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
+        /// Calculates raw kcal cost from duration (including non-work hours) and work exercise, then forwards it to above
+        nutrients camp_food_supply( const time_duration &total_time, float exertion_level = NO_EXERCISE,
+                                    const time_duration &travel_time = 0_hours );
         /// Evenly distributes the actual consumed food from a work project to the workers assigned to it
         void feed_workers( const std::vector<std::reference_wrapper <Character>> &workers, nutrients food,
                            bool is_player_meal = false );
@@ -268,7 +269,8 @@ class basecamp
         /// The number of days the current camp supplies lasts at the given exertion level.
         int camp_food_supply_days( float exertion_level ) const;
         /// Returns the total charges of food time_duration @ref work costs
-        int time_to_food( time_duration work, float exertion_level = NO_EXERCISE ) const;
+        int time_to_food( time_duration total_time, float work_exertion_level = NO_EXERCISE,
+                          time_duration travel_time = 0_hours ) const;
         /// Changes the faction respect for you by @ref change, returns respect
         int camp_discipline( int change = 0 ) const;
         /// Changes the faction opinion for you by @ref change, returns opinion
@@ -359,14 +361,16 @@ class basecamp
 
         // mission start functions
         /// generic mission start function that wraps individual mission
+        npc_ptr start_mission( const mission_id &miss_id, time_duration total_time,
+                               bool must_feed, const std::string &desc, bool group,
+                               const std::vector<item *> &equipment,
+                               const skill_id &skill_tested, int skill_level,
+                               float exertion_level, const time_duration &travel_time = 0_hours );
         npc_ptr start_mission( const mission_id &miss_id, time_duration duration,
                                bool must_feed, const std::string &desc, bool group,
                                const std::vector<item *> &equipment,
-                               const skill_id &skill_tested, int skill_level, float exertion_level );
-        npc_ptr start_mission( const mission_id &miss_id, time_duration duration,
-                               bool must_feed, const std::string &desc, bool group,
-                               const std::vector<item *> &equipment, float exertion_level,
                                const std::map<skill_id, int> &required_skills = {},
+                               float exertion_level = 1.0f, const time_duration &travel_time = 0_hours,
                                const npc_ptr &preselected_choice = nullptr );
         comp_list start_multi_mission( const mission_id &miss_id,
                                        bool must_feed, const std::string &desc,

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -847,6 +847,7 @@ direction direction_from( const coords::coord_point_ob<Point, Origin, Scale> &lo
     return direction_from( loc1.raw(), loc2.raw() );
 }
 
+// line from loc1 to loc2, including loc2 but not loc1
 template<typename Point, coords::origin Origin, coords::scale Scale, std::enable_if_t<std::is_same_v<Point, point>, int> = 0>
 std::vector < coords::coord_point < Point, Origin, Scale >>
         line_to( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
@@ -862,6 +863,7 @@ std::vector < coords::coord_point < Point, Origin, Scale >>
     return result;
 }
 
+// line from loc1 to loc2, including loc2 but not loc1
 template<typename Point, coords::origin Origin, coords::scale Scale, std::enable_if_t<std::is_same_v<Point, point>, int> = 0>
 std::vector < coords::coord_point_ib < Point, Origin, Scale >>
         line_to( const coords::coord_point_ib<Point, Origin, Scale> &loc1,
@@ -877,6 +879,7 @@ std::vector < coords::coord_point_ib < Point, Origin, Scale >>
     return result;
 }
 
+// line from loc1 to loc2, including loc2 but not loc1
 template<typename Tripoint, coords::origin Origin, coords::scale Scale,
          std::enable_if_t<std::is_same_v<Tripoint, tripoint>, int> = 0>
 std::vector < coords::coord_point < Tripoint, Origin, Scale >>
@@ -893,6 +896,7 @@ std::vector < coords::coord_point < Tripoint, Origin, Scale >>
     return result;
 }
 
+// line from loc1 to loc2, including loc2 but not loc1
 template<typename Tripoint, coords::origin Origin, coords::scale Scale,
          std::enable_if_t<std::is_same_v<Tripoint, tripoint>, int> = 0>
 std::vector < coords::coord_point_ib < Tripoint, Origin, Scale>>

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -419,7 +419,7 @@ void overmap_npc_move()
             }
             if( elem->omt_path.empty() ) {
                 elem->omt_path = overmap_buffer.get_travel_path( elem->global_omt_location(), elem->goal,
-                                 overmap_path_params::for_npc() );
+                                 overmap_path_params::for_npc() ).points;
                 if( elem->omt_path.empty() ) { // goal is unreachable, or already reached goal, reset it
                     elem->goal = npc::no_goal_point;
                 }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -66,6 +66,7 @@
 #include "recipe_groups.h"
 #include "requirements.h"
 #include "rng.h"
+#include "simple_pathfinding.h"
 #include "skill.h"
 #include "string_formatter.h"
 #include "string_input_popup.h"
@@ -106,6 +107,7 @@ static const itype_id itype_duffelbag( "duffelbag" );
 static const itype_id itype_fungal_seeds( "fungal_seeds" );
 static const itype_id itype_log( "log" );
 static const itype_id itype_marloss_seed( "marloss_seed" );
+static const itype_id itype_stick_long( "stick_long" );
 
 static const mongroup_id GROUP_CAMP_HUNTING( "GROUP_CAMP_HUNTING" );
 static const mongroup_id GROUP_CAMP_HUNTING_LARGE( "GROUP_CAMP_HUNTING_LARGE" );
@@ -144,8 +146,6 @@ static const oter_str_id oter_rural_road_turn_forest_west( "rural_road_turn_fore
 static const oter_str_id oter_special_forest( "special_forest" );
 static const oter_str_id oter_special_forest_thick( "special_forest_thick" );
 
-static const oter_type_str_id oter_type_forest_trail( "forest_trail" );
-
 static const skill_id skill_bashing( "bashing" );
 static const skill_id skill_combat( "combat" );
 static const skill_id skill_construction( "construction" );
@@ -159,7 +159,6 @@ static const skill_id skill_recruiting( "recruiting" );
 static const skill_id skill_speech( "speech" );
 static const skill_id skill_stabbing( "stabbing" );
 static const skill_id skill_survival( "survival" );
-static const skill_id skill_swimming( "swimming" );
 static const skill_id skill_traps( "traps" );
 static const skill_id skill_unarmed( "unarmed" );
 
@@ -275,7 +274,7 @@ static bool om_set_hide_site( npc &comp, const tripoint_abs_omt &omt_tgt,
                               const drop_locations &itms_rem = {} );
 /**
  * Opens the overmap so that you can select points for missions or constructions.
- * @param omt_pos where your camp is, used for calculating travel distances
+ * @param omt_pos start position, used for calculating travel distances
  * @param min_range
  * @param range max number of OM tiles the user can select
  * @param possible_om_types requires the user to reselect if the OM picked isn't in the list
@@ -295,24 +294,26 @@ static void om_range_mark( const tripoint_abs_omt &origin, int range, bool add_n
 static void om_line_mark(
     const tripoint_abs_omt &origin, const tripoint_abs_omt &dest, bool add_notes = true,
     const std::string &message = "R;X: PATH" );
-static std::vector<tripoint_abs_omt> om_companion_path(
+static void om_path_mark(
+    const std::vector<tripoint_abs_omt> &note_pts, bool add_notes = true,
+    const std::string &message = "R;X: PATH" );
+/**
+ * Select waypoints and plot a path for a companion to travel
+ * @param start start point
+ * @param range_start maximum total distance traveled
+ * @param bounce does visiting a faction hide site extend the range?
+*/
+static pf::simple_path<tripoint_abs_omt> om_companion_path(
     const tripoint_abs_omt &start, int range_start = 90, bool bounce = true );
 /**
  * Can be used to calculate total trip time for an NPC mission or just the traveling portion.
- * Doesn't use the pathingalgorithms yet.
- * @param omt_pos start point
- * @param omt_tgt target point
- * @param work how much time the NPC will stay at the target
+ * @param journey path they will follow
  * @param trips how many trips back and forth the NPC will make
  */
-static time_duration companion_travel_time_calc( const tripoint_abs_omt &pos,
-        const tripoint_abs_omt &tgt,
-        time_duration work, int trips = 1, int haulage = 0 );
-static time_duration companion_travel_time_calc(
-    const std::vector<tripoint_abs_omt> &journey, time_duration work, int trips = 1,
-    int haulage = 0 );
+static time_duration companion_travel_time_calc( const pf::simple_path<tripoint_abs_omt> &journey,
+        int trips = 1 );
 /// Determines how many trips it takes to move @ref mass and @ref volume of items
-/// with @ref carry_mass and @ref carry_volume moved per trip
+/// with @ref carry_mass and @ref carry_volume moved per trip, assuming round trips
 static int om_carry_weight_to_trips( const units::mass &total_mass,
                                      const units::volume &total_volume, const npc_ptr &comp = nullptr );
 static int om_carry_weight_to_trips( const units::mass &mass, const units::volume &volume,
@@ -321,7 +322,7 @@ static int om_carry_weight_to_trips( const units::mass &mass, const units::volum
 static std::string camp_trip_description( const time_duration &total_time,
         const time_duration &working_time,
         const time_duration &travel_time,
-        int distance, int trips, int need_food );
+        int dist_m, int trips, int need_food );
 
 /*
  * check if a companion survives a random encounter
@@ -1506,7 +1507,7 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
                                       "> Rotten: 0%%\n"
                                       "> Rots in < 2 days: 60%%\n"
                                       "> Rots in < 5 days: 80%%\n\n"
-                                      "Total faction food stock: %d kcal\nor %d / %d / %d day's rations\n"
+                                      "Total faction food stock: %d kcal\nor %d / %d / %d days' rations\n"
                                       "where the days is measured for Extra / Moderate / No exercise levels" ),
                                    fac()->food_supply.kcal(), camp_food_supply_days( EXTRA_EXERCISE ),
                                    camp_food_supply_days( MODERATE_EXERCISE ), camp_food_supply_days( NO_EXERCISE ) );
@@ -1971,32 +1972,37 @@ bool basecamp::handle_mission( const ui_mission_id &miss_id )
 }
 
 // camp faction companion mission start functions
-npc_ptr basecamp::start_mission( const mission_id &miss_id, time_duration duration,
+npc_ptr basecamp::start_mission( const mission_id &miss_id, time_duration total_time,
                                  bool must_feed, const std::string &desc, bool /*group*/,
                                  const std::vector<item *> &equipment,
-                                 const skill_id &skill_tested, int skill_level, float exertion_level )
+                                 const skill_id &skill_tested, int skill_level,
+                                 float exertion_level, const time_duration &travel_time )
 {
     std::map<skill_id, int> required_skills;
     required_skills[ skill_tested ] = skill_level;
-    return start_mission( miss_id, duration, must_feed, desc, false, equipment, exertion_level,
-                          required_skills );
+    return start_mission( miss_id, total_time, must_feed, desc, false, equipment,
+                          required_skills, exertion_level, travel_time );
 }
 
-npc_ptr basecamp::start_mission( const mission_id &miss_id, time_duration duration,
+npc_ptr basecamp::start_mission( const mission_id &miss_id, time_duration total_time,
                                  bool must_feed, const std::string &desc, bool /*group*/,
-                                 const std::vector<item *> &equipment, float exertion_level,
-                                 const std::map<skill_id, int> &required_skills, const npc_ptr &preselected_choice )
+                                 const std::vector<item *> &equipment, const std::map<skill_id, int> &required_skills,
+                                 float exertion_level, const time_duration &travel_time, const npc_ptr &preselected_choice )
 {
-    if( must_feed && fac()->food_supply.kcal() < time_to_food( duration, exertion_level ) ) {
+    if( must_feed &&
+        fac()->food_supply.kcal() < time_to_food( total_time, exertion_level, travel_time ) ) {
         popup( _( "You don't have enough food stored to feed your companion." ) );
         return nullptr;
     }
     npc_ptr comp = talk_function::individual_mission( omt_pos, base_camps::id, desc, miss_id,
                    false, equipment, required_skills, false, preselected_choice );
     if( comp != nullptr ) {
-        comp->companion_mission_time_ret = calendar::turn + duration;
+        comp->companion_mission_time_ret = calendar::turn + total_time;
+        comp->companion_mission_exertion = exertion_level;
         if( must_feed ) {
-            feed_workers( *comp.get()->as_character(), camp_food_supply( duration, exertion_level ) );
+            // TODO update spent food after assigning a specific worker to the mission and recalculating travel time
+            feed_workers( *comp.get()->as_character(), camp_food_supply( total_time, exertion_level,
+                          travel_time ) );
         }
         if( !equipment.empty() ) {
             map &target_map = get_camp_map();
@@ -2079,6 +2085,7 @@ comp_list basecamp::start_multi_mission( const mission_id &miss_id,
 
         for( npc_ptr &comp : result ) {
             comp->companion_mission_time_ret = calendar::turn + work_days;
+            comp->companion_mission_exertion = making.exertion_level();
         }
         if( must_feed ) {
             std::vector<std::reference_wrapper <Character>> work_party;
@@ -2578,40 +2585,55 @@ static void change_cleared_terrain( tripoint_abs_omt forest )
     }
 }
 
+static const std::vector<std::string> terrains_forest = { "forest", "forest_thick", "forest_trail", "rural_road_forest", "rural_road_turn_forest", "rural_road_turn1_forest", "rural_road_3way_forest", "dirt_road_forest", "dirt_road_3way_forest", "dirt_road_turn_forest", "forest_trail_intersection", "special_forest", "special_forest_thick", "forest_trail_isolated", "forest_trail_end" };
+static const std::vector<std::string> terrains_field_swamp_forest = [] {
+    std::vector<std::string> tmp = terrains_forest;
+    tmp.emplace_back( "field" );
+    tmp.emplace_back( "forest_water" );
+    return tmp;
+}();
+
+
 void basecamp::start_cut_logs( const mission_id &miss_id, float exertion_level )
 {
-    std::vector<std::string> log_sources = { "forest", "forest_thick", "forest_trail", "rural_road_forest", "rural_road_turn_forest", "rural_road_turn1_forest", "rural_road_3way_forest",
-                                             "dirt_road_forest", "dirt_road_3way_forest", "dirt_road_turn_forest", "forest_trail_intersection", "special_forest", "special_forest_thick", "forest_trail_isolated", "forest_trail_end"
-                                           };
-    tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, log_sources, ot_match_type::type,
+    tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, terrains_forest, ot_match_type::type,
                               _( "Select a forest (or road/trail) from %d to %d tiles away." ) );
     if( forest != overmap::invalid_tripoint ) {
         standard_npc sample_npc( "Temp" );
         sample_npc.set_fake( true );
-        int tree_est = om_cutdown_trees_est( forest, 50 );
-        int tree_young_est = om_harvest_ter_est( sample_npc, forest,
-                             ter_t_tree_young, 50 );
-        int dist = rl_dist( forest.xy(), omt_pos.xy() );
-        //Very roughly what the player does + 6 hours for prep, clean up, breaks
+        const int tree_est = om_cutdown_trees_est( forest, 50 );
+        const int tree_young_est = om_harvest_ter_est( sample_npc, forest,
+                                   ter_t_tree_young, 50 );
+        pf::simple_path<tripoint_abs_omt> path = overmap_buffer.get_travel_path( omt_pos, forest,
+                overmap_path_params::for_npc() );
+        //Very roughly what the player does  + 6 hours for prep, clean up
         time_duration chop_time = 6_hours + 1_hours * tree_est + 7_minutes * tree_young_est;
-        int haul_items = 2 * tree_est + 3 * tree_young_est;
-        time_duration travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes,
-                                    2, haul_items );
-        time_duration work_time = travel_time + chop_time;
-        if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( work_time,
-                       chop_time, travel_time, dist, 2, time_to_food( work_time, exertion_level ) ) ) ) {
+        // approximate average yields
+        // TODO use bash results from t_tree_young to get a better estimate
+        const int trips = om_carry_weight_to_trips(
+                              tree_est * itype_log->weight * 7.5 + tree_young_est * itype_stick_long->weight * 2.5,
+                              tree_est * itype_log->volume * 7.5 + tree_young_est * itype_stick_long->volume * 2.5
+                          );
+        const time_duration travel_time = companion_travel_time_calc( path, trips );
+        const time_duration total_time = base_camps::to_workdays( travel_time + chop_time );
+        const int need_food = time_to_food( total_time, exertion_level, travel_time );
+        if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( total_time,
+                       chop_time, travel_time, path.dist, trips, need_food ) ) ) {
             return;
         }
 
         npc_ptr comp = start_mission( miss_id,
-                                      work_time, true,
+                                      total_time, true,
                                       _( "departs to cut logs…" ), false, {},
-                                      skill_fabrication, 2, exertion_level );
+                                      skill_fabrication, 2, exertion_level, travel_time );
         if( comp != nullptr ) {
             om_cutdown_trees_logs( forest, 50 );
             om_harvest_ter( *comp, forest, ter_t_tree_young, 50 );
-            om_harvest_itm( comp, forest, 95 );
-            comp->companion_mission_time_ret = calendar::turn + work_time;
+            const mass_volume results = om_harvest_itm( comp, forest, 95 );
+            const int trips = om_carry_weight_to_trips( results.wgt, results.vol, comp );
+            const time_duration travel_time = companion_travel_time_calc( path, trips );
+            const time_duration total_time = base_camps::to_workdays( travel_time + chop_time );
+            comp->companion_mission_time_ret = calendar::turn + total_time;
             change_cleared_terrain( forest );
         }
     }
@@ -2619,31 +2641,30 @@ void basecamp::start_cut_logs( const mission_id &miss_id, float exertion_level )
 
 void basecamp::start_clearcut( const mission_id &miss_id, float exertion_level )
 {
-    std::vector<std::string> log_sources = { "forest", "forest_thick", "forest_trail", "rural_road_forest", "rural_road_turn_forest", "rural_road_turn1_forest", "rural_road_3way_forest",
-                                             "dirt_road_forest", "dirt_road_3way_forest", "dirt_road_turn_forest", "forest_trail_intersection", "special_forest", "special_forest_thick", "forest_trail_isolated", "forest_trail_end"
-                                           };
     popup( _( "Forests are the only valid cutting locations, with forest dirt roads, forest rural roads, and trails being valid as well.  Note that it's likely both forest and field roads look exactly the same after having been cleared." ) );
-    tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, log_sources, ot_match_type::type );
+    tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, terrains_forest, ot_match_type::type );
     if( forest != overmap::invalid_tripoint ) {
         standard_npc sample_npc( "Temp" );
         sample_npc.set_fake( true );
-        int tree_est = om_cutdown_trees_est( forest, 95 );
-        int tree_young_est = om_harvest_ter_est( sample_npc, forest,
-                             ter_t_tree_young, 95 );
-        int dist = rl_dist( forest.xy(), omt_pos.xy() );
-        //Very roughly what the player does + 6 hours for prep, clean up, breaks
-        time_duration chop_time = 6_hours + 1_hours * tree_est + 7_minutes * tree_young_est;
-        time_duration travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes, 2 );
-        time_duration work_time = travel_time + chop_time;
-        if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( work_time,
-                       chop_time, travel_time, dist, 2, time_to_food( work_time, exertion_level ) ) ) ) {
+        const int tree_est = om_cutdown_trees_est( forest, 95 );
+        const int tree_young_est = om_harvest_ter_est( sample_npc, forest,
+                                   ter_t_tree_young, 95 );
+        pf::simple_path<tripoint_abs_omt> path = overmap_buffer.get_travel_path( omt_pos, forest,
+                overmap_path_params::for_npc() );
+        //Very roughly what the player does + 6 hours for prep, clean up
+        const time_duration chop_time = 6_hours + 1_hours * tree_est + 7_minutes * tree_young_est;
+        const time_duration travel_time = companion_travel_time_calc( path, 2 );
+        const time_duration total_time = base_camps::to_workdays( travel_time + chop_time );
+        const int need_food = time_to_food( total_time, exertion_level, travel_time );
+        if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( total_time,
+                       chop_time, travel_time, path.dist, 2, need_food ) ) ) {
             return;
         }
 
         npc_ptr comp = start_mission( miss_id,
-                                      work_time,
+                                      total_time,
                                       true, _( "departs to clear a forest…" ), false, {},
-                                      skill_fabrication, 1, exertion_level );
+                                      skill_fabrication, 1, exertion_level, travel_time );
         if( comp != nullptr ) {
             om_cutdown_trees_trunks( forest, 95 );
             om_harvest_ter_break( *comp, forest, ter_t_tree_young, 95 );
@@ -2654,14 +2675,12 @@ void basecamp::start_clearcut( const mission_id &miss_id, float exertion_level )
 
 void basecamp::start_setup_hide_site( const mission_id &miss_id, float exertion_level )
 {
-    std::vector<std::string> hide_locations = { "forest", "forest_thick", "forest_water", "forest_trail"
-                                                "field"
-                                              };
-    tripoint_abs_omt forest = om_target_tile( omt_pos, 10, 90, hide_locations,
+    tripoint_abs_omt forest = om_target_tile( omt_pos, 10, 90, terrains_field_swamp_forest,
                               ot_match_type::type,
-                              true, omt_pos, true, _( "Select an forest, swamp, or field from %d to %d tiles away." ) );
+                              true, omt_pos, true, _( "Select a forest, swamp, or field from %d to %d tiles away." ) );
     if( forest != overmap::invalid_tripoint ) {
-        int dist = rl_dist( forest.xy(), omt_pos.xy() );
+        pf::simple_path<tripoint_abs_omt> path = overmap_buffer.get_travel_path( omt_pos, forest,
+                overmap_path_params::for_npc() );
         Character *pc = &get_player_character();
         const inventory_filter_preset preset( []( const item_location & location ) {
             return !location->can_revive() && !location->will_spill();
@@ -2674,41 +2693,40 @@ void basecamp::start_setup_hide_site( const mission_id &miss_id, float exertion_
                                           _( "These are the items you've selected so far." ), _( "Select items to send" ), total_volume,
                                           total_mass );
 
-        int trips = om_carry_weight_to_trips( total_mass, total_volume, nullptr );
-        int haulage = trips <= 2 ? 0 : losing_equipment.size();
-        time_duration build_time = 6_hours;
-        time_duration travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes,
-                                    2, haulage );
-        time_duration work_time = travel_time + build_time;
-        if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( work_time,
-                       build_time, travel_time, dist, trips, time_to_food( work_time, exertion_level ) ) ) ) {
+        const int trips = om_carry_weight_to_trips( total_mass, total_volume );
+        const time_duration build_time = 6_hours;
+        const time_duration travel_time = companion_travel_time_calc( path, trips );
+        const time_duration total_time = base_camps::to_workdays( travel_time + build_time );
+        const int need_food = time_to_food( total_time, exertion_level, travel_time );
+        if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( total_time,
+                       build_time, travel_time, path.dist, trips, need_food ) ) ) {
             return;
         }
         npc_ptr comp = start_mission( miss_id,
-                                      work_time, true,
+                                      total_time, true,
                                       _( "departs to build a hide site…" ), false, {},
-                                      skill_survival, 3, exertion_level );
+                                      skill_survival, 3, exertion_level, travel_time );
         if( comp != nullptr ) {
-            trips = om_carry_weight_to_trips( total_mass, total_volume, comp );
-            haulage = trips <= 2 ? 0 : losing_equipment.size();
-            work_time = companion_travel_time_calc( forest, omt_pos, 0_minutes, 2, haulage ) +
-                        build_time;
-            comp->companion_mission_time_ret = calendar::turn + work_time;
+            const int trips = om_carry_weight_to_trips( total_mass, total_volume, comp );
+            const time_duration travel_time = companion_travel_time_calc( path, trips );
+            const time_duration total_time = base_camps::to_workdays( travel_time + build_time );
+            comp->companion_mission_time_ret = calendar::turn + total_time;
             om_set_hide_site( *comp, forest, losing_equipment );
         }
     }
 }
 
 static const tripoint_omt_ms relay_site_stash{ 11, 10, 0 };
+static const std::vector<std::string> hide_locations = { faction_hide_site_0_string };
 
 void basecamp::start_relay_hide_site( const mission_id &miss_id, float exertion_level )
 {
-    std::vector<std::string> hide_locations = { faction_hide_site_0_string };
     tripoint_abs_omt forest = om_target_tile( omt_pos, 10, 90, hide_locations, ot_match_type::exact,
                               true, omt_pos, true, string_format(
                                   _( "Select an existing hide site from %d to %d tiles away." ), 10, 90 ) );
     if( forest != overmap::invalid_tripoint ) {
-        int dist = rl_dist( forest.xy(), omt_pos.xy() );
+        pf::simple_path<tripoint_abs_omt> path = overmap_buffer.get_travel_path( omt_pos, forest,
+                overmap_path_params::for_npc() );
         Character *pc = &get_player_character();
         const inventory_filter_preset preset( []( const item_location & location ) {
             return !location->can_revive() && !location->will_spill();
@@ -2733,38 +2751,38 @@ void basecamp::start_relay_hide_site( const mission_id &miss_id, float exertion_
                                            total_import_volume, total_import_mass );
 
         if( !losing_equipment.empty() || !gaining_equipment.empty() ) {
-            //Only get charged the greater trips since return is free for both
-            int trips = std::max( om_carry_weight_to_trips( total_import_mass, total_import_volume, nullptr ),
-                                  om_carry_weight_to_trips( total_export_mass, total_export_volume, nullptr ) );
-            int haulage = trips <= 2 ? 0 : std::max( gaining_equipment.size(),
-                          losing_equipment.size() );
-            time_duration build_time =
-                5_minutes;  //  We're not actually constructing anything, just loading/unloading/performing very light maintenance
-            time_duration travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes,
-                                        trips, haulage );
-            time_duration work_time = travel_time + build_time;
-            if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( work_time, build_time,
-                           travel_time, dist, trips, time_to_food( work_time, exertion_level ) ) ) ) {
+            // After calculating round trips for each direction, only the greater one is used.
+            const int trips = std::max(
+                                  om_carry_weight_to_trips( total_import_mass, total_import_volume ),
+                                  om_carry_weight_to_trips( total_export_mass, total_export_volume )
+                              );
+            // We're not actually constructing anything, just loading/unloading/performing very light maintenance
+            const time_duration build_time = 5_minutes;
+            const time_duration travel_time = companion_travel_time_calc( path, trips );
+            const time_duration total_time = base_camps::to_workdays( travel_time + build_time );
+            const int need_food = time_to_food( total_time, exertion_level, travel_time );
+            if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( total_time, build_time,
+                           travel_time, path.dist, trips, need_food ) ) ) {
                 return;
             }
 
             npc_ptr comp = start_mission( miss_id,
-                                          work_time, true,
+                                          total_time, true,
                                           _( "departs for the hide site…" ), false, {},
-                                          skill_survival, 3, exertion_level );
+                                          skill_survival, 3, exertion_level, travel_time );
             if( comp != nullptr ) {
                 // recalculate trips based on actual load
-                trips = std::max( om_carry_weight_to_trips( total_import_mass, total_import_volume, comp ),
-                                  om_carry_weight_to_trips( total_export_mass, total_export_volume, comp ) );
-                int haulage = trips <= 2 ? 0 : std::max( gaining_equipment.size(),
-                              losing_equipment.size() );
-                work_time = companion_travel_time_calc( forest, omt_pos, 0_minutes, trips,
-                                                        haulage ) + build_time;
-                comp->companion_mission_time_ret = calendar::turn + work_time;
+                const int trips = std::max(
+                                      om_carry_weight_to_trips( total_import_mass, total_import_volume, comp ),
+                                      om_carry_weight_to_trips( total_export_mass, total_export_volume, comp )
+                                  );
+                const time_duration travel_time = companion_travel_time_calc( path, trips );
+                const time_duration total_time = base_camps::to_workdays( travel_time + build_time );
+                comp->companion_mission_time_ret = calendar::turn + total_time;
                 om_set_hide_site( *comp, forest, losing_equipment, gaining_equipment );
             }
         } else {
-            popup( _( "You need equipment to transport between the hide site…" ) );
+            popup( _( "You need equipment to transport to/from the hide site…" ) );
         }
     }
 }
@@ -2828,18 +2846,15 @@ static void apply_fortifications( const mission_id &miss_id, const npc_ptr *comp
 
 void basecamp::start_fortifications( const mission_id &miss_id, float exertion_level )
 {
-    std::vector<std::string> allowed_locations = {
-        "forest", "forest_thick", "forest_water", "forest_trail", "field"
-    };
     popup( _( "Select a start and end point.  Line must be straight.  Fields, forests, and "
               "swamps are valid fortification locations.  In addition to existing fortification "
               "constructions." ) );
-    tripoint_abs_omt start = om_target_tile( omt_pos, 2, 90, allowed_locations,
+    tripoint_abs_omt start = om_target_tile( omt_pos, 2, 90, terrains_field_swamp_forest,
                              ot_match_type::type, true, omt_pos, _( "Select a start point from %d to %d tiles away." ) );
     if( start == overmap::invalid_tripoint ) {
         return;
     }
-    tripoint_abs_omt stop = om_target_tile( omt_pos, 2, 90, allowed_locations,
+    tripoint_abs_omt stop = om_target_tile( omt_pos, 2, 90, terrains_field_swamp_forest,
                                             ot_match_type::type,
                                             true, start, _( "Select an end point from %d to %d tiles away." ) );
     if( stop == overmap::invalid_tripoint ) {
@@ -2886,7 +2901,7 @@ void basecamp::start_fortifications( const mission_id &miss_id, float exertion_l
     for( tripoint_abs_omt &fort_om : fortify_om ) {
         bool valid = false;
         const oter_id &omt_ref = overmap_buffer.ter( fort_om );
-        for( const std::string &pos_om : allowed_locations ) {
+        for( const std::string &pos_om : terrains_field_swamp_forest ) {
             if( omt_ref.id().c_str() == pos_om ) {
                 valid = true;
                 break;
@@ -2897,13 +2912,33 @@ void basecamp::start_fortifications( const mission_id &miss_id, float exertion_l
             popup( _( "Invalid terrain in construction path." ) );
             return;
         }
-        trips += 2;
-        build_time += making.batch_duration( get_player_character() );
-        dist += rl_dist( fort_om.xy(), omt_pos.xy() );
-        travel_time += companion_travel_time_calc( fort_om, omt_pos, 0_minutes, 2 );
+        // spiked pit requires traveling back and forth to carry components
+        // TODO calculate whether one trip can carry multiple tiles worth of components
+        if( miss_id.parameters == faction_wall_level_n_1_string ) {
+            trips += 2;
+            const pf::simple_path<tripoint_abs_omt> &path = overmap_buffer.get_travel_path( omt_pos, fort_om,
+                    overmap_path_params::for_npc() );
+            travel_time += companion_travel_time_calc( path, 2 );
+            dist += path.dist * 2;
+        }
+        build_time += making.batch_duration( get_player_character() ); // TODO calculate for NPC, not player
     }
-    time_duration total_time = base_camps::to_workdays( travel_time + build_time );
-    int need_food = time_to_food( total_time, exertion_level );
+    // trench requires just one triangular trip
+    if( miss_id.parameters != faction_wall_level_n_1_string ) {
+        trips = 1;
+        const pf::simple_path<tripoint_abs_omt> &path1 = overmap_buffer.get_travel_path( omt_pos, start,
+                overmap_path_params::for_npc() );
+        const pf::simple_path<tripoint_abs_omt> &path2 = overmap_buffer.get_travel_path( start, stop,
+                overmap_path_params::for_npc() );
+        const pf::simple_path<tripoint_abs_omt> &path3 = overmap_buffer.get_travel_path( stop, omt_pos,
+                overmap_path_params::for_npc() );
+        travel_time = companion_travel_time_calc( path1, 1 ) +
+                      companion_travel_time_calc( path2, 1 ) +
+                      companion_travel_time_calc( path3, 1 );
+        dist = path1.dist + path2.dist + path3.dist;
+    }
+    const time_duration total_time = base_camps::to_workdays( travel_time + build_time );
+    const int need_food = time_to_food( total_time, exertion_level, travel_time );
     if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( total_time, build_time,
                    travel_time, dist, trips, need_food ) ) ) {
         return;
@@ -2923,7 +2958,7 @@ void basecamp::start_fortifications( const mission_id &miss_id, float exertion_l
     npc_ptr comp = start_mission(
                        miss_id, total_time, true,
                        _( "begins constructing fortifications…" ), false, {},
-                       exertion_level, making.required_skills );
+                       making.required_skills, exertion_level, travel_time );
     if( comp != nullptr ) {
         components.consume_components();
         for( tripoint_abs_omt &pt : fortify_om ) {
@@ -3485,17 +3520,25 @@ void basecamp::continue_salt_water_pipe( const mission_id &miss_id )
 void basecamp::start_combat_mission( const mission_id &miss_id, float exertion_level )
 {
     popup( _( "Select checkpoints until you reach maximum range or select the last point again "
-              "to end." ) );
+              "to end.  Cancel to undo a selection." ) );
     tripoint_abs_omt start = omt_pos;
-    std::vector<tripoint_abs_omt> scout_points = om_companion_path( start, 90, true );
+    const pf::simple_path<tripoint_abs_omt> &scout_path = om_companion_path( start, 90,
+            true );
+    const std::vector<tripoint_abs_omt> &scout_points = scout_path.points;
     if( scout_points.empty() ) {
         return;
     }
-    int dist = scout_points.size();
     int trips = 2;
-    time_duration travel_time = companion_travel_time_calc( scout_points, 0_minutes, trips );
-    if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( 0_hours, 0_hours,
-                   travel_time, dist, trips, time_to_food( travel_time, exertion_level ) ) ) ) {
+    if( scout_points.front() == start ) {
+        trips = 1;
+    }
+    const time_duration travel_time = companion_travel_time_calc( scout_path, trips );
+    const time_duration total_time = base_camps::to_workdays( travel_time );
+    // on this mission, all time is travel, but different exertion level for scout vs combat,
+    // so we use work time calculation instead of travel time to avoid the constant travel exertion
+    const int need_food = time_to_food( total_time, exertion_level );
+    if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( total_time, 0_hours,
+                   travel_time, scout_path.dist, trips, need_food ) ) ) {
         return;
     }
     npc_ptr comp = start_mission( miss_id, travel_time, true, _( "departs on patrol…" ),
@@ -3601,8 +3644,8 @@ void basecamp::start_crafting( const mission_id &miss_id )
     // Now that we know the actual thing we're crafting we will properly form our mission_id
     mission_id actual_id = {miss_id.id, making->ident().str(), miss_id.mapgen_args, miss_id.dir };
     npc_ptr comp = start_mission( actual_id, work_days, true,
-                                  _( "begins to work…" ), false, {}, making->exertion_level(),
-                                  making->required_skills, guy_to_send );
+                                  _( "begins to work…" ), false, {}, making->required_skills, making->exertion_level(),
+                                  0_hours, guy_to_send );
     if( comp != nullptr ) {
         components.consume_components();
         for( const item &results : making->create_results( num_to_make ) ) {
@@ -3849,7 +3892,8 @@ void basecamp::start_farm_op( const point &dir, const mission_id &miss_id,
         }
         case farm_ops::plow:
             work += 5_minutes * plots_cnt;
-            start_mission( miss_id, work, true, _( "begins plowing the field…" ), false, {}, exertion_level );
+            start_mission( miss_id, work, true, _( "begins plowing the field…" ), false, {}, {},
+                           exertion_level );
             break;
         default:
             debugmsg( "Farm operations called with no operation" );
@@ -3894,7 +3938,12 @@ void basecamp::finish_return( npc &comp, const bool fixed_time, const std::strin
     }
 
     // Missions that are not fixed_time pay their food costs at the end, instead of up-front.
-    int need_food = time_to_food( mission_time - reserve_time );
+    int need_food = 0;
+    if( !fixed_time ) {
+        // Assume the travel time is constant and any unplanned time was non-travel
+        need_food = time_to_food( mission_time, comp.companion_mission_exertion,
+                                  comp.companion_mission_travel_time );
+    }
     if( fac()->food_supply.kcal() < need_food ) {
         popup( _( "Your companion seems disappointed that your pantry is empty…" ) );
     }
@@ -3977,6 +4026,7 @@ npc_ptr basecamp::emergency_recall( const mission_id &miss_id )
         }
 
         const std::string return_msg = _( "responds to the emergency recall…" );
+        // FIXME this might charge food for someone who was already fed?
         finish_return( *comp, false, return_msg, skill_menial.str(), 0, true );
     }
     return comp;
@@ -4508,17 +4558,19 @@ void basecamp::combat_mission_return( const mission_id &miss_id )
             patrol.push_back( guy );
         }
         for( tripoint_abs_omt &pt : comp->companion_mission_points ) {
-            const oter_id &omt_ref = overmap_buffer.ter( pt );
-            int swim = comp->get_skill_level( skill_swimming );
-            if( is_river( omt_ref ) && swim < 2 ) {
-                if( swim == 0 ) {
-                    popup( _( "Your companion hit a river and didn't know how to swim…" ) );
-                } else {
-                    popup( _( "Your companion hit a river and didn't know how to swim well "
-                              "enough to cross…" ) );
-                }
-                break;
-            }
+            // // Crossing water is at least temporarily avoided due to the introduction of
+            // // pathfinding to the mission system.
+            // const oter_id &omt_ref = overmap_buffer.ter( pt );
+            // int swim = comp->get_skill_level( skill_swimming );
+            // if( is_river( omt_ref ) && swim < 2 ) {
+            //     if( swim == 0 ) {
+            //         popup( _( "Your companion hit a river and didn't know how to swim…" ) );
+            //     } else {
+            //         popup( _( "Your companion hit a river and didn't know how to swim well "
+            //                   "enough to cross…" ) );
+            //     }
+            //     break;
+            // }
             comp->death_drops = false;
             bool outcome = talk_function::companion_om_combat_check( patrol, pt, patrolling );
             comp->death_drops = true;
@@ -4808,8 +4860,8 @@ int basecamp::recipe_batch_max( const recipe &making ) const
     const int max_checks = 9;
     for( size_t batch_size = 1000; batch_size > 0; batch_size /= 10 ) {
         for( int iter = 0; iter < max_checks; iter++ ) {
-            time_duration work_days = base_camps::to_workdays( making.batch_duration(
-                                          get_player_character(), max_batch + batch_size ) );
+            const time_duration &work_days = base_camps::to_workdays( making.batch_duration(
+                                                 get_player_character(), max_batch + batch_size ) );
             int food_req = time_to_food( work_days );
             bool can_make = making.deduped_requirements().can_make_with_inventory(
                                 _inv, making.get_component_filter(), max_batch + batch_size );
@@ -5159,7 +5211,7 @@ void om_line_mark( const tripoint_abs_omt &origin, const tripoint_abs_omt &dest,
 {
     std::vector<tripoint_abs_omt> note_pts = line_to( origin, dest );
 
-    for( tripoint_abs_omt &pt : note_pts ) {
+    for( const tripoint_abs_omt &pt : note_pts ) {
         if( add_notes ) {
             if( !overmap_buffer.has_note( pt ) ) {
                 overmap_buffer.add_note( pt, message );
@@ -5171,6 +5223,24 @@ void om_line_mark( const tripoint_abs_omt &origin, const tripoint_abs_omt &dest,
         }
     }
 }
+
+static void om_path_mark(
+    const std::vector<tripoint_abs_omt> &note_pts, bool add_notes,
+    const std::string &message )
+{
+    for( const tripoint_abs_omt &pt : note_pts ) {
+        if( add_notes ) {
+            if( !overmap_buffer.has_note( pt ) ) {
+                overmap_buffer.add_note( pt, message );
+            }
+        } else {
+            if( overmap_buffer.has_note( pt ) && overmap_buffer.note( pt ) == message ) {
+                overmap_buffer.delete_note( pt );
+            }
+        }
+    }
+}
+
 
 bool om_set_hide_site( npc &comp, const tripoint_abs_omt &omt_tgt,
                        const drop_locations &itms,
@@ -5222,45 +5292,21 @@ bool om_set_hide_site( npc &comp, const tripoint_abs_omt &omt_tgt,
 }
 
 // path and travel time
-time_duration companion_travel_time_calc( const tripoint_abs_omt &omt_pos,
-        const tripoint_abs_omt &omt_tgt, time_duration work, int trips, int haulage )
+static time_duration companion_travel_time_calc( const pf::simple_path<tripoint_abs_omt> &journey,
+        int trips )
 {
-    std::vector<tripoint_abs_omt> journey = line_to( omt_pos, omt_tgt );
-    return companion_travel_time_calc( journey, work, trips, haulage );
+    return journey.cost * trips * 1_seconds ;
 }
 
-time_duration companion_travel_time_calc( const std::vector<tripoint_abs_omt> &journey,
-        time_duration work, int trips, int haulage )
-{
-    int one_way = 0;
-    for( const tripoint_abs_omt &om : journey ) {
-        const oter_id &omt_ref = overmap_buffer.ter( om );
-        std::string om_id = omt_ref.id().c_str();
-        // Player walks 1 om in roughly 30 seconds
-        if( om_id == "field" ) {
-            one_way += 30 + ( 30 + haulage );
-        } else if( omt_ref->get_type_id() == oter_type_forest_trail ) {
-            one_way += 35 + ( 30 + haulage );
-        } else if( om_id == "forest_thick" ) {
-            one_way += 50 + ( 30 + haulage );
-        } else if( om_id == "forest_water" ) {
-            one_way += 60 + ( 30 + haulage );
-        } else if( is_river( omt_ref ) ) {
-            // hauling stuff over a river is slow, because you have to portage most items
-            one_way += 200 + ( 40 + haulage );
-        } else {
-            one_way += 40 + ( 30 + haulage );
-        }
-    }
-    return work + one_way * trips * 1_seconds;
-}
-
-int om_carry_weight_to_trips( const units::mass &mass, const units::volume &volume,
+int om_carry_weight_to_trips( const units::mass &total_mass, const units::volume &total_volume,
                               const units::mass &carry_mass, const units::volume &carry_volume )
 {
-    int trips_m = 1 + mass / carry_mass;
-    int trips_v = 1 + volume / carry_volume;
-    // return the number of round trips
+    // FIXME handle single high volume items correctly
+    // character can wield up to weight capacity x4, and walk at reduced speed with that single item
+    // hauling may be appropriate
+    int trips_m = ( total_mass + carry_mass - 1_milligram ) / carry_mass;
+    int trips_v = ( total_volume + carry_volume - 1_ml ) / carry_volume;
+    // return based on round trips
     return 2 * std::max( trips_m, trips_v );
 }
 
@@ -5275,27 +5321,51 @@ int om_carry_weight_to_trips( const units::mass &total_mass, const units::volume
     return om_carry_weight_to_trips( total_mass, total_volume, max_m, max_v );
 }
 
-std::vector<tripoint_abs_omt> om_companion_path( const tripoint_abs_omt &start, int range_start,
+pf::simple_path<tripoint_abs_omt> om_companion_path( const tripoint_abs_omt &start, int range_start,
         bool bounce )
 {
-    std::vector<tripoint_abs_omt> scout_points;
+    std::vector<pf::simple_path<tripoint_abs_omt>> scout_segments;
     tripoint_abs_omt last = start;
     int range = range_start;
     int def_range = range_start;
-    while( range > 3 ) {
+    while( true ) {
+        std::optional<std::string> message;
+        if( range == 0 ) {
+            message = _( "Confirm again to finalize the path, or cancel to undo." );
+        }
         tripoint_abs_omt spt = om_target_tile( last, 0, range, {}, ot_match_type::exact, false, last,
-                                               false );
+                                               false, message );
         if( spt == overmap::invalid_tripoint ) {
-            scout_points.clear();
-            return scout_points;
+            if( scout_segments.empty() ) {
+                return {};
+            }
+            om_path_mark( scout_segments.back().points, false );
+            range += scout_segments.back().cost / 24;
+            scout_segments.pop_back();
+            if( scout_segments.empty() ) {
+                last = start;
+            } else {
+                last = scout_segments.back().points.front();
+            }
+            continue;
         }
         if( last == spt ) {
             break;
         }
-        std::vector<tripoint_abs_omt> note_pts = line_to( last, spt );
-        scout_points.insert( scout_points.end(), note_pts.begin(), note_pts.end() );
-        om_line_mark( last, spt );
-        range -= rl_dist( spt.xy(), last.xy() );
+        const pf::simple_path<tripoint_abs_omt> &note_pts = overmap_buffer.get_travel_path( last, spt,
+                overmap_path_params::for_npc() );
+        if( note_pts.points.empty() ) {
+            debugmsg( "Got empty travel path during mission planning." );
+            continue;
+        }
+        om_path_mark( note_pts.points );
+        if( note_pts.cost / 24 > range ) {
+            ui::omap::choose_point( _( "This path is too far, continue to undo and try again." ), spt );
+            om_path_mark( note_pts.points, false );
+            continue;
+        }
+        scout_segments.emplace_back( note_pts );
+        range -= note_pts.cost / 24;
         last = spt;
 
         const oter_id &omt_ref = overmap_buffer.ter( last );
@@ -5305,10 +5375,18 @@ std::vector<tripoint_abs_omt> om_companion_path( const tripoint_abs_omt &start, 
             def_range = range;
         }
     }
-    for( tripoint_abs_omt &pt : scout_points ) {
-        om_line_mark( pt, pt, false );
+    for( const pf::simple_path<tripoint_abs_omt> &scout_segment : scout_segments ) {
+        om_path_mark( scout_segment.points, false );
     }
-    return scout_points;
+    return std::accumulate( scout_segments.begin(), scout_segments.end(),
+                            pf::simple_path<tripoint_abs_omt>(), []( pf::simple_path<tripoint_abs_omt> a,
+    const pf::simple_path<tripoint_abs_omt> &b ) {
+        a.points.insert( a.points.begin(), b.points.begin(), b.points.end() );
+        a.dist += b.dist;
+        a.cost += b.cost;
+        return a;
+    }
+                          );
 }
 
 // camp utility functions
@@ -5475,19 +5553,18 @@ point talk_function::om_simple_dir( const tripoint_abs_omt &omt_pos,
 // mission descriptions
 std::string camp_trip_description( const time_duration &total_time,
                                    const time_duration &working_time,
-                                   const time_duration &travel_time, int distance, int trips,
+                                   const time_duration &travel_time, int dist_m, int trips,
                                    int need_food )
 {
     std::string entry = "\n";
-    //A square is roughly 3 m
-    int dist_m = distance * SEEX * 2 * 3;
+    //A square is roughly 1 m
     if( dist_m > 1000 ) {
         entry += string_format( _( ">Distance:%15.2f (km)\n" ), dist_m / 1000.0 );
-        entry += string_format( _( ">One Way: %15d (trips)\n" ), trips );
+        entry += string_format( _( ">One Way: %15d trips\n" ), trips );
         entry += string_format( _( ">Covered: %15.2f (km)\n" ), dist_m / 1000.0 * trips );
     } else {
         entry += string_format( _( ">Distance:%15d (m)\n" ), dist_m );
-        entry += string_format( _( ">One Way: %15d (trips)\n" ), trips );
+        entry += string_format( _( ">One Way: %15d trips\n" ), trips );
         entry += string_format( _( ">Covered: %15d (m)\n" ), dist_m * trips );
     }
     entry += string_format( _( ">Travel:  %s\n" ), right_justify( to_string( travel_time ), 23 ) );
@@ -5700,9 +5777,10 @@ nutrients basecamp::camp_food_supply( int change )
     return camp_food_supply( added );
 }
 
-nutrients basecamp::camp_food_supply( time_duration work, float exertion_level )
+nutrients basecamp::camp_food_supply( const time_duration &total_time, float exertion_level,
+                                      const time_duration &travel_time )
 {
-    return camp_food_supply( -time_to_food( work, exertion_level ) );
+    return camp_food_supply( -time_to_food( total_time, exertion_level, travel_time ) );
 }
 
 void basecamp::feed_workers( const std::vector<std::reference_wrapper <Character>> &workers,
@@ -5785,13 +5863,20 @@ void basecamp::feed_workers( Character &worker, nutrients food, bool is_player_m
     feed_workers( work_party, std::move( food ), is_player_meal );
 }
 
-int basecamp::time_to_food( time_duration work, float exertion_level ) const
+int basecamp::time_to_food( time_duration total_time, float work_exertion_level,
+                            time_duration travel_time ) const
 {
-    const int days = to_hours<int>( work ) / 24;
-    const int work_time = days * work_day_hours + to_hours<int>( work ) - days * 24;
+    // logic here reverses base_camps::to_workdays
+    const int days = to_days<int>( total_time );
+    const time_duration work_and_travel_time = days * work_day_hours * 1_hours + total_time - days *
+            24_hours;
+    const time_duration work_time = work_and_travel_time - travel_time;
 
-    return base_metabolic_rate * ( work_time * exertion_level + days * work_day_rest_hours * NO_EXERCISE
-                                   + days * work_day_idle_hours * SLEEP_EXERCISE ) / 24;
+    float effective_hours = work_time * work_exertion_level / 1_hours +
+                            travel_time * MODERATE_EXERCISE / 1_hours +
+                            days * work_day_rest_hours * NO_EXERCISE +
+                            days * work_day_idle_hours * SLEEP_EXERCISE ;
+    return base_metabolic_rate * effective_hours / 24;
 }
 
 item basecamp::make_fake_food( const nutrients &to_use ) const

--- a/src/line.h
+++ b/src/line.h
@@ -151,8 +151,10 @@ tripoint move_along_line( const tripoint &loc, const std::vector<tripoint> &line
                           int distance );
 tripoint_bub_ms move_along_line( const tripoint_bub_ms &loc,
                                  const std::vector<tripoint_bub_ms> &line, int distance );
+// line from p1 to p2, including p2 but not p1, using Bresenham's algorithm
 // The "t" value decides WHICH Bresenham line is used.
 std::vector<point> line_to( const point &p1, const point &p2, int t = 0 );
+// line from p1 to p2, including p2 but not p1, using Bresenham's algorithm
 // t and t2 decide which Bresenham line is used.
 std::vector<tripoint> line_to( const tripoint &loc1, const tripoint &loc2, int t = 0, int t2 = 0 );
 // sqrt(dX^2 + dY^2)

--- a/src/npc.h
+++ b/src/npc.h
@@ -1374,16 +1374,23 @@ class npc : public Character
 
         std::vector<tripoint_bub_ms> path; // Our movement plans
 
-        // Personality & other defining characteristics
-        std::string companion_mission_role_id; //Set mission source or squad leader for a patrol
+        //Set mission source or squad leader for a patrol
+        std::string companion_mission_role_id;
         //Mission leader use to determine item sorting, patrols use for points
         std::vector<tripoint_abs_omt> companion_mission_points;
-        time_point companion_mission_time; //When you left for ongoing/repeating missions
-        time_point
-        companion_mission_time_ret; //When you are expected to return for calculated/variable mission returns
-        inventory companion_mission_inv; //Inventory that is added and dropped on mission
+        //When you left for ongoing/repeating missions
+        time_point companion_mission_time;
+        //When you are expected to return for calculated/variable mission returns
+        time_point companion_mission_time_ret;
+        //Work exertion level of current mission
+        float companion_mission_exertion = 1.0f;
+        //Travel time for the current mission
+        time_duration companion_mission_travel_time = 0_hours;
+        //Inventory that is added and dropped on mission
+        inventory companion_mission_inv;
         npc_mission mission = NPC_MISSION_NULL;
         npc_mission previous_mission = NPC_MISSION_NULL;
+        // Personality & other defining characteristics
         npc_personality personality;
         npc_opinion op_of_u;
         npc_combat_memory_cache mem_combat;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4890,7 +4890,8 @@ void npc::set_omt_destination()
         }
         omt_path.clear();
         if( goal != overmap::invalid_tripoint ) {
-            omt_path = overmap_buffer.get_travel_path( surface_omt_loc, goal, overmap_path_params::for_npc() );
+            omt_path = overmap_buffer.get_travel_path( surface_omt_loc, goal,
+                       overmap_path_params::for_npc() ).points;
         }
         if( !omt_path.empty() ) {
             dest_type = overmap_buffer.ter( goal )->get_type_id().str();
@@ -4901,11 +4902,13 @@ void npc::set_omt_destination()
     // couldn't find any places to go, so go somewhere.
     if( goal == overmap::invalid_tripoint || omt_path.empty() ) {
         goal = surface_omt_loc + point( rng( -90, 90 ), rng( -90, 90 ) );
-        omt_path = overmap_buffer.get_travel_path( surface_omt_loc, goal, overmap_path_params::for_npc() );
+        omt_path = overmap_buffer.get_travel_path( surface_omt_loc, goal,
+                   overmap_path_params::for_npc() ).points;
         // try one more time
         if( omt_path.empty() ) {
             goal = surface_omt_loc + point( rng( -90, 90 ), rng( -90, 90 ) );
-            omt_path = overmap_buffer.get_travel_path( surface_omt_loc, goal, overmap_path_params::for_npc() );
+            omt_path = overmap_buffer.get_travel_path( surface_omt_loc, goal,
+                       overmap_path_params::for_npc() ).points;
         }
         if( omt_path.empty() ) {
             goal = no_goal_point;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4509,7 +4509,7 @@ talk_effect_fun_t::func f_npc_goal( const JsonObject &jo, std::string_view membe
             tripoint_abs_omt destination = mission_util::get_om_terrain_pos( dest_params, d );
             guy->goal = destination;
             guy->omt_path = overmap_buffer.get_travel_path( guy->global_omt_location(), guy->goal,
-                            overmap_path_params::for_npc() );
+                            overmap_path_params::for_npc() ).points;
             if( destination == tripoint_abs_omt() || destination == overmap::invalid_tripoint ||
                 guy->omt_path.empty() ) {
                 guy->goal = npc::no_goal_point;

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -403,7 +403,7 @@ void talk_function::goto_location( npc &p )
     }
     p.goal = destination;
     p.omt_path = overmap_buffer.get_travel_path( p.global_omt_location(), p.goal,
-                 overmap_path_params::for_npc() );
+                 overmap_path_params::for_npc() ).points;
     if( destination == tripoint_abs_omt() || destination == overmap::invalid_tripoint ||
         p.omt_path.empty() ) {
         p.goal = npc::no_goal_point;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1794,7 +1794,7 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
     if( dest == player_omt_pos || dest == start_omt_pos ) {
         return {};
     } else {
-        return overmap_buffer.get_travel_path( start_omt_pos, dest, params );
+        return overmap_buffer.get_travel_path( start_omt_pos, dest, params ).points;
     }
 }
 

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -20,6 +20,7 @@
 #include "memory_fast.h"
 #include "omdata.h"
 #include "overmap_types.h"
+#include "simple_pathfinding.h"
 #include "type_id.h"
 
 class basecamp;
@@ -361,7 +362,7 @@ class overmapbuffer
         bool reveal( const tripoint_abs_omt &center, int radius );
         bool reveal( const tripoint_abs_omt &center, int radius,
                      const std::function<bool( const oter_id & )> &filter );
-        std::vector<tripoint_abs_omt> get_travel_path(
+        pf::simple_path<tripoint_abs_omt> get_travel_path(
             const tripoint_abs_omt &src, const tripoint_abs_omt &dest, const overmap_path_params &params );
         bool reveal_route( const tripoint_abs_omt &source, const tripoint_abs_omt &dest,
                            int radius = 0, bool road_only = false );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1838,6 +1838,8 @@ void npc::import_and_clean( const JsonObject &data )
     companion_mission_points = defaults.companion_mission_points;
     companion_mission_time = defaults.companion_mission_time;
     companion_mission_time_ret = defaults.companion_mission_time_ret;
+    companion_mission_exertion = defaults.companion_mission_exertion;
+    companion_mission_travel_time = defaults.companion_mission_travel_time;
     companion_mission_inv.clear();
     chatbin.missions.clear();
     chatbin.missions_assigned.clear();

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2057,6 +2057,8 @@ void npc::load( const JsonObject &data )
     std::string companion_mission_role;
     time_point companion_mission_t = calendar::turn_zero;
     time_point companion_mission_t_r = calendar::turn_zero;
+    float companion_mission_e = 1.0f;
+    time_duration companion_mission_t_t;
     std::string act_id;
 
     data.read( "marked_for_death", marked_for_death );
@@ -2173,6 +2175,14 @@ void npc::load( const JsonObject &data )
         companion_mission_time_ret = companion_mission_t_r;
     }
 
+    if( data.read( "companion_mission_exertion", companion_mission_e ) ) {
+        companion_mission_exertion = companion_mission_e;
+    }
+
+    if( data.read( "comp_mission_travel_time", companion_mission_t_t ) ) {
+        companion_mission_travel_time = companion_mission_t_t;
+    }
+
     companion_mission_inv.clear();
     if( data.has_member( "companion_mission_inv" ) ) {
         companion_mission_inv.json_load_items( data.get_member( "companion_mission_inv" ) );
@@ -2264,6 +2274,8 @@ void npc::store( JsonOut &json ) const
     json.member( "companion_mission_points", companion_mission_points );
     json.member( "companion_mission_time", companion_mission_time );
     json.member( "companion_mission_time_ret", companion_mission_time_ret );
+    json.member( "companion_mission_exertion", companion_mission_exertion );
+    json.member( "companion_mission_travel_time", companion_mission_travel_time );
     json.member( "companion_mission_inv" );
     companion_mission_inv.json_save_items( json );
     json.member( "restock", restock );

--- a/src/simple_pathfinding.h
+++ b/src/simple_pathfinding.h
@@ -43,7 +43,12 @@ struct directed_path {
  */
 template<typename Point>
 struct simple_path {
+    //points along the path, typically starting with the last point of the path
     std::vector<Point> points;
+    //total distance of the path, possibly measured in tiles/meters depending on the pathing operation
+    int dist;
+    //total cost of the path, possibly measured in seconds depending on the scoring function
+    int cost;
 };
 
 // Data structure returned by a node scoring function.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Rework faction camp mission travel calculations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Faction mission travel is broken in many ways. Distances are wrong. Travel times don't make sense. Food consumption isn't consistent. There are numerous irritating prompts and back-to-the-start interface quirks.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Here are the functional changes in this PR.
* Game mechanical changes
  * Missions use pathfinding instead of straight lines for NPC travel.
    * NPC paths across water are now forbidden, and the swim skill checks are commented out until that's resolved.
  * Food cost calculation functions for missions take an extra optional "travel time" parameter and use MODERATE_EXERCISE for that time, instead of assuming that the time spent traveling uses the same exertion level specified for the work part of the mission.
  * Exertion level and travel time are remembered for non-fixed-time missions. Extra time is assumed to be work time, not travel time. Extra time uses the work time exertion level, previously this was a constant minimal exertion level.
  * `companion_travel_time_calc` no longer includes work time or any handling of "haulage". NPCs are just going to make multiple round trips to carry extra stuff. There are a few edge cases where hauling would make more sense, like small numbers of large items (maybe logs, definitely fridges), but I'm not planning to tackle that right now.
  * Wood cutting haul estimation uses weight and volume of logs and sticks, not previous much more rough approximation.
  * Hide sites are now allowed on all the terrain where logging can happen instead of just a few forest types, as well as swamp and field as before.
  * Fortifications are now allowed in all terrain where logging can happen instead of just a few forest types, as well as field as before.
  * Digging trenches no longer requires traveling back to base after each tile. Spiking trenches still does.
  * Combat Patrol and Scouting Mission now make a single trip instead of a round trip if the path you select is a loop back to the starting point.
  * Combat/Scouting mission paths can now be set to the full range, not ending early when reaching range-3.
* Content changes
  * Updated some message wording and mission descriptions.
* Code structure changes
  * Most of the companion pathfinding functions now pass around a `pf::simple_path<tripoint_abs_omt>`, which contains the total traveled distance and the total pathfinder cost for the path in addition to the `vector<tripoint_abs_omt>` that was passed previously.
  * Some path selection and calculation overloads were eliminated when they became unused after all call sites were updated to use the pathfinder functionality.
  * Pathfinder costs have been adjusted mostly proportionally so that they measure seconds of travel (assuming auto drive speed for cars, planes, and boats), with weights and times kept mostly in line with the previous costs and npc mission travel times.
  * Various new and updated comments on and in the relevant and related functions.
* Interface changes
  * New `om_path_mark()` adds/removes map notes along a pathfinder path, similar to the old `om_line_mark()`.
  * `om_companion_path` now allows undoing selections. You have to press escape multiple times to undo then exit to cancel.
* Bug fixes
  * Fixed some bugs in the calculation of pathfinder cost around the start and end of a path.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I went through multiple variations of half of the changes here. I did not keep a list of what they were and why I switched away from them. I could probably work to remember it for any particular change if asked.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I've been playing with this since before I created the PR. I expect a few automated tests are in order as well, but I'm not sure where to start on that.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
This PR is shrinking as smaller PRs get split off from it, 8 so far. I've run out of low hanging fruit. I'll make another round of merge-conflict-heavy PRs if this is still too busy.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
