### PR TITLE
Tweaks for visibility checks regarding vehicles and furniture

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7907,7 +7907,10 @@ int map::coverage( const tripoint_bub_ms &p ) const
     if( const optional_vpart_position vp = veh_at( p ) ) {
         if( vp->obstacle_at_part() ) {
             return 60;
-        } else if( !vp->part_with_feature( VPFLAG_AISLE, true ) ) {
+        }
+        std::optional<vpart_reference> part = vp->part_with_feature( VPFLAG_OBSTACLE, true, true );
+        if( !( part && part->has_feature( VPFLAG_OPENABLE ) && part->part().open ) &&
+            !vp->part_with_feature( VPFLAG_AISLE, true ) ) {
             return 45;
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7904,15 +7904,15 @@ int map::coverage( const tripoint &p ) const
 
 int map::coverage( const tripoint_bub_ms &p ) const
 {
-    if( const furn_id &obstacle_f = furn( p ) ) {
-        return obstacle_f->coverage;
-    }
     if( const optional_vpart_position vp = veh_at( p ) ) {
         if( vp->obstacle_at_part() ) {
             return 60;
         } else if( !vp->part_with_feature( VPFLAG_AISLE, true ) ) {
             return 45;
         }
+    }
+    if( const furn_id &obstacle_f = furn( p ) ) {
+        return obstacle_f->coverage;
     }
     return ter( p )->coverage;
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Tweaks for visibility checks regarding vehicles and furniture"

#### Purpose of change
Visibility checks checked only for `coverage` value of furniture (if any) on a given tile, even if there's a vehicle there. Flowers, being a furniture and having `TRANSPARENT` flag, gave 0% concealment. So if there's a flower underneath vehicle's closed doors, quarterpanels or other opaque part, you were able to see right through that part.
![изображение](https://github.com/user-attachments/assets/2d59ef55-942f-4744-863b-1e6adde2acf8)
I'm crouching here to narrow the field of view, in order to make the bug more demonstrative, but you have that visibility even when standing.

Also previous checks considered open doors as non-transparent if you were crouching.
![изображение](https://github.com/user-attachments/assets/7bc1b45d-832d-46d5-bc31-479b57882c7a)

Closes #49381.

#### Describe the solution
- Reordered checks for visibility. Made game check for vehicles first, and for furniture second.
- Added a check for open doors so they no longer block vision while crouching.

#### Describe alternatives you've considered
None.

#### Testing
Get vehicle, spawned dandelion under one of its closed doors. Crouched, checked that dandelion no longer makes me see through the door.
Opened door while crouched, checked that I can see through open door.

#### Additional context
![изображение](https://github.com/user-attachments/assets/a508ad6b-b5d8-4355-811b-9af7e90a1710)

![изображение](https://github.com/user-attachments/assets/263587e2-27d4-4397-a7f3-c18396066e27)
