### PR TITLE
Add optional message to display when choosing map point

### DIFF
--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -744,7 +744,8 @@ void computer_session::action_miss_disarm()
 void computer_session::action_miss_launch()
 {
     // Target Acquisition.
-    const tripoint_abs_omt target( ui::omap::choose_point( 0 ) );
+    const tripoint_abs_omt target( ui::omap::choose_point(
+                                       _( "Choose a target for the nuclear missile." ), 0 ) );
     if( target == overmap::invalid_tripoint ) {
         add_msg( m_info, _( "Target acquisition canceled." ) );
         return;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1752,7 +1752,8 @@ static void teleport_short()
 
 static void teleport_long()
 {
-    const tripoint_abs_omt where( ui::omap::choose_point( true ) );
+    const tripoint_abs_omt where( ui::omap::choose_point( _( "Choose a teleport destination." ),
+                                  true ) );
     if( where == overmap::invalid_tripoint ) {
         return;
     }
@@ -3526,7 +3527,8 @@ static void map_extra()
     mx_menu.query();
     int mx_choice = mx_menu.ret;
     if( mx_choice >= 0 && mx_choice < static_cast<int>( mx_str.size() ) ) {
-        const tripoint_abs_omt where_omt( ui::omap::choose_point( true ) );
+        const tripoint_abs_omt where_omt( ui::omap::choose_point(
+                                              _( "Select location to spawn map extra." ), true ) );
         if( where_omt != overmap::invalid_tripoint ) {
             smallmap mx_map;
             mx_map.load( where_omt, false );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -285,9 +285,8 @@ static tripoint_abs_omt om_target_tile(
     const tripoint_abs_omt &omt_pos, int min_range = 1, int range = 1,
     const std::vector<std::string> &possible_om_types = {}, ot_match_type match_type =
         ot_match_type::exact, bool must_see = true,
-    bool popup_notice = true,
     const tripoint_abs_omt &source = tripoint_abs_omt( -999, -999, -999 ),
-    bool bounce = false );
+    bool bounce = false, const std::optional<std::string> &message = std::nullopt );
 static void om_range_mark( const tripoint_abs_omt &origin, int range, bool add_notes = true,
                            const std::string &message = "Y;X: MAX RANGE" );
 static void om_line_mark(
@@ -968,7 +967,8 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
         const mission_id miss_id = { Camp_Clearcut, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
-                                  "Send a companion to clear a nearby forest.\n\n"
+                                  "Send a companion to clear a nearby forest.\n"
+                                  "Note that it's likely both forest and field roads look exactly the same after having been cleared.\n\n"
                                   "Skill used: fabrication\n"
                                   "Difficulty: 1\n"
                                   "Effects:\n"
@@ -2582,8 +2582,8 @@ void basecamp::start_cut_logs( const mission_id &miss_id, float exertion_level )
     std::vector<std::string> log_sources = { "forest", "forest_thick", "forest_trail", "rural_road_forest", "rural_road_turn_forest", "rural_road_turn1_forest", "rural_road_3way_forest",
                                              "dirt_road_forest", "dirt_road_3way_forest", "dirt_road_turn_forest", "forest_trail_intersection", "special_forest", "special_forest_thick", "forest_trail_isolated", "forest_trail_end"
                                            };
-    popup( _( "Forests are the only valid cutting locations, with forest dirt roads, forest rural roads, and trails being valid as well.  Note that it's likely both forest and field roads look exactly the same after having been cleared." ) );
-    tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, log_sources, ot_match_type::type );
+    tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, log_sources, ot_match_type::type,
+                              _( "Select a forest (or road/trail) from %d to %d tiles away." ) );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         standard_npc sample_npc( "Temp" );
         sample_npc.set_fake( true );
@@ -2656,9 +2656,9 @@ void basecamp::start_setup_hide_site( const mission_id &miss_id, float exertion_
     std::vector<std::string> hide_locations = { "forest", "forest_thick", "forest_water", "forest_trail"
                                                 "field"
                                               };
-    popup( _( "Forests, swamps, and fields are valid hide site locations." ) );
-    tripoint_abs_omt forest = om_target_tile( omt_pos, 10, 90, hide_locations, ot_match_type::type,
-                              true, true, omt_pos, true );
+    tripoint_abs_omt forest = om_target_tile( omt_pos, 10, 90, hide_locations,
+                              ot_match_type::type,
+                              true, omt_pos, true, _( "Select an forest, swamp, or field from %d to %d tiles away." ) );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         int dist = rl_dist( forest.xy(), omt_pos.xy() );
         Character *pc = &get_player_character();
@@ -2703,9 +2703,9 @@ static const tripoint_omt_ms relay_site_stash{ 11, 10, 0 };
 void basecamp::start_relay_hide_site( const mission_id &miss_id, float exertion_level )
 {
     std::vector<std::string> hide_locations = { faction_hide_site_0_string };
-    popup( _( "You must select an existing hide site." ) );
     tripoint_abs_omt forest = om_target_tile( omt_pos, 10, 90, hide_locations, ot_match_type::exact,
-                              true, true, omt_pos, true );
+                              true, omt_pos, true, string_format(
+                                  _( "Select an existing hide site from %d to %d tiles away." ), 10, 90 ) );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         int dist = rl_dist( forest.xy(), omt_pos.xy() );
         Character *pc = &get_player_character();
@@ -2833,10 +2833,11 @@ void basecamp::start_fortifications( const mission_id &miss_id, float exertion_l
     popup( _( "Select a start and end point.  Line must be straight.  Fields, forests, and "
               "swamps are valid fortification locations.  In addition to existing fortification "
               "constructions." ) );
-    tripoint_abs_omt start = om_target_tile( omt_pos, 2, 90, allowed_locations, ot_match_type::type );
-    popup( _( "Select an end point." ) );
-    tripoint_abs_omt stop = om_target_tile( omt_pos, 2, 90, allowed_locations, ot_match_type::type,
-                                            true, false, start );
+    tripoint_abs_omt start = om_target_tile( omt_pos, 2, 90, allowed_locations,
+                             ot_match_type::type, true, omt_pos, _( "Select a start point from %d to %d tiles away." ) );
+    tripoint_abs_omt stop = om_target_tile( omt_pos, 2, 90, allowed_locations,
+                                            ot_match_type::type,
+                                            true, start, _( "Select an end point from %d to %d tiles away." ) );
     if( start != tripoint_abs_omt( -999, -999, -999 ) &&
         stop != tripoint_abs_omt( -999, -999, -999 ) ) {
         const recipe &making = recipe_id( miss_id.parameters ).obj();
@@ -4486,12 +4487,12 @@ bool basecamp::survey_field_return( const mission_id &miss_id )
         return false;
     }
 
-    popup( _( "Select a tile up to %d tiles away." ), 1 );
 
     tripoint_abs_omt where( get_player_character().global_omt_location() );
 
     while( true ) {
-        where = ui::omap::choose_point( where );
+        where = ui::omap::choose_point( string_format(
+                                            _( "Select a tile up to %d tiles away." ), 1 ) );
         if( where == overmap::invalid_tripoint ) {
             return false;
         }
@@ -4568,12 +4569,12 @@ bool basecamp::survey_return( const mission_id &miss_id )
         return false;
     }
 
-    popup( _( "Select a tile up to %d tiles away." ), 1 );
 
     tripoint_abs_omt where( get_player_character().global_omt_location() );
 
     while( true ) {
-        where = ui::omap::choose_point( where );
+        where = ui::omap::choose_point( string_format(
+                                            _( "Select a tile up to %d tiles away." ), 1 ) );
         if( where == overmap::invalid_tripoint ) {
             return false;
         }
@@ -4984,22 +4985,20 @@ mass_volume om_harvest_itm( const npc_ptr &comp, const tripoint_abs_omt &omt_tgt
 
 tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range, int range,
                                  const std::vector<std::string> &possible_om_types, ot_match_type match_type, bool must_see,
-                                 bool popup_notice, const tripoint_abs_omt &source, bool bounce )
+                                 const tripoint_abs_omt &source, bool bounce, const std::optional<std::string> &message )
 {
     bool errors = false;
-    if( popup_notice ) {
-        popup( _( "Select a location between  %d and  %d tiles away." ), min_range, range );
-    }
-
     std::vector<std::string> bounce_locations = { faction_hide_site_0_string };
 
     tripoint_abs_omt where;
     om_range_mark( omt_pos, range );
     om_range_mark( omt_pos, min_range, true, "Y;X: MIN RANGE" );
+    const std::string &real_message = string_format(
+                                          message ? *message : _( "Select a location from %d to %d tiles away." ), min_range, range );
     if( source == tripoint_abs_omt( -999, -999, -999 ) ) {
-        where = ui::omap::choose_point();
+        where = ui::omap::choose_point( real_message );
     } else {
-        where = ui::omap::choose_point( source );
+        where = ui::omap::choose_point( real_message, source );
     }
     om_range_mark( omt_pos, range, false );
     om_range_mark( omt_pos, min_range, false, "Y;X: MIN RANGE" );
@@ -5009,7 +5008,7 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
     }
     int dist = rl_dist( where.xy(), omt_pos.xy() );
     if( dist > range || dist < min_range ) {
-        popup( _( "You must select a target between %d and %d range from the base.  Range: %d" ),
+        popup( _( "You must select a target from %d to %d range.  Your selection was range %d." ),
                min_range, range, dist );
         errors = true;
     }
@@ -5029,7 +5028,7 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
                 if( query_yn( _( "Do you want to bounce off this location to extend range?" ) ) ) {
                     om_line_mark( omt_pos, omt_tgt );
                     tripoint_abs_omt dest =
-                        om_target_tile( omt_tgt, 2, range * .75, possible_om_types, match_type, true, false,
+                        om_target_tile( omt_tgt, 2, range * .75, possible_om_types, match_type, true,
                                         omt_tgt, true );
                     om_line_mark( omt_pos, omt_tgt, false );
                     return dest;
@@ -5048,7 +5047,8 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
         }
     }
 
-    return om_target_tile( omt_pos, min_range, range, possible_om_types, match_type );
+    return om_target_tile( omt_pos, min_range, range, possible_om_types, match_type, must_see,
+                           omt_pos );
 }
 
 void om_range_mark( const tripoint_abs_omt &origin, int range, bool add_notes,
@@ -5221,7 +5221,7 @@ std::vector<tripoint_abs_omt> om_companion_path( const tripoint_abs_omt &start, 
     int range = range_start;
     int def_range = range_start;
     while( range > 3 ) {
-        tripoint_abs_omt spt = om_target_tile( last, 0, range, {}, ot_match_type::exact, false, true, last,
+        tripoint_abs_omt spt = om_target_tile( last, 0, range, {}, ot_match_type::exact, false, last,
                                                false );
         if( spt == tripoint_abs_omt( -999, -999, -999 ) ) {
             scout_points.clear();

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -854,6 +854,10 @@ static void draw_ascii(
 
     std::vector<std::pair<nc_color, std::string>> corner_text;
 
+    if( !data.message.empty() ) {
+        corner_text.emplace_back( c_white, data.message );
+    }
+
     if( uistate.overmap_show_map_notes ) {
         const std::string &note_text = overmap_buffer.note( cursor_pos );
         if( !note_text.empty() ) {
@@ -1702,8 +1706,8 @@ static void modify_horde_func( tripoint_abs_omt &curs )
             chosen_group.set_interest( new_value );
             break;
         case 1:
-            popup( _( "Select a target destination for the horde." ) );
-            horde_destination = ui::omap::choose_point( true );
+            horde_destination = ui::omap::choose_point( _( "Select a target destination for the horde." ),
+                                true );
             if( horde_destination == overmap::invalid_tripoint || horde_destination == tripoint_abs_omt_zero ) {
                 break;
             }
@@ -2496,30 +2500,26 @@ void ui::omap::display_zones( const tripoint_abs_omt &center, const tripoint_abs
     overmap_ui::display();
 }
 
-tripoint_abs_omt ui::omap::choose_point( bool show_debug_info )
+tripoint_abs_omt ui::omap::choose_point( const std::string &message, bool show_debug_info )
 {
-    g->overmap_data = overmap_ui::overmap_draw_data_t();
-    g->overmap_data.origin_pos = get_player_character().global_omt_location();
-    g->overmap_data.debug_info = show_debug_info;
-    return overmap_ui::display();
+    return choose_point( message, get_player_character().global_omt_location(), show_debug_info );
 }
 
-tripoint_abs_omt ui::omap::choose_point( const tripoint_abs_omt &origin, bool show_debug_info )
+tripoint_abs_omt ui::omap::choose_point( const std::string &message, const tripoint_abs_omt &origin,
+        bool show_debug_info )
 {
     g->overmap_data = overmap_ui::overmap_draw_data_t();
+    g->overmap_data.message = message;
     g->overmap_data.origin_pos = origin;
     g->overmap_data.debug_info = show_debug_info;
     return overmap_ui::display();
 }
 
-tripoint_abs_omt ui::omap::choose_point( int z, bool show_debug_info )
+tripoint_abs_omt ui::omap::choose_point( const std::string &message, int z, bool show_debug_info )
 {
-    g->overmap_data = overmap_ui::overmap_draw_data_t();
-    g->overmap_data.debug_info = show_debug_info;
     tripoint_abs_omt pos = get_player_character().global_omt_location();
     pos.z() = z;
-    g->overmap_data.origin_pos = pos;
-    return overmap_ui::display();
+    return choose_point( message, pos, show_debug_info );
 }
 
 void ui::omap::setup_cities_menu( uilist &cities_menu, std::vector<city> &cities_container )

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -75,20 +75,25 @@ void display_editor();
  * @returns The absolute coordinates of the chosen point or
  * invalid_point if canceled with Escape (or similar key).
  */
-tripoint_abs_omt choose_point( bool show_debug_info = false );
+tripoint_abs_omt choose_point( const std::string &message = "", bool show_debug_info = false );
 
 /**
- * Same as above but start at z-level z instead of players
- * current z-level, x and y are taken from the players position.
+ * Interactive point choosing; used as the map screen.
+ * The map is initially center at the players x and y
+ * location and the given z level.
+ * @returns The absolute coordinates of the chosen point or
+ * invalid_point if canceled with Escape (or similar key).
  */
-tripoint_abs_omt choose_point( int z, bool show_debug_info = false );
+tripoint_abs_omt choose_point( const std::string &message, int z, bool show_debug_info = false );
+
 /**
  * Interactive point choosing; used as the map screen.
  * The map is initially centered on the @ref origin.
  * @returns The absolute coordinates of the chosen point or
  * invalid_point if canceled with Escape (or similar key).
  */
-tripoint_abs_omt choose_point( const tripoint_abs_omt &origin, bool show_debug_info = false );
+tripoint_abs_omt choose_point( const std::string &message, const tripoint_abs_omt &origin,
+                               bool show_debug_info = false );
 
 void setup_cities_menu( uilist &cities_menu, std::vector<city> &cities_container );
 
@@ -114,6 +119,8 @@ struct overmap_draw_data_t {
     bool show_explored = true;
     // currently fast traveling
     bool fast_traveling = false;
+    // message to display while using the map
+    std::string message;
 
     // draw zone location.
     tripoint_abs_omt select = tripoint_abs_omt( -1, -1, -1 );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1108,6 +1108,20 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         notes_window_text.emplace_back( c_white, v.name );
     }
 
+    if( ! g->overmap_data.message.empty() ) {
+        const int padding = 2;
+        SDL_Rect message_background_rect = {
+            0,
+            0,
+            fontwidth * utf8_width( g->overmap_data.message ) + padding * 2,
+            fontheight + padding * 2
+        };
+        geometry->rect( renderer, message_background_rect, SDL_Color{ 0, 0, 0, 175 } );
+        draw_string( *font, renderer, geometry, g->overmap_data.message, point( padding, padding ),
+                     cata_cursesport::colorpairs[c_white.to_color_pair_index()].FG );
+    }
+
+
     if( !notes_window_text.empty() && !fast_traveling ) {
         constexpr int padding = 2;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Replace popups with informative message when choosing point(s) on the map"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Currently many operations that ask the player to choose one or more points on the map either have one or more popups before/between map views, or provide no feedback at all for the purpose of the choice.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Made om_target_tile and choose_point optionally show a message to the user while choosing, replaced most relevant popups with this functionality, added messages to some other cases, and moved part of one verbose popup's contents to a mission description.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I've been playing with a superset of this change for a week now.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
This is the second in a series of PRs being broken out from #77397 


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
