### PR TITLE
Don't try to shoot with empty gun

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -755,7 +755,7 @@ void avatar_action::fire_wielded_weapon( avatar &you )
         return;
     } else if( !weapon->is_gun() ) {
         return;
-    } else if( weapon->ammo_data() &&
+    } else if( weapon->has_ammo_data() &&
                !weapon->ammo_types().count( weapon->loaded_ammo().ammo_type() ) ) {
         add_msg( m_info, _( "The %s can't be fired while loaded with incompatible ammunition %s" ),
                  weapon->tname(), weapon->ammo_current()->nname( 1 ) );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1688,7 +1688,7 @@ class weapon_inventory_preset: public inventory_selector_preset
 
                 const int total_damage = loc->gun_damage( true ).total_damage();
 
-                if( loc->has_ammo_data() && loc->ammo_remaining() ) {
+                if( loc->has_ammo() ) {
                     const int basic_damage = loc->gun_damage( false ).total_damage();
                     const damage_instance &damage = loc->ammo_data()->ammo->damage;
                     if( !damage.empty() ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1688,7 +1688,7 @@ class weapon_inventory_preset: public inventory_selector_preset
 
                 const int total_damage = loc->gun_damage( true ).total_damage();
 
-                if( loc->ammo_data() && loc->ammo_remaining() ) {
+                if( loc->has_ammo_data() && loc->ammo_remaining() ) {
                     const int basic_damage = loc->gun_damage( false ).total_damage();
                     const damage_instance &damage = loc->ammo_data()->ammo->damage;
                     if( !damage.empty() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11179,7 +11179,7 @@ int item::activation_consume( int qty, const tripoint &pos, Character *carrier )
     return ammo_consume( qty * ammo_required(), pos, carrier );
 }
 
-const bool item::has_ammo() const
+bool item::has_ammo() const
 {
     const item *mag = magazine_current();
     if( mag ) {
@@ -11204,7 +11204,7 @@ const bool item::has_ammo() const
     return false;
 }
 
-const bool item::has_ammo_data() const
+bool item::has_ammo_data() const
 {
     const item *mag = magazine_current();
     if( mag ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10590,7 +10590,7 @@ int item::gun_dispersion( bool with_ammo, bool with_scaling ) const
     int dispPerDamage = get_option< int >( "DISPERSION_PER_GUN_DAMAGE" );
     dispersion_sum += damage_level() * dispPerDamage;
     dispersion_sum = std::max( dispersion_sum, 0 );
-    if( with_ammo && has_ammo_data() ) {
+    if( with_ammo && has_ammo() ) {
         dispersion_sum += ammo_data()->ammo->dispersion_considering_length( barrel_length() );
     }
     if( !with_scaling ) {
@@ -10643,7 +10643,7 @@ damage_instance item::gun_damage( bool with_ammo, bool shot ) const
         ret.add( mod->type->gunmod->damage.di_considering_length( bl ) );
     }
 
-    if( with_ammo && has_ammo_data() ) {
+    if( with_ammo && has_ammo() ) {
         if( shot ) {
             ret.add( ammo_data()->ammo->shot_damage.di_considering_length( bl ) );
         } else {
@@ -10728,7 +10728,7 @@ int item::gun_recoil( const Character &p, bool bipod, bool ideal_strength ) cons
     handling = std::pow( wt, 0.8 ) * std::pow( handling, 1.2 );
 
     int qty = type->gun->recoil;
-    if( has_ammo_data() ) {
+    if( has_ammo() ) {
         qty += ammo_data()->ammo->recoil;
     }
 
@@ -10763,7 +10763,7 @@ int item::gun_range( bool with_ammo ) const
         ret += mod->type->gunmod->range;
         range_multiplier *= mod->type->gunmod->range_multiplier;
     }
-    if( with_ammo && has_ammo_data() ) {
+    if( with_ammo && has_ammo() ) {
         ret += ammo_data()->ammo->range;
         range_multiplier *= ammo_data()->ammo->range_multiplier;
     }
@@ -11400,7 +11400,7 @@ std::set<ammo_effect_str_id> item::ammo_effects( bool with_ammo ) const
     }
 
     std::set<ammo_effect_str_id> res = type->gun->ammo_effects;
-    if( with_ammo && has_ammo_data() ) {
+    if( with_ammo && has_ammo() ) {
         res.insert( ammo_data()->ammo->ammo_effects.begin(), ammo_data()->ammo->ammo_effects.end() );
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2962,7 +2962,7 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                       bool /* debug */ ) const
 {
     // Skip this section for guns and items without ammo data
-    if( is_gun() || !ammo_data() ||
+    if( is_gun() || !has_ammo_data() ||
         !parts->test( iteminfo_parts::AMMO_REMAINING_OR_TYPES ) ) {
         return;
     }
@@ -3416,7 +3416,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         }
     }
 
-    if( mod->ammo_data() && parts->test( iteminfo_parts::AMMO_REMAINING ) ) {
+    if( mod->has_ammo_data() && parts->test( iteminfo_parts::AMMO_REMAINING ) ) {
         info.emplace_back( "AMMO", _( "Ammunition: " ), string_format( "<stat>%s</stat>",
                            mod->ammo_data()->nname( mod->ammo_remaining() ) ) );
     }
@@ -4838,7 +4838,7 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                            _( "* This tool <info>runs on bionic power</info>." ) );
     } else if( has_flag( flag_BURNOUT ) && parts->test( iteminfo_parts::TOOL_BURNOUT ) ) {
         int percent_left = 0;
-        if( ammo_data() != nullptr ) {
+        if( has_ammo_data() ) {
             // Candle items that use ammo instead of charges
             // The capacity should never be zero but clang complains about it
             percent_left = 100 * ammo_remaining() / std::max( ammo_capacity( ammo_data()->ammo->type ), 1 );
@@ -10590,7 +10590,7 @@ int item::gun_dispersion( bool with_ammo, bool with_scaling ) const
     int dispPerDamage = get_option< int >( "DISPERSION_PER_GUN_DAMAGE" );
     dispersion_sum += damage_level() * dispPerDamage;
     dispersion_sum = std::max( dispersion_sum, 0 );
-    if( with_ammo && ammo_data() ) {
+    if( with_ammo && has_ammo_data() ) {
         dispersion_sum += ammo_data()->ammo->dispersion_considering_length( barrel_length() );
     }
     if( !with_scaling ) {
@@ -10643,7 +10643,7 @@ damage_instance item::gun_damage( bool with_ammo, bool shot ) const
         ret.add( mod->type->gunmod->damage.di_considering_length( bl ) );
     }
 
-    if( with_ammo && ammo_data() ) {
+    if( with_ammo && has_ammo_data() ) {
         if( shot ) {
             ret.add( ammo_data()->ammo->shot_damage.di_considering_length( bl ) );
         } else {
@@ -10728,7 +10728,7 @@ int item::gun_recoil( const Character &p, bool bipod, bool ideal_strength ) cons
     handling = std::pow( wt, 0.8 ) * std::pow( handling, 1.2 );
 
     int qty = type->gun->recoil;
-    if( ammo_data() ) {
+    if( has_ammo_data() ) {
         qty += ammo_data()->ammo->recoil;
     }
 
@@ -10763,7 +10763,7 @@ int item::gun_range( bool with_ammo ) const
         ret += mod->type->gunmod->range;
         range_multiplier *= mod->type->gunmod->range_multiplier;
     }
-    if( with_ammo && ammo_data() ) {
+    if( with_ammo && has_ammo_data() ) {
         ret += ammo_data()->ammo->range;
         range_multiplier *= ammo_data()->ammo->range_multiplier;
     }
@@ -11179,6 +11179,56 @@ int item::activation_consume( int qty, const tripoint &pos, Character *carrier )
     return ammo_consume( qty * ammo_required(), pos, carrier );
 }
 
+const bool item::has_ammo() const
+{
+    const item *mag = magazine_current();
+    if( mag ) {
+        return mag->has_ammo();
+    }
+
+    if( is_ammo() ) {
+        return true;
+    }
+
+    if( is_magazine() ) {
+        return !contents.empty();
+    }
+
+    auto mods = is_gun() ? gunmods() : toolmods();
+    for( const item *e : mods ) {
+        if( !e->type->mod->ammo_modifier.empty() && e->has_ammo() ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+const bool item::has_ammo_data() const
+{
+    const item *mag = magazine_current();
+    if( mag ) {
+        return mag->has_ammo_data();
+    }
+
+    if( is_ammo() ) {
+        return true;
+    }
+
+    if( is_magazine() ) {
+        return !contents.empty();
+    }
+
+    auto mods = is_gun() ? gunmods() : toolmods();
+    for( const item *e : mods ) {
+        if( !e->type->mod->ammo_modifier.empty() && e->has_ammo_data() ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 const itype *item::ammo_data() const
 {
     const item *mag = magazine_current();
@@ -11350,7 +11400,7 @@ std::set<ammo_effect_str_id> item::ammo_effects( bool with_ammo ) const
     }
 
     std::set<ammo_effect_str_id> res = type->gun->ammo_effects;
-    if( with_ammo && ammo_data() ) {
+    if( with_ammo && has_ammo_data() ) {
         res.insert( ammo_data()->ammo->ammo_effects.begin(), ammo_data()->ammo->ammo_effects.end() );
     }
 

--- a/src/item.h
+++ b/src/item.h
@@ -2567,9 +2567,9 @@ class item : public visitable
         // Returns whether the item has ammo in it, either directly or via a selected magazine, which
         // contrasts with ammo_data(), which just returns the magazine data if a magazine is selected,
         // regardless of whether that magazine is empty or not.
-        const bool has_ammo() const;
+        bool has_ammo() const;
         // Cheaper way to just check if ammo_data exists if the data is to be just discarded afterwards.
-        const bool has_ammo_data() const;
+        bool has_ammo_data() const;
         /** Specific ammo data, returns nullptr if item is neither ammo nor loaded with any */
         const itype *ammo_data() const;
         /** Specific ammo type, returns "null" if item is neither ammo nor loaded with any */

--- a/src/item.h
+++ b/src/item.h
@@ -2564,6 +2564,12 @@ class item : public visitable
          */
         int activation_consume( int qty, const tripoint &pos, Character *carrier );
 
+        // Returns whether the item has ammo in it, either directly or via a selected magazine, which
+        // contrasts with ammo_data(), which just returns the magazine data if a magazine is selected,
+        // regardless of whether that magazine is empty or not.
+        const bool has_ammo() const;
+        // Cheaper way to just check if ammo_data exists if the data is to be just discarded afterwards.
+        const bool has_ammo_data() const;
         /** Specific ammo data, returns nullptr if item is neither ammo nor loaded with any */
         const itype *ammo_data() const;
         /** Specific ammo type, returns "null" if item is neither ammo nor loaded with any */

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -468,7 +468,7 @@ bool npc_attack_gun::can_use( const npc &source ) const
 {
     // can't attack with something you can't wield or which lacks ammo.
     return ( source.is_wielding( *gunmode ) || source.can_wield( *gunmode ).success() )
-           && gun.ammo_data() != nullptr && gun.ammo_data()->ammo != nullptr;
+           && gun.has_ammo();
 }
 
 int npc_attack_gun::base_time_penalty( const npc &source ) const

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -6,6 +6,7 @@
 #include "dialogue.h"
 #include "flag.h"
 #include "item.h"
+#include "itype.h"
 #include "line.h"
 #include "magic.h"
 #include "magic_spell_effect_helpers.h"
@@ -465,8 +466,9 @@ void npc_attack_gun::use( npc &source, const tripoint_bub_ms &location ) const
 
 bool npc_attack_gun::can_use( const npc &source ) const
 {
-    // can't attack with something you can't wield
-    return source.is_wielding( *gunmode ) || source.can_wield( *gunmode ).success();
+    // can't attack with something you can't wield or which lacks ammo.
+    return ( source.is_wielding( *gunmode ) || source.can_wield( *gunmode ).success()
+             && gun.ammo_data() != nullptr && gun.ammo_data()->ammo != nullptr );
 }
 
 int npc_attack_gun::base_time_penalty( const npc &source ) const

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -467,8 +467,8 @@ void npc_attack_gun::use( npc &source, const tripoint_bub_ms &location ) const
 bool npc_attack_gun::can_use( const npc &source ) const
 {
     // can't attack with something you can't wield or which lacks ammo.
-    return ( source.is_wielding( *gunmode ) || source.can_wield( *gunmode ).success()
-             && gun.ammo_data() != nullptr && gun.ammo_data()->ammo != nullptr );
+    return ( source.is_wielding( *gunmode ) || source.can_wield( *gunmode ).success() )
+           && gun.ammo_data() != nullptr && gun.ammo_data()->ammo != nullptr;
 }
 
 int npc_attack_gun::base_time_penalty( const npc &source ) const

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -807,8 +807,8 @@ bool Character::handle_gun_damage( item &it )
         it.inc_damage();
     }
     if( !it.has_flag( flag_PRIMITIVE_RANGED_WEAPON ) ) {
-        if( it.ammo_data() != nullptr && ( ( it.ammo_data()->ammo->recoil < it.min_cycle_recoil() ) ||
-                                           ( it.has_fault_flag( "BAD_CYCLING" ) && one_in( 16 ) ) ) &&
+        if( it.has_ammo_data() && ( ( it.ammo_data()->ammo->recoil < it.min_cycle_recoil() ) ||
+                                    ( it.has_fault_flag( "BAD_CYCLING" ) && one_in( 16 ) ) ) &&
             it.faults_potential().count( fault_gun_chamber_spent ) ) {
             add_msg_player_or_npc( m_bad, _( "Your %s fails to cycle!" ),
                                    _( "<npcname>'s %s fails to cycle!" ),
@@ -2172,12 +2172,12 @@ static projectile make_gun_projectile( const item &gun )
 
     auto &fx = proj.proj_effects;
 
-    if( ( gun.ammo_data() && gun.ammo_data()->phase == phase_id::LIQUID ) ||
+    if( ( gun.has_ammo_data() && gun.ammo_data()->phase == phase_id::LIQUID ) ||
         fx.count( ammo_effect_SHOT ) || fx.count( ammo_effect_BOUNCE ) ) {
         fx.insert( ammo_effect_WIDE );
     }
 
-    if( gun.ammo_data() ) {
+    if( gun.has_ammo_data() ) {
         const auto &ammo = gun.ammo_data()->ammo;
 
         // Some projectiles have a chance of being recoverable
@@ -2312,7 +2312,7 @@ item::sound_data item::gun_noise( const bool burst ) const
     }
 
     int noise = type->gun->loudness;
-    if( ammo_data() ) {
+    if( has_ammo_data() ) {
         noise += ammo_data()->ammo->loudness;
     }
     for( const item *mod : gunmods() ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -807,8 +807,8 @@ bool Character::handle_gun_damage( item &it )
         it.inc_damage();
     }
     if( !it.has_flag( flag_PRIMITIVE_RANGED_WEAPON ) ) {
-        if( it.has_ammo_data() && ( ( it.ammo_data()->ammo->recoil < it.min_cycle_recoil() ) ||
-                                    ( it.has_fault_flag( "BAD_CYCLING" ) && one_in( 16 ) ) ) &&
+        if( it.has_ammo() && ( ( it.ammo_data()->ammo->recoil < it.min_cycle_recoil() ) ||
+                               ( it.has_fault_flag( "BAD_CYCLING" ) && one_in( 16 ) ) ) &&
             it.faults_potential().count( fault_gun_chamber_spent ) ) {
             add_msg_player_or_npc( m_bad, _( "Your %s fails to cycle!" ),
                                    _( "<npcname>'s %s fails to cycle!" ),
@@ -2177,7 +2177,7 @@ static projectile make_gun_projectile( const item &gun )
         fx.insert( ammo_effect_WIDE );
     }
 
-    if( gun.has_ammo_data() ) {
+    if( gun.has_ammo() ) {
         const auto &ammo = gun.ammo_data()->ammo;
 
         // Some projectiles have a chance of being recoverable
@@ -2312,7 +2312,7 @@ item::sound_data item::gun_noise( const bool burst ) const
     }
 
     int noise = type->gun->loudness;
-    if( has_ammo_data() ) {
+    if( has_ammo() ) {
         noise += ammo_data()->ammo->loudness;
     }
     for( const item *mod : gunmods() ) {

--- a/tests/reload_magazine_test.cpp
+++ b/tests/reload_magazine_test.cpp
@@ -72,7 +72,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location] [re
     CHECK( mag->ammo_types().count( gun_ammo ) );
     CHECK( mag->ammo_capacity( gun_ammo ) == mag_cap );
     CHECK( mag->ammo_current().is_null() );
-    CHECK( mag->ammo_data() == nullptr );
+    CHECK( !mag->has_ammo_data() );
 
     GIVEN( "An empty magazine" ) {
         CHECK( mag->ammo_remaining() == 0 );
@@ -96,7 +96,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location] [re
 
                 AND_THEN( "the current ammo is updated" ) {
                     REQUIRE( mag->ammo_current() == ammo_id );
-                    REQUIRE( mag->ammo_data() );
+                    REQUIRE( mag->has_ammo_data() );
                 }
                 AND_THEN( "the magazine is filled to capacity" ) {
                     REQUIRE( mag->remaining_ammo_capacity() == 0 );
@@ -126,7 +126,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location] [re
 
                 AND_THEN( "the current ammo is updated" ) {
                     REQUIRE( mag->ammo_current() == ammo_id );
-                    REQUIRE( mag->ammo_data() );
+                    REQUIRE( mag->has_ammo_data() );
                 }
                 AND_THEN( "the magazine is filled with the correct quantity" ) {
                     REQUIRE( mag->ammo_remaining() == mag_cap - 2 );
@@ -206,7 +206,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location] [re
         CHECK( gun->ammo_capacity( gun_ammo ) == 0 );
         CHECK( gun->ammo_remaining() == 0 );
         CHECK( gun->ammo_current().is_null() );
-        CHECK( gun->ammo_data() == nullptr );
+        CHECK( !gun->has_ammo_data() );
 
         WHEN( "the gun is reloaded with an incompatible magazine" ) {
             item_location mag = player_character.i_add( item( bad_mag ) );
@@ -237,7 +237,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location] [re
                 AND_THEN( "the gun contains no ammo" ) {
                     REQUIRE( gun->ammo_current().is_null() );
                     REQUIRE( gun->ammo_remaining() == 0 );
-                    REQUIRE( gun->ammo_data() == nullptr );
+                    REQUIRE( !gun->has_ammo_data() );
                 }
             }
         }
@@ -264,7 +264,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location] [re
                 AND_THEN( "the gun contains the correct amount and type of ammo" ) {
                     REQUIRE( gun->ammo_remaining() == mag_cap - 2 );
                     REQUIRE( gun->ammo_current() == ammo_id );
-                    REQUIRE( gun->ammo_data() );
+                    REQUIRE( gun->has_ammo_data() );
                 }
 
                 AND_WHEN( "the guns magazine is further reloaded with compatible but different ammo" ) {
@@ -359,7 +359,7 @@ TEST_CASE( "reload_revolver", "[visitable] [item] [item_location] [reload]" )
         CHECK( gun->ammo_capacity( gun_ammo ) == mag_cap );
         CHECK( gun->ammo_remaining() == 0 );
         CHECK( gun->ammo_current().is_null() );
-        CHECK( gun->ammo_data() == nullptr );
+        CHECK( !gun->has_ammo_data() );
 
         WHEN( "the gun is reloaded with incompatible ammo" ) {
             item_location ammo = player_character.i_add( item( bad_ammo ) );
@@ -380,7 +380,7 @@ TEST_CASE( "reload_revolver", "[visitable] [item] [item_location] [reload]" )
 
                 AND_THEN( "the current ammo is updated" ) {
                     REQUIRE( gun->ammo_current() == ammo_id );
-                    REQUIRE( gun->ammo_data() );
+                    REQUIRE( gun->has_ammo_data() );
                 }
                 AND_THEN( "the gun is filled to capacity" ) {
                     REQUIRE( gun->remaining_ammo_capacity() == 0 );
@@ -410,7 +410,7 @@ TEST_CASE( "reload_revolver", "[visitable] [item] [item_location] [reload]" )
 
                 AND_THEN( "the current ammo is updated" ) {
                     REQUIRE( gun->ammo_current() == ammo_id );
-                    REQUIRE( gun->ammo_data() );
+                    REQUIRE( gun->has_ammo_data() );
                 }
                 AND_THEN( "the gun is filled with the correct quantity" ) {
                     REQUIRE( gun->ammo_remaining() == mag_cap - 2 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #77602, i.e. segmentation fault when trying to evaluate dispersion from an empty gun.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change npc_attack_gun::can_use to reject gun usage when a gun is empty, not only when it can't be wielded.
This causes the gun not to be attempted to be evaluated for firing performance down the line.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Leave it to someone qualified. Now those people will have to evaluate this PR instead.
- Add a check in npc::wont_hit_friend to return "false" if there's no ammo. That also causes the symptoms to disappear, but thought it better to not evaluate the firing of an empty gun at all. Competent reviewers may disagree.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the save in the bug report and verified that not only didn't it blow up, but Liam did actually reload a gun (don't know if "varmint gun" is the same as the "Ruger" seen with the debugger), so the rejection doesn't seem to block gun usage to the degree that there is no attempt at reloading.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The comment for the item::ammo_data() function is dangerously misleading. It claims it will return a nullptr if the gun isn't loaded, but that's a partial lie, as it happily returns data involving an empty magazine (although it probably rejects a direct loaded gun that's empty. Thus, anyone trusting enough to believe this may get a nasty surprise (segfault) when faced with an empty magazine and trying to use the ammo pointer that was promised to lead somewhere (it didn't matter here, as the ammo_data() results wasn't checked anyway).

Needs to be reviewed by competent reviewers. I THINK it's reasonable to bail out early, but it's possible this may lead to things that should be attempted being untried. Seeing the companion reload indicates at least one such possible failure seems to not happen in absolutely all cases.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
