### PR TITLE
less usage of generic rewards: Tacoma

### DIFF
--- a/data/json/npcs/tacoma_ranch/NPC_ranch_bartender.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_bartender.json
@@ -235,6 +235,7 @@
     "item": "still",
     "count": 2,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_BARTENDER_2",
     "dialogue": {
       "describe": "We need help…",
@@ -269,6 +270,7 @@
     "item": "yeast",
     "count": 20,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_BARTENDER_3",
     "dialogue": {
       "describe": "We need help…",
@@ -304,6 +306,7 @@
     "item": "seed_sugar_beet",
     "count": 10,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_BARTENDER_4",
     "dialogue": {
       "describe": "We need help…",
@@ -344,6 +347,7 @@
     "item": "metal_tank",
     "count": 12,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_BARTENDER_5",
     "dialogue": {
       "describe": "We need help…",
@@ -378,6 +382,7 @@
     "item": "55gal_drum",
     "count": 2,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_NULL",
     "dialogue": {
       "describe": "We need help…",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_bartender.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_bartender.json
@@ -396,6 +396,7 @@
       "failure": "It was a lost cause anyways…"
     },
     "end": {
+      "effect": { "u_add_var": "mission_flag_Bartender_rewarded", "value": "no" },
       "update_mapgen": {
         "om_terrain": "ranch_camp_51",
         "place_item": [ { "item": "55gal_drum", "x": 18, "y": 3, "repeat": 2, "faction": "tacoma_commune" } ],

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
@@ -304,6 +304,7 @@
     "end": {
       "update_mapgen": [ { "om_terrain": "ranch_camp_50", "set": [ { "point": "furniture", "id": "f_anesthetic", "x": 19, "y": 19 } ] } ],
       "effect": [
+        { "u_add_var": "mission_flag_Doctor_rewarded", "value": "no" },
         { "u_consume_item": "anesthetic", "count": 3000 },
         { "npc_add_var": "dialogue_tacoma_ranch_provides_surgery", "value": "yes" }
       ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
@@ -232,6 +232,7 @@
     "item": "crutches",
     "count": 1,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_DOCTOR_MEDICAL_GLOVES",
     "dialogue": {
       "describe": "We need help…",
@@ -256,6 +257,7 @@
     "item": "gloves_medical",
     "count": 5,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC",
     "dialogue": {
       "describe": "We need help…",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -16,11 +16,11 @@
     "type": "talk_topic",
     "dynamic_line": {
       "compare_string": [ "no", { "u_val": "mission_flag_Bartender_rewarded" } ],
-      "no": "Hello again.  If you have no other business with me, I'd like to talk to you about something.",
-      "yes": {
+      "yes": "Hello again.  If you have no other business with me, I'd like to talk to you about something.",
+      "no": {
         "compare_string": [ "no", { "u_val": "mission_flag_Doctor_rewarded" } ],
-        "no": "Hello again.  If you have no other business with me, I'd like to talk to you about something.",
-        "yes": {
+        "yes": "Hello again.  If you have no other business with me, I'd like to talk to you about something.",
+        "no": {
           "u_is_wearing": "badge_marshal",
           "yes": "Can I help you, marshal?",
           "no": { "u_male": true, "yes": "Morning sir, how can I help you?", "no": "Morning ma'am, how can I help you?" }

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -168,7 +168,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_RANCH_FOREMAN_reward",
-    "dynamic_line": "You've done a lot for the ranch, by generally helping both community with both wellness and trade.  As the project lead, I want to make sure these efforts don't go unnoticed.",
+    "dynamic_line": "You've done a lot for the ranch, by generally helping the community with both wellness and trade.  As the project lead, I want to make sure these efforts don't go unnoticed.",
     "responses": [
       {
         "text": "You mean setting up the doctor's office?",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -148,6 +148,26 @@
     "responses": [ { "text": "I'll keep an eye out.", "topic": "TALK_RANCH_FOREMAN" } ]
   },
   {
+    "type": "talk_topic",
+    "id": "TALK_RANCH_FOREMAN_Bartender_done",
+    "dynamic_line": "Ever since you got the bartender set up, our liquor business has been running so much better!  As thanks for your efforts, I wanted to reward you with a portion of recent profits.",
+    "speaker_effect": { "effect": [ { "u_spawn_item": "FMCNote", "count": 75 }, { "u_lose_var": "mission_flag_Bartender_rewarded" } ] },
+    "responses": [ { "text": "Thanks.", "topic": "TALK_RANCH_FOREMAN" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_RANCH_FOREMAN_Doctor_done",
+    "dynamic_line": "I heard you helped jumpstart our local medical services.  With that basic need covered, everyone has been able to focus on their work a lot more, so to thank you for your efforts, I wanted to reward you.",
+    "speaker_effect": {
+      "effect": [
+        { "u_spawn_item": "FMCNote", "count": 25 },
+        { "u_lose_var": "mission_flag_Doctor_rewarded" },
+        { "u_lose_var": "mission_flag_Nurse_rewarded" }
+      ]
+    },
+    "responses": [ { "text": "Thanks.", "topic": "TALK_RANCH_FOREMAN" } ]
+  },
+  {
     "id": "MISSION_RANCH_FOREMAN_1",
     "type": "mission_definition",
     "name": { "str": "Cut 200 planks" },

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -15,11 +15,29 @@
     "id": "TALK_RANCH_FOREMAN",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_is_wearing": "badge_marshal",
-      "yes": "Can I help you, marshal?",
-      "no": { "u_male": true, "yes": "Morning sir, how can I help you?", "no": "Morning ma'am, how can I help you?" }
+      "compare_string": [ "no", { "u_val": "mission_flag_Bartender_rewarded" } ],
+      "no": "Hello again.  If you have no other business with me, I'd like to talk to you about something.",
+      "yes": {
+        "compare_string": [ "no", { "u_val": "mission_flag_Doctor_rewarded" } ],
+        "no": "Hello again.  If you have no other business with me, I'd like to talk to you about something.",
+        "yes": {
+          "u_is_wearing": "badge_marshal",
+          "yes": "Can I help you, marshal?",
+          "no": { "u_male": true, "yes": "Morning sir, how can I help you?", "no": "Morning ma'am, how can I help you?" }
+        }
+      }
     },
     "responses": [
+      {
+        "text": "What is it?",
+        "topic": "TALK_RANCH_FOREMAN_reward",
+        "condition": {
+          "or": [
+            { "compare_string": [ "no", { "u_val": "mission_flag_Bartender_rewarded" } ] },
+            { "compare_string": [ "no", { "u_val": "mission_flag_Doctor_rewarded" } ] }
+          ]
+        }
+      },
       {
         "text": "The merchant at the Refugee Center sent me to get a prospectus from you.",
         "topic": "TALK_RANCH_FOREMAN_PROSPECTUS",
@@ -149,23 +167,35 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_RANCH_FOREMAN_reward",
+    "dynamic_line": "You've done a lot for the ranch, by generally helping both community with both wellness and trade.  As the project lead, I want to make sure these efforts don't go unnoticed.",
+    "responses": [
+      {
+        "text": "You mean setting up the doctor's office?",
+        "topic": "TALK_RANCH_FOREMAN_Doctor_done",
+        "condition": { "compare_string": [ "no", { "u_val": "mission_flag_Doctor_rewarded" } ] }
+      },
+      {
+        "text": "Is this about bootstrapping the trade relating to the bar?",
+        "topic": "TALK_RANCH_FOREMAN_Bartender_done",
+        "condition": { "compare_string": [ "no", { "u_val": "mission_flag_Bartender_rewarded" } ] }
+      },
+      { "text": "Understood.  Back to business.", "topic": "TALK_RANCH_FOREMAN" }
+    ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_RANCH_FOREMAN_Bartender_done",
     "dynamic_line": "Ever since you got the bartender set up, our liquor business has been running so much better!  As thanks for your efforts, I wanted to reward you with a portion of recent profits.",
     "speaker_effect": { "effect": [ { "u_spawn_item": "FMCNote", "count": 75 }, { "u_lose_var": "mission_flag_Bartender_rewarded" } ] },
-    "responses": [ { "text": "Thanks.", "topic": "TALK_RANCH_FOREMAN" } ]
+    "responses": [ { "text": "Thanks.", "topic": "TALK_RANCH_FOREMAN_reward" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_RANCH_FOREMAN_Doctor_done",
     "dynamic_line": "I heard you helped jumpstart our local medical services.  With that basic need covered, everyone has been able to focus on their work a lot more, so to thank you for your efforts, I wanted to reward you.",
-    "speaker_effect": {
-      "effect": [
-        { "u_spawn_item": "FMCNote", "count": 25 },
-        { "u_lose_var": "mission_flag_Doctor_rewarded" },
-        { "u_lose_var": "mission_flag_Nurse_rewarded" }
-      ]
-    },
-    "responses": [ { "text": "Thanks.", "topic": "TALK_RANCH_FOREMAN" } ]
+    "speaker_effect": { "effect": [ { "u_spawn_item": "FMCNote", "count": 25 }, { "u_lose_var": "mission_flag_Doctor_rewarded" } ] },
+    "responses": [ { "text": "Thanks.", "topic": "TALK_RANCH_FOREMAN_reward" } ]
   },
   {
     "id": "MISSION_RANCH_FOREMAN_1",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -157,6 +157,7 @@
     "item": "2x4",
     "count": 200,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_2",
     "dialogue": {
       "describe": "We need help…",
@@ -219,6 +220,7 @@
     "difficulty": 5,
     "value": 50000,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_3",
     "dialogue": {
       "describe": "We need help…",
@@ -294,6 +296,7 @@
     "item": "nail",
     "count": 2500,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_4",
     "dialogue": {
       "describe": "We need help…",
@@ -352,6 +355,7 @@
     "item": "salt",
     "count": 3888,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_5",
     "dialogue": {
       "describe": "We need help…",
@@ -419,6 +423,7 @@
     "item": "fertilizer_liquid",
     "count": 120,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_6",
     "dialogue": {
       "describe": "We need help…",
@@ -464,6 +469,7 @@
     "item": "rock",
     "count": 75,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_7",
     "dialogue": {
       "describe": "We need help…",
@@ -511,6 +517,7 @@
     "item": "pipe",
     "count": 50,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_8",
     "dialogue": {
       "describe": "We need help…",
@@ -561,6 +568,7 @@
     "item": "motor",
     "count": 2,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_9",
     "dialogue": {
       "describe": "We need help…",
@@ -624,6 +632,7 @@
     "item": "bleach",
     "count": 150,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_10_1",
     "dialogue": {
       "describe": "We need help…",
@@ -663,6 +672,7 @@
     "item": "bandages",
     "count": 36,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_10",
     "dialogue": {
       "describe": "We need help…",
@@ -691,6 +701,7 @@
     "item": "disinfectant",
     "count": 60,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_11",
     "dialogue": {
       "describe": "We need help…",
@@ -723,6 +734,7 @@
     "item": "welder",
     "count": 2,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_12",
     "dialogue": {
       "describe": "We need help…",
@@ -784,6 +796,7 @@
     "item": "battery_car",
     "count": 12,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_13",
     "dialogue": {
       "describe": "We need help…",
@@ -824,6 +837,7 @@
     "item": "two_way_radio",
     "count": 2,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_14",
     "dialogue": {
       "describe": "We need help…",
@@ -862,6 +876,7 @@
     "item": "backpack",
     "count": 5,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_15",
     "dialogue": {
       "describe": "We need help…",
@@ -902,6 +917,7 @@
     "item": "brewing_cookbook",
     "count": 1,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_16",
     "dialogue": {
       "describe": "We need help…",
@@ -935,6 +951,7 @@
     "item": "sugar",
     "count": 10000,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_17",
     "dialogue": {
       "describe": "We need help…",
@@ -967,6 +984,7 @@
     "item": "glass_sheet",
     "count": 30,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_NULL",
     "dialogue": {
       "describe": "We need help…",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
@@ -119,6 +119,7 @@
     "item": "aspirin",
     "count": 100,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_NURSE_2",
     "dialogue": {
       "describe": "We need help…",
@@ -161,6 +162,7 @@
     "item": "hotplate",
     "count": 3,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_NURSE_3",
     "dialogue": {
       "describe": "We need help…",
@@ -200,6 +202,7 @@
     "item": "vitamins",
     "count": 200,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_NURSE_4",
     "dialogue": {
       "describe": "We need help…",
@@ -243,6 +246,7 @@
     "item": "char_purifier",
     "count": 4,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_NURSE_5",
     "dialogue": {
       "describe": "We need help…",
@@ -275,6 +279,7 @@
     "value": 50000,
     "item": "chemistry_set",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_NURSE_6",
     "dialogue": {
       "describe": "We need help…",
@@ -318,6 +323,7 @@
     "item": "mask_filter",
     "count": 10,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_NURSE_7",
     "dialogue": {
       "describe": "We need help…",
@@ -369,6 +375,7 @@
     "item": "gloves_rubber",
     "count": 4,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_NURSE_8",
     "dialogue": {
       "describe": "We need help…",
@@ -418,6 +425,7 @@
     "item": "scalpel",
     "count": 2,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_NURSE_9",
     "dialogue": {
       "describe": "We need help…",
@@ -474,6 +482,7 @@
     "value": 50000,
     "item": "emergency_book",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_RANCH_NURSE_11",
     "dialogue": {
       "describe": "We need help…",
@@ -519,6 +528,7 @@
     "item": "syringe",
     "count": 10,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_NULL",
     "dialogue": {
       "describe": "We need help…",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
@@ -542,6 +542,7 @@
       "failure": "It was a lost cause anyways…"
     },
     "end": {
+      "effect": { "u_add_var": "mission_flag_Nurse_rewarded", "value": "no" },
       "update_mapgen": [
         {
           "om_terrain": "ranch_camp_59",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
@@ -542,7 +542,6 @@
       "failure": "It was a lost cause anyways…"
     },
     "end": {
-      "effect": { "u_add_var": "mission_flag_Nurse_rewarded", "value": "no" },
       "update_mapgen": [
         {
           "om_terrain": "ranch_camp_59",

--- a/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
@@ -278,6 +278,7 @@
     "difficulty": 2,
     "value": 1000,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "item": "fire_brick",
     "count": 20,
     "dialogue": {
@@ -300,6 +301,7 @@
     "difficulty": 2,
     "value": 1000,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "Ask Jenny Forcette if she can help Pablo Nunez with his mill designs.",
       "offer": "n/a",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Bootstrapping the Tacoma ranch right now makes all the inhabitants indebted to you for life, but it's not as though that makes perfect sense: They can't just start giving away all their stock to you, because they still report to the Refugee Center to facilitate trading. Besides, most of them don't even have a shop running (the part that bothers me the most, as you get to look at taking their personal belongings when you don't really have any business doing so).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Set `"has_generic_rewards": false` to most NPCs in Tacoma (exception is Scavenger Boss, because he does have a shop with enough value attached, while giving quests. Reward could feasibly come in the form of wares... you're practically selling gear to him with the quests. I just chose not to touch that because it involves arbitrary adjustment of the "value" value)

~~This being in draft: Setting up~~ Added more believable rewards with the end of Doctor and Bartender quests (the foreman giving you cash for use in other shops)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
~~When this is out of draft, I'll hopefully have done everything in regards to testing it working and adjusting dialogue options.~~

Did all the quests for the Foreman, Nurse, Doctor and Bartender (I couldn't figure out how to do the Pablo quest, but I will trust that the setting change that breaks for noone else, would not break with him). I mostly looked for the post-quest "How about some items as payment?" and did not see any such prompt for the questlines in question.

Tested the Foreman giving you cash, and I see no dialogue out of place (he only says the "Hello again" thing whenever there's an unclaimed reward)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
"Can you share some equipment?" on mission start is not something I've figured out how to avoid, but whether I should is something I have not yet pondered. In doing the Scrapper quests (for the Doctor) it seems such extraneous options don't exist, but I'm not perfectly how to achieve that, nevermind it not really being the point of this PR.

look karol, I'm deleting (rewards) by adding lines!
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
