### PR TITLE
fix mapgen special build errors

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1094,7 +1094,7 @@
     "connections": [ { "point": [ 1, -5, 0 ], "terrain": "road", "connection": "local_road", "existing": true } ],
     "locations": [ "field" ],
     "city_distance": [ 10, 40 ],
-    "occurrences": [ 1, 3 ],
+    "occurrences": [ 0, 3 ],
     "priority": -1,
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1094,7 +1094,7 @@
     "connections": [ { "point": [ 1, -5, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "field" ],
     "city_distance": [ 10, 40 ],
-    "occurrences": [ 1 3 ],
+    "occurrences": [ 1, 3 ],
     "priority": -1,
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -15,7 +15,7 @@
     ],
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
-    "occurrences": [ 0, 2 ],
+    "occurrences": [ 1, 2 ],
     "priority": -1,
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },
@@ -32,10 +32,10 @@
       { "point": [ 0, 1, 1 ], "overmap": "motel_2_roof_north" },
       { "point": [ 1, 1, 1 ], "overmap": "motel_3_roof_north" }
     ],
-    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ], "existing": true } ],
+    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
-    "occurrences": [ 0, 2 ],
+    "occurrences": [ 1, 2 ],
     "priority": -1,
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },
@@ -1091,10 +1091,10 @@
       { "point": [ 3, 1, 0 ], "overmap": "special_field" },
       { "point": [ 1, -5, 0 ], "locations": [ "land", "road" ] }
     ],
-    "connections": [ { "point": [ 1, -5, 0 ], "terrain": "road", "connection": "local_road", "existing": true } ],
+    "connections": [ { "point": [ 1, -5, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "field" ],
     "city_distance": [ 10, 40 ],
-    "occurrences": [ 0, 3 ],
+    "occurrences": [ 1 3 ],
     "priority": -1,
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -10,8 +10,8 @@
       { "point": [ 0, 0, 2 ], "overmap": "motel_twd_1_f2_north" }
     ],
     "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ], "existing": true },
-      { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ], "existing": true }
+      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] },
+      { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
@@ -55,7 +55,7 @@
       { "point": [ 0, 1, 2 ], "overmap": "2fmotel_2_r_north" },
       { "point": [ 1, 1, 2 ], "overmap": "2fmotel_3_r_north" }
     ],
-    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ], "existing": true } ],
+    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 8, 40 ],
     "occurrences": [ 0, 2 ],

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -15,7 +15,7 @@
     ],
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
-    "occurrences": [ 1, 2 ],
+    "occurrences": [ 0, 2 ],
     "priority": -1,
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },
@@ -35,7 +35,7 @@
     "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ], "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
-    "occurrences": [ 1, 2 ],
+    "occurrences": [ 0, 2 ],
     "priority": -1,
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },

--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -14,21 +14,7 @@
       "ravine_floor",
       "ravine_floor_edge",
       "rock_border",
-      "s_restaurant_deserted_test",
-      "wind_turbine_ground",
-      "wind_turbine_pillar",
-      "wind_turbine_pillar_platform",
-      "wind_turbine_roof",
-      "wind_turbine_nacelle",
-      "motel_twd_1",
-      "motel_entrance_no_sidewalk",
-      "motel_twd_2",
-      "motel_twd_1_f1",
-      "motel_1_no_sidewalk",
-      "motel_2_no_sidewalk",
-      "motel_3_no_sidewalk",
-      "motel_twd_2_f1",
-      "motel_twd_1_f2"
+      "s_restaurant_deserted_test"
     ]
   }
 ]

--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -14,7 +14,21 @@
       "ravine_floor",
       "ravine_floor_edge",
       "rock_border",
-      "s_restaurant_deserted_test"
+      "s_restaurant_deserted_test",
+      "wind_turbine_ground",
+      "wind_turbine_pillar",
+      "wind_turbine_pillar_platform",
+      "wind_turbine_roof",
+      "wind_turbine_nacelle",
+      "motel_twd_1",
+      "motel_entrance_no_sidewalk",
+      "motel_twd_2",
+      "motel_twd_1_f1",
+      "motel_1_no_sidewalk",
+      "motel_2_no_sidewalk",
+      "motel_3_no_sidewalk",
+      "motel_twd_2_f1",
+      "motel_twd_1_f2"
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
Bugfixes "fix mapgen special build errors"

#### Purpose of change

Fix build

#### Describe the solution

Removing existing road requirements from new map specials

#### Describe alternatives you've considered

Set the minimum occurrences of these non-unique map specials:

- wind turbine 
- Motel
- motel-twd

 ...to zero as stated in the relevant doc.  See https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/OVERMAP.md

Add related terrains to overmap_terrain_coverage_whitelist

#### Testing

WIP

#### Additional context

Thanks to @Maleclypse for the idea