### PR TITLE
Replace point and tripoint sentinel values with constants

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -285,7 +285,7 @@ static tripoint_abs_omt om_target_tile(
     const tripoint_abs_omt &omt_pos, int min_range = 1, int range = 1,
     const std::vector<std::string> &possible_om_types = {}, ot_match_type match_type =
         ot_match_type::exact, bool must_see = true,
-    const tripoint_abs_omt &source = tripoint_abs_omt( -999, -999, -999 ),
+    const tripoint_abs_omt &source = overmap::invalid_tripoint,
     bool bounce = false, const std::optional<std::string> &message = std::nullopt );
 static void om_range_mark( const tripoint_abs_omt &origin, int range, bool add_notes = true,
                            const std::string &message = "Y;X: MAX RANGE" );
@@ -2591,7 +2591,7 @@ void basecamp::start_cut_logs( const mission_id &miss_id, float exertion_level )
                                            };
     tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, log_sources, ot_match_type::type,
                               _( "Select a forest (or road/trail) from %d to %d tiles away." ) );
-    if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
+    if( forest != overmap::invalid_tripoint ) {
         standard_npc sample_npc( "Temp" );
         sample_npc.set_fake( true );
         int tree_est = om_cutdown_trees_est( forest, 50 );
@@ -2630,7 +2630,7 @@ void basecamp::start_clearcut( const mission_id &miss_id, float exertion_level )
                                            };
     popup( _( "Forests are the only valid cutting locations, with forest dirt roads, forest rural roads, and trails being valid as well.  Note that it's likely both forest and field roads look exactly the same after having been cleared." ) );
     tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, log_sources, ot_match_type::type );
-    if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
+    if( forest != overmap::invalid_tripoint ) {
         standard_npc sample_npc( "Temp" );
         sample_npc.set_fake( true );
         int tree_est = om_cutdown_trees_est( forest, 95 );
@@ -2666,7 +2666,7 @@ void basecamp::start_setup_hide_site( const mission_id &miss_id, float exertion_
     tripoint_abs_omt forest = om_target_tile( omt_pos, 10, 90, hide_locations,
                               ot_match_type::type,
                               true, omt_pos, true, _( "Select an forest, swamp, or field from %d to %d tiles away." ) );
-    if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
+    if( forest != overmap::invalid_tripoint ) {
         int dist = rl_dist( forest.xy(), omt_pos.xy() );
         Character *pc = &get_player_character();
         const inventory_filter_preset preset( []( const item_location & location ) {
@@ -2713,7 +2713,7 @@ void basecamp::start_relay_hide_site( const mission_id &miss_id, float exertion_
     tripoint_abs_omt forest = om_target_tile( omt_pos, 10, 90, hide_locations, ot_match_type::exact,
                               true, omt_pos, true, string_format(
                                   _( "Select an existing hide site from %d to %d tiles away." ), 10, 90 ) );
-    if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
+    if( forest != overmap::invalid_tripoint ) {
         int dist = rl_dist( forest.xy(), omt_pos.xy() );
         Character *pc = &get_player_character();
         const inventory_filter_preset preset( []( const item_location & location ) {
@@ -2842,96 +2842,101 @@ void basecamp::start_fortifications( const mission_id &miss_id, float exertion_l
               "constructions." ) );
     tripoint_abs_omt start = om_target_tile( omt_pos, 2, 90, allowed_locations,
                              ot_match_type::type, true, omt_pos, _( "Select a start point from %d to %d tiles away." ) );
+    if( start == overmap::invalid_tripoint ) {
+        return;
+    }
     tripoint_abs_omt stop = om_target_tile( omt_pos, 2, 90, allowed_locations,
                                             ot_match_type::type,
                                             true, start, _( "Select an end point from %d to %d tiles away." ) );
-    if( start != tripoint_abs_omt( -999, -999, -999 ) &&
-        stop != tripoint_abs_omt( -999, -999, -999 ) ) {
-        const recipe &making = recipe_id( miss_id.parameters ).obj();
-        bool change_x = start.x() != stop.x();
-        bool change_y = start.y() != stop.y();
-        if( change_x && change_y ) {
-            popup( _( "Construction line must be straight!" ) );
+    if( stop == overmap::invalid_tripoint ) {
+        return;
+    }
+    const recipe &making = recipe_id( miss_id.parameters ).obj();
+    bool change_x = start.x() != stop.x();
+    bool change_y = start.y() != stop.y();
+    if( change_x && change_y ) {
+        popup( _( "Construction line must be straight!" ) );
+        return;
+    }
+    if( miss_id.parameters == faction_wall_level_n_1_string ) {
+        std::vector<tripoint_abs_omt> tmp_line = line_to( stop, start );
+        // line_to doesn't include the origin point
+        tmp_line.emplace_back( stop );
+        int line_count = tmp_line.size();
+        int yes_count = 0;
+        for( tripoint_abs_omt &elem : tmp_line ) {
+            if( std::find( fortifications.begin(), fortifications.end(), elem ) != fortifications.end() ) {
+                yes_count += 1;
+            }
+        }
+        if( yes_count < line_count ) {
+            popup( _( "Spiked pits must be built over existing trenches!" ) );
             return;
         }
-        if( miss_id.parameters == faction_wall_level_n_1_string ) {
-            std::vector<tripoint_abs_omt> tmp_line = line_to( stop, start );
-            int line_count = tmp_line.size();
-            int yes_count = 0;
-            for( tripoint_abs_omt &elem : tmp_line ) {
-                if( std::find( fortifications.begin(), fortifications.end(), elem ) != fortifications.end() ) {
-                    yes_count += 1;
-                }
-            }
-            if( yes_count < line_count ) {
-                popup( _( "Spiked pits must be built over existing trenches!" ) );
-                return;
+    }
+    std::vector<tripoint_abs_omt> fortify_om;
+    if( ( change_x && stop.x() < start.x() ) || ( change_y && stop.y() < start.y() ) ) {
+        //line_to doesn't include the origin point
+        fortify_om.push_back( stop );
+        std::vector<tripoint_abs_omt> tmp_line = line_to( stop, start );
+        fortify_om.insert( fortify_om.end(), tmp_line.begin(), tmp_line.end() );
+    } else {
+        fortify_om.push_back( start );
+        std::vector<tripoint_abs_omt> tmp_line = line_to( start, stop );
+        fortify_om.insert( fortify_om.end(), tmp_line.begin(), tmp_line.end() );
+    }
+    int trips = 0;
+    time_duration build_time = 0_hours;
+    time_duration travel_time = 0_hours;
+    int dist = 0;
+    for( tripoint_abs_omt &fort_om : fortify_om ) {
+        bool valid = false;
+        const oter_id &omt_ref = overmap_buffer.ter( fort_om );
+        for( const std::string &pos_om : allowed_locations ) {
+            if( omt_ref.id().c_str() == pos_om ) {
+                valid = true;
+                break;
             }
         }
-        std::vector<tripoint_abs_omt> fortify_om;
-        if( ( change_x && stop.x() < start.x() ) || ( change_y && stop.y() < start.y() ) ) {
-            //line_to doesn't include the origin point
-            fortify_om.push_back( stop );
-            std::vector<tripoint_abs_omt> tmp_line = line_to( stop, start );
-            fortify_om.insert( fortify_om.end(), tmp_line.begin(), tmp_line.end() );
-        } else {
-            fortify_om.push_back( start );
-            std::vector<tripoint_abs_omt> tmp_line = line_to( start, stop );
-            fortify_om.insert( fortify_om.end(), tmp_line.begin(), tmp_line.end() );
-        }
-        int trips = 0;
-        time_duration build_time = 0_hours;
-        time_duration travel_time = 0_hours;
-        int dist = 0;
-        for( tripoint_abs_omt &fort_om : fortify_om ) {
-            bool valid = false;
-            const oter_id &omt_ref = overmap_buffer.ter( fort_om );
-            for( const std::string &pos_om : allowed_locations ) {
-                if( omt_ref.id().c_str() == pos_om ) {
-                    valid = true;
-                    break;
-                }
-            }
 
-            if( !valid ) {
-                popup( _( "Invalid terrain in construction path." ) );
-                return;
-            }
-            trips += 2;
-            build_time += making.batch_duration( get_player_character() );
-            dist += rl_dist( fort_om.xy(), omt_pos.xy() );
-            travel_time += companion_travel_time_calc( fort_om, omt_pos, 0_minutes, 2 );
-        }
-        time_duration total_time = base_camps::to_workdays( travel_time + build_time );
-        int need_food = time_to_food( total_time, exertion_level );
-        if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( total_time, build_time,
-                       travel_time, dist, trips, need_food ) ) ) {
-            return;
-        } else if( !making.deduped_requirements().can_make_with_inventory( _inv,
-                   making.get_component_filter(), ( fortify_om.size() * 2 ) - 2 ) ) {
-            popup( _( "You don't have the material to build the fortification." ) );
+        if( !valid ) {
+            popup( _( "Invalid terrain in construction path." ) );
             return;
         }
+        trips += 2;
+        build_time += making.batch_duration( get_player_character() );
+        dist += rl_dist( fort_om.xy(), omt_pos.xy() );
+        travel_time += companion_travel_time_calc( fort_om, omt_pos, 0_minutes, 2 );
+    }
+    time_duration total_time = base_camps::to_workdays( travel_time + build_time );
+    int need_food = time_to_food( total_time, exertion_level );
+    if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( total_time, build_time,
+                   travel_time, dist, trips, need_food ) ) ) {
+        return;
+    } else if( !making.deduped_requirements().can_make_with_inventory( _inv,
+               making.get_component_filter(), ( fortify_om.size() * 2 ) - 2 ) ) {
+        popup( _( "You don't have the material to build the fortification." ) );
+        return;
+    }
 
-        const int batch_size = fortify_om.size() * 2 - 2;
-        mapgen_arguments arg;  //  Created with a default value.
-        basecamp_action_components components( making, arg, batch_size, *this );
-        if( !components.choose_components() ) {
-            return;
+    const int batch_size = fortify_om.size() * 2 - 2;
+    mapgen_arguments arg;  //  Created with a default value.
+    basecamp_action_components components( making, arg, batch_size, *this );
+    if( !components.choose_components() ) {
+        return;
+    }
+
+    npc_ptr comp = start_mission(
+                       miss_id, total_time, true,
+                       _( "begins constructing fortifications…" ), false, {},
+                       exertion_level, making.required_skills );
+    if( comp != nullptr ) {
+        components.consume_components();
+        for( tripoint_abs_omt &pt : fortify_om ) {
+            comp->companion_mission_points.push_back( pt );
         }
 
-        npc_ptr comp = start_mission(
-                           miss_id, total_time, true,
-                           _( "begins constructing fortifications…" ), false, {},
-                           exertion_level, making.required_skills );
-        if( comp != nullptr ) {
-            components.consume_components();
-            for( tripoint_abs_omt &pt : fortify_om ) {
-                comp->companion_mission_points.push_back( pt );
-            }
-
-            apply_fortifications( miss_id, &comp, true );
-        }
+        apply_fortifications( miss_id, &comp, true );
     }
 }
 
@@ -2956,7 +2961,7 @@ using PathMap = cata::mdarray<double, point, path_map_size, path_map_size>;
 //  recipe approach taken.
 static point check_salt_pipe_neighbors( PathMap &path_map, point pt )
 {
-    point found = { -999, -999 };
+    point found = overmap::invalid_point;
     double lowest_found = -10000.0;
     double cost;
 
@@ -3076,7 +3081,7 @@ point connection_direction_of( const point &dir, const recipe &making )
     }
     if( count > 1 ) {
         popup( _( "Bug, Incorrect recipe: More than one rotation per orientation isn't valid" ) );
-        return {-999, -999};
+        return overmap::invalid_point;
     }
 
     if( making.has_flag( "MAP_MIRROR_HORIZONTAL_IF_" + suffix ) ) {
@@ -3267,7 +3272,7 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
     const recipe &making = recipe_id( miss_id.parameters ).obj();
     point connection_dir = connection_direction_of( dir, making );
 
-    if( connection_dir.x == -999 && connection_dir.y == -999 ) {
+    if( connection_dir == overmap::invalid_point ) {
         return;
     }
 
@@ -3356,7 +3361,7 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
                         if( path_map[max_salt_water_pipe_distance + i][max_salt_water_pipe_distance + k] >
                             0.0 ) { // Tile has been assigned a distance and isn't a swamp
                             point temp = check_salt_pipe_neighbors( path_map, { i, k } );
-                            if( temp != point( -999, -999 ) ) {
+                            if( temp != overmap::invalid_point ) {
                                 if( path_map[max_salt_water_pipe_distance + temp.x][max_salt_water_pipe_distance + temp.y] >
                                     destination_cost ) {
                                     destination_cost = path_map[max_salt_water_pipe_distance + temp.x][max_salt_water_pipe_distance +
@@ -5002,7 +5007,7 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
     om_range_mark( omt_pos, min_range, true, "Y;X: MIN RANGE" );
     const std::string &real_message = string_format(
                                           message ? *message : _( "Select a location from %d to %d tiles away." ), min_range, range );
-    if( source == tripoint_abs_omt( -999, -999, -999 ) ) {
+    if( source == overmap::invalid_tripoint ) {
         where = ui::omap::choose_point( real_message );
     } else {
         where = ui::omap::choose_point( real_message, source );
@@ -5011,7 +5016,7 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
     om_range_mark( omt_pos, min_range, false, "Y;X: MIN RANGE" );
 
     if( where == overmap::invalid_tripoint ) {
-        return tripoint_abs_omt( -999, -999, -999 );
+        return overmap::invalid_tripoint;
     }
     int dist = rl_dist( where.xy(), omt_pos.xy() );
     if( dist > range || dist < min_range ) {
@@ -5230,7 +5235,7 @@ std::vector<tripoint_abs_omt> om_companion_path( const tripoint_abs_omt &start, 
     while( range > 3 ) {
         tripoint_abs_omt spt = om_target_tile( last, 0, range, {}, ot_match_type::exact, false, last,
                                                false );
-        if( spt == tripoint_abs_omt( -999, -999, -999 ) ) {
+        if( spt == overmap::invalid_tripoint ) {
             scout_points.clear();
             return scout_points;
         }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7229,7 +7229,7 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
             p->remove_value( "remote_controlling" );
         } else {
             std::list<std::pair<tripoint_bub_ms, item *>> rc_pairs = here.get_rc_items();
-            tripoint_bub_ms rc_item_location = {999, 999, 999};
+            tripoint_bub_ms rc_item_location = overmap::invalid_tripoint_bub_ms;
             // TODO: grab the closest car or similar?
             for( auto &rc_pairs_rc_pair : rc_pairs ) {
                 if( rc_pairs_rc_pair.second->has_flag( flag_RADIOCAR ) &&
@@ -7237,7 +7237,7 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
                     rc_item_location = rc_pairs_rc_pair.first;
                 }
             }
-            if( rc_item_location.x() == 999 ) {
+            if( rc_item_location == overmap::invalid_tripoint_bub_ms ) {
                 p->add_msg_if_player( _( "No active RC cars on ground and in range." ) );
                 return 1;
             } else {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3617,7 +3617,7 @@ void npc::set_companion_mission( const tripoint_abs_omt &omt_pos, const std::str
 
 void npc::reset_companion_mission()
 {
-    comp_mission.position = tripoint_abs_omt( -999, -999, -999 );
+    comp_mission.position = overmap::invalid_tripoint;
     reset_miss_id( comp_mission.miss_id );
     comp_mission.role_id.clear();
     if( comp_mission.destination ) {

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -294,9 +294,17 @@ class overmap
             return inbounds( tripoint_om_omt( p, 0 ), clearance );
         }
         /**
-         * Dummy value, used to indicate that a point returned by a function is invalid.
+         * Dummy value, used to indicate that a tripoint returned by a function is invalid.
          */
         static constexpr tripoint_abs_omt invalid_tripoint{ tripoint_min };
+        /**
+         * Dummy value, used to indicate that a tripoint returned by a function is invalid.
+         */
+        static constexpr tripoint_bub_ms invalid_tripoint_bub_ms{ tripoint_min };
+        /**
+         * Dummy value, used to indicate that a point returned by a function is invalid.
+         */
+        static constexpr point invalid_point{ point_min };
         /**
          * Return a vector containing the absolute coordinates of
          * every matching note on the current z level of the current overmap.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Most places a point is invalid or the user cancels a selection we use overmap::invalid_tripoint, but a few have custom local sentinel values like tripoint(-999,-999,-999). This inconsistency makes it harder to reason and follow the relevant code.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Update all uses of those sentinel values to use the defined constant, or two new defined constants for other point types.

Also in one case, do early return from basecamp::start_fortifications when the user cancels a selection. That change looks big, but is very small if you view the diff without whitespace changes.

Also due to the whitespace situation, a one line bug fix snuck into that section. It is commented in the PR.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I've been using most of this for a couple of weeks as part of #77397, and have triggered most of the others in manual testing.

The sole remaining `-999, -999` is in `iuse::granade_act` and I can't figure out how to trigger it with an invalid position, even after adding it to an item and using that item in various ways.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
