### PR TITLE
Mutations can have a custom activation message

### DIFF
--- a/doc/MUTATIONS.md
+++ b/doc/MUTATIONS.md
@@ -173,6 +173,7 @@ Note that **all new traits that can be obtained through mutation must be purifia
     }
   ],
   "active": true,                             // When set the mutation is an active mutation that the player needs to activate (default: false).
+  "activation_msg": "Time to rock and roll",  // Optional, default "You activate your %s." where %s is replaced with the mutation's name.
   "starts_active": true,                      // When true, this 'active' mutation starts active (default: false, requires 'active').
   "cost": 8,                                  // Cost to activate this mutation.  Needs one of the hunger, thirst, or sleepiness values set to true (default: 0).
   "time": 100,                                // Sets the amount of (turns * current player speed ) time units that need to pass before the cost is to be paid again.  Needs to be higher than one to have any effect (default: 0).

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -199,6 +199,7 @@ struct mutation_branch {
         bool mixed_effect  = false;
         bool startingtrait = false;
         bool activated     = false;
+        translation activation_msg;
         // Should it activate as soon as it is gained?
         bool starts_active = false;
         // Should it destroy gear on restricted body parts? (otherwise just pushes it off)

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -399,6 +399,8 @@ void mutation_branch::load( const JsonObject &jo, const std::string_view src )
     optional( jo, was_loaded, "can_only_eat", can_only_eat );
     optional( jo, was_loaded, "can_only_heal_with", can_only_heal_with );
     optional( jo, was_loaded, "can_heal_with", can_heal_with );
+    optional( jo, was_loaded, "activation_msg", activation_msg,
+              to_translation( "You activate your %s." ) );
 
     optional( jo, was_loaded, "butchering_quality", butchering_quality, 0 );
 

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -441,7 +441,8 @@ void avatar::power_mutations()
                                        ( !mut_data.thirst || get_thirst() <= 400 ) &&
                                        ( !mut_data.sleepiness || get_sleepiness() <= 400 ) &&
                                        ( !mut_data.mana || magic->available_mana() >= mut_data.cost ) ) {
-                                add_msg_if_player( m_neutral, _( "You activate your %s." ), mutation_name( mut_data.id ) );
+                                add_msg_if_player( m_neutral,
+                                                   string_format( mut_data.activation_msg, mutation_name( mut_data.id ) ) );
                                 // Reset menu in advance
                                 ui.reset();
                                 activate_mutation( mut_id );
@@ -615,7 +616,8 @@ void avatar::power_mutations()
                                            ( !mut_data.thirst || get_thirst() <= 400 ) &&
                                            ( !mut_data.sleepiness || get_sleepiness() <= 400 ) &&
                                            ( !mut_data.mana || magic->available_mana() >= mut_data.cost ) ) {
-                                    add_msg_if_player( m_neutral, _( "You activate your %s." ), mutation_name( mut_data.id ) );
+                                    add_msg_if_player( m_neutral,
+                                                       string_format( mut_data.activation_msg, mutation_name( mut_data.id ) ) );
                                     // Reset menu in advance
                                     ui.reset();
                                     activate_mutation( mut_id );


### PR DESCRIPTION
#### Summary
Features "Mutations can have a custom activation message"

#### Purpose of change
Requested by @Standing-Storm and @RedMisao

Seemed like a reasonable thing to add.

#### Describe the solution
Move the previous hardcoded message "You activate your %s." to become the new default

Load user-defined messages if they exist, otherwise fallback to the default

Dispense translations as needed

#### Describe alternatives you've considered
Removing the activation message entirely and just letting people use activation_eocs?

#### Testing


https://github.com/user-attachments/assets/9865ca21-51c9-4da2-ac54-b8a4a1a64b3c



#### Additional context
