### PR TITLE
Make exodii weaponmaster mute

### DIFF
--- a/data/json/npcs/exodii/exodii_weaponmaster.json
+++ b/data/json/npcs/exodii/exodii_weaponmaster.json
@@ -19,6 +19,7 @@
     "traits": [
       { "trait": "EXODII_BODY_9" },
       { "trait": "IGNORE_SOUND" },
+      { "trait": "MUTE" },
       { "trait": "NO_BASH" },
       { "trait": "RETURN_TO_START_POS" }
     ],


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
![image](https://github.com/user-attachments/assets/3b8256bf-8be8-4bbd-99e0-75ff5d372b82)
#### Describe the solution
Add MUTE trait
#### Testing
I still can talk with weaponmaster, but this time they do not say `Bye.`