### PR TITLE
remove sulfurless gunpowder recipe

### DIFF
--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -1462,37 +1462,6 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "chem_black_powder",
-    "id_suffix": "sulfurless",
-    "category": "CC_AMMO",
-    "subcategory": "CSC_AMMO_COMPONENTS",
-    "skill_used": "chemistry",
-    "difficulty": 4,
-    "time": "60 m",
-    "book_learn": [ [ "textbook_anarch", 6 ], [ "recipe_labchem", 4 ], [ "textbook_chemistry", 5 ], [ "textbook_armschina", 5 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_intro_chemistry" },
-      { "proficiency": "prof_inorganic_chemistry" },
-      { "proficiency": "prof_organic_chemistry" }
-    ],
-    "charges": 2183,
-    "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "FINE_GRIND", "level": 1 } ],
-    "components": [
-      [ [ "chem_saltpetre", 50 ] ],
-      [ [ "water_clean", 1 ] ],
-      [
-        [ "chem_ethanol", 83 ],
-        [ "chem_methanol", 83 ],
-        [ "ether", 83 ],
-        [ "denat_alcohol", 83 ],
-        [ "methed_alcohol", 83 ]
-      ],
-      [ [ "charcoal", 64 ] ]
-    ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "result": "red_phosphorous",
     "id_suffix": "with_white_phosphorous",
     "charges": 3,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
A sulphurless gunpowder recipe was added way back in #55169 
The source it references for making it notes that the resulting granules are "delicate", which is a critical problem for a gunpowder, and that the "lift" is poor compared to draditional gunpowder, which is also a critical problem.

#### Describe the solution
Remove the recipe.

#### Describe alternatives you've considered
The alternative is adding a distinct sulfurless black powder item *and adjust all the downstream recipes to be notably lower performing*. This is a non-starter to support such a suboptimal and niche item.