### PR TITLE
Made tree tops burn and more collapse on wall loss

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3937,7 +3937,7 @@ int map::collapse_check( const tripoint_bub_ms &p ) const
     int num_supports = p.z() == OVERMAP_DEPTH ? 0 : -5;
     // if there's support below, things are less likely to collapse
     if( p.z() > -OVERMAP_DEPTH ) {
-        const tripoint_bub_ms &pbelow = tripoint_bub_ms( p.xy(), p.z() - 1 );
+        const tripoint_bub_ms &pbelow = p + tripoint_below;
         for( const tripoint_bub_ms &tbelow : points_in_radius( pbelow, 1 ) ) {
             if( has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, tbelow ) ) {
                 num_supports += 1;
@@ -3982,7 +3982,8 @@ void map::collapse_at( const tripoint_bub_ms &p, const bool silent, const bool w
                        const bool destroy_pos )
 {
     const bool supports = was_supporting || has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p );
-    const bool wall = was_supporting || has_flag( ter_furn_flag::TFLAG_WALL, p );
+    const bool wall_tree = was_supporting || has_flag( ter_furn_flag::TFLAG_WALL, p ) ||
+                           has_flag( ter_furn_flag::TFLAG_TREE, p );
     // don't bash again if the caller already bashed here
     if( destroy_pos ) {
         destroy( p, silent );
@@ -3995,34 +3996,19 @@ void map::collapse_at( const tripoint_bub_ms &p, const bool silent, const bool w
     if( supports && !still_supports ) {
         for( const tripoint_bub_ms &t : points_in_radius( p, 1 ) ) {
             // If z-levels are off, tz == t, so we end up skipping a lot of stuff to avoid bugs.
-            const tripoint_bub_ms &tz = tripoint_bub_ms( t.xy(), t.z() + 1 );
-            // if nothing above us had the chance of collapsing, move on
-            if( !one_in( collapse_check( tz ) ) ) {
-                continue;
-            }
-            // if a wall collapses, walls without support from below risk collapsing and
-            //propagate the collapse upwards
-            if( zlevels && wall && p == t && has_flag( ter_furn_flag::TFLAG_WALL, tz ) ) {
+            const tripoint_bub_ms &tz = t + tripoint_above;
+            const bool collapse_above = one_in( collapse_check( tz ) );
+
+            if( zlevels && ( wall_tree ) && collapse_above ) {
                 collapse_at( tz, silent );
-            }
-            // floors without support from below risk collapsing into open air and can propagate
-            // the collapse horizontally but not vertically
-            if( p != t && ( has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, t ) &&
-                            has_flag( ter_furn_flag::TFLAG_COLLAPSES, t ) ) ) {
-                collapse_at( t, silent );
-            }
-            // this tile used to support a roof, now it doesn't, which means there is only
-            // open air above us
-            if( zlevels ) {
-                // ensure that the layer below this one is not a wall, otherwise you have a ledge dropping onto
-                // a wall which doesn't make sense.
-                if( !has_flag( ter_furn_flag::TFLAG_WALL, t ) ) {
-                    furn_set( tz, furn_str_id::NULL_ID() );
-                    ter_set( tz, ter_t_open_air );
-                    Creature *critter = get_creature_tracker().creature_at( tz );
-                    if( critter != nullptr ) {
-                        creature_on_trap( *critter );
-                    }
+
+                // this tile used to support a roof, now it doesn't, which means there is only
+                // open air above us
+                furn_set( tz, furn_str_id::NULL_ID() );
+                ter_set( tz, ter_t_open_air );
+                Creature *critter = get_creature_tracker().creature_at( tz );
+                if( critter != nullptr ) {
+                    creature_on_trap( *critter );
                 }
             }
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3999,7 +3999,7 @@ void map::collapse_at( const tripoint_bub_ms &p, const bool silent, const bool w
             const tripoint_bub_ms &tz = t + tripoint_above;
             const bool collapse_above = one_in( collapse_check( tz ) );
 
-            if( zlevels && ( wall_tree ) && collapse_above ) {
+            if( zlevels && wall_tree && collapse_above ) {
                 collapse_at( tz, silent );
 
                 // this tile used to support a roof, now it doesn't, which means there is only

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1116,19 +1116,8 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
+                here.bash( p, 999, false, true, true );
                 here.spawn_item( p, "ash", 1, rng( 10, 1000 ) );
-                if( p.z > 0 ) {
-                    // We're in the air. Need to invalidate the furniture otherwise it'll cause problems
-                    here.furn_set( p, furn_str_id::NULL_ID() );
-                    here.ter_set( p, ter_t_open_air );
-                } else if( p.z < -1 ) {
-                    // We're deep underground, in bedrock. Whatever terrain was here is burned to the ground, leaving only the carved out rock (including ceiling)
-                    here.ter_set( p, ter_t_rock_floor );
-                } else {
-                    // Need to invalidate the furniture otherwise it'll cause problems when supporting terrain collapses
-                    here.furn_set( p, furn_str_id::NULL_ID() );
-                    here.ter_set( p, ter_t_dirt );
-                }
             }
 
         } else if( frn.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {
@@ -1310,8 +1299,9 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
     // Consume adjacent fuel / terrain / webs to spread.
     // Allow raging fires (and only raging fires) to spread up
     // Spreading down is achieved by wrecking the walls/floor and then falling
-    if( cur.get_field_intensity() == 3 && p.z < OVERMAP_HEIGHT ) {
-        const tripoint_bub_ms dst_p = tripoint_bub_ms( p.x, p.y, p.z + 1 );
+    if( ( cur.get_field_intensity() == 3 ||
+          here.ter( p ).obj().has_flag( ter_furn_flag::TFLAG_TREE ) ) && p.z < OVERMAP_HEIGHT ) {
+        const tripoint_bub_ms dst_p = tripoint_bub_ms( p + tripoint_above );
         // Let it burn through the floor
         maptile dst = here.maptile_at_internal( dst_p );
         const ter_t &dst_ter = dst.get_ter_t();

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -98,9 +98,7 @@ static const material_id material_veggy( "veggy" );
 static const species_id species_FUNGUS( "FUNGUS" );
 
 static const ter_str_id ter_t_dirt( "t_dirt" );
-static const ter_str_id ter_t_open_air( "t_open_air" );
 static const ter_str_id ter_t_pit( "t_pit" );
-static const ter_str_id ter_t_rock_floor( "t_rock_floor" );
 
 static const trait_id trait_ACIDPROOF( "ACIDPROOF" );
 static const trait_id trait_GASTROPOD_FOOT( "GASTROPOD_FOOT" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Address a bit over half of #77590, i.e. make sure burning trees also set their tops alight and that the tops fall when the trunk has burned up (although it probably burned up by itself before that).
Make collapses due to loss of support a little more likely (but levitating terrain is still a thing).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Changed the logic for propagating fire upwards to allow it to happen when the thing on fire is a tree, as trees don't seem to burn hot enough (unlike bushes).
- Changed the logic for terrain burning to ash to smash the terrain like other cases do, resulting in tree tops falling, should it not already be gone due to propagating fire.
- Changed the logic for support loss processing so surrounding tiles aren't magically saved from the effect of the loss of side support below just because the tile directly on top of the wall didn't crumble.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
You can play with the support stuff for as long as you want, but you can't fix the root of the problem, which is that actual support isn't checked, just the nearest tiles. You'd have to change the logic to calculate support to actual support beneath at some reasonable range and use horizontal support only to reach the vertical one. That's tricky to do without risking a lot of slowdown due to support calculations at times (such as fires and explosions).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Set my base on fire, plus a tree, killing Liam in the process...
Debug mutated both versions of clairvoyance to be able to see what happens.
![Screenshot (634)](https://github.com/user-attachments/assets/a090570e-70b2-4330-ac1d-a41e9afc9173)
![Screenshot (635)](https://github.com/user-attachments/assets/b0156861-8671-43f2-84b7-8506289d5bc0)
![Screenshot (636)](https://github.com/user-attachments/assets/200a54ec-619d-4695-afd5-bcb2586415b7)

Waited 6 hours.
![Screenshot (637)](https://github.com/user-attachments/assets/8e835e28-9fbb-4eee-a1cc-01156988f3a4)
![Screenshot (638)](https://github.com/user-attachments/assets/f4408e31-462f-426c-a2b9-365873f6b0d0)
![Screenshot (639)](https://github.com/user-attachments/assets/a1622005-78b0-4515-b0e2-a8eae201161d)

In this case the gutters were gone, but that doesn't happen every time.
The tree top is gone as well (and you'll have to trust me when I say I climbed the stairs and looked out the window to verify the treetop was on fire at one run).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
- A side effect of the changes is that the ground is now gone over all of the cellar wall. Before there was ground left where doors and windows had been. I believe this is an improvement.
- The reason the cellar wall to the east isn't exposed is because it's mismatched with the house wall, so it's placed one tile further east.
- Comments in the code indicate fire should spread downward, but that doesn't happen. I haven't investigated it, but wouldn't be surprised if there's some check against Z level 0, rather than whether there's something burnable beneath. It may also just be plain broken, as an alternative.
- The kitchen linoleum floor levitates in every run. I haven't tried to investigate why.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
