### PR TITLE
Balance/fix ranged weapon selection for random NPCs

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/archery_weapons.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/archery_weapons.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "item_group",
+    "id": "archery_common",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "shortbow", "prob": 8 },
+      { "item": "longbow", "prob": 4 },
+      { "item": "reflexbow", "prob": 2 },
+      { "item": "compositebow", "prob": 1 },
+      { "item": "bullet_crossbow", "prob": 1 },
+      { "item": "hand_crossbow", "prob": 8 },
+      { "item": "crossbow", "prob": 4 },
+      { "item": "compositecrossbow", "prob": 1 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "archery_rare",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "compbow", "prob": 8 },
+      { "item": "recurbow", "prob": 4 },
+      { "item": "takedown_recurbow", "prob": 1 },
+      { "item": "woodgreatbow", "prob": 1 },
+      { "item": "compgreatbow", "prob": 1 },
+      { "item": "compcrossbow", "prob": 1 },
+      { "item": "huge_crossbow", "prob": 1 },
+      { "item": "rep_crossbow", "prob": 1 }
+    ]
+  }
+]

--- a/data/json/npcs/NC_NONE.json
+++ b/data/json/npcs/NC_NONE.json
@@ -80,7 +80,13 @@
     "type": "item_group",
     "id": "NC_NONE_archery",
     "subtype": "distribution",
-    "items": [ "crossbow" ]
+    "groups": [ "archery_common" ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_NONE_quiver",
+    "subtype": "distribution",
+    "groups": [ "archery_quivers" ]
   },
   {
     "type": "item_group",

--- a/data/json/npcs/NC_NONE_HARDENED.json
+++ b/data/json/npcs/NC_NONE_HARDENED.json
@@ -80,7 +80,13 @@
     "type": "item_group",
     "id": "NC_NONE_HARDENED_archery",
     "subtype": "distribution",
-    "items": [ "longbow" ]
+    "groups": [ "archery_rare" ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_NONE_HARDENED_quiver",
+    "subtype": "distribution",
+    "groups": [ "NC_NONE_quiver" ]
   },
   {
     "type": "item_group",

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -981,16 +981,6 @@ void starting_inv_ammo( npc &who, std::list<item> &res, int multiplier )
 void npc::starting_inv_passtime()
 {
     static int max_time = to_days<int>( 180_days );
-    auto npc_wear_item = []( npc * who, item & it ) {
-        if( it.has_flag( flag_VARSIZE ) ) {
-            it.set_flag( flag_FIT );
-        }
-        if( who->can_wear( it ).success() ) {
-            it.on_wear( *who );
-            who->worn.wear_item( *who, it, false, false );
-            it.set_owner( *who );
-        }
-    };
     auto found_good_item = []( int day ) {
         return ( x_in_y( day, max_time ) ? NC_NONE_HARDENED : NC_NONE );
     };
@@ -1005,7 +995,7 @@ void npc::starting_inv_passtime()
     //give storage item if too little volume
     if( worn.volume_capacity() < 10000_ml ) {
         item storage = random_item_from( found_good_item( days_since_cata ), "storage" );
-        npc_wear_item( this, storage );
+        starting_inv_wear_item( this, storage );
     }
     //damage worn starting equipment
     starting_inv_damage_worn( days_since_cata );
@@ -1018,20 +1008,29 @@ void npc::starting_inv_passtime()
             if( one_in( 2 ) ) {
                 clothing.inc_damage(); //lightly used equipment
             }
-            npc_wear_item( this, clothing );
+            starting_inv_wear_item( this, clothing );
         }
     }
     //if no weapon on person, give one based on best weapon skill
+    npc_class_id found_weapon_quality = found_good_item( days_since_cata );
+    bool found_great_weapon = found_weapon_quality == NC_NONE_HARDENED;
     std::vector<item_location> items = all_items_loc();
-    bool has_weapon = false;
+    bool has_ranged_weapon = false;
+    bool has_melee_weapon = false;
     for( const item_location &i : items ) {
-        if( i->is_melee() || i->is_gun() ) {
-            has_weapon = true;
+        if( i->is_melee() && !i->is_armor() ) {
+            //if a great weapon was selected, poor weapons don't count
+            if( !found_great_weapon || i->base_damage_melee().total_damage() >= MELEE_STAT * 2 ) {
+                has_melee_weapon = true;
+            }
+            break;
+        } else if( i->is_gun() ) {
+            has_ranged_weapon = true;
             break;
         }
     }
-    if( !has_weapon ) {
-        starting_weapon( NC_NONE );
+    if( !has_melee_weapon && !has_ranged_weapon ) {
+        starting_weapon( found_weapon_quality );
         //additional ammo guaranteed if given a weapon
         std::list<item> res;
         starting_inv_ammo( *this, res, 1 );
@@ -1061,6 +1060,18 @@ void npc::starting_inv_passtime()
         }
         items_added++;
     } while( items_added <= items_limit );
+}
+
+void npc::starting_inv_wear_item( npc *who, item &it )
+{
+    if( it.has_flag( flag_VARSIZE ) ) {
+        it.set_flag( flag_FIT );
+    }
+    if( who->can_wear( it ).success() ) {
+        it.on_wear( *who );
+        who->worn.wear_item( *who, it, false, false );
+        it.set_owner( *who );
+    }
 }
 
 void npc::revert_after_activity()
@@ -1167,13 +1178,13 @@ void npc::place_on_map()
     debugmsg( "Failed to place NPC in a valid location near (%d,%d,%d)", posx(), posy(), posz() );
 }
 
-//Subset: whether "combat skill" includes all combat skills, no "general" (dodge, melee, marksman) skills, or only weapons you would expect NPCs to wield
-//Returns a pair with the skill_id (first) of the best skill, and the level (int) of that skill. If there is no best skill, defaults to stabbing.
-std::pair<skill_id, int> npc::best_combat_skill( combat_skills subset ) const
+std::pair<skill_id, int> npc::best_combat_skill( combat_skills subset, bool randomize ) const
 {
-    std::pair<skill_id, int> highest_skill( skill_stabbing, 0 );
+    std::vector<std::pair<skill_id, SkillLevel>> skill_subset;
+    std::pair<skill_id, int> default_skill( skill_stabbing, 0 );
+    int highest_level;
 
-    for( const auto &p : *_skills ) {
+    for( const std::pair<const skill_id, SkillLevel> &p : *_skills ) {
         if( p.first.obj().is_combat_skill() ) {
             switch( subset ) {
                 case combat_skills::ALL:
@@ -1189,17 +1200,41 @@ std::pair<skill_id, int> npc::best_combat_skill( combat_skills subset ) const
                         continue;
                     }
                     break;
+                case combat_skills::WEAPONS_ONLY_NO_THROW:
+                    if( p.first == skill_dodge || p.first == skill_gun || p.first == skill_melee ||
+                        p.first == skill_unarmed || p.first == skill_launcher || p.first == skill_throw ) {
+                        continue;
+                    }
+                    break;
             }
 
-            const int level = p.second.level();
-            if( level > highest_skill.second ) {
-                highest_skill.second = level;
-                highest_skill.first = p.first;
-            }
+            skill_subset.emplace_back( p );
+        }
+    }
+    std::sort( skill_subset.begin(), skill_subset.end(), []( std::pair<skill_id, SkillLevel> &s1,
+    std::pair<skill_id, SkillLevel> &s2 ) {
+        return s1.second.level() > s2.second.level();
+    } );
+    highest_level = skill_subset.front().second.level();
+
+    std::list<std::pair<skill_id, SkillLevel>> tied_skills;
+    for( const std::pair<skill_id, SkillLevel> &p : skill_subset ) {
+        if( p.second == highest_level ) {
+            tied_skills.emplace_back( p );
         }
     }
 
-    return highest_skill;
+    if( tied_skills.size() == skill_subset.size() ) {
+        default_skill.second = highest_level;
+        if( randomize ) {
+            default_skill.first = random_entry( tied_skills ).first;
+        }
+        return default_skill;
+    }
+
+    skill_id return_skill = randomize ? random_entry( tied_skills ).first :
+                            tied_skills.front().first;
+    return std::pair<skill_id, int>( return_skill, highest_level );
 }
 
 void npc::starting_weapon( const npc_class_id &type )
@@ -1209,7 +1244,7 @@ void npc::starting_weapon( const npc_class_id &type )
         return;
     }
 
-    const skill_id best = best_combat_skill( combat_skills::WEAPONS_ONLY ).first;
+    const skill_id best = best_combat_skill( combat_skills::WEAPONS_ONLY_NO_THROW, true ).first;
 
     if( best == skill_stabbing ) {
         set_wielded_item( random_item_from( type, "stabbing", Item_spawn_data_survivor_stabbing ) );
@@ -1221,6 +1256,8 @@ void npc::starting_weapon( const npc_class_id &type )
         set_wielded_item( random_item_from( type, "throw" ) );
     } else if( best == skill_archery ) {
         set_wielded_item( random_item_from( type, "archery" ) );
+        item quiver = random_item_from( type, "quiver" );
+        starting_inv_wear_item( this, quiver );
     } else if( best == skill_pistol ) {
         set_wielded_item( random_item_from( type, "pistol", Item_spawn_data_guns_pistol_common ) );
     } else if( best == skill_shotgun ) {

--- a/src/npc.h
+++ b/src/npc.h
@@ -253,7 +253,8 @@ const std::unordered_map<std::string, combat_engagement> combat_engagement_strs 
 enum class combat_skills : int {
     ALL = 0,
     NO_GENERAL,
-    WEAPONS_ONLY
+    WEAPONS_ONLY,
+    WEAPONS_ONLY_NO_THROW
 };
 
 enum class aim_rule : int {
@@ -819,14 +820,21 @@ class npc : public Character
          */
         void add_new_mission( mission *miss );
         void update_missions_target( character_id old_character, character_id new_character );
-        std::pair<skill_id, int> best_combat_skill( combat_skills subset ) const;
+        /**
+        @param subset - whether "combat skill" includes all combat skills, no "general" (dodge, melee, marksman) skills, or only weapons you would expect NPCs to wield
+        @param randomize - if more than one skill is tied for top, pick randomly
+        @return a pair with the skill_id (first) of the best skill, and the level (int) of that skill. If subset skills are all the same level, defaults to stabbing.
+        */
+        std::pair<skill_id, int> best_combat_skill( combat_skills subset, bool randomize = false ) const;
         void starting_weapon( const npc_class_id &type );
         /**
         * Adds items to a randomly generated NPC (i.e. not having a defined npc_class)
-        * As time passes, NPCs get stronger (reaching peak at 90 days)
+        * As time passes, NPCs have a greater chance to get better equipment
         * See NC_NONE_*.json and NC_NONE_HARDENED_*.json for item selection
         */
         void starting_inv_passtime();
+        //helper function for equipping NPCs
+        void starting_inv_wear_item( npc *who, item &it );
 
         // Save & load
         void deserialize( const JsonObject &data ) override;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "ranged weapon selection for random NPCs"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Another follow-up to #77334

Weapon selection for random NPCs still wasn't great. `best_combat_skill()` picked `stabbing` by default, and in case of a tie between skills would pick whatever skill was arbitrarily first in order. This happened to be `archery` a lot of the time, which would result in NPCs without any ammo because it doesn't fit in their inventory.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- adds a randomize parameter (default false) to `best_combat_skill()`, which will randomly pick from _tied_ skills if true.
- adds a quiver to any NPC that gets an `archery` weapon
- adds proper  `archery` item groups for random NPCs to select from
- temporarily removes `throwing` as an option for picking random NPC weapons. There's currently no way to prioritize an NPC to specifically throw certain items (when I gave an NPC a bag of rocks to test this, they wielded a rock as a melee weapon), and a lot of professions have high `throwing` skill which means it's selected often.

And, additional quality fixes to #77334: 
- equipped armor no longer counts as a weapon for random NPC weapon selection (to avoid e.g. hard hats counting), and
- if they get a rare weapon, weapons with a total damage rating of less than MELEE_STAT * 2 don't count either (e.g. a basketball).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Archery ammo spawn counts should probably be increased. Most gun ammo spawns in multiples, but archery ammo doesn't.

#### Testing

Passed all tests locally
Spawned a bunch of NPCs and checked variety of items compared to profession
Tested new item groups multiple times

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
