### PR TITLE
dirty caches on translucency change

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -227,15 +227,15 @@ bool map::build_vision_transparency_cache( int zlev )
         }
     }
 
+    memcpy( &vision_transparency_cache, &transparency_cache, sizeof( transparency_cache ) );
+
     // This segment handles blocking vision through TRANSLUCENT flagged terrain.
+    // We don't need to deal with cache dirtying, because that was handled when the terrain was changed.
     for( const tripoint_bub_ms &loc : points_in_radius( p, MAX_VIEW_DISTANCE ) ) {
         if( map::ter( loc ).obj().has_flag( ter_furn_flag::TFLAG_TRANSLUCENT ) && loc != p ) {
-            dirty |= vision_transparency_cache[loc.x()][loc.y()] != LIGHT_TRANSPARENCY_SOLID;
-            solid_tiles.emplace_back( loc );
+            vision_transparency_cache[loc.x()][loc.y()] = LIGHT_TRANSPARENCY_SOLID;
         }
     }
-
-    memcpy( &vision_transparency_cache, &transparency_cache, sizeof( transparency_cache ) );
 
     // The tile player is standing on should always be visible
     vision_transparency_cache[p.x()][p.y()] = LIGHT_TRANSPARENCY_OPEN_AIR;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1848,7 +1848,9 @@ bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, cons
     if( !new_f.emissions.empty() ) {
         field_furn_locs.push_back( p );
     }
-    if( old_f.transparent != new_f.transparent ) {
+    if( old_f.transparent != new_f.transparent ||
+        old_f.has_flag( ter_furn_flag::TFLAG_TRANSLUCENT ) != new_f.has_flag(
+            ter_furn_flag::TFLAG_TRANSLUCENT ) ) {
         set_transparency_cache_dirty( p );
         set_seen_cache_dirty( p );
     }
@@ -2352,7 +2354,9 @@ bool map::ter_set( const tripoint_bub_ms &p, const ter_id &new_terrain, bool avo
     if( !new_t.emissions.empty() ) {
         field_ter_locs.push_back( p );
     }
-    if( old_t.transparent != new_t.transparent ) {
+    if( old_t.transparent != new_t.transparent ||
+        old_t.has_flag( ter_furn_flag::TFLAG_TRANSLUCENT ) != new_t.has_flag(
+            ter_furn_flag::TFLAG_TRANSLUCENT ) ) {
         set_transparency_cache_dirty( p );
         set_seen_cache_dirty( p );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #77521 (but only in a very literal sense).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Add checks to terrain/furniture changes as to whether translucency changes, not only "transparency", as the latter is set for both transparent and translucent terrain/furniture.
- Update build_vision_transparency_cache to rely on the terrain setting cache invalidation, which also means the translucency juggling can be moved after the cache replacement, and so the appropriate tiles can be updated directly rather than stored in an array.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Wait until someone can figure out how to deal with closing door effects being delayed (see Additional context).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Load bug report save.
- Open door.
- Verify that the area beyond is now shown.
- Close door.
- See that the area beyond remains displayed, which it shouldn't be.
- Wait a tick (or smash the floor, or whatever).
- See that the displayed area beyond the door is finally hidden as it should be.
- Walk to a regular door and open it.
- Verify that the area beyond is shown.
- Close the door again.
- Verify that the area beyond is hidden immediately, as it should.
- Translucent furniture is not tested. I don't think there is any currently, and I don't think it would work, as I don't see any code that seems to deal with it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The translucency handling is a hack that's not fully carried through. Translucent terrain is handled as transparent in the terrain information (i.e. both flags set the same boolean). This means that the operations and transparency cache accessing code is completely oblivious of there being such a thing as translucency which is ignored by the access operations and the transparency cache.
As mentioned above, there is now a problem with the lingering visibility when a translucent door is closed (this was hidden previously, because nothing was revealed, so that state remaining didn't differ from it being set).
A lot of these usages of transparency information should probably also check transparency (such as e.g. whether creatures can see each other), but which? And how to test the changes?
I've tried to hack in checks in a number of suspects, one at a time, but none have removed the door closing update delay, so they are all removed again.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
