### PR TITLE
debug: check for SIGINT during debug prompt

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -33,6 +33,7 @@
 #include "color.h"
 #include "cursesdef.h"
 #include "filesystem.h"
+#include "game.h"
 #include "get_version.h"
 #include "input.h"
 #include "loading_ui.h"
@@ -382,7 +383,15 @@ static void debug_error_prompt(
 #endif
     for( bool stop = false; !stop; ) {
         ui_manager::redraw();
-        switch( inp_mngr.get_input_event().get_first_input() ) {
+        inp_mngr.set_timeout( 50 );
+        input_event ievent = inp_mngr.get_input_event();
+        if( ievent.type == input_event_t::timeout ) {
+            if( g && g->uquit == QUIT_EXIT ) {
+                g->query_exit_to_OS();
+            }
+            continue;
+        }
+        switch( ievent.get_first_input() ) {
 #if defined(TILES)
             case 'c':
             case 'C':

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -131,9 +131,7 @@ namespace
 void check_sigint()
 {
     if( g && g->uquit == quit_status::QUIT_EXIT ) {
-        if( g->query_exit_to_OS() ) {
-            throw game::exit_exception();
-        }
+        g->query_exit_to_OS();
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -852,13 +852,13 @@ int main( int argc, const char *argv[] )
 
     while( true ) {
         main_menu menu;
-        if( !menu.opening_screen() ) {
-            break;
-        }
-
-        shared_ptr_fast<ui_adaptor> ui = g->create_or_get_main_ui_adaptor();
-        get_event_bus().send<event_type::game_begin>( getVersionString() );
         try {
+            if( !menu.opening_screen() ) {
+                break;
+            }
+
+            shared_ptr_fast<ui_adaptor> ui = g->create_or_get_main_ui_adaptor();
+            get_event_bus().send<event_type::game_begin>( getVersionString() );
             while( !do_turn() ) { }
         } catch( game::exit_exception const &/* ex */ ) {
             break;

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -1065,6 +1065,8 @@ bool main_menu::new_character_tab()
         world_generator->set_active_world( world );
         try {
             g->setup();
+        } catch( const game::exit_exception &ex ) {
+            throw ex; // re-throw to main loop
         } catch( const std::exception &err ) {
             debugmsg( "Error: %s", err.what() );
             return false;


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Sending a SIGINT or closing the window doesn't work while a debug message is displayed.
* Fixup for #75999

#### Describe the solution
Check for SIGINT in the debug message input loop too...

#### Describe alternatives you've considered
Reverting #75999 and #67893 since pedantry is sometimes hard and fruitless

#### Testing
<details>
<summary>Sending a SIGINT or trying to close the window now shows the prompt during a debug message.</summary>

![Screenshot From 2024-10-30 19-56-11](https://github.com/user-attachments/assets/eb85b8f2-465d-4d15-93bb-1bd733a30fe0)


</details>
The debug prompt can be dismissed as usual

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
