### PR TITLE
[Xedra Evolved] Add (very small) chance of being attacked by a lilit in your sleep

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -2297,6 +2297,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_lilin_health_effects_of_draining",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "bad",
+    "base_mods": { "health_min": [ -1 ], "health_chance": [ 2 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "effect_lilin_vampire_immune",
     "//": "Hidden effects, prevents you from being vampirized",
     "name": [ "" ],

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -2290,6 +2290,13 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_lilin_attack_warning_cooldown",
+    "//": "Hidden effect, used as a blocker",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_lilin_vampire_immune",
     "//": "Hidden effects, prevents you from being vampirized",
     "name": [ "" ],

--- a/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
@@ -1,0 +1,35 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SLEEPING_SEIZED_BY_LILIT",
+    "eoc_type": "EVENT",
+    "required_event": "character_falls_asleep",
+    "condition": {
+      "and": [
+        { "not": { "u_has_trait": "LILIN_TRAITS" } },
+        { "math": [ "u_characters_nearby('radius': 45)", "==", "0" ] },
+        { "not": "is_day": },
+        { "not": "u_is_outside" },
+        { "x_in_y_chance": { "x": 1, "y": 365 } },
+        { "not": { "u_has_worn_with_flag": "WARDING_SYMBOL" } }
+      ]
+    },
+    "effect": [ { "run_eocs": "EOC_SLEEPING_SEIZED_BY_LILIT_EFFECTS", "time_in_future": [ "3 hours", "5 hours" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SLEEPING_SEIZED_BY_LILIT_EFFECTS",
+    "condition": {
+      "and": [
+        { "math": [ "u_characters_nearby('radius': 45)", "==", "0" ] },
+        { "u_has_effect": "sleep" },
+        { "not": "is_day": },
+        { "not": { "u_has_effect": "effect_sleep_shield" } }
+      ] 
+    },
+    "effect": [
+      { "u_add_effect": "effect_lilin_ruach_drain_side_effects", "intensity": { "math": [ "rand(2) + 1" ] }, "duration": 259200 },
+      { "u_message": "snippet_drained_by_lilit", "snippet": true, "type": "bad" }
+    ]
+  }
+]

--- a/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
@@ -1,6 +1,30 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_SLEEPING_SEIZED_BY_LILIT_WARNING",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+    "condition": {
+      "and": [
+        { "not": { "u_has_trait": "LILIN_TRAITS" } },
+        { "math": [ "u_characters_nearby('radius': 45)", "==", "0" ] },
+        { "not": "is_day" },
+        { "not": "u_is_outside" },
+        { "x_in_y_chance": { "x": 1, "y": 3 } },
+        { "math": [ "time_since('cataclysm', 'unit':'days')", "<=", "7" ] },
+        { "not": { "u_has_effect": "effect_lilin_attack_warning_cooldown" } }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "The night was a little rough.  You tossed and turned, aware of every single noise and creak of wood in a way you never were before all of this happened, before you finally fell asleep.  You weren't attacked and woke up without trouble, but you have to wonder if it's really safe, sleeping alone like this in an abandoned building?",
+        "popup": true
+      },
+      { "u_add_effect": "effect_lilin_attack_warning_cooldown", "duration": "7 days" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_SLEEPING_SEIZED_BY_LILIT",
     "eoc_type": "EVENT",
     "required_event": "character_falls_asleep",

--- a/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
@@ -34,7 +34,14 @@
         { "not": "is_day" },
         { "not": "u_is_outside" },
         {
-          "x_in_y_chance": { "x": { "math": [ "1 + min( (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * 90 ), 180)" ] }, "y": 365 }
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "1 + min( (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * 90 ), 180) + (u_effect_intensity('common_cold') > -1 ? 15 : 0) + (u_effect_intensity('influenza') > -1 ? 25 : 0) + (u_effect_intensity('pre_common_cold') > -1 ? 7 : 0) + (u_effect_intensity('pre_flu') > -1 ? 12 : 0)"
+              ]
+            },
+            "y": 365
+          }
         },
         { "not": { "u_has_worn_with_flag": "WARDING_SYMBOL" } }
       ]

--- a/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
@@ -8,9 +8,11 @@
       "and": [
         { "not": { "u_has_trait": "LILIN_TRAITS" } },
         { "math": [ "u_characters_nearby('radius': 45)", "==", "0" ] },
-        { "not": "is_day": },
+        { "not": "is_day" },
         { "not": "u_is_outside" },
-        { "x_in_y_chance": { "x": {"math": [ "1 + min( (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * 90 ), 180)" ] }, "y": 365 } },
+        {
+          "x_in_y_chance": { "x": { "math": [ "1 + min( (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * 90 ), 180)" ] }, "y": 365 }
+        },
         { "not": { "u_has_worn_with_flag": "WARDING_SYMBOL" } }
       ]
     },
@@ -23,12 +25,16 @@
       "and": [
         { "math": [ "u_characters_nearby('radius': 45)", "==", "0" ] },
         { "u_has_effect": "sleep" },
-        { "not": "is_day": },
+        { "not": "is_day" },
         { "not": { "u_has_effect": "effect_sleep_shield" } }
-      ] 
+      ]
     },
     "effect": [
-      { "u_add_effect": "effect_lilin_ruach_drain_side_effects", "intensity": { "math": [ "rand(2) + 1" ] }, "duration": 259200 },
+      {
+        "u_add_effect": "effect_lilin_ruach_drain_side_effects",
+        "intensity": { "math": [ "rand(2) + 1" ] },
+        "duration": 259200
+      },
       { "u_message": "snippet_drained_by_lilit", "snippet": true, "type": "bad" },
       { "math": [ "u_lilin_ruach_drained_recently", "=", "1" ] }
     ]

--- a/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
@@ -10,7 +10,7 @@
         { "math": [ "u_characters_nearby('radius': 45)", "==", "0" ] },
         { "not": "is_day": },
         { "not": "u_is_outside" },
-        { "x_in_y_chance": { "x": 1, "y": 365 } },
+        { "x_in_y_chance": { "x": {"math": [ "1 + min( (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * 90 ), 180)" ] }, "y": 365 } },
         { "not": { "u_has_worn_with_flag": "WARDING_SYMBOL" } }
       ]
     },
@@ -29,7 +29,8 @@
     },
     "effect": [
       { "u_add_effect": "effect_lilin_ruach_drain_side_effects", "intensity": { "math": [ "rand(2) + 1" ] }, "duration": 259200 },
-      { "u_message": "snippet_drained_by_lilit", "snippet": true, "type": "bad" }
+      { "u_message": "snippet_drained_by_lilit", "snippet": true, "type": "bad" },
+      { "math": [ "u_lilin_ruach_drained_recently", "=", "1" ] }
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
@@ -8,10 +8,9 @@
       "and": [
         { "not": { "u_has_trait": "LILIN_TRAITS" } },
         { "math": [ "u_characters_nearby('radius': 45)", "==", "0" ] },
-        { "not": "is_day" },
         { "not": "u_is_outside" },
-        { "x_in_y_chance": { "x": 1, "y": 3 } },
-        { "math": [ "time_since('cataclysm', 'unit':'days')", "<=", "7" ] },
+        { "x_in_y_chance": { "x": 1, "y": 2 } },
+        { "math": [ "time_since('cataclysm', 'unit':'days')", "<=", "20" ] },
         { "not": { "u_has_effect": "effect_lilin_attack_warning_cooldown" } }
       ]
     },
@@ -20,7 +19,7 @@
         "u_message": "The night was a little rough.  You tossed and turned, aware of every single noise and creak of wood in a way you never were before all of this happened, before you finally fell asleep.  You weren't attacked and woke up without trouble, but you have to wonder if it's really safe, sleeping alone like this in an abandoned building?",
         "popup": true
       },
-      { "u_add_effect": "effect_lilin_attack_warning_cooldown", "duration": "7 days" }
+      { "u_add_effect": "effect_lilin_attack_warning_cooldown", "duration": "20 days" }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/flags.json
+++ b/data/mods/Xedra_Evolved/flags.json
@@ -40,6 +40,11 @@
     "info": "You are immune to the evil eye."
   },
   {
+    "id": "WARDING_SYMBOL",
+    "type": "json_flag",
+    "info": "Wearing this is <good>comforting</good>."
+  },
+  {
     "id": "EVIL_EYE_IMMUNE_MONSTER",
     "type": "monster_flag"
   }

--- a/data/mods/Xedra_Evolved/items/clothes.json
+++ b/data/mods/Xedra_Evolved/items/clothes.json
@@ -430,5 +430,19 @@
     "flags": [ "OVERSIZE", "HOOD", "BELTED" ],
     "armor": [ { "encumbrance": 4, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ],
     "relic_data": { "passive_effects": [ { "id": "ench_verdant_cloak" } ] }
+  },
+  {
+    "id": "holy_symbol",
+    "type": "ARMOR",
+    "copy-from": "holy_symbol",
+    "name": { "str": "holy symbol" },
+    "extend": { "flags": [ "WARDING_SYMBOL" ] }
+  },
+  {
+    "id": "holy_symbol_wood",
+    "type": "ARMOR",
+    "copy-from": "holy_symbol_wood",
+    "name": { "str": "handmade holy symbol" },
+    "extend": { "flags": [ "WARDING_SYMBOL" ] }
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/xe_lilin_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_lilin_eocs.json
@@ -7,8 +7,11 @@
     "condition": { "u_has_effect": "effect_lilin_ruach_drain_side_effects" },
     "effect": [
       { "math": [ "u_val('sleepiness')", "+=", "40 + (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * 20)" ] },
-      { "math": [ "u_val('health')", "-=", "5 - (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * rng(5,10) )" ] },
-      { "if": { "math": [ "u_lilin_ruach_drained_recently", "==", "1" ] },
+      {
+        "math": [ "u_val('health')", "-=", "5 - (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * rng(5,10) )" ]
+      },
+      {
+        "if": { "math": [ "u_lilin_ruach_drained_recently", "==", "1" ] },
         "then": [
           { "math": [ "u_lilin_ruach_drained_recently", "==", "0" ] },
           {

--- a/data/mods/Xedra_Evolved/mutations/xe_lilin_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_lilin_eocs.json
@@ -8,6 +8,41 @@
     "effect": [
       { "math": [ "u_val('sleepiness')", "+=", "40 + (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * 20)" ] },
       { "math": [ "u_val('health')", "-=", "5 - (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * rng(5,10) )" ] },
+      { "if": { "math": [ "u_lilin_ruach_drained_recently", "==", "1" ] },
+        "then": [
+          { "math": [ "u_lilin_ruach_drained_recently", "==", "0" ] },
+          {
+            "u_deal_damage": "biological",
+            "amount": { "math": [ "max(((u_effect_intensity('effect_lilin_ruach_drain_side_effects') / 2)- 3), 0 )" ] },
+            "bodypart": "head"
+          },
+          {
+            "u_deal_damage": "biological",
+            "amount": { "math": [ "max(((u_effect_intensity('effect_lilin_ruach_drain_side_effects') / 2)- 3), 0 )" ] },
+            "bodypart": "arm_l"
+          },
+          {
+            "u_deal_damage": "biological",
+            "amount": { "math": [ "max(((u_effect_intensity('effect_lilin_ruach_drain_side_effects') / 2)- 3), 0 )" ] },
+            "bodypart": "arm_r"
+          },
+          {
+            "u_deal_damage": "biological",
+            "amount": { "math": [ "max(((u_effect_intensity('effect_lilin_ruach_drain_side_effects') / 2)- 3), 0 )" ] },
+            "bodypart": "torso"
+          },
+          {
+            "u_deal_damage": "biological",
+            "amount": { "math": [ "max(((u_effect_intensity('effect_lilin_ruach_drain_side_effects') / 2)- 3), 0 )" ] },
+            "bodypart": "leg_r"
+          },
+          {
+            "u_deal_damage": "biological",
+            "amount": { "math": [ "max(((u_effect_intensity('effect_lilin_ruach_drain_side_effects') / 2)- 3), 0 )" ] },
+            "bodypart": "leg_l"
+          }
+        ]
+      }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/xe_lilin_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_lilin_eocs.json
@@ -8,12 +8,13 @@
     "effect": [
       { "math": [ "u_val('sleepiness')", "+=", "40 + (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * 20)" ] },
       {
-        "math": [ "u_val('health')", "-=", "5 - (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * rng(5,10) )" ]
+        "u_add_effect": "effect_lilin_health_effects_of_draining",
+        "duration": { "math": [ "10 + (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * rng(10,20) )" ] }
       },
       {
         "if": { "math": [ "u_lilin_ruach_drained_recently", "==", "1" ] },
         "then": [
-          { "math": [ "u_lilin_ruach_drained_recently", "==", "0" ] },
+          { "math": [ "u_lilin_ruach_drained_recently", "=", "0" ] },
           {
             "u_deal_damage": "biological",
             "amount": { "math": [ "max(((u_effect_intensity('effect_lilin_ruach_drain_side_effects') / 2)- 3), 0 )" ] },

--- a/data/mods/Xedra_Evolved/mutations/xe_lilin_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_lilin_eocs.json
@@ -1,6 +1,17 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_RUACH_DRAINED_AWAKENING_PENALTIES",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+    "condition": { "u_has_effect": "effect_lilin_ruach_drain_side_effects" },
+    "effect": [
+      { "math": [ "u_val('sleepiness')", "+=", "40 + (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * 20)" ] },
+      { "math": [ "u_val('health')", "-=", "5 - (u_effect_intensity('effect_lilin_ruach_drain_side_effects') * rng(5,10) )" ] },
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_LILIN_RUACH_DRAIN_SELF",
     "recurrence": [ "6 minutes", "6 minutes" ],
     "condition": { "u_has_trait": "LILIN_TRAITS" },

--- a/data/mods/Xedra_Evolved/snippets/dreams.json
+++ b/data/mods/Xedra_Evolved/snippets/dreams.json
@@ -116,7 +116,7 @@
       "You dream of falling through darkness.",
       "You dream of whistling winds as you stand on a mountaintop.",
       "You dream of the moon growing larger and larger, filling the sky.",
-      "You dream of walking through the forest and suddenly seeing an owl fly past you within arm's reach.",
+      "You dream of walking through the forest and suddenly seeing an owl fly past you, so close you could touch it.",
       "You dream of something sitting on your chest, suffocating you.",
       "You dream of slipping under dark water, none of your attempts to swim keeping you afloat.",
       "You dream of standing in a dark room, being buffeted by silent wings."

--- a/data/mods/Xedra_Evolved/snippets/dreams.json
+++ b/data/mods/Xedra_Evolved/snippets/dreams.json
@@ -108,5 +108,18 @@
       "You are in a field where the scarecrows come to life and chase you with knives.",
       "You are in a house where the paintings change every time you look away, showing your worst fears."
     ]
+  },
+  {
+    "type": "snippet",
+    "category": "snippet_drained_by_lilit",
+    "text": [
+      "You dream of falling through darkness.",
+      "You dream of whistling winds as you stand on a mountaintop.",
+      "You dream of the moon growing larger and larger, filling the sky.",
+      "You dream of walking through the forest and suddenly seeing an owl fly past you within arm's reach.",
+      "You dream of something sitting on your chest, suffocating you.",
+      "You dream of slipping under dark water, none of your attempts to swim keeping you afloat.",
+      "You dream of standing in a dark room, being buffeted by silent wings."
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/lilin_spell_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/lilin_spell_eocs.json
@@ -7,7 +7,7 @@
     "effect": [
       { "math": [ "n_vitamin('lilin_ruach_vitamin')", "+=", "rng(200,300)" ] },
       { "npc_message": "You feel a rush of warmth as you absorb the ruach.", "type": "good" },
-      { "math": [ "u_lilin_ruach_drained_recently", "==", "1" ] },
+      { "math": [ "u_lilin_ruach_drained_recently", "=", "1" ] },
       { "run_eocs": "EOC_LILIN_RUACH_DRAIN_SIDE_EFFECTS" }
     ],
     "false_effect": [

--- a/data/mods/Xedra_Evolved/spells/lilin_spell_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/lilin_spell_eocs.json
@@ -7,6 +7,7 @@
     "effect": [
       { "math": [ "n_vitamin('lilin_ruach_vitamin')", "+=", "rng(200,300)" ] },
       { "npc_message": "You feel a rush of warmth as you absorb the ruach.", "type": "good" },
+      { "math": [ "u_lilin_ruach_drained_recently", "==", "1" ] },
       { "run_eocs": "EOC_LILIN_RUACH_DRAIN_SIDE_EFFECTS" }
     ],
     "false_effect": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Add (very small) chance of being attacked by a lilit in your sleep"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

> Rav Chanina said: It is forbidden to sleep alone in a house, and whoever sleeps alone in a house will be seized by a lilit.
-Tractate Shabbat, 151b

I thought it might be interesting in XE to have some random weird events with a very low probability, so you aren't likely (or expected to) run into it in every playthrough. This is one. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the chance of being attacked by a lilit in your sleep. This is very rare, because it requires the following:

1. You aren't a lilit yourself (professional courtesy)
2. You are sleeping alone (any nearby NPCs prevent it)
3. At night (sleeping during the daytime prevents it)
4. Inside (sleeping outdoors prevents it)
5. Very rarely (base 1 in 365 chance to occur)

You can also prevent it entirely by wearing a holy symbol (no way to narrow it down to a ḥamsa or something similar since all holy symbols are variants, but that's fine)

If this event fires, you have some bad dreams and gain the Ruach-Drained effect, which lowers your health and makes you more fatigued on waking up for as long as it lasts. On future nights, you have a much higher chance of being attacked again (up to 180 in 365), unless you take one of the above precautions, which completely prevents it from occurring. 

If you are sick (cold or flu), the chance also rises, though not nearly as high as having been recently attacked.

If you sleep in a place that fulfills the conditions within the first couple weeks of the Cataclysm, when you wake up you get a popup about how sleeping alone in an abandoned building is much more creepy than it used to be. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![Untitled2](https://github.com/user-attachments/assets/b94b0f4c-a4b6-4a89-a56d-0e147a207e06)

Warning can fire, lilit attack can fire, further attacks can happen if you've already been attacked once, they happen in abandoned buildings. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

NPCs are subject to this too, but if you keep NPCs around to drain ruach from, you won't have to worry about them being "attacked" again by virtue of you (or other NPCs) being around them when they sleep. 

Ran into a weird effect where `character_wakes_up` eocs were being triggered multiple times, but have no idea how to replicate it. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
