### PR TITLE
Backport #73386 "Fix obtain cost when reloading, and a typo."

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7264,7 +7264,7 @@ int Character::item_handling_cost( const item &it, bool penalties, int base_cost
 {
     int mv = base_cost;
     if( penalties ) {
-        // 40 moves per liter, up to 200 at 5 liters
+        // 50 moves per liter, up to 200 at 4 liters
         mv += std::min( 200, it.volume( false, false, charges_in_it ) / 20_ml );
     }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -718,7 +718,7 @@ class item_location::impl::item_in_container : public item_location::impl
             }
 
             int primary_cost = ch.mutation_value( "obtain_cost_multiplier" ) * ch.item_handling_cost( *target(),
-                               true, container_mv );
+                               true, container_mv, qty );
             int parent_obtain_cost = container.obtain_cost( ch, qty );
             if( container->get_use( "holster" ) ) {
                 if( ch.is_worn( *container ) ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/73354 for 0.H RC.
#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context
As #71926 and #72106 are not backported, it looks different on Master and 0.H.