### PR TITLE
DoT spell fixes

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -645,7 +645,7 @@ static void damage_targets( const spell &sp, Creature &caster,
                 damage_over_time_data dot_data = sp.damage_over_time( target_bdpts, caster );
                 dot_data.amount /= target_bdpts.size();
                 cr->add_damage_over_time( dot_data );
-            } else if( !target_bdpts.empty() ) {
+            } else if( sp.bps_affected() > 0 ) {
                 cr->add_damage_over_time( sp.damage_over_time( target_bdpts, caster ) );
             } else {
                 cr->add_damage_over_time( sp.damage_over_time( { cr->get_random_body_part() }, caster ) );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -622,38 +622,36 @@ static void damage_targets( const spell &sp, Creature &caster,
         }
 
         // handling DOTs here
-        if( sp.damage_dot( caster ) > 0 ) {
-            if( cr->as_character() != nullptr ) {
-                std::vector<bodypart_id> target_bdpts = cr->get_all_body_parts( get_body_part_flags::only_main );
+        if( cr->as_character() != nullptr ) {
+            std::vector<bodypart_id> target_bdpts = cr->get_all_body_parts( get_body_part_flags::only_main );
 
-                if( sp.bps_affected() > 0 ) {
-                    for( auto it = target_bdpts.begin(); it != target_bdpts.end(); ) {
-                        if( !sp.bp_is_affected( it->id() ) ) {
-                            it = target_bdpts.erase( it );
-                        } else {
-                            ++it;
-                        }
+            if( sp.bps_affected() > 0 ) {
+                for( auto it = target_bdpts.begin(); it != target_bdpts.end(); ) {
+                    if( !sp.bp_is_affected( it->id() ) ) {
+                        it = target_bdpts.erase( it );
+                    } else {
+                        ++it;
                     }
                 }
-
-                if( sp.has_flag( spell_flag::PERCENTAGE_DAMAGE ) ) {
-                    for( bodypart_id bpid : target_bdpts ) {
-                        damage_over_time_data foo = sp.damage_over_time( { bpid }, caster );
-                        foo.amount = cr->get_hp( bpid ) * foo.amount / 100.0;
-                        cr->add_damage_over_time( foo );
-                    }
-                } else if( sp.has_flag( spell_flag::SPLIT_DAMAGE ) ) {
-                    damage_over_time_data dot_data = sp.damage_over_time( target_bdpts, caster );
-                    dot_data.amount /= target_bdpts.size();
-                    cr->add_damage_over_time( dot_data );
-                } else if( !target_bdpts.empty() ) {
-                    cr->add_damage_over_time( sp.damage_over_time( target_bdpts, caster ) );
-                } else {
-                    cr->add_damage_over_time( sp.damage_over_time( { cr->get_random_body_part() }, caster ) );
-                }
-            } else {
-                cr->add_damage_over_time( sp.damage_over_time( { body_part_bp_null }, caster ) );
             }
+
+            if( sp.has_flag( spell_flag::PERCENTAGE_DAMAGE ) ) {
+                for( bodypart_id bpid : target_bdpts ) {
+                    damage_over_time_data foo = sp.damage_over_time( { bpid }, caster );
+                    foo.amount = cr->get_hp( bpid ) * foo.amount / 100.0;
+                    cr->add_damage_over_time( foo );
+                }
+            } else if( sp.has_flag( spell_flag::SPLIT_DAMAGE ) ) {
+                damage_over_time_data dot_data = sp.damage_over_time( target_bdpts, caster );
+                dot_data.amount /= target_bdpts.size();
+                cr->add_damage_over_time( dot_data );
+            } else if( !target_bdpts.empty() ) {
+                cr->add_damage_over_time( sp.damage_over_time( target_bdpts, caster ) );
+            } else {
+                cr->add_damage_over_time( sp.damage_over_time( { cr->get_random_body_part() }, caster ) );
+            }
+        } else {
+            cr->add_damage_over_time( sp.damage_over_time( { body_part_bp_null }, caster ) );
         }
     }
 }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
for some reason i added `if( sp.damage_dot( caster ) > 0 )` check, that simply bypassed any logic if dot was zero or negative value
also found a bug, when dot was applied to all bodyparts when it was not supposed to
Fix #77470
#### Describe the solution
Remove check
Replace second check with something that works better
#### Testing
![GIF 08-11-2024 14-39-37](https://github.com/user-attachments/assets/0c949f10-10fc-4d71-9f34-4f4f4aad446a)