### PR TITLE
input_context.h: make registered_manual_keys private

### DIFF
--- a/src/input_context.h
+++ b/src/input_context.h
@@ -82,8 +82,6 @@ class input_context
             }
         };
 
-        std::vector<manual_key> registered_manual_keys;
-
         // If true, prevent virtual keyboard from dismissing after a key press while this input context is active.
         // NOTE: This won't auto-bring up the virtual keyboard, for that use sdltiles.cpp is_string_input()
         bool allow_text_entry;
@@ -416,7 +414,9 @@ class input_context
         input_event first_unassigned_hotkey( const hotkey_queue &queue ) const;
         input_event next_unassigned_hotkey( const hotkey_queue &queue, const input_event &prev ) const;
     private:
-
+#if defined(__ANDROID__)
+        std::vector<manual_key> registered_manual_keys;
+#endif
         std::vector<std::string> registered_actions;
         std::string edittext;
     public:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I find codes receiving this [variable](https://github.com/search?q=repo%3ACleverRaven%2FCataclysm-DDA+registered_manual_keys&type=code) uses `get_registered_manual_keys` anyway, so it shouldn't be public.

#### Describe the solution
Move it to private class.

#### Describe alternatives you've considered
NONE

#### Testing
Should work

#### Additional context
On a side note, can someone look at #77197 and find the problem with my code?