### PR TITLE
[Magiclysm] Add a trait that prevents magical spellcasting

### DIFF
--- a/data/mods/Magiclysm/eoc_spell_difficulty_modifiers.json
+++ b/data/mods/Magiclysm/eoc_spell_difficulty_modifiers.json
@@ -128,5 +128,16 @@
       { "math": [ "u_spellcasting_adjustment('difficulty', 'flag_whitelist': 'TRANSFORMATION_SPELL')", "=", "999" ] },
       { "math": [ "u_spellcasting_adjustment('cost', 'flag_whitelist': 'TRANSFORMATION_SPELL')", "=", "999" ] }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NO_CASTING_FOR_EMPTY",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": { "u_has_trait": "MAGIC_EMPTY" },
+    "effect": [
+      { "math": [ "u_spellcasting_adjustment('difficulty', 'flag_blacklist': 'PSIONIC')", "=", "999" ] },
+      { "math": [ "u_spellcasting_adjustment('cost', 'flag_blacklist': 'PSIONIC')", "=", "999" ] }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/traits/mutation.json
+++ b/data/mods/Magiclysm/traits/mutation.json
@@ -385,5 +385,18 @@
     "starting_trait": false,
     "category": [ "CHIMERA" ],
     "flags": [ "UNCANNY_DODGE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "MAGIC_EMPTY",
+    "name": { "str": "Empty" },
+    "points": -10,
+    "description": "You are one of the Empty, the rare few unable to cast even the simplest spells.  Your complete lack of mana prevents you from ever casting any magic, no matter how well you know it.  At least it doesn't prevent the use of magical items and potions.",
+    "purifiable": false,
+    "valid": false,
+    "starting_trait": true,
+    "types": [ "MANA_ADD", "MANA_REGEN", "MANA_MULT" ],
+    "flags": [ "NON_THRESH", "NO_SPELLCASTING" ],
+    "enchantments": [ { "values": [ { "value": "REGEN_MANA", "multiply": -1000 }, { "value": "MAX_MANA", "multiply": -1000 } ] } ]
   }
 ]

--- a/data/mods/Magiclysm/traits/mutation.json
+++ b/data/mods/Magiclysm/traits/mutation.json
@@ -397,7 +397,7 @@
     "valid": false,
     "starting_trait": true,
     "types": [ "MANA_ADD", "MANA_REGEN", "MANA_MULT" ],
-    "flags": [ "NON_THRESH", "NO_SPELLCASTING" ],
+    "flags": [ "NO_SPELLCASTING" ],
     "enchantments": [ { "values": [ { "value": "REGEN_MANA", "multiply": -1 }, { "value": "MAX_MANA", "multiply": -1 } ] } ]
   }
 ]

--- a/data/mods/Magiclysm/traits/mutation.json
+++ b/data/mods/Magiclysm/traits/mutation.json
@@ -390,6 +390,7 @@
     "type": "mutation",
     "id": "MAGIC_EMPTY",
     "name": { "str": "Empty" },
+    "//": "This is intended to prevent magical spellcasting.  Psionics don't need mana, so they can be used even as an Empty.",
     "points": -10,
     "description": "You are one of the Empty, the rare few unable to cast even the simplest spells.  Your complete lack of mana prevents you from ever casting any magic, no matter how well you know it.  At least it doesn't prevent the use of magical items and potions.",
     "purifiable": false,
@@ -397,6 +398,6 @@
     "starting_trait": true,
     "types": [ "MANA_ADD", "MANA_REGEN", "MANA_MULT" ],
     "flags": [ "NON_THRESH", "NO_SPELLCASTING" ],
-    "enchantments": [ { "values": [ { "value": "REGEN_MANA", "multiply": -1000 }, { "value": "MAX_MANA", "multiply": -1000 } ] } ]
+    "enchantments": [ { "values": [ { "value": "REGEN_MANA", "multiply": -1 }, { "value": "MAX_MANA", "multiply": -1 } ] } ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "[Magiclysm] Add a trait that prevents magical spellcasting"

#### Purpose of change

#76230 added lore about some rare people who are completely unable to cast any magic.

This PR adds the ability to play as one of them.

#### Describe the solution

Add the "Empty" starting trait that locks the player to zero mana while making all non-psionic spells 1000 times more difficult to cast and cost 1000 times more mana to be certain that they won't ever cast any.

#### Describe alternatives you've considered

Not adding more starting traits

#### Testing

Create a character with the trait.
Try to use a magic spell, notice how impossible it is.
Try to use a psionic spell, cast it without issue.

#### Additional context

The trait only aims at preventing spellcasting. Using magical items, potions, recipes, etc isn't prevented by this trait and shouldn't be, as it represents someone without magic in them, not someone who disrupts nearby magic.
