### PR TITLE
[Magiclysm] Feral dabblers: add small chance ferals know a single spell

### DIFF
--- a/data/mods/Magiclysm/Spells/monsterspells.json
+++ b/data/mods/Magiclysm/Spells/monsterspells.json
@@ -443,5 +443,66 @@
         ]
       }
     ]
+  },
+  {
+    "type": "SPELL",
+    "id": "feral_dabble_spell_selector_spell",
+    "name": { "str": "Dabbler Spell selector", "//~": "NO_I18N" },
+    "description": "Random chance for a feral to have a single spell.  This picks a random spell.",
+    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "MUST_HAVE_CLASS_TO_LEARN" ],
+    "valid_targets": [ "hostile" ],
+    "max_level": 1,
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_FERAL_DABBLE_SPELLS_SELECTOR_SPELL",
+    "shape": "blast",
+    "min_range": 60,
+    "max_range": 60
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FERAL_DABBLE_SPELLS_SELECTOR_SPELL",
+    "effect": [ { "math": [ "n_feral_dabbler_chosen_spell_number", "=", "rand(99) + 1" ] } ]
+  },
+  {
+    "id": "summon_wisps_monster",
+    "type": "SPELL",
+    "name": "Ignus Fatuus Monster",
+    "description": "Summons ghostly foxfire worked from living marsh vapor to lead your enemies astray.  With more experience, this spell can conjure multiple ghost lights.",
+    "valid_targets": [ "ground" ],
+    "effect": "summon",
+    "effect_str": "mon_wisp",
+    "shape": "blast",
+    "flags": [ "CONJURATION_SPELL", "LOUD", "SOMATIC", "HOSTILE_SUMMON" ],
+    "energy_source": "MANA",
+    "difficulty": 2,
+    "max_level": 25,
+    "min_damage": 1,
+    "max_damage": 8,
+    "damage_increment": 0.28,
+    "min_aoe": 3,
+    "max_aoe": 3,
+    "min_range": 3,
+    "max_range": 7,
+    "range_increment": 0.16,
+    "min_duration": 6000,
+    "max_duration": 60000,
+    "duration_increment": 2160
+  },
+  {
+    "id": "windrun_monster",
+    "type": "SPELL",
+    "name": "Windrunning Monster",
+    "description": "A magical wind pushes you forward as you move, easing your movements and increasing speed.",
+    "energy_source": "MANA",
+    "difficulty": 1,
+    "effect": "attack",
+    "effect_str": "enchant_windrun_monster",
+    "shape": "blast",
+    "valid_targets": [ "self" ],
+    "flags": [ "ENHANCEMENT_SPELL", "SILENT", "VERBAL", "NO_HANDS", "NO_PROJECTILE" ],
+    "max_level": 10,
+    "min_duration": 6000,
+    "max_duration": 30000,
+    "duration_increment": 2400
   }
 ]

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -116,6 +116,18 @@
   },
   {
     "type": "effect_type",
+    "id": "enchant_windrun_monster",
+    "name": [ "Windrunning" ],
+    "desc": [ "You are bolstered and pushed along by the power of the wind." ],
+    "apply_message": "You are bolstered and pushed along by the power of the wind",
+    "remove_message": "The wind at your back dies down.",
+    "rating": "good",
+    "show_in_info": true,
+    "enchantments": [ { "values": [ { "value": "SPEED", "add": 20 } ] } ],
+    "base_mods": { "stamina_min": [ 10 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "dark_sight",
     "name": [ "Dark Sight" ],
     "desc": [ "You can see in the dark." ],

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1570,7 +1570,8 @@
       "effect_stormshaper_loud_voice",
       "effect_technomancer_gain_electronics_computer",
       "effect_technomancer_pain_ignore",
-      "effect_feral_stormshaper_stormhammer"
+      "effect_feral_stormshaper_stormhammer",
+      "enchant_windrun_monster"
     ]
   },
   {
@@ -1719,7 +1720,8 @@
       "effect_flame_immunity",
       "effect_burning_trail",
       "effect_ring_of_flight",
-      "effect_feral_stormshaper_stormhammer"
+      "effect_feral_stormshaper_stormhammer",
+      "enchant_windrun_monster"
     ]
   },
   {

--- a/data/mods/Magiclysm/monsters/feral_dabbler_overrides.json
+++ b/data/mods/Magiclysm/monsters/feral_dabbler_overrides.json
@@ -700,6 +700,45 @@
             ]
           },
           "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        },
+        {
+          "type": "monster_attack",
+          "//": "soldiers might have actually known some combat magic",
+          "attack_type": "melee",
+          "id": "feral_dabbler_soldier_magicmissile",
+          "cooldown": 10,
+          "move_cost": 100,
+          "range": 12,
+          "damage_max_instance": [ { "damage_type": "nether", "amount": 7 } ],
+          "dodgeable": false,
+          "blockable": false,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "25" ] }
+            ]
+          },
+          "hit_dmg_u": "%1$s screams words of magic and an eldritch bolt impacts your %2$s!",
+          "hit_dmg_npc": "%1$s screams words of magic and an eldritch bolt impacts <npcname>'s %2$s!",
+          "miss_msg_u": "%1$s screams words of magic and you narrowly avoid an eldritch bolt!",
+          "miss_msg_npc": "%1$s screams words of magic and <npcname> narrowly avoids an eldritch bolt!",
+          "no_dmg_msg_u": "%1$s screams words of magic and your %2$s is impacted by an eldritch bolt, but it does no damage.",
+          "no_dmg_msg_npc": "%1$s screams words of magic and <npcname>'s %2$s is impacted by an eldritch bolt, but it does no damage."
+        },
+        {
+          "id": "feral_dabbler_ethereal_grasp",
+          "type": "spell",
+          "spell_data": { "id": "ethereal_grasp", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "26" ] }
+            ]
+          },
+          "monster_message": "%1$s makes a grasping gesture and ethereal hands burst from the ground around %3$s."
         }
       ]
     }
@@ -788,6 +827,45 @@
             ]
           },
           "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        },
+        {
+          "type": "monster_attack",
+          "//": "soldiers might have actually known some combat magic",
+          "attack_type": "melee",
+          "id": "feral_dabbler_soldier_magicmissile",
+          "cooldown": 10,
+          "move_cost": 100,
+          "range": 12,
+          "damage_max_instance": [ { "damage_type": "nether", "amount": 7 } ],
+          "dodgeable": false,
+          "blockable": false,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "25" ] }
+            ]
+          },
+          "hit_dmg_u": "%1$s screams words of magic and an eldritch bolt impacts your %2$s!",
+          "hit_dmg_npc": "%1$s screams words of magic and an eldritch bolt impacts <npcname>'s %2$s!",
+          "miss_msg_u": "%1$s screams words of magic and you narrowly avoid an eldritch bolt!",
+          "miss_msg_npc": "%1$s screams words of magic and <npcname> narrowly avoids an eldritch bolt!",
+          "no_dmg_msg_u": "%1$s screams words of magic and your %2$s is impacted by an eldritch bolt, but it does no damage.",
+          "no_dmg_msg_npc": "%1$s screams words of magic and <npcname>'s %2$s is impacted by an eldritch bolt, but it does no damage."
+        },
+        {
+          "id": "feral_dabbler_ethereal_grasp",
+          "type": "spell",
+          "spell_data": { "id": "ethereal_grasp", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "26" ] }
+            ]
+          },
+          "monster_message": "%1$s makes a grasping gesture and ethereal hands burst from the ground around %3$s."
         }
       ]
     }

--- a/data/mods/Magiclysm/monsters/feral_dabbler_overrides.json
+++ b/data/mods/Magiclysm/monsters/feral_dabbler_overrides.json
@@ -1,0 +1,795 @@
+[
+  {
+    "id": "mon_feral_human_pipe",
+    "//": "Unfortunately various individually-defined special attack entries means this has to be duplicated",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_human_pipe",
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_dabbler_spell_picker",
+          "type": "spell",
+          "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+          "cooldown": 1,
+          "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+          "monster_message": ""
+        },
+        {
+          "id": "feral_dabbler_sound_bomb",
+          "type": "spell",
+          "spell_data": { "id": "sound_bomb", "min_level": 5 },
+          "cooldown": 25,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+            ]
+          },
+          "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+        },
+        {
+          "id": "feral_dabbler_cure_light_wounds",
+          "type": "spell",
+          "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+          "cooldown": 75,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+            ]
+          },
+          "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+        },
+        {
+          "id": "feral_dabbler_light_target",
+          "type": "spell",
+          "spell_data": { "id": "magus_light_target", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+            ]
+          },
+          "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+        },
+        {
+          "id": "feral_dabbler_summon_wisps",
+          "type": "spell",
+          "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+            ]
+          },
+          "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+        },
+        {
+          "id": "feral_dabbler_windrunning",
+          "type": "spell",
+          "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+          "cooldown": 50,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+              { "not": { "u_has_effect": "enchant_windrun_monster" } }
+            ]
+          },
+          "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_feral_human_crowbar",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_human_crowbar",
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_dabbler_spell_picker",
+          "type": "spell",
+          "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+          "cooldown": 1,
+          "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+          "monster_message": ""
+        },
+        {
+          "id": "feral_dabbler_sound_bomb",
+          "type": "spell",
+          "spell_data": { "id": "sound_bomb", "min_level": 5 },
+          "cooldown": 25,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+            ]
+          },
+          "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+        },
+        {
+          "id": "feral_dabbler_cure_light_wounds",
+          "type": "spell",
+          "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+          "cooldown": 75,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+            ]
+          },
+          "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+        },
+        {
+          "id": "feral_dabbler_light_target",
+          "type": "spell",
+          "spell_data": { "id": "magus_light_target", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+            ]
+          },
+          "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+        },
+        {
+          "id": "feral_dabbler_summon_wisps",
+          "type": "spell",
+          "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+            ]
+          },
+          "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+        },
+        {
+          "id": "feral_dabbler_windrunning",
+          "type": "spell",
+          "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+          "cooldown": 50,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+              { "not": { "u_has_effect": "enchant_windrun_monster" } }
+            ]
+          },
+          "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_feral_human_axe",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_human_axe",
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_dabbler_spell_picker",
+          "type": "spell",
+          "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+          "cooldown": 1,
+          "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+          "monster_message": ""
+        },
+        {
+          "id": "feral_dabbler_sound_bomb",
+          "type": "spell",
+          "spell_data": { "id": "sound_bomb", "min_level": 5 },
+          "cooldown": 25,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+            ]
+          },
+          "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+        },
+        {
+          "id": "feral_dabbler_cure_light_wounds",
+          "type": "spell",
+          "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+          "cooldown": 75,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+            ]
+          },
+          "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+        },
+        {
+          "id": "feral_dabbler_light_target",
+          "type": "spell",
+          "spell_data": { "id": "magus_light_target", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+            ]
+          },
+          "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+        },
+        {
+          "id": "feral_dabbler_summon_wisps",
+          "type": "spell",
+          "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+            ]
+          },
+          "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+        },
+        {
+          "id": "feral_dabbler_windrunning",
+          "type": "spell",
+          "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+          "cooldown": 50,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+              { "not": { "u_has_effect": "enchant_windrun_monster" } }
+            ]
+          },
+          "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_feral_human_tool",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_human_tool",
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_dabbler_spell_picker",
+          "type": "spell",
+          "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+          "cooldown": 1,
+          "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+          "monster_message": ""
+        },
+        {
+          "id": "feral_dabbler_sound_bomb",
+          "type": "spell",
+          "spell_data": { "id": "sound_bomb", "min_level": 5 },
+          "cooldown": 25,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+            ]
+          },
+          "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+        },
+        {
+          "id": "feral_dabbler_cure_light_wounds",
+          "type": "spell",
+          "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+          "cooldown": 75,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+            ]
+          },
+          "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+        },
+        {
+          "id": "feral_dabbler_light_target",
+          "type": "spell",
+          "spell_data": { "id": "magus_light_target", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+            ]
+          },
+          "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+        },
+        {
+          "id": "feral_dabbler_summon_wisps",
+          "type": "spell",
+          "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+            ]
+          },
+          "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+        },
+        {
+          "id": "feral_dabbler_windrunning",
+          "type": "spell",
+          "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+          "cooldown": 50,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+              { "not": { "u_has_effect": "enchant_windrun_monster" } }
+            ]
+          },
+          "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_feral_scientist_scalpel",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_scientist_scalpel",
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_dabbler_spell_picker",
+          "type": "spell",
+          "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+          "cooldown": 1,
+          "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+          "monster_message": ""
+        },
+        {
+          "id": "feral_dabbler_sound_bomb",
+          "type": "spell",
+          "spell_data": { "id": "sound_bomb", "min_level": 5 },
+          "cooldown": 25,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+            ]
+          },
+          "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+        },
+        {
+          "id": "feral_dabbler_cure_light_wounds",
+          "type": "spell",
+          "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+          "cooldown": 75,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+            ]
+          },
+          "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+        },
+        {
+          "id": "feral_dabbler_light_target",
+          "type": "spell",
+          "spell_data": { "id": "magus_light_target", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+            ]
+          },
+          "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+        },
+        {
+          "id": "feral_dabbler_summon_wisps",
+          "type": "spell",
+          "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+            ]
+          },
+          "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+        },
+        {
+          "id": "feral_dabbler_windrunning",
+          "type": "spell",
+          "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+          "cooldown": 50,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+              { "not": { "u_has_effect": "enchant_windrun_monster" } }
+            ]
+          },
+          "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_feral_labsecurity_9mm",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_labsecurity_9mm",
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_dabbler_spell_picker",
+          "type": "spell",
+          "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+          "cooldown": 1,
+          "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+          "monster_message": ""
+        },
+        {
+          "id": "feral_dabbler_sound_bomb",
+          "type": "spell",
+          "spell_data": { "id": "sound_bomb", "min_level": 5 },
+          "cooldown": 25,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+            ]
+          },
+          "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+        },
+        {
+          "id": "feral_dabbler_cure_light_wounds",
+          "type": "spell",
+          "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+          "cooldown": 75,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+            ]
+          },
+          "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+        },
+        {
+          "id": "feral_dabbler_light_target",
+          "type": "spell",
+          "spell_data": { "id": "magus_light_target", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+            ]
+          },
+          "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+        },
+        {
+          "id": "feral_dabbler_summon_wisps",
+          "type": "spell",
+          "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+            ]
+          },
+          "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+        },
+        {
+          "id": "feral_dabbler_windrunning",
+          "type": "spell",
+          "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+          "cooldown": 50,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+              { "not": { "u_has_effect": "enchant_windrun_monster" } }
+            ]
+          },
+          "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_feral_labsecurity_flashlight",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_labsecurity_flashlight",
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_dabbler_spell_picker",
+          "type": "spell",
+          "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+          "cooldown": 1,
+          "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+          "monster_message": ""
+        },
+        {
+          "id": "feral_dabbler_sound_bomb",
+          "type": "spell",
+          "spell_data": { "id": "sound_bomb", "min_level": 5 },
+          "cooldown": 25,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+            ]
+          },
+          "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+        },
+        {
+          "id": "feral_dabbler_cure_light_wounds",
+          "type": "spell",
+          "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+          "cooldown": 75,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+            ]
+          },
+          "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+        },
+        {
+          "id": "feral_dabbler_light_target",
+          "type": "spell",
+          "spell_data": { "id": "magus_light_target", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+            ]
+          },
+          "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+        },
+        {
+          "id": "feral_dabbler_summon_wisps",
+          "type": "spell",
+          "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+            ]
+          },
+          "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+        },
+        {
+          "id": "feral_dabbler_windrunning",
+          "type": "spell",
+          "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+          "cooldown": 50,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+              { "not": { "u_has_effect": "enchant_windrun_monster" } }
+            ]
+          },
+          "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_feral_cop",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_cop",
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_dabbler_spell_picker",
+          "type": "spell",
+          "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+          "cooldown": 1,
+          "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+          "monster_message": ""
+        },
+        {
+          "id": "feral_dabbler_sound_bomb",
+          "type": "spell",
+          "spell_data": { "id": "sound_bomb", "min_level": 5 },
+          "cooldown": 25,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+            ]
+          },
+          "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+        },
+        {
+          "id": "feral_dabbler_cure_light_wounds",
+          "type": "spell",
+          "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+          "cooldown": 75,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+            ]
+          },
+          "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+        },
+        {
+          "id": "feral_dabbler_light_target",
+          "type": "spell",
+          "spell_data": { "id": "magus_light_target", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+            ]
+          },
+          "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+        },
+        {
+          "id": "feral_dabbler_summon_wisps",
+          "type": "spell",
+          "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+            ]
+          },
+          "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+        },
+        {
+          "id": "feral_dabbler_windrunning",
+          "type": "spell",
+          "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+          "cooldown": 50,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+              { "not": { "u_has_effect": "enchant_windrun_monster" } }
+            ]
+          },
+          "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_feral_soldier",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_soldier",
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_dabbler_spell_picker",
+          "type": "spell",
+          "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+          "cooldown": 1,
+          "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+          "monster_message": ""
+        },
+        {
+          "id": "feral_dabbler_sound_bomb",
+          "type": "spell",
+          "spell_data": { "id": "sound_bomb", "min_level": 5 },
+          "cooldown": 25,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+            ]
+          },
+          "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+        },
+        {
+          "id": "feral_dabbler_cure_light_wounds",
+          "type": "spell",
+          "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+          "cooldown": 75,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+            ]
+          },
+          "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+        },
+        {
+          "id": "feral_dabbler_light_target",
+          "type": "spell",
+          "spell_data": { "id": "magus_light_target", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+            ]
+          },
+          "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+        },
+        {
+          "id": "feral_dabbler_summon_wisps",
+          "type": "spell",
+          "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+          "cooldown": 30,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+            ]
+          },
+          "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+        },
+        {
+          "id": "feral_dabbler_windrunning",
+          "type": "spell",
+          "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+          "cooldown": 50,
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+              { "not": { "u_has_effect": "enchant_windrun_monster" } }
+            ]
+          },
+          "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+        }
+      ]
+    }
+  }
+]

--- a/data/mods/Magiclysm/monsters/feral_fantasy_species.json
+++ b/data/mods/Magiclysm/monsters/feral_fantasy_species.json
@@ -20,7 +20,86 @@
       },
       { "id": "feral_weapon_pipe" },
       [ "BROWSE", 100 ],
-      [ "EAT_FOOD", 100 ]
+      [ "EAT_FOOD", 100 ],
+      {
+        "id": "feral_dabbler_spell_picker",
+        "type": "spell",
+        "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+        "cooldown": 1,
+        "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+        "monster_message": ""
+      },
+      {
+        "id": "feral_dabbler_sound_bomb",
+        "type": "spell",
+        "spell_data": { "id": "sound_bomb", "min_level": 5 },
+        "cooldown": 25,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+          ]
+        },
+        "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+      },
+      {
+        "id": "feral_dabbler_cure_light_wounds",
+        "type": "spell",
+        "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+        "cooldown": 75,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+          ]
+        },
+        "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+      },
+      {
+        "id": "feral_dabbler_light_target",
+        "type": "spell",
+        "spell_data": { "id": "magus_light_target", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+          ]
+        },
+        "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+      },
+      {
+        "id": "feral_dabbler_summon_wisps",
+        "type": "spell",
+        "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+          ]
+        },
+        "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+      },
+      {
+        "id": "feral_dabbler_windrunning",
+        "type": "spell",
+        "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+        "cooldown": 50,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+            { "not": { "u_has_effect": "enchant_windrun_monster" } }
+          ]
+        },
+        "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+      }
     ],
     "name": { "str": "feral elf", "str_pl": "feral elves" },
     "description": "Fair folk no longer, this elf's pupils are dilated and what can be seen of the iris and sclera are bloodshot.  They clutch a pipe in one delicate hand as they gracefully walk unbothered amidst the zombies.",
@@ -54,7 +133,86 @@
       },
       { "id": "feral_weapon_pipe" },
       [ "BROWSE", 100 ],
-      [ "EAT_FOOD", 100 ]
+      [ "EAT_FOOD", 100 ],
+      {
+        "id": "feral_dabbler_spell_picker",
+        "type": "spell",
+        "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+        "cooldown": 1,
+        "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+        "monster_message": ""
+      },
+      {
+        "id": "feral_dabbler_sound_bomb",
+        "type": "spell",
+        "spell_data": { "id": "sound_bomb", "min_level": 5 },
+        "cooldown": 25,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+          ]
+        },
+        "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+      },
+      {
+        "id": "feral_dabbler_cure_light_wounds",
+        "type": "spell",
+        "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+        "cooldown": 75,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+          ]
+        },
+        "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+      },
+      {
+        "id": "feral_dabbler_light_target",
+        "type": "spell",
+        "spell_data": { "id": "magus_light_target", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+          ]
+        },
+        "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+      },
+      {
+        "id": "feral_dabbler_summon_wisps",
+        "type": "spell",
+        "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+          ]
+        },
+        "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+      },
+      {
+        "id": "feral_dabbler_windrunning",
+        "type": "spell",
+        "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+        "cooldown": 50,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+            { "not": { "u_has_effect": "enchant_windrun_monster" } }
+          ]
+        },
+        "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+      }
     ],
     "looks_like": "mon_forgedwarves",
     "name": { "str": "feral dwarf", "str_pl": "feral dwarves" },
@@ -87,7 +245,86 @@
         "ranges": [ [ 2, 5, "DEFAULT" ] ],
         "description": "The feral elf throws a rock!"
       },
-      { "id": "feral_weapon_crowbar" }
+      { "id": "feral_weapon_crowbar" },
+      {
+        "id": "feral_dabbler_spell_picker",
+        "type": "spell",
+        "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+        "cooldown": 1,
+        "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+        "monster_message": ""
+      },
+      {
+        "id": "feral_dabbler_sound_bomb",
+        "type": "spell",
+        "spell_data": { "id": "sound_bomb", "min_level": 5 },
+        "cooldown": 25,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+          ]
+        },
+        "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+      },
+      {
+        "id": "feral_dabbler_cure_light_wounds",
+        "type": "spell",
+        "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+        "cooldown": 75,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+          ]
+        },
+        "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+      },
+      {
+        "id": "feral_dabbler_light_target",
+        "type": "spell",
+        "spell_data": { "id": "magus_light_target", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+          ]
+        },
+        "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+      },
+      {
+        "id": "feral_dabbler_summon_wisps",
+        "type": "spell",
+        "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+          ]
+        },
+        "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+      },
+      {
+        "id": "feral_dabbler_windrunning",
+        "type": "spell",
+        "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+        "cooldown": 50,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+            { "not": { "u_has_effect": "enchant_windrun_monster" } }
+          ]
+        },
+        "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+      }
     ],
     "name": { "str": "feral elf", "str_pl": "feral elves" },
     "description": "Fair folk no longer, this elf's pupils are dilated and what can be seen of the iris and sclera are bloodshot.  They clutch a crowbar in one delicate hand as they gracefully walk unbothered amidst the zombies.",
@@ -119,7 +356,86 @@
         "ranges": [ [ 2, 5, "DEFAULT" ] ],
         "description": "The feral dwarf throws a rock!"
       },
-      { "id": "feral_weapon_crowbar" }
+      { "id": "feral_weapon_crowbar" },
+      {
+        "id": "feral_dabbler_spell_picker",
+        "type": "spell",
+        "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+        "cooldown": 1,
+        "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+        "monster_message": ""
+      },
+      {
+        "id": "feral_dabbler_sound_bomb",
+        "type": "spell",
+        "spell_data": { "id": "sound_bomb", "min_level": 5 },
+        "cooldown": 25,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+          ]
+        },
+        "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+      },
+      {
+        "id": "feral_dabbler_cure_light_wounds",
+        "type": "spell",
+        "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+        "cooldown": 75,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+          ]
+        },
+        "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+      },
+      {
+        "id": "feral_dabbler_light_target",
+        "type": "spell",
+        "spell_data": { "id": "magus_light_target", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+          ]
+        },
+        "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+      },
+      {
+        "id": "feral_dabbler_summon_wisps",
+        "type": "spell",
+        "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+          ]
+        },
+        "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+      },
+      {
+        "id": "feral_dabbler_windrunning",
+        "type": "spell",
+        "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+        "cooldown": 50,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+            { "not": { "u_has_effect": "enchant_windrun_monster" } }
+          ]
+        },
+        "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+      }
     ],
     "looks_like": "mon_forgedwarves",
     "name": { "str": "feral dwarf", "str_pl": "feral dwarves" },
@@ -199,6 +515,85 @@
         "cooldown": 1,
         "condition": { "not": { "u_has_effect": "maimed_arm" } },
         "damage_max_instance": [ { "damage_type": "cut", "amount": 8 } ]
+      },
+      {
+        "id": "feral_dabbler_spell_picker",
+        "type": "spell",
+        "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+        "cooldown": 1,
+        "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+        "monster_message": ""
+      },
+      {
+        "id": "feral_dabbler_sound_bomb",
+        "type": "spell",
+        "spell_data": { "id": "sound_bomb", "min_level": 5 },
+        "cooldown": 25,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+          ]
+        },
+        "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+      },
+      {
+        "id": "feral_dabbler_cure_light_wounds",
+        "type": "spell",
+        "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+        "cooldown": 75,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+          ]
+        },
+        "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+      },
+      {
+        "id": "feral_dabbler_light_target",
+        "type": "spell",
+        "spell_data": { "id": "magus_light_target", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+          ]
+        },
+        "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+      },
+      {
+        "id": "feral_dabbler_summon_wisps",
+        "type": "spell",
+        "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+          ]
+        },
+        "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+      },
+      {
+        "id": "feral_dabbler_windrunning",
+        "type": "spell",
+        "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+        "cooldown": 50,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+            { "not": { "u_has_effect": "enchant_windrun_monster" } }
+          ]
+        },
+        "monster_message": "%1$s whistles words of magic and a wind picks up around them."
       }
     ],
     "vision_day": 8,
@@ -283,7 +678,86 @@
         "cooldown": 1,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 11 } ]
       },
-      { "type": "leap", "cooldown": 10, "max_range": 6, "message": "%1$s leaps with a flutter of wings!" }
+      { "type": "leap", "cooldown": 10, "max_range": 6, "message": "%1$s leaps with a flutter of wings!" },
+      {
+        "id": "feral_dabbler_spell_picker",
+        "type": "spell",
+        "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+        "cooldown": 1,
+        "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+        "monster_message": ""
+      },
+      {
+        "id": "feral_dabbler_sound_bomb",
+        "type": "spell",
+        "spell_data": { "id": "sound_bomb", "min_level": 5 },
+        "cooldown": 25,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+          ]
+        },
+        "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+      },
+      {
+        "id": "feral_dabbler_cure_light_wounds",
+        "type": "spell",
+        "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+        "cooldown": 75,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+          ]
+        },
+        "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+      },
+      {
+        "id": "feral_dabbler_light_target",
+        "type": "spell",
+        "spell_data": { "id": "magus_light_target", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+          ]
+        },
+        "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+      },
+      {
+        "id": "feral_dabbler_summon_wisps",
+        "type": "spell",
+        "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+          ]
+        },
+        "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+      },
+      {
+        "id": "feral_dabbler_windrunning",
+        "type": "spell",
+        "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+        "cooldown": 50,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+            { "not": { "u_has_effect": "enchant_windrun_monster" } }
+          ]
+        },
+        "monster_message": "%1$s whistles words of magic and a wind picks up around them."
+      }
     ],
     "vision_day": 40,
     "vision_night": 3,
@@ -345,6 +819,85 @@
         "no_dmg_msg_npc": "%1$s's lunges at <npcname>, but its teeth glance off their armor.",
         "miss_msg_u": "%s lunges forward to bite you, but you dodge!",
         "miss_msg_npc": "%s lunges forward to bite <npcname>, but they dodge!"
+      },
+      {
+        "id": "feral_dabbler_spell_picker",
+        "type": "spell",
+        "spell_data": { "id": "feral_dabble_spell_selector_spell" },
+        "cooldown": 1,
+        "condition": { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "0" ] },
+        "monster_message": ""
+      },
+      {
+        "id": "feral_dabbler_sound_bomb",
+        "type": "spell",
+        "spell_data": { "id": "sound_bomb", "min_level": 5 },
+        "cooldown": 25,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "1" ] }
+          ]
+        },
+        "monster_message": "%1$s points at %3$s and a loud noise erupts around %3$s."
+      },
+      {
+        "id": "feral_dabbler_cure_light_wounds",
+        "type": "spell",
+        "spell_data": { "id": "light_healing", "min_level": 5, "hit_self": true },
+        "cooldown": 75,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "2" ] }
+          ]
+        },
+        "monster_message": "%1$s chants and makes a gesture trailed by glowing green lights."
+      },
+      {
+        "id": "feral_dabbler_light_target",
+        "type": "spell",
+        "spell_data": { "id": "magus_light_target", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "3" ] }
+          ]
+        },
+        "monster_message": "%1$s screams words of magic and waves their hands toward %3$s."
+      },
+      {
+        "id": "feral_dabbler_summon_wisps",
+        "type": "spell",
+        "spell_data": { "id": "summon_wisps_monster", "min_level": 5 },
+        "cooldown": 30,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "4" ] }
+          ]
+        },
+        "monster_message": "%1$s make several expansive gestures and eerie lights appear."
+      },
+      {
+        "id": "feral_dabbler_windrunning",
+        "type": "spell",
+        "spell_data": { "id": "windrun_monster", "min_level": 5, "hit_self": true },
+        "cooldown": 50,
+        "condition": {
+          "and": [
+            { "not": { "u_has_flag": "MUTE" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+            { "math": [ "u_feral_dabbler_chosen_spell_number", "==", "5" ] },
+            { "not": { "u_has_effect": "enchant_windrun_monster" } }
+          ]
+        },
+        "monster_message": "%1$s whistles words of magic and a wind picks up around them."
       }
     ],
     "vision_day": 30,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Feral dabblers: add small chance ferals know a single spell"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

30% of the population knew at least one spell before the Cataclysm. A bunch of those people went feral. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a selector spell that puts a variable on the casting feral (sadly, it produces a message due to bug #77436, but it works), cast once the first time it sees a hostile target and then never again. That variable mostly locks the feral out of casting any spells, but occasionally it allows them to use one--Faerie Fire, Ignus Fatuus, Sound Bomb, Windrunning, or Cure Light Wounds (police and soldiers may also and instead know Ethereal Grasp or Magic Missile). No other spells are modeled, because there's probably a lot of ferals who know Magic Lamp or Freshen Up, but it's not relevant (and some, like Traverse the Wilds, are relevant but currently impossible to model).

The massive line count is because due to the way feral special attacks work (they're mostly individually defined, rather than extended) I had to add these attacks to each feral individually.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![Untitled2](https://github.com/user-attachments/assets/6a407fa9-b2bf-4bd9-b050-bb1b60daec3d)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
