### PR TITLE
Add `IRRITANT_IMMUNE` to more armors and exoskeletons

### DIFF
--- a/data/json/items/armor/combat_exoskeleton.json
+++ b/data/json/items/armor/combat_exoskeleton.json
@@ -16,6 +16,7 @@
       "PADDED",
       "WATERPROOF",
       "RAINPROOF",
+      "IRRITANT_IMMUNE",
       "RAD_PROOF",
       "ELECTRIC_IMMUNE",
       "SUN_GLASSES",
@@ -481,7 +482,17 @@
     "warmth": 0,
     "environmental_protection": 0,
     "delete": {
-      "flags": [ "STURDY", "PADDED", "WATERPROOF", "RAINPROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "SUN_GLASSES", "COMBAT_TOGGLEABLE" ]
+      "flags": [
+        "STURDY",
+        "PADDED",
+        "WATERPROOF",
+        "RAINPROOF",
+        "IRRITANT_IMMUNE",
+        "RAD_PROOF",
+        "ELECTRIC_IMMUNE",
+        "SUN_GLASSES",
+        "COMBAT_TOGGLEABLE"
+      ]
     },
     "armor": [
       {

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1344,6 +1344,7 @@
       "ALARMCLOCK",
       "SWIM_GOGGLES",
       "SUN_GLASSES",
+      "IRRITANT_IMMUNE",
       "RAD_PROOF",
       "GAS_PROOF",
       "ELECTRIC_IMMUNE",
@@ -1521,6 +1522,7 @@
     "environmental_protection": 10,
     "material_thickness": 3,
     "flags": [
+      "IRRITANT_IMMUNE",
       "RAD_PROOF",
       "PORTAL_PROOF",
       "STURDY",
@@ -1631,6 +1633,7 @@
     },
     "environmental_protection": 80,
     "flags": [
+      "IRRITANT_IMMUNE",
       "RAD_PROOF",
       "PORTAL_PROOF",
       "STURDY",


### PR DESCRIPTION
#### Summary
Content "Add `IRRITANT_IMMUNE` to `rm13_armor_on` `phase_immersion_suit` and combat exoskeletons"
#### Purpose of change
#74680 added `IRRITANT_IMMUNE` flag, but didn't add it to armors that should be capable of preventing skin irritants.
#### Describe the solution
Add `IRRITANT_IMMUNE` to `rm13_armor_on` `phase_immersion_suit` `phase_immersion_suit_on` and combat exoskeletons, that are `WATERPROOF` and `RAD_PROOF`, thus should be able to prevent skin irritants. As `rm13_armor` is only `RAD_RESIST`, leave it as it is.
#### Describe alternatives you've considered
Also add it to cleansuit and rm13_armor.
#### Testing
Game loads normally, and wearing `rm13_armor_on` etc now makes you immune to `bile_irritant`.
#### Additional context
