### PR TITLE
[Perf] Cache the absolute map square position of the first submap

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10045,18 +10045,19 @@ tripoint_abs_ms map::getglobal( const tripoint &p ) const
 
 tripoint_abs_ms map::getglobal( const tripoint_bub_ms &p ) const
 {
-    return project_to<coords::ms>( abs_sub.xy() ) + p.raw();
+    return tripoint_abs_ms{ p.x() + abs_ms.x(), p.y() + abs_ms.y(), p.z() };
 }
 
 tripoint_bub_ms map::bub_from_abs( const tripoint_abs_ms &p ) const
 {
-    return tripoint_bub_ms() + ( p - project_to<coords::ms>( abs_sub.xy() ) );
+    return tripoint_bub_ms { p.x() - abs_ms.x(), p.y() - abs_ms.y(), p.z()};
 }
 
 void map::set_abs_sub( const tripoint_abs_sm &p )
 {
     abs_sub = p;
-}
+    abs_ms = point_abs_ms{ project_to<coords::ms>( abs_sub.xy() ) };
+};
 
 tripoint_abs_sm map::get_abs_sub() const
 {

--- a/src/map.h
+++ b/src/map.h
@@ -2251,6 +2251,8 @@ class map
          * - shifting the map with @ref shift
          */
         tripoint_abs_sm abs_sub;
+        // Cached value of project_to<coords::ms>( abs_sub.xy() )
+        point_abs_ms abs_ms;
         /**
          * Sets @ref abs_sub, see there. Uses the same coordinate system as @ref abs_sub.
          */


### PR DESCRIPTION
#### Summary
Performance "the absolute map square position of the first submap"

#### Purpose of change

`bub_from_abs` previously took ~3% of CPU time (when waiting in the refugee centre). It now takes ~0.2%.

#### Describe the solution

Cache the result of `project_to` and manually inline the tripoint subtraction. Manually inlining is surprisingly important. Compare the following assembly for un-inlined and inlined variants:

**Non-Inlined**
```asm
	sub	rsp, 24
; File point.h
; 145  :         return tripoint( x - rhs.x, y - rhs.y, z - rhs.z );
	mov	eax, DWORD PTR [r8]
	sub	eax, DWORD PTR [rcx+64]
; 136  :     constexpr tripoint( int X, int Y, int Z ) : x( X ), y( Y ), z( Z ) {}
	mov	DWORD PTR $T1[rsp], eax
; 145  :         return tripoint( x - rhs.x, y - rhs.y, z - rhs.z );
	mov	eax, DWORD PTR [r8+4]
	sub	eax, DWORD PTR [rcx+68]
; 136  :     constexpr tripoint( int X, int Y, int Z ) : x( X ), y( Y ), z( Z ) {}
	mov	DWORD PTR $T1[rsp+4], eax
; 145  :         return tripoint( x - rhs.x, y - rhs.y, z - rhs.z );
	mov	eax, DWORD PTR [r8+8]
	sub	eax, DWORD PTR [rcx+72]
; File coordinates.h
; 114  :         explicit constexpr coord_point_base( Ts &&... ts ) : raw_( std::forward<Ts>( ts )... ) {}
	movsd	xmm0, QWORD PTR $T1[rsp]
	movsd	QWORD PTR [rdx], xmm0
	mov	DWORD PTR [rdx+8], eax
; File map.cpp
; 10053:     return tripoint_bub_ms{ (p - abs_ms).raw() };
	mov	rax, rdx
; 10054: }
	add	rsp, 24
	ret	0
```

**Inlined**
```asm
; 10053:     return tripoint_bub_ms { p.x() - abs_ms.x(), p.y() - abs_ms.y(), p.z()};
	mov	eax, DWORD PTR [r8]
	mov	r9d, DWORD PTR [r8+4]
	sub	eax, DWORD PTR [rcx+64]
; File coordinates.h
; 114  :         explicit constexpr coord_point_base( Ts &&... ts ) : raw_( std::forward<Ts>( ts )... ) {}
	mov	r10d, DWORD PTR [r8+8]
; File map.cpp
; 10053:     return tripoint_bub_ms { p.x() - abs_ms.x(), p.y() - abs_ms.y(), p.z()};
	sub	r9d, DWORD PTR [rcx+68]
; File point.h
; 136  :     constexpr tripoint( int X, int Y, int Z ) : x( X ), y( Y ), z( Z ) {}
	mov	DWORD PTR [rdx], eax
; File map.cpp
; 10053:     return tripoint_bub_ms { p.x() - abs_ms.x(), p.y() - abs_ms.y(), p.z()};
	mov	rax, rdx
; File point.h
; 136  :     constexpr tripoint( int X, int Y, int Z ) : x( X ), y( Y ), z( Z ) {}
	mov	DWORD PTR [rdx+4], r9d
	mov	DWORD PTR [rdx+8], r10d
; File map.cpp
; 10054: }
	ret	0
```

#### Describe alternatives you've considered
None.

#### Testing
Nothing's visibly broken. This is a refactor before anything else so there shouldn't be any issues. `abs_sub` is only set through `set_abs_sub` so `abs_ms` and `abs_sub` should always be in sync.

#### Additional context
It should be possible to inline all tripoint operations automatically, perhaps using something like `reinterpret_cast` for construction.