### PR TITLE
Forbid drinking liquids underwater for characters with `Aqueous Repose` and `Embrace of the Waters` mutations, as it stated in mutations' descriptions

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -834,8 +834,9 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
 
     // TODO: This condition occurs way too often. Unify it.
     // update Sep. 26 2018: this apparently still occurs way too often. yay!
-    if( is_underwater() && ( !has_trait( trait_WATERSLEEP ) ||
-                             has_trait( trait_UNDINE_SLEEP_WATER ) ) ) {
+    if( is_underwater() &&
+        ( ( !has_trait( trait_WATERSLEEP ) && !has_trait( trait_UNDINE_SLEEP_WATER ) ) ||
+          ( ( has_trait( trait_WATERSLEEP ) || has_trait( trait_UNDINE_SLEEP_WATER ) ) && drinkable ) ) ) {
         return ret_val<edible_rating>::make_failure( _( "You can't do that while underwater." ) );
     }
 

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -126,6 +126,7 @@ static const trait_id trait_INFRESIST( "INFRESIST" );
 static const trait_id trait_M_IMMUNE( "M_IMMUNE" );
 static const trait_id trait_M_SKIN3( "M_SKIN3" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
+static const trait_id trait_UNDINE_SLEEP_WATER( "UNDINE_SLEEP_WATER" );
 static const trait_id trait_WATERSLEEP( "WATERSLEEP" );
 
 static const vitamin_id vitamin_blood( "blood" );
@@ -1090,7 +1091,7 @@ static void eff_fun_sleep( Character &u, effect &it )
                 }
             }
         }
-        if( u.has_trait( trait_WATERSLEEP ) ) {
+        if( u.has_trait( trait_WATERSLEEP ) || u.has_trait( trait_UNDINE_SLEEP_WATER ) ) {
             u.mod_sleepiness( -3 ); // Fish sleep less in water
         }
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Forbid drinking liquids underwater for characters with `Aqueous Repose` and `Embrace of the Waters` mutations, as it stated in mutations' descriptions"

#### Purpose of change
* Closes #53733.

#### Describe the solution
- Reworked check for eating/drinking underwater. The logic now is this: 
- - If underwater AND [ doesn't have "watersleep" mutations OR ( have "watersleep" mutations, but comestible is a liquid ) ], then forbid consuming.
- Also, while I'm here, I added the forgotten check for `Embrace of the Waters` mutation in `eff_fun_sleep` function.

#### Describe alternatives you've considered
None.

#### Testing
Normal characters (no "watersleep" mutations): can eat and drink on the shore. Can't eat or drink underwater.
Characters with "watersleep" mutations: can eat and drink on the shore. Can eat underwater. Can't drink underwater.

#### Additional context
None.