### PR TITLE
[Magiclysm] Zombie versions of lizardfolk and ravenfolk drop tainted flesh like all other zombies

### DIFF
--- a/data/mods/Magiclysm/harvest.json
+++ b/data/mods/Magiclysm/harvest.json
@@ -213,6 +213,29 @@
     ]
   },
   {
+    "id": "zombie_lizardfolk",
+    "type": "harvest",
+    "copy-from": "zombie_humanoid",
+    "delete": {
+      "entries": [ { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ]
+    }
+  },
+  {
+    "id": "zombie_ravenfolk",
+    "type": "harvest",
+    "copy-from": "demihuman_large_fur",
+    "//": "removes 66% of their featers due to most being unusable due to being from an undead corpse.",
+    "delete": {
+      "entries": [ { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ]
+    },
+    "extend": {
+      "entries": [
+        { "drop": "feather", "type": "skin", "mass_ratio": 0.007 },
+        { "drop": "down_feather", "type": "skin", "mass_ratio": 0.003 }
+      ]
+    }
+  },
+  {
     "id": "ogre",
     "type": "harvest",
     "copy-from": "demihuman_large_fur",

--- a/data/mods/Magiclysm/harvest.json
+++ b/data/mods/Magiclysm/harvest.json
@@ -216,9 +216,7 @@
     "id": "zombie_lizardfolk",
     "type": "harvest",
     "copy-from": "zombie_humanoid",
-    "delete": {
-      "entries": [ { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ]
-    }
+    "delete": { "entries": [ { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "zombie_ravenfolk",

--- a/data/mods/Magiclysm/harvest.json
+++ b/data/mods/Magiclysm/harvest.json
@@ -223,9 +223,7 @@
     "type": "harvest",
     "copy-from": "zombie_humanoid",
     "//": "removes 66% of their featers due to most being unusable due to being from an undead corpse.",
-    "delete": {
-      "entries": [ { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ]
-    },
+    "delete": { "entries": [ { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] },
     "extend": {
       "entries": [
         { "drop": "feather", "type": "skin", "mass_ratio": 0.007 },

--- a/data/mods/Magiclysm/harvest.json
+++ b/data/mods/Magiclysm/harvest.json
@@ -223,7 +223,7 @@
   {
     "id": "zombie_ravenfolk",
     "type": "harvest",
-    "copy-from": "demihuman_large_fur",
+    "copy-from": "zombie_humanoid",
     "//": "removes 66% of their featers due to most being unusable due to being from an undead corpse.",
     "delete": {
       "entries": [ { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ]

--- a/data/mods/Magiclysm/monsters/zombified_fantasy_species.json
+++ b/data/mods/Magiclysm/monsters/zombified_fantasy_species.json
@@ -75,7 +75,7 @@
       }
     ],
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_demihuman", "prof_wp_basic_bird" ],
-    "harvest": "demihuman",
+    "harvest": "zombie_ravenfolk",
     "special_attacks": [
       [ "SHRIEK_ALERT", 15 ],
       {
@@ -117,7 +117,7 @@
     "weakpoint_sets": [ "wps_humanoid_body" ],
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_demihuman" ],
     "armor": { "bash": 3, "cut": 4, "stab": 4, "bullet": 2 },
-    "harvest": "lizardfolk",
+    "harvest": "zombie_lizardfolk",
     "//": "No grab--they have multiple natural weapons so they just attack",
     "special_attacks": [
       [ "PARROT", 400 ],


### PR DESCRIPTION
#### Summary
Mods "[Magiclysm] Zombie versions of lizardfolk and ravenfolk drop tainted flesh like all other zombies"

#### Purpose of change

I noticed that these two zombie types dropped demihuman flesh unlike all other zombies, so I'm bringing them in line with the rest by giving them tainted flesh drops.

#### Describe the solution

Switching their harvests to some dropping tainted things.

#### Describe alternatives you've considered

Leaving them as a source of edible meat for all these starving survivors.

#### Testing

Before:
![nontainted](https://github.com/user-attachments/assets/47a1ca83-920e-45cf-8271-1e8a58a38a64)

After:
![nowtainted](https://github.com/user-attachments/assets/3034b8a1-399c-49be-9519-fb47f08953c1)

#### Additional context

The other fantasy zombies already dropped tainted stuff as expected.