### PR TITLE
[Xedra Evolved] Fix talker errors with a couple lilin spells

### DIFF
--- a/data/mods/Xedra_Evolved/spells/lilin_spell_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/lilin_spell_eocs.json
@@ -259,27 +259,32 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_LILIN_AOE_LINE_DISEASE",
-    "condition": { "math": [ "n_vitamin('lilin_ruach_vitamin')", ">=", "240" ] },
+    "condition": "has_alpha",
     "effect": [
-      { "math": [ "n_vitamin('lilin_ruach_vitamin')", "-=", "240" ] },
-      { "npc_message": "You summon a wind filled with pestilence.", "type": "neutral" },
       {
-        "u_add_effect": "effect_lilin_supernatural_disease",
-        "duration": [
+        "if": { "math": [ "n_vitamin('lilin_ruach_vitamin')", ">=", "240" ] },
+        "then": [
+          { "math": [ "n_vitamin('lilin_ruach_vitamin')", "-=", "240" ] },
+          { "npc_message": "You summon a wind filled with pestilence.", "type": "neutral" },
           {
-            "math": [
-              "1 + ( (u_vitamin('lilin_ruach_vitamin') * 0.09) * ( (u_has_trait('INFIMMUNE') * 0.25) + 1) * ( (u_has_trait('DISIMMUNE') * 0.25) + 1) * ( (u_has_trait('LILIN_DISEASE_DAMAGE_STRIKES') * 0.35) + 1) )"
-            ]
-          },
-          {
-            "math": [
-              "15 + ( (u_vitamin('lilin_ruach_vitamin') * 0.24) * ( (u_has_trait('INFIMMUNE') * 0.25) + 1) * ( (u_has_trait('DISIMMUNE') * 0.25) + 1) * ( (u_has_trait('LILIN_DISEASE_DAMAGE_STRIKES') * 0.35) + 1) )"
+            "u_add_effect": "effect_lilin_supernatural_disease",
+            "duration": [
+              {
+                "math": [
+                  "1 + ( (n_vitamin('lilin_ruach_vitamin') * 0.09) * ( (n_has_trait('INFIMMUNE') * 0.25) + 1) * ( (n_has_trait('DISIMMUNE') * 0.25) + 1) * ( (n_has_trait('LILIN_DISEASE_DAMAGE_STRIKES') * 0.35) + 1) )"
+                ]
+              },
+              {
+                "math": [
+                  "15 + ( (n_vitamin('lilin_ruach_vitamin') * 0.24) * ( (n_has_trait('INFIMMUNE') * 0.25) + 1) * ( (n_has_trait('DISIMMUNE') * 0.25) + 1) * ( (n_has_trait('LILIN_DISEASE_DAMAGE_STRIKES') * 0.35) + 1) )"
+                ]
+              }
             ]
           }
-        ]
+        ],
+        "else": [ { "npc_message": "You don't have enough ruach to summon the miasma!", "type": "bad" } ]
       }
-    ],
-    "false_effect": { "npc_message": "You don't have enough ruach to summon the miasma!", "type": "bad" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -293,12 +298,12 @@
         "duration": [
           {
             "math": [
-              "1 + ( (u_vitamin('lilin_ruach_vitamin') * 0.03) * ( (u_has_trait('INFIMMUNE') * 0.25) + 1) * ( (u_has_trait('DISIMMUNE') * 0.25) + 1) * ( (u_has_trait('LILIN_DISEASE_DAMAGE_STRIKES') * 0.35) + 1) )"
+              "1 + ( (n_vitamin('lilin_ruach_vitamin') * 0.03) * ( (n_has_trait('INFIMMUNE') * 0.25) + 1) * ( (n_has_trait('DISIMMUNE') * 0.25) + 1) * ( (n_has_trait('LILIN_DISEASE_DAMAGE_STRIKES') * 0.35) + 1) )"
             ]
           },
           {
             "math": [
-              "15 + ( (u_vitamin('lilin_ruach_vitamin') * 0.09) * ( (u_has_trait('INFIMMUNE') * 0.25) + 1) * ( (u_has_trait('DISIMMUNE') * 0.25) + 1) * ( (u_has_trait('LILIN_DISEASE_DAMAGE_STRIKES') * 0.35) + 1) )"
+              "15 + ( (n_vitamin('lilin_ruach_vitamin') * 0.09) * ( (n_has_trait('INFIMMUNE') * 0.25) + 1) * ( (n_has_trait('DISIMMUNE') * 0.25) + 1) * ( (n_has_trait('LILIN_DISEASE_DAMAGE_STRIKES') * 0.35) + 1) )"
             ]
           }
         ]
@@ -308,44 +313,44 @@
         "then": [
           {
             "u_deal_damage": "biological",
-            "amount": { "math": [ "rng(4,8) * max( (u_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
+            "amount": { "math": [ "rng(4,8) * max( (n_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
             "bodypart": "head"
           },
           {
             "u_deal_damage": "biological",
-            "amount": { "math": [ "rng(4,8) * max( (u_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
+            "amount": { "math": [ "rng(4,8) * max( (n_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
             "bodypart": "arm_l"
           },
           {
             "u_deal_damage": "biological",
-            "amount": { "math": [ "rng(4,8) * max( (u_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
+            "amount": { "math": [ "rng(4,8) * max( (n_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
             "bodypart": "arm_r"
           },
           {
             "u_deal_damage": "biological",
-            "amount": { "math": [ "rng(4,8) * max( (u_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
+            "amount": { "math": [ "rng(4,8) * max( (n_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
             "bodypart": "torso"
           },
           {
             "u_deal_damage": "biological",
-            "amount": { "math": [ "rng(4,8) * max( (u_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
+            "amount": { "math": [ "rng(4,8) * max( (n_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
             "bodypart": "leg_r"
           },
           {
             "u_deal_damage": "biological",
-            "amount": { "math": [ "rng(4,8) * max( (u_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
+            "amount": { "math": [ "rng(4,8) * max( (n_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] },
             "bodypart": "leg_l"
           }
         ],
         "else": [
           {
             "u_deal_damage": "biological",
-            "amount": { "math": [ "rng(10,35) * max( (u_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] }
+            "amount": { "math": [ "rng(10,35) * max( (n_vitamin('lilin_ruach_vitamin') / 3000), 1)" ] }
           }
         ]
       }
     ],
-    "false_effect": { "npc_message": "You don't have enough ruach to summon the miasma!", "type": "bad" }
+    "false_effect": { "npc_message": "You don't have enough ruach to enhance the miasma around <u_name>!", "type": "bad" }
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/spells/lilin_spells.json
+++ b/data/mods/Xedra_Evolved/spells/lilin_spells.json
@@ -139,7 +139,6 @@
     "name": "Unleash the Night-Wind",
     "description": "Summon a miasma filled with pestilence to infect your enemies.  This supernatural disease can even strike zombies or stranger creatures.",
     "message": "",
-    "//": "Need to target a specific target in order to display the values in the UI.  Hopefully someday we'll be able to target arbitrary ground areas with EoC-based spells",
     "valid_targets": [ "hostile", "ally", "ground" ],
     "flags": [ "SILENT", "NO_FAIL", "RANDOM_DURATION" ],
     "spell_class": "LILIN_TRAITS",

--- a/data/mods/Xedra_Evolved/spells/lilin_spells.json
+++ b/data/mods/Xedra_Evolved/spells/lilin_spells.json
@@ -140,7 +140,7 @@
     "description": "Summon a miasma filled with pestilence to infect your enemies.  This supernatural disease can even strike zombies or stranger creatures.",
     "message": "",
     "//": "Need to target a specific target in order to display the values in the UI.  Hopefully someday we'll be able to target arbitrary ground areas with EoC-based spells",
-    "valid_targets": [ "hostile", "ally" ],
+    "valid_targets": [ "hostile", "ally", "ground" ],
     "flags": [ "SILENT", "NO_FAIL", "RANDOM_DURATION" ],
     "spell_class": "LILIN_TRAITS",
     "max_level": 1,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[Xedra Evolved] Fix talker errors with a couple lilin spells"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Targeting an area of ground with Unleash the Night-Wind would evoke a talker error because if there were no creature there, there's no alpha talker. However, Procyonæ informed me that this actually doesn't matter--if you just tell the EoC not to run on the target point if there's no creature there, it still runs on everyone else in the AoE.

Also, I found a couple places where it was trying to read the ruach of the target, not the lilit. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `has_alpha` to the night-wind EoC, so it runs as described above.

Swap some u_ to n_ in various checks to prevent "non-character vitamin" errors.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

No more errors. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
