### PR TITLE
Refactoring Hub01's prototype menu

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -223,13 +223,7 @@
       "TALK_ROBOFAC_INTERCOM_SERVICES",
       "TALK_ROBOFAC_INTERCOM_SERVICES_FIRST",
       "TALK_ROBOFAC_INTERCOM_PORTAL_STORMS_END",
-      "TALK_ROBOFAC_INTERCOM_FREE_MERCHANT_DELIVERY_MERCENARY_END",
-      "TALK_ROBOFAC_INTERCOM_ARMOR_BREAKTHROUGH_END",
-      "TALK_ROBOFAC_INTERCOM_RIFLE_STARTED",
-      "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_SHORT",
-      "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_LONG",
-      "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1_STARTED",
-      "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2_STARTED"
+      "TALK_ROBOFAC_INTERCOM_FREE_MERCHANT_DELIVERY_MERCENARY_END"
     ],
     "type": "talk_topic",
     "dynamic_line": {
@@ -237,7 +231,6 @@
       "no": [
         "So, do you need something?",
         "Yes, mercenary?",
-        "Mercenary.",
         "Mercenary.",
         "Well?",
         "Say it.",
@@ -594,20 +587,12 @@
     "dynamic_line": "Thank you.  This might be of use benefit to us, but we will need at least a day to read the contents of the template.  Please speak with us again once we've had time.",
     "speaker_effect": {
       "effect": [
-        {
-          "u_sell_item": "template_armor",
-          "count": 1,
-          "true_eocs": {
-            "id": "EOC_nano_ask",
-            "effect": [
-              { "u_add_faction_trust": 2 },
-              { "math": [ "u_timer_hub_rnd_u_waiting_on_armor", "=", "time('now')" ] },
-              { "u_add_var": "dialogue_hub_rnd_u_gave_armor_disk", "value": "yes" },
-              { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-              { "u_add_var": "dialogue_intercom_u_hub_prototypes", "value": "yes" }
-            ]
-          }
-        }
+        { "u_consume_item": "template_armor", "count": 1, "popup": true },
+        { "u_add_faction_trust": 2 },
+        { "math": [ "u_timer_hub_rnd_u_waiting_on_armor", "=", "time('now')" ] },
+        { "u_add_var": "dialogue_hub_rnd_u_gave_armor_disk", "value": "yes" },
+        { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+        { "u_add_var": "dialogue_intercom_u_hub_prototypes", "value": "yes" }
       ],
       "sentinel": "gave_armor_template"
     },
@@ -615,11 +600,6 @@
       { "text": "Very well.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
       { "text": "I'll see you then.", "topic": "TALK_DONE" }
     ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_fema_data",
-    "effect": { "u_add_var": "dialogue_intercom_completed_free_merchants_hub_delivery_1", "value": "yes" }
   },
   {
     "//": "These are all dialogues related to the breadcrumb quest from the refugee center to deliver a hard drive.",
@@ -642,7 +622,10 @@
       {
         "text": "[Hand over the FEMA data.]",
         "condition": { "u_has_items": { "item": "fema_data", "count": 1 } },
-        "effect": [ { "u_sell_item": "fema_data", "count": 1, "true_eocs": "EOC_fema_data" } ],
+        "effect": [
+          { "u_consume_item": "fema_data", "count": 1, "popup": true },
+          { "u_add_var": "dialogue_intercom_completed_free_merchants_hub_delivery_1", "value": "yes" }
+        ],
         "topic": "TALK_ROBOFAC_INTERCOM_FREE_MERCHANT_DELIVERY_END"
       },
       {
@@ -678,7 +661,10 @@
       {
         "text": "[Hand over the FEMA data.]",
         "condition": { "u_has_items": { "item": "fema_data", "count": 1 } },
-        "effect": [ { "u_sell_item": "fema_data", "count": 1, "true_eocs": "EOC_fema_data" } ],
+        "effect": [
+          { "u_consume_item": "fema_data", "count": 1, "popup": true },
+          { "u_add_var": "dialogue_intercom_completed_free_merchants_hub_delivery_1", "value": "yes" }
+        ],
         "topic": "TALK_ROBOFAC_INTERCOM_FREE_MERCHANT_DELIVERY_MERCENARY_END"
       },
       {

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -1109,7 +1109,7 @@
       {
         "text": "I appreciate the credit.  I've got your payment now.",
         "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 8 },
+          { "u_consume_item": "RobofacCoin", "count": 8, "popup": true },
           { "finish_mission": "MISSION_HUB01_PAY_BACK_RIOT_GEAR", "success": true }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -1,28 +1,86 @@
 [
   {
-    "id": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU",
+    "id": "EOC_INTERCOM_SPAWN_ARMOR_SET",
+    "type": "effect_on_condition",
+    "condition": { "expects_vars": [ "armor_type" ] },
+    "effect": [
+      {
+        "if": { "compare_string": [ "robofac_armor_pieces_rig", { "context_val": "armor_type" } ] },
+        "then": [ { "u_spawn_item": "robofac_armor_rig" }, { "u_spawn_item": "robofac_head_rig" } ]
+      },
+      {
+        "if": { "compare_string": [ "robofac_armor_pieces_basic", { "context_val": "armor_type" } ] },
+        "then": [
+          { "u_spawn_item": "robofac_basic_mantle" },
+          { "u_spawn_item": "robofac_basic_skirt" },
+          { "u_spawn_item": "robofac_basic_vambraces" },
+          { "u_spawn_item": "robofac_basic_greaves" },
+          { "u_spawn_item": "robofac_basic_helmet" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ "robofac_armor_pieces_nomex", { "context_val": "armor_type" } ] },
+        "then": [
+          { "u_spawn_item": "robofac_nomex_mantle" },
+          { "u_spawn_item": "robofac_nomex_skirt" },
+          { "u_spawn_item": "robofac_nomex_vambraces" },
+          { "u_spawn_item": "robofac_nomex_greaves" },
+          { "u_spawn_item": "robofac_nomex_helmet" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ "robofac_armor_pieces_kevlar", { "context_val": "armor_type" } ] },
+        "then": [
+          { "u_spawn_item": "robofac_kevlar_mantle" },
+          { "u_spawn_item": "robofac_kevlar_skirt" },
+          { "u_spawn_item": "robofac_kevlar_vambraces" },
+          { "u_spawn_item": "robofac_kevlar_greaves" },
+          { "u_spawn_item": "robofac_kevlar_helmet" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ "robofac_armor_pieces_rubber", { "context_val": "armor_type" } ] },
+        "then": [
+          { "u_spawn_item": "robofac_rubber_skirt" },
+          { "u_spawn_item": "robofac_rubber_vambraces" },
+          { "u_spawn_item": "robofac_rubber_greaves" },
+          { "u_spawn_item": "robofac_rubber_mantle" },
+          { "u_spawn_item": "robofac_rubber_helmet" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ "robofac_armor_pieces_military", { "context_val": "armor_type" } ] },
+        "then": [
+          { "u_spawn_item": "robofac_military_skirt" },
+          { "u_spawn_item": "robofac_military_vambraces" },
+          { "u_spawn_item": "robofac_military_greaves" },
+          { "u_spawn_item": "robofac_military_mantle" },
+          { "u_spawn_item": "robofac_military_helmet" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": [
+      "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1_STARTED",
+      "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2_STARTED",
+      "TALK_ROBOFAC_INTERCOM_ARMOR_STARTED",
+      "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU",
+      "TALK_ROBOFAC_INTERCOM_PROTOTYPE_NO",
+      "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_LONG",
+      "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_SHORT",
+      "TALK_ROBOFAC_INTERCOM_RIFLE_STARTED"
+    ],
     "//": "Overall menu for all Robofac projects",
     "type": "talk_topic",
-    "dynamic_line": "Certainly.  What project would you like to know about?",
+    "dynamic_line": "What project would you like to know about?",
     "responses": [
       {
         "text": "Have you decoded the disk?",
         "condition": {
           "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_armor)", "<", "time('1 d')" ] },
             { "math": [ "hub01_uhmwpe_researched", "!=", "1" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_gave_armor_disk" } ] }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_ONGOING"
-      },
-      {
-        "text": "It's been a while.  Have you decoded that disk from the tower?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_armor)", ">", "time('1 d')" ] },
-            { "math": [ "hub01_uhmwpe_researched", "!=", "1" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_gave_armor_disk" } ] }
+            { "math": [ "has_var(u_dialogue_hub_rnd_u_gave_armor_disk)" ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_BREAKTHROUGH"
@@ -32,17 +90,16 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 6 } },
-            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_buy_armor" } ] }
+            { "math": [ "has_var(u_dialogue_hub_rnd_u_can_buy_armor)" ] }
           ]
         },
         "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 6 },
-          { "u_spawn_item": "robofac_military_skirt" },
-          { "u_spawn_item": "robofac_military_vambraces" },
-          { "u_spawn_item": "robofac_military_greaves" },
-          { "u_spawn_item": "robofac_military_mantle" },
-          { "u_spawn_item": "robofac_military_helmet" },
-          { "u_add_var": "dialogue_hub_rnd_u_can_buy_armor", "value": "no" }
+          { "u_consume_item": "RobofacCoin", "count": 6, "popup": true },
+          {
+            "run_eoc_with": "EOC_INTERCOM_SPAWN_ARMOR_SET",
+            "variables": { "armor_type": "robofac_armor_pieces_military" }
+          },
+          { "u_lose_var": "dialogue_hub_rnd_u_can_buy_armor" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
       },
@@ -50,150 +107,48 @@
         "text": "I'd like to request a Hybrid Weapons Platform.",
         "condition": {
           "and": [
-            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
+            { "math": [ "has_var(u_dialogue_robofac_merc_1_robofac_merc_1_HWP)" ] },
+            { "math": [ "!has_var(u_dialogue_hub_rnd_u_project_ongoing)" ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_RIFLE_REQUEST"
       },
       {
         "text": "How goes work on the HWP?",
-        "condition": {
-          "and": [
-            { "math": [ "has_var(u_timer_hub_rnd_u_waiting_on_gun)" ] },
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_gun)", "<", "time('7 d')" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING"
+        "condition": { "math": [ "has_var(u_timer_hub_rnd_u_waiting_on_gun)" ] },
+        "topic": "TALK_ROBOFAC_INTERCOM_RIFLE_BREAKTHROUGH"
       },
       {
-        "text": "I'd like to request a replacement Modular Defense System.",
-        "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rig" },
+        "text": "I'd like to request a set of armor.",
         "condition": {
           "and": [
-            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
-      },
-      {
-        "text": "I'd like to request a set of prototype armor.",
-        "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_basic" },
-        "condition": {
-          "and": [
-            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
-      },
-      {
-        "text": "I'd like to request a set of turnout armor.",
-        "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_nomex" },
-        "condition": {
-          "and": [
-            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
-      },
-      {
-        "text": "I'd like to request a set of ballistic armor.",
-        "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_kevlar" },
-        "condition": {
-          "and": [
-            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
-      },
-      {
-        "text": "I'd like to request a set of kinetic armor.",
-        "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rubber" },
-        "condition": {
-          "and": [
-            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
-      },
-      {
-        "text": "I'd like to request a set of soldier armor.",
-        "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_military" },
-        "condition": {
-          "and": [
-            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_buy_armor" } ] } },
-            { "math": [ "hub01_uhmwpe_researched", "==", "1" ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
+            { "math": [ "has_var(u_dialogue_robofac_merc_1_robofac_merc_1_HWP)" ] },
+            { "math": [ "!has_var(u_dialogue_hub_rnd_u_project_ongoing)" ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
       },
       {
         "text": "How is my ordered armor going?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('1 d')" ] },
-            {
-              "or": [
-                { "compare_string": [ "robofac_armor_pieces_rig", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-                { "compare_string": [ "robofac_armor_pieces_basic", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-                { "compare_string": [ "robofac_armor_pieces_rubber", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-                { "compare_string": [ "robofac_armor_pieces_nomex", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-                { "compare_string": [ "robofac_armor_pieces_kevlar", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-                {
-                  "compare_string": [ "robofac_armor_pieces_military", { "u_val": "dialogue_hub_rnd_u_armor_type" } ]
-                }
-              ]
-            }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_FINISHED_NO"
+        "condition": { "math": [ "has_var(u_dialogue_hub_rnd_u_armor_type)" ] },
+        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_FINISHED"
       },
       {
-        "text": "How is my ordered armor going?  It should be done by now.",
+        "text": "I would like you to upgrade my modular defense system.",
         "condition": {
           "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('1 d')" ] },
-            {
-              "or": [
-                { "compare_string": [ "robofac_armor_pieces_rig", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-                { "compare_string": [ "robofac_armor_pieces_basic", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-                { "compare_string": [ "robofac_armor_pieces_rubber", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-                { "compare_string": [ "robofac_armor_pieces_nomex", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-                { "compare_string": [ "robofac_armor_pieces_kevlar", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-                {
-                  "compare_string": [ "robofac_armor_pieces_military", { "u_val": "dialogue_hub_rnd_u_armor_type" } ]
-                }
-              ]
-            }
+            { "math": [ "has_var(u_dialogue_hub_rnd_u_completed_anchor_pt_1)" ] },
+            { "math": [ "!has_var(u_dialogue_hub_rnd_u_project_ongoing)" ] }
           ]
         },
-        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_FINISHED_YES"
-      },
-      {
-        "text": "The HWP should be complete by now, right?",
-        "condition": {
-          "and": [
-            { "math": [ "has_var(u_timer_hub_rnd_u_waiting_on_gun)" ] },
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_gun)", ">", "time('7 d')" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_RIFLE_BREAKTHROUGH"
+        "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2"
       },
       {
         "text": "My phase immersion suit has taken a serious beating.  Could someone repair it for me?",
         "condition": {
           "and": [
             { "u_has_items": { "item": "phase_immersion_suit", "count": 1 } },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
+            { "math": [ "!has_var(u_dialogue_hub_rnd_u_project_ongoing)" ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PHASE_REPAIR"
@@ -203,7 +158,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "rm13_armor", "count": 1 } },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
+            { "math": [ "!has_var(u_dialogue_hub_rnd_u_project_ongoing)" ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_RM13_REPAIR"
@@ -213,7 +168,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "combat_exoskeleton_light_salvaged", "count": 1 } },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
+            { "math": [ "!has_var(u_dialogue_hub_rnd_u_project_ongoing)" ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_EXOSKELETON_REPAIR"
@@ -221,110 +176,33 @@
       {
         "text": "How are my armor repairs coming?",
         "condition": {
-          "and": [
-            { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", ">", "time('now')" ] },
-            {
-              "or": [
-                { "compare_string": [ "combat_exoskeleton_light_salvaged", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
-                { "compare_string": [ "phase_immersion_suit", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
-                { "compare_string": [ "rm13_armor", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
-              ]
-            }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING"
-      },
-      {
-        "text": "How are my armor repairs coming?",
-        "condition": {
-          "and": [
-            { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "<", "time('now')" ] },
-            { "compare_string": [ "phase_immersion_suit", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_PHASE_REPAIR_COMPLETE"
-      },
-      {
-        "text": "How are my armor repairs coming?",
-        "condition": {
-          "and": [
-            { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "<", "time('now')" ] },
+          "or": [
+            { "compare_string": [ "combat_exoskeleton_light_salvaged", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
+            { "compare_string": [ "phase_immersion_suit", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
             { "compare_string": [ "rm13_armor", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
           ]
         },
-        "topic": "TALK_ROBOFAC_INTERCOM_RM13_REPAIR_COMPLETE"
-      },
-      {
-        "text": "How are my exoskeleton repairs coming?",
-        "condition": {
-          "and": [
-            { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "<", "time('now')" ] },
-            {
-              "compare_string": [ "combat_exoskeleton_light_salvaged", { "u_val": "dialogue_hub_rnd_u_current_project" } ]
-            }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_EXOSKELETON_REPAIR_COMPLETE"
+        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR"
       },
       {
         "text": "I've found this piece of XEDRA tech; it seems to offer some kind of protection.  I'm curious what you all can make of it.",
         "condition": {
           "and": [
             { "u_has_items": { "item": "dimensional_anchor", "count": 1 } },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_completed_anchor_pt_1" } ] } }
+            { "math": [ "!has_var(u_dialogue_hub_rnd_u_project_ongoing)" ] },
+            { "math": [ "!has_var(u_dialogue_hub_rnd_u_completed_anchor_pt_1)" ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1"
       },
       {
         "text": "Any progress on the anchor?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('5 d')" ] },
-            { "compare_string": [ "anchor_pt_1", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING"
-      },
-      {
-        "text": "Any progress on the anchor?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('5 d')" ] },
-            { "compare_string": [ "anchor_pt_1", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
-          ]
-        },
+        "condition": { "compare_string": [ "anchor_pt_1", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
         "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1_COMPLETE"
       },
       {
-        "text": "I would like you to upgrade my modular defense system.",
-        "condition": {
-          "and": [
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } },
-            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_completed_anchor_pt_1" } ] }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2"
-      },
-      {
         "text": "Any progress on the Hub anchor?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('2 d')" ] },
-            { "compare_string": [ "anchor_pt_2", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING"
-      },
-      {
-        "text": "Any progress on the Hub anchor?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('2 d')" ] },
-            { "compare_string": [ "anchor_pt_2", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
-          ]
-        },
+        "condition": { "compare_string": [ "anchor_pt_2", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
         "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2_COMPLETE"
       },
       {
@@ -332,8 +210,8 @@
         "condition": {
           "and": [
             { "math": [ "hub01_hwp_exotic_researched", "!=", "1" ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } },
-            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_has_researched_gun" } ] },
+            { "math": [ "!has_var(u_dialogue_hub_rnd_u_project_ongoing)" ] },
+            { "math": [ "has_var(u_dialogue_hub_rnd_u_has_researched_gun)" ] },
             {
               "or": [ { "u_has_items": { "item": "pamd68", "count": 1 } }, { "u_has_items": { "item": "pamd71z", "count": 1 } } ]
             }
@@ -342,49 +220,17 @@
         "topic": "TALK_ROBOFAC_INTERCOM_HWP_EXODII"
       },
       {
-        "text": "Any progress on the exotic barrel?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('3 d')" ] },
-            { "compare_string": [ "hwp_exodii", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING"
-      },
-      {
         "text": "Have you finished work on that exotic conversion kit?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('3 d')" ] },
-            { "compare_string": [ "hwp_exodii", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
-          ]
-        },
+        "condition": { "compare_string": [ "hwp_exodii", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
         "topic": "TALK_ROBOFAC_INTERCOM_HWP_EXODII_COMPLETE"
       },
       { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" }
     ]
   },
   {
-    "id": [
-      "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING",
-      "TALK_ROBOFAC_INTERCOM_ARMOR_ONGOING",
-      "TALK_ROBOFAC_INTERCOM_ROBOT_ONGOING"
-    ],
-    "//": "default response to any project that isn't completed",
-    "type": "talk_topic",
-    "dynamic_line": "Work is still ongoing.  These things can take time.",
-    "responses": [
-      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" },
-      { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
-      { "text": "I'll check in later.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
     "id": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_NO",
-    "//": "default response to any project that isn't allowed",
     "type": "talk_topic",
-    "dynamic_line": "At the moment, no.  While you are no doubt proficient, distribution of prototype equipment is so far restricted to trusted field agents.  Were someone else from the organization to vouch for your competency, we may consider extending access.",
-    "responses": [ { "text": "I see.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
+    "dynamic_line": "At the moment, no.  While you are no doubt proficient, distribution of prototype equipment is so far restricted to trusted field agents.  Were someone else from the organization to vouch for your competency, we may consider extending access."
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_GUN_YES",
@@ -397,57 +243,40 @@
         "text": "Great.  What exactly is this 'Hybrid Weapons Platform', anyway?",
         "topic": "TALK_ROBOFAC_INTERCOM_RIFLE_REQUEST"
       },
-      { "text": "Thanks.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" }
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
     ]
   },
   {
-    "id": "TALK_ROBOFAC_INTERCOM_ARMOR_BREAKTHROUGH",
-    "//": "armor reward blurb after waiting",
+    "id": "TALK_ROBOFAC_INTERCOM_RIFLE_BREAKTHROUGH",
+    "//": "getting an HWP",
     "type": "talk_topic",
-    "dynamic_line": "Yes we have!  The disk contained the configuration necessary to print our armors with a much more resilient composite than was previously available to us, without sacrificing any maneuverability.  As a form of payment, we are willing to provide you with the first functional models of the armor at a good price - six HGC.  While that may seem steep, the materials used are very high-end, and six coins just barely covers the production cost alone.  If you are unwilling or incapable of filling that price now, the offer will remain available indefinitely - just let us know when you'd like it.\n\n\"Should you find anything else of interest in the world, please bring it to us.  We would be happy to collaborate like this again in the future.",
-    "speaker_effect": {
-      "effect": [
-        { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-        { "math": [ "hub01_uhmwpe_researched", "=", "1" ] }
-      ]
+    "dynamic_line": {
+      "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_gun)", ">=", "time('7 d')" ],
+      "yes": "The Platform is complete.  As a reminder, the HWP will not function as a weapon without a conversion kit installed.  Transferring the requested items now.\"\n\nThe tray shakes as several heavy objects are dropped into it, and it slides open.  Inside: the Hybrid Weapons Platform.  On its own, it doesn't look like much; it resembles the body of a service rifle without a stock or barrel, colored in sleek black with blue highlights around the magazine well.  Small yellow arrows and inscriptions are present at certain points, highlighting the fasteners used to assemble the thing in earnest.  Accompanying the Platform itself is a series of four bundles of parts for it, each held together using velcro strips and tagged by caliber.  A drawstring nylon bag, embroidered with the Hub's logo and filled with proprietary tools, completes the whole package.\n\nAll in all, not a bad deal.\n\n\"Should you require magazines of any given caliber, we are willing to provide them through standard requisitions.  We hope you find its performance to be satisfactory.",
+      "no": "Work is still ongoing.  These things can take time."
     },
     "responses": [
       {
-        "text": "[6 HGC] Let's see what this armor is capable of.",
-        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 6 } },
+        "text": "Thanks.",
+        "condition": { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_gun)", ">=", "time('7 d')" ] },
         "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 6 },
-          { "u_spawn_item": "robofac_military_skirt" },
-          { "u_spawn_item": "robofac_military_vambraces" },
-          { "u_spawn_item": "robofac_military_greaves" },
-          { "u_spawn_item": "robofac_military_mantle" },
-          { "u_spawn_item": "robofac_military_helmet" }
+          { "u_add_var": "dialogue_hub_rnd_u_has_researched_gun", "value": "yes" },
+          { "u_lose_var": "dialogue_hub_rnd_u_project_ongoing" },
+          { "u_lose_var": "timer_hub_rnd_u_waiting_on_gun" },
+          { "u_spawn_item": "robofac_gun" },
+          { "u_spawn_item": "robofac_gun_ar" },
+          { "u_spawn_item": "robofac_gun_smg" },
+          { "u_spawn_item": "robofac_gun_dmr" },
+          { "u_spawn_item": "robofac_gun_shotgun" },
+          { "u_spawn_item": "robofac_gun_kit" },
+          { "u_spawn_item": "robofac40", "count": 2 },
+          { "u_spawn_item": "robofac60", "count": 2 },
+          { "u_spawn_item": "robofac20", "count": 2 },
+          { "u_spawn_item": "robofac10", "count": 2 }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
       },
-      {
-        "text": "What about another project?",
-        "effect": [ { "u_add_var": "dialogue_hub_rnd_u_can_buy_armor", "value": "yes" } ],
-        "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU"
-      },
-      {
-        "text": "<done_conversation_section>",
-        "effect": [ { "u_add_var": "dialogue_hub_rnd_u_can_buy_armor", "value": "yes" } ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "text": "I'll check in later.",
-        "effect": [ { "u_add_var": "dialogue_hub_rnd_u_can_buy_armor", "value": "yes" } ],
-        "topic": "TALK_DONE"
-      }
-    ]
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_ARMOR_ONGOING",
-    "type": "talk_topic",
-    "dynamic_line": [
-      "Not yet.  The contents are very strongly encrypted, so simply pulling the data is impossible.  Work is underway to deduce the correct access key, but even with our facilities, it will take some time.",
-      "Unfortunately, no.  Though the disk was well-protected, the environment did cause some damage.  It's nothing unsalvageable, but care is being taken to restore the contents without causing further damage."
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
     ]
   },
   {
@@ -465,7 +294,7 @@
         "text": "[8 HGC] A week is fine.",
         "condition": { "u_has_items": { "item": "RobofacCoin", "count": 8 } },
         "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 8 },
+          { "u_consume_item": "RobofacCoin", "count": 8, "popup": true },
           { "u_add_faction_trust": 2 },
           { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" }
@@ -484,221 +313,7 @@
         "text": "Why should I use this over something like a rifle that doesn't need proprietary parts?",
         "topic": "TALK_ROBOFAC_INTERCOM_RIFLE_BENEFITS"
       },
-      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" },
-      { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
-      { "text": "I'll check in later.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "id": [ "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST" ],
-    "//": "buying armor",
-    "type": "talk_topic",
-    "dynamic_line": "Understood.  The parts will finish fabrication in 24 hours, once you hand over the stipulated HGC.  Depending on our currently available selection, the price will range from 2 to 4 HGC for non-specialty equipment.",
-    "responses": [
-      {
-        "//": "Armor Rig response.",
-        "text": "[3 HGC] Here you go.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 3 } },
-            { "compare_string": [ "robofac_armor_pieces_rig", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 3 },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "yes" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "//": "Prototype Armor response.",
-        "text": "[2 HGC] Here you go.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 2 } },
-            { "compare_string": [ "robofac_armor_pieces_basic", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 2 },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "yes" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "//": "Turnout Armor response.",
-        "text": "[4 HGC] Here you go.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 4 } },
-            { "compare_string": [ "robofac_armor_pieces_nomex", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 4 },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "yes" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "//": "Ballistic Armor response.",
-        "text": "[4 HGC] Here you go.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 4 } },
-            { "compare_string": [ "robofac_armor_pieces_kevlar", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 4 },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "yes" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "//": "Kinetic Armor response.",
-        "text": "[4 HGC] Here you go.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 4 } },
-            { "compare_string": [ "robofac_armor_pieces_rubber", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 4 },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "yes" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "//": "Military Armor response.",
-        "text": "[12 HGC] Here you go.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "compare_string": [ "robofac_armor_pieces_military", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 12 },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "yes" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
-      { "text": "I'll check in later.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_ARMOR_FINISHED_NO",
-    "type": "talk_topic",
-    "dynamic_line": "The parts are still being printed.  Please be patient.",
-    "responses": [ { "text": "Okay, I'll check in later.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_ARMOR_FINISHED_YES",
-    "type": "talk_topic",
-    "dynamic_line": "Yes, we've finished printing the requested armor pieces.  Transferring to you now.",
-    "responses": [
-      {
-        "//": "Armor Rig response.",
-        "text": "Sweet, thanks.",
-        "condition": { "compare_string": [ "robofac_armor_pieces_rig", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-        "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
-          { "u_spawn_item": "robofac_armor_rig" },
-          { "u_spawn_item": "robofac_head_rig" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "//": "Prototype Armor response.",
-        "text": "Sweet, thanks.",
-        "condition": { "compare_string": [ "robofac_armor_pieces_basic", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-        "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
-          { "u_spawn_item": "robofac_basic_mantle" },
-          { "u_spawn_item": "robofac_basic_skirt" },
-          { "u_spawn_item": "robofac_basic_vambraces" },
-          { "u_spawn_item": "robofac_basic_greaves" },
-          { "u_spawn_item": "robofac_basic_helmet" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "//": "Turnout Armor response.",
-        "text": "Sweet, thanks.",
-        "condition": { "compare_string": [ "robofac_armor_pieces_nomex", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-        "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
-          { "u_spawn_item": "robofac_nomex_mantle" },
-          { "u_spawn_item": "robofac_nomex_skirt" },
-          { "u_spawn_item": "robofac_nomex_vambraces" },
-          { "u_spawn_item": "robofac_nomex_greaves" },
-          { "u_spawn_item": "robofac_nomex_helmet" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "//": "Ballistic Armor response.",
-        "text": "Sweet, thanks.",
-        "condition": { "compare_string": [ "robofac_armor_pieces_kevlar", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-        "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
-          { "u_spawn_item": "robofac_kevlar_mantle" },
-          { "u_spawn_item": "robofac_kevlar_skirt" },
-          { "u_spawn_item": "robofac_kevlar_vambraces" },
-          { "u_spawn_item": "robofac_kevlar_greaves" },
-          { "u_spawn_item": "robofac_kevlar_helmet" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "//": "Kinetic Armor response.",
-        "text": "Sweet, thanks.",
-        "condition": { "compare_string": [ "robofac_armor_pieces_rubber", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-        "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
-          { "u_spawn_item": "robofac_rubber_skirt" },
-          { "u_spawn_item": "robofac_rubber_vambraces" },
-          { "u_spawn_item": "robofac_rubber_greaves" },
-          { "u_spawn_item": "robofac_rubber_mantle" },
-          { "u_spawn_item": "robofac_rubber_helmet" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      },
-      {
-        "//": "Military Armor response.",
-        "text": "Sweet, thanks.",
-        "condition": { "compare_string": [ "robofac_armor_pieces_military", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
-        "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
-          { "u_spawn_item": "robofac_military_skirt" },
-          { "u_spawn_item": "robofac_military_vambraces" },
-          { "u_spawn_item": "robofac_military_greaves" },
-          { "u_spawn_item": "robofac_military_mantle" },
-          { "u_spawn_item": "robofac_military_helmet" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      }
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
     ]
   },
   {
@@ -722,6 +337,335 @@
     "dynamic_line": "Excellent.  Report back in seven days' time, and your Platform will be ready."
   },
   {
+    "id": "TALK_ROBOFAC_INTERCOM_ARMOR_STARTED",
+    "type": "talk_topic",
+    "dynamic_line": "Excellent.  We will begin work shortly.  Report back in 24 hours for pickup."
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_ARMOR_BREAKTHROUGH",
+    "//": "armor reward blurb after waiting",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_armor)", ">=", "time('1 d')" ],
+      "yes": "Yes we have!  The disk contained the configuration necessary to print our armors with a much more resilient composite than was previously available to us, without sacrificing any maneuverability.  As a form of payment, we are willing to provide you with the first functional models of the armor at a good price - six HGC.  While that may seem steep, the materials used are very high-end, and six coins just barely covers the production cost alone.  If you are unwilling or incapable of filling that price now, the offer will remain available indefinitely - just let us know when you'd like it.\n\n\"Should you find anything else of interest in the world, please bring it to us.  We would be happy to collaborate like this again in the future.",
+      "no": "Not yet.  The contents are very strongly encrypted, so simply pulling the data is impossible.  Work is underway to deduce the correct access key, but even with our facilities, it will take some time."
+    },
+    "speaker_effect": {
+      "condition": { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_armor)", ">=", "time('1 d')" ] },
+      "effect": [
+        { "u_lose_var": "dialogue_hub_rnd_u_project_ongoing" },
+        { "u_add_var": "dialogue_hub_rnd_u_can_buy_armor", "value": "yes" },
+        { "math": [ "hub01_uhmwpe_researched", "=", "1" ] }
+      ]
+    },
+    "responses": [
+      {
+        "text": "[6 HGC] Let's see what this armor is capable of.",
+        "condition": {
+          "and": [
+            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_armor)", ">=", "time('1 d')" ] },
+            { "u_has_items": { "item": "RobofacCoin", "count": 6 } }
+          ]
+        },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 6, "popup": true },
+          {
+            "run_eoc_with": "EOC_INTERCOM_SPAWN_ARMOR_SET",
+            "variables": { "armor_type": "robofac_armor_pieces_military" }
+          }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
+      },
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST",
+    "//": "buying armor",
+    "type": "talk_topic",
+    "dynamic_line": "Understood.  The parts will finish fabrication in 24 hours, once you hand over the stipulated HGC.  Depending on our currently available selection, the price will range from 2 to 4 HGC for non-specialty equipment.",
+    "responses": [
+      {
+        "text": "[3 HGC] I'd like to request a replacement Modular Defense System.",
+        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 3 } },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 3, "popup": true },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rig" },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_STARTED"
+      },
+      {
+        "text": "[2 HGC] I'd like to request a set of prototype armor.",
+        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 2 } },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 2, "popup": true },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_basic" },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_STARTED"
+      },
+      {
+        "text": "[4 HGC] I'd like to request a set of turnout armor.",
+        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 4 } },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 4, "popup": true },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_nomex" },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_STARTED"
+      },
+      {
+        "text": "[4 HGC] I'd like to request a set of ballistic armor.",
+        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 4 } },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 4, "popup": true },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_kevlar" },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_STARTED"
+      },
+      {
+        "text": "[4 HGC] I'd like to request a set of kinetic armor.",
+        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 4 } },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 4, "popup": true },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rubber" },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_STARTED"
+      },
+      {
+        "text": "[12 HGC] I'd like to request a set of soldier armor.",
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
+            { "math": [ "!has_var(u_dialogue_hub_rnd_u_can_buy_armor)" ] },
+            { "math": [ "hub01_uhmwpe_researched", "==", "1" ] }
+          ]
+        },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 12, "popup": true },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_military" },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_STARTED"
+      },
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_ARMOR_FINISHED",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">=", "time('1 d')" ],
+      "yes": "Yes, we've finished printing the requested armor pieces.  Transferring to you now.",
+      "no": "The parts are still being printed.  Please be patient."
+    },
+    "responses": [
+      {
+        "text": "Sweet, thanks.",
+        "condition": { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">=", "time('1 d')" ] },
+        "effect": [
+          {
+            "run_eoc_with": "EOC_INTERCOM_SPAWN_ARMOR_SET",
+            "variables": { "armor_type": { "u_val": "dialogue_hub_rnd_u_armor_type" } }
+          },
+          { "u_lose_var": "dialogue_hub_rnd_u_project_ongoing" },
+          { "u_lose_var": "dialogue_hub_rnd_u_armor_type" },
+          { "u_lose_var": "timer_hub_rnd_u_waiting_on_hub" }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
+      },
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_REPAIR",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "<", "time('now')" ],
+      "yes": "The repairs and tuneup are complete.  Should be good as new or better.",
+      "no": "Work is still ongoing.  These things can take time."
+    },
+    "responses": [
+      {
+        "text": "Thanks.",
+        "condition": { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "<", "time('now')" ] },
+        "effect": [
+          {
+            "if": { "compare_string": [ "phase_immersion_suit", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
+            "then": [ { "npc_add_var": "phase_suit_reverse_engineered", "value": "yes" }, { "u_spawn_item": "phase_immersion_suit" } ]
+          },
+          {
+            "if": { "compare_string": [ "rm13_armor", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
+            "then": [ { "npc_add_var": "rm13_reverse_engineered", "value": "yes" }, { "u_spawn_item": "rm13_armor" } ]
+          },
+          {
+            "if": { "compare_string": [ "combat_exoskeleton_light_salvaged", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
+            "then": [
+              { "npc_add_var": "combat_exoskeleton_reverse_engineered", "value": "yes" },
+              { "u_spawn_item": "combat_exoskeleton_light" }
+            ]
+          },
+          { "u_lose_var": "dialogue_hub_rnd_u_current_project" },
+          { "u_lose_var": "dialogue_hub_rnd_u_project_ongoing" },
+          { "u_lose_var": "timer_hub_rnd_u_waiting_on_hub" }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
+      },
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_PHASE_REPAIR",
+    "type": "talk_topic",
+    "dynamic_line": [
+      {
+        "math": [ "has_var(n_phase_suit_reverse_engineered)" ],
+        "yes": "Certainly; for a fee of ten coins, repairs and adjustments could be completed in two weeks.  We'll also pull suit metrics and haptic data to better understand the situation on the ground.  I'd ask you to make sure everything has been removed from the suit before giving it to us.",
+        "no": "&The camera starts scanning the armor, after a moment the intercom cracks back to life.  \"This technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.\""
+      }
+    ],
+    "responses": [
+      {
+        "text": "[10 HGC] Alright.",
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
+            { "math": [ "has_var(n_phase_suit_reverse_engineered)" ] }
+          ]
+        },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 10, "popup": true },
+          { "u_consume_item": "phase_immersion_suit", "count": 1, "popup": true },
+          { "u_add_faction_trust": 1 },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('14 day')" ] },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_SHORT"
+      },
+      {
+        "text": "[12 HGC] Fine.",
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
+            { "math": [ "!has_var(n_phase_suit_reverse_engineered)" ] }
+          ]
+        },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 12, "popup": true },
+          { "u_consume_item": "phase_immersion_suit", "count": 1, "popup": true },
+          { "u_add_faction_trust": 1 },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('44 day')" ] },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_LONG"
+      },
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_RM13_REPAIR",
+    "type": "talk_topic",
+    "dynamic_line": [
+      {
+        "math": [ "has_var(n_rm13_reverse_engineered)" ],
+        "yes": "Yes, that is within our capabilities.  For ten coins, repairs and adjustments can be completed by tomorrow; we will recharge the internal battery as well.  Please note that if you have made any modifications to the armor, it will be reverted to factory standard as part of the repairs.",
+        "no": "&The camera starts scanning the armor, after a moment the intercom cracks back to life.  \"This technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.\""
+      }
+    ],
+    "responses": [
+      {
+        "text": "[10 HGC] Alright.",
+        "condition": {
+          "and": [ { "u_has_items": { "item": "RobofacCoin", "count": 10 } }, { "math": [ "has_var(n_rm13_reverse_engineered)" ] } ]
+        },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 10, "popup": true },
+          { "u_consume_item": "rm13_armor", "count": 1, "popup": true },
+          { "u_add_faction_trust": 1 },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('14 day')" ] },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_SHORT"
+      },
+      {
+        "text": "[12 HGC] Fine.",
+        "condition": {
+          "and": [ { "u_has_items": { "item": "RobofacCoin", "count": 12 } }, { "math": [ "!has_var(n_rm13_reverse_engineered)" ] } ]
+        },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 12, "popup": true },
+          { "u_consume_item": "rm13_armor", "count": 1, "popup": true },
+          { "u_add_faction_trust": 1 },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('44 day')" ] },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_LONG"
+      },
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_EXOSKELETON_REPAIR",
+    "type": "talk_topic",
+    "dynamic_line": [
+      {
+        "math": [ "has_var(n_combat_exoskeleton_reverse_engineered)" ],
+        "yes": "Certainly, it'll cost you 10 coins and should be ready in two weeks.  Remember to take off any attachments and batteries before turning it in.",
+        "no": "One moment,\" the respondent audibly leaves for a moment and after a short period the intercom cracks with life.  \"We have never attempted repairs on a military exoskeleton, we will have to reverse-engineer it first, expect this to take around a month and a half, it will also cost you 12 coins.  Please make sure to take off any attachments and batteries before turning it in."
+      }
+    ],
+    "responses": [
+      {
+        "text": "[10 HGC] Alright.",
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
+            { "math": [ "has_var(n_combat_exoskeleton_reverse_engineered)" ] }
+          ]
+        },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 10, "popup": true },
+          { "u_consume_item": "combat_exoskeleton_light_salvaged", "count": 1, "popup": true },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('14 day')" ] },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "combat_exoskeleton_light_salvaged" }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_SHORT"
+      },
+      {
+        "text": "[12 HGC] Fine.",
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
+            { "math": [ "!has_var(n_combat_exoskeleton_reverse_engineered)" ] }
+          ]
+        },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 12, "popup": true },
+          { "u_consume_item": "combat_exoskeleton_light_salvaged", "count": 1, "popup": true },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('44 day')" ] },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "combat_exoskeleton_light_salvaged" }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_LONG"
+      },
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
+    ]
+  },
+  {
     "id": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_SHORT",
     "type": "talk_topic",
     "dynamic_line": "We will begin work shortly.  Report back in two weeks for pickup."
@@ -730,250 +674,6 @@
     "id": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_LONG",
     "type": "talk_topic",
     "dynamic_line": "We will begin work shortly.  Report back in around one and a half months for pickup."
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1_STARTED",
-    "type": "talk_topic",
-    "dynamic_line": "Lovely.  Research will begin within the next few hours."
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2_STARTED",
-    "type": "talk_topic",
-    "dynamic_line": "The combination should be a fairly simple matter.  Return in two days to pick up the finished product."
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_RIFLE_BREAKTHROUGH",
-    "//": "getting an HWP",
-    "type": "talk_topic",
-    "dynamic_line": "The Platform is complete.  As a reminder, the HWP will not function as a weapon without a conversion kit installed.  Transferring the requested items now.\"\n\nThe tray shakes as several heavy objects are dropped into it, and it slides open.  Inside: the Hybrid Weapons Platform.  On its own, it doesn't look like much; it resembles the body of a service rifle without a stock or barrel, colored in sleek black with blue highlights around the magazine well.  Small yellow arrows and inscriptions are present at certain points, highlighting the fasteners used to assemble the thing in earnest.  Accompanying the Platform itself is a series of four bundles of parts for it, each held together using velcro strips and tagged by caliber.  A drawstring nylon bag, embroidered with the Hub's logo and filled with proprietary tools, completes the whole package.\n\nAll in all, not a bad deal.\n\n\"Should you require magazines of any given caliber, we are willing to provide them through standard requisitions.  We hope you find its performance to be satisfactory.",
-    "responses": [
-      {
-        "text": "Thanks.",
-        "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_has_researched_gun", "value": "yes" },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "u_lose_var": "timer_hub_rnd_u_waiting_on_gun" },
-          { "u_spawn_item": "robofac_gun" },
-          { "u_spawn_item": "robofac_gun_ar" },
-          { "u_spawn_item": "robofac_gun_smg" },
-          { "u_spawn_item": "robofac_gun_dmr" },
-          { "u_spawn_item": "robofac_gun_shotgun" },
-          { "u_spawn_item": "robofac_gun_kit" },
-          { "u_spawn_item": "robofac40", "count": 2 },
-          { "u_spawn_item": "robofac60", "count": 2 },
-          { "u_spawn_item": "robofac20", "count": 2 },
-          { "u_spawn_item": "robofac10", "count": 2 }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      }
-    ]
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_PHASE_REPAIR",
-    "type": "talk_topic",
-    "dynamic_line": [
-      {
-        "compare_string": [ "yes", { "npc_val": "phase_suit_reverse_engineered" } ],
-        "yes": "Certainly; for a fee of ten coins, repairs and adjustments could be completed in two weeks.  We'll also pull suit metrics and haptic data to better understand the situation on the ground.  I'd ask you to make sure everything has been removed from the suit before giving it to us.",
-        "no": "The camera starts scanning the armor, after a moment the intercom cracks back to life, 'this technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.'"
-      }
-    ],
-    "responses": [
-      {
-        "text": "[10 HGC] Alright.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
-            { "compare_string": [ "yes", { "npc_val": "phase_suit_reverse_engineered" } ] }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 10 },
-          { "u_consume_item": "phase_immersion_suit", "count": 1, "popup": true },
-          { "u_add_faction_trust": 1 },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('14 day')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_SHORT"
-      },
-      {
-        "text": "[12 HGC] Fine.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "not": { "compare_string": [ "yes", { "npc_val": "phase_suit_reverse_engineered" } ] } }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 12 },
-          { "u_consume_item": "phase_immersion_suit", "count": 1, "popup": true },
-          { "u_add_faction_trust": 1 },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('44 day')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_LONG"
-      },
-      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" },
-      { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
-      { "text": "I'll check in later.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_PHASE_REPAIR_COMPLETE",
-    "//": "repairing Phase Immersion Suit",
-    "type": "talk_topic",
-    "dynamic_line": "The repairs and tuneup are complete.  Should be good as new or better.",
-    "responses": [
-      {
-        "text": "Thanks.",
-        "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "none" },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "npc_add_var": "phase_suit_reverse_engineered", "value": "yes" },
-          { "u_spawn_item": "phase_immersion_suit" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      }
-    ]
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_RM13_REPAIR",
-    "type": "talk_topic",
-    "dynamic_line": [
-      {
-        "compare_string": [ "yes", { "npc_val": "rm13_reverse_engineered" } ],
-        "yes": "Yes, that is within our capabilities.  For ten coins, repairs and adjustments can be completed by tomorrow; we will recharge the internal battery as well.  Please note that if you have made any modifications to the armor, it will be reverted to factory standard as part of the repairs.",
-        "no": "The camera starts scanning the armor, after a moment the intercom cracks back to life, 'this technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.'"
-      }
-    ],
-    "responses": [
-      {
-        "text": "[10 HGC] Alright.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
-            { "compare_string": [ "yes", { "npc_val": "rm13_reverse_engineered" } ] }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 10 },
-          { "u_consume_item": "rm13_armor", "count": 1, "popup": true },
-          { "u_add_faction_trust": 1 },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('14 day')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_SHORT"
-      },
-      {
-        "text": "[12 HGC] Fine.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "not": { "compare_string": [ "yes", { "npc_val": "rm13_reverse_engineered" } ] } }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 12 },
-          { "u_consume_item": "rm13_armor", "count": 1, "popup": true },
-          { "u_add_faction_trust": 1 },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('44 day')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_LONG"
-      },
-      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" },
-      { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
-      { "text": "I'll check in later.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_RM13_REPAIR_COMPLETE",
-    "//": "repairing RM13 armor",
-    "type": "talk_topic",
-    "dynamic_line": "The repairs and tuneup are complete.  Should be good as new or better.",
-    "responses": [
-      {
-        "text": "Thanks.",
-        "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "none" },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "npc_add_var": "rm13_reverse_engineered", "value": "yes" },
-          { "u_spawn_item": "rm13_armor" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      }
-    ]
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_EXOSKELETON_REPAIR",
-    "type": "talk_topic",
-    "dynamic_line": [
-      {
-        "compare_string": [ "yes", { "npc_val": "combat_exoskeleton_reverse_engineered" } ],
-        "yes": "Certainly, it'll cost you 10 coins and should be ready in two weeks.  Remember to take off any attachments and batteries before turning it in.",
-        "no": "'One moment,' the respondent audibly leaves for a moment and after a short period the intercom cracks with life.  'We have never attempted repairs on a military exoskeleton, we will have to reverse-engineer it first, expect this to take around a month and a half, it will also cost you 12 coins.  Please make sure to take off any attachments and batteries before turning it in.'"
-      }
-    ],
-    "responses": [
-      {
-        "text": "[10 HGC] Alright.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
-            { "compare_string": [ "yes", { "npc_val": "combat_exoskeleton_reverse_engineered" } ] }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 10 },
-          { "u_consume_item": "combat_exoskeleton_light_salvaged", "count": 1, "popup": true },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('14 day')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "combat_exoskeleton_light_salvaged" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_SHORT"
-      },
-      {
-        "text": "[12 HGC] Fine.",
-        "condition": {
-          "and": [
-            { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "not": { "compare_string": [ "yes", { "npc_val": "combat_exoskeleton_reverse_engineered" } ] } }
-          ]
-        },
-        "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 12 },
-          { "u_consume_item": "combat_exoskeleton_light_salvaged", "count": 1, "popup": true },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('44 day')" ] },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "combat_exoskeleton_light_salvaged" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED_LONG"
-      },
-      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" },
-      { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
-      { "text": "I'll check in later.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "id": "TALK_ROBOFAC_INTERCOM_EXOSKELETON_REPAIR_COMPLETE",
-    "type": "talk_topic",
-    "dynamic_line": "The repairs are complete.  Calibration will be done automatically when you boot it up",
-    "responses": [
-      {
-        "text": "Thanks.",
-        "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "none" },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "npc_add_var": "combat_exoskeleton_reverse_engineered", "value": "yes" },
-          { "u_spawn_item": "combat_exoskeleton_light" }
-        ],
-        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      }
-    ]
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1",
@@ -990,7 +690,7 @@
           ]
         },
         "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 2 },
+          { "u_consume_item": "RobofacCoin", "count": 2, "popup": true },
           { "u_consume_item": "dimensional_anchor", "count": 1, "popup": true },
           { "u_add_faction_trust": 1 },
           { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
@@ -999,27 +699,32 @@
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1_STARTED"
       },
-      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" },
-      { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
-      { "text": "I'll check in later.", "topic": "TALK_DONE" }
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
     ]
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1_COMPLETE",
     "//": "creating better MDS",
     "type": "talk_topic",
-    "dynamic_line": "We've made some notable progress.  The anchor itself appears to provide some degree of protection from extradimensional phenomena, and we believe that we can integrate it into our current modular armor system.  This will, however, make it heavier and less portable.  The armor will remain wearable outside of metal armor, although it will be a more snug fit than the anchor alone would have been.\n\n\"We are returning the anchor now.",
+    "dynamic_line": {
+      "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">=", "time('5 d')" ],
+      "yes": "We've made some notable progress.  The anchor itself appears to provide some degree of protection from extradimensional phenomena, and we believe that we can integrate it into our current modular armor system.  This will, however, make it heavier and less portable.  The armor will remain wearable outside of metal armor, although it will be a more snug fit than the anchor alone would have been.\"\n\n\"We are returning the anchor now.",
+      "no": "Work is still ongoing.  These things can take time."
+    },
     "responses": [
       {
         "text": "Interesting.",
+        "condition": { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">=", "time('5 d')" ] },
         "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "none" },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
+          { "u_lose_var": "dialogue_hub_rnd_u_current_project" },
+          { "u_lose_var": "dialogue_hub_rnd_u_project_ongoing" },
+          { "u_lose_var": "timer_hub_rnd_u_waiting_on_hub" },
           { "u_add_var": "dialogue_hub_rnd_u_completed_anchor_pt_1", "value": "yes" },
           { "u_spawn_item": "dimensional_anchor" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      }
+      },
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
     ]
   },
   {
@@ -1038,7 +743,7 @@
           ]
         },
         "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 1 },
+          { "u_consume_item": "RobofacCoin", "count": 1, "popup": true },
           { "u_consume_item": "dimensional_anchor", "count": 1, "popup": true },
           { "u_consume_item": "robofac_armor_rig", "count": 1, "popup": true },
           { "u_add_faction_trust": 1 },
@@ -1048,33 +753,48 @@
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2_STARTED"
       },
-      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" },
-      { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
-      { "text": "I'll check in later.", "topic": "TALK_DONE" }
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
     ]
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2_COMPLETE",
     "//": "creating better MDS",
     "type": "talk_topic",
-    "dynamic_line": "The anchor has been integrated into the harness.  Thank you as always for your contributions to our research and technology.",
+    "dynamic_line": {
+      "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">=", "time('2 d')" ],
+      "yes": "The anchor has been integrated into the harness.  Thank you as always for your contributions to our research and technology.",
+      "no": "Work is still ongoing.  These things can take time."
+    },
     "responses": [
       {
         "text": "Thanks.",
+        "condition": { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">=", "time('2 d')" ] },
         "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "none" },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
+          { "u_lose_var": "dialogue_hub_rnd_u_current_project" },
+          { "u_lose_var": "dialogue_hub_rnd_u_project_ongoing" },
+          { "u_lose_var": "timer_hub_rnd_u_waiting_on_hub" },
           { "u_spawn_item": "robofac_armor_anchor" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      }
+      },
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
     ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1_STARTED",
+    "type": "talk_topic",
+    "dynamic_line": "Lovely.  Research will begin within the next few hours."
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2_STARTED",
+    "type": "talk_topic",
+    "dynamic_line": "The combination should be a fairly simple matter.  Return in two days to pick up the finished product."
   },
   {
     "id": [ "TALK_ROBOFAC_INTERCOM_HWP_EXODII", "TALK_ROBOFAC_INTERCOM_HWP_EXODII_1", "TALK_ROBOFAC_INTERCOM_HWP_EXODII_2" ],
     "//": "creating EXODII barrel",
     "type": "talk_topic",
-    "dynamic_line": "Excuse me for a moment.\" The intercom turns off abruptly.  It comes back on after roughly a minute, and when it speaks again, another voice is on the other side, speaking carefully.\n\n\"Yes… the Exodii.  We have yet to make contact, but we are keenly interested in their capabilities and technology.  If you were to provide us with, say, five rounds, in addition to the rifle itself and a magazine suitable for it, we believe we would be able to replicate the parts.  We expect it to take three days of research.\"\n\n\"Please note that the requested materials will not be returned, as they are likely to be damaged during research.",
+    "dynamic_line": "Excuse me for a moment.\"  The intercom turns off abruptly.  It comes back on after roughly a minute, and when it speaks again, another voice is on the other side, speaking carefully.\n\n\"Yes… the Exodii.  We have yet to make contact, but we are keenly interested in their capabilities and technology.  If you were to provide us with, say, five rounds, in addition to the rifle itself and a magazine suitable for it, we believe we would be able to replicate the parts.  We expect it to take three days of research.\"\n\n\"Please note that the requested materials will not be returned, as they are likely to be damaged during research.",
     "responses": [
       {
         "text": "[5 12.3ln, PA md. 68 magazine, PA md. 68] Is this what you need?",
@@ -1110,17 +830,15 @@
       },
       {
         "text": "Why not contact them directly?",
-        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] } },
+        "condition": { "math": [ "!has_var(u_general_meeting_u_met_Rubik)" ] },
         "topic": "TALK_ROBOFAC_INTERCOM_HWP_EXODII_1"
       },
       {
         "text": "I've met them already.  They seem friendly; if you'd like to reach out to them yourself, I'm sure that they could help.",
-        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
+        "condition": { "math": [ "has_var(u_general_meeting_u_met_Rubik)" ] },
         "topic": "TALK_ROBOFAC_INTERCOM_HWP_EXODII_2"
       },
-      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" },
-      { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
-      { "text": "I'll check in later.", "topic": "TALK_DONE" }
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
     ]
   },
   {
@@ -1150,8 +868,7 @@
     },
     "responses": [
       { "text": "You seem very… excited about this.", "topic": "TALK_ROBOFAC_INTERCOM_HWP_EXODII_STARTED_1" },
-      { "text": "<done_conversation_section>", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" },
-      { "text": "I'll check in later.", "topic": "TALK_DONE" }
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
     ]
   },
   {
@@ -1164,19 +881,29 @@
     "id": "TALK_ROBOFAC_INTERCOM_HWP_EXODII_COMPLETE",
     "//": "creating EXODII barrel",
     "type": "talk_topic",
-    "dynamic_line": "The project was a success!  The ammo is fairly rudimentary, but ultimately proved simple to manufacture, and has lent itself well to large magazines.  We will transfer a copy of the conversion kit in a moment; it is capable of accepting specialized magazines that we have just begun to produce ourselves.  Thank you for allowing us this opportunity.",
-    "speaker_effect": { "effect": [ { "math": [ "hub01_hwp_exotic_researched", "=", "1" ] } ] },
+    "dynamic_line": {
+      "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">=", "time('3 d')" ],
+      "yes": "The project was a success!  The ammo is fairly rudimentary, but ultimately proved simple to manufacture, and has lent itself well to large magazines.  We will transfer a copy of the conversion kit in a moment; it is capable of accepting specialized magazines that we have just begun to produce ourselves.  Thank you for allowing us this opportunity.",
+      "no": "Work is still ongoing.  These things can take time."
+    },
+    "speaker_effect": {
+      "condition": { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">=", "time('3 d')" ] },
+      "effect": [ { "math": [ "hub01_hwp_exotic_researched", "=", "1" ] } ]
+    },
     "responses": [
       {
         "text": "Thanks.",
+        "condition": { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">=", "time('3 d')" ] },
         "effect": [
-          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "none" },
-          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
+          { "u_lose_var": "dialogue_hub_rnd_u_current_project" },
+          { "u_lose_var": "dialogue_hub_rnd_u_project_ongoing" },
+          { "u_lose_var": "timer_hub_rnd_u_waiting_on_hub" },
           { "u_spawn_item": "robofac_gun_exodii" },
           { "u_spawn_item": "robofac60_123ln", "count": 2 }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
-      }
+      },
+      { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" }
     ]
   }
 ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -8,7 +8,7 @@
         "text": "[2 HGC] Deal!",
         "condition": { "u_has_items": { "item": "RobofacCoin", "count": 2 } },
         "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 2 },
+          { "u_consume_item": "RobofacCoin", "count": 2, "popup": true },
           { "u_spawn_item": "mask_gas_half" },
           { "u_spawn_item": "robofac_enviro_suit" },
           { "u_spawn_item": "gasfilter_med", "count": 1 },
@@ -34,7 +34,7 @@
         "text": "[1 HGC] Deal!",
         "condition": { "u_has_items": { "item": "RobofacCoin", "count": 1 } },
         "effect": [
-          { "u_buy_item": "RobofacCoin", "count": 1 },
+          { "u_consume_item": "RobofacCoin", "count": 1, "popup": true },
           { "mapgen_update": "robofachq_surface_entrance", "reveal_radius": 40, "random": true, "search_range": 70 },
           { "npc_add_var": "dialogue_intercom_sold_local_map", "value": "yes" }
         ],
@@ -174,7 +174,7 @@
         "text": "[8 HGC] Deal!",
         "condition": { "u_has_items": { "item": "RobofacCoin", "count": 8 } },
         "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 8 },
+          { "u_consume_item": "RobofacCoin", "count": 8, "popup": true },
           { "u_spawn_item": "armor_riot", "count": 5 },
           { "u_spawn_item": "helmet_riot", "count": 5 },
           { "u_spawn_item": "armor_riot_arm", "count": 5 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Refactoring Hub01 dialogues"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
One time I was trying to understand the context for a line in a dialog, looked at the file and got even more confused.
Plus there were some minor flaws for a long time.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Rewrite a little, reducing the number of lines. Merge some topics into one.
2. Move armor ordering to a separate subtopic. Rewrite armor spawn in EOC.
3. Added `TALK_ROBOFAC_INTERCOM_ARMOR_STARTED` topic that confirms that the armor has been ordered, instead of silently returning to the menu.
4. `u_sell_item` is replaced by `u_consume_item`. Because the sold item is sometimes displayed in the trade menu as wielded by the intercom.
5. Fixed that for purchasing a surface map the intercom gives a coin to the player.
6. Fixed quotes in a couple of dialogs.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
[Test-1-CLEAN-START.tar.gz](https://github.com/user-attachments/files/17584662/Test-1-CLEAN-START.tar.gz)
[Test-4-LIGHT-RETRIEVAL.tar.gz](https://github.com/user-attachments/files/17584670/Test-4-LIGHT-RETRIEVAL.tar.gz)

I think I've tested all possible dialogues. All quests, HWP and armor orders, equipment repair, reverse engineering(the second repair for each item individually is cheaper and takes less time), anchor research and MDS anchor upgrade, Exodii adapter for HWP.

<details><summary>Screenshots</summary>
<p>

![rf1](https://github.com/user-attachments/assets/aaa6f6d4-0574-475a-ae31-cbd771d5a39c)
![rf2](https://github.com/user-attachments/assets/109f5ec8-1e3b-47a8-83d6-3f7373f08466)
![rf3](https://github.com/user-attachments/assets/922bb9f9-0cb7-483b-bd8a-55f06fb3ae52)
![rf4](https://github.com/user-attachments/assets/2b98a32e-a71c-43cf-bf08-19f962d8ca91)
![rf5](https://github.com/user-attachments/assets/8628eb11-7609-47a9-a28a-1fab855cedc9)
![rf6](https://github.com/user-attachments/assets/d8142728-e848-461f-a76c-e007174bee04)
![rf7](https://github.com/user-attachments/assets/c2e36223-b9fc-4c7f-9ba2-ba022963e280)
![rf8](https://github.com/user-attachments/assets/2e8758d3-e551-4571-955b-13bbc92ebce9)
![rf9](https://github.com/user-attachments/assets/4abf274c-c1b5-4316-bf7d-c18849c185e3)
![rf10](https://github.com/user-attachments/assets/d68e4613-5a8f-41c6-a772-cc426335aedd)
![rf11](https://github.com/user-attachments/assets/4875d278-40fb-4a20-8723-29c023e43d1a)
![rf12](https://github.com/user-attachments/assets/ef372310-b9a0-4ada-9ab9-af99549b592f)
![rf13](https://github.com/user-attachments/assets/8129c445-653b-464f-a633-bd8a2a9e8142)
![rf14](https://github.com/user-attachments/assets/b436dc20-bdd9-4edb-a675-fc6aefdd0c76)
![rf15](https://github.com/user-attachments/assets/e8f14d2f-8870-4d7e-872f-f4d1438f33e7)

</p>
</details> 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
```json
{ "not": { "compare_string": [ "yes", { "u_val": "variable" } ] } },
"//": "is replaced by",
{ "math": [ "!has_var(u_variable)" ] }
```
Any harmful effects from this replacement? Besides the fact that in theory it could break dialogs when updating from a previous version? The variable is deleted when the player picks up the order, so the code with the math makes no assumptions about the value of the variable, which is in fact used as a boolean or as a flag. Not to mention it's more readable.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
