### PR TITLE
Fix Dino Dave mapgen_update referencing an obsoleted omt

### DIFF
--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -246,7 +246,6 @@
         { "finish_mission": "MISSION_BEGGAR_2_PERMISSION", "success": true },
         { "npc_first_topic": "TALK_DINODAVE_1" },
         { "mapgen_update": "cardboard_castle_1_main", "om_terrain": "evac_center_13_z1" },
-        { "mapgen_update": "cardboard_castle_1_roof", "om_terrain": "evac_center_13_z2" },
         { "npc_teleport": { "global_val": "dave_castle" } }
       ]
     },
@@ -428,12 +427,6 @@
   },
   {
     "type": "mapgen",
-    "update_mapgen_id": "cardboard_castle_1_roof",
-    "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "cardboard_castle_1_roof" ], "x": 0, "y": 16 } ] }
-  },
-  {
-    "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "cardboard_castle_1_main",
     "//": "First iteration of Dino Dave's cardboard castle - main floor.",
@@ -453,7 +446,8 @@
         "_": "f_cardboard_floor",
         "C": "f_cardboard_box",
         "B": "f_floor_mattress"
-      }
+      },
+      "place_nested": [ { "chunks": [ "cardboard_castle_1_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #69193
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Just makes the z2 nest as part of the z1 update
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Remembering to do this in May
Using location_variable_adjust but that feels unnecessarily clunky here
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Found Dino Dave and debug called TALK_REFUGEE_BEGGAR_2_PERMISSION with expected results
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Not entirely sure why the roof works period when it's a furniture but I did check it doesn't collapse/vanish on save/load and having a cardboard castle that's exposed to the elements doesn't exactly make any sense but oh well
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
