### PR TITLE
Fleeing NPCs will now attack player that got too close

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1368,7 +1368,11 @@ void npc::move()
         action = method_of_fleeing();
     } else if( ( target == &player_character && attitude == NPCATT_FLEE_TEMP ) ||
                has_effect( effect_npc_run_away ) ) {
-        action = method_of_fleeing();
+        if( rl_dist( pos(), player_character.pos() ) <= 1 ) {
+            action = method_of_attack();
+        } else {
+            action = method_of_fleeing();
+        }
     } else if( has_effect( effect_asthma ) && ( has_charges( itype_inhaler, 1 ) ||
                has_charges( itype_oxygen_tank, 1 ) ||
                has_charges( itype_smoxygen_tank, 1 ) ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1368,7 +1368,7 @@ void npc::move()
         action = method_of_fleeing();
     } else if( ( target == &player_character && attitude == NPCATT_FLEE_TEMP ) ||
                has_effect( effect_npc_run_away ) ) {
-        if( target && rl_dist( pos(), target.pos() ) <= 1 ) {
+        if( target && rl_dist( pos(), target->pos() ) <= 1 ) {
             action = method_of_attack();
         } else {
             action = method_of_fleeing();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1368,7 +1368,7 @@ void npc::move()
         action = method_of_fleeing();
     } else if( ( target == &player_character && attitude == NPCATT_FLEE_TEMP ) ||
                has_effect( effect_npc_run_away ) ) {
-        if( rl_dist( pos(), player_character.pos() ) <= 1 ) {
+        if( target && rl_dist( pos(), target.pos() ) <= 1 ) {
             action = method_of_attack();
         } else {
             action = method_of_fleeing();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1144,6 +1144,7 @@ void npc::act_on_danger_assessment()
                 add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s upgrades reposition to flat out retreat.", name );
                 mem_combat.repositioning = false; // we're not just moving, we're running.
                 warn_about( "run_away", run_away_for );
+                set_attitude( NPCATT_FLEE_TEMP );
                 if( mem_combat.panic > 5 && is_player_ally() && sees( player_character.pos_bub() ) ) {
                     // consider warning player about panic
                     int panic_alert = rl_dist( pos(), player_character.pos() ) - player_character.get_per();
@@ -1368,7 +1369,7 @@ void npc::move()
         action = method_of_fleeing();
     } else if( ( target == &player_character && attitude == NPCATT_FLEE_TEMP ) ||
                has_effect( effect_npc_run_away ) ) {
-        if( target && rl_dist( pos(), target->pos() ) <= 1 ) {
+        if( hp_percentage() > 30 && target && rl_dist( pos(), target->pos() ) <= 1 ) {
             action = method_of_attack();
         } else {
             action = method_of_fleeing();


### PR DESCRIPTION
#### Summary
Features "Fleeing NPCs will now attack player that got too close"

#### Purpose of change
* Closes #49299.

#### Describe the solution
Player gets adjacent to fleeing NPC -> NPC (if they have more than 30% health) attacks the player.
Also NPC will change their attitude to `NPCATT_FLEE_TEMP` if they decide to flee during danger assessment. This fixes the issue of NPC still having the attitude of `Attacking to kill` despite they decided to flee when they realized that things are going bad for them.

#### Describe alternatives you've considered
Make NPCs attack only 50% or 75% of time.
Make NPCs fire their ranged weapons when distance between him and player is 2 or 3.

#### Testing
Spawned NPC, gave him fleeing attitude. Ran to him, got a hit in the face.

#### Additional context
None.