### PR TITLE
[0.H] Fix crash when not wielding item from map/vehicle after reloading

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4631,9 +4631,11 @@ void reload_activity_actor::finish( player_activity &act, Character &who )
         case 2:
         default:
             // In player inventory and player is wielding something.
-            loc.carrier()->add_msg_if_player( m_neutral,
-                                              _( "The %s no longer fits in your inventory so you drop it instead." ),
-                                              reloadable_name );
+            if( loc.carrier() ) {
+                loc.carrier()->add_msg_if_player( m_neutral,
+                                                  _( "The %s no longer fits in your inventory so you drop it instead." ),
+                                                  reloadable_name );
+            }
             get_map().add_item_or_charges( loc.position(), reloadable );
             loc.remove_item();
             break;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #77284

#### Describe the solution

Don't dereference nullpointer.

#### Describe alternatives you've considered



#### Testing

Save from the issue doesn't crash on selecting drop anymore.

#### Additional context

