### PR TITLE
deprecate type and context in dialogues (json side)

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
@@ -159,7 +159,7 @@
         "type": "good",
         "popup": true
       },
-      { "u_lose_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge" },
+      { "u_lose_var": "general_knowledge_u_dont_know_about_farm" },
       {
         "if": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
         "then": [

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -1599,7 +1599,7 @@
                 { "u_spawn_item": "helmet_riot", "count": 5 },
                 { "u_spawn_item": "armor_riot_arm", "count": 5 },
                 { "u_spawn_item": "armor_riot_leg", "count": 5 },
-                { "npc_add_var": "npc_bought_riot_gear", "type": "dialogue", "context": "exodii", "value": "yes" }
+                { "npc_add_var": "npc_dialogue_exodii_npc_bought_riot_gear", "value": "yes" }
               ]
             }
           }
@@ -1627,7 +1627,7 @@
           { "u_spawn_item": "armor_riot_arm", "count": 5 },
           { "u_spawn_item": "armor_riot_leg", "count": 5 },
           { "assign_mission": "MISSION_EXODII_PAY_BACK_RIOT_GEAR" },
-          { "npc_add_var": "npc_bought_riot_gear", "type": "dialogue", "context": "exodii", "value": "yes" }
+          { "npc_add_var": "npc_dialogue_exodii_npc_bought_riot_gear", "value": "yes" }
         ],
         "topic": "TALK_EXODII_MERCHANT_Talk"
       },

--- a/data/json/npcs/isherwood_farm/Isherwood_Rescue_NPC_Duplicates.json
+++ b/data/json/npcs/isherwood_farm/Isherwood_Rescue_NPC_Duplicates.json
@@ -34,8 +34,8 @@
           ]
         },
         "effect": [
-          { "u_lose_var": "barry_following", "type": "general", "context": "meeting" },
-          { "u_add_var": "u_saved_barry", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_lose_var": "general_meeting_barry_following" },
+          { "u_add_var": "u_saved_barry_isherwood", "value": "yes" },
           { "finish_mission": "MISSION_ISHERWOOD_CHRIS_1", "success": true },
           { "mapgen_update": "isherwood_rescue_remove_npcs", "om_terrain": "isherwood_barry_rescue_field" },
           { "math": [ "barry_travelling_home", "=", "1" ] },

--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -93,7 +93,7 @@
         "text": "Okay then, your family's outside.  Let me go get them.",
         "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
         "effect": [
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
         ],
@@ -104,7 +104,7 @@
         "condition": { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
         "effect": [
           "follow_only",
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
           { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
@@ -124,7 +124,7 @@
         "text": "Yeah, they did, I'll go get them.",
         "condition": { "math": [ "isherwood_family_coming", "==", "1" ] },
         "effect": [
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
         ],
@@ -135,7 +135,7 @@
         "condition": { "math": [ "isherwood_family_coming", "!=", "1" ] },
         "effect": [
           "follow_only",
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
           { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
@@ -156,7 +156,7 @@
         "condition": { "math": [ "isherwood_family_coming", "!=", "1" ] },
         "effect": [
           "follow_only",
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
           { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
@@ -168,7 +168,7 @@
         "condition": { "math": [ "isherwood_family_coming", "!=", "1" ] },
         "effect": [
           "follow_only",
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
           { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
@@ -179,7 +179,7 @@
         "text": "Okay, me too.  I'll go get your family.",
         "condition": { "math": [ "isherwood_family_coming", "==", "1" ] },
         "effect": [
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
         ],
@@ -189,7 +189,7 @@
         "text": "All right, we're leaving, but you better not test me again.  I'll be back with your family.",
         "condition": { "math": [ "isherwood_family_coming", "==", "1" ] },
         "effect": [
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
         ],
@@ -207,14 +207,14 @@
         "text": "What farm?",
         "topic": "TALK_ISHERWOOD_BARRY_Escaping_What_Farm",
         "condition": { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
-        "effect": { "u_add_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge", "value": "yes" }
+        "effect": { "u_add_var": "general_knowledge_u_dont_know_about_farm", "value": "yes" }
       },
       {
         "text": "That shouldn't take long, your family's outside waiting.  I'll be back with them.",
         "topic": "TALK_DONE",
         "condition": { "math": [ "isherwood_family_coming", "==", "1" ] },
         "effect": [
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
         ]
@@ -225,7 +225,7 @@
         "condition": { "and": [ { "math": [ "isherwood_family_coming", "!=", "1" ] }, { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } ] },
         "effect": [
           "follow_only",
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
           { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
@@ -243,7 +243,7 @@
         "topic": "TALK_DONE",
         "effect": [
           "follow_only",
-          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "u_add_var": "general_meeting_barry_following", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
         ]
@@ -526,21 +526,18 @@
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_BARRY_TOWER_farm",
     "dynamic_line": "Oh, yeah, now I remember.  That farm I was talking about is where I live, almost the whole Isherwood family lives there, including me.  I just wanted to get back home as fast as possible so I can see everyone again, and so everyone knows that I'm okay.",
-    "speaker_effect": {
-      "sentinel": "u_learned_about_farm",
-      "effect": [ { "u_lose_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge" } ]
-    },
+    "speaker_effect": { "sentinel": "u_learned_about_farm", "effect": [ { "u_lose_var": "general_knowledge_u_dont_know_about_farm" } ] },
     "responses": [
       { "text": "Can you give me some directions to it?", "topic": "TALK_ISHERWOOD_BARRY_TOWER_farm_directions" },
       {
         "text": "That's pretty cool.  <done_conversation_section>",
         "topic": "TALK_ISHERWOOD_BARRY_askback",
-        "effect": { "u_add_var": "u_thinking_about_farm", "type": "general", "context": "knowledge", "value": "yes" }
+        "effect": { "u_add_var": "general_knowledge_u_thinking_about_farm", "value": "yes" }
       },
       {
         "text": "<end_talking_leave>",
         "topic": "TALK_DONE",
-        "effect": { "u_add_var": "u_thinking_about_farm", "type": "general", "context": "knowledge", "value": "yes" }
+        "effect": { "u_add_var": "general_knowledge_u_thinking_about_farm", "value": "yes" }
       }
     ]
   },
@@ -554,13 +551,13 @@
         "topic": "TALK_DONE",
         "effect": [
           { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" },
-          { "u_lose_var": "u_thinking_about_farm", "type": "general", "context": "knowledge" }
+          { "u_lose_var": "general_knowledge_u_thinking_about_farm" }
         ]
       },
       {
         "text": "I'd like to think about it some more.",
         "topic": "TALK_DONE",
-        "effect": { "u_add_var": "u_thinking_about_farm", "type": "general", "context": "knowledge", "value": "yes" }
+        "effect": { "u_add_var": "general_knowledge_u_thinking_about_farm", "value": "yes" }
       }
     ]
   },

--- a/data/json/npcs/militia/GM_Militia_Merchant.json
+++ b/data/json/npcs/militia/GM_Militia_Merchant.json
@@ -141,7 +141,7 @@
       "yes": "Hello again.",
       "no": "Welcome to our camp.  Behave yourself while you are here.  What can I do for you?"
     },
-    "speaker_effect": { "effect": { "u_add_var": "talked_to_MILITIAMAIN", "type": "dialogue", "context": "first_meeting", "value": "yes" } },
+    "speaker_effect": { "effect": { "u_add_var": "dialogue_first_meeting_talked_to_MILITIAMAIN", "value": "yes" } },
     "responses": [
       {
         "text": "What do you do here?",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -179,7 +179,7 @@
           { "u_spawn_item": "helmet_riot", "count": 5 },
           { "u_spawn_item": "armor_riot_arm", "count": 5 },
           { "u_spawn_item": "armor_riot_leg", "count": 5 },
-          { "npc_add_var": "npc_bought_riot_gear", "type": "dialogue", "context": "intercom", "value": "yes" }
+          { "npc_add_var": "npc_dialogue_exodii_npc_bought_riot_gear", "value": "yes" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
       },
@@ -198,12 +198,12 @@
     "responses": [
       {
         "text": "I can pay you what I owe in cash and looted gear.",
-        "effect": [ { "npc_add_var": "u_pay_back_on_cash", "type": "dialogue", "context": "intercom", "value": "yes" } ],
+        "effect": [ { "npc_add_var": "npc_dialogue_intercom_u_pay_back_on_cash", "value": "yes" } ],
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_RIOT_GEAR_ON_CREDIT_ACCEPT"
       },
       {
         "text": "If you give me this deal you can have all the alien corpses, their stuff and their tower",
-        "effect": [ { "npc_add_var": "u_pay_back_on_specimens", "type": "dialogue", "context": "intercom", "value": "yes" } ],
+        "effect": [ { "npc_add_var": "npc_dialogue_intercom_u_pay_back_on_specimens", "value": "yes" } ],
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_RIOT_GEAR_ON_CREDIT_ACCEPT"
       },
       { "text": "I'll have to give it some thought.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" }
@@ -226,7 +226,7 @@
           { "u_spawn_item": "armor_riot_arm", "count": 5 },
           { "u_spawn_item": "armor_riot_leg", "count": 5 },
           { "assign_mission": "MISSION_HUB01_PAY_BACK_RIOT_GEAR" },
-          { "npc_add_var": "npc_bought_riot_gear", "type": "dialogue", "context": "intercom", "value": "yes" }
+          { "npc_add_var": "npc_dialogue_exodii_npc_bought_riot_gear", "value": "yes" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
       },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Part of #77515
#### Describe the solution
deprecation caused a bunch of json errors; this pr get rid of them
#### Testing
The game loads, no another context field popped up anywhere else; finding type is harder, but i guess there is no example of this field in dialogues either
#### Additional context
there was few incorrectly used variables, so if there was any issues with robofac or exodii not selling armor it was resolved