### PR TITLE
Backport #77446 for 0.H (Pathfinding accounts for SMALL_PASSAGE)

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -587,7 +587,7 @@ Character::Character() :
     name.clear();
     custom_profession.clear();
 
-    *path_settings = pathfinding_settings{ 0, 1000, 1000, 0, true, true, true, true, false, true };
+    *path_settings = pathfinding_settings{ 0, 1000, 1000, 0, true, true, true, true, false, true, creature_size::medium };
 
     move_mode = move_mode_walk;
     next_expected_position = std::nullopt;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10213,6 +10213,10 @@ void map::update_pathfinding_cache( const tripoint &p ) const
         cur_value |= PF_SHARP;
     }
 
+    if( terrain.has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) {
+        cur_value |= PF_SMALL_PASSAGE;
+    }
+
     cache.special[p.x][p.y] = cur_value;
 }
 

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -36,6 +36,7 @@
 #include "options.h"
 #include "output.h"
 #include "overmapbuffer.h"
+#include "pathfinding.h"
 #include "pimpl.h"
 #include "player_activity.h"
 #include "rng.h"
@@ -457,6 +458,7 @@ void Character::recalculate_size()
     } else {
         size_class = creature_size::medium;
     }
+    path_settings->size = size_class;
 }
 
 void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_override )

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -241,7 +241,8 @@ npc::npc()
     patience = 0;
     attitude = NPCATT_NULL;
 
-    *path_settings = pathfinding_settings( 0, 1000, 1000, 10, true, true, true, true, false, true, get_size() );
+    *path_settings = pathfinding_settings( 0, 1000, 1000, 10, true, true, true, true, false, true,
+                                           get_size() );
     for( direction threat_dir : npc_threat_dir ) {
         ai_cache.threat_map[ threat_dir ] = 0.0f;
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -241,7 +241,7 @@ npc::npc()
     patience = 0;
     attitude = NPCATT_NULL;
 
-    *path_settings = pathfinding_settings( 0, 1000, 1000, 10, true, true, true, true, false, true );
+    *path_settings = pathfinding_settings( 0, 1000, 1000, 10, true, true, true, true, false, true, get_size() );
     for( direction threat_dir : npc_threat_dir ) {
         ai_cache.threat_map[ threat_dir ] = 0.0f;
     }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -180,7 +180,8 @@ std::vector<tripoint> map::straight_route( const tripoint &f, const tripoint &t 
         const pathfinding_cache &pf_cache = get_pathfinding_cache_ref( f.z );
         // Check all points for any special case (including just hard terrain)
         if( std::any_of( ret.begin(), ret.end(), [&pf_cache]( const tripoint & p ) {
-        constexpr pf_special non_normal = PF_SLOW | PF_WALL | PF_VEHICLE | PF_TRAP | PF_SHARP | PF_SMALL_PASSAGE;
+        constexpr pf_special non_normal = PF_SLOW | PF_WALL | PF_VEHICLE | PF_TRAP | PF_SHARP |
+                                          PF_SMALL_PASSAGE;
         return pf_cache.special[p.x][p.y] & non_normal;
         } ) ) {
             ret.clear();
@@ -256,7 +257,8 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
 
     bool done = false;
 
-    constexpr pf_special non_normal = PF_SLOW | PF_WALL | PF_VEHICLE | PF_TRAP | PF_SHARP | PF_SMALL_PASSAGE;
+    constexpr pf_special non_normal = PF_SLOW | PF_WALL | PF_VEHICLE | PF_TRAP | PF_SHARP |
+                                      PF_SMALL_PASSAGE;
     do {
         tripoint cur = pf.get_next();
 
@@ -331,17 +333,17 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
                     continue;
                 }
 
-                if(settings.size) {
-                    if(p_special & PF_SMALL_PASSAGE && settings.size > creature_size::medium) {
+                if( settings.size ) {
+                    if( p_special & PF_SMALL_PASSAGE && settings.size > creature_size::medium ) {
                         layer.closed[index] = true;
                         continue;
                     }
                     if( doors &&
-                            ( ( terrain.open && terrain.open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ||
-                              ( furniture.open && furniture.open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ||
-                              // Windows with curtains need to be opened twice
-                              ( terrain.open->open && terrain.open->open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ) &&
-                            settings.size > creature_size::medium) {
+                        ( ( terrain.open && terrain.open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ||
+                          ( furniture.open && furniture.open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ||
+                          // Windows with curtains need to be opened twice
+                          ( terrain.open->open && terrain.open->open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ) &&
+                        settings.size > creature_size::medium ) {
                         layer.closed[index] = true;
                         continue;
                     }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -180,7 +180,7 @@ std::vector<tripoint> map::straight_route( const tripoint &f, const tripoint &t 
         const pathfinding_cache &pf_cache = get_pathfinding_cache_ref( f.z );
         // Check all points for any special case (including just hard terrain)
         if( std::any_of( ret.begin(), ret.end(), [&pf_cache]( const tripoint & p ) {
-        constexpr pf_special non_normal = PF_SLOW | PF_WALL | PF_VEHICLE | PF_TRAP | PF_SHARP;
+        constexpr pf_special non_normal = PF_SLOW | PF_WALL | PF_VEHICLE | PF_TRAP | PF_SHARP | PF_SMALL_PASSAGE;
         return pf_cache.special[p.x][p.y] & non_normal;
         } ) ) {
             ret.clear();
@@ -256,7 +256,7 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
 
     bool done = false;
 
-    constexpr pf_special non_normal = PF_SLOW | PF_WALL | PF_VEHICLE | PF_TRAP | PF_SHARP;
+    constexpr pf_special non_normal = PF_SLOW | PF_WALL | PF_VEHICLE | PF_TRAP | PF_SHARP | PF_SMALL_PASSAGE;
     do {
         tripoint cur = pf.get_next();
 
@@ -329,6 +329,22 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
                     climb_cost <= 0 ) {
                     layer.closed[index] = true; // Close it so that next time we won't try to calculate costs
                     continue;
+                }
+
+                if(settings.size) {
+                    if(p_special & PF_SMALL_PASSAGE && settings.size > creature_size::medium) {
+                        layer.closed[index] = true;
+                        continue;
+                    }
+                    if( doors &&
+                            ( ( terrain.open && terrain.open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ||
+                              ( furniture.open && furniture.open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ||
+                              // Windows with curtains need to be opened twice
+                              ( terrain.open->open && terrain.open->open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ) &&
+                            settings.size > creature_size::medium) {
+                        layer.closed[index] = true;
+                        continue;
+                    }
                 }
 
                 newg += cost;

--- a/src/pathfinding.h
+++ b/src/pathfinding.h
@@ -2,9 +2,12 @@
 #ifndef CATA_SRC_PATHFINDING_H
 #define CATA_SRC_PATHFINDING_H
 
+#include <optional>
+
 #include "coordinates.h"
 #include "game_constants.h"
 #include "mdarray.h"
+#include "character.h"
 
 enum pf_special : int {
     PF_NORMAL = 0x00,    // Plain boring tile (grass, dirt, floor etc.)
@@ -16,6 +19,7 @@ enum pf_special : int {
     PF_UPDOWN = 0x20,    // Stairs, ramp etc.
     PF_CLIMBABLE = 0x40, // 0 move cost but can be climbed on examine
     PF_SHARP = 0x80,     // sharp items (barbed wire, etc)
+    PF_SMALL_PASSAGE = 0x100,   // Only medium or smaller characters can fit
 };
 
 constexpr pf_special operator | ( pf_special lhs, pf_special rhs )
@@ -66,14 +70,16 @@ struct pathfinding_settings {
     bool avoid_rough_terrain = false;
     bool avoid_sharp = false;
 
+    std::optional<creature_size> size = std::nullopt;
+
     pathfinding_settings() = default;
     pathfinding_settings( const pathfinding_settings & ) = default;
 
     pathfinding_settings( int bs, int md, int ml, int cc, bool aod, bool aud, bool at, bool acs,
-                          bool art, bool as )
+                          bool art, bool as, std::optional<creature_size> sz = std::nullopt )
         : bash_strength( bs ), max_dist( md ), max_length( ml ), climb_cost( cc ),
           allow_open_doors( aod ), allow_unlock_doors( aud ), avoid_traps( at ), allow_climb_stairs( acs ),
-          avoid_rough_terrain( art ), avoid_sharp( as ) {}
+          avoid_rough_terrain( art ), avoid_sharp( as ), size( sz )  {}
 
     pathfinding_settings &operator=( const pathfinding_settings & ) = default;
 };


### PR DESCRIPTION
In draft until
- [ ] original PR passes / doesn't
- [ ] some extra dogfooding in gameplay, since 0.H is the version I actually have a run on as a large character

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #77385 for 0.H.

If mergers consider this too risky at this stage it's cool and perfectly understandable.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rewrite the code from #77446 for the older pathfinding code. The logic should be the same.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with the same process as in #77446

Also tested via several hours of looting heavy gameplay as a large character.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
