### PR TITLE
[XE] fix two bugs about learning new blood gifts

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -411,7 +411,6 @@
   {
     "type": "effect_type",
     "id": "vampire_virus_ascendant",
-    "//": "Currently unobtainable.  Needs to be player choice and significant quest/difficulty to advance to this stage. VAMPIRE4 will be gated behind this.",
     "name": [ "Terminal Porphyria" ],
     "desc": [ "Your skin is deathly white and will redden and burn when exposed to the sun." ],
     "apply_message": "You've chosen to embrace this illness and enhance your curse.",
@@ -427,7 +426,6 @@
   {
     "type": "effect_type",
     "id": "vampire_virus_post_mortal",
-    "//": "Currently unobtainable.  Needs to be player choice and significant quest/difficulty to advance to this stage. VAMPIRE5 will be gated behind this.",
     "name": [ "Homo sapiens homovorus" ],
     "desc": [
       "Your skin is deathly white, your eyes are solid red except for a huge pupil, the only food you can consume is human blood, and if sunlight hits you that part of your body instantly burns."

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -217,7 +217,8 @@
     "id": "EOC_XE_VAMPIRE_BLOOD_RESEARCH_FAILURE",
     "effect": [
       { "u_lose_effect": "effect_vampire_studying_blood_gifts" },
-      { "u_message": "Your experiments are fruitless.  You'll have to try again." } ]
+      { "u_message": "Your experiments are fruitless.  You'll have to try again." }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -83,7 +83,6 @@
     "//": "This should contain all tier 1 vampire powers",
     "condition": { "u_has_effect": "effect_vampire_studying_blood_gifts" },
     "effect": [
-      { "u_lose_effect": "effect_vampire_studying_blood_gifts" },
       {
         "u_roll_remainder": [
           "EYEGLEAM",
@@ -107,7 +106,6 @@
     "//": "This should contain all tier 2 vampire powers",
     "condition": { "u_has_effect": "effect_vampire_studying_blood_gifts" },
     "effect": [
-      { "u_lose_effect": "effect_vampire_studying_blood_gifts" },
       {
         "u_roll_remainder": [
           "BLOODHEAL",
@@ -130,7 +128,6 @@
     "//": "This should contain all tier 3 vampire powers",
     "condition": { "u_has_effect": "effect_vampire_studying_blood_gifts" },
     "effect": [
-      { "u_lose_effect": "effect_vampire_studying_blood_gifts" },
       {
         "u_roll_remainder": [ "BLOODHASTE", "MAGICFORBLOOD", "HYPNOTIC_GAZE", "BLOODBANK", "VAMPIRE_COMMAND_BEAST", "VAMPIRE_EARTH_SLUMBER" ],
         "type": "mutation",
@@ -145,7 +142,6 @@
     "//": "This should contain all tier 4 vampire powers",
     "condition": { "u_has_effect": "effect_vampire_studying_blood_gifts" },
     "effect": [
-      { "u_lose_effect": "effect_vampire_studying_blood_gifts" },
       {
         "u_roll_remainder": [
           "TRUE_VAMPIRE_POWER",
@@ -166,10 +162,20 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_XE_VAMPIRE_BLOOD_RESEARCH_RESULTS_05",
+    "//": "This checks if the vampire has the required tier before trying to give them tier 5 powers",
+    "condition": { "u_has_trait": "BLOOD_DRINKER" },
+    "effect": [ { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_RESEARCH_RESULTS_05_REAL" } ],
+    "false_effect": [
+      { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_RESEARCH_RESULTS_04" },
+      { "u_message": "Your vampirism isn't potent enough to unlock a gift of this level, so you have to settle for a weaker gift.", "type": "bad" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XE_VAMPIRE_BLOOD_RESEARCH_RESULTS_05_REAL",
     "//": "This should contain all tier 5 vampire powers",
     "condition": { "u_has_effect": "effect_vampire_studying_blood_gifts" },
     "effect": [
-      { "u_lose_effect": "effect_vampire_studying_blood_gifts" },
       {
         "u_roll_remainder": [
           "VAMPIRE_MASTER_MORTAL_MIND",
@@ -199,13 +205,16 @@
     "effect": [
       { "u_message": "You learn a new blood gift.", "popup": true },
       { "run_eocs": "EOC_MIST_FORM_BEFORE_LAST_BREATH" },
+      { "u_lose_effect": "effect_vampire_studying_blood_gifts" },
       { "u_add_effect": "effect_vampire_recently_learned_blood_gifts", "duration": "5 days" }
     ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_XE_VAMPIRE_BLOOD_RESEARCH_FAILURE",
-    "effect": [ { "u_message": "Your experiments are fruitless.  You'll have to try again." } ]
+    "effect": [ 
+      { "u_lose_effect": "effect_vampire_studying_blood_gifts" },
+      { "u_message": "Your experiments are fruitless.  You'll have to try again." } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -167,7 +167,10 @@
     "effect": [ { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_RESEARCH_RESULTS_05_REAL" } ],
     "false_effect": [
       { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_RESEARCH_RESULTS_04" },
-      { "u_message": "Your vampirism isn't potent enough to unlock a gift of this level, so you have to settle for a weaker gift.", "type": "bad" }
+      {
+        "u_message": "Your vampirism isn't potent enough to unlock a gift of this level, so you have to settle for a weaker gift.",
+        "type": "bad"
+      }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -215,7 +215,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_XE_VAMPIRE_BLOOD_RESEARCH_FAILURE",
-    "effect": [ 
+    "effect": [
       { "u_lose_effect": "effect_vampire_studying_blood_gifts" },
       { "u_message": "Your experiments are fruitless.  You'll have to try again." } ]
   },


### PR DESCRIPTION
#### Summary
Mods "[XE] fix two bugs about learning new blood gifts"

#### Purpose of change

Fix two bugs related to learning new blood gifts in XEDRA Evolved:
Being able to gain tier 5 powers without being a tier 5 vampire, fixing #77076.
The EoC not trying to give you powers of a lesser tier if you already have all the powers from the tier you rolled due to how it handles effect removal.

I also removed the outdated comments about the tier 4 and 5 effects being unobtainable, which isn't the case anymore.

#### Describe the solution

Modify the gift learning EoC to fix the aforementioned bugs

#### Describe alternatives you've considered

Not fixing bugs.

#### Testing

Set the character's intelligence to 100 so the EoC would always pick the highest tier.
Tried to get a power without having tier 5: I get told that I can't get tier 5 powers yet and obtain a tier 4 power instead.
Tried to get a power while having tier 5: I get a tier 5 power.
Tried to get a power while having all tier 5 powers: I get a tier 4 power.

#### Additional context
None yet
