### PR TITLE
[Xedra Evolved/Innawood] Remove modern items from XE spawns Innawood, allow starting with XE-specific scenarios

### DIFF
--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/itemgroups/itemgroup_overrides.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/itemgroups/itemgroup_overrides.json
@@ -25,9 +25,8 @@
       { "group": "gossamer_upper_body", "prob": 70 },
       { "group": "gossamer_lower_body", "prob": 70 },
       { "group": "gossamer_outerwear", "prob": 25 },
-      { "item": "loincloth_gossamer" },
+      { "item": "loincloth_gossamer", "prob": 80 },
       { "group": "gossamer_socks", "prob": 25 },
-      { "group": "clothing_glasses", "prob": 5 },
       { "group": "fae_furs", "prob": 10 }
     ]
   },
@@ -54,7 +53,7 @@
       { "group": "gossamer_clothes", "prob": 100, "damage": [ 0, 4 ] },
       { "group": "bannerman_armor", "prob": 20, "damage": [ 0, 5 ] },
       { "group": "pendant_necklaces_silver", "prob": 5 },
-      { "item": "mirror_march_estoc", "prob": 25, "damage": [ 0, 5 ] },
+      { "group": "bannerman_weapons", "prob": 50, "damage": [ 0, 5 ] },
       { "item": "baldric", "prob": 100 },
       { "item": "scrap_dreamdross", "prob": 75, "count": [ 1, 4 ] }
     ]
@@ -67,7 +66,7 @@
       { "group": "gossamer_clothes", "prob": 100, "damage": [ 0, 4 ] },
       { "group": "redcap_armor", "prob": 20, "damage": [ 0, 4 ] },
       { "group": "pendant_necklaces_silver", "prob": 5 },
-      { "item": "redcap_club", "prob": 25, "damage": [ 0, 5 ] },
+      { "group": "redcap_weapons", "prob": 50, "damage": [ 0, 5 ] },
       { "item": "scrap_dreamdross", "prob": 75, "count": [ 4, 8 ] }
     ]
   },
@@ -79,7 +78,7 @@
       { "group": "gossamer_clothes", "prob": 100, "damage": [ 0, 4 ] },
       { "group": "pooka_armor", "prob": 20, "damage": [ 0, 4 ] },
       { "group": "pendant_necklaces_silver", "prob": 5 },
-      { "item": "pooka_gladius", "prob": 25, "damage": [ 0, 5 ] },
+      { "group": "pooka_weapons", "prob": 50, "damage": [ 0, 5 ] },
       { "item": "scabbard", "prob": 100 },
       { "item": "scrap_dreamdross", "prob": 75, "count": [ 4, 8 ] }
     ]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/itemgroups/itemgroup_overrides.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/itemgroups/itemgroup_overrides.json
@@ -1,0 +1,135 @@
+[
+  {
+    "type": "item_group",
+    "id": "fae_furs",
+    "items": [
+      [ "hat_fur", 30 ],
+      [ "sleeveless_trenchcoat_fur", 10 ],
+      [ "sleeveless_duster_fur", 10 ],
+      [ "coat_fur", 30 ],
+      [ "gloves_fur", 30 ],
+      [ "boots_fur", 20 ],
+      [ "boots_glimmer_fur", 8 ],
+      [ "cloak_glimmer_fur", 10 ],
+      [ "coat_glimmer_fur", 1 ],
+      [ "duster_glimmer_fur", 1 ],
+      [ "sleeveless_duster_glimmer_fur", 1 ],
+      [ "sleeveless_trenchcoat_glimmer_fur", 1 ]
+    ]
+  },
+  {
+    "id": "gossamer_clothes",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "gossamer_upper_body", "prob": 70 },
+      { "group": "gossamer_lower_body", "prob": 70 },
+      { "group": "gossamer_outerwear", "prob": 25 },
+      { "item": "loincloth_gossamer" },
+      { "group": "gossamer_socks", "prob": 25 },
+      { "group": "clothing_glasses", "prob": 5 },
+      { "group": "fae_furs", "prob": 10 }
+    ]
+  },
+  {
+    "id": "changeling_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "cufflinks_silver", "prob": 30, "damage": [ 1, 4 ] },
+      { "group": "gossamer_clothes", "prob": 100, "damage": [ 0, 4 ] },
+      { "group": "tiaras_silver", "prob": 5 },
+      { "group": "pendant_necklaces_silver", "prob": 5 },
+      { "group": "clothing_watch", "prob": 5 },
+      { "group": "fae_furs", "damage": [ 0, 4 ] },
+      { "item": "scrap_dreamdross", "prob": 75, "count": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "changeling_bannerman_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "cufflinks_silver", "prob": 30, "damage": [ 0, 4 ] },
+      { "group": "gossamer_clothes", "prob": 100, "damage": [ 0, 4 ] },
+      { "group": "bannerman_armor", "prob": 20, "damage": [ 0, 5 ] },
+      { "group": "pendant_necklaces_silver", "prob": 5 },
+      { "item": "mirror_march_estoc", "prob": 25, "damage": [ 0, 5 ] },
+      { "item": "baldric", "prob": 100 },
+      { "item": "scrap_dreamdross", "prob": 75, "count": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "changeling_redcap_aspirant_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "gossamer_clothes", "prob": 100, "damage": [ 0, 4 ] },
+      { "group": "redcap_armor", "prob": 20, "damage": [ 0, 4 ] },
+      { "group": "pendant_necklaces_silver", "prob": 5 },
+      { "item": "redcap_club", "prob": 25, "damage": [ 0, 5 ] },
+      { "item": "scrap_dreamdross", "prob": 75, "count": [ 4, 8 ] }
+    ]
+  },
+  {
+    "id": "changeling_pooka_aspirant_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "gossamer_clothes", "prob": 100, "damage": [ 0, 4 ] },
+      { "group": "pooka_armor", "prob": 20, "damage": [ 0, 4 ] },
+      { "group": "pendant_necklaces_silver", "prob": 5 },
+      { "item": "pooka_gladius", "prob": 25, "damage": [ 0, 5 ] },
+      { "item": "scabbard", "prob": 100 },
+      { "item": "scrap_dreamdross", "prob": 75, "count": [ 4, 8 ] }
+    ]
+  },
+  {
+    "id": "changeling_lord_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "cufflinks_silver", "prob": 30, "damage": [ 0, 4 ] },
+      { "group": "gossamer_clothes", "prob": 100, "damage": [ 0, 4 ] },
+      { "group": "bannerman_armor", "prob": 20, "damage": [ 0, 4 ] },
+      { "group": "pendant_necklaces_silver", "prob": 5 },
+      { "item": "winter_lord_estoc", "prob": 25, "damage": [ 0, 5 ] },
+      { "item": "baldric", "prob": 100 },
+      { "item": "purity_crackers", "prob": 10 },
+      { "item": "golden_bridle", "prob": 5 },
+      { "item": "scrap_dreamdross", "prob": 75, "count": [ 12, 24 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "renfield_death_drops",
+    "entries": [
+      { "group": "default_innawood_zombie_clothes", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "default_innawood_zombie_items", "prob": 30, "count": [ 1, 2 ] },
+      { "group": "default_feral_weapons", "prob": 75, "damage": [ 2, 4 ] },
+      { "group": "default_feral_armor", "prob": 25, "damage": [ 2, 4 ] },
+      { "item": "scrap_dreamdross", "prob": 75, "count": [ 1, 4 ] },
+      { "group": "blood_containers", "prob": 15 }
+    ]
+  },
+  {
+    "id": "default_moroi_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "default_innawood_zombie_clothes", "prob": 90, "damage": [ 1, 4 ] },
+      { "group": "default_feral_armor", "prob": 50, "damage": [ 2, 4 ] },
+      { "group": "default_innawood_zombie_items", "prob": 5 },
+      { "group": "blood_containers", "prob": 30 },
+      { "item": "grimy_recipe", "prob": 55 },
+      { "item": "scrap_dreamdross", "prob": 35, "count": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "blood_containers",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [ [ "bowl_skull", 100 ], { "item": "blood", "prob": 400, "container-item": "waterskin" } ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/itemgroups/itemgroups_new.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/itemgroups/itemgroups_new.json
@@ -148,5 +148,29 @@
       { "item": "kiwi", "prob": 2 },
       { "item": "apricot", "prob": 1 }
     ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "fetch_child_death_drops",
+    "entries": [
+      { "group": "default_innawood_zombie_clothes", "custom-flags": [ "UNDERSIZE" ], "prob": 100 },
+      { "group": "child_items", "prob": 65 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "child_items",
+    "entries": [
+      { "item": "pointy_stick", "prob": 15 },
+      { "item": "rock", "prob": 50 },
+      { "item": "feather", "prob": 40, "count": [ 1, 10 ] },
+      { "item": "hickory_nut", "prob": 20, "count": [ 1, 10 ] },
+      { "item": "acorns", "prob": 20, "count": [ 1, 10 ] },
+      { "item": "straw_doll", "prob": 5 },
+      { "item": "bag_canvas_small", "prob": 10 },
+      { "group": "tools_common_small", "prob": 1, "entry-wrapper": "makeshift_sling" }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/itemgroups/itemgroups_new.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/itemgroups/itemgroups_new.json
@@ -1,0 +1,152 @@
+[
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "default_innawood_zombie_clothes",
+    "entries": [
+      {
+        "distribution": [
+          { "group": "default_innawood_zombie_clothes_male", "prob": 50 },
+          { "group": "default_innawood_zombie_clothes_female", "prob": 50 }
+        ],
+        "prob": 100
+      },
+      { "group": "coats_unisex", "prob": 20 },
+      { "group": "common_gloves", "prob": 20 },
+      { "group": "hatstore_hats", "prob": 20 },
+      { "group": "scarfs_unisex", "prob": 20 },
+      { "group": "shoes_unisex", "prob": 20 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "default_innawood_zombie_clothes_male",
+    "entries": [
+      { "group": "male_underwear_bottom", "prob": 95 },
+      { "group": "male_underwear_top", "prob": 50 },
+      { "group": "pants_male", "prob": 95 },
+      { "group": "shirts", "prob": 40 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "default_innawood_zombie_clothes_female",
+    "entries": [
+      { "group": "female_underwear_bottom", "prob": 95 },
+      { "group": "female_underwear_top", "prob": 95 },
+      { "group": "pants_female", "prob": 95 },
+      { "group": "shirts", "prob": 40 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "default_feral_weapons",
+    "entries": [
+      {
+        "collection": [
+          { "item": "shortbow", "prob": 100 },
+          { "item": "quiver_birchbark", "contents-group": "quiver_bow_hunter", "prob": 100 }
+        ],
+        "prob": 15
+      },
+      { "item": "primitive_axe", "prob": 35 },
+      { "item": "sheath_birchbark", "contents-item": "primitive_knife", "prob": 15 },
+      { "item": "spear_stone", "prob": 50 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "default_feral_armor",
+    "entries": [
+      { "item": "legguard_larmor", "prob": 50 },
+      { "item": "vambrace_larmor", "prob": 50 },
+      { "item": "helmet_larmor", "prob": 50 },
+      { "item": "armor_larmor", "prob": 50 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "default_innawood_zombie_items",
+    "entries": [
+      { "item": "wicker_backpack", "prob": 2 },
+      { "group": "tools_common_small", "prob": 25, "entry-wrapper": "makeshift_sling" },
+      { "item": "bandages_birchbark", "prob": 5 },
+      { "group": "trash_forest", "prob": 80 },
+      { "group": "renfield_food", "prob": 30, "count": [ 1, 3 ] },
+      { "item": "water_clean", "prob": 50 },
+      { "item": "straw_doll", "prob": 3 },
+      {
+        "item": "wild_herbs",
+        "prob": 15,
+        "container-item": "null",
+        "entry-wrapper": "bag_canvas_small",
+        "count": [ 3, 12 ]
+      },
+      {
+        "item": "faewild",
+        "prob": 3,
+        "container-item": "null",
+        "entry-wrapper": "bag_canvas_small",
+        "count": [ 3, 12 ]
+      },
+      {
+        "item": "lotus_blossom",
+        "prob": 3,
+        "container-item": "null",
+        "entry-wrapper": "bag_canvas_small",
+        "count": [ 2, 16 ]
+      },
+      { "item": "scrap_dreamdross", "prob": 15, "count": [ 1, 4 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "renfield_food",
+    "container-item": "bag_canvas_small",
+    "on_overflow": "spill",
+    "entries": [
+      { "item": "dry_meat", "prob": 300 },
+      { "item": "dry_veggy", "prob": 300 },
+      { "item": "dry_fruit", "prob": 300 },
+      { "item": "apple", "prob": 70 },
+      { "item": "orange", "prob": 65 },
+      { "item": "banana", "prob": 40 },
+      { "item": "mushroom", "prob": 4 },
+      { "item": "blueberries", "prob": 3 },
+      { "item": "strawberries", "prob": 2 },
+      { "item": "cucumber", "prob": 8 },
+      { "item": "tomato", "prob": 9 },
+      { "item": "pumpkin", "prob": 8 },
+      { "item": "broccoli", "prob": 9 },
+      { "item": "zucchini", "prob": 7 },
+      { "item": "celery", "prob": 2 },
+      { "item": "onion", "prob": 3 },
+      { "item": "carrot", "prob": 3 },
+      { "item": "potato", "prob": 10 },
+      { "item": "pear", "prob": 65 },
+      { "item": "grapefruit", "prob": 1 },
+      { "item": "cherries", "prob": 5 },
+      { "item": "plums", "prob": 9 },
+      { "item": "grapes", "prob": 45 },
+      { "item": "pineapple", "prob": 2 },
+      { "item": "peach", "prob": 1 },
+      { "item": "cranberries", "prob": 15 },
+      { "item": "watermelon", "prob": 2 },
+      { "item": "melon", "prob": 1 },
+      { "item": "raspberries", "prob": 3 },
+      { "item": "blackberries", "prob": 3 },
+      { "item": "mango", "prob": 1 },
+      { "item": "pomegranate", "prob": 1 },
+      { "item": "rhubarb", "prob": 5 },
+      { "item": "papaya", "prob": 1 },
+      { "item": "kiwi", "prob": 2 },
+      { "item": "apricot", "prob": 1 }
+    ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/mapgen/caves.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/mapgen/caves.json
@@ -1,0 +1,100 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "cave_underground_innawood" ],
+    "weight": 150,
+    "object": {
+      "fill_ter": "t_dirt_underground",
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "..................~~~~..",
+        ".....    ........   ~~~.",
+        "...   B   .......    ~~~",
+        "..  B    B  ......    ..",
+        "..     O    ........ ...",
+        "..  B       ........ ...",
+        "...   B       .....   ..",
+        "....             .XXXX .",
+        ".....     ..       XXXX ",
+        ".....  ........   XXXXX ",
+        ".....  ........... XXXX ",
+        "..      ...........  XX.",
+        ".           .......  ...",
+        ".            ......  ...",
+        ".  ..  ....   .....  ...",
+        ".   ..YY....  .....  ...",
+        ".    .YY....  ...    ...",
+        "...  .....    ...    ...",
+        "...___...          .....",
+        ".._____..          .....",
+        "._______..      ........",
+        "._______...    .........",
+        ".._____..... ...........",
+        "....__......>..........."
+      ],
+      "terrain": {
+        ".": "t_soil",
+        " ": "t_dirt_underground",
+        "_": "t_dirt_underground",
+        "X": "t_dirt_underground",
+        "Y": "t_dirt_underground",
+        "B": "t_dirt_underground",
+        ">": "t_slope_up",
+        "~": "t_water_sh_underground"
+      },
+      "furniture": { "B": "f_straw_bed", "O": "f_firering" },
+      "items": {
+        "_": { "item": "trash_forest", "chance": 40, "repeat": [ 1, 2 ] },
+        " ": { "item": "trash_forest", "chance": 2 },
+        "X": [ { "item": "corpses", "chance": 5, "repeat": 1 }, { "item": "ant_food", "chance": 25, "repeat": [ 2, 5 ] } ],
+        "Y": [ { "item": "corpses", "chance": 100, "repeat": [ 1, 2 ] } ]
+      },
+      "place_fields": [
+        { "field": "fd_blood", "x": [ 17, 21 ], "y": [ 7, 11 ], "repeat": [ 4, 6 ] },
+        { "field": "fd_blood", "x": [ 6, 7 ], "y": [ 14, 16 ], "repeat": [ 4, 6 ] }
+      ],
+      "place_monster": [ { "group": "GROUP_CAVE_VAMPIRE", "x": [ 1, 21 ], "y": [ 1, 21 ], "chance": 60, "repeat": [ 3, 6 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "cave_underground_innawood" ],
+    "weight": 400,
+    "object": {
+      "fill_ter": "t_dirt_underground",
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "........................",
+        "..........         .....",
+        "...    ... .......  ....",
+        "... ..  ..  ..   ..  ...",
+        "... ..W  ..   111 ..  ..",
+        "... ....  ... 1C1  .W ..",
+        "...  ....  .. 111  .. ..",
+        "....  ....  ..    ..  ..",
+        ".....  ....  ......  ...",
+        "......  ....        ....",
+        "......W  ...............",
+        ".......           ......",
+        "....     ... ....  .....",
+        ".... ......111....  ....",
+        ".... ......1C1.....  ...",
+        "..    .....111...... ...",
+        ".. ..  ..... ....... ...",
+        ".. ...  W     ...... ...",
+        ".. ..........  ....  ...",
+        "..  ..........      ....",
+        "...  ........  ....W....",
+        "....          ..........",
+        "........W... ...........",
+        "............>..........."
+      ],
+      "terrain": { ".": "t_soil", " ": "t_dirt_underground", ">": "t_slope_up" },
+      "nested": { "C": { "chunks": [ "goblin_spider_cocoon" ] } },
+      "fields": { "W": { "field": "fd_web", "intensity": 2, "age": 10 }, "1": { "field": "fd_web", "intensity": 3, "age": 1 } },
+      "monsters": { "W": { "monster": "GROUP_GOBLIN_SPIDER", "chance": 2, "density": 0.01 } }
+    }
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/monstergroups/monstergroup_overrides.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/monstergroups/monstergroup_overrides.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "monstergroup",
+    "name": "GROUP_RENFIELD_UPGRADE_INNAWOOD",
+    "monsters": [ { "monster": "mon_renfield", "weight": 950 }, { "monster": "mon_renfield_abomination", "weight": 50 } ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/monstergroups/monstergroups_new.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/monstergroups/monstergroups_new.json
@@ -1,0 +1,45 @@
+[
+  {
+    "type": "monstergroup",
+    "name": "GROUP_FOREST",
+    "is_animal": true,
+    "monsters": [
+      { "group": "GROUP_CHANGELING_MIRRORED_FIELD", "weight": 10, "cost_multiplier": 10 },
+      { "group": "GROUP_CHANGELING_MIRRORED_FIELD", "weight": 3, "cost_multiplier": 15, "pack_size": [ 2, 6 ] },
+      { "group": "GROUP_CHANGELING_STRIKE_FORCE", "weight": 3, "cost_multiplier": 15, "pack_size": [ 2, 6 ] },
+      { "group": "GROUP_OVERLAND_RENFIELD", "weight": 10, "cost_multiplier": 5 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_SWAMP",
+    "//": "Current SPRING first DAY count is X.",
+    "is_animal": true,
+    "monsters": [
+      { "group": "GROUP_CHANGELING_MIRRORED_FIELD", "weight": 5, "cost_multiplier": 10 },
+      { "group": "GROUP_CHANGELING_MIRRORED_FIELD", "weight": 1, "cost_multiplier": 15, "pack_size": [ 2, 6 ] },
+      { "group": "GROUP_CHANGELING_STRIKE_FORCE", "weight": 1, "cost_multiplier": 15, "pack_size": [ 2, 6 ] },
+      { "group": "GROUP_OVERLAND_RENFIELD", "weight": 10, "cost_multiplier": 5 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_OVERLAND_RENFIELD",
+    "is_animal": true,
+    "monsters": [ { "monster": "mon_renfield", "weight": 200 }, { "monster": "mon_renfield", "weight": 50, "pack_size": [ 2, 5 ] } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_CAVE_VAMPIRE",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_renfield", "weight": 200 },
+      { "monster": "mon_renfield", "weight": 50, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_vampire_moroi", "weight": 35 },
+      { "monster": "mon_vampire_strigoi", "weight": 25 },
+      { "monster": "mon_vampire_strigoi", "weight": 5, "pack_size": [ 2, 4 ] },
+      { "monster": "xe_mon_bat", "weight": 100, "pack_size": [ 2, 4 ] },
+      { "monster": "mon_bat_giant", "weight": 35, "pack_size": [ 1, 2 ] }
+    ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/monsters/monster_overrides.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/monsters/monster_overrides.json
@@ -5,5 +5,11 @@
     "type": "MONSTER",
     "name": { "str": "renfield" },
     "upgrades": { "half_life": 50, "into_group": "GROUP_RENFIELD_UPGRADE_INNAWOOD" }
+  },
+  {
+    "copy-from": "mon_fetch_child",
+    "id": "mon_renfield",
+    "type": "MONSTER",
+    "death_drops": "fetch_child_death_drops"
   }
 ]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/monsters/monster_overrides.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/monsters/monster_overrides.json
@@ -1,0 +1,9 @@
+[
+  {
+    "copy-from": "mon_renfield",
+    "id": "mon_renfield",
+    "type": "MONSTER",
+    "name": { "str": "renfield" },
+    "upgrades": { "half_life": 50, "into_group": "GROUP_RENFIELD_UPGRADE_INNAWOOD" }
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/player/professions.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/player/professions.json
@@ -1,0 +1,62 @@
+[
+  {
+    "type": "profession",
+    "id": "paraclesian_ierde_naked_afraid",
+    "name": { "male": "Ierde", "female": "Ierda" },
+    "description": "You are the spirit of a place that slowly gained sentience, a genius loci, born alone in the wilderness.  With no parents, no kin, and no guidance, it's up to you to make your own way in the world.",
+    "points": 5,
+    "traits": [ "IERDE" ],
+    "recipes": [ "mutagen_earthkin", "cthonic_poultice" ],
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "paraclesian_arvore_naked_afraid",
+    "name": { "male": "Arvi", "female": "Arvori" },
+    "description": "You are the spirit of a place that slowly gained sentience, a genius loci, born alone in the wilderness.  With no parents, no kin, and no guidance, it's up to you to make your own way in the world.",
+    "points": 5,
+    "traits": [ "ARVORE" ],
+    "recipes": [ "mutagen_plantkin", "verdant_poultice" ],
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "paraclesian_undine_naked_afraid",
+    "name": { "male": "Onduine", "female": "Ondua" },
+    "description": "You are the spirit of a place that slowly gained sentience, a genius loci, born alone in the wilderness.  With no parents, no kin, and no guidance, it's up to you to make your own way in the world.",
+    "points": 5,
+    "traits": [ "UNDINE" ],
+    "recipes": [ "mutagen_waterkin", "cerulean_poultice" ],
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "paraclesian_salamander_naked_afraid",
+    "name": { "male": "Kéményseprő", "female": "Bejárónő" },
+    "description": "You are the spirit of a place that slowly gained sentience, a genius loci, born alone in the wilderness.  With no parents, no kin, and no guidance, it's up to you to make your own way in the world.",
+    "points": 5,
+    "traits": [ "SALAMANDER" ],
+    "recipes": [ "mutagen_flamekin", "charred_sacrifice" ],
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "paraclesian_homullus_naked_afraid",
+    "name": { "male": "Dúln", "female": "Dúkka" },
+    "description": "You are the spirit of a place that slowly gained sentience, a genius loci, born alone in the wilderness.  With no parents, no kin, and no guidance, it's up to you to make your own way in the world.",
+    "points": 5,
+    "traits": [ "HOMULLUS", "HOMULLUS_MINIMIZED_MUTATIONS" ],
+    "recipes": [ "mutagen_dollkin", "doll_repair_paste" ],
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "paraclesian_sylph_naked_afraid",
+    "name": { "male": "Silvestris", "female": "Silvestra" },
+    "description": "You are the spirit of a place that slowly gained sentience, a genius loci, born alone in the wilderness.  With no parents, no kin, and no guidance, it's up to you to make your own way in the world.",
+    "points": 5,
+    "traits": [ "SYLPH" ],
+    "recipes": [ "mutagen_airkin", "ethereal_draught" ],
+    "flags": [ "SCEN_ONLY" ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/player/scenarios.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/player/scenarios.json
@@ -47,7 +47,7 @@
   },
   {
     "type": "scenario",
-    "id": "xe_lilin_scenario",
+    "id": "xe_lilin_scenario_naked_afraid",
     "name": "The Owl, Naked and Afraid",
     "points": 0,
     "description": "For most or all of your life, you've had a secret; you are a predator.  While you don't need to drink blood or eat flesh or anything so crude, you must absorb the spiritual essence, the \"ruach\", of living beings in order to maintain your health and vitality.  Something happened, and now you're alone in the wilderness, without any of your possessions.  You'd best find others quick, or you'll wither away.",
@@ -55,7 +55,8 @@
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
     "professions": [ "naked" ],
     "eoc": [ "scenario_lilin_starting_ruach" ],
-    "forced_traits": [ "LILIN_TRAITS", "LILIN_DRAIN_RUACH_MELEE" ]
+    "forced_traits": [ "LILIN_TRAITS", "LILIN_DRAIN_RUACH_MELEE" ],
+    "flags": [ "LONE_START" ]
   },
   {
     "type": "scenario",

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/player/scenarios.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/player/scenarios.json
@@ -1,0 +1,73 @@
+[
+  {
+    "type": "scenario",
+    "id": "paraclesian_birth_naked_afraid",
+    "name": "Paraclesian Birth, Lost and Alone",
+    "flags": [ "LONE_START" ],
+    "points": 0,
+    "description": "Your first moments of life, born of the elements, alone.  An elemental fae on a dying world, lost in the wilderness.",
+    "start_name": "Paraclesian Birth",
+    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
+    "professions": [
+      "paraclesian_ierde_naked_afraid",
+      "paraclesian_undine_naked_afraid",
+      "paraclesian_salamander_naked_afraid",
+      "paraclesian_sylph_naked_afraid",
+      "paraclesian_arvore_naked_afraid",
+      "paraclesian_homullus_naked_afraid"
+    ],
+    "eoc": [ "scenario_paraclesian_birth" ],
+    "traits": [ "ELEMENTAL_MANA1", "ELEMENTAL_MANA2" ],
+    "reveal_locale": false
+  },
+  {
+    "type": "scenario",
+    "id": "werewolf_native",
+    "name": "Werewolf, Natural-born",
+    "flags": [ "LONE_START" ],
+    "points": 0,
+    "description": "You had no idea what was going on the first time it happened, when you woke up with mud on your bare feet and a sour taste in your mouth, but you were soon found.  The People of the Moon, they called themselves, and they said you were one of them.  A werewolf.  You lived out in the wilderness for a while with them.  Maybe some of the People are still out there.",
+    "start_name": "Alone",
+    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
+    "forced_traits": [ "NATIVE_SHAPESHIFTER", "WEREWOLF_ANIMAL_FORM", "WEREWOLF_HYBRID_FORM" ],
+    "reveal_locale": false
+  },
+  {
+    "type": "scenario",
+    "id": "werewolf_native_naked_unafraid",
+    "name": "Werewolf, Naked and Unafraid",
+    "flags": [ "LONE_START" ],
+    "points": 0,
+    "description": "You have no idea what happened, but you're alone in the unspoiled wilderness.  You have mud on your feet, none of your clothes or possessions, and you don't know where you are.  But you have learned there's a beast inside you, and anyone who crosses you had best beware.",
+    "start_name": "Alone",
+    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
+    "professions": [ "naked" ],
+    "forced_traits": [ "NATIVE_SHAPESHIFTER", "WEREWOLF_ANIMAL_FORM", "WEREWOLF_HYBRID_FORM" ],
+    "reveal_locale": false
+  },
+  {
+    "type": "scenario",
+    "id": "xe_lilin_scenario",
+    "name": "The Owl, Naked and Afraid",
+    "points": 0,
+    "description": "For most or all of your life, you've had a secret; you are a predator.  While you don't need to drink blood or eat flesh or anything so crude, you must absorb the spiritual essence, the \"ruach\", of living beings in order to maintain your health and vitality.  Something happened, and now you're alone in the wilderness, without any of your possessions.  You'd best find others quick, or you'll wither away.",
+    "start_name": "Alone",
+    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
+    "professions": [ "naked" ],
+    "eoc": [ "scenario_lilin_starting_ruach" ],
+    "forced_traits": [ "LILIN_TRAITS", "LILIN_DRAIN_RUACH_MELEE" ]
+  },
+  {
+    "type": "scenario",
+    "id": "once_bitten",
+    "copy-from": "infected",
+    "name": "Once Bitten",
+    "points": 0,
+    "description": "Whether you were visiting Salem's Lot, boating on the Demeter, vacationing to Transylvania, or just another lost boy or girl, you've been bitten by a stranger at twilight the night before.  And to make matters worse, when you woke up, you were alone in the wilderness with no sign of humanity anywhere.  You're going to have to survive somehow.",
+    "allowed_locs": [ "sloc_cave_underground_innawood", "sloc_cave_innawood" ],
+    "start_name": "Cave",
+    "eoc": [ "scenario_once_bitten" ],
+    "requirement": "avchievement_gains_vampire_trait",
+    "flags": [ "LONE_START" ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/player/scenarios.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/player/scenarios.json
@@ -70,5 +70,19 @@
     "eoc": [ "scenario_once_bitten" ],
     "requirement": "avchievement_gains_vampire_trait",
     "flags": [ "LONE_START" ]
+  },
+  {
+    "type": "scenario",
+    "id": "once_bitten_naked_and_afraid",
+    "copy-from": "infected",
+    "name": "Once Bitten, Naked and Afraid",
+    "points": 0,
+    "description": "Whether you were visiting Salem's Lot, boating on the Demeter, vacationing to Transylvania, or just another lost boy or girl, you've been bitten by a stranger at twilight the night before.  And to make matters worse, when you woke up, you were alone in the wilderness with no sign of humanity anywhere.  You're going to have to survive somehow.",
+    "start_name": "Alone",
+    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
+    "professions": [ "naked" ],
+    "eoc": [ "scenario_once_bitten" ],
+    "requirement": "avchievement_gains_vampire_trait",
+    "flags": [ "LONE_START" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/scenario_whitelist.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/scenario_whitelist.json
@@ -25,7 +25,7 @@
       "werewolf_native",
       "werewolf_native_naked_unafraid",
       "xe_lilin_scenario",
-      "xe_lilin_scenario_naked_unafraid",
+      "xe_lilin_scenario_naked_afraid",
       "once_bitten"
     ]
   }

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/scenario_whitelist.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/scenario_whitelist.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "SCENARIO_BLACKLIST",
+    "subtype": "whitelist",
+    "scenarios": [
+      "evacuee",
+      "cave_lonesome",
+      "medieval",
+      "migo_prisoner",
+      "mutant",
+      "wilderness",
+      "strong_portal_storm",
+      "portal_dependent",
+      "heli_crash",
+      "infected",
+      "hunted_start",
+      "fungal_start",
+      "bad_day",
+      "bordered",
+      "ambushed",
+      "summer_advanced_start",
+      "car_crash",
+      "paraclesian_birth",
+      "paraclesian_birth_naked_afraid",
+      "werewolf_native",
+      "werewolf_native_naked_unafraid",
+      "xe_lilin_scenario",
+      "xe_lilin_scenario_naked_unafraid",
+      "once_bitten"
+    ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/scenario_whitelist.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/scenario_whitelist.json
@@ -26,7 +26,8 @@
       "werewolf_native_naked_unafraid",
       "xe_lilin_scenario",
       "xe_lilin_scenario_naked_afraid",
-      "once_bitten"
+      "once_bitten",
+      "once_bitten_naked_and_afraid"
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/skills.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/skills.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "skill",
+    "ident": "deduction",
+    "name": { "str": "occult" },
+    "description": "Your knowledge of spirits, the unseen world, and other mystical topics, occult is a path to abilities many might consider to be unnatural.",
+    "companion_industry_rank_factor": 1,
+    "tags": [ "combat_skill" ],
+    "time_to_attack": { "min_time": 60, "base_time": 200, "time_reduction_per_level": 14 },
+    "display_category": "display_interaction",
+    "sort_rank": 26500,
+    "companion_skill_practice": [ { "skill": "speech", "weight": 1 }, { "skill": "devices", "weight": 1 } ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved/Innawood] Remove modern items from XE spawns Innawood, allow starting with XE-specific scenarios"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

If you've checked out my Github, you've seen I have a mod that's dedicated to doing just this. But now that we have mod compatibility, I can just PR those changes.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Edit renfield and changeling deathdrops to remove all modern items. Allow changelings or renfields to spawn very rarely in the forest, and add a renfield-themed cave and a goblin spider themed cave. Allowing choosing Lilin, werewolves, vampires, and Paraclesians and add a Naked and Afraid start to all of those.

...well, the werewolf one is called "Naked and Unafraid" for obvious reasons.

This does increase the availability of some gear, but if you want an absolutely pure Innawood experience, you probably shouldn't combine it with Xedra Evolved. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Scenarios are selectable, renfields and changelings do not drop modern gear.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
