### PR TITLE
Fix godco mapgen_updates searches

### DIFF
--- a/data/json/effects_on_condition/mapgen_eocs/godco_mapgen_eocs.json
+++ b/data/json/effects_on_condition/mapgen_eocs/godco_mapgen_eocs.json
@@ -3,7 +3,10 @@
     "type": "effect_on_condition",
     "id": "godco_place_coop_new",
     "global": false,
-    "effect": [ { "mapgen_update": "darryl_place_coop", "om_terrain": "godco_7" }, { "math": [ "darryl_building_coop", "=", "2" ] } ]
+    "effect": [
+      { "mapgen_update": "darryl_place_coop", "om_terrain": "godco_7", "target_var": { "context_val": "search_locale" } },
+      { "math": [ "darryl_building_coop", "=", "2" ] }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/json/effects_on_condition/mapgen_eocs/godco_mapgen_eocs.json
+++ b/data/json/effects_on_condition/mapgen_eocs/godco_mapgen_eocs.json
@@ -13,7 +13,7 @@
     "id": "godco_place_herb_garden_new",
     "global": false,
     "effect": [
-      { "mapgen_update": "place_herb_garden", "om_terrain": "godco_1_2" },
+      { "mapgen_update": "place_herb_garden", "om_terrain": "godco_1_2", "target_var": { "context_val": "search_locale" } },
       { "math": [ "kostas_building_garden", "=", "2" ] }
     ]
   },
@@ -23,14 +23,46 @@
     "global": false,
     "//": "4 hours 20 minutes per wall (from regular ground to full palisade) * 373 walls = ~1,567 hours.  Divided into 8-hour work shifts, that's ~196 days, or six and a half months for one person.  Presuming we have ~11 people working in a single shift, each building 1 wall, that should be ~18 days to build.  Please correct me if I messed up the math.",
     "effect": [
-      { "mapgen_update": "place_right_corner_wall", "om_terrain": "godco_1" },
-      { "mapgen_update": "place_gate_wall", "om_terrain": "godco_2" },
-      { "mapgen_update": "place_left_corner_wall", "om_terrain": "godco_3" },
-      { "mapgen_update": "place_straight_up_wall_right", "om_terrain": "godco_4" },
-      { "mapgen_update": "place_straight_up_wall_left", "om_terrain": "godco_6" },
-      { "mapgen_update": "place_right_corner_wall_bottom", "om_terrain": "godco_7" },
-      { "mapgen_update": "place_straight_bottom_wall", "om_terrain": "godco_8" },
-      { "mapgen_update": "place_left_corner_wall_bottom", "om_terrain": "godco_9" },
+      {
+        "mapgen_update": "place_right_corner_wall",
+        "om_terrain": "godco_1",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_gate_wall",
+        "om_terrain": "godco_2",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_left_corner_wall",
+        "om_terrain": "godco_3",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_straight_up_wall_right",
+        "om_terrain": "godco_4",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_straight_up_wall_left",
+        "om_terrain": "godco_6",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_right_corner_wall_bottom",
+        "om_terrain": "godco_7",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_straight_bottom_wall",
+        "om_terrain": "godco_8",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_left_corner_wall_bottom",
+        "om_terrain": "godco_9",
+        "target_var": { "context_val": "search_locale" }
+      },
       { "math": [ "wall_in_progress", "=", "2" ] }
     ]
   },
@@ -41,7 +73,11 @@
     "//": "1 hour 30 minutes per wood wall * 50 walls = 75 hours for walls. 132 wood floors * 1 hour 40 minutes a floor = 220 hours. 1 hour 30 minutes per shelf * 68 shelves = 102 hours. (397 so far)  2 hours per roof * 132 roof tiles (assume same as floors) = 264 hours.",
     "//2": "In total, this takes 661 labor hours to build. Assuming work is in 8-hour shifts, that's 83 days, or 2 months and 22 days for a single worker.  Assume we have ~6 people on the job (isn't as urgent as a wall), this takes us ~14 days to build, or two weeks.",
     "effect": [
-      { "mapgen_update": "place_food_warehouse", "om_terrain": "forest_thick" },
+      {
+        "mapgen_update": "place_food_warehouse",
+        "om_terrain": "forest_thick",
+        "target_var": { "context_val": "search_locale" }
+      },
       { "math": [ "godco_warehouse_in_progress", "=", "2" ] }
     ]
   }

--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -312,8 +312,13 @@
     },
     "end": {
       "effect": [
+        { "npc_location_variable": { "context_val": "search_locale" } },
         { "math": [ "darryl_building_coop", "=", "1" ] },
-        { "queue_eocs": "godco_place_coop_new", "time_in_future": "168 hours" },
+        {
+          "queue_eocs": "godco_place_coop_new",
+          "time_in_future": "168 hours",
+          "variables": { "search_locale": { "context_val": "search_locale" } }
+        },
         { "u_spawn_item": "icon", "count": 6 }
       ],
       "opinion": { "trust": 2, "value": 2 }

--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -181,7 +181,12 @@
     },
     "end": {
       "effect": [
-        { "queue_eocs": "godco_place_warehouse_new", "time_in_future": "336 hours" },
+        { "npc_location_variable": { "context_val": "search_locale" } },
+        {
+          "queue_eocs": "godco_place_warehouse_new",
+          "time_in_future": "336 hours",
+          "variables": { "search_locale": { "context_val": "search_locale" } }
+        },
         { "u_spawn_item": "icon", "count": 137 }
       ],
       "opinion": { "trust": 7, "value": 6, "anger": -3 }
@@ -973,7 +978,12 @@
     "end": {
       "effect": [
         { "u_spawn_item": "icon", "count": 90 },
-        { "queue_eocs": "godco_place_herb_garden_new", "time_in_future": "72 hours" }
+        { "npc_location_variable": { "context_val": "search_locale" } },
+        {
+          "queue_eocs": "godco_place_herb_garden_new",
+          "time_in_future": "72 hours",
+          "variables": { "search_locale": { "context_val": "search_locale" } }
+        }
       ],
       "opinion": { "trust": 3, "value": 2 }
     },
@@ -1248,7 +1258,12 @@
     "end": {
       "effect": [
         { "mapgen_update": "helena_planer", "om_terrain": "godco_8" },
-        { "queue_eocs": "godco_place_wall_new", "time_in_future": "432 hours" },
+        { "npc_location_variable": { "context_val": "search_locale" } },
+        {
+          "queue_eocs": "godco_place_wall_new",
+          "time_in_future": "432 hours",
+          "variables": { "search_locale": { "context_val": "search_locale" } }
+        },
         { "u_spawn_item": "icon", "count": 40 }
       ],
       "opinion": { "trust": 2, "value": 1 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #77440
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Sets a location variable when the upgrades start being built to use with their respective searches
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Changed the coop time_in_future to 2hrs, did the missions up to it, teleported 100 OMs away, waited a few hours and then teleported back with expected results
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
