### PR TITLE
Increased available space for skills chapter in description tab of character creation menu

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3998,9 +3998,9 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
     const auto init_windows = [&]( ui_adaptor & ui ) {
         const int freeWidth = TERMX - FULL_SCREEN_WIDTH;
         isWide = freeWidth > 15;
-        const int beginx2 = 46;
+        const int beginx2 = 52;
         const int ncol2 = 40;
-        const int beginx3 = TERMX <= 88 ? TERMX - TERMX / 4 : 86;
+        const int beginx3 = TERMX <= 88 ? TERMX - TERMX / 4 : 90;
         const int ncol3 = TERMX - beginx3 - 2;
         const int beginx4 = TERMX <= 130 ? TERMX - TERMX / 5 : 128;
         const int ncol4 = TERMX - beginx4 - 2;
@@ -4023,7 +4023,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
             w_hobbies = catacurses::newwin( TERMY - 11 - 11, ncol4, point( beginx4, 10 ) );
             w_scenario = catacurses::newwin( 1, ncol2, point( beginx2, 3 ) );
             w_profession = catacurses::newwin( 1, ncol3, point( beginx3, 3 ) );
-            w_skills = catacurses::newwin( TERMY - 11, 23, point( 22, 10 ) );
+            w_skills = catacurses::newwin( TERMY - 11, 27, point( 22, 10 ) );
             w_height = catacurses::newwin( 1, ncol2, point( beginx2, 6 ) );
             w_age = catacurses::newwin( 1, ncol2, point( beginx2, 7 ) );
             w_blood = catacurses::newwin( 1, ncol2, point( beginx2, 8 ) );


### PR DESCRIPTION
#### Summary
Interface "Increased available space for skills chapter in description tab of character creation menu"

#### Purpose of change
* Closes #51179.

#### Describe the solution
Increased available space for skills chapter in description tab of character creation menu.

#### Describe alternatives you've considered
None.

#### Testing
Opened character creation menu, set piercing weapons to 10. Also selected some traits with long names to check that they still fit in nicely.

#### Additional context
![изображение](https://github.com/user-attachments/assets/4ad84da4-10fd-46b0-bedb-4c4881b4a381)

