### PR TITLE
less usage of generic rewards: Refugee Center

### DIFF
--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -276,6 +276,7 @@
     "count": 40,
     "followup": "MISSION_BEGGAR_2_DUCT_TAPE",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "Gotta start small right?  Little ones for keeping little things safe.  I could use 'em.",
       "offer": "Gotta start small right?  Little ones for keeping little things safe.  I could use 'em.  I need a bunch of 'em.  Little ones, you know?  Can you bring me like… like… forty?",
@@ -299,6 +300,7 @@
     "count": 200,
     "followup": "MISSION_BEGGAR_2_BOX_MEDIUM",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "These ones are good, good ones.  They need something to, you know, bind them together.  Surround them, light side, dark side.",
       "offer": "These ones are good, good ones.  They need something to, you know, bind them together.  Surround them, light side, dark side.  Bring me the Force!",
@@ -322,6 +324,7 @@
     "count": 10,
     "followup": "MISSION_BEGGAR_2_PLASTIC_SHEET",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "Ten bigger ones now please.  The list doesn't lie.  You've done so well.",
       "offer": "Ten bigger ones now please.  The list doesn't lie.  You've done so well.  I got a little more on the list, but we're more than half there.",
@@ -345,6 +348,7 @@
     "count": 10,
     "followup": "MISSION_BEGGAR_2_BOX_LARGE",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "If I can set it up in here I won't need it, but they might drive me out, so I guess I need some plastic just in case.  I don't like it, the sandman can smell through plastic, but I think the cardboard is stronger.",
       "offer": "If I can set it up in here I won't need it, but they might drive me out, so I guess I need some plastic just in case.  I don't like it, the sandman can smell through plastic, but I think the cardboard is stronger.  Please bring me some plastic sheets.",
@@ -367,6 +371,7 @@
     "item": "box_large",
     "count": 5,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "This is the last thing I need from you.  I've been collecting the other parts myself, it's been easier with more cardboard around.  Can you bring me five more really big cardboard boxes?",
       "offer": "This is the last thing I need from you.  I've been collecting the other parts myself, it's been easier with more cardboard around.  Can you bring me five more really big cardboard boxes?  Five more cardboard boxes, as big as it gets.  I have a few already stored up, that should be all I need.",
@@ -389,6 +394,7 @@
     "goal_condition": { "compare_string": [ "yes", { "u_val": "mission_Dave_Permission" } ] },
     "count": 5,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "I have it, I have it all, but I can't find a place to put it.  Will you ask the masters?  Maybe?  I've tried but they ignore me.",
       "offer": "I have it, I have it all, but I can't find a place to put it.  Will you ask the masters?  Maybe?  I've tried but they ignore me.  I just need a place to put it all, a place I can be safe, and not make anyone upset.",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
@@ -337,6 +337,7 @@
       ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "I think I might know where those special pants might be though…",
       "offer": "This clown was into some of the different things, not the vanilla, you understand me?  Yes.  I think you will find my valuables in a toy shop not so so far.",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Boris_Borichenko.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Boris_Borichenko.json
@@ -512,6 +512,7 @@
     "goal_condition": { "math": [ "u_mission_cleanup_promises_Boris_mission_1", ">=", "5" ] },
     "followup": "MISSION_REFUGEE_Boris_WORKSPACE",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "Find a few people able to help clean the back, people without too much trauma there.",
       "offer": "Yes, please.  If you can ask around for someone who can help, I can gather the tools they will need and some payment for them.",
@@ -544,6 +545,7 @@
     "goal": "MGOAL_FIND_ITEM",
     "item": "circsaw_off",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_REFUGEE_Boris_LAPTOP",
     "dialogue": {
       "describe": "Find a circular saw for Boris.",
@@ -575,6 +577,7 @@
     "goal": "MGOAL_FIND_ITEM",
     "item": "laptop_boris",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "start": {
       "assign_mission_target": {
         "om_terrain": "shelter_2_vandal",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Dana_Nunez.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Dana_Nunez.json
@@ -555,6 +555,7 @@
       ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "I could get my real sourdough starter…",
       "offer": "If you really like this second-rate bread, you could risk your life for something actually worth it.  I left my actual sourdough starter back in the bakery where I worked.  That baby is a hundred years old, and has been in my family for generations… if you can bring him to me, I'll bake you the finest bread you've ever had.",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Draco_Dune.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Draco_Dune.json
@@ -543,6 +543,7 @@
     "goal": "MGOAL_FIND_ITEM",
     "item": "acoustic_guitar",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "end": {
       "effect": [
         { "u_add_var": "general_mission_NC_REFUGEE_Draco_has_guitar", "value": "yes" },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Fatima_Al_Jadir.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Fatima_Al_Jadir.json
@@ -289,6 +289,7 @@
     "value": 0,
     "item": "holybook_quran",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "I could use a bit of help to find a copy of the Quran.",
       "offer": "I feel silly asking this, but here goes.  I've never been really into reading holy books and stuff like that.  I usually went to the mosque on Friday, and I try to pray five times a day but I hardly ever manage it.  I guess I'm not a very good Muslim, but with all that's happened I would really love to have a copy of the Quran to read.  This seems like a time to get back in touch with God, you know?",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -577,6 +577,7 @@
     "goal": "MGOAL_FIND_ITEM",
     "item": "book_pneumatics",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "If you happen to see anything in your travels about high-powered air rifles, it would help a lot.",
       "offer": "If you happen to see anything in your travels about high-powered air rifles, it would help a lot.",
@@ -602,6 +603,7 @@
     "item": "motor",
     "followup": "MISSION_REFUGEE_Jenny_GET_TANK",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "Yeah, if you want to risk your neck out there and bring me what I need, I'm not gonna say no.  I can't, like, pay you or anything though, you know that right?",
       "offer": "Before I get anything going, I'm going to need to set up a compressor.  I have a lot of the stuff for that, but I need a large tank for air, and a good sized electric motor - about 10 kg or so.  I'm also going to need a 60 liter tank, after that.",
@@ -630,6 +632,7 @@
     "goal": "MGOAL_FIND_ITEM",
     "item": "metal_tank",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_REFUGEE_Jenny_GET_TEXT",
     "dialogue": {
       "describe": "Now that I've got that motor, I can get my compressor mostly built.  I will need a tank though.",
@@ -660,6 +663,7 @@
     "goal": "MGOAL_FIND_ITEM",
     "item": "text_gunsmith",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "I hate to admit it, but my first few tests haven't gone well.  I think I know what's wrong, but I need more information.",
       "offer": "I need a good quality reference book on gunsmithing.  This isn't my area of expertise, and I don't want to blow anybody up.",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
@@ -276,6 +276,7 @@
     "item": "disinfectant",
     "count": 50,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_REFUGEE_Uyen_2",
     "dialogue": {
       "describe": "We need help…",
@@ -307,6 +308,7 @@
     "item": "bandages",
     "count": 30,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_REFUGEE_Uyen_3",
     "dialogue": {
       "describe": "We need help…",
@@ -338,6 +340,7 @@
     "item": "prozac",
     "count": 60,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "We could still use your help…",
       "offer": "I probably shouldn't be prescribing things, but there's a ton of people needing help with sleep in here.  If you could get us some antidepressants, Rhyzaea and I can probably make sure they're doled out appropriately without people having to starve to pay for them.  Three month's worth - about 6 bottles - would last us a little while.",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
@@ -267,6 +267,7 @@
     "value": 0,
     "item": "survivor_hairtrimmer",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "If I had some equipment, I could do some hairdresser work here.",
       "offer": "I didn't think to pack my hairdressing equipment when I was evacuated.  If you could put together a basic hair cutting kit for me, I could do a bit of styling for people around here.  I'll even give you a free haircut for your troubles.",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_broker.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_broker.json
@@ -223,6 +223,7 @@
       "effect": [ { "u_spawn_item": "FMCNote", "count": 25 }, { "u_add_var": "mission_flag_FMBroker_Mission1", "value": "yes" } ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "I do have some work for you.",
       "offer": "You heard right.  When you brought in those canning jars, it got us thinking about expanding our food storage from dehydrated to include cans.  We could use some larger jars though for big stock items.  Can you bring me 50 large three liter jars?  I'll pay you a Certified Note per two.",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard1.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard1.json
@@ -118,6 +118,7 @@
     "item": "cig",
     "count": 100,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "Come on man, I just need a smoke.",
       "offer": "With all that's been going on, it's been more and more difficult to find a smoke.  My stash has been running low for a while now.  Think you could help me out here?  A few packs is all I need.",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -104,7 +104,7 @@
     "followup": "MISSION_SCIENCE_REP_2",
     "dialogue": {
       "describe": "It could be very informative to perform an analysis of zombie blood…",
-      "offer": "We don't have the equipment for real analysis here so it'll need to be done in the field.  I need you to get a fresh sample of zombie blood, take it to a hospital, and perform a centrifuge analysis of it.  I've been authorized to reward the completion of this job with <reward_count:FMCNote> merch, a sizeable sum of the local currency.",
+      "offer": "We don't have the equipment for real analysis here so it'll need to be done in the field.  I need you to get a fresh sample of zombie blood, take it to a hospital, and perform a centrifuge analysis of it.  I've been authorized to reward the completion of this job with 30 merch, a sizeable sum of the local currency.",
       "accepted": "Excellent.  Take this blood draw kit; once you've found a zombie corpse, use it to extract blood from the body, then take it to a hospital for analysis.",
       "rejected": "Are you sure?  The scientific value of that blood data could be priceless…",
       "advice": "The centrifuge is a bit technical; you might want to study up on the usage of computers before completing that part.",
@@ -129,7 +129,7 @@
     "followup": "MISSION_SCIENCE_REP_3",
     "dialogue": {
       "describe": "We need help…",
-      "offer": "The medical software didn't just analyze the blood, it triggered a government alert.  Medical staff was under orders to immediately drive any matching samples to the nearest laboratory.  That must mean the government knew!  We have the destination address.  Go there, get in, and bring back any records you can download off a computer.  Like last time, I can compensate you, and the Old Guard saw enough promise in this assignment to spare a larger sum of <reward_count:FMCNote> merch.  I'm sure you're also free to lay claim to any valuables you might find at the target location.",
+      "offer": "The medical software didn't just analyze the blood, it triggered a government alert.  Medical staff was under orders to immediately drive any matching samples to the nearest laboratory.  That must mean the government knew!  We have the destination address.  Go there, get in, and bring back any records you can download off a computer.  Like last time, I can compensate you, and the Old Guard saw enough promise in this assignment to spare a larger sum of 60 merch.  I'm sure you're also free to lay claim to any valuables you might find at the target location.",
       "accepted": "Great!  I've mapped out a route to the address.",
       "rejected": "Can't blame you, but come back if you change your mind.",
       "advice": "If the laboratory is locked, maybe you can find an id card from employees who died in the evacuation.  Also brush up on your computer skills, any computers will have some security on them.  Bring back anything you find on a USB drive.",
@@ -178,7 +178,7 @@
     "followup": "MISSION_SCIENCE_REP_5",
     "dialogue": {
       "describe": "We need help…",
-      "offer": "So there looks to be months, maybe years of experiments, and that data set must be huge.  Database servers massive enough to house it would overheat running on emergency power.  But I did find communications from a lab that had some kind of freezing portal open during the Cataclysm, sending everything to subzero temperatures.  I bet the archives inside that lab are still working.  The Old Guard didn't seem very convinced, but still ended up providing <reward_count:FMCNote> merch for this.",
+      "offer": "So there looks to be months, maybe years of experiments, and that data set must be huge.  Database servers massive enough to house it would overheat running on emergency power.  But I did find communications from a lab that had some kind of freezing portal open during the Cataclysm, sending everything to subzero temperatures.  I bet the archives inside that lab are still working.  The Old Guard didn't seem very convinced, but still ended up providing 100 merch for this.",
       "accepted": "Great!  I've mapped out a route.  Bundle up, it gets colder the deeper you go and it looks like the archives were on the fourth basement level.",
       "rejected": "Can't blame you, but come back if you change your mind.",
       "advice": "That lab is going to start freezing and just get colder the deeper you go.  You'll really need special equipment to survive that far down.  Bring back anything you find on a USB drive.",
@@ -212,7 +212,7 @@
     "has_generic_rewards": false,
     "dialogue": {
       "describe": "We need help…",
-      "offer": "In the data we found a major contract for tunneling and train equipment, ordered eight months ago.  It's the best lead we have.  Here's the address of the government lab where the equipment was delivered.  I want you to go there, find the tunnels that they dug, and download everything you can about the train network.  On the other hand, our sponsors were extremely impressed in getting this far without their direction, and would like to apologize by supporting this mission with a whole <reward_count:FMCNote> merch!",
+      "offer": "In the data we found a major contract for tunneling and train equipment, ordered eight months ago.  It's the best lead we have.  Here's the address of the government lab where the equipment was delivered.  I want you to go there, find the tunnels that they dug, and download everything you can about the train network.  On the other hand, our sponsors were extremely impressed in getting this far without their direction, and would like to apologize by supporting this mission with a whole 300 merch!",
       "accepted": "So glad for your help.",
       "rejected": "Can't blame you, but come back if you change your mind.",
       "advice": "The equipment was rated for 50 feet underground, so that tunnel entrance is going to be deeper inside a lab than a normal subway.  Fifty feet would mean maybe four stories down.  Bring back anything you find on a USB drive.",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -100,6 +100,7 @@
       "assign_mission_target": { "om_terrain": "hospital_2", "search_range": 540, "reveal_radius": 3 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_SCIENCE_REP_2",
     "dialogue": {
       "describe": "It could be very informative to perform an analysis of zombie blood…",
@@ -123,6 +124,7 @@
     "item": "software_lab_data",
     "start": "create_lab_console",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_SCIENCE_REP_3",
     "dialogue": {
       "describe": "We need help…",
@@ -146,6 +148,7 @@
     "item": "software_encryption_codes",
     "start": "create_hidden_lab_console",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_SCIENCE_REP_4",
     "dialogue": {
       "describe": "We need help…",
@@ -169,6 +172,7 @@
     "item": "software_archived_data",
     "start": "create_ice_lab_console",
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_SCIENCE_REP_5",
     "dialogue": {
       "describe": "We need help…",
@@ -202,6 +206,7 @@
       "effect": [ { "u_spawn_item": "usb_drive_nano" } ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "We need help…",
       "offer": "In the data we found a major contract for tunneling and train equipment, ordered eight months ago.  It's the best lead we have.  Here's the address of the government lab where the equipment was delivered.  I want you to go there, find the tunnels that they dug, and download everything you can about the train network.",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -129,7 +129,7 @@
     "followup": "MISSION_SCIENCE_REP_3",
     "dialogue": {
       "describe": "We need help…",
-      "offer": "The medical software didn't just analyze the blood, it triggered a government alert.  Medical staff was under orders to immediately drive any matching samples to the nearest laboratory.  That must mean the government knew!  We have the destination address.  Go there, get in, and bring back any records you can download off a computer.  Like last time, I can compensate you, and the Old Guard saw enough promise in this assignment to spare a larger sum of <reward_count:FMCNote> merch.",
+      "offer": "The medical software didn't just analyze the blood, it triggered a government alert.  Medical staff was under orders to immediately drive any matching samples to the nearest laboratory.  That must mean the government knew!  We have the destination address.  Go there, get in, and bring back any records you can download off a computer.  Like last time, I can compensate you, and the Old Guard saw enough promise in this assignment to spare a larger sum of <reward_count:FMCNote> merch.  I'm sure you're also free to lay claim to any valuables you might find at the target location.",
       "accepted": "Great!  I've mapped out a route to the address.",
       "rejected": "Can't blame you, but come back if you change your mind.",
       "advice": "If the laboratory is locked, maybe you can find an id card from employees who died in the evacuation.  Also brush up on your computer skills, any computers will have some security on them.  Bring back anything you find on a USB drive.",
@@ -221,6 +221,6 @@
       "success_lie": "What good does this do us?",
       "failure": "It was a lost cause anyways…"
     },
-    "end": { "effect": { "u_spawn_item": "FMCNote", "count": 200 } }
+    "end": { "effect": { "u_spawn_item": "FMCNote", "count": 300 } }
   }
 ]

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -104,7 +104,7 @@
     "followup": "MISSION_SCIENCE_REP_2",
     "dialogue": {
       "describe": "It could be very informative to perform an analysis of zombie blood…",
-      "offer": "We don't have the equipment for real analysis here so it'll need to be done in the field.  I need you to get a fresh sample of zombie blood, take it to a hospital, and perform a centrifuge analysis of it.",
+      "offer": "We don't have the equipment for real analysis here so it'll need to be done in the field.  I need you to get a fresh sample of zombie blood, take it to a hospital, and perform a centrifuge analysis of it.  I've been authorized to reward the completion of this job with <reward_count:FMCNote> merch, a sizeable sum of the local currency.",
       "accepted": "Excellent.  Take this blood draw kit; once you've found a zombie corpse, use it to extract blood from the body, then take it to a hospital for analysis.",
       "rejected": "Are you sure?  The scientific value of that blood data could be priceless…",
       "advice": "The centrifuge is a bit technical; you might want to study up on the usage of computers before completing that part.",
@@ -112,7 +112,8 @@
       "success": "Excellent!  This may be the key to removing the infection.",
       "success_lie": "Wait, you couldn't possibly have the data!  Liar!",
       "failure": "What a shame, that data could have proved invaluable…"
-    }
+    },
+    "end": { "effect": { "u_spawn_item": "FMCNote", "count": 30 } }
   },
   {
     "id": "MISSION_SCIENCE_REP_2",
@@ -128,7 +129,7 @@
     "followup": "MISSION_SCIENCE_REP_3",
     "dialogue": {
       "describe": "We need help…",
-      "offer": "The medical software didn't just analyze the blood, it triggered a government alert.  Medical staff was under orders to immediately drive any matching samples to the nearest laboratory.  That must mean the government knew!  We have the destination address.  Go there, get in, and bring back any records you can download off a computer.",
+      "offer": "The medical software didn't just analyze the blood, it triggered a government alert.  Medical staff was under orders to immediately drive any matching samples to the nearest laboratory.  That must mean the government knew!  We have the destination address.  Go there, get in, and bring back any records you can download off a computer.  Like last time, I can compensate you, and the Old Guard saw enough promise in this assignment to spare a larger sum of <reward_count:FMCNote> merch.",
       "accepted": "Great!  I've mapped out a route to the address.",
       "rejected": "Can't blame you, but come back if you change your mind.",
       "advice": "If the laboratory is locked, maybe you can find an id card from employees who died in the evacuation.  Also brush up on your computer skills, any computers will have some security on them.  Bring back anything you find on a USB drive.",
@@ -136,7 +137,8 @@
       "success": "Thanks!  This data looks damaged, but maybe I can make something out of it.",
       "success_lie": "What good does this do us?",
       "failure": "It was a lost cause anyways…"
-    }
+    },
+    "end": { "effect": { "u_spawn_item": "FMCNote", "count": 60 } }
   },
   {
     "id": "MISSION_SCIENCE_REP_3",
@@ -152,7 +154,7 @@
     "followup": "MISSION_SCIENCE_REP_4",
     "dialogue": {
       "describe": "We need help…",
-      "offer": "Unfortunately the data you got was incomplete and mostly encrypted.  There may be a way to get encryption codes, though.  I found a complaint by the infosec team that they were unable to deliver critical security updates to one research site.  It was some kind of more restricted secondary site hidden beneath a town, they weren't allowed in.  That means it should have unsecured computers we can get the codes from.",
+      "offer": "Unfortunately the data you got was incomplete and mostly encrypted.  There may be a way to get encryption codes, though.  I found a complaint by the infosec team that they were unable to deliver critical security updates to one research site.  It was some kind of more restricted secondary site hidden beneath a town, they weren't allowed in.  That means it should have unsecured computers we can get the codes from.  I couldn't secure any funding for this due to a lack of obvious results, but if you believe in this enough, maybe we can convince them otherwise?",
       "accepted": "Great!  I've mapped out a route, it should look like a normal house.  Bring back anything you find on a USB drive.",
       "rejected": "Can't blame you, but come back if you change your mind.",
       "advice": "Expect the lab to be locked as usual.",
@@ -176,7 +178,7 @@
     "followup": "MISSION_SCIENCE_REP_5",
     "dialogue": {
       "describe": "We need help…",
-      "offer": "So there looks to be months, maybe years of experiments, and that data set must be huge.  Database servers massive enough to house it would overheat running on emergency power.  But I did find communications from a lab that had some kind of freezing portal open during the Cataclysm, sending everything to subzero temperatures.  I bet the archives inside that lab are still working.",
+      "offer": "So there looks to be months, maybe years of experiments, and that data set must be huge.  Database servers massive enough to house it would overheat running on emergency power.  But I did find communications from a lab that had some kind of freezing portal open during the Cataclysm, sending everything to subzero temperatures.  I bet the archives inside that lab are still working.  The Old Guard didn't seem very convinced, but still ended up providing <reward_count:FMCNote> merch for this.",
       "accepted": "Great!  I've mapped out a route.  Bundle up, it gets colder the deeper you go and it looks like the archives were on the fourth basement level.",
       "rejected": "Can't blame you, but come back if you change your mind.",
       "advice": "That lab is going to start freezing and just get colder the deeper you go.  You'll really need special equipment to survive that far down.  Bring back anything you find on a USB drive.",
@@ -184,7 +186,8 @@
       "success": "Thanks!  This is a lot of data to go through.",
       "success_lie": "What good does this do us?",
       "failure": "It was a lost cause anyways…"
-    }
+    },
+    "end": { "effect": { "u_spawn_item": "FMCNote", "count": 100 } }
   },
   {
     "id": "MISSION_SCIENCE_REP_5",
@@ -209,7 +212,7 @@
     "has_generic_rewards": false,
     "dialogue": {
       "describe": "We need help…",
-      "offer": "In the data we found a major contract for tunneling and train equipment, ordered eight months ago.  It's the best lead we have.  Here's the address of the government lab where the equipment was delivered.  I want you to go there, find the tunnels that they dug, and download everything you can about the train network.",
+      "offer": "In the data we found a major contract for tunneling and train equipment, ordered eight months ago.  It's the best lead we have.  Here's the address of the government lab where the equipment was delivered.  I want you to go there, find the tunnels that they dug, and download everything you can about the train network.  On the other hand, our sponsors were extremely impressed in getting this far without their direction, and would like to apologize by supporting this mission with a whole <reward_count:FMCNote> merch!",
       "accepted": "So glad for your help.",
       "rejected": "Can't blame you, but come back if you change your mind.",
       "advice": "The equipment was rated for 50 feet underground, so that tunnel entrance is going to be deeper inside a lab than a normal subway.  Fifty feet would mean maybe four stories down.  Bring back anything you find on a USB drive.",
@@ -217,6 +220,7 @@
       "success": "Fantastic!  I should be able to reconstruct what cargo moved between which labs.  I wonder what was really going on down there.",
       "success_lie": "What good does this do us?",
       "failure": "It was a lost cause anyways…"
-    }
+    },
+    "end": { "effect": { "u_spawn_item": "FMCNote", "count": 200 } }
   }
 ]

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -201,7 +201,6 @@
     "difficulty": 1,
     "value": 500,
     "origins": [ "ORIGIN_SECONDARY" ],
-    "has_generic_rewards": false,
     "goal": "MGOAL_FIND_ITEM",
     "item": "fertilizer_commercial",
     "count": 120,

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -201,6 +201,7 @@
     "difficulty": 1,
     "value": 500,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "goal": "MGOAL_FIND_ITEM",
     "item": "fertilizer_commercial",
     "count": 120,

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
@@ -190,6 +190,7 @@
       }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_OLD_GUARD_REP_2",
     "dialogue": {
       "describe": "We need help…",
@@ -221,6 +222,7 @@
       ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_OLD_GUARD_REP_3",
     "dialogue": {
       "describe": "We need help…",
@@ -248,6 +250,7 @@
       "effect": [ { "math": [ "old_guard_rep_scouting", "=", "1" ] } ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_OLD_GUARD_REP_4",
     "dialogue": {
       "describe": "Got a weird one for you this time…",
@@ -277,6 +280,7 @@
       }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_OLD_GUARD_REP_5",
     "dialogue": {
       "describe": "We need help…",
@@ -316,6 +320,7 @@
       ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_OLD_GUARD_REPEATER_BEGIN",
     "dialogue": {
       "describe": "We need help…",
@@ -338,6 +343,7 @@
     "difficulty": 5,
     "value": 5000,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_OLD_GUARD_REPEATER",
     "dialogue": {
       "describe": "I don't need anything major for now, Marshal.  Well, except…",
@@ -372,6 +378,7 @@
     "difficulty": 5,
     "value": 5000,
     "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
     "followup": "MISSION_OLD_GUARD_REPEATER",
     "dialogue": {
       "describe": "We need more help…",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Pretty much the same reasoning as #77453, but this time focusing on that the Old Guard doctor says `"We can't.  There's nothing we can spare to sell and I've got no budget to buy from you.  I don't suppose you want to donate?"` and still giving you an opportunity to sweep his stock once you complete one of his quests.

None of the refugees getting help from you have anything of value to give, so instead of giving you a weird dialogue that is kind of like "Hey can you give me some of your practically worthless belongings for this huge undertaking I'm doing for you?" (an exaggeration). So I figured it be best for the dialogue to treat the exchange like the charity it really is.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Giving `"has_generic_rewards": false` to most quests (except Pablo, the auto-completing one. also Makayla, for having an equally small credit reward as the relative size of the store.)

~~Still in draft: Need to communicate that the doctor can't give anything.~~

The Old Guard doctor now gives you merch rewards via his backers.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
~~Once this is out of draft, I will hopefully have tested everything and adjusting more dialogue as needed.~~

I tested out every Refugee Center quest (with the exception of giving Jenny a copy of `book_pneumatics`. I couldn't figure out the necessary conditions.) and found that noone (except Pablo's auto-completing quest, as well as Makayla having a shop attached to being a quest-giver) provides store credit.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I have been hoping at getting the true Old Guard rewards to resemble something more like trust for the faction, building towards PR 77309, but that's scope creep for right now.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
