### PR TITLE
Fix profession parser

### DIFF
--- a/lang/string_extractor/parsers/profession.py
+++ b/lang/string_extractor/parsers/profession.py
@@ -14,23 +14,27 @@ def parse_profession(json, origin):
 
     desc_male = ""
     desc_female = ""
-    if type(json["description"]) is dict:
-        if "male" in json["description"]:
-            desc_male = json["description"]["male"]
-            desc_female = json["description"]["female"]
-        elif "str" in json["description"]:
-            desc_male = desc_female = json["description"]["str"]
-    else:
-        desc_male = desc_female = json["description"]
+    has_description = "description" in json
+    if has_description:
+        if type(json["description"]) is dict:
+            if "male" in json["description"]:
+                desc_male = json["description"]["male"]
+                desc_female = json["description"]["female"]
+            elif "str" in json["description"]:
+                desc_male = desc_female = json["description"]["str"]
+        else:
+            desc_male = desc_female = json["description"]
 
     write_text(name_male, origin, context="profession_male",
                comment="Profession name for male")
-    write_text(desc_male, origin, context="prof_desc_male",
-               comment="Description of profession \"{}\" for male".
-               format(name_male))
+    if has_description:
+        write_text(desc_male, origin, context="prof_desc_male",
+                   comment="Description of profession \"{}\" for male".
+                   format(name_male))
 
     write_text(name_female, origin, context="profession_female",
                comment="Profession name for female")
-    write_text(desc_female, origin, context="prof_desc_female",
-               comment="Description of profession \"{}\" for female".
-               format(name_female))
+    if has_description:
+        write_text(desc_female, origin, context="prof_desc_female",
+                   comment="Description of profession \"{}\" for female".
+                   format(name_female))


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Text Changes Analyzer fails because professions using `copy-from` can omit the `description` field.

#### Describe the solution

Check if description exists before trying to read it.

#### Describe alternatives you've considered



#### Testing

Ran `update_pot.sh` and it completed successfully.

#### Additional context


