### PR TITLE
Spell activated EoCs are passed the target as a context val

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -633,12 +633,30 @@
     "skill": "deduction",
     "max_level": 20,
     "difficulty": 6,
-    "effect": "ter_transform",
-    "effect_str": "ter_arvore_wood_wall",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_GROWING_WOOD_WALLS_WALL",
     "shape": "blast",
     "min_range": 1,
     "max_range": 4,
     "range_increment": 0.25
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GROWING_WOOD_WALLS_WALL",
+    "eoc_type": "ACTIVATION",
+    "effect": [
+      {
+        "npc_transform_radius": 0,
+        "ter_furn_transform": "ter_arvore_wood_wall",
+        "target_var": { "context_val": "spell_location" }
+      },
+      { "location_variable_adjust": { "context_val": "spell_location" }, "z_adjust": 1 },
+      {
+        "npc_transform_radius": 0,
+        "ter_furn_transform": "ter_arvore_wood_wall_top",
+        "target_var": { "context_val": "spell_location" }
+      }
+    ]
   },
   {
     "id": "arvore_growing_wood_walls_floor",

--- a/data/mods/Xedra_Evolved/ter_transforms/arvore_ter_transforms.json
+++ b/data/mods/Xedra_Evolved/ter_transforms/arvore_ter_transforms.json
@@ -84,6 +84,11 @@
   },
   {
     "type": "ter_furn_transform",
+    "id": "ter_arvore_wood_wall_top",
+    "terrain": [ { "result": [ "t_barkfloor_no_roof" ], "valid_terrain": [ "t_open_air" ] } ]
+  },
+  {
+    "type": "ter_furn_transform",
     "id": "ter_arvore_wood_floor",
     "terrain": [
       {

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -67,7 +67,7 @@ For example, `{ "npc_has_effect": "Shadow_Reveal" }`, used by shadow lieutenant,
 | Talk with monster                                | player (Avatar)             | monster (monster)           |
 | Use computer                                     | player (Avatar)             | computer (Furniture)        |
 | furniture: "examine_action"                      | player (Avatar)             | NONE                        |
-| SPELL: "effect": "effect_on_condition"           | target (Character, Monster) | spell caster (Character, Monster) |
+| SPELL: "effect": "effect_on_condition"           | target (Character, Monster) | spell caster (Character, Monster) | `spell_location`, location variable, location of target for use primarily when the target isn't a creature
 | monster_attack: "eoc"                          | attacker ( Monster)         | victim (Creature)           | `damage`, int, damage dealt by attack
 | use_action: "type": "effect_on_conditions"       | user (Character)            | item (item)                 | `id`, string, stores item id
 | tick_action: "type": "effect_on_conditions"      | carrier (Character)         | item (item)                 |

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -172,7 +172,7 @@ Effect                 | Description
 `charm_monster`        | Charms a monster that has less hp than damage() for approximately duration().
 `dash`                 | Dashes forward up to range and hits targets in a cone at the target.
 `directed_push`        | Pushes `valid_targets` in aoe away from the target location, with a distance of damage().  Negative values pull instead.
-`effect_on_condition`  | Runs the `effect_on_condition` from `effect_str` on all valid targets.  The EOC will be centered on the player, with the NPC as caster.
+`effect_on_condition`  | Runs the `effect_on_condition` from `effect_str` on all valid targets.  The EOC will be centered on the player, with the NPC as caster and a context val location variable `spell_location` for the target primarily useful if the target isn't a creature.
 `emit`                 | Causes an `emit` at the target.
 `explosion`            | Causes an explosion centered on the target.  Uses damage() for power and factor aoe()/10.
 `flashbang`            | Causes a flashbang effect is centered on the target.  Uses damage() for power and factor aoe()/10.

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -390,7 +390,7 @@ tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, dialogue con
         }
     }
     if( !d.has_actor( is_npc ) ) {
-        debugmsg( "Tried to access location of invalid %s talker. %s", is_npc ? "beta" : "alpha",
+        debugmsg( "Tried to access location of invalid %s talker.  %s", is_npc ? "beta" : "alpha",
                   d.get_callstack() );
         return tripoint_abs_ms( tripoint_min );
     }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -383,14 +383,18 @@ str_translation_or_var get_str_translation_or_var(
 
 tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, dialogue const &d, bool is_npc )
 {
-    tripoint_abs_ms target_pos = get_map().getglobal( d.actor( is_npc )->pos() );
     if( var.has_value() ) {
         std::string value = read_var_value( var.value(), d );
         if( !value.empty() ) {
-            target_pos = tripoint_abs_ms( tripoint::from_string( value ) );
+            return tripoint_abs_ms( tripoint::from_string( value ) );
         }
     }
-    return target_pos;
+    if( !d.has_actor( is_npc ) ) {
+        debugmsg( "Tried to access location of invalid %s talker. %s", is_npc ? "beta" : "alpha",
+                  d.get_callstack() );
+        return tripoint_abs_ms( tripoint_min );
+    }
+    return get_map().getglobal( d.actor( is_npc )->pos() );
 }
 
 template<class T>

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1894,6 +1894,9 @@ void spell_effect::effect_on_condition( const spell &sp, Creature &caster,
         }
         Creature *victim = creatures.creature_at<Creature>( potential_target );
         dialogue d( victim ? get_talker_for( victim ) : nullptr, get_talker_for( caster ) );
+        const tripoint_abs_ms target_abs = get_map().getglobal( potential_target );
+        write_var_value( var_type::context, "npctalk_var_spell_location", &d,
+                         target_abs.to_string() );
         d.amend_callstack( string_format( "Spell: %s Caster: %s", sp.id().c_str(), caster.disp_name() ) );
         effect_on_condition_id eoc = effect_on_condition_id( sp.effect_data() );
         if( eoc->type == eoc_type::ACTIVATION ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Spell activated EoCs are passed the target as a context val location variable spell_location"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Provides a solution for #70873 (Up to @Standing-Storm whether this should close it given this isn't what the issue is directly asking for but autoroofs are ew and should be avoided where possible and adding infra to the spell transform field feels somewhat redundant when EoCs have much more powerful transform infra)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Spell activated EoCs are passed the target location as a context val location variable `"spell_location"` for use primarily when the target isn't a creature
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
This can probably be applied to more in repo spells that rely on autoroofs or spell EoCs that use less ideal ways to attempt to obtain ground targets, I'll have a look to see what I can find
Giving the context val a more obviously not manually defined name but I couldn't think of anything non clunky (I checked spell_location isn't used as a var anywhere in repo)
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested using the included spell and the save from #70873 with expected results
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
