### PR TITLE
teleport_to_point() tweaks

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -97,12 +97,17 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
     //handles teleporting into solids.
     if( dest->impassable( dest_target ) ) {
         if( force ) {
-            const std::optional<tripoint_bub_ms> nt =
-                random_point( points_in_radius( dest_target, 5 ),
-            [dest]( const tripoint_bub_ms & el ) {
-                return dest->passable( el );
-            } );
-            dest_target = nt ? *nt : dest_target;
+            std::vector<tripoint_bub_ms> nearest_points = closest_points_first( dest_target, 5 );
+            nearest_points.erase( nearest_points.begin() );
+            //TODO: Swap for this once #75961 merges
+            //std::vector<tripoint_bub_ms> nearest_points = closest_points_first( dest_target, 1, 5 );
+            for( tripoint_bub_ms p : nearest_points ) {
+                if( dest->passable( p ) ) {
+                    dest_target = p;
+                    break;
+                }
+            }
+
         } else {
             if( safe ) {
                 if( c_is_u && display_message ) {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -26,8 +26,6 @@
 #include "viewer.h"
 #include "map_iterator.h"
 
-static const damage_type_id damage_pure( "pure" );
-
 static const efftype_id effect_teleglow( "teleglow" );
 
 static const flag_id json_flag_DIMENSIONAL_ANCHOR( "DIMENSIONAL_ANCHOR" );
@@ -191,14 +189,13 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 for( const effect &grab : poor_soul->get_effects_with_flag( json_flag_GRAB ) ) {
                     poor_soul->remove_effect( grab.get_id() );
                 }
-                //apply a bunch of damage to it, similar to a tear in reality
+                //apply a bunch of damage to it
                 std::vector<bodypart_id> target_bdpts = poor_soul->get_all_body_parts(
                         get_body_part_flags::only_main );
-                for( bodypart_id bp_id : target_bdpts ) {
-                    damage_instance bp_damage( damage_pure,
-                                               poor_soul->get_part_hp_max( bp_id ) / static_cast<float>( rng( 6,
-                                                       12 ) ) );
-                    poor_soul->deal_damage( nullptr, bp_id, bp_damage );
+                for( const bodypart_id &bp_id : target_bdpts ) {
+                    const float damage_to_deal =
+                        static_cast<float>( poor_soul->get_part_hp_max( bp_id ) ) / static_cast<float>( rng( 6, 12 ) );
+                    poor_soul->apply_damage( nullptr, bp_id, damage_to_deal );
                 }
                 poor_soul->check_dead_state();
             }
@@ -212,11 +209,10 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
         //do a bunch of damage to it too.
         std::vector<bodypart_id> target_bdpts = critter.get_all_body_parts(
                 get_body_part_flags::only_main );
-        for( bodypart_id bp_id : target_bdpts ) {
-            damage_instance bp_damage( damage_pure,
-                                       critter.get_part_hp_max( bp_id ) / static_cast<float>( rng( 6,
-                                               12 ) ) );
-            critter.deal_damage( nullptr, bp_id, bp_damage );
+        for( const bodypart_id &bp_id : target_bdpts ) {
+            float damage_to_deal =
+                static_cast<float>( critter.get_part_hp_max( bp_id ) ) / static_cast<float>( rng( 6, 12 ) );
+            critter.apply_damage( nullptr, bp_id, damage_to_deal );
         }
         critter.check_dead_state();
     }

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -26,6 +26,8 @@
 #include "viewer.h"
 #include "map_iterator.h"
 
+static const damage_type_id damage_pure( "pure" );
+
 static const efftype_id effect_teleglow( "teleglow" );
 
 static const flag_id json_flag_DIMENSIONAL_ANCHOR( "DIMENSIONAL_ANCHOR" );
@@ -185,12 +187,14 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                     poor_soul->remove_effect( grab.get_id() );
                 }
                 //apply a bunch of damage to it, similar to a tear in reality
-                poor_soul->apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
-                poor_soul->apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
-                poor_soul->apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );
-                poor_soul->apply_damage( nullptr, bodypart_id( "leg_r" ), rng( 7, 12 ) );
-                poor_soul->apply_damage( nullptr, bodypart_id( "torso" ), rng( 5, 15 ) );
-                poor_soul->apply_damage( nullptr, bodypart_id( "head" ), rng( 2, 8 ) );
+                std::vector<bodypart_id> target_bdpts = poor_soul->get_all_body_parts(
+                        get_body_part_flags::only_main );
+                for( bodypart_id bp_id : target_bdpts ) {
+                    damage_instance bp_damage( damage_pure,
+                                               poor_soul->get_part_hp_max( bp_id ) / static_cast<float>( rng( 6,
+                                                       12 ) ) );
+                    poor_soul->deal_damage( nullptr, bp_id, bp_damage );
+                }
                 poor_soul->check_dead_state();
             }
         }
@@ -201,12 +205,14 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
         //throw the thing that teleported in the opposite direction as the thing it teleported into.
         g->fling_creature( &critter, units::from_degrees( collision_angle - 180 ), 40, false, true );
         //do a bunch of damage to it too.
-        critter.apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
-        critter.apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
-        critter.apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );
-        critter.apply_damage( nullptr, bodypart_id( "leg_r" ), rng( 7, 12 ) );
-        critter.apply_damage( nullptr, bodypart_id( "torso" ), rng( 5, 15 ) );
-        critter.apply_damage( nullptr, bodypart_id( "head" ), rng( 2, 8 ) );
+        std::vector<bodypart_id> target_bdpts = critter.get_all_body_parts(
+                get_body_part_flags::only_main );
+        for( bodypart_id bp_id : target_bdpts ) {
+            damage_instance bp_damage( damage_pure,
+                                       critter.get_part_hp_max( bp_id ) / static_cast<float>( rng( 6,
+                                               12 ) ) );
+            critter.deal_damage( nullptr, bp_id, bp_damage );
+        }
         critter.check_dead_state();
     }
     //player and npc exclusive teleporting effects


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #77507
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make force teleporting to impassable tiles redirect to nearest passable one rather than randomly
Replace some hardcoded bodypart id references with iterating
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked the EoC linked in #77507 now works results in you teleporting adjacent to the target tree
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
