### PR TITLE
Armor order refactoring

### DIFF
--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -133,9 +133,9 @@
         "text": "Could you make me a weapon?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_artisans_gunsmith_mentioned_quest", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" } },
-            { "u_has_var": "dialogue_artisans_blacksmith_heard_the_deal", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_mentioned_quest" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_heard_the_deal" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_NOT_INTERESTED_FABRICATE"
@@ -144,11 +144,10 @@
         "text": "Could you make me a weapon?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] } },
             {
               "//": "this variable means that you have completed quest 1 for Cody and shown Jay",
-              "u_has_var": "dialogue_artisans_gunsmith_mentioned_quest",
-              "value": "yes"
+              "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_mentioned_quest" } ]
             }
           ]
         },
@@ -158,68 +157,6 @@
         "text": "How is my armor coming?",
         "condition": {
           "and": [
-            { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", "<", "time('21 d')" ] },
-            { "math": [ "u_number_artisans_blacksmith_wait", "==", "3" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
-            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
-          ]
-        },
-        "topic": "TALK_BLACKSMITH_ARMOR_NOT_READY"
-      },
-      {
-        "text": "How is my armor coming?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", ">=", "time('21 d')" ] },
-            { "math": [ "u_number_artisans_blacksmith_wait", "==", "3" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
-            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
-          ]
-        },
-        "topic": "TALK_BLACKSMITH_ARMOR_READY"
-      },
-      {
-        "text": "How is my armor coming?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", "<", "time('28 d')" ] },
-            { "math": [ "u_number_artisans_blacksmith_wait", "==", "4" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
-            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
-          ]
-        },
-        "topic": "TALK_BLACKSMITH_ARMOR_NOT_READY"
-      },
-      {
-        "text": "How is my armor coming?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", ">=", "time('28 d')" ] },
-            { "math": [ "u_number_artisans_blacksmith_wait", "==", "4" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
-            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
-          ]
-        },
-        "topic": "TALK_BLACKSMITH_ARMOR_READY"
-      },
-      {
-        "text": "How is my armor coming?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", "<", "time('35 d')" ] },
-            { "math": [ "u_number_artisans_blacksmith_wait", "==", "5" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
-            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
-          ]
-        },
-        "topic": "TALK_BLACKSMITH_ARMOR_NOT_READY"
-      },
-      {
-        "text": "How is my armor coming?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", ">=", "time('35 d')" ] },
-            { "math": [ "u_number_artisans_blacksmith_wait", "==", "5" ] },
             { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
             { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
@@ -230,8 +167,8 @@
         "text": "How is my weapon coming?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "weapon" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
+            { "compare_string": [ "weapon", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_WEAPON_READY"
@@ -449,5 +386,14 @@
         "topic": "TALK_DONE"
       }
     ]
+  },
+  {
+    "id": "TALK_BLACKSMITH_NOT_INTERESTED_FABRICATE",
+    "//": "If you haven't completed the opening quest yet Cody will blow you off",
+    "type": "talk_topic",
+    "dynamic_line": [
+      "Sorry, I don't really have the time to work on something like that.  I've got lots of pieces for sale on the shelves."
+    ],
+    "responses": [ { "text": "Alright.", "topic": "TALK_BLACKSMITH_SERVICES" } ]
   }
 ]

--- a/data/json/npcs/isolated_road/isolated_road_cody_fabricate.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_fabricate.json
@@ -1,14 +1,5 @@
 [
   {
-    "id": "TALK_BLACKSMITH_NOT_INTERESTED_FABRICATE",
-    "//": "If you haven't completed the opening quest yet Cody will blow you off",
-    "type": "talk_topic",
-    "dynamic_line": [
-      "Sorry, I don't really have the time to work on something like that.  I've got lots of pieces for sale on the shelves."
-    ],
-    "responses": [ { "text": "Alright.", "topic": "TALK_BLACKSMITH_SERVICES" } ]
-  },
-  {
     "id": "TALK_BLACKSMITH_FABRICATE",
     "//": "this is all the dialogue related to working on armor with Cody",
     "type": "talk_topic",
@@ -20,26 +11,34 @@
       { "text": "Forget it.", "topic": "TALK_BLACKSMITH_SERVICES" },
       {
         "text": "[350 merch, 1.2mm] I'd prefer to just have chainmail.",
-        "condition": { "u_has_items": { "item": "FMCNote", "count": 350 } },
-        "effect": [ { "math": [ "u_number_artisans_blacksmith_thickness", "=", "1.2" ] } ],
+        "effect": [
+          { "math": [ "u_number_artisans_blacksmith_thickness", "=", "1.2" ] },
+          { "math": [ "u_number_artisans_blacksmith_armor_cost", "=", "350" ] }
+        ],
         "topic": "TALK_BLACKSMITH_FABRICATE_TYPE"
       },
       {
         "text": "[400 merch, 2mm] I like to stay light.",
-        "condition": { "u_has_items": { "item": "FMCNote", "count": 400 } },
-        "effect": [ { "math": [ "u_number_artisans_blacksmith_thickness", "=", "2" ] } ],
+        "effect": [
+          { "math": [ "u_number_artisans_blacksmith_thickness", "=", "2" ] },
+          { "math": [ "u_number_artisans_blacksmith_armor_cost", "=", "400" ] }
+        ],
         "topic": "TALK_BLACKSMITH_FABRICATE_TYPE"
       },
       {
         "text": "[500 merch, 4mm] A middle ground would be good.",
-        "condition": { "u_has_items": { "item": "FMCNote", "count": 500 } },
-        "effect": [ { "math": [ "u_number_artisans_blacksmith_thickness", "=", "4" ] } ],
+        "effect": [
+          { "math": [ "u_number_artisans_blacksmith_thickness", "=", "4" ] },
+          { "math": [ "u_number_artisans_blacksmith_armor_cost", "=", "500" ] }
+        ],
         "topic": "TALK_BLACKSMITH_FABRICATE_TYPE"
       },
       {
         "text": "[600 merch, 6mm] Never skimp on protection.",
-        "condition": { "u_has_items": { "item": "FMCNote", "count": 600 } },
-        "effect": [ { "math": [ "u_number_artisans_blacksmith_thickness", "=", "6" ] } ],
+        "effect": [
+          { "math": [ "u_number_artisans_blacksmith_thickness", "=", "6" ] },
+          { "math": [ "u_number_artisans_blacksmith_armor_cost", "=", "600" ] }
+        ],
         "topic": "TALK_BLACKSMITH_FABRICATE_TYPE"
       }
     ]
@@ -49,12 +48,16 @@
     "//": "this is all the dialogue related to working on armor with Cody",
     "type": "talk_topic",
     "dynamic_line": {
-      "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting_EXODII" } ],
-      "yes": "Alright, <u_val:number_artisans_blacksmith_thickness>mm, so the next question is time.  Currently, it's the classic problem: if you want quality, you gotta wait.  Two processes I could offer that you would be hard-pressed to find anywhere else are either really great high carbon steel, or I can go through the lengthy process of tempering.  High carbon will take three weeks to process and do the work, and tempering will take me four.  For five I could, I think, create a suit of that nomad armor.  It would incorporate climate control, help you support more weight, and it'll have a jumpsuit built in, but you won't be able to wear normal clothes with it.",
-      "no": "Alright, <u_val:number_artisans_blacksmith_thickness>mm, so the next question is time.  Currently, it's the classic problem: if you want quality, you gotta wait.  Two processes I could offer that you would be hard-pressed to find anywhere else are either really great high carbon steel, or I can go through the lengthy process of tempering.  High carbon will take three weeks to process and do the work, and tempering will take me four."
+      "concatenate": [
+        "Alright, <u_val:number_artisans_blacksmith_thickness>mm, so the next question is time.  Currently, it's the classic problem: if you want quality, you gotta wait.  Two processes I could offer that you would be hard-pressed to find anywhere else are either really great high carbon steel, or I can go through the lengthy process of tempering.  High carbon will take three weeks to process and do the work, and tempering will take me four.",
+        {
+          "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting_EXODII" } ],
+          "yes": "  For five I could, I think, create a suit of that nomad armor.  It would incorporate climate control, help you support more weight, and it'll have a jumpsuit built in, but you won't be able to wear normal clothes with it.",
+          "no": ""
+        }
+      ]
     },
     "responses": [
-      { "text": "Forget it.", "topic": "TALK_BLACKSMITH_SERVICES" },
       {
         "text": "[3 weeks, great protection] High steel sounds great.",
         "effect": [ { "math": [ "u_number_artisans_blacksmith_wait", "=", "3" ] } ],
@@ -70,17 +73,8 @@
         "condition": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_has_exodii_items" } ] },
         "effect": [ { "math": [ "u_number_artisans_blacksmith_wait", "=", "5" ] } ],
         "topic": "TALK_BLACKSMITH_FABRICATE_MEASUREMENTS"
-      }
-    ]
-  },
-  {
-    "id": "EOC_blacksmith_crafting_armor",
-    "type": "effect_on_condition",
-    "effect": [
-      { "u_add_var": "dialogue_artisans_u_current_project", "value": "armor" },
-      { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
-      { "math": [ "u_timer_artisans_u_waiting_on_armor", "=", "time('now')" ] },
-      { "u_assign_activity": "ACT_MEASURE", "duration": "10 minutes" }
+      },
+      { "text": "Forget it.", "topic": "TALK_BLACKSMITH_SERVICES" }
     ]
   },
   {
@@ -97,253 +91,94 @@
       }
     },
     "responses": [
-      { "text": "Forget it.", "topic": "TALK_BLACKSMITH_SERVICES" },
       {
-        "text": "[350 merch] Sounds good.  See you in <u_val:number_artisans_blacksmith_wait> weeks.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "FMCNote", "count": 350 } },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 1.2" ] }
-          ]
-        },
-        "effect": [ { "u_sell_item": "FMCNote", "count": 350, "true_eocs": "EOC_blacksmith_crafting_armor" } ],
+        "text": "[<u_val:number_artisans_blacksmith_armor_cost> merch] Sounds good.  See you in <u_val:number_artisans_blacksmith_wait> weeks.",
+        "condition": { "u_has_items": { "item": "FMCNote", "count": { "u_val": "number_artisans_blacksmith_armor_cost" } } },
+        "switch": true,
+        "effect": [
+          { "u_sell_item": "FMCNote", "count": { "u_val": "number_artisans_blacksmith_armor_cost" } },
+          { "u_add_var": "dialogue_artisans_u_current_project", "value": "armor" },
+          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
+          { "math": [ "u_timer_artisans_u_waiting_on_armor", "=", "time('now')" ] },
+          { "u_assign_activity": "ACT_MEASURE", "duration": "10 minutes" }
+        ],
         "topic": "TALK_DONE"
       },
       {
-        "text": "[400 merch] Sounds good.  See you in <u_val:number_artisans_blacksmith_wait> weeks.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "FMCNote", "count": 400 } },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 2" ] }
-          ]
-        },
-        "effect": [ { "u_sell_item": "FMCNote", "count": 400, "true_eocs": "EOC_blacksmith_crafting_armor" } ],
-        "topic": "TALK_DONE"
+        "text": "Um… wait, I don't have that kind of money right now.",
+        "switch": true,
+        "topic": "TALK_BLACKSMITH_SERVICES"
       },
-      {
-        "text": "[500 merch] Sounds good.  See you in <u_val:number_artisans_blacksmith_wait> weeks.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "FMCNote", "count": 500 } },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 4" ] }
-          ]
-        },
-        "effect": [ { "u_sell_item": "FMCNote", "count": 500, "true_eocs": "EOC_blacksmith_crafting_armor" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "[600 merch] Sounds good.  See you in <u_val:number_artisans_blacksmith_wait> weeks.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "FMCNote", "count": 600 } },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 6" ] }
-          ]
-        },
-        "effect": [ { "u_sell_item": "FMCNote", "count": 600, "true_eocs": "EOC_blacksmith_crafting_armor" } ],
-        "topic": "TALK_DONE"
-      }
+      { "text": "Forget it.", "topic": "TALK_BLACKSMITH_SERVICES" }
     ]
   },
   {
     "id": "TALK_BLACKSMITH_ARMOR_READY",
-    "//": "this is dialogue to pickup the armor",
     "type": "talk_topic",
-    "dynamic_line": [ "It's all done!  Sorry for the long wait; hopefully it's worth it.  If you need it refitted, let me know." ],
+    "dynamic_line": {
+      "math": [ "time_since(u_timer_artisans_u_waiting_on_armor, 'unit':'days')", ">=", "u_number_artisans_blacksmith_wait*7" ],
+      "yes": "It's all done!  Sorry for the long wait; hopefully it's worth it.  If you need it refitted, let me know.",
+      "no": "Still working on it."
+    },
     "responses": [
       {
         "text": "Thanks.",
         "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 3" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 1.2" ] }
-          ]
+          "math": [ "time_since(u_timer_artisans_u_waiting_on_armor, 'unit':'days')", ">=", "u_number_artisans_blacksmith_wait*7" ]
         },
+        "switch": true,
         "effect": [
-          { "u_spawn_item": "hc_chainmail_suit" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 4" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 1.2" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "qt_chainmail_suit" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 5" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 1.2" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "armor_nomad_chainmail" },
           { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
           { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" },
-          { "u_lose_var": "dialogue_artisans_blacksmith_has_exodii_items" }
+          {
+            "switch": { "u_val": "number_artisans_blacksmith_wait" },
+            "cases": [
+              {
+                "case": 3,
+                "effect": {
+                  "switch": { "u_val": "number_artisans_blacksmith_thickness" },
+                  "cases": [
+                    { "case": 1.2, "effect": { "u_spawn_item": "hc_chainmail_suit" } },
+                    { "case": 2, "effect": { "u_spawn_item": "armor_hc_lightplate" } },
+                    { "case": 4, "effect": { "u_spawn_item": "armor_hc_plate" } },
+                    { "case": 6, "effect": { "u_spawn_item": "armor_hc_heavyplate" } }
+                  ]
+                }
+              },
+              {
+                "case": 4,
+                "effect": {
+                  "switch": { "u_val": "number_artisans_blacksmith_thickness" },
+                  "cases": [
+                    { "case": 1.2, "effect": { "u_spawn_item": "qt_chainmail_suit" } },
+                    { "case": 2, "effect": { "u_spawn_item": "armor_qt_lightplate" } },
+                    { "case": 4, "effect": { "u_spawn_item": "armor_qt_plate" } },
+                    { "case": 6, "effect": { "u_spawn_item": "armor_qt_heavyplate" } }
+                  ]
+                }
+              },
+              {
+                "case": 5,
+                "effect": {
+                  "switch": { "u_val": "number_artisans_blacksmith_thickness" },
+                  "cases": [
+                    { "case": 1.2, "effect": { "u_spawn_item": "armor_nomad_chainmail" } },
+                    { "case": 2, "effect": { "u_spawn_item": "armor_nomad_lightplate" } },
+                    { "case": 4, "effect": { "u_spawn_item": "armor_nomad_plate" } },
+                    { "case": 6, "effect": { "u_spawn_item": "armor_nomad_heavyplate" } }
+                  ]
+                }
+              }
+            ]
+          },
+          { "u_lose_var": "number_artisans_blacksmith_wait" },
+          { "u_lose_var": "number_artisans_blacksmith_thickness" },
+          { "u_lose_var": "number_artisans_blacksmith_armor_cost" },
+          { "u_lose_var": "timer_artisans_u_waiting_on_armor" }
         ],
         "topic": "TALK_BLACKSMITH_SERVICES"
       },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 3" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 2" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "armor_hc_lightplate" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 4" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 2" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "armor_qt_lightplate" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 5" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 2" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "armor_nomad_lightplate" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" },
-          { "u_lose_var": "dialogue_artisans_blacksmith_has_exodii_items" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 3" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 4" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "armor_hc_plate" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 4" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 4" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "armor_qt_plate" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 5" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 4" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "armor_nomad_plate" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" },
-          { "u_lose_var": "dialogue_artisans_blacksmith_has_exodii_items" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 3" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 6" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "armor_hc_heavyplate" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 4" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 6" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "armor_qt_heavyplate" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      },
-      {
-        "text": "Thanks.",
-        "condition": {
-          "and": [
-            { "math": [ "u_number_artisans_blacksmith_wait == 5" ] },
-            { "math": [ "u_number_artisans_blacksmith_thickness == 6" ] }
-          ]
-        },
-        "effect": [
-          { "u_spawn_item": "armor_nomad_heavyplate" },
-          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
-          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" },
-          { "u_lose_var": "dialogue_artisans_blacksmith_has_exodii_items" }
-        ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      }
-    ]
-  },
-  {
-    "id": "TALK_BLACKSMITH_ARMOR_NOT_READY",
-    "//": "this is dialogue if your armor isn't ready to pickup",
-    "type": "talk_topic",
-    "dynamic_line": [ "Still working on it." ],
-    "responses": [
-      { "text": "Thanks.", "topic": "TALK_BLACKSMITH_SERVICES" },
-      { "text": "See you when it's done.", "topic": "TALK_DONE" }
+      { "text": "See you when it's done.", "switch": true, "topic": "TALK_DONE" }
     ]
   },
   {
@@ -353,6 +188,7 @@
     "dynamic_line": [
       "Oh wow, this is really interesting, huh?  The way they balance weight for travel is genius.  If you wanted a real suit of armor for a traveling warrior, I think I could do it with this.  I'll need one of each of these wire kits, though, for each set I make.  Bring some to me if you want me to use them."
     ],
+    "speaker_effect": { "effect": { "u_add_var": "dialogue_artisans_blacksmith_crafting_EXODII", "value": "yes" } },
     "responses": [
       {
         "text": "I have some right now.  [Hand over a CBM interface wire kit and an external climate control kit.]",
@@ -364,11 +200,7 @@
         ],
         "topic": "TALK_BLACKSMITH_PROTOTYPE_EXODII_ITEMS_READY"
       },
-      {
-        "text": "I'll try and find some.",
-        "effect": [ { "u_add_var": "dialogue_artisans_blacksmith_crafting_EXODII", "value": "yes" } ],
-        "topic": "TALK_BLACKSMITH_SERVICES"
-      }
+      { "text": "I'll try and find some.", "topic": "TALK_BLACKSMITH_SERVICES" }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Refactoring armor order from Cody"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
1. Bloated code can be rewritten to be more compact.
2. The player could not see possible responses unless they had enough money.
3. There is a bug, if you show Cody the blueprint for the nomad  and immediately give her the necessary parts, then one variable will not be set and the dialogue will break a little.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Rewrite the dialog code ('111 additions and 333 deletions' woah). Now armor ordering is not scattered across dozens of different topics and responses.
2. Responses are always visible, the amount of money is checked only upon payment.
3. The variable that is responsible for the fact that the blacksmith knows about the nomad blueprints (but does not necessarily have the CBM kits) is moved to `speaker_effect`.
4. Replaced deprecated `u_has_var` with `compare_string`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
[Test-trimmed.tar.gz](https://github.com/user-attachments/files/17551489/Test-trimmed.tar.gz)
Ordering armor works as intended.
Bug fixed, blacksmith can create nomad armor after giving her parts through both dialogues.

New code didn't cause regression #76710. Although the error appears (master branch/not only in this dialog) if you change the in-game locale halfway to one that does not use a decimal period or vice versa.
<details><summary>Details</summary>
<p>

```
 DEBUG    : Could not convert variable "npctalk_var_timer_artisans_u_waiting_on_armor" with value "5.21284e+06" to double
 FUNCTION : diag_value::dbl(const dialogue&) const::<lambda(const var_info&)>
 FILE     : src/math_parser_diag_value.cpp
 LINE     : 90
 VERSION  : cdda-experimental-2024-10-23-0605 5d32050
-----------------------------------------------------------------
 DEBUG    : failed to convert variable "npctalk_var_number_artisans_blacksmith_thickness" with value "1.2" to a number
 FUNCTION : double var::eval(dialogue&) const
 FILE     : src/math_parser.cpp
 LINE     : 241
 VERSION  : cdda-experimental-2024-10-23-0605 5d32050
-----------------------------------------------------------------
 DEBUG    : Could not convert variable "npctalk_var_timer_time_of_last_succession" with value "5.2128e+06" to double
 FUNCTION : diag_value::dbl(const dialogue&) const::<lambda(const var_info&)>
 FILE     : src/math_parser_diag_value.cpp
 LINE     : 90
 VERSION  : cdda-experimental-2024-10-23-0605 5d32050
-----------------------------------------------------------------
build type: linux-tiles-x64
build number: 2024-10-23-0605
commit sha: 5d320508149b28da05fc4d45e4a8f2d1c7547ef6
commit url: https://github.com/CleverRaven/Cataclysm-DDA/commit/5d320508149b28da05fc4d45e4a8f2d1c7547ef6
```

</p>
</details> 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![cody2](https://github.com/user-attachments/assets/32bcb826-e36d-4285-9416-5fb5ec24ccdb)
![cody3](https://github.com/user-attachments/assets/d8bdd0d4-bc31-4397-a05e-5db3acf53243)
![cody4](https://github.com/user-attachments/assets/82ad8a26-f6c2-4e81-b944-7c01eaa25dfd)
![cody5](https://github.com/user-attachments/assets/cababecc-9681-4df6-868a-d1d70717cbac)
![cody6](https://github.com/user-attachments/assets/f93f05f5-d37a-4d35-a989-24d42237e819)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
