### PR TITLE
Feral Agent fix and loot update

### DIFF
--- a/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
+++ b/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
@@ -396,9 +396,12 @@
     "magazine": 100,
     "ammo": 20,
     "entries": [
-    {
-      "distribution": [ { "item": "fn57_sup", "prob": 100, "damage": [ 2, 4 ] }, { "item": "fn57", "variant": "fn57", "prob": 100, "damage": [ 2, 4 ] } ]
-    },
+      {
+        "distribution": [
+          { "item": "fn57_sup", "prob": 100, "damage": [ 2, 4 ] },
+          { "item": "fn57", "variant": "fn57", "prob": 100, "damage": [ 2, 4 ] }
+        ]
+      },
       { "group": "security_armor", "prob": 30, "damage": [ 0, 2 ] },
       { "group": "security_gear", "prob": 50, "damage": [ 0, 2 ] },
       { "group": "cop_gloves", "prob": 30, "damage": [ 1, 4 ] },

--- a/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
+++ b/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
@@ -396,7 +396,9 @@
     "magazine": 100,
     "ammo": 20,
     "entries": [
-      { "item": "feral_57", "prob": 100, "damage": [ 2, 4 ] },
+    {
+      "distribution": [ { "item": "fn57_sup", "prob": 100, "damage": [ 2, 4 ] }, { "item": "fn57", "variant": "fn57", "prob": 100, "damage": [ 2, 4 ] } ]
+    },
       { "group": "security_armor", "prob": 30, "damage": [ 0, 2 ] },
       { "group": "security_gear", "prob": 50, "damage": [ 0, 2 ] },
       { "group": "cop_gloves", "prob": 30, "damage": [ 1, 4 ] },


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

This is to fix the previously unintended drops of the Monster only Feral_57 weapon with the originally intended normal FN style guns. To test the original flawed loot drop simply kill any Deranged Zebra Agent, it will drop a weapon with over 4000 dispersion not meant for players.

#### Describe the solution

This change simply replaces the Feral_57 with the fn57 and fn57_sup, the intended loot drops from the monster and adds a 50/50 chance of either weapon spawning. 

#### Describe alternatives you've considered

None.

#### Testing

I have tested using the debug menu in game with the 100 loot drop test, it has worked consistently. I have also manually debug spawned Deranged Feral Agents and checked their loot directly and it still worked.

#### Additional context

I could not have finished this fix without the help of GettingUsedTo who helped simplify and correct my own messy and non working code.



