### PR TITLE
use the monospaced font for the art on the end screen

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2956,6 +2956,7 @@ void end_screen_ui_impl::draw_controls()
     }
 
     if( art.is_valid() ) {
+        cataimgui::PushMonoFont();
         int row = 1;
         for( const std::string &line : art->picture ) {
             cataimgui::draw_colored_text( line );
@@ -2969,10 +2970,12 @@ void end_screen_ui_impl::draw_controls()
             }
             row++;
         }
+        ImGui::PopFont();
     }
 
     if( !input_label.empty() ) {
         ImGui::NewLine();
+        ImGui::AlignTextToFramePadding();
         cataimgui::draw_colored_text( input_label );
         ImGui::SameLine( str_width_to_pixels( input_label.size() + 2 ), 0 );
         ImGui::InputText( "##LAST_WORD_BOX", text.data(), text.size() );


### PR DESCRIPTION
#### Summary
Interface "use the monospaced font for the ascii art on the end screen"
#### Purpose of change

because ascii art. 

Fixes some of problems in #77297
Fixes #77402

#### Describe the solution

We have a monospaced font available; use it. Also, vertically align the “Last Words:” label in front of the textbox, so that the baselines of the two are lined up.

#### Testing

Use Play Now to get a game started. Walk outside and get eaten by zombies or wasps or whatever is handy. Observe the end screen.

![Screenshot from 2024-10-31 16-38-35](https://github.com/user-attachments/assets/5ac1355d-f436-4d8d-97e7-9d408f90d372)
![Screenshot from 2024-10-31 16-51-44](https://github.com/user-attachments/assets/c8aefeaa-db92-47e7-9af1-997a312b0ec4)
