### PR TITLE
Dropped lit cigarette won't start fires if there's no flammable terrain, furniture, or items on that tile

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13396,10 +13396,17 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint &pos )
         // If not carried by someone, but laying on the ground:
         if( item_counter % 5 == 0 ) {
             // lit cigarette can start fires
-            if( here.flammable_items_at( pos ) ||
-                here.has_flag( ter_furn_flag::TFLAG_FLAMMABLE, pos ) ||
-                here.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH, pos ) ) {
-                here.add_field( pos, fd_fire, 1 );
+            for( const item &i : here.i_at( pos ) ) {
+                if( i.typeId() == typeId() ) {
+                    if( here.has_flag( ter_furn_flag::TFLAG_FLAMMABLE, pos ) ||
+                        here.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH, pos ) ) {
+                        here.add_field( pos, fd_fire, 1 );
+                        break;
+                    }
+                } else if( i.flammable( 0 ) ) {
+                    here.add_field( pos, fd_fire, 1 );
+                    break;
+                }
             }
         }
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -596,7 +596,7 @@ std::optional<int> iuse::smoking( Character *p, item *it, const tripoint & )
     p->use_charges_if_avail( itype_fire, 1 );
     cig.active = true;
     p->inv->add_item( cig, false, true );
-    p->add_msg_if_player( m_neutral, _( "You light a %s." ), cig.tname() );
+    p->add_msg_if_player( m_neutral, _( "You light a %s." ), it->tname() );
 
     // Parting messages
     if( it->typeId() == itype_joint ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Dropped lit cigarette won't start fires if there's no flammable terrain, furniture, or items on that tile"

#### Purpose of change
Previously, when game checked for `flammable_items_at` on the tile with dropped lit cigarette, it always returned true since cigarette is itself a flammable item. So, lit cigarette will set itself on fire even on tiles with dirt, concrete and so on without any other flammable terrain, furniture, or items.

* Closes #53393.

#### Describe the solution
Reworked the check for flammability. Now it checks for lit cigarette on a given tile AND ( flammable terrain/furniture OR _any other_ flammable items ).
Also, while I'm here, I changed text from `You light a cigarette (lit) (active).` to `You light a cigarette`.

#### Describe alternatives you've considered
None.

#### Testing
Dropped lit cigarette:
- on a bare dirt. No fire.
- on a dirt with a newspaper. Fire.
- on a wooden table. Fire.

#### Additional context
None.