### PR TITLE
[Xedra Evolve] Add Ruach counter to sidebars

### DIFF
--- a/data/mods/Xedra_Evolved/ui/ruach_counter.json
+++ b/data/mods/Xedra_Evolved/ui/ruach_counter.json
@@ -1,15 +1,15 @@
 [
-   {
+  {
     "id": "spacebar_ruach_counter_block",
     "type": "widget",
     "style": "layout",
     "label": "Ruach",
     "arrange": "minimum_columns",
     "width": 58,
-    "widgets": [ "spacebar_separator_2", "spacebar_ruach_counter_meter" ]
+    "widgets": [ "spacebar_separator_2", "ruach_counter_meter" ]
   },
   {
-    "id": "spacebar_nether_attunement_meter",
+    "id": "ruach_counter_meter",
     "type": "widget",
     "style": "text",
     "label": "Ruach",
@@ -33,7 +33,7 @@
           ]
         }
       },
-     {
+      {
         "id": "ruach_level_2",
         "text": "<color_light_red>Drained</color>",
         "condition": {
@@ -61,8 +61,8 @@
         "condition": {
           "and": [
             { "u_has_trait": "LILIN_TRAITS" },
-            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "1200" ] },
-            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "2401" ] }
+            { "math": [ "u_vitamin('lilin_ruach_vitamin')", ">=", "1200" ] },
+            { "math": [ "u_vitamin('lilin_ruach_vitamin')", "<", "2401" ] }
           ]
         }
       },
@@ -72,7 +72,8 @@
         "condition": {
           "and": [
             { "u_has_trait": "LILIN_TRAITS" },
-            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "2400" ] }
+            { "u_has_trait": "LILIN_HOLD_MORE_RUACH" },
+            { "math": [ "u_vitamin('lilin_ruach_vitamin')", ">=", "2400" ] }
           ]
         }
       }

--- a/data/mods/Xedra_Evolved/ui/ruach_counter.json
+++ b/data/mods/Xedra_Evolved/ui/ruach_counter.json
@@ -1,0 +1,82 @@
+[
+   {
+    "id": "spacebar_ruach_counter_block",
+    "type": "widget",
+    "style": "layout",
+    "label": "Ruach",
+    "arrange": "minimum_columns",
+    "width": 58,
+    "widgets": [ "spacebar_separator_2", "spacebar_ruach_counter_meter" ]
+  },
+  {
+    "id": "spacebar_nether_attunement_meter",
+    "type": "widget",
+    "style": "text",
+    "label": "Ruach",
+    "flags": [ "W_DISABLED_WHEN_EMPTY" ],
+    "width": 56,
+    "clauses": [
+      {
+        "id": "out_of_ruach",
+        "text": "Starving",
+        "color": "c_pink",
+        "condition": { "and": [ { "u_has_trait": "LILIN_TRAITS" }, { "math": [ "u_vitamin('lilin_ruach_vitamin')", "==", "0" ] } ] }
+      },
+      {
+        "id": "ruach_level_1",
+        "text": "<color_red>Almost Spent</color>",
+        "condition": {
+          "and": [
+            { "u_has_trait": "LILIN_TRAITS" },
+            { "math": [ "u_vitamin('lilin_ruach_vitamin')", ">=", "1" ] },
+            { "math": [ "u_vitamin('lilin_ruach_vitamin')", "<", "241" ] }
+          ]
+        }
+      },
+     {
+        "id": "ruach_level_2",
+        "text": "<color_light_red>Drained</color>",
+        "condition": {
+          "and": [
+            { "u_has_trait": "LILIN_TRAITS" },
+            { "math": [ "u_vitamin('lilin_ruach_vitamin')", ">=", "241" ] },
+            { "math": [ "u_vitamin('lilin_ruach_vitamin')", "<", "481" ] }
+          ]
+        }
+      },
+      {
+        "id": "ruach_level_3",
+        "text": "<color_yellow>Refreshed</color>",
+        "condition": {
+          "and": [
+            { "u_has_trait": "LILIN_TRAITS" },
+            { "math": [ "u_vitamin('lilin_ruach_vitamin')", ">=", "480" ] },
+            { "math": [ "u_vitamin('lilin_ruach_vitamin')", "<", "1201" ] }
+          ]
+        }
+      },
+      {
+        "id": "ruach_level_4",
+        "text": "<color_light_green>Satiated</color>",
+        "condition": {
+          "and": [
+            { "u_has_trait": "LILIN_TRAITS" },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "1200" ] },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", "<", "2401" ] }
+          ]
+        }
+      },
+      {
+        "id": "ruach_level_5",
+        "text": "<color_green>Suffused</color>",
+        "condition": {
+          "and": [
+            { "u_has_trait": "LILIN_TRAITS" },
+            { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "2400" ] }
+          ]
+        }
+      }
+    ],
+    "padding": 0
+  }
+]

--- a/data/mods/Xedra_Evolved/ui/sidebar.json
+++ b/data/mods/Xedra_Evolved/ui/sidebar.json
@@ -191,7 +191,7 @@
     "copy-from": "spacebar",
     "type": "widget",
     "id": "spacebar",
-    "extend": { "widgets": [ "xe_spacebar_mana_numbers_block", "xe_spacebar_mana_bar_block", "vampire_blood_levels" ] }
+    "extend": { "widgets": [ "xe_spacebar_mana_numbers_block", "xe_spacebar_mana_bar_block", "vampire_blood_levels", "spacebar_ruach_counter_block" ] }
   },
   {
     "//": "Extend the custom sidebar with Xedra-specific sections",

--- a/data/mods/Xedra_Evolved/ui/sidebar.json
+++ b/data/mods/Xedra_Evolved/ui/sidebar.json
@@ -74,7 +74,13 @@
     "type": "widget",
     "id": "legacy_classic_sidebar",
     "extend": {
-      "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout", "vampire_blood_levels" ]
+      "widgets": [
+        "xe_current_max_mana_nums_layout",
+        "xe_mana_graph_layout",
+        "xe_mana_pool_layout",
+        "vampire_blood_levels",
+        "ruach_counter_meter"
+      ]
     }
   },
   {
@@ -83,7 +89,13 @@
     "type": "widget",
     "id": "legacy_compact_sidebar",
     "extend": {
-      "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout", "vampire_blood_levels" ]
+      "widgets": [
+        "xe_current_max_mana_nums_layout",
+        "xe_mana_graph_layout",
+        "xe_mana_pool_layout",
+        "vampire_blood_levels",
+        "ruach_counter_meter"
+      ]
     }
   },
   {
@@ -92,7 +104,13 @@
     "type": "widget",
     "id": "legacy_labels_narrow_sidebar",
     "extend": {
-      "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout", "vampire_blood_levels" ]
+      "widgets": [
+        "xe_current_max_mana_nums_layout",
+        "xe_mana_graph_layout",
+        "xe_mana_pool_layout",
+        "vampire_blood_levels",
+        "ruach_counter_meter"
+      ]
     }
   },
   {
@@ -101,7 +119,13 @@
     "type": "widget",
     "id": "legacy_labels_sidebar",
     "extend": {
-      "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout", "vampire_blood_levels" ]
+      "widgets": [
+        "xe_current_max_mana_nums_layout",
+        "xe_mana_graph_layout",
+        "xe_mana_pool_layout",
+        "vampire_blood_levels",
+        "ruach_counter_meter"
+      ]
     }
   },
   {
@@ -110,7 +134,13 @@
     "type": "widget",
     "id": "structured_sidebar",
     "extend": {
-      "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout", "vampire_blood_levels" ]
+      "widgets": [
+        "xe_current_max_mana_nums_layout",
+        "xe_mana_graph_layout",
+        "xe_mana_pool_layout",
+        "vampire_blood_levels",
+        "ruach_counter_meter"
+      ]
     }
   },
   {
@@ -191,7 +221,14 @@
     "copy-from": "spacebar",
     "type": "widget",
     "id": "spacebar",
-    "extend": { "widgets": [ "xe_spacebar_mana_numbers_block", "xe_spacebar_mana_bar_block", "vampire_blood_levels", "spacebar_ruach_counter_block" ] }
+    "extend": {
+      "widgets": [
+        "xe_spacebar_mana_numbers_block",
+        "xe_spacebar_mana_bar_block",
+        "vampire_blood_levels",
+        "spacebar_ruach_counter_block"
+      ]
+    }
   },
   {
     "//": "Extend the custom sidebar with Xedra-specific sections",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolve] Add Ruach counter to sidebars"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Vampires have a blood counter, lilin need a ruach counter.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a ruach counter to the sidebar if you're playing a lilit. It's modeled off the vampire blood levels where it's a text description of various levels rather than telling you your exact amount. Starving (none), Almost Spent (one day's worth), Drained (a few days' worth), and so on. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Sidebar appears: 
![Untitled2](https://github.com/user-attachments/assets/d73051bc-41fa-4d9f-ad84-aa5b1ef07ade)

(I did say it wasn't very exciting)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
