### PR TITLE
Bunny suits

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -4196,7 +4196,6 @@
       { "item": "dragonsuit", "prob": 1 },
       { "item": "wool_suit", "prob": 40 },
       { "item": "wool_suit_devil", "prob": 15 },
-      { "item": "wool_suit_bunny", "prob": 25 },
       { "item": "unitard", "prob": 60 },
       { "item": "zentai", "prob": 5 },
       { "item": "wetsuit", "prob": 2 },

--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -4196,6 +4196,7 @@
       { "item": "dragonsuit", "prob": 1 },
       { "item": "wool_suit", "prob": 40 },
       { "item": "wool_suit_devil", "prob": 15 },
+      { "item": "wool_suit_bunny", "prob": 25 },
       { "item": "unitard", "prob": 60 },
       { "item": "zentai", "prob": 5 },
       { "item": "wetsuit", "prob": 2 },

--- a/data/json/itemgroups/Clothing_Gear/costumes.json
+++ b/data/json/itemgroups/Clothing_Gear/costumes.json
@@ -348,7 +348,7 @@
       { "item": "felinesuit", "prob": 10 },
       { "item": "bondage_suit", "prob": 15 },
       { "item": "wool_suit_devil", "prob": 15 },
-      { "item": "wool_suit_bunny", "prob": 25 }, 
+      { "item": "wool_suit_bunny", "prob": 25 },
       { "item": "bunny_suit_playboy", "prob": 25 },
       { "item": "dinosuit", "prob": 10 },
       { "item": "sharksuit", "prob": 10 },

--- a/data/json/itemgroups/Clothing_Gear/costumes.json
+++ b/data/json/itemgroups/Clothing_Gear/costumes.json
@@ -348,7 +348,6 @@
       { "item": "felinesuit", "prob": 10 },
       { "item": "bondage_suit", "prob": 15 },
       { "item": "wool_suit_devil", "prob": 15 },
-      { "item": "wool_suit_bunny", "prob": 25 },
       { "item": "bunny_suit_playboy", "prob": 25 },
       { "item": "dinosuit", "prob": 10 },
       { "item": "sharksuit", "prob": 10 },

--- a/data/json/itemgroups/Clothing_Gear/costumes.json
+++ b/data/json/itemgroups/Clothing_Gear/costumes.json
@@ -77,7 +77,10 @@
       { "item": "eyepatch_leather", "prob": 20 },
       { "item": "hakama", "prob": 1 },
       { "item": "devil_tail", "prob": 15 },
-      { "item": "angel_wings", "prob": 15 }
+      { "item": "angel_wings", "prob": 15 },
+      { "item": "cuffs", "prob": 25 },
+      { "item": "collar_playboy", "prob": 25 },
+      { "item": "tail_bunny_playboy", "prob": 25 }
     ]
   },
   {
@@ -210,7 +213,8 @@
       { "item": "porkpie", "prob": 10 },
       { "item": "nun_wimple", "prob": 12 },
       { "item": "devil_horn_headband", "prob": 15 },
-      { "item": "angel_halo_headband", "prob": 15 }
+      { "item": "angel_halo_headband", "prob": 15 },
+      { "item": "bunny_ears_black", "prob": 25 }
     ]
   },
   {
@@ -344,6 +348,8 @@
       { "item": "felinesuit", "prob": 10 },
       { "item": "bondage_suit", "prob": 15 },
       { "item": "wool_suit_devil", "prob": 15 },
+      { "item": "wool_suit_bunny", "prob": 25 }, 
+      { "item": "bunny_suit_playboy", "prob": 25 },
       { "item": "dinosuit", "prob": 10 },
       { "item": "sharksuit", "prob": 10 },
       { "item": "beekeeping_suit", "prob": 5 },

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1604,7 +1604,11 @@
       [ "garter_belt", 5 ],
       [ "bullwhip", 20 ],
       { "item": "candle", "prob": 20, "charges": [ 0, 100 ] },
-      [ "condom", 50 ]
+      [ "condom", 50 ],
+      { "item": "cuffs", "prob": 30 },
+      { "item": "collar_playboy", "prob": 30 },
+      { "item": "bunny_ears_black", "prob": 30 },
+      { "item": "tail_bunny_playboy", "prob": 30 }
     ]
   },
   {
@@ -1633,7 +1637,8 @@
       [ "ninja_dress_sleeveless", 5 ],
       [ "sinister_dress_short", 2 ],
       [ "witch_dress", 3 ],
-      [ "witch_dress_short", 5 ]
+      [ "witch_dress_short", 5 ],
+      { "item": "bunny_suit_playboy", "prob": 30 }
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/private_resort_item_groups.json
+++ b/data/json/itemgroups/Locations_MapExtras/private_resort_item_groups.json
@@ -45,7 +45,11 @@
       { "item": "faux_fur_collar", "prob": 80 },
       { "item": "leather_collar", "prob": 50 },
       { "item": "fur_collar", "prob": 10 },
-      { "item": "maid_hat", "prob": 25 }
+      { "item": "maid_hat", "prob": 25 },
+      { "item": "cuffs", "prob": 30 },
+      { "item": "collar_playboy", "prob": 30 },
+      { "item": "bunny_ears_black", "prob": 30 },
+      { "item": "tail_bunny_playboy", "prob": 30 }
     ]
   },
   {
@@ -61,7 +65,8 @@
       { "item": "waist_apron_short", "variant": "maid_apron", "prob": 30 },
       { "item": "waist_apron_short", "variant": "gothic_apron", "prob": 10 },
       [ "cheerleader_top_short", 10 ],
-      [ "halter_top", 50 ]
+      [ "halter_top", 50 ],
+      { "item": "bunny_suit_playboy", "prob": 30 }
     ]
   },
   {

--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -4924,7 +4924,7 @@
   {
     "id": "collar_playboy",
     "type": "ARMOR",
-    "name": { "str": "collar with bowtie" },
+    "name": { "str": "collar with bowtie", "str_pl": "collars with bowtie" },
     "description": "It's a detached collar with a bow tie, too.  It's usually worn with a sexy one-piece bunny suit and bunny ears headband.",
     "weight": "100 g",
     "volume": "100 ml",

--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -4920,5 +4920,72 @@
     "material_thickness": 2,
     "flags": [ "BELTED", "NO_WEAR_EFFECT" ],
     "armor": [ { "encumbrance": 15, "coverage": 60, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
+  },
+  {
+    "id": "collar_playboy",
+    "type": "ARMOR",
+    "name": { "str": "collar with bowtie" },
+    "description": "It's a detached collar with a bow tie, too.  It's usually worn with a sexy one-piece bunny suit and bunny ears headband.",
+    "weight": "100 g",
+    "volume": "100 ml",
+    "price": "10 USD",
+    "price_postapoc": "10 cent",
+    "material": [ "cotton" ],
+    "symbol": "-",
+    "color": "light_gray",
+    "flags": [ "NO_WEAR_EFFECT" ]
+  },
+  {
+    "id": "cuffs",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "pair of cuffs", "str_pl": "pairs of cuffs" },
+    "description": "A pair of white cuffs.",
+    "weight": "100 g",
+    "volume": "100 ml",
+    "price": "20 USD",
+    "price_postapoc": "50 cent",
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "color": "light_gray",
+    "warmth": 1,
+    "material_thickness": 1,
+    "flags": [ "NO_WEAR_EFFECT" ],
+    "armor": [
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "encumbrance": 2,
+        "coverage": 10,
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
+      }
+    ]
+  },
+  {
+    "id": "bunny_ears_black",
+    "type": "ARMOR",
+    "name": { "str": "pair of black bunny ears", "str_pl": "pairs of black bunny ears" },
+    "description": "A fuzzy pair of black bunny ears on a headband.  It does nothing, but there's no reason not to look good even if no one's looking.",
+    "weight": "100 g",
+    "volume": "100 ml",
+    "price": "15 USD",
+    "price_postapoc": "10 cent",
+    "material": [ "cotton", "plastic" ],
+    "symbol": "^",
+    "color": "dark_gray",
+    "flags": [ "NO_WEAR_EFFECT" ]
+  },
+  {
+    "id": "tail_bunny_playboy",
+    "type": "ARMOR",
+    "name": { "str": "bunny tail" },
+    "description": "A fluffy bunny tail ball, usually worn with a sexy one-piece bunny suit and bunny ears headband.",
+    "weight": "100 g",
+    "volume": "100 ml",
+    "price": "10 USD",
+    "price_postapoc": "10 cent",
+    "material": [ "cotton" ],
+    "symbol": "*",
+    "color": "light_gray",
+    "flags": [ "NO_WEAR_EFFECT" ]
   }
 ]

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -940,7 +940,7 @@
     "warmth": 50,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "HOOD" ]
-  },  
+  },
   {
     "id": "wool_suit_bunny",
     "type": "ARMOR",

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -919,6 +919,52 @@
     "flags": [ "VARSIZE", "HOOD" ]
   },
   {
+    "id": "wool_suit_bunny",
+    "type": "ARMOR",
+    "name": { "str": "bunny onesie" },
+    "description": "An encumbering and fluffy bunny onesie with a hood and adorned with a pair of bunny ears.  Very fluffy.",
+    "weight": "883 g",
+    "volume": "3 L",
+    "price": "80 USD",
+    "price_postapoc": "3 USD 50 cent",
+    "material": [ "wool" ],
+    "symbol": "[",
+    "looks_like": "touring_suit",
+    "color": "light_gray",
+    "armor": [
+      { "covers": [ "torso", "leg_l", "leg_r" ], "coverage": 100, "encumbrance": 20 },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 20 },
+      { "covers": [ "head" ], "coverage": 80, "encumbrance": 15 },
+      { "covers": [ "foot_l", "foot_r" ], "coverage": 100, "encumbrance": 15 }
+    ],
+    "warmth": 50,
+    "material_thickness": 1,
+    "flags": [ "VARSIZE", "HOOD" ]
+  },  
+  {
+    "id": "wool_suit_bunny",
+    "type": "ARMOR",
+    "name": { "str": "bunny onesie" },
+    "description": "An encumbering and fluffy bunny onesie with a hood and adorned with a pair of bunny ears.  Very fluffy.",
+    "weight": "883 g",
+    "volume": "3 L",
+    "price": "80 USD",
+    "price_postapoc": "3 USD 50 cent",
+    "material": [ "wool" ],
+    "symbol": "[",
+    "looks_like": "touring_suit",
+    "color": "light_gray",
+    "armor": [
+      { "covers": [ "torso", "leg_l", "leg_r" ], "coverage": 100, "encumbrance": 20 },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 20 },
+      { "covers": [ "head" ], "coverage": 80, "encumbrance": 15 },
+      { "covers": [ "foot_l", "foot_r" ], "coverage": 100, "encumbrance": 15 }
+    ],
+    "warmth": 50,
+    "material_thickness": 1,
+    "flags": [ "VARSIZE", "HOOD" ]
+  },
+  {
     "id": "zentai",
     "type": "ARMOR",
     "name": { "str": "zentai" },

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -916,53 +916,22 @@
     ],
     "warmth": 50,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "HOOD" ]
-  },
-  {
-    "id": "wool_suit_bunny",
-    "type": "ARMOR",
-    "name": { "str": "bunny onesie" },
-    "description": "An encumbering and fluffy bunny onesie with a hood and adorned with a pair of bunny ears.  Very fluffy.",
-    "weight": "883 g",
-    "volume": "3 L",
-    "price": "80 USD",
-    "price_postapoc": "3 USD 50 cent",
-    "material": [ "wool" ],
-    "symbol": "[",
-    "looks_like": "touring_suit",
-    "color": "light_gray",
-    "armor": [
-      { "covers": [ "torso", "leg_l", "leg_r" ], "coverage": 100, "encumbrance": 20 },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 20 },
-      { "covers": [ "head" ], "coverage": 80, "encumbrance": 15 },
-      { "covers": [ "foot_l", "foot_r" ], "coverage": 100, "encumbrance": 15 }
-    ],
-    "warmth": 50,
-    "material_thickness": 1,
-    "flags": [ "VARSIZE", "HOOD" ]
-  },
-  {
-    "id": "wool_suit_bunny",
-    "type": "ARMOR",
-    "name": { "str": "bunny onesie" },
-    "description": "An encumbering and fluffy bunny onesie with a hood and adorned with a pair of bunny ears.  Very fluffy.",
-    "weight": "883 g",
-    "volume": "3 L",
-    "price": "80 USD",
-    "price_postapoc": "3 USD 50 cent",
-    "material": [ "wool" ],
-    "symbol": "[",
-    "looks_like": "touring_suit",
-    "color": "light_gray",
-    "armor": [
-      { "covers": [ "torso", "leg_l", "leg_r" ], "coverage": 100, "encumbrance": 20 },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 20 },
-      { "covers": [ "head" ], "coverage": 80, "encumbrance": 15 },
-      { "covers": [ "foot_l", "foot_r" ], "coverage": 100, "encumbrance": 15 }
-    ],
-    "warmth": 50,
-    "material_thickness": 1,
-    "flags": [ "VARSIZE", "HOOD" ]
+    "flags": [ "VARSIZE", "HOOD" ],
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "devil_onesie",
+        "name": { "str": "devil onesie" },
+        "description": "An encumbering red wool suit with a hood adorned with cartoonish devil horns and a devil's tail on the back.  It's for those who want to feel devilishly warm in their sleep.",
+        "color": "red"
+      },
+      {
+        "id": "bunny_onesie",
+        "name": { "str": "bunny onesie" },
+        "description": "An encumbering and fluffy bunny onesie with a hood and adorned with a pair of bunny ears.  Very fluffy.",
+        "color": "light_gray"
+      }
+    ]
   },
   {
     "id": "zentai",

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -2511,5 +2511,25 @@
     "warmth": 25,
     "material_thickness": 1.5,
     "flags": [ "VARSIZE", "OUTER" ]
+  },
+  {
+    "id": "bunny_suit_playboy",
+    "type": "ARMOR",
+    "name": { "str": "bunny suit" },
+    "description": "A bunny suit, still shiny despite the time its likely spent in storage, or worse, on a corpse.  While not resembling a bunny without its accompanying tail and ears, it was a recognizable piece of clothing often found in clubs or in playboy magazines.",
+    "weight": "136 g",
+    "volume": "750 ml",
+    "price": "50 USD",
+    "price_postapoc": "60 cent",
+    "material": [ "leather" ],
+    "symbol": "[",
+    "looks_like": "wetsuit_spring",
+    "color": "dark_gray",
+    "armor": [
+      { "covers": [ "torso" ], "coverage": 60 },
+      { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] }
+    ],
+    "material_thickness": 0.1,
+    "flags": [ "VARSIZE", "SKINTIGHT" ]
   }
 ]

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -2516,7 +2516,7 @@
     "id": "bunny_suit_playboy",
     "type": "ARMOR",
     "name": { "str": "bunny suit" },
-    "description": "A bunny suit, still shiny despite the time its likely spent in storage, or worse, on a corpse.  While not resembling a bunny without its accompanying tail and ears, it was a recognizable piece of clothing often found in clubs or in playboy magazines.",
+    "description": "A bunny suit, still shiny despite the time it's likely spent in storage, or worse, on a corpse.  While not resembling a bunny without its accompanying tail and ears, it was a recognizable piece of clothing often found in clubs or in playboy magazines.",
     "weight": "136 g",
     "volume": "750 ml",
     "price": "50 USD",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change

Adds bunny suits and the itemgroups for it.

#### Describe the solution

Adds the item and itemgroup jsons in suitable places for it.

#### Describe alternatives you've considered

Keeping it to myself.

#### Testing

![Screenshot_20241105_151239_1](https://github.com/user-attachments/assets/ac5b1311-fd79-40b3-bf16-616c07a7640b)

Also tested up the itemgroups in sex shops and sleek zombies, checked that the thing does spawns in there.
#### Additional context

Special thanks to @Holli-Git in particular for giving me the description for the bunny suit.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
