### PR TITLE
kill non-mzvc windows release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include:
           - name: Windows Tiles x64 MSVC
-            artifact: windows-tiles-x64-msvc
+            artifact: windows-with-graphics-x64
             arch: x64
             os: windows-2019
             mxe: none
@@ -64,26 +64,10 @@ jobs:
             content: application/zip
             sound: 0
           - name: Windows Tiles Sounds x64 MSVC
-            artifact: windows-tiles-sounds-x64-msvc
+            artifact: windows-with-graphics-and-sounds-x64
             arch: x64
             os: windows-2019
             mxe: none
-            ext: zip
-            content: application/zip
-            sound: 1
-          - name: Windows Tiles x64
-            mxe: x86_64
-            libbacktrace: 1
-            artifact: windows-tiles-x64
-            os: ubuntu-latest
-            ext: zip
-            content: application/zip
-            sound: 0
-          - name: Windows Tiles Sounds x64
-            mxe: x86_64
-            libbacktrace: 1
-            artifact: windows-tiles-sounds-x64
-            os: ubuntu-latest
             ext: zip
             content: application/zip
             sound: 1
@@ -94,7 +78,7 @@ jobs:
             libbacktrace: 1
             tiles: 1
             sound: 0
-            artifact: linux-tiles-x64
+            artifact: linux-with-graphics-x64
             ext: tar.gz
             content: application/gzip
           - name: Linux Tiles Sounds x64
@@ -104,7 +88,7 @@ jobs:
             libbacktrace: 1
             tiles: 1
             sound: 1
-            artifact: linux-tiles-sounds-x64
+            artifact: linux-with-graphics-and-sounds-x64
             ext: tar.gz
             content: application/gzip
           - name: Linux Curses x64
@@ -114,7 +98,7 @@ jobs:
             libbacktrace: 1
             tiles: 0
             sound: 0
-            artifact: linux-curses-x64
+            artifact: linux-terminal-only-x64
             ext: tar.gz
             content: application/gzip
           - name: macOS Curses Universal Binary (x64 and arm64)
@@ -122,7 +106,7 @@ jobs:
             mxe: none
             tiles: 0
             sound: 0
-            artifact: osx-curses-universal
+            artifact: osx-terminal-only-universal
             ext: dmg
             content: application/x-apple-diskimage
           - name: macOS Tiles Universal Binary (x64 and arm64)
@@ -130,7 +114,7 @@ jobs:
             mxe: none
             tiles: 1
             sound: 0
-            artifact: osx-tiles-universal
+            artifact: osx-with-graphics-universal
             ext: dmg
             content: application/x-apple-diskimage
           - name: Android x64


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
There has been a notable amount of confusion about windows builds due to having msvc and non-msvc builds both available.
Also the naming of "tiles" contributed to confusion because if people don't know it's "tiles vs ascii" they're not sure what that means.
Fixes #74699

#### Describe the solution
This removes the non-msvc builds FROM THE RELEASE. They are still built and tested in ci, just not bundled for release.
It also renames some of the artifacts to make their attributes clearer as recommended by #74699 
Specifically -tiles- becomes -with-graphics-, -sounds- becomes -and-sounds- and -curses- becomes -terminal-only-

#### Describe alternatives you've considered
Leaving in non-msvc builds, but ehh I have no indication that they're providing any value at all to anyone. 
If anyone is bundling stuff downstream of us the tiles/curses name changes will break them. If that's the case that's a lower priority change. 