### PR TITLE
Backport #74075 Correctly display the cost to learn the proficiency

### DIFF
--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -1066,7 +1066,8 @@ std::string talker_character_const::proficiency_training_text( const talker &stu
 
     if( cost > 0 ) {
         //~ Proficiency name: (current_practice) -> (next_practice) (cost in dollars)
-        return string_format( _( "%s: (%2.0f%%) -> (%s) (cost $%d)" ), name, pct_before, after_str, cost );
+        return string_format( _( "%s: (%2.0f%%) -> (%s) (cost $%d)" ), name, pct_before, after_str,
+                              cost / 100 );
     }
     //~ Proficiency name: (current_practice) -> (next_practice)
     return string_format( _( "%s: (%2.0f%%) -> (%s)" ), name, pct_before, after_str );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Simply add the missing / 100 to `talker_character_const::proficiency_training_text`.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context