### PR TITLE
Move NPC bye message to snippet

### DIFF
--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -57,6 +57,7 @@ Format:
   "carry_override": "NC_EXAMPLE_carried",                                  // Optional. Defines an item group that replaces their carried items (in pockets, etc). Items which cannot
                                                                            // be carried will overflow(fall to the ground) when the NPC is loaded.
   "weapon_override": "NC_EXAMPLE_weapon",                                  // Optional. Defines an item group that replaces their wielded weapon.
+  "bye_message_override": "<fuck_you>",                                    // Optional. If used, overrides the default bye message (picked from <bye> snippet) to any another custom snippet
   "shopkeeper_item_group": [                                               // Optional. See [Shopkeeper NPC configuration](#shopkeeper-npc-configuration) below.
     { "group": "example_shopkeeper_itemgroup1" },
     { "group": "example_shopkeeper_itemgroup2", "trust": 10 },

--- a/src/dialogue_chatbin.h
+++ b/src/dialogue_chatbin.h
@@ -132,7 +132,7 @@ struct dialogue_chatbin_snippets {
 
     // talk from npctalk.cpp(can use snippets in json)
     translation snip_acknowledged = no_translation( "<acknowledged>" );
-    translation snip_bye = to_translation( "Bye." );
+    translation snip_bye = to_translation( "<end_talking_bye>" );
 
     // talk from talker_npc.cpp(can use snippets in json)
     translation snip_consume_cant_accept =

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -266,6 +266,7 @@ void npc_class::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "worn_override", worn_override );
     optional( jo, was_loaded, "carry_override", carry_override );
     optional( jo, was_loaded, "weapon_override", weapon_override );
+    optional( jo, was_loaded, "bye_message_override", bye_message_override );
 
     if( jo.has_member( "traits" ) ) {
         traits = trait_group::load_trait_group( jo.get_member( "traits" ), "collection" );

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -110,6 +110,8 @@ class npc_class
         item_group_id carry_override;
         item_group_id weapon_override;
 
+        translation bye_message_override;
+
         std::map<mutation_category_id, distribution> mutation_rounds;
         trait_group::Trait_group_tag traits = trait_group::Trait_group_tag( "EMPTY_GROUP" );
         // the int is what level the spell starts at

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -62,6 +62,7 @@
 #include "npctalk.h"
 #include "npctalk_rules.h"
 #include "npctrade.h"
+#include "npc_class.h"
 #include "output.h"
 #include "overmapbuffer.h"
 #include "pimpl.h"
@@ -1567,7 +1568,11 @@ void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,
         if( next.id == "TALK_DONE" || d.topic_stack.empty() ) {
             npc *npc_actor = d.actor( true )->get_npc();
             if( npc_actor ) {
-                d.actor( true )->say( npc_actor->chat_snippets().snip_bye.translated() );
+                if( npc_actor->myclass->bye_message_override.empty() ) {
+                    d.actor( true )->say( npc_actor->chat_snippets().snip_bye.translated() );
+                } else {
+                    d.actor( true )->say( npc_actor->myclass->bye_message_override.translated() );
+                }
             }
             d.done = true;
         } else if( next.id != "TALK_NONE" ) {
@@ -1689,7 +1694,12 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic )
     }
 
     if( topic == "TALK_NONE" || topic == "TALK_DONE" ) {
-        return actor( true )->get_npc()->chat_snippets().snip_bye.translated();
+        npc *guy = actor( true )->get_npc();
+        if( guy->myclass->bye_message_override.empty() ) {
+            return guy->chat_snippets().snip_bye.translated();
+        } else {
+            return guy->myclass->bye_message_override.translated();
+        }
     } else if( topic == "TALK_TRAIN" ) {
         if( !player_character.backlog.empty() && player_character.backlog.front().id() == ACT_TRAIN ) {
             return _( "Shall we resume?" );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Intended to be used for #77647, until i found that `say()` function checks if our talker is mute; Further testing revealed dialogues still work even if you are mute, which is cool
#### Describe the solution
Move hardcoded bye message to snippet, add a json field to be able to override it if necessary (for Rubik, for example)
#### Testing
![image](https://github.com/user-attachments/assets/393c4302-6e94-48ce-baa0-5b32324cc6ac)
![image](https://github.com/user-attachments/assets/bfbe0c4a-4c58-4b4f-ab88-bb98fd5557df)