### PR TITLE
Factions don't mind the player smashing zombie corpses

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -902,6 +902,12 @@ static void haul_toggle()
     get_avatar().toggle_hauling();
 }
 
+static bool is_smashable_corpse( const item &maybe_corpse )
+{
+    return maybe_corpse.is_corpse() && maybe_corpse.damage() < maybe_corpse.max_damage() &&
+           maybe_corpse.can_revive();
+}
+
 static void smash()
 {
     const bool allow_floor_bash = debug_mode; // Should later become "true"
@@ -911,7 +917,17 @@ static void smash()
     }
     tripoint_bub_ms smashp = tripoint_bub_ms( *smashp_ );
 
-    if( !g->warn_player_maybe_anger_local_faction( true ) ) {
+    // Little hack: If there's a smashable corpse, it'll always be bashed first. So don't bother warning about
+    // terrain smashing unless it's actually possible.
+    bool smashable_corpse_at_target = false;
+    for( const item &maybe_corpse : get_map().i_at( smashp ) ) {
+        if( is_smashable_corpse( maybe_corpse ) ) {
+            smashable_corpse_at_target = true;
+            break;
+        }
+    }
+
+    if( !smashable_corpse_at_target && !g->warn_player_maybe_anger_local_faction( true ) ) {
         return; // player declined to smash faction's stuff
     }
 
@@ -1003,8 +1019,7 @@ avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
 
     bool should_pulp = false;
     for( const item &maybe_corpse : here.i_at( smashp ) ) {
-        if( maybe_corpse.is_corpse() && maybe_corpse.damage() < maybe_corpse.max_damage() &&
-            maybe_corpse.can_revive() ) {
+        if( is_smashable_corpse( maybe_corpse ) ) {
             if( maybe_corpse.get_mtype()->bloodType()->has_acid &&
                 !is_immune_field( fd_acid ) ) {
                 if( !query_yn( _( "Are you sure you want to pulp an acid filled corpse?" ) ) ) {


### PR DESCRIPTION
#### Summary
Balance "Factions don't mind the player smashing zombie corpses"

#### Purpose of change
* Relates to #77239

Does not close the issue.

#### Describe the solution
Pre-check the target to see if there's a corpse that might end up getting smashed. Corpses are always smashed before terrain, so if there's a corpse we can't possibly smash terrain. Therefore, skip the warning (and possible relations loss).

This does technically iterate the target tile twice, which is slightly wasteful

#### Describe alternatives you've considered
I thought about passing the corpse smashing information along as an optional argument to avatar::smash() as a bool or container of item_location, to prevent the double iteration of the map tile.

I thought about refactoring smash() and avatar::smash() so target information is available before the checks for whether we should smash

But in the end I went with this. It could be unknowingly broken in the future if avatar::smash() changes the order of checks, but at worst it would produce a obviously-unintended exploit (e.g. being able to put a corpse on a tile and then bash the terrain). I think this possibility for breakage is a safer idea than refactoring which could introduce other bugs.

#### Testing

Smash left, then smash right

https://github.com/user-attachments/assets/0144cf11-9f93-4837-a68c-df5339b510f2

#### Additional context
