### PR TITLE
Terrain/furniture: code deduplication and improved "copy-from" support

### DIFF
--- a/data/json/connect_groups.json
+++ b/data/json/connect_groups.json
@@ -1,9 +1,7 @@
 [
   {
     "type": "connect_group",
-    "id": "WALL",
-    "group_flags": [ "WALL", "CONNECT_WITH_WALL" ],
-    "connects_to_flags": [ "WALL", "CONNECT_WITH_WALL" ]
+    "id": "WALL"
   },
   {
     "type": "connect_group",
@@ -135,8 +133,6 @@
   },
   {
     "type": "connect_group",
-    "id": "INDOORFLOOR",
-    "group_flags": [ "INDOORS" ],
-    "rotates_to_flags": [ "WINDOW", "DOOR" ]
+    "id": "INDOORFLOOR"
   }
 ]

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4863,12 +4863,15 @@ int om_harvest_ter( npc &comp, const tripoint_abs_omt &omt_tgt, const ter_id &t,
                 continue;
             }
             if( bring_back ) {
-                for( const item &itm : item_group::items_from( ter_tgt.bash.drop_group,
-                        calendar::turn ) ) {
-                    comp.companion_mission_inv.push_back( itm );
+                const std::optional<map_ter_bash_info> &bash = ter_tgt.bash;
+                if( bash ) {
+                    for( const item &itm : item_group::items_from( ter_tgt.bash->drop_group,
+                            calendar::turn ) ) {
+                        comp.companion_mission_inv.push_back( itm );
+                    }
+                    harvested++;
+                    target_bay.ter_set( p, ter_tgt.bash->ter_set );
                 }
-                harvested++;
-                target_bay.ter_set( p, ter_tgt.bash.ter_set );
             }
         }
     }

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -309,8 +309,12 @@ void field_type::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "mopsafe", mopsafe, false );
 
     optional( jo, was_loaded, "decrease_intensity_on_contact", decrease_intensity_on_contact, false );
-
-    bash_info.load( jo, "bash", map_bash_info::field, "field " + id.str() );
+    if( jo.has_object( "bash" ) ) {
+        if( !bash_info ) {
+            bash_info.emplace();
+        }
+        bash_info->load( jo.get_object( "bash" ), was_loaded, "field " + id.str() );
+    }
     if( was_loaded && jo.has_member( "copy-from" ) && looks_like.empty() ) {
         looks_like = jo.get_string( "copy-from" );
     }

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -207,7 +207,7 @@ struct field_type {
         bool has_elec = false;
         bool has_fume = false;
         description_affix desc_affix = description_affix::DESCRIPTION_AFFIX_NUM;
-        map_bash_info bash_info;
+        std::optional<map_fd_bash_info> bash_info;
 
         // chance, issue, duration, speech
         std::tuple<int, std::string, time_duration, translation> npc_complain_data;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -993,30 +993,31 @@ avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
         }
     }
     for( std::pair<const field_type_id, field_entry> &fd_to_smsh : here.field_at( smashp ) ) {
-        const map_bash_info &bash_info = fd_to_smsh.first->bash_info;
-        if( bash_info.str_min == -1 ) {
+        const std::optional<map_fd_bash_info> &bash_info = fd_to_smsh.first->bash_info;
+        if( !bash_info ) {
             continue;
         }
-        if( smashskill < bash_info.str_min && one_in( 10 ) ) {
+        if( smashskill < bash_info->str_min && one_in( 10 ) ) {
             add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), fd_to_smsh.first->get_name() );
             ret.did_smash = true;
             return ret;
-        } else if( smashskill >= rng( bash_info.str_min, bash_info.str_max ) ) {
-            sounds::sound( smashp, bash_info.sound_vol, sounds::sound_t::combat, bash_info.sound, true, "smash",
+        } else if( smashskill >= rng( bash_info->str_min, bash_info->str_max ) ) {
+            sounds::sound( smashp, bash_info->sound_vol, sounds::sound_t::combat, bash_info->sound, true,
+                           "smash",
                            "field" );
             here.remove_field( smashp, fd_to_smsh.first );
-            here.spawn_items( smashp, item_group::items_from( bash_info.drop_group, calendar::turn ) );
-            mod_moves( - bash_info.fd_bash_move_cost );
-            add_msg( m_info, bash_info.field_bash_msg_success.translated() );
+            here.spawn_items( smashp, item_group::items_from( bash_info->drop_group, calendar::turn ) );
+            mod_moves( - bash_info->fd_bash_move_cost );
+            add_msg( m_info, bash_info->field_bash_msg_success.translated() );
             ret.did_smash = true;
             ret.success = true;
             return ret;
         } else {
-            sounds::sound( smashp, bash_info.sound_fail_vol, sounds::sound_t::combat, bash_info.sound_fail,
+            sounds::sound( smashp, bash_info->sound_fail_vol, sounds::sound_t::combat, bash_info->sound_fail,
                            true, "smash",
                            "field" );
 
-            ret.resistance = bash_info.str_min;
+            ret.resistance = bash_info->str_min;
             ret.did_smash = true;
             return ret;
         }
@@ -1123,7 +1124,7 @@ avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
             // Bash not effective
             g->draw_async_anim( smashp, "bash_ineffective" );
             if( one_in( 10 ) ) {
-                if( here.has_furn( smashp ) && here.furn( smashp ).obj().bash.str_min != -1 ) {
+                if( here.has_furn( smashp ) && here.furn( smashp ).obj().bash ) {
                     // %s is the smashed furniture
                     add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), here.furnname( smashp ) );
                 } else {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1713,7 +1713,8 @@ void iexamine::portable_structure( Character &you, const tripoint_bub_ms &examp 
         }
         radius = actor.radius;
     } else {
-        radius = std::max( 1, fid->bash.collapse_radius );
+        const std::optional<map_furn_bash_info> &furn_bash = fid.obj().bash;
+        radius = std::max( 1, furn_bash ? furn_bash->collapse_radius : 0 );
     }
 
     if( !query_yn( _( "Take down the %s?" ), name ) ) {

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -30,6 +30,7 @@
 #include "type_id.h"
 
 static furn_id f_null;
+static const furn_str_id furn_f_null( "f_null" );
 
 static const item_group_id Item_spawn_data_EMPTY_GROUP( "EMPTY_GROUP" );
 
@@ -306,30 +307,6 @@ void connect_group::load( const JsonObject &jo )
         return;
     }
 
-    if( jo.has_string( "group_flags" ) || jo.has_array( "group_flags" ) ) {
-        const std::vector<std::string> str_flags = jo.get_as_string_array( "group_flags" );
-        for( const std::string &flag : str_flags ) {
-            const ter_furn_flag f = io::string_to_enum<ter_furn_flag>( flag );
-            result.group_flags.insert( f );
-        }
-    }
-
-    if( jo.has_string( "connects_to_flags" ) || jo.has_array( "connects_to_flags" ) ) {
-        const std::vector<std::string> str_flags = jo.get_as_string_array( "connects_to_flags" );
-        for( const std::string &flag : str_flags ) {
-            const ter_furn_flag f = io::string_to_enum<ter_furn_flag>( flag );
-            result.connects_to_flags.insert( f );
-        }
-    }
-
-    if( jo.has_string( "rotates_to_flags" ) || jo.has_array( "rotates_to_flags" ) ) {
-        const std::vector<std::string> str_flags = jo.get_as_string_array( "rotates_to_flags" );
-        for( const std::string &flag : str_flags ) {
-            const ter_furn_flag f = io::string_to_enum<ter_furn_flag>( flag );
-            result.rotates_to_flags.insert( f );
-        }
-    }
-
     ter_connects_map[ result.id.str() ] = result;
 }
 
@@ -340,106 +317,98 @@ void connect_group::reset()
 
 static void load_map_bash_tent_centers( const JsonArray &ja, std::vector<furn_str_id> &centers )
 {
+    centers.clear();
     for( const std::string line : ja ) {
         centers.emplace_back( line );
     }
 }
 
-map_bash_info::map_bash_info() : str_min( -1 ), str_max( -1 ),
-    str_min_blocked( -1 ), str_max_blocked( -1 ),
-    str_min_supported( -1 ), str_max_supported( -1 ),
-    explosive( 0 ), sound_vol( -1 ), sound_fail_vol( -1 ),
-    collapse_radius( 1 ), destroy_only( false ), bash_below( false ),
-    drop_group( Item_spawn_data_EMPTY_GROUP ),
-    ter_set( ter_str_id::NULL_ID() ), furn_set( furn_str_id::NULL_ID() ) {}
-
-bool map_bash_info::load( const JsonObject &jsobj, const std::string_view member,
-                          map_object_type obj_type, const std::string &context )
+void map_common_bash_info::load( const JsonObject &jo, const bool was_loaded,
+                                 const std::string &context )
 {
-    if( !jsobj.has_object( member ) ) {
-        return false;
-    }
+    optional( jo, was_loaded, "str_min", str_min, -1 );
+    optional( jo, was_loaded, "str_max", str_max, -1 );
 
-    JsonObject j = jsobj.get_object( member );
-    str_min = j.get_int( "str_min", 0 );
-    str_max = j.get_int( "str_max", 0 );
+    optional( jo, was_loaded, "str_min_blocked", str_min_blocked, -1 );
+    optional( jo, was_loaded, "str_max_blocked", str_max_blocked, -1 );
 
-    str_min_blocked = j.get_int( "str_min_blocked", -1 );
-    str_max_blocked = j.get_int( "str_max_blocked", -1 );
+    optional( jo, was_loaded, "str_min_supported", str_min_supported, -1 );
+    optional( jo, was_loaded, "str_max_supported", str_max_supported, -1 );
 
-    str_min_supported = j.get_int( "str_min_supported", -1 );
-    str_max_supported = j.get_int( "str_max_supported", -1 );
+    optional( jo, was_loaded, "explosive", explosive, -1 );
 
-    explosive = j.get_int( "explosive", -1 );
+    optional( jo, was_loaded, "sound_vol", sound_vol, -1 );
+    optional( jo, was_loaded, "sound_fail_vol", sound_fail_vol, -1 );
 
-    sound_vol = j.get_int( "sound_vol", -1 );
-    sound_fail_vol = j.get_int( "sound_fail_vol", -1 );
+    optional( jo, was_loaded, "collapse_radius", collapse_radius, 1 );
 
-    collapse_radius = j.get_int( "collapse_radius", 1 );
+    optional( jo, was_loaded, "destroy_only", destroy_only, false );
 
-    destroy_only = j.get_bool( "destroy_only", false );
+    optional( jo, was_loaded, "bash_below", bash_below, false );
 
-    bash_below = j.get_bool( "bash_below", false );
+    optional( jo, was_loaded, "sound", sound, to_translation( "smash!" ) );
+    optional( jo, was_loaded, "sound_fail", sound_fail, to_translation( "thump!" ) );
 
-    sound = to_translation( "smash!" );
-    sound_fail = to_translation( "thump!" );
-    j.read( "sound", sound );
-    j.read( "sound_fail", sound_fail );
-
-    switch( obj_type ) {
-        case map_bash_info::furniture:
-            furn_set = furn_str_id( j.get_string( "furn_set", "f_null" ) );
-            break;
-        case map_bash_info::terrain:
-            ter_set = ter_str_id( j.get_string( "ter_set" ) );
-            ter_set_bashed_from_above = ter_str_id( j.get_string( "ter_set_bashed_from_above",
-                                                    ter_set.c_str() ) );
-            break;
-        case map_bash_info::field:
-            fd_bash_move_cost = j.get_int( "move_cost", 100 );
-            j.read( "msg_success", field_bash_msg_success );
-            break;
-    }
-
-    if( j.has_member( "items" ) ) {
-        drop_group = item_group::load_item_group( j.get_member( "items" ), "collection",
+    if( jo.has_member( "items" ) ) {
+        drop_group = item_group::load_item_group( jo.get_member( "items" ), "collection",
                      "map_bash_info for " + context );
-    } else {
+    } else if( !was_loaded ) {
         drop_group = Item_spawn_data_EMPTY_GROUP;
     }
 
-    if( j.has_array( "tent_centers" ) ) {
-        load_map_bash_tent_centers( j.get_array( "tent_centers" ), tent_centers );
+    if( jo.has_array( "tent_centers" ) ) {
+        load_map_bash_tent_centers( jo.get_array( "tent_centers" ), tent_centers );
     }
-
-    return true;
+}
+void map_ter_bash_info::load( const JsonObject &jo, const bool was_loaded,
+                              const std::string &context )
+{
+    map_common_bash_info::load( jo, was_loaded, context );
+    mandatory( jo, was_loaded, "ter_set", ter_set );
+    optional( jo, was_loaded, "ter_set_bashed_from_above", ter_set_bashed_from_above, ter_set );
+}
+void map_furn_bash_info::load( const JsonObject &jo, const bool was_loaded,
+                               const std::string &context )
+{
+    map_common_bash_info::load( jo, was_loaded, context );
+    optional( jo, was_loaded, "furn_set", furn_set, furn_f_null );
+}
+void map_fd_bash_info::load( const JsonObject &jo, const bool was_loaded,
+                             const std::string &context )
+{
+    map_common_bash_info::load( jo, was_loaded, context );
+    optional( jo, was_loaded, "move_cost", fd_bash_move_cost, 100 );
+    optional( jo, was_loaded, "msg_success", field_bash_msg_success );
 }
 
-map_deconstruct_info::map_deconstruct_info() : can_do( false ), deconstruct_above( false ),
-    ter_set( ter_str_id::NULL_ID() ), furn_set( furn_str_id::NULL_ID() ) {}
 
-bool map_deconstruct_info::load( const JsonObject &jsobj, const std::string_view member,
-                                 bool is_furniture, const std::string &context )
+void map_common_deconstruct_info::load( const JsonObject &jo, const bool was_loaded,
+                                        const std::string &context )
 {
-    if( !jsobj.has_object( member ) ) {
-        return false;
+    if( jo.has_object( "skill" ) ) {
+        JsonObject jos = jo.get_object( "skill" );
+        skill = { skill_id( jos.get_string( "skill" ) ), jos.get_int( "min", 0 ), jos.get_int( "max", 10 ), jos.get_float( "multiplier", 1.0 ) };
     }
-    JsonObject j = jsobj.get_object( member );
-    furn_set = furn_str_id( j.get_string( "furn_set", "f_null" ) );
+    optional( jo, was_loaded, "deconstruct_above", deconstruct_above, false );
+    if( jo.has_member( "items" ) ) {
+        drop_group = item_group::load_item_group( jo.get_member( "items" ), "collection",
+                     "map_deconstruct_info for " + context );
+    } else if( !was_loaded ) {
+        drop_group = Item_spawn_data_EMPTY_GROUP;
+    }
+}
 
-    if( !is_furniture ) {
-        ter_set = ter_str_id( j.get_string( "ter_set" ) );
-    }
-    if( j.has_object( "skill" ) ) {
-        JsonObject jo = j.get_object( "skill" );
-        skill = { skill_id( jo.get_string( "skill" ) ), jo.get_int( "min", 0 ), jo.get_int( "max", 10 ), jo.get_float( "multiplier", 1.0 ) };
-    }
-    can_do = true;
-    deconstruct_above = j.get_bool( "deconstruct_above", false );
-
-    drop_group = item_group::load_item_group( j.get_member( "items" ), "collection",
-                 "map_deconstruct_info for " + context );
-    return true;
+void map_ter_deconstruct_info::load( const JsonObject &jo, const bool was_loaded,
+                                     const std::string &context )
+{
+    mandatory( jo, was_loaded, "ter_set", ter_set );
+    map_common_deconstruct_info::load( jo, was_loaded, context );
+}
+void map_furn_deconstruct_info::load( const JsonObject &jo, const bool was_loaded,
+                                      const std::string &context )
+{
+    optional( jo, was_loaded, "furn_set", furn_set, furn_f_null );
+    map_common_deconstruct_info::load( jo, was_loaded, context );
 }
 
 bool map_shoot_info::load( const JsonObject &jsobj, const std::string_view member, bool was_loaded )
@@ -771,7 +740,7 @@ std::vector<std::string> map_data_common_t::extended_description() const
             add( text );
         }
     };
-    add_if( bash.str_max != -1 && !bash.bash_below, _( "Smashable." ) );
+    add_if( is_smashable(), _( "Smashable." ) );
     add_if( has_flag( ter_furn_flag::TFLAG_DIGGABLE ), _( "Diggable." ) );
     add_if( has_flag( ter_furn_flag::TFLAG_PLOWABLE ), _( "Plowable." ) );
     add_if( has_flag( ter_furn_flag::TFLAG_ROUGH ), _( "Rough." ) );
@@ -780,9 +749,7 @@ std::vector<std::string> map_data_common_t::extended_description() const
     add_if( has_flag( ter_furn_flag::TFLAG_FLAT ), _( "Flat." ) );
     add_if( has_flag( ter_furn_flag::TFLAG_EASY_DECONSTRUCT ), _( "Simple." ) );
     add_if( has_flag( ter_furn_flag::TFLAG_MOUNTABLE ), _( "Mountable." ) );
-    add_if( has_flag( ter_furn_flag::TFLAG_FLAMMABLE ) ||
-            has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ||
-            has_flag( ter_furn_flag::TFLAG_FLAMMABLE_HARD ), _( "Flammable." ) );
+    add_if( is_flammable(), _( "Flammable." ) );
     tmp.emplace_back( result );
 
     std::vector<std::string> ret;
@@ -810,33 +777,14 @@ void load_terrain( const JsonObject &jo, const std::string &src )
     terrain_data.load( jo, src );
 }
 
-void map_data_common_t::extraprocess_flags( const ter_furn_flag flag )
-{
-    if( !transparent && ( flag == ter_furn_flag::TFLAG_TRANSPARENT ||
-                          flag == ter_furn_flag::TFLAG_TRANSLUCENT ) ) {
-        transparent = true;
-    }
-
-    for( std::pair<const std::string, connect_group> &item : ter_connects_map ) {
-        if( item.second.group_flags.find( flag ) != item.second.group_flags.end() ) {
-            set_connect_groups( { item.second.id.str() } );
-        }
-        if( item.second.connects_to_flags.find( flag ) != item.second.connects_to_flags.end() ) {
-            set_connects_to( { item.second.id.str() } );
-        }
-        if( item.second.rotates_to_flags.find( flag ) != item.second.rotates_to_flags.end() ) {
-            set_rotates_to( { item.second.id.str() } );
-        }
-    }
-}
-
 void map_data_common_t::set_flag( const std::string &flag )
 {
     flags.insert( flag );
     std::optional<ter_furn_flag> f = io::string_to_enum_optional<ter_furn_flag>( flag );
     if( f.has_value() ) {
         bitflags.set( f.value() );
-        extraprocess_flags( f.value() );
+        transparent |= f.value() == ter_furn_flag::TFLAG_TRANSPARENT ||
+                       f.value() == ter_furn_flag::TFLAG_TRANSLUCENT;
     }
 }
 
@@ -844,7 +792,28 @@ void map_data_common_t::set_flag( const ter_furn_flag flag )
 {
     flags.insert( io::enum_to_string<ter_furn_flag>( flag ) );
     bitflags.set( flag );
-    extraprocess_flags( flag );
+    transparent |= flag == ter_furn_flag::TFLAG_TRANSPARENT || flag == ter_furn_flag::TFLAG_TRANSLUCENT;
+}
+
+void map_data_common_t::unset_flag( const std::string &flag )
+{
+    if( auto it_flag = flags.find( flag ); it_flag != flags.end() ) {
+        flags.erase( it_flag );
+    } //else return false?
+    std::optional<ter_furn_flag> f = io::string_to_enum_optional<ter_furn_flag>( flag );
+    if( f.has_value() ) {
+        bitflags.reset( f.value() );
+        if( transparent ) {
+            transparent = f.value() != ter_furn_flag::TFLAG_TRANSPARENT;
+        }
+    }
+}
+
+void map_data_common_t::unset_flags()
+{
+    flags.clear();
+    bitflags.reset();
+    transparent = false; //?
 }
 
 void map_data_common_t::set_connect_groups( const std::vector<std::string>
@@ -968,6 +937,27 @@ void init_mapdata()
 
 void map_data_common_t::load( const JsonObject &jo, const std::string &src )
 {
+    mandatory( jo, was_loaded, "name", name_ );
+    mandatory( jo, was_loaded, "description", description );
+
+    optional( jo, was_loaded, "comfort", comfort, 0 );
+
+    if( jo.has_member( "connect_groups" ) ) {
+        connect_groups.reset();
+        set_connect_groups( jo.get_as_string_array( "connect_groups" ) );
+    }
+    if( jo.has_member( "connects_to" ) ) {
+        connect_to_groups.reset();
+        set_connects_to( jo.get_as_string_array( "connects_to" ) );
+    }
+    if( jo.has_member( "rotates_to" ) ) {
+        rotate_to_groups.reset();
+        set_rotates_to( jo.get_as_string_array( "rotates_to" ) );
+    }
+    optional( jo, was_loaded, "coverage", coverage );
+    optional( jo, was_loaded, "curtain_transform", curtain_transform );
+    optional( jo, was_loaded, "emissions", emissions );
+
     if( jo.has_string( "examine_action" ) ) {
         examine_actor = nullptr;
         examine_func = iexamine_functions_from_string( jo.get_string( "examine_action" ) );
@@ -979,6 +969,25 @@ void map_data_common_t::load( const JsonObject &jo, const std::string &src )
     } else if( !was_loaded ) {
         examine_actor = nullptr;
         examine_func = iexamine_functions_from_string( "none" );
+    }
+
+    if( was_loaded && jo.has_member( "flags" ) ) {
+        unset_flags();
+    }
+    for( auto &flag : jo.get_string_array( "flags" ) ) {
+        set_flag( flag );
+    }
+    if( was_loaded && jo.has_member( "extend" ) ) {
+        JsonObject joe = jo.get_object( "extend" );
+        for( auto &flag : joe.get_string_array( "flags" ) ) {
+            set_flag( flag );
+        }
+    }
+    if( was_loaded && jo.has_member( "delete" ) ) {
+        JsonObject jod = jo.get_object( "delete" );
+        for( auto &flag : jod.get_string_array( "flags" ) ) {
+            unset_flag( flag );
+        }
     }
 
     if( jo.has_array( "harvest_by_season" ) ) {
@@ -1010,13 +1019,20 @@ void map_data_common_t::load( const JsonObject &jo, const std::string &src )
         }
     }
 
-    mandatory( jo, was_loaded, "description", description );
     optional( jo, was_loaded, "curtain_transform", curtain_transform );
+    int legacy_floor_bedding_warmth = units::to_legacy_bodypart_temp_delta(
+                                          floor_bedding_warmth ); //TODO: Should be in map_data_common_t::load?
+    optional( jo, was_loaded, "floor_bedding_warmth", legacy_floor_bedding_warmth, 0 );
+    floor_bedding_warmth = units::from_legacy_bodypart_temp_delta( legacy_floor_bedding_warmth );
+
+    optional( jo, was_loaded, "lockpick_message", lockpick_message, translation() );
+    optional( jo, was_loaded, "light_emitted", light_emitted );
 
     if( jo.has_object( "shoot" ) ) {
         shoot = cata::make_value<map_shoot_info>();
         shoot->load( jo, "shoot", was_loaded );
     }
+
 }
 
 bool ter_t::is_null() const
@@ -1027,41 +1043,14 @@ bool ter_t::is_null() const
 void ter_t::load( const JsonObject &jo, const std::string &src )
 {
     map_data_common_t::load( jo, src );
-    mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "move_cost", movecost );
-    optional( jo, was_loaded, "coverage", coverage );
     assign( jo, "max_volume", max_volume, src == "dda" );
     optional( jo, was_loaded, "trap", trap_id_str );
     optional( jo, was_loaded, "heat_radiation", heat_radiation );
-    optional( jo, was_loaded, "light_emitted", light_emitted );
-    int legacy_floor_bedding_warmth = units::to_legacy_bodypart_temp_delta( floor_bedding_warmth );
-    optional( jo, was_loaded, "floor_bedding_warmth", legacy_floor_bedding_warmth, 0 );
-    floor_bedding_warmth = units::from_legacy_bodypart_temp_delta( legacy_floor_bedding_warmth );
-    optional( jo, was_loaded, "comfort", comfort, 0 );
 
     load_symbol( jo, "terrain " + id.str() );
 
     trap = tr_null;
-    transparent = false;
-    connect_groups.reset();
-    connect_to_groups.reset();
-    rotate_to_groups.reset();
-
-    for( auto &flag : jo.get_string_array( "flags" ) ) {
-        set_flag( flag );
-    }
-    // connect_to_groups is initialized to none, then terrain flags are set, then finally
-    // connections from JSON are set. This is so that wall flags can set wall connections
-    // but can be overridden by explicit connections in JSON.
-    if( jo.has_member( "connect_groups" ) ) {
-        set_connect_groups( jo.get_as_string_array( "connect_groups" ) );
-    }
-    if( jo.has_member( "connects_to" ) ) {
-        set_connects_to( jo.get_as_string_array( "connects_to" ) );
-    }
-    if( jo.has_member( "rotates_to" ) ) {
-        set_rotates_to( jo.get_as_string_array( "rotates_to" ) );
-    }
 
     optional( jo, was_loaded, "allowed_template_ids", allowed_template_id );
 
@@ -1071,10 +1060,9 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "roof", roof, ter_str_id::NULL_ID() );
 
     optional( jo, was_loaded, "lockpick_result", lockpick_result, ter_str_id::NULL_ID() );
-    optional( jo, was_loaded, "lockpick_message", lockpick_message, translation() );
 
     oxytorch = cata::make_value<activity_data_ter>();
-    if( jo.has_object( "oxytorch" ) ) {
+    if( jo.has_object( "oxytorch" ) ) { //TODO: Make overwriting these with eg "oxytorch": { } work while still allowing overwriting single values
         oxytorch->load( jo.get_object( "oxytorch" ) );
     }
 
@@ -1093,57 +1081,93 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
         prying->load( jo.get_object( "prying" ) );
     }
 
-    optional( jo, was_loaded, "emissions", emissions );
-
-    bash.load( jo, "bash", map_bash_info::terrain, "terrain " + id.str() );
-    deconstruct.load( jo, "deconstruct", false, "terrain " + id.str() );
-}
-
-static void check_bash_items( const map_bash_info &mbi, const std::string &id, bool is_terrain )
-{
-    if( !item_group::group_is_defined( mbi.drop_group ) ) {
-        debugmsg( "%s: bash result item group %s does not exist", id.c_str(), mbi.drop_group.c_str() );
+    if( jo.has_object( "bash" ) ) {
+        if( !bash ) {
+            bash.emplace();
+        }
+        bash->load( jo.get_object( "bash" ), was_loaded,
+                    "terrain " +
+                    id.str() ); //TODO: Make overwriting these with "bash": { } works while still allowing overwriting single values ie for "ter_set"
     }
-    if( mbi.str_max != -1 ) {
-        if( is_terrain && mbi.ter_set.is_empty() ) { // Some tiles specify t_null explicitly
-            debugmsg( "bash result terrain of %s is undefined/empty", id.c_str() );
+    if( jo.has_object( "deconstruct" ) ) {
+        if( !deconstruct ) {
+            deconstruct.emplace();
         }
-        if( !mbi.ter_set.is_valid() ) {
-            debugmsg( "bash result terrain %s of %s does not exist", mbi.ter_set.c_str(), id.c_str() );
-        }
-        if( !mbi.furn_set.is_valid() ) {
-            debugmsg( "bash result furniture %s of %s does not exist", mbi.furn_set.c_str(), id.c_str() );
-        }
+        deconstruct->load( jo.get_object( "deconstruct" ), was_loaded, "terrain " + id.str() );
     }
 }
 
-static void check_decon_items( const map_deconstruct_info &mbi, const std::string &id,
-                               bool is_terrain )
+void map_common_bash_info::check( const std::string &id ) const
 {
-    if( !mbi.can_do ) {
-        return;
+    if( !drop_group.is_empty() ) {
+        if( !item_group::group_is_defined( drop_group ) ) {
+            debugmsg( "%s: bash result item group %s does not exist", id, drop_group.c_str() );
+        }
     }
-    if( !item_group::group_is_defined( mbi.drop_group ) ) {
-        debugmsg( "%s: deconstruct result item group %s does not exist", id.c_str(),
-                  mbi.drop_group.c_str() );
+}
+void map_ter_bash_info::check( const std::string &id ) const
+{
+    map_common_bash_info::check( id );
+    if( str_max != -1 ) {
+        if( ter_set.is_empty() ) { // Some tiles specify t_null explicitly
+            debugmsg( "bash result terrain of %s is undefined/empty", id );
+        }
+        if( !ter_set.is_valid() ) {
+            debugmsg( "bash result terrain %s of %s does not exist", ter_set.c_str(), id );
+        }
     }
-    if( is_terrain && mbi.ter_set.is_empty() ) { // Some tiles specify t_null explicitly
-        debugmsg( "deconstruct result terrain of %s is undefined/empty", id.c_str() );
+}
+void map_furn_bash_info::check( const std::string &id ) const
+{
+    map_common_bash_info::check( id );
+    if( str_max != -1 ) {
+        if( !furn_set.is_valid() ) {
+            debugmsg( "bash result furniture %s of %s does not exist", furn_set.c_str(), id );
+        }
     }
-    if( !mbi.ter_set.is_valid() ) {
-        debugmsg( "deconstruct result terrain %s of %s does not exist", mbi.ter_set.c_str(), id.c_str() );
+}
+void map_fd_bash_info::check( const std::string &id ) const
+{
+    map_common_bash_info::check( id );
+}
+
+void map_common_deconstruct_info::check( const std::string &id ) const
+{
+    if( !item_group::group_is_defined( drop_group ) ) {
+        debugmsg( "%s: deconstruct result item group %s does not exist", id, drop_group.c_str() );
     }
-    if( !mbi.furn_set.is_valid() ) {
-        debugmsg( "deconstruct result furniture %s of %s does not exist", mbi.furn_set.c_str(),
-                  id.c_str() );
+}
+
+void map_ter_deconstruct_info::check( const std::string &id ) const
+{
+    if( !ter_set.is_valid() ) {
+        debugmsg( "deconstruct result terrain %s of %s does not exist", ter_set.c_str(), id );
     }
+    map_common_deconstruct_info::check( id );
+}
+
+void map_furn_deconstruct_info::check( const std::string &id ) const
+{
+    if( !furn_set.is_valid() ) {
+        debugmsg( "deconstruct result furniture %s of %s does not exist", furn_set.c_str(), id );
+    }
+    map_common_deconstruct_info::check( id );
+}
+
+bool ter_t::is_smashable() const
+{
+    return bash && !bash->bash_below;
 }
 
 void ter_t::check() const
 {
     map_data_common_t::check();
-    check_bash_items( bash, id.str(), true );
-    check_decon_items( deconstruct, id.str(), true );
+    if( bash ) {
+        bash->check( id.c_str() );
+    }
+    if( deconstruct ) {
+        deconstruct->check( id.c_str() );
+    }
 
     if( !transforms_into.is_valid() ) {
         debugmsg( "invalid transforms_into %s for %s", transforms_into.c_str(), id.c_str() );
@@ -1186,9 +1210,9 @@ void ter_t::check() const
             debugmsg( "ter %s has invalid emission %s set", id.c_str(), e.str().c_str() );
         }
     }
-    if( has_flag( ter_furn_flag::TFLAG_EASY_DECONSTRUCT ) && !deconstruct.can_do ) {
+    if( has_flag( ter_furn_flag::TFLAG_EASY_DECONSTRUCT ) && !deconstruct ) {
         debugmsg( "ter %s has EASY_DECONSTRUCT flag but cannot be deconstructed",
-                  id.c_str(), deconstruct.drop_group.c_str() );
+                  id.c_str() );
     }
 }
 
@@ -1207,15 +1231,8 @@ bool furn_t::is_movable() const
 void furn_t::load( const JsonObject &jo, const std::string &src )
 {
     map_data_common_t::load( jo, src );
-    mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "move_cost_mod", movecost );
-    optional( jo, was_loaded, "coverage", coverage );
-    optional( jo, was_loaded, "comfort", comfort, 0 );
     optional( jo, was_loaded, "fall_damage_reduction", fall_damage_reduction, 0 );
-    int legacy_floor_bedding_warmth = units::to_legacy_bodypart_temp_delta( floor_bedding_warmth );
-    optional( jo, was_loaded, "floor_bedding_warmth", legacy_floor_bedding_warmth, 0 );
-    floor_bedding_warmth = units::from_legacy_bodypart_temp_delta( legacy_floor_bedding_warmth );
-    optional( jo, was_loaded, "emissions", emissions );
     int legacy_bonus_fire_warmth_feet = units::to_legacy_bodypart_temp_delta( bonus_fire_warmth_feet );
     optional( jo, was_loaded, "bonus_fire_warmth_feet", legacy_bonus_fire_warmth_feet, 300 );
     bonus_fire_warmth_feet = units::from_legacy_bodypart_temp_delta( legacy_bonus_fire_warmth_feet );
@@ -1225,35 +1242,12 @@ void furn_t::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "crafting_pseudo_item", crafting_pseudo_item, itype_id() );
     optional( jo, was_loaded, "deployed_item", deployed_item );
     load_symbol( jo, "furniture " + id.str() );
-    transparent = false;
-
-    optional( jo, was_loaded, "light_emitted", light_emitted );
-
-    // see the comment in ter_id::load for connect_group handling
-    connect_groups.reset();
-    connect_to_groups.reset();
-    rotate_to_groups.reset();
-
-    for( auto &flag : jo.get_string_array( "flags" ) ) {
-        set_flag( flag );
-    }
-
-    if( jo.has_member( "connect_groups" ) ) {
-        set_connect_groups( jo.get_as_string_array( "connect_groups" ) );
-    }
-    if( jo.has_member( "connects_to" ) ) {
-        set_connects_to( jo.get_as_string_array( "connects_to" ) );
-    }
-    if( jo.has_member( "rotates_to" ) ) {
-        set_rotates_to( jo.get_as_string_array( "rotates_to" ) );
-    }
 
     optional( jo, was_loaded, "open", open, string_id_reader<furn_t> {}, furn_str_id::NULL_ID() );
     optional( jo, was_loaded, "close", close, string_id_reader<furn_t> {}, furn_str_id::NULL_ID() );
 
     optional( jo, was_loaded, "lockpick_result", lockpick_result, string_id_reader<furn_t> {},
               furn_str_id::NULL_ID() );
-    optional( jo, was_loaded, "lockpick_message", lockpick_message, translation() );
 
     oxytorch = cata::make_value<activity_data_furn>();
     if( jo.has_object( "oxytorch" ) ) {
@@ -1275,8 +1269,18 @@ void furn_t::load( const JsonObject &jo, const std::string &src )
         prying->load( jo.get_object( "prying" ) );
     }
 
-    bash.load( jo, "bash", map_bash_info::furniture, "furniture " + id.str() );
-    deconstruct.load( jo, "deconstruct", true, "furniture " + id.str() );
+    if( jo.has_object( "bash" ) ) {
+        if( !bash ) {
+            bash.emplace();
+        }
+        bash->load( jo.get_object( "bash" ), was_loaded, "furniture " + id.str() );
+    }
+    if( jo.has_object( "deconstruct" ) ) {
+        if( !deconstruct ) {
+            deconstruct.emplace();
+        }
+        deconstruct->load( jo.get_object( "deconstruct" ), was_loaded, "furniture " + id.str() );
+    }
 
     if( jo.has_object( "workbench" ) ) {
         workbench = cata::make_value<furn_workbench_info>();
@@ -1291,11 +1295,20 @@ void furn_t::load( const JsonObject &jo, const std::string &src )
     }
 }
 
+bool furn_t::is_smashable() const
+{
+    return bash && !bash->bash_below;
+}
+
 void furn_t::check() const
 {
     map_data_common_t::check();
-    check_bash_items( bash, id.str(), false );
-    check_decon_items( deconstruct, id.str(), false );
+    if( bash ) {
+        bash->check( id.c_str() );
+    }
+    if( deconstruct ) {
+        deconstruct->check( id.c_str() );
+    }
 
     if( !open.is_valid() ) {
         debugmsg( "invalid furniture %s for opening %s", open.c_str(), id.c_str() );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -38,37 +38,47 @@ connect_group get_connect_group( const std::string &name );
 
 template <typename E> struct enum_traits;
 
-struct map_bash_info {
-    int str_min;            // min str(*) required to bash
-    int str_max;            // max str required: bash succeeds if str >= random # between str_min & str_max
-    int str_min_blocked;    // same as above; alternate values for has_adjacent_furniture(...) == true
-    int str_max_blocked;
-    int str_min_supported;  // Alternative values for floor supported by something from below
-    int str_max_supported;
-    int explosive;          // Explosion on destruction
-    int sound_vol;          // sound volume of breaking terrain/furniture
-    int sound_fail_vol;     // sound volume on fail
-    int collapse_radius;    // Radius of the tent supported by this tile
-    int fd_bash_move_cost = 100; // cost to bash a field
-    bool destroy_only;      // Only used for destroying, not normally bashable
-    bool bash_below;        // This terrain is the roof of the tile below it, try to destroy that too
-    item_group_id drop_group; // item group of items that are dropped when the object is bashed
-    translation sound;      // sound made on success ('You hear a "smash!"')
-    translation sound_fail; // sound  made on fail
-    translation field_bash_msg_success; // message upon successfully bashing a field
-    ter_str_id ter_set;    // terrain to set (REQUIRED for terrain))
+struct map_common_bash_info { //TODO: Half of this shouldn't be common
+        int str_min;            // min str(*) required to bash
+        int str_max;            // max str required: bash succeeds if str >= random # between str_min & str_max
+        int str_min_blocked;    // same as above; alternate values for has_adjacent_furniture(...) == true
+        int str_max_blocked;
+        int str_min_supported;  // Alternative values for floor supported by something from below
+        int str_max_supported;
+        int explosive;          // Explosion on destruction
+        int sound_vol;          // sound volume of breaking terrain/furniture
+        int sound_fail_vol;     // sound volume on fail
+        int collapse_radius;    // Radius of the tent supported by this tile
+        bool destroy_only;      // Only used for destroying, not normally bashable
+        bool bash_below;        // This terrain is the roof of the tile below it, try to destroy that too
+        item_group_id drop_group; // item group of items that are dropped when the object is bashed
+        translation sound;      // sound made on success ('You hear a "smash!"')
+        translation sound_fail; // sound made on fail
+        std::vector<furn_str_id> tent_centers;
+        void load( const JsonObject &jo, bool was_loaded, const std::string &context );
+        void check( const std::string &id ) const;
+    public:
+        virtual ~map_common_bash_info() = default;
+};
+struct map_ter_bash_info : map_common_bash_info {
+    ter_str_id ter_set;    // terrain to set
     ter_str_id ter_set_bashed_from_above; // terrain to set if bashed from above (defaults to ter_set)
+    map_ter_bash_info() = default;
+    void load( const JsonObject &jo, bool was_loaded, const std::string &context );
+    void check( const std::string &id ) const;
+};
+struct map_furn_bash_info : map_common_bash_info {
     furn_str_id furn_set;   // furniture to set (only used by furniture, not terrain)
-    // ids used for the special handling of tents
-    std::vector<furn_str_id> tent_centers;
-    map_bash_info();
-    enum map_object_type {
-        furniture = 0,
-        terrain,
-        field
-    };
-    bool load( const JsonObject &jsobj, std::string_view member, map_object_type obj_type,
-               const std::string &context );
+    map_furn_bash_info() = default;;
+    void load( const JsonObject &jo, bool was_loaded, const std::string &context );
+    void check( const std::string &id ) const;
+};
+struct map_fd_bash_info : map_common_bash_info {
+    int fd_bash_move_cost; // cost to bash a field
+    translation field_bash_msg_success; // message upon successfully bashing a field
+    map_fd_bash_info() = default;
+    void load( const JsonObject &jo, bool was_loaded, const std::string &context );
+    void check( const std::string &id ) const;
 };
 struct map_deconstruct_skill {
     skill_id id; // Id of skill to increase on successful deconstruction
@@ -76,19 +86,28 @@ struct map_deconstruct_skill {
     int max; // Level cap after which no xp is recieved but practise still occurs delaying rust
     double multiplier; // Multiplier of the base xp given that's calced using the mean of the min and max
 };
-struct map_deconstruct_info {
-    // Only if true, the terrain/furniture can be deconstructed
-    bool can_do;
-    // This terrain provided a roof, we need to tear it down now
-    bool deconstruct_above;
-    // items you get when deconstructing.
-    item_group_id drop_group;
-    ter_str_id ter_set;    // terrain to set (REQUIRED for terrain))
-    furn_str_id furn_set;    // furniture to set (only used by furniture, not terrain)
-    map_deconstruct_info();
-    std::optional<map_deconstruct_skill> skill;
-    bool load( const JsonObject &jsobj, std::string_view member, bool is_furniture,
-               const std::string &context );
+struct map_common_deconstruct_info {
+        // This terrain provided a roof, we need to tear it down now
+        bool deconstruct_above = false;
+        // items you get when deconstructing.
+        item_group_id drop_group;
+        std::optional<map_deconstruct_skill> skill;
+        virtual void load( const JsonObject &jo, bool was_loaded, const std::string &context );
+        virtual void check( const std::string &id ) const;
+    public:
+        virtual ~map_common_deconstruct_info() = default;
+};
+struct map_ter_deconstruct_info : map_common_deconstruct_info {
+    ter_str_id ter_set = ter_str_id::NULL_ID();
+    void load( const JsonObject &jo, bool was_loaded, const std::string &context ) override;
+    void check( const std::string &id ) const override;
+    map_ter_deconstruct_info() = default;
+};
+struct map_furn_deconstruct_info : map_common_deconstruct_info {
+    furn_str_id furn_set = furn_str_id::NULL_ID();
+    void load( const JsonObject &jo, bool was_loaded, const std::string &context ) override;
+    void check( const std::string &id ) const override;
+    map_furn_deconstruct_info() = default;
 };
 struct map_shoot_info {
     // Base chance to hit the object at all (defaults to 100%)
@@ -451,9 +470,10 @@ class activity_data_furn : public activity_data_common
 
 void init_mapdata();
 
+//handles data common between terrain and furniture
 struct map_data_common_t {
-        map_bash_info        bash;
-        map_deconstruct_info deconstruct;
+        std::set<emit_id> emissions;
+        translation lockpick_message; // Lockpick action: message when successfully lockpicked
         cata::value_ptr<map_shoot_info> shoot;
 
     public:
@@ -462,17 +482,17 @@ struct map_data_common_t {
     protected:
         friend furn_t null_furniture_t();
         friend ter_t null_terrain_t();
-        // The (untranslated) plaintext name of the terrain type the user would see (i.e. dirt)
+        // The (untranslated) plaintext name of the terrain/furniture type the user would see (i.e. dirt)
         translation name_;
 
-        // Hardcoded examination function
-        iexamine_functions examine_func; // What happens when the terrain/furniture is examined
+        // Hardcoded examination function; what happens when the terrain/furniture is examined
+        iexamine_functions examine_func;
 
         // Data-driven examine actor
         cata::clone_ptr<iexamine_actor> examine_actor;
 
     private:
-        std::set<std::string> flags;    // string flags which possibly refer to what's documented above.
+        std::set<std::string> flags; // string flags which possibly refer to what's documented above.
         enum_bitset<ter_furn_flag> bitflags; // bitfield of -certain- string flags which are heavily checked
 
     public:
@@ -485,7 +505,7 @@ struct map_data_common_t {
         std::string name() const;
 
         /*
-        * The symbol drawn on the screen for the terrain. Please note that
+        * The symbol drawn on the screen for the terrain/furniture. Please note that
         * there are extensive rules as to which possible object/field/entity in
         * a single square gets drawn and that some symbols are "reserved" such
         * as * and % to do programmatic behavior.
@@ -502,14 +522,14 @@ struct map_data_common_t {
         // The amount of movement points required to pass this terrain by default.
         int movecost = 0;
         int heat_radiation = 0;
-        // The coverage percentage of a furniture piece of terrain. <30 won't cover from sight.
+        // The coverage percentage of furniture/terrain. coverage < 30 won't cover from sight.
         int coverage = 0;
-        // Warmth provided by the terrain (for sleeping, etc.)
+        // Warmth provided by the furniture/terrain (for sleeping, etc.)
         units::temperature_delta floor_bedding_warmth = 0_C_delta;
         int comfort = 0;
         //flat damage reduction (increase if negative) on fall (some logic may apply)
         int fall_damage_reduction = 0;
-        // Maximal volume of items that can be stored in/on this furniture
+        // Maximal volume of items that can be stored in/on this furniture/terrain
         units::volume max_volume = DEFAULT_TILE_VOLUME;
 
         std::string liquid_source_item_id; // id of a liquid this tile provides
@@ -525,7 +545,7 @@ struct map_data_common_t {
         std::string looks_like;
 
         /**
-         * When will this terrain/furniture get harvested and what will drop?
+         * When will this furniture/terrain get harvested and what will drop?
          * Note: This excludes items that take extra tools to harvest.
          */
         std::array<harvest_id, NUM_SEASONS> harvest_by_season = {{
@@ -547,11 +567,10 @@ struct map_data_common_t {
             return bitflags[flag];
         }
 
-        void extraprocess_flags( ter_furn_flag flag );
-
         void set_flag( const std::string &flag );
-
         void set_flag( ter_furn_flag flag );
+        void unset_flag( const std::string &flag );
+        void unset_flags();
 
         // Terrain groups of this type, for others to connect or rotate to; not symmetric, passive part
         std::bitset<NUM_TERCONN> connect_groups;
@@ -588,6 +607,9 @@ struct map_data_common_t {
         virtual std::vector<std::string> extended_description() const;
 
         bool was_loaded = false;
+        virtual bool is_smashable() const {
+            return false;
+        }
 
         bool is_flammable() const {
             return has_flag( ter_furn_flag::TFLAG_FLAMMABLE ) ||
@@ -611,8 +633,10 @@ struct ter_t : map_data_common_t {
     ter_str_id open;  // Open action: transform into terrain with matching id
     ter_str_id close; // Close action: transform into terrain with matching id
 
+    std::optional<map_ter_bash_info> bash;
+    std::optional<map_ter_deconstruct_info> deconstruct;
+
     ter_str_id lockpick_result; // Lockpick action: transform when successfully lockpicked
-    translation lockpick_message; // Lockpick action: message when successfully lockpicked
 
     cata::value_ptr<activity_data_ter> boltcut; // Bolt cutting action data
     cata::value_ptr<activity_data_ter> hacksaw; // Hacksaw action data
@@ -625,7 +649,6 @@ struct ter_t : map_data_common_t {
 
     trap_id trap; // The id of the trap located at this terrain. Limit one trap per tile currently.
 
-    std::set<emit_id> emissions;
     std::set<itype_id> allowed_template_id;
 
     ter_t();
@@ -635,6 +658,7 @@ struct ter_t : map_data_common_t {
     bool is_null() const;
 
     std::vector<std::string> extended_description() const override;
+    bool is_smashable() const override;
 
     void load( const JsonObject &jo, const std::string &src ) override;
     void check() const override;
@@ -656,11 +680,10 @@ struct furn_t : map_data_common_t {
     furn_str_id open;  // Open action: transform into furniture with matching id
     furn_str_id close; // Close action: transform into furniture with matching id
     furn_str_id lockpick_result; // Lockpick action: transform when successfully lockpicked
-    translation lockpick_message; // Lockpick action: message when successfully lockpicked
+    std::optional<map_furn_bash_info> bash;
+    std::optional<map_furn_deconstruct_info> deconstruct;
     itype_id crafting_pseudo_item;
     units::volume keg_capacity = 0_ml;
-    /** Emissions of furniture */
-    std::set<emit_id> emissions;
 
     units::temperature_delta bonus_fire_warmth_feet = 0.6_C_delta;
     itype_id deployed_item; // item id string used to create furniture
@@ -690,6 +713,7 @@ struct furn_t : map_data_common_t {
     bool is_movable() const;
 
     std::vector<std::string> extended_description() const override;
+    bool is_smashable() const override;
 
     void load( const JsonObject &jo, const std::string &src ) override;
     void check() const override;
@@ -697,9 +721,6 @@ struct furn_t : map_data_common_t {
 
 void load_furniture( const JsonObject &jo, const std::string &src );
 void load_terrain( const JsonObject &jo, const std::string &src );
-
-void verify_furniture();
-void verify_terrain();
 
 class ter_furn_migrations
 {
@@ -744,7 +765,5 @@ extern ter_id t_null;
 
 // consistency checking of terlist & furnlist.
 void check_furniture_and_terrain();
-
-void finalize_furniture_and_terrain();
 
 #endif // CATA_SRC_MAPDATA_H

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3112,20 +3112,23 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
                                                p ).id().str() : "";
                 while( dat.m.has_furn( p ) && max_recurse-- > 0 ) {
                     const furn_t &f = dat.m.furn( p ).obj();
-                    if( f.deconstruct.can_do ) {
-                        if( f.deconstruct.furn_set.str().empty() ) {
+                    if( f.deconstruct ) {
+                        if( f.deconstruct->furn_set.str().empty() ) {
                             dat.m.furn_clear( p );
                         } else {
-                            dat.m.furn_set( p, f.deconstruct.furn_set );
+                            dat.m.furn_set( p, f.deconstruct->furn_set );
                         }
-                        dat.m.spawn_items( p, item_group::items_from( f.deconstruct.drop_group, calendar::turn ) );
+                        dat.m.spawn_items( p, item_group::items_from( f.deconstruct->drop_group, calendar::turn ) );
                     } else {
-                        if( f.bash.furn_set.str().empty() ) {
-                            dat.m.furn_clear( p );
-                        } else {
-                            dat.m.furn_set( p, f.bash.furn_set );
+                        const std::optional<map_furn_bash_info> &furn_bash = f.bash;
+                        if( furn_bash ) {
+                            if( furn_bash->furn_set.str().empty() ) {
+                                dat.m.furn_clear( p );
+                            } else {
+                                dat.m.furn_set( p, furn_bash->furn_set );
+                            }
+                            dat.m.spawn_items( p, item_group::items_from( furn_bash->drop_group, calendar::turn ) );
                         }
-                        dat.m.spawn_items( p, item_group::items_from( f.bash.drop_group, calendar::turn ) );
                     }
                 }
                 if( !max_recurse ) {

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2800,45 +2800,56 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
     std::set<item> return_items;
     for( const tripoint_omt_ms &p : bay.points_on_zlevel() ) {
         const ter_id &t = bay.ter( p );
-        const ter_t &to = t.obj();
         //Open all the doors, doesn't need to be exhaustive
         const std::unordered_set<ter_str_id> openable_doors = {ter_t_door_c, ter_t_door_c_peep, ter_t_door_b, ter_t_door_boarded, ter_t_door_boarded_damaged, ter_t_rdoor_boarded, ter_t_rdoor_boarded_damaged, ter_t_door_boarded_peep, ter_t_door_boarded_damaged_peep };
         if( openable_doors.find( t.id() ) != openable_doors.end() ) {
             bay.ter_set( p, ter_t_door_o );
         } else if( t == ter_t_door_locked || t == ter_t_door_locked_peep || t == ter_t_door_locked_alarm ) {
-            const map_bash_info &bash = to.bash;
-            bay.ter_set( p, bash.ter_set );
+            const std::optional<map_ter_bash_info> &bash = bay.ter( p ).obj().bash;
+            if( bash ) {
+                bay.ter_set( p, bash->ter_set );
+            }
             // Bash doors twice
-            const map_bash_info &bash_again = to.bash;
-            bay.ter_set( p, bash_again.ter_set );
-            bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
-            bay.spawn_items( p, item_group::items_from( bash_again.drop_group, calendar::turn ) );
+            const std::optional <map_ter_bash_info> &bash_again = bay.ter( p ).obj().bash;
+            if( bash_again ) {
+                bay.ter_set( p, bash_again->ter_set );
+                bay.spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
+                bay.spawn_items( p, item_group::items_from( bash_again->drop_group, calendar::turn ) );
+            }
         } else if( t == ter_t_door_metal_c || t == ter_t_door_metal_locked ||
                    t == ter_t_door_metal_pickable ) {
             bay.ter_set( p, ter_t_door_metal_o );
         } else if( t == ter_t_door_glass_c ) {
             bay.ter_set( p, ter_t_door_glass_o );
         } else if( t == ter_t_wall && one_in( 25 ) ) {
-            const map_bash_info &bash = to.bash;
-            bay.ter_set( p, bash.ter_set );
-            bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
-            bay.collapse_at( p, false );
+            const std::optional<map_ter_bash_info> &bash = bay.ter( p ).obj().bash;
+            if( bash ) {
+                bay.ter_set( p, bash->ter_set );
+                bay.spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
+                bay.collapse_at( p, false );
+            }
         }
         //Smash easily breakable stuff
         else if( const std::unordered_set<ter_str_id> weak_window_ters = {ter_t_window, ter_t_window_taped, ter_t_window_domestic, ter_t_window_boarded_noglass, ter_t_window_domestic_taped, ter_t_window_alarm_taped, ter_t_window_boarded, ter_t_curtains, ter_t_window_alarm, ter_t_window_no_curtains, ter_t_window_no_curtains_taped };
                  weak_window_ters.find( t.id() ) != weak_window_ters.end() && one_in( 4 ) ) {
-            const map_bash_info &bash = to.bash;
-            bay.ter_set( p, bash.ter_set );
-            bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
+            const std::optional<map_ter_bash_info> &bash = bay.ter( p ).obj().bash;
+            if( bash ) {
+                bay.ter_set( p, bash->ter_set );
+                bay.spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
+            }
         } else if( ( t == ter_t_wall_glass || t == ter_t_wall_glass_alarm ) && one_in( 3 ) ) {
-            const map_bash_info &bash = to.bash;
-            bay.ter_set( p, bash.ter_set );
-            bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
-        } else if( bay.has_furn( p ) && to.bash.str_max != -1 && one_in( 10 ) ) {
-            const map_bash_info &bash = to.bash;
-            bay.furn_set( p, bash.furn_set );
-            bay.delete_signage( p );
-            bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
+            const std::optional<map_ter_bash_info> &bash = bay.ter( p ).obj().bash;
+            if( bash ) {
+                bay.ter_set( p, bash->ter_set );
+                bay.spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
+            }
+        } else if( bay.has_furn( p ) && bay.furn( p ).obj().bash && one_in( 10 ) ) {
+            const std::optional<map_furn_bash_info> &bash = bay.furn( p ).obj().bash;
+            if( bash ) {
+                bay.furn_set( p, bash->furn_set );
+                bay.delete_signage( p );
+                bay.spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
+            }
         }
         //Kill zombies!  Only works against pre-spawned enemies at the moment...
         Creature *critter = creatures.creature_at( rebase_bub( p ) );

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -778,7 +778,7 @@ bool vehicle::autodrive_controller::check_drivable( const tripoint_bub_ms &pt ) 
         // terrain with neutral move cost or tagged with NOCOLLIDE will never cause
         // collisions
         return true;
-    } else if( terrain_type.bash.str_max >= 0 && !terrain_type.bash.bash_below ) {
+    } else if( terrain_type.is_smashable() ) {
         // bashable terrain (but not bashable floors) will cause collisions
         return false;
     } else if( terrain_type.has_flag( ter_furn_flag::TFLAG_LIQUID ) ) {

--- a/tests/map_bash_test.cpp
+++ b/tests/map_bash_test.cpp
@@ -100,10 +100,10 @@ TEST_CASE( "map_bash_ephemeral_persistence", "[map][bash]" )
     const tripoint_bub_ms test_pt( 40, 40, 0 );
 
     // Assumptions
-    REQUIRE( furn_test_f_bash_persist->bash.str_min == 4 );
-    REQUIRE( furn_test_f_bash_persist->bash.str_max == 100 );
-    REQUIRE( ter_test_t_bash_persist->bash.str_min == 4 );
-    REQUIRE( ter_test_t_bash_persist->bash.str_max == 100 );
+    REQUIRE( furn_test_f_bash_persist->bash->str_min == 4 );
+    REQUIRE( furn_test_f_bash_persist->bash->str_max == 100 );
+    REQUIRE( ter_test_t_bash_persist->bash->str_min == 4 );
+    REQUIRE( ter_test_t_bash_persist->bash->str_max == 100 );
 
     SECTION( "bashing a furniture to completion leaves behind no map bash info" ) {
         here.furn_set( test_pt, furn_test_f_bash_persist );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "terrain/furniture: code deduplication and improved copy-from support"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Roughly the other half of #73211; `copy-from` terrain/furniture is a desirable feature

Closes #54702

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- `TRANSPARENT` flag inherits correctly
- `flags` support extend/delete
- `connect_groups`, `connects_to` and `rotates_to` support copy-from
- Removes legacy connects_to/rotates_to flag support (made possible by #73415)
- Merges some duplicate code in ter_t::load and furn_t::load into map_data_common_t::load
- Makes `map_X_bash_info` and `map_X_deconstruct_info` optional, replaces bad "str_max > -1" checks


Sorry for the encroaching line count. A lot of the line "additions" are very minor, like '.' to '->'
This PR should not make any functional changes to gameplay. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

What's left to be done (next on my to-do list):
- `symbol`,`color` supports copy-from
- remove LINE_OXOX and LINE_XOXO handling, replace it with better generic unicode character handling. The original PR attempted to do this, but it didn't work, so I didn't include it here.
- handle `bash`, etc. special inheritance handling

Once all that's done, _attempt_ to implement abstract furniture/terrain; there's a ton of JSON bloat that can be removed.

#### Testing

Passed all tests, clang-tidy should be good

Made sure the following work as usual:
- deconstruct t_wall
- smash t_wall until broken (STR 40)
- repeat above with an identical copy-from child of t_wall
- blow up bomb
- burn down building
- test breaking down a tent
- using bolt cutters, hacksaw to cut a fence

I made five test walls and they all worked as expected, including connect groups and rotation:
- test wall 1 copied from t_wall and added `"extend": { "flags": ["TRANSPARENT"] }`
- test wall 2 copied test wall 1 and added `"delete": { "flags": ["TRANSPARENT"] }`
- test wall 3 copied from t_wall and added `"delete": { "flags": ["FLAMMABLE"] }`
- test wall 4 copied from test wall 2 and re-added `"extend": { "flags": ["TRANSPARENT"] }`
- test wall 5 copied from t_window (for a rotation check)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Proof for #54702: removed `flags` from `t_deck_coating_no_roof_r` and it's still transparent
![image](https://github.com/user-attachments/assets/b8e9079e-642e-4e1f-a6df-a7e386a8bb72)

As with last time, thanks to @Procyonae for writing the original PR, I just cleaned it up

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
