### PR TITLE
Allow mission UI to scroll

### DIFF
--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -60,8 +60,7 @@ class mission_ui_impl : public cataimgui::window
     public:
         std::string last_action;
         explicit mission_ui_impl() : cataimgui::window( _( "Your missions" ),
-                    ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoNav |
-                    ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse ) {
+                    ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoNav ) {
         }
 
     private:
@@ -139,6 +138,12 @@ void mission_ui_impl::draw_controls()
         selected_mission = 0;
         switch_tab = selected_tab;
         --switch_tab;
+    } else if( last_action == "PAGE_UP" ) {
+        ImGui::SetWindowFocus(); // Dumb hack! Clear our focused item so listbox selection isn't nav highlighted.
+        ImGui::SetScrollY( ImGui::GetScrollY() - ( window_height / 5.0f ) );
+    } else if( last_action == "PAGE_DOWN" ) {
+        ImGui::SetWindowFocus(); // Dumb hack! Clear our focused item so listbox selection isn't nav highlighted.
+        ImGui::SetScrollY( ImGui::GetScrollY() + ( window_height / 5.0f ) );
     }
 
     ImGuiTabItemFlags_ flags = ImGuiTabItemFlags_None;


### PR DESCRIPTION
#### Summary
Interface "The mission UI can scroll to read longer description"

#### Purpose of change
![image](https://github.com/user-attachments/assets/b6265584-e1db-4bf5-b6e6-cfd0bfdefea3)

(It was not a known issue)


#### Describe the solution
Just let it scroll. (Vertically. See testing for text wrapping issues/etc.)

I originally set it up not to allow scrolling due to concerns with how it interacted with listbox. Listbox seems to ignore the ImGuiWindowFlags_NoNav flag when setting highlights. I came up with a dumb little kludge to make sure the highlights only appear when they should (when keyboard input is registered to move on the listbox).

Scrolling is done normally with the mouse (scroll wheel or drag the scroll bar). For the keyboard it's handled by pageup/pagedown since these were already registered to uilist, whose controls we are emulating.

https://github.com/CleverRaven/Cataclysm-DDA/blob/93c608cab7c028638c95b2be3dfd930e33f4bedb/src/mission_ui.cpp#L88

#### Describe alternatives you've considered
Enforce length limitations on our descriptions? 

Figure out what listbox/nav shennanigans are going on upstream

#### Testing
Copy-pasted lorem ipsum text into the description of a mission about a dozen times, checked it ingame. Scrolled all the way to the end. 

No weird behavior spotted except some text wrapping issues - those seem to be due to the freetype changeover. Checking before and after shows the wrapping behavior doesn't change with this PR, so unrelated.


https://github.com/user-attachments/assets/6320b331-d0db-4b6f-b211-58fc77972a16


#### Additional context

