### PR TITLE
typified a bit of vehicle.h and dependents

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -586,7 +586,7 @@ static bool vehicle_activity( Character &you, const tripoint_bub_ms &src_loc, in
     // so , NPCs can remove the last part on a position, then there is no vehicle there anymore,
     // for someone else who stored that position at the start of their activity.
     // so we may need to go looking a bit further afield to find it , at activities end.
-    for( const tripoint &pt : veh->get_points( true ) ) {
+    for( const tripoint_bub_ms &pt : veh->get_points( true ) ) {
         you.activity.coord_set.insert( here.getglobal( pt ).raw() );
     }
     // values[0]
@@ -1056,7 +1056,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             // find out if there is a vehicle part here we can remove.
             // TODO: fix point types
             std::vector<vehicle_part *> parts =
-                veh->get_parts_at( src_loc.raw(), "", part_status_flag::any );
+                veh->get_parts_at( src_loc, "", part_status_flag::any );
             for( vehicle_part *part_elem : parts ) {
                 const int vpindex = veh->index_of_part( part_elem, true );
                 // if part is not on this vehicle, or if its attached to another part that needs to be removed first.
@@ -1101,7 +1101,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
         } else if( act == ACT_VEHICLE_REPAIR ) {
             // find out if there is a vehicle part here we can repair.
             // TODO: fix point types
-            std::vector<vehicle_part *> parts = veh->get_parts_at( src_loc.raw(), "", part_status_flag::any );
+            std::vector<vehicle_part *> parts = veh->get_parts_at( src_loc, "", part_status_flag::any );
             for( vehicle_part *part_elem : parts ) {
                 const vpart_info &vpinfo = part_elem->info();
                 int vpindex = veh->index_of_part( part_elem, true );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -688,7 +688,7 @@ void avatar::grab( object_type grab_type_new, const tripoint_rel_ms &grab_point_
         map &m = get_map();
         if( gtype == object_type::VEHICLE ) {
             if( const optional_vpart_position ovp = m.veh_at( pos_bub() + gpoint ) ) {
-                for( const tripoint &target : ovp->vehicle().get_points() ) {
+                for( const tripoint_bub_ms &target : ovp->vehicle().get_points() ) {
                     if( erase ) {
                         memorize_clear_decoration( m.getglobal( target ), /* prefix = */ "vp_" );
                     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1429,12 +1429,12 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         if( g->display_overlay_state( ACTION_DISPLAY_VEHICLE_AI ) ) {
             for( const wrapped_vehicle &elem : here.get_vehicles() ) {
                 const vehicle &veh = *elem.v;
-                const point veh_pos = veh.global_pos3().xy();
+                const point_bub_ms veh_pos = veh.pos_bub().xy();
                 for( const auto &overlay_data : veh.get_debug_overlay_data() ) {
-                    const point pt = veh_pos + std::get<0>( overlay_data );
+                    const point_bub_ms pt = veh_pos + std::get<0>( overlay_data );
                     const int color = std::get<1>( overlay_data );
                     const std::string &text = std::get<2>( overlay_data );
-                    overlay_strings.emplace( player_to_screen( pt ),
+                    overlay_strings.emplace( player_to_screen( pt.raw() ),
                                              formatted_text( text, color,
                                                      text_alignment::left ) );
                 }
@@ -3940,7 +3940,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             avatar &you = get_avatar();
             if( !veh.forward_velocity() && !veh.player_in_control( you )
                 && !( you.get_grab_type() == object_type::VEHICLE
-                      && veh.get_points().count( ( you.pos_bub() + you.grab_point ).raw() ) )
+                      && veh.get_points().count( ( you.pos_bub() + you.grab_point ) ) )
                 && here.memory_cache_dec_is_dirty( p ) ) {
                 you.memorize_decoration( here.getglobal( p ), vd.get_tileset_id(), subtile, rotation );
             }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11106,7 +11106,7 @@ void Character::stagger()
         const optional_vpart_position vp_there = here.veh_at( dest );
         if( vp_there ) {
             vehicle &veh = vp_there->vehicle();
-            if( veh.enclosed_at( dest.raw() ) ) {
+            if( veh.enclosed_at( dest ) ) {
                 blocked = true;
             }
         }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1733,7 +1733,8 @@ void construct::done_vehicle( const tripoint_bub_ms &p, Character & )
     const item &base = components.front();
 
     veh->name = name;
-    const int partnum = veh->install_part( point_zero, vpart_from_item( base.typeId() ), item( base ) );
+    const int partnum = veh->install_part( point_rel_ms_zero, vpart_from_item( base.typeId() ),
+                                           item( base ) );
     veh->part( partnum ).set_flag( vp_flag::unsalvageable_flag );
 
     // Update the vehicle cache immediately,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -245,7 +245,7 @@ bool Creature::will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) con
     }
     if( capacity > 0_ml ) {
         // First, we'll try to squeeze in. Open-topped vehicle parts have more room to step over cargo.
-        if( !veh.enclosed_at( here.bub_from_abs( loc ).raw() ) ) {
+        if( !veh.enclosed_at( here.bub_from_abs( loc ) ) ) {
             free_cargo *= 1.2;
         }
         const creature_size size = get_size();
@@ -630,10 +630,10 @@ bool Creature::sees( const tripoint_bub_ms &t, bool is_avatar, int range_mod ) c
 
 // Helper function to check if potential area of effect of a weapon overlaps vehicle
 // Maybe TODO: If this is too slow, precalculate a bounding box and clip the tested area to it
-static bool overlaps_vehicle( const std::set<tripoint> &veh_area, const tripoint &pos,
+static bool overlaps_vehicle( const std::set<tripoint_bub_ms> &veh_area, const tripoint_bub_ms &pos,
                               const int area )
 {
-    for( const tripoint &tmp : tripoint_range<tripoint>( pos - tripoint( area, area, 0 ),
+    for( const tripoint_bub_ms &tmp : tripoint_range<tripoint_bub_ms>( pos - tripoint( area, area, 0 ),
             pos + tripoint( area - 1, area - 1, 0 ) ) ) {
         if( veh_area.count( tmp ) > 0 ) {
             return true;
@@ -775,7 +775,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
             continue; // Handle this late so that boo_hoo++ can happen
         }
         // Expensive check for proximity to vehicle
-        if( self_area_iff && overlaps_vehicle( in_veh->get_points(), m->pos(), area ) ) {
+        if( self_area_iff && overlaps_vehicle( in_veh->get_points(), tripoint_bub_ms( m->pos() ), area ) ) {
             continue;
         }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2716,8 +2716,8 @@ void game::setremoteveh( vehicle *veh )
     }
 
     std::stringstream remote_veh_string;
-    const tripoint vehpos = veh->global_pos3();
-    remote_veh_string << vehpos.x << ' ' << vehpos.y << ' ' << vehpos.z;
+    const tripoint_bub_ms vehpos = veh->pos_bub();
+    remote_veh_string << vehpos.x() << ' ' << vehpos.y() << ' ' << vehpos.z();
     u.set_value( "remote_controlling_vehicle", remote_veh_string.str() );
 }
 
@@ -5576,7 +5576,7 @@ void game::control_vehicle()
 {
     if( vehicle *remote_veh = remoteveh() ) { // remote controls have priority
         for( const vpart_reference &vpr : remote_veh->get_avail_parts( "REMOTE_CONTROLS" ) ) {
-            remote_veh->interact_with( vpr.pos() );
+            remote_veh->interact_with( vpr.pos_bub() );
             return;
         }
     }
@@ -5690,7 +5690,7 @@ void game::control_vehicle()
     if( veh ) {
         // If we reached here, we gained control of a vehicle.
         // Clear the map memory for the area covered by the vehicle to eliminate ghost vehicles.
-        for( const tripoint &target : veh->get_points() ) {
+        for( const tripoint_bub_ms &target : veh->get_points() ) {
             u.memorize_clear_decoration( m.getglobal( target ), "vp_" );
             m.memory_cache_dec_set_dirty( target, true );
         }
@@ -10025,7 +10025,7 @@ void game::reload_weapon( bool try_everything )
     // If we make it here and haven't found anything to reload, start looking elsewhere.
     const optional_vpart_position ovp = m.veh_at( u.pos_bub() );
     if( ovp ) {
-        const turret_data turret = ovp->vehicle().turret_query( ovp->pos() );
+        const turret_data turret = ovp->vehicle().turret_query( ovp->pos_bub() );
         if( turret.can_reload() ) {
             item::reload_option opt = u.select_ammo( turret.base(), true );
             if( opt ) {

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -148,7 +148,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     if( str_req <= str ) {
         if( str_req == max_str_req ) {
             //if vehicle has no wheels, make a noise.
-            sounds::sound( grabbed_vehicle->global_pos3(), str_req * 2, sounds::sound_t::movement,
+            sounds::sound( grabbed_vehicle->pos_bub(), str_req * 2, sounds::sound_t::movement,
                            _( "a scraping noise." ), true, "misc", "scraping" );
         }
         //calculate exertion factor and movement penalty
@@ -217,7 +217,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
             precalc_dir = mdir.dir();
         }
         grabbed_vehicle->precalc_mounts( 1, precalc_dir, grabbed_vehicle->pivot_point() );
-        grabbed_vehicle->pos -= grabbed_vehicle->pivot_displacement();
+        grabbed_vehicle->pos -= grabbed_vehicle->pivot_displacement().raw();
 
         // Grabbed part has to stay at distance 1 to the player
         // and in roughly the same direction.
@@ -257,7 +257,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         const tripoint player_prev = u.pos();
         u.setpos( tripoint_zero );
         std::vector<veh_collision> colls;
-        failed = grabbed_vehicle->collision( colls, actual_dir.raw(), true );
+        failed = grabbed_vehicle->collision( colls, actual_dir, true );
         u.setpos( player_prev );
         if( !colls.empty() ) {
             blocker_name = colls.front().target_name;
@@ -308,7 +308,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     for( int p : wheel_indices ) {
         if( one_in( 2 ) ) {
             vehicle_part &vp_wheel = grabbed_vehicle->part( p );
-            tripoint wheel_p = grabbed_vehicle->global_part_pos3( vp_wheel );
+            tripoint_bub_ms wheel_p = grabbed_vehicle->bub_part_pos( vp_wheel );
             grabbed_vehicle->handle_trap( wheel_p, vp_wheel );
         }
     }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -567,7 +567,7 @@ static void pldrive( const tripoint &p )
             return;
         }
     }
-    veh->pldrive( get_avatar(), p.xy(), p.z );
+    veh->pldrive( get_avatar(), p.x, p.y, p.z );
 }
 
 static void pldrive( point d )
@@ -762,7 +762,7 @@ static void grab()
         //solid vehicles can't be grabbed while boarded
         const optional_vpart_position vp_boarded = here.veh_at( you.pos_bub() );
         if( vp_boarded ) {
-            const std::set<tripoint> grabbed_veh_points = vp->vehicle().get_points();
+            const std::set<tripoint_bub_ms> grabbed_veh_points = vp->vehicle().get_points();
             if( &vp_boarded->vehicle() == &vp->vehicle() &&
                 !empty( vp->vehicle().get_avail_parts( VPFLAG_OBSTACLE ) ) ) {
                 add_msg( m_info, _( "You can't move the %s while you're boarding it." ), veh_name );
@@ -1767,7 +1767,7 @@ static void fire()
     }
     // try firing turrets
     if( const optional_vpart_position ovp = here.veh_at( you.pos_bub() ) ) {
-        if( turret_data turret_here = ovp->vehicle().turret_query( you.pos() ) ) {
+        if( turret_data turret_here = ovp->vehicle().turret_query( you.pos_bub() ) ) {
             if( avatar_action::fire_turret_manual( you, here, turret_here ) ) {
                 return;
             }

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -54,9 +54,9 @@ static void serialize_liquid_source( player_activity &act, const vehicle &veh, c
     act.values.push_back( static_cast<int>( liquid_source_type::VEHICLE ) );
     act.values.push_back( part_num );
     if( part_num != -1 ) {
-        act.coords.push_back( veh.global_part_pos3( part_num ) );
+        act.coords.push_back( veh.bub_part_pos( part_num ).raw() );
     } else {
-        act.coords.push_back( veh.global_pos3() );
+        act.coords.push_back( veh.pos_bub().raw() );
     }
     act.str_values.push_back( serialize( liquid ) );
 }
@@ -84,7 +84,7 @@ static void serialize_liquid_target( player_activity &act, const vpart_reference
 {
     act.values.push_back( static_cast<int>( liquid_target_type::VEHICLE ) );
     act.values.push_back( 0 ); // dummy
-    act.coords.push_back( vp.vehicle().global_part_pos3( 0 ) );
+    act.coords.push_back( vp.vehicle().bub_part_pos( 0 ).raw() );
     act.values.push_back( vp.part_index() ); // tank part index
 }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1365,7 +1365,8 @@ void iexamine::elevator( Character &you, const tripoint_bub_ms &examp )
     }
 
     for( vehicle *v : vehs.v ) {
-        tripoint_bub_ms const p = tripoint_bub_ms( _rotate_point_sm( { v->global_pos3().xy(), movez }, erot,
+        tripoint_bub_ms const p = tripoint_bub_ms( _rotate_point_sm( { v->pos_bub().xy().raw(), movez},
+                                  erot,
                                   sm_orig.raw() ) );
         here.displace_vehicle( *v, p - v->pos_bub() );
         v->turn( erot * 90_degrees );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13681,12 +13681,12 @@ ret_val<void> item::link_to( vehicle &veh, const point_rel_ms &mount, link_state
     }
 
     // Prepare target tripoints for the cable parts that'll be added to the selected/previous vehicles
-    const std::pair<tripoint, tripoint> prev_part_target = std::make_pair(
-                ( veh.global_square_location() + veh.coord_translate( mount ) ).raw(),
-                veh.global_square_location().raw() );
-    const std::pair<tripoint, tripoint> sel_part_target = std::make_pair(
-                ( link().t_abs_pos + prev_veh->coord_translate( link().t_mount ) ).raw(),
-                link().t_abs_pos.raw() );
+    const std::pair<tripoint_abs_ms, tripoint_abs_ms> prev_part_target = std::make_pair(
+                veh.global_square_location() + veh.coord_translate( mount ),
+                veh.global_square_location() );
+    const std::pair<tripoint_abs_ms, tripoint_abs_ms> sel_part_target = std::make_pair(
+                link().t_abs_pos + prev_veh->coord_translate( link().t_mount ),
+                link().t_abs_pos );
 
     for( const vpart_reference &vpr : prev_veh->get_any_parts( VPFLAG_POWER_TRANSFER ) ) {
         if( vpr.part().target.first == prev_part_target.first &&

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -485,7 +485,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         }
 
         tripoint position() const override {
-            return cur.veh.global_part_pos3( cur.part );
+            return cur.veh.bub_part_pos( cur.part ).raw();
         }
 
         Character *carrier() const override {
@@ -534,7 +534,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
 
             item *obj = target();
             int mv = ch.item_handling_cost( *obj, true, VEHICLE_HANDLING_PENALTY, qty );
-            mv += 100 * rl_dist( ch.pos(), cur.veh.global_part_pos3( cur.part ) );
+            mv += 100 * rl_dist( ch.pos_bub(), cur.veh.bub_part_pos( cur.part ) );
 
             // TODO: handle unpacking costs
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7356,7 +7356,7 @@ static vehicle *pickveh( const tripoint &center, bool advanced )
 
     for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
         vehicle *&v = veh.v;
-        if( rl_dist( center, v->global_pos3() ) < 40 &&
+        if( rl_dist( center, v->pos_bub().raw() ) < 40 &&
             v->fuel_left( itype_battery ) > 0 &&
             ( !empty( v->get_avail_parts( advctrl ) ) ||
               ( !advanced && !empty( v->get_avail_parts( ctrl ) ) ) ) ) {
@@ -7366,7 +7366,7 @@ static vehicle *pickveh( const tripoint &center, bool advanced )
     std::vector<tripoint> locations;
     for( int i = 0; i < static_cast<int>( vehs.size() ); i++ ) {
         vehicle *veh = vehs[i];
-        locations.push_back( veh->global_pos3() );
+        locations.push_back( veh->pos_bub().raw() );
         pmenu.addentry( i, true, MENU_AUTOASSIGN, veh->name );
     }
 
@@ -7461,9 +7461,9 @@ std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint &pos 
         const auto electronics_parts = veh->get_avail_parts( "CTRL_ELECTRONIC" );
         // Revert to original behavior if we can't find remote controls.
         if( empty( rctrl_parts ) ) {
-            veh->interact_with( electronics_parts.begin()->pos() );
+            veh->interact_with( electronics_parts.begin()->pos_bub() );
         } else {
-            veh->interact_with( rctrl_parts.begin()->pos() );
+            veh->interact_with( rctrl_parts.begin()->pos_bub() );
         }
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -389,7 +389,7 @@ void map::memory_cache_ter_set_dirty( const tripoint_bub_ms &p, bool value ) con
 void map::memory_clear_vehicle_points( const vehicle &veh ) const
 {
     avatar &player_character = get_avatar();
-    for( const tripoint &p : veh.get_points() ) {
+    for( const tripoint_bub_ms &p : veh.get_points() ) {
         if( !inbounds( p ) ) {
             continue;
         }
@@ -625,7 +625,7 @@ std::unique_ptr<vehicle> map::detach_vehicle( vehicle *veh )
     level_cache &ch = get_cache( z );
     for( size_t i = 0; i < current_submap->vehicles.size(); i++ ) {
         if( current_submap->vehicles[i].get() == veh ) {
-            for( const tripoint &pt : veh->get_points() ) {
+            for( const tripoint_bub_ms &pt : veh->get_points() ) {
                 if( inbounds( pt ) ) {
                     memory_cache_dec_set_dirty( pt, true );
                 }
@@ -669,7 +669,7 @@ void map::vehmove()
     VehicleList vehicle_list;
     int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z();
     int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z();
-    const tripoint_bub_ms player_pos = get_player_character().pos_bub();
+    const tripoint_abs_ms player_pos = get_player_character().get_location();
     for( int zlev = minz; zlev <= maxz; ++zlev ) {
         level_cache *cache_lazy = get_cache_lazy( zlev );
         if( !cache_lazy ) {
@@ -678,7 +678,7 @@ void map::vehmove()
         level_cache &cache = *cache_lazy;
         for( vehicle *veh : cache.vehicle_list ) {
             if( veh->is_following ) {
-                veh->drive_to_local_target( getglobal( player_pos ).raw(), true );
+                veh->drive_to_local_target( player_pos, true );
             } else if( veh->is_patrolling ) {
                 veh->autopilot_patrol();
             }
@@ -770,7 +770,7 @@ bool map::vehproceed( VehicleList &vehicle_list )
 static bool sees_veh( const Creature &c, vehicle &veh, bool force_recalc )
 {
     const auto &veh_points = veh.get_points( force_recalc );
-    return std::any_of( veh_points.begin(), veh_points.end(), [&c]( const tripoint & pt ) {
+    return std::any_of( veh_points.begin(), veh_points.end(), [&c]( const tripoint_bub_ms & pt ) {
         return c.sees( pt );
     } );
 }
@@ -835,7 +835,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
     size_t collision_attempts = 10;
     do {
         collisions.clear();
-        veh.collision( collisions, dp1.raw(), false );
+        veh.collision( collisions, dp1, false );
 
         // Vehicle collisions
         std::map<vehicle *, std::vector<veh_collision> > veh_collisions;
@@ -896,7 +896,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
         veh.stop_autodriving();
         const int volume = std::min<int>( 100, std::sqrt( impulse ) );
         // TODO: Center the sound at weighted (by impulse) average of collisions
-        sounds::sound( veh.global_pos3(), volume, sounds::sound_t::combat, _( "crash!" ),
+        sounds::sound( veh.pos_bub(), volume, sounds::sound_t::combat, _( "crash!" ),
                        false, "smash_success", "hit_vehicle" );
     }
 
@@ -909,7 +909,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
     if( !vertical && !veh.valid_wheel_config() && !( veh.is_watercraft() && veh.can_float() ) &&
         !veh.is_flying_in_air() && dp.z() == 0 ) {
         veh.velocity -= std::clamp( veh.velocity, -2000, 2000 ); // extra drag
-        for( const tripoint &p : veh.get_points() ) {
+        for( const tripoint_bub_ms &p : veh.get_points() ) {
             const ter_id &pter = ter( p );
             if( pter == ter_t_dirt || pter == ter_t_grass ) {
                 ter_set( p, ter_t_dirtmound );
@@ -983,7 +983,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
                                "environment", "splash" );
             }
 
-            veh.handle_trap( wheel_p.raw(), vp_wheel );
+            veh.handle_trap( wheel_p, vp_wheel );
             // dont use vp_wheel or vp_wheel_idx below this - handle_trap might've removed it from parts
 
             if( !has_flag( ter_furn_flag::TFLAG_SEALED, wheel_p ) ) {
@@ -1076,16 +1076,16 @@ float map::vehicle_vehicle_collision( vehicle &veh, vehicle &veh2,
                   0.5 * m2 * velo_veh2.magnitude() * velo_veh2.magnitude();
 
         // Collision_axis
-        point cof1 = veh .rotated_center_of_mass();
-        point cof2 = veh2.rotated_center_of_mass();
-        int &x_cof1 = cof1.x;
-        int &y_cof1 = cof1.y;
-        int &x_cof2 = cof2.x;
-        int &y_cof2 = cof2.y;
+        point_rel_ms cof1 = veh .rotated_center_of_mass();
+        point_rel_ms cof2 = veh2.rotated_center_of_mass();
+        int &x_cof1 = cof1.x();
+        int &y_cof1 = cof1.y();
+        int &x_cof2 = cof2.x();
+        int &y_cof2 = cof2.y();
         rl_vec2d collision_axis_y;
 
-        collision_axis_y.x = ( veh.global_pos3().x + x_cof1 ) - ( veh2.global_pos3().x + x_cof2 );
-        collision_axis_y.y = ( veh.global_pos3().y + y_cof1 ) - ( veh2.global_pos3().y + y_cof2 );
+        collision_axis_y.x = ( veh.pos_bub().x() + x_cof1 ) - ( veh2.pos_bub().x() + x_cof2 );
+        collision_axis_y.y = ( veh.pos_bub().y() + y_cof1 ) - ( veh2.pos_bub().y() + y_cof2 );
         collision_axis_y = collision_axis_y.normalized();
         rl_vec2d collision_axis_x = collision_axis_y.rotated( M_PI / 2 );
         // imp? & delta? & final? reworked:
@@ -1324,7 +1324,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
                     elem->sm_pos.z = cz;
                     wrapped_vehicle w;
                     w.v = elem.get();
-                    w.pos = w.v->global_pos3();
+                    w.pos = w.v->pos_bub().raw();
                     vehs.push_back( w );
                 }
             }
@@ -1608,7 +1608,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const bool 
 
     if( src_submap != dst_submap ) {
         dst_submap->ensure_nonuniform();
-        veh.set_submap_moved( tripoint( dst.x() / SEEX, dst.y() / SEEY, dst.z() ) );
+        veh.set_submap_moved( { dst.x() / SEEX, dst.y() / SEEY, dst.z() } );
         auto src_submap_veh_it = src_submap->vehicles.begin() + our_i;
         dst_submap->vehicles.push_back( std::move( *src_submap_veh_it ) );
         src_submap->vehicles.erase( src_submap_veh_it );
@@ -5860,8 +5860,8 @@ void map::process_items()
         level_cache &cache = access_cache( gz );
         std::set<tripoint> submaps_with_vehicles;
         for( vehicle *this_vehicle : cache.vehicle_list ) {
-            tripoint pos = this_vehicle->global_pos3();
-            submaps_with_vehicles.emplace( pos.x / SEEX, pos.y / SEEY, pos.z );
+            tripoint_bub_ms pos = this_vehicle->pos_bub();
+            submaps_with_vehicles.emplace( pos.x() / SEEX, pos.y() / SEEY, pos.z() );
         }
         for( const tripoint &pos : submaps_with_vehicles ) {
             submap *const current_submap = get_submap_at_grid( tripoint_rel_sm( pos ) );
@@ -7541,7 +7541,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
         if( !veh->forward_velocity() && !veh->player_in_control( player_character )
             && !( player_character.get_grab_type() == object_type::VEHICLE
                   && veh->get_points().count( ( player_character.pos_bub() +
-                                                player_character.grab_point ).raw() ) ) ) {
+                                                player_character.grab_point ) ) ) ) {
             memory_sym = sym;
         }
     }
@@ -9915,25 +9915,25 @@ static void vehicle_caching_internal( level_cache &zch, const vpart_reference &v
     auto &floor_cache = zch.floor_cache;
 
     const size_t part = vp.part_index();
-    const tripoint part_pos =  v->global_part_pos3( vp.part() );
+    const tripoint_bub_ms part_pos =  v->bub_part_pos( vp.part() );
 
     bool vehicle_is_opaque = vp.has_feature( VPFLAG_OPAQUE ) && !vp.part().is_broken();
 
     if( vehicle_is_opaque ) {
         int dpart = v->part_with_feature( part, VPFLAG_OPENABLE, true );
         if( dpart < 0 || !v->part( dpart ).open ) {
-            transparency_cache[part_pos.x][part_pos.y] = LIGHT_TRANSPARENCY_SOLID;
+            transparency_cache[part_pos.x()][part_pos.y()] = LIGHT_TRANSPARENCY_SOLID;
         } else {
             vehicle_is_opaque = false;
         }
     }
 
     if( vehicle_is_opaque || vp.is_inside() ) {
-        outside_cache[part_pos.x][part_pos.y] = false;
+        outside_cache[part_pos.x()][part_pos.y()] = false;
     }
 
     if( vp.has_feature( VPFLAG_BOARDABLE ) && !vp.part().is_broken() ) {
-        floor_cache[part_pos.x][part_pos.y] = true;
+        floor_cache[part_pos.x()][part_pos.y()] = true;
     }
 }
 
@@ -9941,8 +9941,8 @@ static void vehicle_caching_internal_above( level_cache &zch_above, const vpart_
         vehicle *v )
 {
     if( vp.has_feature( VPFLAG_ROOF ) || vp.has_feature( VPFLAG_OPAQUE ) ) {
-        const tripoint part_pos = v->global_part_pos3( vp.part() );
-        zch_above.floor_cache[part_pos.x][part_pos.y] = true;
+        const tripoint_bub_ms part_pos = v->bub_part_pos( vp.part() );
+        zch_above.floor_cache[part_pos.x()][part_pos.y()] = true;
     }
 }
 

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -445,10 +445,10 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
                 break;
         }
         if( !one_in( 4 ) ) {
-            wreckage->smash( m, 0.8f, 1.2f, 1.0f, point( dice( 1, 8 ) - 5, dice( 1, 8 ) - 5 ), 6 + dice( 1,
+            wreckage->smash( m, 0.8f, 1.2f, 1.0f, { dice( 1, 8 ) - 5, dice( 1, 8 ) - 5 }, 6 + dice( 1,
                              10 ) );
         } else {
-            wreckage->smash( m, 0.1f, 0.9f, 1.0f, point( dice( 1, 8 ) - 5, dice( 1, 8 ) - 5 ), 6 + dice( 1,
+            wreckage->smash( m, 0.1f, 0.9f, 1.0f, { dice( 1, 8 ) - 5, dice( 1, 8 ) - 5 }, 6 + dice( 1,
                              10 ) );
         }
     }
@@ -1360,7 +1360,7 @@ static void burned_ground_parser( map &m, const tripoint &loc )
             } else {
                 tripoint_abs_omt pos = project_to<coords::omt>( m.getglobal( loc ) );
                 oter_id terrain_type = overmap_buffer.ter( pos );
-                tripoint veh_origin = vehicle.v->global_pos3();
+                tripoint_bub_ms veh_origin = vehicle.v->pos_bub();
                 debugmsg( "burned_ground_parser: Vehicle %s (origin %s; rotation (%f,%f)) has "
                           "out of bounds part at %s in terrain_type %s\n",
                           vehicle.v->name, veh_origin.to_string(),
@@ -1505,18 +1505,18 @@ static bool mx_burned_ground( map &m, const tripoint &abs_sub )
     }
     VehicleList vehs = m.get_vehicles();
     std::vector<vehicle *> vehicles;
-    std::vector<tripoint> points;
+    std::vector<tripoint_bub_ms> points;
     for( wrapped_vehicle vehicle : vehs ) {
         vehicles.push_back( vehicle.v );
-        std::set<tripoint> occupied = vehicle.v->get_points();
-        for( const tripoint &t : occupied ) {
+        std::set<tripoint_bub_ms> occupied = vehicle.v->get_points();
+        for( const tripoint_bub_ms &t : occupied ) {
             points.push_back( t );
         }
     }
     for( vehicle *vrem : vehicles ) {
         m.destroy_vehicle( vrem );
     }
-    for( const tripoint &tri : points ) {
+    for( const tripoint_bub_ms &tri : points ) {
         m.furn_set( tri, furn_f_wreckage );
     }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6994,7 +6994,7 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, cons
     veh->turn_dir = dir;
     // for backwards compatibility, we always spawn with a pivot point of (0,0) so
     // that the mount at (0,0) is located at the spawn position.
-    veh->precalc_mounts( 0, dir, point() );
+    veh->precalc_mounts( 0, dir, point_rel_ms_zero );
 
     std::unique_ptr<vehicle> placed_vehicle_up =
         add_vehicle_to_map( std::move( veh ), merge_wrecks );
@@ -7087,7 +7087,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
              */
             std::unique_ptr<RemovePartHandler> handler_ptr;
             bool did_merge = false;
-            for( const tripoint &map_pos : first_veh->get_points( true ) ) {
+            for( const tripoint_bub_ms &map_pos : first_veh->get_points( true ) ) {
                 std::vector<vehicle_part *> parts_to_move = veh_to_add->get_parts_at( map_pos, "",
                         part_status_flag::any );
                 if( !parts_to_move.empty() ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1761,7 +1761,7 @@ float npc::vehicle_danger( int radius ) const
         const wrapped_vehicle &wrapped_veh = vehicles[i];
         if( wrapped_veh.v->is_moving() ) {
             const auto &points_to_check = wrapped_veh.v->immediate_path();
-            point p( get_map().getglobal( pos_bub() ).xy().raw() );
+            point_abs_ms p( get_map().getglobal( pos_bub() ).xy() );
             if( points_to_check.find( p ) != points_to_check.end() ) {
                 danger = i;
             }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -521,13 +521,13 @@ target_handler::trajectory target_handler::mode_turrets( avatar &you, vehicle &v
     int range_total = 0;
     for( vehicle_part *t : turrets ) {
         int range = veh.turret_query( *t ).range();
-        tripoint pos = veh.global_part_pos3( *t );
+        tripoint_bub_ms pos = veh.bub_part_pos( *t );
 
         int res = 0;
-        res = std::max( res, rl_dist( you.pos(), pos + point( range, 0 ) ) );
-        res = std::max( res, rl_dist( you.pos(), pos + point( -range, 0 ) ) );
-        res = std::max( res, rl_dist( you.pos(), pos + point( 0, range ) ) );
-        res = std::max( res, rl_dist( you.pos(), pos + point( 0, -range ) ) );
+        res = std::max( res, rl_dist( you.pos_bub(), pos + point( range, 0 ) ) );
+        res = std::max( res, rl_dist( you.pos_bub(), pos + point( -range, 0 ) ) );
+        res = std::max( res, rl_dist( you.pos_bub(), pos + point( 0, range ) ) );
+        res = std::max( res, rl_dist( you.pos_bub(), pos + point( 0, -range ) ) );
         range_total = std::max( range_total, res );
     }
 
@@ -998,7 +998,7 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
     bool bipod = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, pos_bub() ) || is_prone();
     if( !bipod ) {
         if( const optional_vpart_position vp = here.veh_at( pos_bub() ) ) {
-            bipod = vp->vehicle().has_part( pos(), "MOUNTABLE" );
+            bipod = vp->vehicle().has_part( pos_bub(), "MOUNTABLE" );
         }
     }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3189,12 +3189,12 @@ void vehicle_part::deserialize( const JsonObject &data )
     data.read( "items", items );
     data.read( "tools", tools );
     data.read( "salvageable", salvageable );
-    data.read( "target_first_x", target.first.x );
-    data.read( "target_first_y", target.first.y );
-    data.read( "target_first_z", target.first.z );
-    data.read( "target_second_x", target.second.x );
-    data.read( "target_second_y", target.second.y );
-    data.read( "target_second_z", target.second.z );
+    data.read( "target_first_x", target.first.x() );
+    data.read( "target_first_y", target.first.y() );
+    data.read( "target_first_z", target.first.z() );
+    data.read( "target_second_x", target.second.x() );
+    data.read( "target_second_y", target.second.y() );
+    data.read( "target_second_z", target.second.z() );
     data.read( "ammo_pref", ammo_pref );
     data.read( "locked", locked );
     data.read( "last_disconnected", last_disconnected );
@@ -3240,15 +3240,15 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "items", items );
     json.member( "tools", tools );
     json.member( "salvageable", salvageable );
-    if( target.first != tripoint_min ) {
-        json.member( "target_first_x", target.first.x );
-        json.member( "target_first_y", target.first.y );
-        json.member( "target_first_z", target.first.z );
+    if( target.first != tripoint_abs_ms_min ) {
+        json.member( "target_first_x", target.first.x() );
+        json.member( "target_first_y", target.first.y() );
+        json.member( "target_first_z", target.first.z() );
     }
-    if( target.second != tripoint_min ) {
-        json.member( "target_second_x", target.second.x );
-        json.member( "target_second_y", target.second.y );
-        json.member( "target_second_z", target.second.z );
+    if( target.second != tripoint_abs_ms_min ) {
+        json.member( "target_second_x", target.second.x() );
+        json.member( "target_second_y", target.second.y() );
+        json.member( "target_second_z", target.second.z() );
     }
     json.member( "ammo_pref", ammo_pref );
     json.member( "locked", locked );
@@ -3283,16 +3283,16 @@ void vehicle_part::carried_part_data::serialize( JsonOut &json ) const
 void label::deserialize( const JsonObject &data )
 {
     data.allow_omitted_members();
-    data.read( "x", x );
-    data.read( "y", y );
+    data.read( "x", x() );
+    data.read( "y", y() );
     data.read( "text", text );
 }
 
 void label::serialize( JsonOut &json ) const
 {
     json.start_object();
-    json.member( "x", x );
-    json.member( "y", y );
+    json.member( "x", x() );
+    json.member( "y", y() );
     json.member( "text", text );
     json.end_object();
 }
@@ -3475,11 +3475,11 @@ void vehicle::serialize( JsonOut &json ) const
         json.end_object();
     }
     json.end_array();
-    tripoint other_tow_temp_point;
+    tripoint_bub_ms other_tow_temp_point;
     if( is_towed() ) {
         vehicle *tower = tow_data.get_towed_by();
         if( tower ) {
-            other_tow_temp_point = tower->global_part_pos3( tower->get_tow_part() );
+            other_tow_temp_point = tower->bub_part_pos( tower->get_tow_part() );
         }
     }
     json.member( "other_tow_point", other_tow_temp_point );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1063,10 +1063,10 @@ void sfx::do_vehicle_exterior_engine_sfx()
     for( wrapped_vehicle vehicle : vehs ) {
         if( vehicle.v->vehicle_noise > 0 &&
             vehicle.v->vehicle_noise -
-            sound_distance( player_character.pos(), vehicle.v->global_pos3() ) > noise_factor ) {
+            sound_distance( player_character.pos_bub().raw(), vehicle.v->pos_bub().raw() ) > noise_factor ) {
 
-            noise_factor = vehicle.v->vehicle_noise - sound_distance( player_character.pos(),
-                           vehicle.v->global_pos3() );
+            noise_factor = vehicle.v->vehicle_noise - sound_distance( player_character.pos_bub().raw(),
+                           vehicle.v->pos_bub().raw() );
             veh = vehicle.v;
         }
     }
@@ -1105,7 +1105,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
 
     if( is_channel_playing( ch ) ) {
         if( engine_external_id_and_variant == id_and_variant ) {
-            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->global_pos3() ) ), 0 );
+            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub().raw() ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg_debug( debugmode::DF_SOUND, "PLAYING exterior_engine_sound, vol: ex:%d true:%d", vol,
                            Mix_Volume( ch_int, -1 ) );
@@ -1115,7 +1115,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
             add_msg_debug( debugmode::DF_SOUND, "STOP exterior_engine_sound, change id/var" );
             play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                         seas_str, indoors, night, 128, ch, 0 );
-            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->global_pos3() ) ), 0 );
+            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub().raw() ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg_debug( debugmode::DF_SOUND, "START exterior_engine_sound %s %s vol: %d",
                            id_and_variant.first,
@@ -1126,7 +1126,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
         play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                     seas_str, indoors, night, 128, ch, 0 );
         add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
-        Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->global_pos3() ) ), 0 );
+        Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub().raw() ) ), 0 );
         add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
         set_channel_volume( ch, vol );
         add_msg_debug( debugmode::DF_SOUND, "START exterior_engine_sound NEW %s %s vol: ex:%d true:%d",

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -76,9 +76,9 @@ bool place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
             // transform the deploying item into what it *should* be before storing it
             copied.convert( vpinfo.base_item );
         }
-        partnum = veh->install_part( point_zero, vpart, std::move( copied ) );
+        partnum = veh->install_part( point_rel_ms_zero, vpart, std::move( copied ) );
     } else {
-        partnum = veh->install_part( point_zero, vpart );
+        partnum = veh->install_part( point_rel_ms_zero, vpart );
     }
     if( partnum == -1 ) {
         // unrecoverable, failed to be installed somehow
@@ -112,7 +112,7 @@ bool place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
                 continue;
             }
             if( connected_vehicles.find( &veh_target ) == connected_vehicles.end() ) {
-                veh->connect( p.raw(), trip.raw() );
+                veh->connect( p, trip );
                 connected_vehicles.insert( &veh_target );
             }
         }
@@ -403,7 +403,7 @@ void veh_app_interact::refill()
         act.str_values.push_back( pt->info().id.str() );
         const point_rel_ms q = veh->coord_translate( pt->mount );
         map &here = get_map();
-        for( const tripoint &p : veh->get_points( true ) ) {
+        for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
             act.coord_set.insert( here.getglobal( p ).raw() );
         }
         act.values.push_back( here.getglobal( veh->pos_bub() ).x() + q.x() );
@@ -492,7 +492,7 @@ void veh_app_interact::remove()
     } else if( query_yn( _( "Are you sure you want to take down the %s?" ), veh->name ) ) {
         act = player_activity( ACT_VEHICLE, to_moves<int>( time ), static_cast<int>( 'O' ) );
         act.str_values.push_back( vpinfo.id.str() );
-        for( const tripoint &p : veh->get_points( true ) ) {
+        for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
             act.coord_set.insert( here.getglobal( p ).raw() );
         }
         const tripoint a_point_abs( here.getglobal( a_point_bub ).raw() );
@@ -526,7 +526,7 @@ void veh_app_interact::disconnect()
 void veh_app_interact::plug()
 {
     const int part = veh->part_at( veh->coord_translate( a_point ) );
-    const tripoint pos = veh->global_part_pos3( part );
+    const tripoint_bub_ms pos = veh->bub_part_pos( part );
     item cord( "power_cord" );
     cord.link_to( *veh, a_point, link_state::automatic );
     if( cord.get_use( "link_up" ) ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -177,7 +177,7 @@ player_activity veh_interact::serialize_activity()
     const point_rel_ms q = veh->coord_translate( pt ? pt->mount : veh->part( 0 ).mount );
     const vehicle_part *vpt = pt ? pt : &veh->part( 0 );
     map &here = get_map();
-    for( const tripoint &p : veh->get_points( true ) ) {
+    for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
         res.coord_set.insert( here.getglobal( p ).raw() );
     }
     res.values.push_back( here.getglobal( veh->pos_bub() ).x() + q.x() );   // values[0]
@@ -2316,15 +2316,15 @@ void veh_interact::display_veh()
     if( debug_mode ) {
         // show CoM, pivot in debug mode
 
-        const point &pivot = veh->pivot_point();
-        const point &com = veh->local_center_of_mass();
+        const point_rel_ms &pivot = veh->pivot_point();
+        const point_rel_ms &com = veh->local_center_of_mass();
 
-        mvwprintz( w_disp, point_zero, c_green, "CoM   %d,%d", com.x, com.y );
+        mvwprintz( w_disp, point_zero, c_green, "CoM   %d,%d", com.x(), com.y() );
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        mvwprintz( w_disp, point( 0, 1 ), c_red,   "Pivot %d,%d", pivot.x, pivot.y );
+        mvwprintz( w_disp, point( 0, 1 ), c_red,   "Pivot %d,%d", pivot.x(), pivot.y() );
 
-        const point com_s = ( com + dd ).rotate( 3 ) + h_size;
-        const point pivot_s = ( pivot + dd ).rotate( 3 ) + h_size;
+        const point com_s = ( com.raw() + dd ).rotate( 3 ) + h_size;
+        const point pivot_s = ( pivot.raw() + dd ).rotate( 3 ) + h_size;
 
         for( int x = 0; x < getmaxx( w_disp ); ++x ) {
             if( x <= com_s.x ) {
@@ -3088,7 +3088,7 @@ void veh_interact::complete_vehicle( Character &you )
     }
 
     vehicle &veh = ovp->vehicle();
-    const point d( you.activity.values[4], you.activity.values[5] );
+    const point_rel_ms d( you.activity.values[4], you.activity.values[5] );
     const vpart_id part_id( you.activity.str_values[0] );
     const vpart_info &vpinfo = part_id.obj();
 
@@ -3136,7 +3136,7 @@ void veh_interact::complete_vehicle( Character &you )
             const int partnum = veh.install_part( d, part_id, std::move( base ), installed_with );
             if( partnum < 0 ) {
                 debugmsg( "complete_vehicle install part fails dx=%d dy=%d id=%s",
-                          d.x, d.y, part_id.c_str() );
+                          d.x(), d.y(), part_id.c_str() );
                 break;
             }
             ::vehicle_part &vp_new = veh.part( partnum );
@@ -3146,15 +3146,15 @@ void veh_interact::complete_vehicle( Character &you )
 
             // Need map-relative coordinates to compare to output of look_around.
             // Need to call coord_translate() directly since it's a new part.
-            const point q = veh.coord_translate( d );
+            const point_rel_ms q = veh.coord_translate( d );
 
             if( vpinfo.has_flag( VPFLAG_CONE_LIGHT ) ||
                 vpinfo.has_flag( VPFLAG_WIDE_CONE_LIGHT ) ||
                 vpinfo.has_flag( VPFLAG_HALF_CIRCLE_LIGHT ) ) {
-                orient_part( &veh, vpinfo, partnum, q );
+                orient_part( &veh, vpinfo, partnum, q.raw() );
             }
 
-            const tripoint_bub_ms vehp = veh.pos_bub() + tripoint( q, 0 );
+            const tripoint_bub_ms vehp = veh.pos_bub() + tripoint_rel_ms( q, 0 );
             // TODO: allow boarding for non-players as well.
             Character *const pl = get_creature_tracker().creature_at<Character>( vehp );
             if( vpinfo.has_flag( VPFLAG_BOARDABLE ) && pl ) {
@@ -3341,7 +3341,7 @@ void veh_interact::complete_vehicle( Character &you )
                 veh.part_removal_cleanup();
                 // Ensure the position, pivot, and precalc points are up-to-date
                 veh.pos -= veh.pivot_anchor[0];
-                veh.precalc_mounts( 0, veh.turn_dir, point() );
+                veh.precalc_mounts( 0, veh.turn_dir, point_rel_ms_zero );
                 here.rebuild_vehicle_level_caches();
 
                 if( auto newpart = here.veh_at( act_pos ).part_with_feature( VPFLAG_APPLIANCE, false ) ) {

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -28,7 +28,7 @@ player_activity veh_shape::start( const tripoint_bub_ms &pos )
 
     if( !set_cursor_pos( pos ) ) {
         debugmsg( "failed to set cursor at given part" );
-        set_cursor_pos( tripoint_bub_ms( veh.global_part_pos3( 0 ) ) );
+        set_cursor_pos( veh.bub_part_pos( 0 ) );
     }
 
     const auto target_ui_cb = make_shared_fast<game::draw_callback_t>(
@@ -141,7 +141,7 @@ void veh_shape::change_part_shape( vpart_reference vpr ) const
             .keep_menu_open()
             .skip_locked_check()
             .skip_theft_check()
-            .location( veh.global_part_pos3( part ) )
+            .location( veh.bub_part_pos( part ).raw() )
             .select( part.variant == vvid )
             .desc( _( "Confirm to save or exit to revert" ) )
             .symbol( vv.get_symbol_curses( 0_degrees, false ) )

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1420,11 +1420,11 @@ void vehicle_prototype::save_vehicle_as_prototype( const vehicle &veh, JsonOut &
     for( int x = mount_max_x; x >= mount_min_x; x-- ) {
         std::string row;
         for( int y = mount_min_y; y <= mount_max_y; y++ ) {
-            if( veh.part_displayed_at( point( x, y ), false, true, true ) == -1 ) {
+            if( veh.part_displayed_at( point_rel_ms( x, y ), false, true, true ) == -1 ) {
                 row += " ";
                 continue;
             }
-            const vpart_display &c = veh.get_display_of_tile( point( x, y ), false, false, true, true );
+            const vpart_display &c = veh.get_display_of_tile( point_rel_ms( x, y ), false, false, true, true );
             row += utf32_to_utf8( c.symbol );
         }
         json.write( row );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -649,13 +649,13 @@ void vehicle::autopilot_patrol()
      */
     map &here = get_map();
     // if we are close to a waypoint, then return to come back to this function next turn.
-    if( autodrive_local_target != tripoint_zero ) {
-        if( rl_dist( global_square_location().raw(), autodrive_local_target ) <= 3 ) {
-            autodrive_local_target = tripoint_zero;
+    if( autodrive_local_target != tripoint_abs_ms_zero ) {
+        if( rl_dist( global_square_location(), autodrive_local_target ) <= 3 ) {
+            autodrive_local_target = tripoint_abs_ms_zero;
             return;
         }
-        if( !here.inbounds( here.bub_from_abs( tripoint_abs_ms( autodrive_local_target ) ) ) ) {
-            autodrive_local_target = tripoint_zero;
+        if( !here.inbounds( here.bub_from_abs( autodrive_local_target ) ) ) {
+            autodrive_local_target = tripoint_abs_ms_zero;
             is_patrolling = false;
             return;
         }
@@ -697,13 +697,13 @@ void vehicle::autopilot_patrol()
         chosen_tri = max_tri;
     }
     // TODO: fix point types
-    autodrive_local_target = chosen_tri.raw();
+    autodrive_local_target = chosen_tri;
     drive_to_local_target( autodrive_local_target, false );
 }
 
-std::set<point> vehicle::immediate_path( const units::angle &rotate )
+std::set<point_abs_ms> vehicle::immediate_path( const units::angle &rotate )
 {
-    std::set<point> points_to_check;
+    std::set<point_abs_ms> points_to_check;
     const int distance_to_check = 10 + ( velocity / 800 );
     units::angle adjusted_angle = normalize( face.dir() + rotate );
     // clamp to multiples of 15.
@@ -719,7 +719,7 @@ std::set<point> vehicle::immediate_path( const units::angle &rotate )
         for( int i = 0; i < distance_to_check; ++i ) {
             collision_vector.advance( i );
             point_abs_ms point_to_add = elem + point( collision_vector.dx(), collision_vector.dy() );
-            points_to_check.emplace( point_to_add.raw() );
+            points_to_check.emplace( point_to_add );
         }
     }
     collision_check_points = points_to_check;
@@ -749,11 +749,11 @@ static int get_turn_from_angle( const units::angle &angle, const tripoint &vehpo
     return 0;
 }
 
-void vehicle::drive_to_local_target( const tripoint &target, bool follow_protocol )
+void vehicle::drive_to_local_target( const tripoint_abs_ms &target, bool follow_protocol )
 {
     Character &player_character = get_player_character();
     if( follow_protocol && player_character.in_vehicle ) {
-        sounds::sound( global_pos3(), 30, sounds::sound_t::alert,
+        sounds::sound( pos_bub(), 30, sounds::sound_t::alert,
                        string_format( _( "the %s emitting a beep and saying \"Autonomous driving protocols suspended!\"" ),
                                       name ) );
         stop_autodriving();
@@ -767,14 +767,14 @@ void vehicle::drive_to_local_target( const tripoint &target, bool follow_protoco
     bool stop = precollision_check( angle, here, follow_protocol );
     if( stop ) {
         if( autopilot_on ) {
-            sounds::sound( global_pos3(), 30, sounds::sound_t::alert,
+            sounds::sound( pos_bub(), 30, sounds::sound_t::alert,
                            string_format( _( "the %s emitting a beep and saying \"Obstacle detected!\"" ),
                                           name ) );
         }
         stop_autodriving();
         return;
     }
-    int turn_x = get_turn_from_angle( angle, vehpos.raw(), target );
+    int turn_x = get_turn_from_angle( angle, vehpos.raw(), target.raw() );
     int accel_y = 0;
     // best to cruise around at a safe velocity or 40mph, whichever is lowest
     // accelerate when it doesn't need to turn.
@@ -808,7 +808,7 @@ void vehicle::drive_to_local_target( const tripoint &target, bool follow_protoco
             accel_y = 1;
         }
     }
-    selfdrive( point( turn_x, accel_y ) );
+    selfdrive( turn_x, accel_y );
 }
 
 bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_protocol )
@@ -819,10 +819,10 @@ bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_pr
     Character &player_character = get_player_character();
     // now we got the angle to the target, we can work out when we are heading towards disaster.
     // Check the tileray in the direction we need to head towards.
-    std::set<point> points_to_check = immediate_path( angle );
+    std::set<point_abs_ms> points_to_check = immediate_path( angle );
     bool stop = false;
     creature_tracker &creatures = get_creature_tracker();
-    for( const point &pt_elem : points_to_check ) {
+    for( const point_abs_ms &pt_elem : points_to_check ) {
         point_bub_ms elem = here.bub_from_abs( point_abs_ms( pt_elem ) );
         if( stop ) {
             break;
@@ -864,12 +864,12 @@ bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_pr
     return stop;
 }
 
-units::angle vehicle::get_angle_from_targ( const tripoint &targ ) const
+units::angle vehicle::get_angle_from_targ( const tripoint_abs_ms &targ ) const
 {
-    tripoint vehpos = global_square_location().raw();
+    tripoint_abs_ms vehpos = global_square_location();
     rl_vec2d facevec = face_vec();
-    point rel_pos_target = targ.xy() - vehpos.xy();
-    rl_vec2d targetvec = rl_vec2d( rel_pos_target.x, rel_pos_target.y );
+    point_rel_ms rel_pos_target = targ.xy() - vehpos.xy();
+    rl_vec2d targetvec = rl_vec2d( rel_pos_target.x(), rel_pos_target.y() );
     // cross product
     double crossy = ( facevec.x * targetvec.y ) - ( targetvec.x * facevec.y );
     // dot product.
@@ -885,7 +885,7 @@ units::angle vehicle::get_angle_from_targ( const tripoint &targ ) const
  * was the collision point.
  */
 void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_max,
-                     float percent_of_parts_to_affect, point damage_origin, float damage_size )
+                     float percent_of_parts_to_affect, point_rel_ms damage_origin, float damage_size )
 {
     for( vehicle_part &part : parts ) {
         //Skip any parts already mashed up or removed.
@@ -915,9 +915,9 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
         int roll = dice( 1, 1000 );
         int pct_af = ( percent_of_parts_to_affect * 1000.0f );
         if( roll < pct_af ) {
-            double dist =  damage_size == 0.0f ? 1.0f :
-                           clamp( 1.0f - trig_dist( damage_origin, part.precalc[0].xy().raw() ) /
-                                  damage_size, 0.0f, 1.0f );
+            double dist = damage_size == 0.0f ? 1.0f :
+                          clamp( 1.0f - trig_dist( damage_origin, part.precalc[0].xy() ) /
+                                 damage_size, 0.0f, 1.0f );
             //Everywhere else, drop by 10-120% of max HP (anything over 100 = broken)
             const float roll = rng_float( hp_percent_loss_min * dist, hp_percent_loss_max * dist );
             if( mod_hp( part, -part.info().durability * roll ) ) {
@@ -929,13 +929,13 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
     std::unique_ptr<RemovePartHandler> handler_ptr;
     // clear out any duplicated locations
     for( int p = static_cast<int>( parts.size() ) - 1; p >= 0; p-- ) {
-        vehicle_part &part = parts[ p ];
+        vehicle_part &part = parts[p];
         if( part.removed ) {
             continue;
         }
         std::vector<int> parts_here = parts_at_relative( part.mount, true );
-        for( int other_i = static_cast<int>( parts_here.size() ) - 1; other_i >= 0; other_i -- ) {
-            int other_p = parts_here[ other_i ];
+        for( int other_i = static_cast<int>( parts_here.size() ) - 1; other_i >= 0; other_i-- ) {
+            int other_p = parts_here[other_i];
             if( p == other_p ) {
                 continue;
             }
@@ -1090,7 +1090,7 @@ void vehicle::backfire( const vehicle_part &vp ) const
     // single space after the exclamation mark because it does not end the sentence
     //~ backfire sound
     const std::string text = _( "a loud BANG! from the %s" ); // NOLINT(cata-text-style);
-    const tripoint pos = global_part_pos3( vp );
+    const tripoint_bub_ms pos = bub_part_pos( vp );
     const int volume = 40 + units::to_watt( part_vpower_w( vp, true ) ) / 10000;
     sounds::sound( pos, volume, sounds::sound_t::movement,
                    string_format( text, vp.name() ), true, "vehicle", "engine_backfire" );
@@ -1483,12 +1483,12 @@ bool vehicle::is_appliance() const
 
 int vehicle::install_part( const point &dp, const vpart_id &type )
 {
-    return install_part( dp, type, item( type.obj().base_item ) );
+    return install_part( point_rel_ms( dp ), type, item( type.obj().base_item ) );
 }
 
-int vehicle::install_part( const point &dp, const vpart_id &type, item &&base )
+int vehicle::install_part( const point_rel_ms &dp, const vpart_id &type )
 {
-    return install_part( dp, vehicle_part( type, std::move( base ) ) );
+    return install_part( dp, type, item( type.obj().base_item ) );
 }
 
 int vehicle::install_part( const point_rel_ms &dp, const vpart_id &type, item &&base )
@@ -1496,7 +1496,7 @@ int vehicle::install_part( const point_rel_ms &dp, const vpart_id &type, item &&
     return install_part( dp, vehicle_part( type, std::move( base ) ) );
 }
 
-int vehicle::install_part( const point &dp, const vpart_id &type, item &&base,
+int vehicle::install_part( const point_rel_ms &dp, const vpart_id &type, item &&base,
                            std::vector<item> &installed_with )
 {
     return install_part( dp, vehicle_part( type, std::move( base ), installed_with ) );
@@ -2024,6 +2024,11 @@ bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
 
 void vehicle::separate_from_grid( const point mount )
 {
+    vehicle::separate_from_grid( point_rel_ms( mount ) );
+}
+
+void vehicle::separate_from_grid( const point_rel_ms mount )
+{
     // Disconnect items and power cords
     unlink_cables( mount, get_player_character(), true, true, true );
     part_removal_cleanup();
@@ -2042,7 +2047,7 @@ void vehicle::separate_from_grid( const point mount )
     const std::string part_name = part( idx ).name();
     std::vector<std::vector<int>> split_indices( { { idx } } );
     const std::vector<vehicle *> null_vehicles( 2, nullptr );
-    const std::vector<std::vector<point>> null_mounts( 2, std::vector<point>() );
+    const std::vector<std::vector<point_rel_ms>> null_mounts( 2, std::vector<point_rel_ms>() );
     if( !split_vehicles( here, split_indices, null_vehicles, null_mounts ) ) {
         debugmsg( "unable to split %s from power grid", part( idx ).name( false ) );
         return;
@@ -2054,7 +2059,7 @@ void vehicle::separate_from_grid( const point mount )
     // Ensure the position, pivot, and precalc points are up-to-date.
     shift_if_needed( get_map() );
     pos -= pivot_anchor[0];
-    precalc_mounts( 0, turn_dir, point() );
+    precalc_mounts( 0, turn_dir, point_rel_ms_zero );
 
     add_msg( _( "You separate the %s from the power grid" ), part_name );
 
@@ -2192,7 +2197,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
     handler.removed( *this, vp_idx );
 
     const point_rel_ms &vp_mount = vp.mount;
-    const auto iter = labels.find( label( vp_mount.raw() ) );
+    const auto iter = labels.find( label( vp_mount ) );
     if( iter != labels.end() && parts_at_relative( vp_mount, false ).empty() ) {
         labels.erase( iter );
     }
@@ -2307,7 +2312,7 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts,
         return false;
     }
 
-    std::vector<point> new_mounts;
+    std::vector<point_rel_ms> new_mounts;
     new_vehicle->name = carried_pivot->veh_name;
     new_vehicle->owner = owner;
     new_vehicle->old_owner = old_owner;
@@ -2333,7 +2338,7 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts,
                 }
             }
         }
-        new_mounts.push_back( mount.xy().raw() );
+        new_mounts.push_back( mount.xy() );
     }
 
     for( const int &rack_part : racks ) {
@@ -2458,7 +2463,8 @@ bool vehicle::find_and_split_vehicles( map &here, std::set<int> exclude )
 
     if( !all_vehicles.empty() ) {
         const std::vector<vehicle *> null_vehicles( all_vehicles.size(), nullptr );
-        const std::vector<std::vector<point>> null_mounts( all_vehicles.size(), std::vector<point>() );
+        const std::vector<std::vector<point_rel_ms>> null_mounts( all_vehicles.size(),
+                std::vector<point_rel_ms>() );
         std::vector<vehicle *> mark_wreckage { this };
         if( split_vehicles( here, all_vehicles, null_vehicles, null_mounts, &mark_wreckage ) ) {
             for( vehicle *veh : mark_wreckage ) {
@@ -2466,7 +2472,7 @@ bool vehicle::find_and_split_vehicles( map &here, std::set<int> exclude )
                     veh->add_tag( "wreckage" ); // wreckages don't get fake parts added
                 }
             }
-            shift_parts( here, point_zero ); // update the active cache
+            shift_parts( here, point_rel_ms_zero ); // update the active cache
             return true;
         }
     }
@@ -2483,26 +2489,6 @@ void vehicle::relocate_passengers( const std::vector<Character *> &passengers ) 
             }
         }
     }
-}
-
-bool vehicle::split_vehicles( map &here,
-                              const std::vector<std::vector <int>> &new_vehs,
-                              const std::vector<vehicle *> &new_vehicles,
-                              const std::vector<std::vector<point>> &new_mounts,
-                              std::vector<vehicle *> *added_vehicles )
-{
-    std::vector<std::vector<point_rel_ms>> temp;
-    for( const std::vector<point> &sub : new_mounts ) {
-        std::vector<point_rel_ms> temp2;
-        temp2.reserve( sub.size() );
-        for( const point pt : sub ) {
-            const point_rel_ms temp3{pt};
-            temp2.emplace_back( temp3 );
-        }
-        temp.emplace_back( temp2 );
-    }
-
-    return vehicle::split_vehicles( here, new_vehs, new_vehicles, temp, added_vehicles );
 }
 
 bool vehicle::split_vehicles( map &here,
@@ -2616,11 +2602,11 @@ bool vehicle::split_vehicles( map &here,
             new_vehicle->parts.back().mount = new_mount;
 
             // remove labels associated with the mov_part
-            const auto iter = labels.find( label( cur_mount.raw() ) );
+            const auto iter = labels.find( label( cur_mount ) );
             if( iter != labels.end() ) {
                 std::string label_str = iter->text;
                 labels.erase( iter );
-                new_labels.insert( label( new_mount.raw(), label_str ) );
+                new_labels.insert( label( new_mount, label_str ) );
             }
             // Prepare the zones to be moved to the new vehicle
             const std::pair<std::unordered_multimap<point, zone_data>::iterator, std::unordered_multimap<point, zone_data>::iterator>
@@ -2672,7 +2658,7 @@ bool vehicle::split_vehicles( map &here,
         }
 
         // update the precalc points
-        new_vehicle->precalc_mounts( 0, new_vehicle->turn_dir, point() );
+        new_vehicle->precalc_mounts( 0, new_vehicle->turn_dir, point_rel_ms_zero );
         new_vehicle->precalc_mounts( 1, new_vehicle->skidding ?
                                      new_vehicle->turn_dir : new_vehicle->face.dir(),
                                      new_vehicle->pivot_point() );
@@ -2949,12 +2935,6 @@ int vehicle::part_with_feature( int part, vpart_bitflags flag, bool unbroken,
     return -1;
 }
 
-int vehicle::part_with_feature( const point &pt, vpart_bitflags f, bool unbroken,
-                                bool include_fake ) const
-{
-    return vehicle::part_with_feature( point_rel_ms( pt ), f, unbroken, include_fake );
-}
-
 int vehicle::part_with_feature( const point_rel_ms &pt, vpart_bitflags f, bool unbroken,
                                 bool include_fake ) const
 {
@@ -2996,6 +2976,11 @@ int vehicle::avail_part_with_feature( int part, vpart_bitflags flag ) const
 
 int vehicle::avail_part_with_feature( const point &pt, const std::string &flag ) const
 {
+    return vehicle::avail_part_with_feature( point_rel_ms( pt ), flag );
+}
+
+int vehicle::avail_part_with_feature( const point_rel_ms &pt, const std::string &flag ) const
+{
     const int part_a = part_with_feature( pt, flag, true );
     if( ( part_a >= 0 ) && this->part( part_a ).is_available() ) {
         return part_a;
@@ -3034,10 +3019,15 @@ bool vehicle::has_part( const std::string &flag, bool enabled ) const
 
 bool vehicle::has_part( const tripoint &pos, const std::string &flag, bool enabled ) const
 {
-    const tripoint relative_pos = pos - global_pos3();
+    return vehicle::has_part( tripoint_bub_ms( pos ), flag, enabled );
+}
+
+bool vehicle::has_part( const tripoint_bub_ms &pos, const std::string &flag, bool enabled ) const
+{
+    const tripoint_rel_ms relative_pos = pos - pos_bub();
 
     for( const vpart_reference &vpr : get_all_parts() ) {
-        if( vpr.part().precalc[0].raw() != relative_pos ) {
+        if( vpr.part().precalc[0] != relative_pos ) {
             continue;
         }
         if( !vpr.part().removed && ( !enabled || vpr.part().enabled ) && !vpr.part().is_broken() &&
@@ -3052,11 +3042,18 @@ bool vehicle::has_part( const tripoint &pos, const std::string &flag, bool enabl
 std::vector<vehicle_part *> vehicle::get_parts_at( const tripoint &pos, const std::string &flag,
         const part_status_flag condition )
 {
+    return vehicle::get_parts_at( tripoint_bub_ms( pos ), flag, condition );
+}
+
+std::vector<vehicle_part *> vehicle::get_parts_at( const tripoint_bub_ms &pos,
+        const std::string &flag,
+        const part_status_flag condition )
+{
     // TODO: provide access to fake parts via argument ?
-    const tripoint relative_pos = pos - global_pos3();
+    const tripoint_rel_ms relative_pos = pos - pos_bub();
     std::vector<vehicle_part *> res;
     for( const vpart_reference &vpr : get_all_parts() ) {
-        if( vpr.part().precalc[ 0 ].raw() != relative_pos ) {
+        if( vpr.part().precalc[0] != relative_pos ) {
             continue;
         }
         if( !vpr.part().removed &&
@@ -3069,21 +3066,14 @@ std::vector<vehicle_part *> vehicle::get_parts_at( const tripoint &pos, const st
     return res;
 }
 
-std::vector<vehicle_part *> vehicle::get_parts_at( const tripoint_bub_ms &pos,
-        const std::string &flag,
-        const part_status_flag condition )
-{
-    return vehicle::get_parts_at( pos.raw(), flag, condition );
-}
-
-std::vector<const vehicle_part *> vehicle::get_parts_at( const tripoint &pos,
+std::vector<const vehicle_part *> vehicle::get_parts_at( const tripoint_bub_ms &pos,
         const std::string &flag,
         const part_status_flag condition ) const
 {
-    const tripoint relative_pos = pos - global_pos3();
+    const tripoint_rel_ms relative_pos = pos - pos_bub();
     std::vector<const vehicle_part *> res;
     for( const vpart_reference &vpr : get_all_parts() ) {
-        if( vpr.part().precalc[ 0 ].raw() != relative_pos ) {
+        if( vpr.part().precalc[ 0 ] != relative_pos ) {
             continue;
         }
         if( !vpr.part().removed &&
@@ -3098,7 +3088,7 @@ std::vector<const vehicle_part *> vehicle::get_parts_at( const tripoint &pos,
 
 std::optional<std::string> vpart_position::get_label() const
 {
-    const auto it = vehicle().labels.find( label( mount() ) );
+    const auto it = vehicle().labels.find( label( mount_pos() ) );
     if( it == vehicle().labels.end() ) {
         return std::nullopt;
     }
@@ -3112,13 +3102,13 @@ std::optional<std::string> vpart_position::get_label() const
 void vpart_position::set_label( const std::string &text ) const
 {
     std::set<label> &labels = vehicle().labels;
-    const auto it = labels.find( label( mount() ) );
+    const auto it = labels.find( label( mount_pos() ) );
     // TODO: empty text should remove the label instead of just storing an empty string, see get_label
     if( it == labels.end() ) {
-        labels.insert( label( mount(), text ) );
+        labels.insert( label( mount_pos(), text ) );
     } else {
         // labels should really be a map
-        labels.insert( labels.erase( it ), label( mount(), text ) );
+        labels.insert( labels.erase( it ), label( mount_pos(), text ) );
     }
 }
 
@@ -3539,15 +3529,6 @@ void vehicle::coord_translate( const units::angle &dir, const point_rel_ms &pivo
     q.y() = tdir.dy() + tdir.ortho_dy( p.y() - pivot.y() );
 }
 
-void vehicle::coord_translate( tileray tdir, const point &pivot, const point &p,
-                               tripoint &q ) const
-{
-    tdir.clear_advance();
-    tdir.advance( p.x - pivot.x );
-    q.x = tdir.dx() + tdir.ortho_dx( p.y - pivot.y );
-    q.y = tdir.dy() + tdir.ortho_dy( p.y - pivot.y );
-}
-
 void vehicle::coord_translate( tileray tdir, const point_rel_ms &pivot, const point_rel_ms &p,
                                tripoint_rel_ms &q ) const
 {
@@ -3559,19 +3540,12 @@ void vehicle::coord_translate( tileray tdir, const point_rel_ms &pivot, const po
 
 tripoint vehicle::mount_to_tripoint( const point &mount ) const
 {
-    return mount_to_tripoint( mount, point_zero );
+    return mount_to_tripoint( point_rel_ms( mount ), point_rel_ms_zero ).raw();
 }
 
 tripoint_bub_ms vehicle::mount_to_tripoint( const point_rel_ms &mount ) const
 {
     return mount_to_tripoint( mount, point_rel_ms_zero );
-}
-
-tripoint vehicle::mount_to_tripoint( const point &mount, const point &offset ) const
-{
-    tripoint mnt_translated;
-    coord_translate( pivot_rotation[0], pivot_anchor[ 0 ], mount + offset, mnt_translated );
-    return global_pos3() + mnt_translated;
 }
 
 tripoint_bub_ms vehicle::mount_to_tripoint( const point_rel_ms &mount,
@@ -3698,24 +3672,9 @@ tripoint_abs_omt vehicle::global_omt_location() const
     return project_to<coords::omt>( global_square_location() );
 }
 
-tripoint vehicle::global_pos3() const
-{
-    return vehicle::pos_bub().raw();
-}
-
 tripoint_bub_ms vehicle::pos_bub() const
 {
     return coords::project_to<coords::ms>( tripoint_bub_sm( sm_pos ) ) + pos;
-}
-
-tripoint vehicle::global_part_pos3( const int &index ) const
-{
-    return global_part_pos3( parts[ index ] );
-}
-
-tripoint vehicle::global_part_pos3( const vehicle_part &pt ) const
-{
-    return global_pos3() + pt.precalc[ 0 ].raw();
 }
 
 tripoint_bub_ms vehicle::bub_part_pos( const int index ) const
@@ -3728,10 +3687,10 @@ tripoint_bub_ms vehicle::bub_part_pos( const vehicle_part &pt ) const
     return pos_bub() + pt.precalc[ 0 ];
 }
 
-void vehicle::set_submap_moved( const tripoint &p )
+void vehicle::set_submap_moved( const tripoint_sm_ms &p )
 {
     const point_abs_ms old_msp = global_square_location().xy();
-    sm_pos = p;
+    sm_pos = p.raw();
     if( !tracking_on ) {
         return;
     }
@@ -3766,12 +3725,7 @@ units::mass vehicle::weight_on_wheels() const
     return vehicle_mass - animal_mass;
 }
 
-const point &vehicle::rotated_center_of_mass() const
-{
-    return vehicle::rotated_center_of_mass_rel().raw();
-}
-
-const point_rel_ms &vehicle::rotated_center_of_mass_rel() const
+const point_rel_ms &vehicle::rotated_center_of_mass() const
 {
     // TODO: Bring back caching of this point
     calc_mass_center( true );
@@ -3779,12 +3733,7 @@ const point_rel_ms &vehicle::rotated_center_of_mass_rel() const
     return mass_center_precalc;
 }
 
-const point &vehicle::local_center_of_mass() const
-{
-    return vehicle::local_center_of_mass_rel().raw();
-}
-
-const point_rel_ms &vehicle::local_center_of_mass_rel() const
+const point_rel_ms &vehicle::local_center_of_mass() const
 {
     if( mass_center_no_precalc_dirty ) {
         calc_mass_center( false );
@@ -3793,7 +3742,7 @@ const point_rel_ms &vehicle::local_center_of_mass_rel() const
     return mass_center_no_precalc;
 }
 
-point vehicle::pivot_displacement() const
+point_rel_ms vehicle::pivot_displacement() const
 {
     // precalc_mounts always produces a result that puts the pivot point at (0,0).
     // If the pivot point changes, this artificially moves the vehicle, as the position
@@ -3803,8 +3752,8 @@ point vehicle::pivot_displacement() const
     // the vehicle.
 
     // rotate the old pivot point around the new pivot point with the old rotation angle
-    tripoint dp;
-    coord_translate( pivot_rotation[0], pivot_anchor[1], pivot_anchor[0], dp );
+    tripoint_rel_ms dp;
+    coord_translate( pivot_rotation[0], pivot_anchor[1], pivot_anchor[0], dp.raw() );
     return dp.xy();
 }
 
@@ -4396,7 +4345,7 @@ void vehicle::noise_and_smoke( int load, time_duration time )
     }
     add_msg_debug( debugmode::DF_VEHICLE, "VEH NOISE final: %d", static_cast<int>( noise ) );
     vehicle_noise = static_cast<unsigned char>( noise );
-    sounds::sound( global_pos3(), noise, sounds::sound_t::movement,
+    sounds::sound( pos_bub(), noise, sounds::sound_t::movement,
                    _( is_rotorcraft() ? heli_noise : sounds[lvl].first ), true );
 }
 
@@ -5055,7 +5004,7 @@ bool vehicle::balanced_wheel_config() const
     }
 
     // Check center of mass inside support of wheels (roughly)
-    const point_rel_ms &com = local_center_of_mass_rel();
+    const point_rel_ms &com = local_center_of_mass();
     const inclusive_rectangle<point_rel_ms> support( min, max );
     return support.contains( com );
 }
@@ -5986,7 +5935,7 @@ void vehicle::idle( bool on_map )
         if( engine_on &&
             ( has_engine_type_not( fuel_type_muscle, true ) && has_engine_type_not( fuel_type_animal, true ) &&
               has_engine_type_not( fuel_type_wind, true ) && has_engine_type_not( fuel_type_mana, true ) ) ) {
-            add_msg_if_player_sees( global_pos3(), _( "The %s's engine dies!" ), name );
+            add_msg_if_player_sees( pos_bub(), _( "The %s's engine dies!" ), name );
         }
         engine_on = false;
     }
@@ -5995,7 +5944,7 @@ void vehicle::idle( bool on_map )
         for( int i : planters ) {
             vehicle_part &vp = parts[ i ];
             if( vp.enabled ) {
-                add_msg_if_player_sees( global_pos3(), _( "The %s's planter turns off due to low temperature." ),
+                add_msg_if_player_sees( pos_bub(), _( "The %s's planter turns off due to low temperature." ),
                                         name );
                 vp.enabled = false;
             }
@@ -6048,7 +5997,7 @@ void vehicle::idle( bool on_map )
     }
 
     // Notify player about status of all turrets if they're at controls
-    bool player_at_controls = !get_parts_at( player_character.pos(), "CONTROLS",
+    bool player_at_controls = !get_parts_at( player_character.pos_bub(), "CONTROLS",
                               part_status_flag::working ).empty();
 
     for( vehicle_part *turret : turrets() ) {
@@ -6165,7 +6114,7 @@ void vehicle::disable_smart_controller_if_needed()
 void vehicle::make_active( item_location &loc )
 {
     item &target = *loc;
-    auto cargo_parts = get_parts_at( loc.position(), "CARGO", part_status_flag::any );
+    auto cargo_parts = get_parts_at( loc.pos_bub(), "CARGO", part_status_flag::any );
     if( cargo_parts.empty() ) {
         return;
     }
@@ -6226,7 +6175,7 @@ std::optional<vehicle_stack::iterator> vehicle::add_item( vehicle_part &vp, cons
     if( itm_copy.is_bucket_nonempty() ) {
         // this is a vehicle, so there is only one pocket.
         // so if it will spill, spill all of it
-        itm_copy.spill_contents( global_part_pos3( vp ) );
+        itm_copy.spill_contents( bub_part_pos( vp ) );
     }
 
     const vehicle_stack::iterator new_pos = vp.items.insert( itm_copy );
@@ -6464,7 +6413,7 @@ bool vehicle::decrement_summon_timer()
             }
             vp.items.clear();
         }
-        add_msg_if_player_sees( global_pos3(), m_info, _( "Your %s winks out of existence." ), name );
+        add_msg_if_player_sees( pos_bub().raw(), m_info, _( "Your %s winks out of existence." ), name );
         get_map().destroy_vehicle( this );
         return true;
     } else {
@@ -6693,7 +6642,7 @@ void vehicle::refresh( const bool remove_fakes )
         } else if( !camera_on && vpi.has_flag( "CAMERA" ) ) {
             vp.part().enabled = false;
         }
-        if( vpi.has_flag( "TURRET" ) && !has_part( global_part_pos3( vp.part() ), "TURRET_CONTROLS" ) ) {
+        if( vpi.has_flag( "TURRET" ) && !has_part( bub_part_pos( vp.part() ), "TURRET_CONTROLS" ) ) {
             vp.part().enabled = false;
         }
         if( vpi.has_flag( "MUFFLER" ) ) {
@@ -6767,7 +6716,7 @@ void vehicle::refresh( const bool remove_fakes )
             part_real.fake_part_at = fake_index;
             fake_parts.push_back( fake_index );
             relative_parts[ part_fake.mount.raw()].push_back( fake_index );
-            edges.emplace( real_mount.raw(), edge_info );
+            edges.emplace( real_mount, edge_info );
             parts.push_back( std::move( part_fake ) );
         }
     };
@@ -6815,11 +6764,6 @@ void vehicle::refresh( const bool remove_fakes )
     invalidate_mass();
     occupied_cache_pos = { -1, -1, -1 };
     refresh_active_item_cache();
-}
-
-vpart_edge_info vehicle::get_edge_info( const point &mount ) const
-{
-    return vehicle::get_edge_info( point_rel_ms( mount ) );
 }
 
 vpart_edge_info vehicle::get_edge_info( const point_rel_ms &mount ) const
@@ -6890,12 +6834,7 @@ void vehicle::remove_fake_parts( const bool cleanup )
     }
 }
 
-const point &vehicle::pivot_point() const
-{
-    return vehicle::pivot_point_rel().raw();
-}
-
-const point_rel_ms &vehicle::pivot_point_rel() const
+const point_rel_ms &vehicle::pivot_point() const
 {
     if( pivot_dirty ) {
         refresh_pivot();
@@ -6911,7 +6850,7 @@ void vehicle::refresh_pivot() const
 
     if( wheelcache.empty() || !valid_wheel_config() ) {
         // No usable wheels, use CoM (dragging)
-        pivot_cache = local_center_of_mass_rel();
+        pivot_cache = local_center_of_mass();
         return;
     }
 
@@ -6997,7 +6936,7 @@ void vehicle::refresh_pivot() const
     if( xc_denominator < 0.1 || yc_denominator < 0.1 ) {
         debugmsg( "vehicle::refresh_pivot had a bad weight: xc=%.3f/%.3f yc=%.3f/%.3f",
                   xc_numerator, xc_denominator, yc_numerator, yc_denominator );
-        pivot_cache = local_center_of_mass_rel();
+        pivot_cache = local_center_of_mass();
     } else {
         pivot_cache.x() = std::round( xc_numerator / xc_denominator );
         pivot_cache.y() = std::round( yc_numerator / yc_denominator );
@@ -7035,7 +6974,7 @@ void vehicle::do_towing_move()
     const tripoint_abs_ms towed_tow_point = here.getglobal( towed_veh->bub_part_pos(
             other_tow_index ) );
     // same as above, but where the pulling vehicle is pulling from
-    units::angle towing_veh_angle = towed_veh->get_angle_from_targ( tower_tow_point.raw() );
+    units::angle towing_veh_angle = towed_veh->get_angle_from_targ( tower_tow_point );
     const bool reverse = towed_veh->tow_data.tow_direction == TOW_BACK;
     int accel_y = 0;
     tripoint_abs_ms vehpos = global_square_location();
@@ -7058,7 +6997,7 @@ void vehicle::do_towing_move()
     switch( towed_veh->tow_data.tow_direction ) {
         case TOW_FRONT:
         case TOW_BACK:
-            towed_veh->selfdrive( point( turn_x, accel_y ) );
+            towed_veh->selfdrive( turn_x, accel_y );
             break;
 
         default:
@@ -7308,7 +7247,7 @@ std::optional<vpart_reference> vehicle::get_remote_part( const vehicle_part &vp_
     if( veh != nullptr ) {
         const tripoint_abs_ms local_abs = get_map().getglobal( bub_part_pos( vp_local ) );
         for( const int remote_partnum : veh->loose_parts ) {
-            if( veh->parts[remote_partnum].target.first == local_abs.raw() &&
+            if( veh->parts[remote_partnum].target.first == local_abs &&
                 veh->parts[remote_partnum].info().has_flag( VPFLAG_POWER_TRANSFER ) ) {
                 return vpart_reference( *veh, remote_partnum );
             }
@@ -7348,19 +7287,19 @@ void vehicle::shed_loose_parts( const trinary shed_cables, const tripoint_bub_ms
             }
             tripoint_abs_ms vp_loose_dst = here.getglobal( dst ? *dst + vp_loose.precalc[1] : bub_part_pos(
                                                vp_loose ) );
-            const int distance = rl_dist( vp_loose_dst.raw(), vp_loose.target.first );
+            const int distance = rl_dist( vp_loose_dst, vp_loose.target.first );
             const int max_dist = vp_loose.get_base().max_link_length();
 
             if( distance > max_dist || shed_cables == trinary::ALL ) {
-                add_msg_if_player_sees( global_part_pos3( vp_loose ), m_warning,
+                add_msg_if_player_sees( bub_part_pos( vp_loose ).raw(), m_warning,
                                         _( "The %s's %s was detached!" ), name, vp_loose.name( false ) );
                 remove_remote = true;
             } else {
                 // cable still has some slack to it, so update the remote part's target and continue.
                 const auto remote = get_remote_part( vp_loose );
                 if( remote ) {
-                    remote->part().target.first = vp_loose_dst.raw();
-                    remote->part().target.second = here.getglobal( dst ? *dst : pos_bub() ).raw();
+                    remote->part().target.first = vp_loose_dst;
+                    remote->part().target.second = here.getglobal( dst ? *dst : pos_bub() );
                 }
                 continue;
             }
@@ -7426,7 +7365,7 @@ void vehicle::unlink_cables( const point_rel_ms &mount, Character &remover,
     }
 }
 
-bool vehicle::enclosed_at( const tripoint &pos )
+bool vehicle::enclosed_at( const tripoint_bub_ms &pos )
 {
     refresh_insides();
     std::vector<vehicle_part *> parts_here = get_parts_at( pos, "BOARDABLE",
@@ -7576,11 +7515,6 @@ int vehicle::damage( map &here, int p, int dmg, const damage_type_id &type, bool
     }
 }
 
-void vehicle::damage_all( int dmg1, int dmg2, const damage_type_id &type, const point &impact )
-{
-    vehicle::damage_all( dmg1, dmg2, type, point_rel_ms( impact ) );
-}
-
 void vehicle::damage_all( int dmg1, int dmg2, const damage_type_id &type,
                           const point_rel_ms &impact )
 {
@@ -7655,7 +7589,7 @@ void vehicle::shift_parts( map &here, const point_rel_ms &delta )
  */
 bool vehicle::shift_if_needed( map &here )
 {
-    std::vector<int> vehicle_origin = parts_at_relative( point_zero, true );
+    std::vector<int> vehicle_origin = parts_at_relative( point_rel_ms_zero, true );
     if( !vehicle_origin.empty() && !parts[ vehicle_origin[ 0 ] ].removed ) {
         // Shifting is not needed.
         return false;
@@ -7825,7 +7759,7 @@ bool vehicle::explode_fuel( vehicle_part &vp, const damage_type_id &type )
         get_event_bus().send<event_type::fuel_tank_explodes>( name );
         const int pow = 120 * ( 1 - std::exp( data.explosion_factor / -5000 *
                                               ( vp.ammo_remaining() * data.fuel_size_factor ) ) );
-        explosion_handler::explosion( nullptr, global_part_pos3( vp ), pow, 0.7, data.fiery_explosion );
+        explosion_handler::explosion( nullptr, bub_part_pos( vp ).raw(), pow, 0.7, data.fiery_explosion );
         mod_hp( vp, -vp.hp() );
         vp.ammo_unset();
     }
@@ -7935,8 +7869,8 @@ void vehicle::leak_fuel( vehicle_part &pt ) const
 
     map &here = get_map();
     // leak in random directions but prefer closest tiles and avoid walls or other obstacles
-    std::vector<tripoint> tiles = closest_points_first( global_part_pos3( pt ), 1 );
-    tiles.erase( std::remove_if( tiles.begin(), tiles.end(), [&here]( const tripoint & e ) {
+    std::vector<tripoint_bub_ms> tiles = closest_points_first( bub_part_pos( pt ), 1 );
+    tiles.erase( std::remove_if( tiles.begin(), tiles.end(), [&here]( const tripoint_bub_ms & e ) {
         return !here.passable( e );
     } ), tiles.end() );
 
@@ -8106,25 +8040,26 @@ bool vehicle::restore_folded_parts( const item &it )
     return true;
 }
 
-const std::set<tripoint> &vehicle::get_points( const bool force_refresh, const bool no_fake ) const
+const std::set<tripoint_bub_ms> &vehicle::get_points( const bool force_refresh,
+        const bool no_fake ) const
 {
-    if( force_refresh || occupied_cache_pos != global_pos3() ||
+    if( force_refresh || occupied_cache_pos != pos_bub() ||
         occupied_cache_direction != face.dir() ) {
-        occupied_cache_pos = global_pos3();
+        occupied_cache_pos = pos_bub();
         occupied_cache_direction = face.dir();
         occupied_points.clear();
         for( const std::pair<const point, std::vector<int>> &part_location : relative_parts ) {
             if( no_fake && part( part_location.second.front() ).is_fake ) {
                 continue;
             }
-            occupied_points.insert( global_part_pos3( part_location.second.front() ) );
+            occupied_points.insert( bub_part_pos( part_location.second.front() ) );
         }
     }
 
     return occupied_points;
 }
 
-void vehicle::part_project_points( const tripoint &dp )
+void vehicle::part_project_points( const tripoint_rel_ms &dp )
 {
     std::set<tripoint> projected_points;
     for( int p = 0; p < part_count(); p++ ) {
@@ -8231,11 +8166,11 @@ point_rel_ms vpart_position::mount_pos() const
 
 tripoint_bub_ms vpart_position::pos_bub() const
 {
-    return tripoint_bub_ms( pos() );
+    return vehicle().bub_part_pos( part_index() );
 }
 tripoint vpart_position::pos() const
 {
-    return vehicle().global_part_pos3( part_index() );
+    return pos_bub().raw();
 }
 
 bool vpart_reference::has_feature( const std::string &f ) const
@@ -8481,19 +8416,19 @@ bounding_box vehicle::get_bounding_box( bool use_precalc, bool no_fake )
 
     face.init( turn_dir );
 
-    precalc_mounts( 0, turn_dir, point() );
+    precalc_mounts( 0, turn_dir, point_rel_ms_zero );
 
-    for( const tripoint &p : get_points( true, no_fake ) ) {
+    for( const tripoint_bub_ms &p : get_points( true, no_fake ) ) {
         point_rel_ms pt;
         if( use_precalc ) {
             const int i_use = 0;
-            int part_idx = part_at( p.xy() );
+            int part_idx = part_at( p.xy().raw() );
             if( part_idx < 0 ) {
                 continue;
             }
             pt = parts[part_idx].precalc[i_use].xy();
         } else {
-            pt = point_rel_ms( p.xy() );
+            pt = rebase_rel( p.xy() );
         }
         if( pt.x() < min_x ) {
             min_x = pt.x();

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3045,6 +3045,7 @@ std::vector<vehicle_part *> vehicle::get_parts_at( const tripoint &pos, const st
     return vehicle::get_parts_at( tripoint_bub_ms( pos ), flag, condition );
 }
 
+// NOLINTNEXTLINE(readability-make-member-function-const)
 std::vector<vehicle_part *> vehicle::get_parts_at( const tripoint_bub_ms &pos,
         const std::string &flag,
         const part_status_flag condition )

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -525,9 +525,8 @@ struct vehicle_part {
         /**
          * Coordinates for some kind of target; jumper cables and turrets use this
          * Two coordinate pairs are stored: actual target point, and target vehicle center.
-         * Both cases use reality bubble coordinates
          */
-        std::pair<tripoint, tripoint> target = { tripoint_min, tripoint_min };
+        std::pair<tripoint_abs_ms, tripoint_abs_ms> target = { tripoint_abs_ms_min, tripoint_abs_ms_min };
 
         /** If it's a part with variants, which variant it is */
         std::string variant;
@@ -688,12 +687,12 @@ class turret_data
 
 /**
  * Struct used for storing labels
- * (easier to json opposed to a std::map<point, std::string>)
+ * (easier to json opposed to a std::map<point_rel_ms, std::string>)
  */
-struct label : public point {
+struct label : public point_rel_ms {
     label() = default;
-    explicit label( const point &p ) : point( p ) {}
-    label( const point &p, std::string text ) : point( p ), text( std::move( text ) ) {}
+    explicit label( const point_rel_ms &p ) : point_rel_ms( p ) {}
+    label( const point_rel_ms &p, std::string text ) : point_rel_ms( p ), text( std::move( text ) ) {}
 
     std::string text;
 
@@ -839,9 +838,11 @@ class vehicle
         bool do_environmental_effects() const;
 
         // Vehicle fuel indicator (by fuel)
+        // TODO: Figure out what coordinate system "point" is in and type it.
         void print_fuel_indicator( const catacurses::window &w, const point &p,
                                    const itype_id &fuel_type,
                                    bool verbose = false, bool desc = false );
+        // TODO: Figure out what coordinate system "point" is in and type it.
         void print_fuel_indicator( const catacurses::window &w, const point &p,
                                    const itype_id &fuel_type,
                                    std::map<itype_id, units::energy> fuel_usages,
@@ -944,7 +945,8 @@ class vehicle
 
         // damages all parts of a vehicle by a random amount
         void smash( map &m, float hp_percent_loss_min = 0.1f, float hp_percent_loss_max = 1.2f,
-                    float percent_of_parts_to_affect = 1.0f, point damage_origin = point_zero, float damage_size = 0 );
+                    float percent_of_parts_to_affect = 1.0f, point_rel_ms damage_origin = point_rel_ms_zero,
+                    float damage_size = 0 );
 
         void serialize( JsonOut &json ) const;
         // deserializes vehicle from json (including parts)
@@ -1003,17 +1005,17 @@ class vehicle
         }
         bool handle_potential_theft( Character const &you, bool check_only = false, bool prompt = true );
         // project a tileray forward to predict obstacles
-        std::set<point> immediate_path( const units::angle &rotate = 0_degrees );
-        std::set<point> collision_check_points; // NOLINT(cata-serialize)
+        std::set<point_abs_ms> immediate_path( const units::angle &rotate = 0_degrees );
+        std::set<point_abs_ms> collision_check_points; // NOLINT(cata-serialize)
         void autopilot_patrol();
-        units::angle get_angle_from_targ( const tripoint &targ ) const;
-        void drive_to_local_target( const tripoint &target, bool follow_protocol );
+        units::angle get_angle_from_targ( const tripoint_abs_ms &targ ) const;
+        void drive_to_local_target( const tripoint_abs_ms &target, bool follow_protocol );
         // Drive automatically towards some destination for one turn.
         autodrive_result do_autodrive( Character &driver );
         // Stop any kind of automatic vehicle control and apply the brakes.
         void stop_autodriving( bool apply_brakes = true );
 
-        void connect( const tripoint &source_pos, const tripoint &target_pos );
+        void connect( const tripoint_bub_ms &source_pos, const tripoint_bub_ms &target_pos );
 
         bool precollision_check( units::angle &angle, map &here, bool follow_protocol );
         // Try select any fuel for engine, returns true if some fuel is available
@@ -1043,15 +1045,15 @@ class vehicle
 
         // install a part of type \p type at mount \p dp
         // @return installed part index or -1 if can_mount(...) failed
+        // TODO: Get rid of untyped overload.
         int install_part( const point &dp, const vpart_id &type );
+        int install_part( const point_rel_ms &dp, const vpart_id &type );
 
         // install a part of type \p type at mount \p dp with \p base (std::move -ing it)
         // @return installed part index or -1 if can_mount(...) failed
-        // TODO: Get rid of untyped overload.
-        int install_part( const point &dp, const vpart_id &type, item &&base );
         int install_part( const point_rel_ms &dp, const vpart_id &type, item &&base );
 
-        int install_part( const point &dp, const vpart_id &type, item &&base,
+        int install_part( const point_rel_ms &dp, const vpart_id &type, item &&base,
                           std::vector<item> &installed_with );
 
         // install the given part \p vp (std::move -ing it)
@@ -1085,7 +1087,9 @@ class vehicle
         // merges vehicles together by copying parts, does not account for any vehicle complexities
         bool merge_vehicle_parts( vehicle *veh );
         bool merge_appliance_into_grid( vehicle &veh_target );
+        // TODO: Get rid of untyped overload.
         void separate_from_grid( point mount );
+        void separate_from_grid( point_rel_ms mount );
 
         bool is_powergrid() const;
 
@@ -1126,11 +1130,6 @@ class vehicle
         // in new_vehicles, and forces the part indices in new_vehs to be mounted on the new vehicle
         // at those mount points
         // @param added_vehicles if not nullptr any newly added vehicles will be appended to the vector
-        // TODO: Get rid of untyped overload.
-        bool split_vehicles( map &here, const std::vector<std::vector <int>> &new_vehs,
-                             const std::vector<vehicle *> &new_vehicles,
-                             const std::vector<std::vector<point>> &new_mounts,
-                             std::vector<vehicle *> *added_vehicles = nullptr );
         bool split_vehicles( map &here, const std::vector<std::vector <int>> &new_vehs,
                              const std::vector<vehicle *> &new_vehicles,
                              const std::vector<std::vector<point_rel_ms>> &new_mounts,
@@ -1225,9 +1224,6 @@ class vehicle
         *  @param include_fake if true fake parts are included
         *  @returns part index or -1
         */
-        // TODO: Get rid of untyped overload.
-        int part_with_feature( const point &pt, vpart_bitflags f, bool unbroken,
-                               bool include_fake = false ) const;
         int part_with_feature( const point_rel_ms &pt, vpart_bitflags f, bool unbroken,
                                bool include_fake = false ) const;
         /**
@@ -1249,7 +1245,9 @@ class vehicle
         *  @param unbroken if true also requires the part to be !is_broken
         *  @returns part index or -1
         */
+        // TODO: Get rid of untyped overload.
         int avail_part_with_feature( const point &pt, const std::string &f ) const;
+        int avail_part_with_feature( const point_rel_ms &pt, const std::string &f ) const;
         /**
         *  Returns \p p or part index at mount point \p pt which has given \p f flag
         *  and is_available(), or -1 if no such part or it's not is_available()
@@ -1283,11 +1281,13 @@ class vehicle
 
         /**
          *  Check if vehicle has at least one unbroken part with specified flag
-         *  @param pos limit check for parts to this global position
+         *  @param pos limit check for parts to this bubble position
          *  @param flag The specified flag
          *  @param enabled if set part must also be enabled to be considered
          */
+        // TODO: Get rid of untyped overload.
         bool has_part( const tripoint &pos, const std::string &flag, bool enabled = false ) const;
+        bool has_part( const tripoint_bub_ms &pos, const std::string &flag, bool enabled = false ) const;
 
         /**
          *  Get all enabled, available, unbroken vehicle parts at specified position
@@ -1295,11 +1295,12 @@ class vehicle
          *  @param flag if set only flags with this part will be considered
          *  @param condition enum to include unabled, unavailable, and broken parts
          */
+        // TODO: Get rid of untyped overload.
         std::vector<vehicle_part *> get_parts_at( const tripoint &pos, const std::string &flag,
-                part_status_flag condition );  // TODO: Get rid of untyped operation.
+                part_status_flag condition );
         std::vector<vehicle_part *> get_parts_at( const tripoint_bub_ms &pos, const std::string &flag,
                 part_status_flag condition );
-        std::vector<const vehicle_part *> get_parts_at( const tripoint &pos,
+        std::vector<const vehicle_part *> get_parts_at( const tripoint_bub_ms &pos,
                 const std::string &flag, part_status_flag condition ) const;
 
         /** Test if part can be enabled (unbroken, sufficient fuel etc), optionally displaying failures to user */
@@ -1374,16 +1375,12 @@ class vehicle
                               tripoint_rel_ms &q ) const;
         // Translate mount coordinates "p" into tile coordinates "q" using given tileray and anchor
         // should be faster than previous call for repeated translations
-        // TODO: Get rid of untyped overload.
-        void coord_translate( tileray tdir, const point &pivot, const point &p, tripoint &q ) const;
         void coord_translate( tileray tdir, const point_rel_ms &pivot, const point_rel_ms &p,
                               tripoint_rel_ms &q ) const;
 
         // TODO: Get rid of untyped overload.
         tripoint mount_to_tripoint( const point &mount ) const;
         tripoint_bub_ms mount_to_tripoint( const point_rel_ms &mount ) const;
-        // TODO: Get rid of untyped overload.
-        tripoint mount_to_tripoint( const point &mount, const point &offset ) const;
         tripoint_bub_ms mount_to_tripoint( const point_rel_ms &mount, const point_rel_ms &offset ) const;
 
         // Seek a vehicle part which obstructs tile with given coordinates relative to vehicle position
@@ -1418,6 +1415,7 @@ class vehicle
         std::vector<itype_id> get_printable_fuel_types() const;
 
         // Vehicle fuel indicators (all of them)
+        // TODO: Figure out what coordinate system this uses and convert to it.
         void print_fuel_indicators(
             const catacurses::window &win, const point &, int start_index = 0,
             bool fullsize = false, bool verbose = false, bool desc = false,
@@ -1430,6 +1428,7 @@ class vehicle
          * @param spacing Sets size of space between components
          * @warning if spacing is negative it is changed to 0
          */
+        // TODO: Figure out what coordinate system this uses and convert to it.
         void print_speed_gauge( const catacurses::window &win, const point &, int spacing = 0 ) const;
 
         // Pre-calculate mount points for (idir=0) - current direction or
@@ -1454,23 +1453,17 @@ class vehicle
         // get monster on a boardable part at p
         monster *get_monster( int p ) const;
 
-        bool enclosed_at( const tripoint &pos ); // not const because it calls refresh_insides
+        bool enclosed_at( const tripoint_bub_ms &pos ); // not const because it calls refresh_insides
         // Returns the location of the vehicle in global map square coordinates.
         tripoint_abs_ms global_square_location() const;
         // Returns the location of the vehicle in global overmap terrain coordinates.
         tripoint_abs_omt global_omt_location() const;
         // Returns the coordinates (in map squares) of the vehicle relative to the local map.
         // Warning: Don't assume this position contains a vehicle part
-        tripoint global_pos3() const;
-        // Warning: Don't assume this position contains a vehicle part
         tripoint_bub_ms pos_bub() const;
         /**
          * Get the coordinates of the studied part of the vehicle
          */
-        // TODO: fix point types (remove global_part_pos3 in favour of
-        // bub_part_pos)
-        tripoint global_part_pos3( const int &index ) const;
-        tripoint global_part_pos3( const vehicle_part &pt ) const;
         tripoint_bub_ms bub_part_pos( int index ) const;
         tripoint_bub_ms bub_part_pos( const vehicle_part &pt ) const;
         /**
@@ -1595,24 +1588,18 @@ class vehicle
         units::mass weight_on_wheels() const;
 
         // Gets the center of mass calculated for precalc[0] coordinates
-        // TODO: Get rid of untyped "overload".
-        const point &rotated_center_of_mass() const;
-        const point_rel_ms &rotated_center_of_mass_rel() const;
+        const point_rel_ms &rotated_center_of_mass() const;
         // Gets the center of mass calculated for mount point coordinates
-        // TODO: Get rid of untyped "overload" and rename rel.
-        const point &local_center_of_mass() const;
-        const point_rel_ms &local_center_of_mass_rel() const;
+        const point_rel_ms &local_center_of_mass() const;
 
         // Get the pivot point of vehicle; coordinates are unrotated mount coordinates.
         // This may result in refreshing the pivot point if it is currently stale.
-        // TODO: Get rid of untyped "overload".
-        const point &pivot_point() const;
-        const point_rel_ms &pivot_point_rel() const;
+        const point_rel_ms &pivot_point() const;
 
         // Get the (artificial) displacement of the vehicle due to the pivot point changing
         // between precalc[0] and precalc[1]. This needs to be subtracted from any actual
         // vehicle motion after precalc[1] is prepared.
-        point pivot_displacement() const;
+        point_rel_ms pivot_displacement() const;
 
         // Get combined power of all engines. If fueled == true, then only engines which
         // vehicle have fuel for are accounted.  If safe == true, then limit engine power to
@@ -1822,22 +1809,22 @@ class vehicle
 
         // Returns if any collision occurred
         bool collision( std::vector<veh_collision> &colls,
-                        const tripoint &dp,
+                        const tripoint_rel_ms &dp,
                         bool just_detect, bool bash_floor = false );
 
         // Handle given part collision with vehicle, monster/NPC/player or terrain obstacle
         // Returns collision, which has type, impulse, part, & target.
-        veh_collision part_collision( int part, const tripoint &p,
+        veh_collision part_collision( int part, const tripoint_bub_ms &p,
                                       bool just_detect, bool bash_floor );
 
         // Process the trap beneath
-        void handle_trap( const tripoint &p, vehicle_part &vp_wheel );
+        void handle_trap( const tripoint_bub_ms &p, vehicle_part &vp_wheel );
         void activate_magical_follow();
         void activate_animal_follow();
         /**
          * vehicle is driving itself
          */
-        void selfdrive( const point & );
+        void selfdrive( const int turn, const int acceleration );
         /**
          * can the helicopter descend/ascend here?
          */
@@ -1846,10 +1833,11 @@ class vehicle
         bool check_is_heli_landed();
         /**
          * Player is driving the vehicle
-         * @param p direction player is steering
+         * @param turn is turn direction
+         * @param acceleration is acceleration
          * @param z for vertical movement - e.g helicopters
          */
-        void pldrive( Character &driver, const point &p, int z = 0 );
+        void pldrive( Character &driver, const int turn, const int acceleration, const int z = 0 );
 
         /**
         * Flags item \p tool with PSEUDO, if it has MOD pocket then a `pseudo_magazine_mod` is
@@ -1930,8 +1918,6 @@ class vehicle
                     bool aimed = true );
 
         // damage all parts (like shake from strong collision), range from dmg1 to dmg2
-        // TODO: Get rid of untyped overload.
-        void damage_all( int dmg1, int dmg2, const damage_type_id &type, const point &impact );
         void damage_all( int dmg1, int dmg2, const damage_type_id &type, const point_rel_ms &impact );
 
         //Shifts the coordinates of all parts and moves the vehicle in the opposite direction.
@@ -1972,11 +1958,11 @@ class vehicle
         std::vector<vehicle_part *> turrets();
 
         /** Get all vehicle turrets loaded and ready to fire at target */
-        std::vector<vehicle_part *> turrets( const tripoint &target );
+        std::vector<vehicle_part *> turrets( const tripoint_bub_ms &target );
 
         /** Get firing data for a turret */
         turret_data turret_query( vehicle_part &pt );
-        turret_data turret_query( const tripoint &pos );
+        turret_data turret_query( const tripoint_bub_ms &pos );
 
         /** Set targeting mode for specific turrets */
         void turrets_set_targeting();
@@ -2033,10 +2019,11 @@ class vehicle
         bool assign_seat( vehicle_part &pt, const npc &who );
 
         // Update the set of occupied points and return a reference to it
-        const std::set<tripoint> &get_points( bool force_refresh = false, bool no_fake = false ) const;
+        const std::set<tripoint_bub_ms> &get_points( bool force_refresh = false,
+                bool no_fake = false ) const;
 
         // calculate the new projected points for all vehicle parts to move to
-        void part_project_points( const tripoint &dp );
+        void part_project_points( const tripoint_rel_ms &dp );
 
         // get all vehicle parts' projected points
         std::set<tripoint_bub_ms> get_projected_part_points() const;
@@ -2083,7 +2070,7 @@ class vehicle
 
         // Honk the vehicle's horn, if there are any
         void honk_horn() const;
-        void reload_seeds( const tripoint &pos );
+        void reload_seeds( const tripoint_bub_ms &pos );
         void beeper_sound() const;
         void play_music() const;
         void play_chimes() const;
@@ -2165,18 +2152,17 @@ class vehicle
          * This should be called only when the vehicle has actually been moved, not when
          * the map is just shifted (in the later case simply set smx/smy directly).
          */
-        void set_submap_moved( const tripoint &p );
+        void set_submap_moved( const tripoint_sm_ms &p );
         void use_autoclave( int p );
         void use_washing_machine( int p );
         void use_dishwasher( int p );
-        void use_monster_capture( int part, const tripoint &pos );
-        void use_harness( int part, const tripoint &pos );
+        void use_monster_capture( int part, const tripoint_bub_ms &pos );
+        void use_harness( int part, const tripoint_bub_ms &pos );
 
         void build_electronics_menu( veh_menu &menu );
         void build_bike_rack_menu( veh_menu &menu, int part );
+        // TODO: Make it typed. One call uses bubble coordinates, the other untyped veh_app_interact::a_point
         void build_interact_menu( veh_menu &menu, const tripoint &p, bool with_pickup );
-        // TODO: Get rid of untyped overload.
-        void interact_with( const tripoint &p, bool with_pickup = false );
         void interact_with( const tripoint_bub_ms &p, bool with_pickup = false );
 
         std::string disp_name() const;
@@ -2204,29 +2190,24 @@ class vehicle
         mutable double draft_m = 1; // NOLINT(cata-serialize)
         mutable double hull_height = 0.3; // NOLINT(cata-serialize)
 
-        // Global location when cache was last refreshed.
-        mutable tripoint occupied_cache_pos = { -1, -1, -1 }; // NOLINT(cata-serialize)
+        // Bubble location when cache was last refreshed.
+        mutable tripoint_bub_ms occupied_cache_pos = { -1, -1, -1 }; // NOLINT(cata-serialize)
         // Vehicle facing when cache was last refreshed.
         mutable units::angle occupied_cache_direction = 0_degrees; // NOLINT(cata-serialize)
         // Cached points occupied by the vehicle
-        mutable std::set<tripoint> occupied_points; // NOLINT(cata-serialize)
+        mutable std::set<tripoint_bub_ms> occupied_points; // NOLINT(cata-serialize)
 
         // Master list of parts installed in the vehicle.
         std::vector<vehicle_part> parts; // NOLINT(cata-serialize)
         // Used in savegame.cpp to only save real parts to json
         std::vector<std::reference_wrapper<const vehicle_part>> real_parts() const;
         // Map of edge parts and their adjacency information
-        std::map<point, vpart_edge_info> edges; // NOLINT(cata-serialize)
+        std::map<point_rel_ms, vpart_edge_info> edges; // NOLINT(cata-serialize)
         // For a given mount point, returns its adjacency info
-        // TODO: Get rid of untyped overload.
-        vpart_edge_info get_edge_info( const point &mount ) const;
         vpart_edge_info get_edge_info( const point_rel_ms &mount ) const;
 
         // Removes fake parts from the parts vector
         void remove_fake_parts( bool cleanup = true );
-        // TODO: Get rid of untyped overload.
-        bool should_enable_fake( const tripoint &fake_precalc, const tripoint &parent_precalc,
-                                 const tripoint &neighbor_precalc ) const;
         bool should_enable_fake( const tripoint_rel_ms &fake_precalc, const tripoint_rel_ms &parent_precalc,
                                  const tripoint_rel_ms &neighbor_precalc ) const;
     public:
@@ -2340,7 +2321,8 @@ class vehicle
         mutable point mount_min; // NOLINT(cata-serialize)
         mutable point_rel_ms mass_center_precalc; // NOLINT(cata-serialize)
         mutable point_rel_ms mass_center_no_precalc; // NOLINT(cata-serialize)
-        tripoint autodrive_local_target = tripoint_zero; // current node the autopilot is aiming for
+        tripoint_abs_ms autodrive_local_target =
+            tripoint_abs_ms_zero; // current node the autopilot is aiming for
         class autodrive_controller;
         std::shared_ptr<autodrive_controller> active_autodrive_controller; // NOLINT(cata-serialize)
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1824,7 +1824,7 @@ class vehicle
         /**
          * vehicle is driving itself
          */
-        void selfdrive( const int turn, int acceleration );
+        void selfdrive( int turn, int acceleration );
         /**
          * can the helicopter descend/ascend here?
          */
@@ -1837,7 +1837,7 @@ class vehicle
          * @param acceleration is acceleration
          * @param z for vertical movement - e.g helicopters
          */
-        void pldrive( Character &driver, int turn, const int acceleration, int z = 0 );
+        void pldrive( Character &driver, int turn, int acceleration, int z = 0 );
 
         /**
         * Flags item \p tool with PSEUDO, if it has MOD pocket then a `pseudo_magazine_mod` is

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1824,7 +1824,7 @@ class vehicle
         /**
          * vehicle is driving itself
          */
-        void selfdrive( const int turn, const int acceleration );
+        void selfdrive( const int turn, int acceleration );
         /**
          * can the helicopter descend/ascend here?
          */
@@ -1837,7 +1837,7 @@ class vehicle
          * @param acceleration is acceleration
          * @param z for vertical movement - e.g helicopters
          */
-        void pldrive( Character &driver, const int turn, const int acceleration, const int z = 0 );
+        void pldrive( Character &driver, int turn, const int acceleration, int z = 0 );
 
         /**
         * Flags item \p tool with PSEUDO, if it has MOD pocket then a `pseudo_magazine_mod` is

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1824,7 +1824,7 @@ class vehicle
         /**
          * vehicle is driving itself
          */
-        void selfdrive( int turn, int acceleration );
+        void selfdrive( int trn, int acceleration );
         /**
          * can the helicopter descend/ascend here?
          */
@@ -1833,11 +1833,11 @@ class vehicle
         bool check_is_heli_landed();
         /**
          * Player is driving the vehicle
-         * @param turn is turn direction
+         * @param trn is turn direction
          * @param acceleration is acceleration
          * @param z for vertical movement - e.g helicopters
          */
-        void pldrive( Character &driver, int turn, int acceleration, int z = 0 );
+        void pldrive( Character &driver, int trn, int acceleration, int z = 0 );
 
         /**
         * Flags item \p tool with PSEUDO, if it has MOD pocket then a `pseudo_magazine_mod` is

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -637,7 +637,7 @@ vehicle_profile vehicle::autodrive_controller::compute_profile( orientation faci
     tileray tdir( to_angle( facing ) );
     ret.tdir = tdir;
     std::map<int, std::pair<int, int>> extent_map;
-    const point_rel_ms pivot = driven_veh.pivot_point_rel();
+    const point_rel_ms pivot = driven_veh.pivot_point();
     for( const vehicle_part &part : driven_veh.parts ) {
         if( part.removed ) {
             continue;
@@ -1268,11 +1268,11 @@ std::vector<std::tuple<point, int, std::string>> vehicle::get_debug_overlay_data
     std::vector<std::tuple<point, int, std::string>> ret;
 
     const tripoint_abs_ms veh_pos = global_square_location();
-    if( autodrive_local_target != tripoint_zero ) {
-        ret.emplace_back( ( autodrive_local_target - veh_pos.raw() ).xy(), catacurses::red, "T" );
+    if( autodrive_local_target != tripoint_abs_ms_zero ) {
+        ret.emplace_back( ( autodrive_local_target - veh_pos ).xy().raw(), catacurses::red, "T" );
     }
-    for( const point &pt_elem : collision_check_points ) {
-        ret.emplace_back( pt_elem - veh_pos.raw().xy(), catacurses::yellow, "C" );
+    for( const point_abs_ms &pt_elem : collision_check_points ) {
+        ret.emplace_back( pt_elem.raw() - veh_pos.raw().xy(), catacurses::yellow, "C" );
     }
 
     if( !active_autodrive_controller ) {
@@ -1422,7 +1422,7 @@ autodrive_result vehicle::do_autodrive( Character &driver )
             // nothing we can do about it now, hope we don't crash!
             break;
         }
-        pldrive( driver, { signum( turn_delta ), 0 } );
+        pldrive( driver, signum( turn_delta ), 0 );
     }
     // Don't do anything else below; the driver's turn may be over (moves <= 0) so
     // any extra actions would be "cheating".
@@ -1442,7 +1442,7 @@ void vehicle::stop_autodriving( bool apply_brakes )
     is_patrolling = false;
     is_following = false;
     autopilot_on = false;
-    autodrive_local_target = tripoint_zero;
+    autodrive_local_target = tripoint_abs_ms_zero;
     collision_check_points.clear();
     active_autodrive_controller.reset();
 }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1304,7 +1304,6 @@ monster *vehicle::get_harnessed_animal() const
     return nullptr;
 }
 
-// "turn" parameter changed to "trn" to avoid clashing with "turn" operation.
 void vehicle::selfdrive( const int trn, const int acceleration )
 {
     if( !is_towed() && !magic && !get_harnessed_animal() && !has_part( "AUTOPILOT" ) ) {
@@ -1413,7 +1412,6 @@ bool vehicle::check_heli_ascend( Character &p ) const
     return true;
 }
 
-// Parameter "turn" changed to "trn" to not clash with operation "turn".
 void vehicle::pldrive( Character &driver, const int trn, const int acceleration, const int z )
 {
     bool is_non_proficient = false;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -685,7 +685,7 @@ void vehicle::stop()
     last_turn = 0_degrees;
     of_turn_carry = 0;
     map &here = get_map();
-    for( const tripoint &p : get_points() ) {
+    for( const tripoint_bub_ms &p : get_points() ) {
         if( here.inbounds( p ) ) {
             here.memory_cache_dec_set_dirty( p, true );
         }
@@ -693,7 +693,7 @@ void vehicle::stop()
 }
 
 bool vehicle::collision( std::vector<veh_collision> &colls,
-                         const tripoint &dp,
+                         const tripoint_rel_ms &dp,
                          bool just_detect, bool bash_floor )
 {
 
@@ -711,21 +711,21 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
      *  the vehicle will phase into it.
      */
 
-    if( dp.z != 0 && ( dp.x != 0 || dp.y != 0 ) ) {
+    if( dp.z() != 0 && ( dp.x() != 0 || dp.y() != 0 ) ) {
         // Split into horizontal + vertical
-        return collision( colls, tripoint( dp.xy(), 0 ), just_detect, bash_floor ) ||
-               collision( colls, tripoint( 0,    0,    dp.z ), just_detect, bash_floor );
+        return collision( colls, tripoint_rel_ms( dp.xy(), 0 ), just_detect, bash_floor ) ||
+               collision( colls, tripoint_rel_ms( 0,    0,    dp.z() ), just_detect, bash_floor );
     }
 
-    if( dp.z == -1 && !bash_floor ) {
+    if( dp.z() == -1 && !bash_floor ) {
         // First check current level, then the one below if current had no collisions
         // Bash floors on the current one, but not on the one below.
-        if( collision( colls, tripoint_zero, just_detect, true ) ) {
+        if( collision( colls, tripoint_rel_ms_zero, just_detect, true ) ) {
             return true;
         }
     }
 
-    const bool vertical = bash_floor || dp.z != 0;
+    const bool vertical = bash_floor || dp.z() != 0;
     const int &coll_velocity = vertical ? vertical_velocity : velocity;
     // Skip collisions when there is no apparent movement, except verticially moving rotorcraft.
     if( coll_velocity == 0 && !is_rotorcraft() ) {
@@ -752,11 +752,11 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
         // Coordinates of where part will go due to movement (dx/dy/dz)
         //  and turning (precalc[1])
         const tripoint_bub_ms dsp = vp.next_pos;
-        veh_collision coll = part_collision( p, dsp.raw(), just_detect, bash_floor );
+        veh_collision coll = part_collision( p, dsp, just_detect, bash_floor );
         if( coll.type == veh_coll_nothing && info.has_flag( VPFLAG_ROTOR ) ) {
             size_t radius = static_cast<size_t>( std::round( info.rotor_info->rotor_diameter / 2.0f ) );
             for( const tripoint_bub_ms &rotor_point : here.points_in_radius( dsp, radius ) ) {
-                veh_collision rotor_coll = part_collision( p, rotor_point.raw(), just_detect, false );
+                veh_collision rotor_coll = part_collision( p, rotor_point, just_detect, false );
                 if( rotor_coll.type != veh_coll_nothing ) {
                     coll = rotor_coll;
                     if( just_detect ) {
@@ -816,7 +816,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
 }
 
 // A helper to make sure mass and density is always calculated the same way
-static void terrain_collision_data( const tripoint &p, bool bash_floor,
+static void terrain_collision_data( const tripoint_bub_ms &p, bool bash_floor,
                                     float &mass, float &density, float &elastic )
 {
     elastic = 0.30;
@@ -828,12 +828,12 @@ static void terrain_collision_data( const tripoint &p, bool bash_floor,
     density = bash_min;
 }
 
-veh_collision vehicle::part_collision( int part, const tripoint &p,
+veh_collision vehicle::part_collision( int part, const tripoint_bub_ms &p,
                                        bool just_detect, bool bash_floor )
 {
     // Vertical collisions need to be handled differently
     // All collisions have to be either fully vertical or fully horizontal for now
-    const bool vert_coll = bash_floor || p.z != sm_pos.z;
+    const bool vert_coll = bash_floor || p.z() != sm_pos.z;
     Creature *critter = get_creature_tracker().creature_at( p, true );
     Character *ph = dynamic_cast<Character *>( critter );
 
@@ -884,18 +884,18 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         }
         // we just ran into a fish, so move it out of the way
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, critter->pos_bub() ) ) {
-            tripoint end_pos = critter->pos();
-            tripoint start_pos;
+            tripoint_bub_ms end_pos = critter->pos_bub();
+            tripoint_bub_ms start_pos;
             const std::set<tripoint_bub_ms> projected_points = get_projected_part_points();
             const units::angle angle =
                 move.dir() + ( coll_velocity > 0 ? 0_degrees : 180_degrees ) + 45_degrees *
-                ( parts[part].mount.x() > pivot_point().x ? -1 : 1 );
-            const std::set<tripoint> &cur_points = get_points( true );
+                ( parts[part].mount.x() > pivot_point().x() ? -1 : 1 );
+            const std::set<tripoint_bub_ms> &cur_points = get_points( true );
             // push the animal out of way until it's no longer in our vehicle and not in
             // anyone else's position
             while( get_creature_tracker().creature_at( end_pos, true ) ||
                    cur_points.find( end_pos ) != cur_points.end() ||
-                   projected_points.find( tripoint_bub_ms( end_pos ) ) != projected_points.end() ) {
+                   projected_points.find( end_pos ) != projected_points.end() ) {
                 start_pos = end_pos;
                 calc_ray_end( angle, 2, start_pos, end_pos );
             }
@@ -1141,7 +1141,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
                     smashed = true;
                 } else if( critter != nullptr ) {
                     // Only count critter as pushed away if it actually changed position
-                    smashed = critter->pos() != p;
+                    smashed = critter->pos_bub() != p;
                 }
             }
         }
@@ -1215,7 +1215,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
     return ret;
 }
 
-void vehicle::handle_trap( const tripoint &p, vehicle_part &vp_wheel )
+void vehicle::handle_trap( const tripoint_bub_ms &p, vehicle_part &vp_wheel )
 {
     if( !vp_wheel.info().has_flag( VPFLAG_WHEEL ) ) {
         debugmsg( "vehicle::handle_trap called on non-WHEEL part" );
@@ -1254,7 +1254,7 @@ void vehicle::handle_trap( const tripoint &p, vehicle_part &vp_wheel )
                            veh_data.sound_type, veh_data.sound_variant );
         }
         if( veh_data.do_explosion ) {
-            explosion_handler::explosion( driver, p, veh_data.damage, 0.5f, false, veh_data.shrapnel );
+            explosion_handler::explosion( driver, p.raw(), veh_data.damage, 0.5f, false, veh_data.shrapnel );
             // Don't damage wheels with very high durability, such as roller drums or rail wheels
         } else if( damage_done ) {
             // Hit the wheel directly since it ran right over the trap.
@@ -1279,11 +1279,11 @@ void vehicle::handle_trap( const tripoint &p, vehicle_part &vp_wheel )
             const trap &tr = here.tr_at( p );
             if( seen || known ) {
                 // known status has been reset by map::trap_set()
-                player_character.add_known_trap( p, tr );
+                player_character.add_known_trap( p.raw(), tr );
             }
             if( seen && !known ) {
                 // hard to miss!
-                const std::string direction = direction_name( direction_from( player_character.pos(), p ) );
+                const std::string direction = direction_name( direction_from( player_character.pos_bub(), p ) );
                 add_msg( _( "You've spotted a %1$s to the %2$s!" ), tr.name(), direction );
             }
         }
@@ -1304,24 +1304,25 @@ monster *vehicle::get_harnessed_animal() const
     return nullptr;
 }
 
-void vehicle::selfdrive( const point &p )
+// "turn" parameter changed to "trn" to avoid clashing with "turn" operation.
+void vehicle::selfdrive( const int trn, const int acceleration )
 {
     if( !is_towed() && !magic && !get_harnessed_animal() && !has_part( "AUTOPILOT" ) ) {
         is_following = false;
         return;
     }
-    if( p.x != 0 ) {
+    if( trn != 0 ) {
         if( steering_effectiveness() <= 0 ) {
             return; // no steering
         }
-        turn( p.x * vehicles::steer_increment );
+        turn( trn * vehicles::steer_increment );
     }
-    if( p.y != 0 ) {
+    if( acceleration != 0 ) {
         if( !is_towed() ) {
             const int thr_amount = std::abs( velocity ) < 2000 ? 400 : 500;
-            cruise_thrust( -p.y * thr_amount );
+            cruise_thrust( -acceleration * thr_amount );
         } else {
-            thrust( -p.y );
+            thrust( -acceleration );
         }
     }
     // TODO: Actually check if we're on land on water (or disable water-skidding)
@@ -1339,7 +1340,7 @@ bool vehicle::check_is_heli_landed()
 {
     // @TODO - when there are chasms that extend below z-level 0 - perhaps the heli
     // will be able to descend into them but for now, assume z-level-0 == the ground.
-    if( global_pos3().z == 0 ||
+    if( pos_bub().z() == 0 ||
         !get_map().has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_FLOOR, pos_bub() ) ) {
         is_flying = false;
         return true;
@@ -1357,9 +1358,9 @@ bool vehicle::check_heli_descend( Character &p ) const
     int air_count = 0;
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &pt : get_points( true ) ) {
-        tripoint below( pt.xy(), pt.z - 1 );
-        if( pt.z < -OVERMAP_DEPTH || !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_FLOOR, pt ) ) {
+    for( const tripoint_bub_ms &pt : get_points( true ) ) {
+        tripoint_bub_ms below( pt + tripoint_below );
+        if( pt.z() < -OVERMAP_DEPTH || !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_FLOOR, pt ) ) {
             p.add_msg_if_player( _( "You are already landed!" ) );
             return false;
         }
@@ -1397,8 +1398,8 @@ bool vehicle::check_heli_ascend( Character &p ) const
     }
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &pt : get_points( true ) ) {
-        tripoint above( pt.xy(), pt.z + 1 );
+    for( const tripoint_bub_ms &pt : get_points( true ) ) {
+        tripoint_bub_ms above( pt + tripoint_above );
         const optional_vpart_position ovp = here.veh_at( above );
         if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_INDOORS, pt ) ||
             here.impassable_ter_furn( above ) ||
@@ -1412,7 +1413,8 @@ bool vehicle::check_heli_ascend( Character &p ) const
     return true;
 }
 
-void vehicle::pldrive( Character &driver, const point &p, int z )
+// Parameter "turn" changed to "trn" to not clash with operation "turn".
+void vehicle::pldrive( Character &driver, const int trn, const int acceleration, const int z )
 {
     bool is_non_proficient = false;
     float effective_driver_skill = driver.get_skill_level( skill_driving );
@@ -1448,7 +1450,7 @@ void vehicle::pldrive( Character &driver, const point &p, int z )
         driver.set_moves( std::min( driver.get_moves(), 0 ) );
         thrust( 0, z );
     }
-    units::angle turn_delta = vehicles::steer_increment * p.x;
+    units::angle turn_delta = vehicles::steer_increment * trn;
     const float handling_diff = handling_difficulty() + non_prof_penalty;
     if( turn_delta != 0_degrees ) {
         float eff = steering_effectiveness();
@@ -1527,12 +1529,12 @@ void vehicle::pldrive( Character &driver, const point &p, int z )
         driver.mod_moves( -std::max( cost, driver.get_speed() / 3 + 1 ) );
     }
 
-    if( p.y != 0 ) {
-        cruise_thrust( -p.y * 400 );
+    if( acceleration != 0 ) {
+        cruise_thrust( -acceleration * 400 );
     }
 
     // TODO: Actually check if we're on land on water (or disable water-skidding)
-    if( skidding && p.x != 0 && valid_wheel_config() ) {
+    if( skidding && trn != 0 && valid_wheel_config() ) {
         ///\EFFECT_DEX increases chance of regaining control of a vehicle
 
         ///\EFFECT_DRIVING increases chance of regaining control of a vehicle
@@ -1663,7 +1665,7 @@ void vehicle::precalculate_vehicle_turning( units::angle new_turn_dir, bool chec
         const auto &wheel = parts[ part_index ];
         bool rails_ahead = true;
         tripoint_rel_ms wheel_point;
-        coord_translate( mdir.dir(), this->pivot_point_rel(), wheel.mount,
+        coord_translate( mdir.dir(), this->pivot_point(), wheel.mount,
                          wheel_point );
 
         tripoint_bub_ms wheel_tripoint = pos_bub() + wheel_point;
@@ -2024,11 +2026,11 @@ bool vehicle::level_vehicle()
             if( no_support.find( zlevel ) == no_support.end() || !no_support[zlevel] ) {
                 continue;
             }
-            center_drop |= global_pos3().z == zlevel;
+            center_drop |= pos_bub().z() == zlevel;
             adjust_level = true;
             // drop unsupported parts 1 zlevel
             for( size_t prt = 0; prt < parts.size(); prt++ ) {
-                if( global_part_pos3( prt ).z == zlevel ) {
+                if( bub_part_pos( prt ).z() == zlevel ) {
                     dropped_parts.insert( static_cast<int>( prt ) );
                 }
             }
@@ -2090,7 +2092,7 @@ void vehicle::check_falling_or_floating()
     }
     // TODO: Make the vehicle "slide" towards its center of weight
     //  when it's not properly supported
-    const std::set<tripoint> &pts = get_points();
+    const std::set<tripoint_bub_ms> &pts = get_points();
     if( pts.empty() ) {
         // Dirty vehicle with no parts
         is_falling = false;
@@ -2102,13 +2104,13 @@ void vehicle::check_falling_or_floating()
 
     size_t deep_water_tiles = 0;
     size_t water_tiles = 0;
-    for( const tripoint &position : pts ) {
+    for( const tripoint_bub_ms &position : pts ) {
         deep_water_tiles += here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, position ) ? 1 : 0;
         water_tiles += here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, position ) ? 1 : 0;
         if( !is_falling ) {
             continue;
         }
-        is_falling = !has_support( tripoint_bub_ms( position ), true );
+        is_falling = !has_support( position, true );
     }
     // in_deep_water if 2/3 of the vehicle is in deep water
     in_deep_water = 3 * deep_water_tiles >= 2 * pts.size();
@@ -2289,13 +2291,6 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
     return coll_turn;
 }
 
-bool vehicle::should_enable_fake( const tripoint &fake_precalc, const tripoint &parent_precalc,
-                                  const tripoint &neighbor_precalc ) const
-{
-    return vehicle::should_enable_fake( tripoint_rel_ms( fake_precalc ),
-                                        tripoint_rel_ms( parent_precalc ), tripoint_rel_ms( neighbor_precalc ) );
-}
-
 bool vehicle::should_enable_fake( const tripoint_rel_ms &fake_precalc,
                                   const tripoint_rel_ms &parent_precalc,
                                   const tripoint_rel_ms &neighbor_precalc ) const
@@ -2318,7 +2313,7 @@ void vehicle::update_active_fakes()
         const vehicle_part &part_real = parts.at( part_fake.fake_part_to );
         const tripoint_rel_ms &fake_precalc = part_fake.precalc[0];
         const tripoint_rel_ms &real_precalc = part_real.precalc[0];
-        const vpart_edge_info &real_edge = edges[part_real.mount.raw()];
+        const vpart_edge_info &real_edge = edges[part_real.mount];
         const bool is_protrusion = part_real.info().has_flag( "PROTRUSION" );
 
         if( real_edge.forward != -1 ) {

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -555,8 +555,9 @@ void vehicle_part::unset_crew()
 
 void vehicle_part::reset_target( const tripoint_bub_ms &pos )
 {
-    target.first = pos.raw();
-    target.second = pos.raw();
+    const tripoint_abs_ms tgt = get_map().getglobal( pos );
+    target.first = tgt;
+    target.second = tgt;
 }
 
 bool vehicle_part::is_engine() const

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -178,7 +178,7 @@ void vehicle::control_doors()
         const bool open = !vp.open;
         menu.add( string_format( "%s %s", actname, vp.name() ) )
         .hotkey_auto()
-        .location( global_part_pos3( vp ) )
+        .location( bub_part_pos( vp ).raw() )
         .keep_menu_open()
         .on_submit( [this, vp_idx, open] {
             if( can_close( vp_idx, get_player_character() ) )
@@ -197,7 +197,7 @@ void vehicle::control_doors()
         const bool lock = !vp.locked;
         menu.add( string_format( "%s %s", actname, vp.name() ) )
         .hotkey_auto()
-        .location( global_part_pos3( vp ) )
+        .location( bub_part_pos( vp ).raw() )
         .keep_menu_open()
         .on_submit( [this, vp_idx, lock] {
             lock_or_unlock( vp_idx, lock );
@@ -524,7 +524,7 @@ void vehicle::toggle_autopilot()
         autopilot_on = false;
         is_patrolling = false;
         is_following = false;
-        autodrive_local_target = tripoint_zero;
+        autodrive_local_target = tripoint_abs_ms_zero;
         add_msg( _( "You turn the engine off." ) );
         stop_engines();
     } );
@@ -554,7 +554,7 @@ void vehicle::toggle_tracking()
     }
 }
 
-void vehicle::connect( const tripoint &source_pos, const tripoint &target_pos )
+void vehicle::connect( const tripoint_bub_ms &source_pos, const tripoint_bub_ms &target_pos )
 {
     map &here = get_map();
     const optional_vpart_position sel_vp = here.veh_at( target_pos );
@@ -579,8 +579,8 @@ double vehicle::engine_cold_factor( const vehicle_part &vp ) const
         return 0.0;
     }
 
-    const tripoint pos = global_part_pos3( vp );
-    double eff_temp = units::to_fahrenheit( get_weather().get_temperature( pos ) );
+    const tripoint_bub_ms pos = bub_part_pos( vp );
+    double eff_temp = units::to_fahrenheit( get_weather().get_temperature( pos.raw() ) );
     if( !vp.has_fault_flag( "BAD_COLD_START" ) ) {
         eff_temp = std::min( eff_temp, 20.0 );
     }
@@ -653,23 +653,23 @@ bool vehicle::start_engine( vehicle_part &vp )
         }
     }
 
-    if( has_part( player_character.pos(), "NEED_LEG" ) &&
+    if( has_part( player_character.pos_bub(), "NEED_LEG" ) &&
         player_character.get_working_leg_count() < 1 &&
-        !has_part( player_character.pos(), "IGNORE_LEG_REQUIREMENT" ) ) {
+        !has_part( player_character.pos_bub(), "IGNORE_LEG_REQUIREMENT" ) ) {
         add_msg( _( "You need at least one leg to control the %s." ), vp.name() );
         return false;
     }
-    if( has_part( player_character.pos(), "INOPERABLE_SMALL" ) &&
+    if( has_part( player_character.pos_bub(), "INOPERABLE_SMALL" ) &&
         ( player_character.get_size() == creature_size::small ||
           player_character.get_size() == creature_size::tiny ) &&
-        !has_part( player_character.pos(), "IGNORE_HEIGHT_REQUIREMENT" ) ) {
+        !has_part( player_character.pos_bub(), "IGNORE_HEIGHT_REQUIREMENT" ) ) {
         add_msg( _( "You are too short to reach the pedals!" ) );
         return false;
     }
 
     const double dmg = vp.damage_percent();
     const time_duration start_time = engine_start_time( vp );
-    const tripoint pos = global_part_pos3( vp );
+    const tripoint_bub_ms pos = bub_part_pos( vp );
 
     if( ( 1 - dmg ) < vpi.engine_info->backfire_threshold &&
         one_in( vpi.engine_info->backfire_freq ) ) {
@@ -754,7 +754,7 @@ void vehicle::stop_engines()
             continue;
         }
 
-        sounds::sound( global_part_pos3( vp ), 2, sounds::sound_t::movement, _( "the engine go silent" ) );
+        sounds::sound( bub_part_pos( vp ), 2, sounds::sound_t::movement, _( "the engine go silent" ) );
 
         std::string variant = vp.info().id.str();
 
@@ -830,7 +830,7 @@ void vehicle::enable_patrol()
 {
     is_patrolling = true;
     autopilot_on = true;
-    autodrive_local_target = tripoint_zero;
+    autodrive_local_target = tripoint_abs_ms_zero;
     if( !engine_on ) {
         start_engines();
     }
@@ -874,7 +874,7 @@ void vehicle::honk_horn() const
     }
 }
 
-void vehicle::reload_seeds( const tripoint &pos )
+void vehicle::reload_seeds( const tripoint_bub_ms &pos )
 {
     Character &player_character = get_player_character();
     std::vector<item *> seed_inv = player_character.cache_get_items_with( "is_seed", &item::is_seed );
@@ -1171,7 +1171,7 @@ void vehicle::alarm()
                     _( "WHOOP WHOOP" ), _( "NEEeu NEEeu NEEeu" ), _( "BLEEEEEEP" ), _( "WREEP" )
                 }
             };
-            sounds::sound( global_pos3(), static_cast<int>( rng( 45, 80 ) ),
+            sounds::sound( pos_bub(), static_cast<int>( rng( 45, 80 ) ),
                            sounds::sound_t::alarm,  random_entry_ref( sound_msgs ), false, "vehicle", "car_alarm" );
             if( one_in( 1000 ) ) {
                 is_alarm_on = false;
@@ -1258,7 +1258,7 @@ bool vehicle::can_close( int part_index, Character &who )
         for( int partID : vec ) {
             // Check the part for collisions, then if there's a fake part present check that too.
             while( partID >= 0 ) {
-                const Creature *const mon = creatures.creature_at( global_part_pos3( parts[partID] ) );
+                const Creature *const mon = creatures.creature_at( bub_part_pos( parts[partID] ) );
                 if( mon ) {
                     if( mon->is_avatar() ) {
                         who.add_msg_if_player( m_info, _( "There's some buffoon in the way!" ) );
@@ -1551,13 +1551,13 @@ void vehicle::use_dishwasher( int p )
     }
 }
 
-void vehicle::use_monster_capture( int part, const tripoint &pos )
+void vehicle::use_monster_capture( int part, const tripoint_bub_ms &pos )
 {
     if( parts[part].is_broken() || parts[part].removed ) {
         return;
     }
     item base = item( parts[part].get_base() );
-    base.type->invoke( &get_avatar(), base, pos );
+    base.type->invoke( &get_avatar(), base, pos.raw() );
     if( base.has_var( "contained_name" ) ) {
         parts[part].set_flag( vp_flag::animal_flag );
     } else {
@@ -1567,7 +1567,7 @@ void vehicle::use_monster_capture( int part, const tripoint &pos )
     invalidate_mass();
 }
 
-void vehicle::use_harness( int part, const tripoint &pos )
+void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
 {
     const vehicle_part &vp = parts[part];
     const vpart_info &vpi = vp.info();
@@ -2016,14 +2016,14 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         } );
     }
 
-    const turret_data turret = turret_query( vp.pos() );
+    const turret_data turret = turret_query( vp.pos_bub() );
 
     if( turret.can_unload() ) {
         menu.add( string_format( _( "Unload %s" ), turret.name() ) )
         .hotkey( "UNLOAD_TURRET" )
         .skip_locked_check()
         .on_submit( [this, vppos] {
-            item_location loc = turret_query( vppos.raw() ).base();
+            item_location loc = turret_query( vppos ).base();
             get_player_character().unload( loc );
         } );
     }
@@ -2033,7 +2033,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .hotkey( "RELOAD_TURRET" )
         .skip_locked_check()
         .on_submit( [this, vppos] {
-            item_location loc = turret_query( vppos.raw() ).base();
+            item_location loc = turret_query( vppos ).base();
             item::reload_option opt = get_player_character().select_ammo( loc, true );
             if( opt )
             {
@@ -2297,7 +2297,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         const size_t mc_idx = vp_monster_capture->part_index();
         menu.add( _( "Capture or release a creature" ) )
         .hotkey( "USE_CAPTURE_MONSTER_VEH" )
-        .on_submit( [this, mc_idx, vppos] { use_monster_capture( mc_idx, vppos.raw() ); } );
+        .on_submit( [this, mc_idx, vppos] { use_monster_capture( mc_idx, vppos ); } );
     }
 
     const std::optional<vpart_reference> vp_bike_rack = vp.avail_part_with_feature( "BIKE_RACK_VEH" );
@@ -2310,13 +2310,13 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         const size_t hn_idx = vp_harness->part_index();
         menu.add( _( "Harness an animal" ) )
         .hotkey( "USE_ANIMAL_CTRL" )
-        .on_submit( [this, hn_idx, vppos] { use_harness( hn_idx, vppos.raw() ); } );
+        .on_submit( [this, hn_idx, vppos] { use_harness( hn_idx, vppos ); } );
     }
 
     if( vp.avail_part_with_feature( "PLANTER" ) ) {
         menu.add( _( "Reload seed drill with seeds" ) )
         .hotkey( "USE_PLANTER" )
-        .on_submit( [this, vppos] { reload_seeds( vppos.raw() ); } );
+        .on_submit( [this, vppos] { reload_seeds( vppos ); } );
     }
 
     const std::optional<vpart_reference> vp_workbench = vp.avail_part_with_feature( "WORKBENCH" );
@@ -2430,11 +2430,6 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
             } );
         }
     }
-}
-
-void vehicle::interact_with( const tripoint &p, bool with_pickup )
-{
-    vehicle::interact_with( tripoint_bub_ms( p ), with_pickup );
 }
 
 void vehicle::interact_with( const tripoint_bub_ms &p, bool with_pickup )

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -2327,7 +2327,7 @@ TEST_CASE( "pseudo_tools_in_crafting_inventory", "[crafting][tools]" )
                 CHECK( player.crafting_inventory().charges_of( itype_water ) == 0 );
             }
             WHEN( "the vehicle has a water faucet part" ) {
-                REQUIRE( veh->install_part( point_zero, vpart_water_faucet ) >= 0 );
+                REQUIRE( veh->install_part( point_rel_ms_zero, vpart_water_faucet ) >= 0 );
                 THEN( "crafting inventory contains the liquid" ) {
                     player.invalidate_crafting_inventory();
                     CHECK( player.crafting_inventory().count_item( itype_water_faucet ) == 1 );
@@ -2335,7 +2335,7 @@ TEST_CASE( "pseudo_tools_in_crafting_inventory", "[crafting][tools]" )
                 }
             }
             WHEN( "the vehicle has two water faucets" ) {
-                REQUIRE( veh->install_part( point_south, vpart_water_faucet ) >= 0 );
+                REQUIRE( veh->install_part( point_rel_ms_south, vpart_water_faucet ) >= 0 );
                 THEN( "crafting inventory contains the liquid" ) {
                     player.invalidate_crafting_inventory();
                     CHECK( player.crafting_inventory().count_item( itype_water_faucet ) == 1 );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -473,8 +473,8 @@ TEST_CASE( "npc-movement" )
             if( type == 'V' || type == 'W' || type == 'M' ) {
                 vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 270_degrees, 0, 0 );
                 REQUIRE( veh != nullptr );
-                veh->install_part( point_zero, vpart_frame );
-                veh->install_part( point_zero, vpart_seat );
+                veh->install_part( point_rel_ms_zero, vpart_frame );
+                veh->install_part( point_rel_ms_zero, vpart_seat );
                 here.add_vehicle_to_cache( veh );
             }
             // spawn npcs

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -231,7 +231,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
         veh.idle( true );
         // If the vehicle starts skidding, the effects become random and test is RUINED
         REQUIRE( !veh.skidding );
-        for( const tripoint &pos : veh.get_points() ) {
+        for( const tripoint_bub_ms &pos : veh.get_points() ) {
             REQUIRE( here.ter( pos ) );
         }
         // How much it moved

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -211,14 +211,14 @@ TEST_CASE( "vehicle_collision_applies_damage_to_fake_parent", "[vehicle] [vehicl
         WHEN( "A bashable object is placed in the vehicle's path such that it will hit a fake part" ) {
             // we know the mount point of the front right headlight is 2,2
             // that places it's fake mirror at 2,3
-            const point fake_r_hl( 2, 3 );
-            tripoint fake_front_right_headlight = veh->mount_to_tripoint( fake_r_hl );
+            const point_rel_ms fake_r_hl( 2, 3 );
+            tripoint_bub_ms fake_front_right_headlight = veh->mount_to_tripoint( fake_r_hl );
             // we're travelling south east, so placing it SE of the fake headlight mirror
             // will impact it on next move
-            tripoint obstacle_point = fake_front_right_headlight + tripoint_south_east;
+            tripoint_bub_ms obstacle_point = fake_front_right_headlight + tripoint_south_east;
             here.furn_set( obstacle_point.xy(), furn_id( "f_boulder_large" ) );
 
-            int part_count = veh->parts_at_relative( point( 2, 2 ), true, false ).size();
+            int part_count = veh->parts_at_relative( point_rel_ms( 2, 2 ), true, false ).size();
             THEN( "The collision damage is applied to the fake's parent" ) {
                 here.vehmove();
                 std::vector<int> damaged_parts;
@@ -226,14 +226,14 @@ TEST_CASE( "vehicle_collision_applies_damage_to_fake_parent", "[vehicle] [vehicl
                 // hitting the boulder should have slowed the vehicle down
                 REQUIRE( veh->velocity < target_velocity );
 
-                std::vector<int> parent_parts = veh->parts_at_relative( point( 2, 2 ), true, false );
+                std::vector<int> parent_parts = veh->parts_at_relative( point_rel_ms( 2, 2 ), true, false );
                 for( int rel : parent_parts ) {
                     vehicle_part &vp = veh->part( rel );
                     if( vp.info().durability > vp.hp() ) {
                         damaged_parts.push_back( rel );
                     }
                 }
-                for( int rel : veh->parts_at_relative( point( 2, 3 ), true, false ) ) {
+                for( int rel : veh->parts_at_relative( point_rel_ms( 2, 3 ), true, false ) ) {
                     vehicle_part &vp = veh->part( rel );
                     if( vp.info().durability > vp.hp() ) {
                         damaged_fake_parts.push_back( rel );
@@ -258,7 +258,7 @@ TEST_CASE( "vehicle_to_vehicle_collision", "[vehicle] [vehicle_fake]" )
         const tripoint_bub_ms test_origin( 30, 30, 0 );
         vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 30_degrees, 100, 0 );
         REQUIRE( veh != nullptr );
-        const tripoint global_origin = veh->global_pos3();
+        const tripoint_bub_ms global_origin = veh->pos_bub();
 
         veh->tags.insert( "IN_CONTROL_OVERRIDE" );
         veh->engine_on = true;
@@ -266,7 +266,7 @@ TEST_CASE( "vehicle_to_vehicle_collision", "[vehicle] [vehicle_fake]" )
         veh->cruise_velocity = target_velocity;
         veh->velocity = veh->cruise_velocity;
         here.vehmove();
-        const tripoint global_move = veh->global_pos3();
+        const tripoint_bub_ms global_move = veh->pos_bub();
         const tripoint_bub_ms obstacle_point = test_origin + 2 * ( global_move - global_origin );
         vehicle *trg = here.add_vehicle( vehicle_prototype_schoolbus, obstacle_point, 90_degrees, 100, 0 );
         REQUIRE( trg != nullptr );

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -70,8 +70,8 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
 
         point vcoords = source_vp->mount();
         vehicle_part source_part( vpid, item( cord ) );
-        source_part.target.first = target_global.raw();
-        source_part.target.second = target_veh->global_square_location().raw();
+        source_part.target.first = target_global;
+        source_part.target.second = target_veh->global_square_location();
         source_veh->install_part( vcoords, std::move( source_part ) );
 
         vcoords = target_vp->mount();
@@ -79,8 +79,8 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
         tripoint_bub_ms source_global( cord.get_var( "source_x", 0 ),
                                        cord.get_var( "source_y", 0 ),
                                        cord.get_var( "source_z", 0 ) );
-        target_part.target.first = here.getglobal( source_global ).raw();
-        target_part.target.second = source_veh->global_square_location().raw();
+        target_part.target.first = here.getglobal( source_global );
+        target_part.target.second = source_veh->global_square_location();
         target_veh->install_part( vcoords, std::move( target_part ) );
     };
 
@@ -90,9 +90,9 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
         REQUIRE( !here.veh_at( p ).has_value() );
         vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 0_degrees, 0, 0 );
         REQUIRE( veh != nullptr );
-        const int frame_part_idx = veh->install_part( point_zero, vpart_frame );
+        const int frame_part_idx = veh->install_part( point_rel_ms_zero, vpart_frame );
         REQUIRE( frame_part_idx != -1 );
-        const int bat_part_idx = veh->install_part( point_zero, vpart_small_storage_battery );
+        const int bat_part_idx = veh->install_part( point_rel_ms_zero, vpart_small_storage_battery );
         REQUIRE( bat_part_idx != -1 );
         veh->refresh();
         here.add_vehicle_to_cache( veh );

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -132,14 +132,14 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
     int cycles = 0;
     const int target_z = use_ramp ? ( up ? 1 : -1 ) : 0;
 
-    std::set<tripoint> vpts = veh.get_points();
+    std::set<tripoint_bub_ms> vpts = veh.get_points();
     while( veh.engine_on && veh.safe_velocity() > 0 && cycles < 10 ) {
         clear_creatures();
         CAPTURE( cycles );
-        for( const tripoint &checkpt : vpts ) {
+        for( const tripoint_bub_ms &checkpt : vpts ) {
             int partnum = 0;
-            vehicle *check_veh = here.veh_at_internal( tripoint_bub_ms( checkpt ), partnum );
-            CAPTURE( veh_ptr->global_pos3() );
+            vehicle *check_veh = here.veh_at_internal( checkpt, partnum );
+            CAPTURE( veh_ptr->pos_bub() );
             CAPTURE( veh_ptr->face.dir() );
             CAPTURE( checkpt );
             CHECK( check_veh == veh_ptr );
@@ -149,7 +149,7 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
         CHECK( veh.velocity == target_velocity );
         // If the vehicle starts skidding, the effects become random and test is RUINED
         REQUIRE( !veh.skidding );
-        for( const tripoint &pos : veh.get_points() ) {
+        for( const tripoint_bub_ms &pos : veh.get_points() ) {
             REQUIRE( here.ter( pos ) );
         }
         for( const vpart_reference &vp : veh.get_all_parts() ) {
@@ -266,7 +266,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
     CHECK( veh.safe_velocity() > 0 );
 
     std::vector<vehicle_part *> all_parts;
-    for( const tripoint &pos : veh.get_points() ) {
+    for( const tripoint_bub_ms &pos : veh.get_points() ) {
         for( vehicle_part *prt : veh.get_parts_at( pos, "", part_status_flag::any ) ) {
             all_parts.push_back( prt );
             if( drop_pos && prt->mount.x() < 0 ) {
@@ -280,7 +280,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
     }
     std::set<int> z_span;
     for( vehicle_part *prt : all_parts ) {
-        z_span.insert( veh.global_part_pos3( *prt ).z );
+        z_span.insert( veh.bub_part_pos( *prt ).z() );
     }
     REQUIRE( z_span.size() > 1 );
 
@@ -306,10 +306,10 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
 
     here.vehmove();
     for( vehicle_part *prt : all_parts ) {
-        CHECK( veh.global_part_pos3( *prt ).z == 0 );
+        CHECK( veh.bub_part_pos( *prt ).z() == 0 );
     }
     CHECK( dmon.posz() == 0 );
-    CHECK( veh.global_pos3().z == 0 );
+    CHECK( veh.pos_bub().z() == 0 );
 }
 
 static void test_leveling( const std::string &type )

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -29,7 +29,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_cross_split_test,
                                              vehicle_origin, dir, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        std::set<tripoint> original_points = veh_ptr->get_points( true );
+        std::set<tripoint_bub_ms> original_points = veh_ptr->get_points( true );
 
         here.destroy( vehicle_origin );
         veh_ptr->part_removal_cleanup();
@@ -43,21 +43,21 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
             CHECK( vehs[1].v->part_count() == 12 );
             CHECK( vehs[2].v->part_count() == 2 );
             CHECK( vehs[3].v->part_count() == 3 );
-            std::vector<std::set<tripoint>> all_points;
+            std::vector<std::set<tripoint_bub_ms>> all_points;
             for( int i = 0; i < 4; i++ ) {
-                const std::set<tripoint> &veh_points = vehs[i].v->get_points( true );
+                const std::set<tripoint_bub_ms> &veh_points = vehs[i].v->get_points( true );
                 all_points.push_back( veh_points );
             }
             for( int i = 0; i < 4; i++ ) {
-                std::set<tripoint> &veh_points = all_points[i];
+                std::set<tripoint_bub_ms> &veh_points = all_points[i];
                 // every point in the new vehicle was in the old vehicle
-                for( const tripoint &vpos : veh_points ) {
+                for( const tripoint_bub_ms &vpos : veh_points ) {
                     CHECK( original_points.find( vpos ) != original_points.end() );
                 }
                 // no point in any new vehicle is in any other new vehicle
                 for( int j = i + 1; j < 4; j++ ) {
-                    std::set<tripoint> &other_points = all_points[j];
-                    for( const tripoint &vpos : veh_points ) {
+                    std::set<tripoint_bub_ms> &other_points = all_points[j];
+                    for( const tripoint_bub_ms &vpos : veh_points ) {
                         CHECK( other_points.find( vpos ) == other_points.end() );
                     }
                 }

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -334,7 +334,7 @@ static void check_folded_item_to_parts_damage_transfer( const folded_item_damage
 
     // don't actually need point_north but damage_all filters out direct damage
     // do some damage so it is transferred when folding
-    ovp->vehicle().damage_all( 100, 100, damage_pure, ovp->mount() + point_north );
+    ovp->vehicle().damage_all( 100, 100, damage_pure, ovp->mount() + point_rel_ms_north );
 
     // fold vehicle into an item
     complete_activity( u, vehicle_folding_activity_actor( ovp->vehicle() ) );
@@ -563,7 +563,7 @@ struct rack_activation {
 struct rack_preset {
     std::vector<vproto_id> vehicles;            // vehicles to spawn, index matching positions/facings
     std::vector<tripoint_bub_ms> positions;     // spawned vehicle position
-    std::vector<point_bub_ms> install_racks;    // install racks on first vehicle at these mounts
+    std::vector<point_rel_ms> install_racks;    // install racks on first vehicle at these mounts
     std::vector<units::angle> facings;          // spawned vehicle facing
     std::vector<rack_activation> rack_orders;   // racking orders
     std::vector<rack_activation> unrack_orders; // unracking orders
@@ -594,8 +594,8 @@ static void rack_check( const rack_preset &preset )
         veh_names.push_back( veh_ptr->name );
     }
 
-    for( const point_bub_ms &rack_pos : preset.install_racks ) {
-        vehs[0]->install_part( rack_pos.raw(), vpart_bike_rack );
+    for( const point_rel_ms &rack_pos : preset.install_racks ) {
+        vehs[0]->install_part( rack_pos, vpart_bike_rack );
     }
 
     for( const rack_activation &rack_act : preset.rack_orders ) {
@@ -604,7 +604,7 @@ static void rack_check( const rack_preset &preset )
         vehicle &racking_veh = *vehs[rack_act.racking_vehicle_index];
         vehicle &racked_veh = *vehs[rack_act.racked_vehicle_index];
 
-        const std::vector<vehicle_part *> rack_parts = racking_veh.get_parts_at( rack_act.rack_pos.raw(),
+        const std::vector<vehicle_part *> rack_parts = racking_veh.get_parts_at( rack_act.rack_pos,
                 "BIKE_RACK_VEH",
                 part_status_flag::available );
         REQUIRE( rack_parts.size() == 1 );
@@ -695,7 +695,7 @@ TEST_CASE( "Racking_and_unracking_tests", "[vehicle][bikerack]" )
         {
             { vehicle_prototype_car, vehicle_prototype_bicycle },
             { tripoint_bub_ms_zero,         tripoint_bub_ms( -4, 0, 0 ) },
-            { point_bub_ms( -3, -1 ), point_bub_ms( -3, 0 ), point_bub_ms( -3, 1 ), point_bub_ms( -3, 2 ) },
+            { { -3, -1 }, { -3, 0}, { -3, 1}, { -3, 2}},
             { 0_degrees,             90_degrees },
 
             { { 0, tripoint_bub_ms( -3, -1, 0 ), 1, false } }, // rack bicycle to car
@@ -706,7 +706,7 @@ TEST_CASE( "Racking_and_unracking_tests", "[vehicle][bikerack]" )
         {
             { vehicle_prototype_car, vehicle_prototype_wheelchair, vehicle_prototype_wheelchair },
             { tripoint_bub_ms_zero,         tripoint_bub_ms( -4, 0, 0 ),         tripoint_bub_ms( -4, 1, 0 )         },
-            { point_bub_ms( -3, -1 ), point_bub_ms( -3, 0 ), point_bub_ms( -3, 1 ), point_bub_ms( -3, 2 ) },
+            { { -3, -1 }, { -3, 0}, { -3, 1}, { -3, 2}},
             { 0_degrees,             0_degrees,                    0_degrees                    },
 
             // rack both wheelchairs to car, second rack activation should fail with debugmsg

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             REQUIRE( veh );
             veh->unlock();
 
-            const int turr_idx = veh->install_part( point_zero, turret_vpi->id );
+            const int turr_idx = veh->install_part( point_rel_ms_zero, turret_vpi->id );
             REQUIRE( turr_idx >= 0 );
             vehicle_part &vp = veh->part( turr_idx );
             CHECK( vp.is_turret() );
@@ -96,7 +96,7 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             REQUIRE( qry.query() == turret_data::status::ready );
             REQUIRE( qry.range() > 0 );
 
-            player_character.setpos( veh->global_part_pos3( vp ) );
+            player_character.setpos( veh->bub_part_pos( vp ) );
             int shots_fired = 0;
             // 3 attempts to fire, to account for possible misfires
             for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -929,11 +929,11 @@ TEST_CASE( "vision_vehicle_camera_skew", "[shadowcasting][vision][vehicle][vehic
 
     auto const fiddle_parts = [&]() {
         if( fiddle > 0 ) {
-            std::vector<vehicle_part *> const horns = v->get_parts_at( v->global_pos3(), "HORN", {} );
+            std::vector<vehicle_part *> const horns = v->get_parts_at( v->pos_bub(), "HORN", {} );
             v->remove_part( *horns.front() );
         }
         if( fiddle > 1 ) {
-            REQUIRE( v->install_part( point_zero, vpart_inboard_mirror ) != -1 );
+            REQUIRE( v->install_part( point_rel_ms_zero, vpart_inboard_mirror ) != -1 );
         }
         if( fiddle > 0 ) {
             get_map().add_vehicle_to_cache( v );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Another step on the path to use typed coordinates, this time focusing on vehicle.h and dependents.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Continue from where the previous PR left off to:
Change untyped coordinate fields and operation parameter/results into appropriate typed ones, converting reasonably easy usages and removing orphaned untyped operations.
There should be no functional changes.

Also split a "point" parameter used to hide turn direction + acceleration into its parts in a couple of operations so it's actually possible to understand what the parameters are. It can be noted that one of the users of this seems to use the same practice, but dealing with that was considered out of scope.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded a save, walked up a ramp, jumped into a car, drove through some hay bales (which are no longer reinforced), missed zombie corpses, but ran over a turkey and smashed into a stationary vehicle. Nothing odd seen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There was one untyped element of vehicle that was used to store both absolute coordinates (for item use) and bubble coordinates (for turret use). I settled on absolute coordinates, as that's the one that won't break with a change of bubble references, and converted the bubble usage to convert to/from absolute. Presumably the two usages don't overlap, but I wouldn't bet on what happens if a cannon engages while your doing whatever the item stuff does.

It's not that much left of the vehicle header after this pass. The next one will probably deal with that and start with the implementation. Vehicle parts have a bunch of annoying untyped fields blocking some conversion, so that's probably the next target after the vehicle implementation has been dealt with, but it's unlikely that will being in the next PR.

Given that this touches a lot of files, there's definitely a merge conflict risk merging this PR concurrently with others, so that should probably be avoided.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
