### PR TITLE
Armor destroyed Event

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1398,6 +1398,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | character_falls_asleep | triggers in the moment character actually falls asleep; trigger includes cases where character sleep for a short time because of sleepiness or drugs; duration of the sleep can be changed mid sleep because of hurt/noise/light/pain thresholds and another factors | { "character", `character_id` }, { "duration", `int_` (in seconds) } | character / NONE |
 | character_wields_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wield |
 | character_wears_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear |
+| character_armor_destroyed | triggers when a worn armor is set to be destroyed from damage. The armor still exists but will be destroyed immediately after the EOCs finish running. | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear |
 | consumes_marloss_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
 | crosses_marloss_threshold | | { "character", `character_id` } | character / NONE |
 | crosses_mutation_threshold | | { "character", `character_id` },<br/> { "category", `mutation_category_id` }, | character / NONE |

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1965,14 +1965,14 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
             armor.on_takeoff( guy );
 
             item_location loc = item_location( guy, &armor );
-            cata::event e = cata::event::make<event_type::character_armor_destroyed>( guy.getID() ,armor.typeId() );
+            cata::event e = cata::event::make<event_type::character_armor_destroyed>( guy.getID(),
+                            armor.typeId() );
             get_event_bus().send_with_talker( &guy, &loc, e );
-            
             for( const item *it : armor.all_items_top( pocket_type::CONTAINER ) ) {
                 worn_remains.push_back( *it );
             }
             // decltype is the type name of the iterator, note that reverse_iterator::base returns the
-            // iterator to the next element, not the one the revers_iterator points to. 
+            // iterator to the next element, not the one the revers_iterator points to.
             // http://stackoverflow.com/questions/1830158/how-to-call-erase-with-a-reverse-iterator
             iter = decltype( iter )( worn.erase( --iter.base() ) );
         } else {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1963,11 +1963,16 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
             destroyed_armor_msg( guy, pre_damage_name );
             armor_destroyed = true;
             armor.on_takeoff( guy );
+
+            item_location loc = item_location( guy, &armor );
+            cata::event e = cata::event::make<event_type::character_armor_destroyed>( guy.getID() ,armor.typeId() );
+            get_event_bus().send_with_talker( &guy, &loc, e );
+            
             for( const item *it : armor.all_items_top( pocket_type::CONTAINER ) ) {
                 worn_remains.push_back( *it );
             }
             // decltype is the type name of the iterator, note that reverse_iterator::base returns the
-            // iterator to the next element, not the one the revers_iterator points to.
+            // iterator to the next element, not the one the revers_iterator points to. 
             // http://stackoverflow.com/questions/1830158/how-to-call-erase-with-a-reverse-iterator
             iter = decltype( iter )( worn.erase( --iter.base() ) );
         } else {

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -57,6 +57,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::character_attempt_to_fall_asleep: return "character_attempt_to_fall_asleep";
         case event_type::character_wakes_up: return "character_wakes_up";
         case event_type::character_wears_item: return "character_wears_item";
+         case event_type::character_armor_destroyed: return "character_armor_destroyed";
         case event_type::character_wields_item: return "character_wields_item";
         case event_type::consumes_marloss_item: return "consumes_marloss_item";
         case event_type::crosses_marloss_threshold: return "crosses_marloss_threshold";
@@ -144,7 +145,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 105,
+static_assert( static_cast<int>( event_type::num_event_types ) == 106,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );

--- a/src/event.h
+++ b/src/event.h
@@ -66,6 +66,7 @@ enum class event_type : int {
     character_wakes_up,
     character_wields_item,
     character_wears_item,
+    character_armor_destroyed,
     consumes_marloss_item,
     crosses_marloss_threshold,
     crosses_mutation_threshold,
@@ -189,7 +190,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 105,
+static_assert( static_cast<int>( event_type::num_event_types ) == 106,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -528,6 +529,9 @@ struct event_spec<event_type::character_butchered_corpse> {
 
 template<>
 struct event_spec<event_type::character_wears_item> : event_spec_character_item {};
+
+template<>
+struct event_spec<event_type::character_armor_destroyed> : event_spec_character_item {};
 
 template<>
 struct event_spec<event_type::character_wields_item> : event_spec_character_item {};

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -1135,6 +1135,7 @@ void memorial_logger::notify( const cata::event &e )
         case event_type::character_radioactively_mutates:
         case event_type::character_wears_item:
         case event_type::character_wields_item:
+        case event_type::character_armor_destroyed:
         case event_type::character_casts_spell:
         case event_type::cuts_tree:
         case event_type::opens_spellbook:


### PR DESCRIPTION
#### Summary
Infrastructure "Add a new event for when worn armor is detroyed by damage."

#### Purpose of change
This is part of my work of adding energy shields to Aftershock, split out for easier review.

#### Describe the solution
The event passes the same arguments as character_wears_item.

