### PR TITLE
Don't apply parkour bonus when moving prone

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10215,7 +10215,7 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
                               1 );
         run_cost_effect_mul( obstacle_mult, _( "Obstacle Muts." ) );
 
-        if( has_proficiency( proficiency_prof_parkour ) ) {
+        if( has_proficiency( proficiency_prof_parkour ) && !is_prone() ) {
             run_cost_effect_mul( 0.5, _( "Parkour" ) );
         }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Don't apply parkour bonus when moving prone"

#### Purpose of change
Parkour is about walking and running, not about moving prone.

#### Describe the solution
Added check for being prone in `Character::run_cost_effects`.

#### Describe alternatives you've considered
Also add a check for moving crouched. 

#### Testing
Changed move mode to prone. Moved over the bench in starting evac shelter. Checked that move cost is 750.
Get parkour expert proficiency. Moved over the same bench. Checked that move cost is still 750.

#### Additional context
None.