### PR TITLE
input: fix no-op input loop when quitting

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -386,7 +386,7 @@ static void debug_error_prompt(
         inp_mngr.set_timeout( 50 );
         input_event ievent = inp_mngr.get_input_event();
         if( ievent.type == input_event_t::timeout ) {
-            if( g && g->uquit == QUIT_EXIT ) {
+            if( are_we_quitting() ) {
                 g->query_exit_to_OS();
             }
             continue;

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -103,7 +103,7 @@ namespace turn_handler
 bool cleanup_at_end()
 {
     avatar &u = get_avatar();
-    if( g->uquit == QUIT_EXIT ) {
+    if( are_we_quitting() ) {
         return true;
     }
     if( g->uquit == QUIT_DIED || g->uquit == QUIT_SUICIDE ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2818,7 +2818,7 @@ bool game::query_exit_to_OS()
 
 bool game::is_game_over()
 {
-    if( uquit == QUIT_EXIT ) {
+    if( are_we_quitting() ) {
         return query_exit_to_OS();
     }
     if( uquit == QUIT_DIED || uquit == QUIT_WATCH ) {
@@ -14008,4 +14008,9 @@ weather_manager &get_weather()
 global_variables &get_globals()
 {
     return g->global_variables_instance;
+}
+
+bool are_we_quitting()
+{
+    return g && ( g->uquit == QUIT_EXIT || g->uquit == QUIT_EXIT_PENDING );
 }

--- a/src/game.h
+++ b/src/game.h
@@ -1347,4 +1347,6 @@ namespace cata_event_dispatch
 void avatar_moves( const tripoint &old_abs_pos, const avatar &u, const map &m );
 } // namespace cata_event_dispatch
 
+bool are_we_quitting();
+
 #endif // CATA_SRC_GAME_H

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -334,7 +334,7 @@ input_context game::get_player_input( std::string &action )
 
         creature_tracker &creatures = get_creature_tracker();
         do {
-            if( g->uquit == QUIT_EXIT ) {
+            if( are_we_quitting() ) {
                 break;
             }
             if( bWeatherEffect && get_option<bool>( "ANIMATION_RAIN" ) ) {
@@ -3117,7 +3117,7 @@ bool game::handle_action()
     // of location clicked.
     std::optional<tripoint_bub_ms> mouse_target;
 
-    if( uquit == QUIT_EXIT ) {
+    if( are_we_quitting() ) {
         return false;
     }
 

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -447,6 +447,7 @@ const std::string &input_context::handle_input( const int timeout )
         }
 
         if( g->uquit == QUIT_EXIT ) {
+            g->uquit = QUIT_EXIT_PENDING;
             result = &QUIT;
             break;
         }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -707,7 +707,7 @@ bool main_menu::opening_screen()
 #endif
 
     while( !start ) {
-        if( g->uquit == QUIT_EXIT ) {
+        if( are_we_quitting() ) {
             return false;
         }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1044,7 +1044,7 @@ void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
                 ret = entries[selected].retval;
             }
         } else if( ( allow_cancel && ret_act == "UILIST.QUIT" ) ||
-                   ( g->uquit == QUIT_EXIT && ret_act == "QUIT" ) ) {
+                   ( are_we_quitting() && ret_act == "QUIT" ) ) {
             ret = UILIST_CANCEL;
         } else if( ret_act == "TIMEOUT" ) {
             ret = UILIST_WAIT_INPUT;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
SIGINT handling from #75999 uses a `QUIT` input action to escape (most) input loops. However, some UIs double check that you really want to quit, leading to a stuck query loop.

- Fixes: #77636

#### Describe the solution
Ensure that a no-op input loop can't be reached by resetting quit reason to `QUIT_EXIT_PENDING`
Also check for `QUIT_EXIT_PENDING` in every other place that checks for `QUIT_EXIT`


#### Describe alternatives you've considered
Reverting #67893, #75999, and #77457: sunk cost or something

Adding a new *new* input action called `QUIT_ALREADY` then propagating that to every input loop in the game: maybe we can avoid this...

#### Testing
SIGINT or closing the window prompts and closes the game at the main menu, at character creation, while loading a save file, while idling, while executing an action, from all inventory UIs, and from debug prompt.

#### Additional context
This definitely fixes the SIGINT issue. For sure. G U A R A N T E E D. No other bugs are possible. Nope!