### PR TITLE
Silenced compiler warnings

### DIFF
--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -386,7 +386,7 @@ void bodygraph_display::draw_partlist()
     werase( w_partlist );
     int y = 0;
     for( int i = top_part; y < all_height - 2 && i < static_cast<int>( partlist.size() ); i++ ) {
-        const auto bgt = partlist[i];
+        const auto &bgt = partlist[i];
         std::string txt = !std::get<1>( bgt ) ?
                           std::get<0>( bgt )->name.translated() :
                           std::get<1>( bgt )->name.translated();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9799,7 +9799,7 @@ Character::moncam_cache_t Character::get_active_moncams() const
 {
     moncam_cache_t ret;
     for( monster const &mon : g->all_monsters() ) {
-        for( std::pair<mtype_id, int> const &moncam : get_moncams() ) {
+        for( const std::pair<const mtype_id, int> &moncam : get_moncams() ) {
             if( mon.type->id == moncam.first && mon.friendly != 0 &&
                 rl_dist( get_avatar().get_location(), mon.get_location() ) < moncam.second ) {
                 ret.insert( { &mon, mon.get_location() } );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9799,7 +9799,7 @@ Character::moncam_cache_t Character::get_active_moncams() const
 {
     moncam_cache_t ret;
     for( monster const &mon : g->all_monsters() ) {
-        for( std::pair<mtype_id, int> const moncam : get_moncams() ) {
+        for( std::pair<mtype_id, int> const &moncam : get_moncams() ) {
             if( mon.type->id == moncam.first && mon.friendly != 0 &&
                 rl_dist( get_avatar().get_location(), mon.get_location() ) < moncam.second ) {
                 ret.insert( { &mon, mon.get_location() } );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1723,7 +1723,7 @@ units::temperature_delta get_convection_temperature( const tripoint &location )
                                         units::from_fahrenheit_delta( fd_fire->get_intensity_level().convection_temperature_mod ) :
                                         units::from_kelvin_delta( 0 );
     // Modifier from fields
-    for( auto fd : here.field_at( location ) ) {
+    for( auto &fd : here.field_at( location ) ) {
         // Nullify lava modifier when there is open fire
         if( fd.first.obj().has_fire ) {
             lava_mod = units::from_kelvin_delta( 0 );
@@ -1955,7 +1955,7 @@ static hint_rating rate_action_eat( const avatar &you, const item &it )
                 if( rate.success() ) {
                     best_rate = hint_rating::good;
                     return VisitResponse::ABORT;
-                } else if( rate.value() != INEDIBLE || rate.value() != INEDIBLE_MUTATION ) {
+                } else if( rate.value() != INEDIBLE && rate.value() != INEDIBLE_MUTATION ) {
                     best_rate = hint_rating::iffy;
                 }
             }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -6162,7 +6162,7 @@ static void mill_activate( Character &you, const tripoint_bub_ms &examp )
         }
     }
 
-    for( std::pair<const string_id<itype>, int> mill_type_count : millable_counts ) {
+    for( const std::pair<const string_id<itype>, int> &mill_type_count : millable_counts ) {
         item source( mill_type_count.first );
         const item product( source.type->milling_data->into_ );
         const recipe rec = *source.type->milling_data->recipe_;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8965,7 +8965,7 @@ int item::chip_resistance( bool worst, const bodypart_id &bp ) const
     }
 
     const int total = type->mat_portion_total == 0 ? 1 : type->mat_portion_total;
-    for( const std::pair<material_id, int> mat : made_of() ) {
+    for( const std::pair<material_id, int> &mat : made_of() ) {
         const int val = ( mat.first->chip_resist() * mat.second ) / total;
         res = worst ? std::min( res, val ) : std::max( res, val );
     }
@@ -10466,7 +10466,7 @@ const material_type &item::get_random_material() const
     std::vector<material_id> matlist;
     const std::map<material_id, int> &mats = made_of();
     matlist.reserve( mats.size() );
-    for( auto mat : mats ) {
+    for( const std::pair<material_id, int> &mat : mats ) {
         matlist.emplace_back( mat.first );
     }
     return *random_entry( matlist, material_id::NULL_ID() );
@@ -10477,7 +10477,7 @@ const material_type &item::get_base_material() const
     const std::map<material_id, int> &mats = made_of();
     const material_type *m = &material_id::NULL_ID().obj();
     int portion = 0;
-    for( const std::pair<material_id, int> mat : mats ) {
+    for( const std::pair<material_id, int> &mat : mats ) {
         if( mat.second > portion ) {
             portion = mat.second;
             m = &mat.first.obj();
@@ -12022,7 +12022,7 @@ bool item::flammable( int threshold ) const
 
     int flammability = 0;
     units::volume volume_per_turn = 0_ml;
-    for( const std::pair<material_id, int> m : mats ) {
+    for( const std::pair<material_id, int> &m : mats ) {
         const mat_burn_data &bd = m.first->burn_data( 1 );
         if( bd.immune ) {
             // Made to protect from fire

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8965,7 +8965,7 @@ int item::chip_resistance( bool worst, const bodypart_id &bp ) const
     }
 
     const int total = type->mat_portion_total == 0 ? 1 : type->mat_portion_total;
-    for( const std::pair<material_id, int> &mat : made_of() ) {
+    for( const std::pair<const material_id, int> &mat : made_of() ) {
         const int val = ( mat.first->chip_resist() * mat.second ) / total;
         res = worst ? std::min( res, val ) : std::max( res, val );
     }
@@ -10466,7 +10466,7 @@ const material_type &item::get_random_material() const
     std::vector<material_id> matlist;
     const std::map<material_id, int> &mats = made_of();
     matlist.reserve( mats.size() );
-    for( const std::pair<material_id, int> &mat : mats ) {
+    for( const std::pair<const material_id, int> &mat : mats ) {
         matlist.emplace_back( mat.first );
     }
     return *random_entry( matlist, material_id::NULL_ID() );
@@ -10477,7 +10477,7 @@ const material_type &item::get_base_material() const
     const std::map<material_id, int> &mats = made_of();
     const material_type *m = &material_id::NULL_ID().obj();
     int portion = 0;
-    for( const std::pair<material_id, int> &mat : mats ) {
+    for( const std::pair<const material_id, int> &mat : mats ) {
         if( mat.second > portion ) {
             portion = mat.second;
             m = &mat.first.obj();
@@ -12022,7 +12022,7 @@ bool item::flammable( int threshold ) const
 
     int flammability = 0;
     units::volume volume_per_turn = 0_ml;
-    for( const std::pair<material_id, int> &m : mats ) {
+    for( const std::pair<const material_id, int> &m : mats ) {
         const mat_burn_data &bd = m.first->burn_data( 1 );
         if( bd.immune ) {
             // Made to protect from fire

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1660,7 +1660,7 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
     std::map<itype_id, int> salvage;
     std::map<material_id, units::mass> mat_to_weight;
     std::set<material_id> mat_set;
-    for( std::pair<material_id, int> mat : cut.get_item()->made_of() ) {
+    for( const std::pair<material_id, int> &mat : cut.get_item()->made_of() ) {
         mat_set.insert( mat.first );
     }
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1660,7 +1660,7 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
     std::map<itype_id, int> salvage;
     std::map<material_id, units::mass> mat_to_weight;
     std::set<material_id> mat_set;
-    for( const std::pair<material_id, int> &mat : cut.get_item()->made_of() ) {
+    for( const std::pair<const material_id, int> &mat : cut.get_item()->made_of() ) {
         mat_set.insert( mat.first );
     }
 

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -1030,7 +1030,7 @@ void enchant_cache::activate_passive( Character &guy ) const
     if( emitter ) {
         get_map().emit_field( guy.pos_bub(), *emitter );
     }
-    for( const std::pair<efftype_id, int> &eff : ench_effects ) {
+    for( const std::pair<const efftype_id, int> &eff : ench_effects ) {
         guy.add_effect( eff.first, 1_seconds, false, eff.second );
     }
     for( const std::pair<const time_duration, std::vector<fake_spell>> &activation :

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -1030,7 +1030,7 @@ void enchant_cache::activate_passive( Character &guy ) const
     if( emitter ) {
         get_map().emit_field( guy.pos_bub(), *emitter );
     }
-    for( const std::pair<efftype_id, int> eff : ench_effects ) {
+    for( const std::pair<efftype_id, int> &eff : ench_effects ) {
         guy.add_effect( eff.first, 1_seconds, false, eff.second );
     }
     for( const std::pair<const time_duration, std::vector<fake_spell>> &activation :

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -272,7 +272,7 @@ std::function<double( dialogue & )> faction_food_supply_eval( char /* scope */,
 {
     return [fac_val = params[0]]( dialogue & d ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
-        return fac->food_supply.calories;
+        return static_cast<double>( fac->food_supply.calories );
     };
 }
 

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -662,7 +662,7 @@ void Character::mutation_loss_effect( const trait_id &mut )
         recalculate_bodyparts();
     }
 
-    for( const std::pair<mtype_id, int> &moncam : branch.moncams ) {
+    for( const std::pair<const mtype_id, int> &moncam : branch.moncams ) {
         remove_moncam( moncam.first );
     }
 

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -628,7 +628,7 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
         return true;
     } );
 
-    for( std::pair<mtype_id, int> moncam : branch.moncams ) {
+    for( const std::pair<mtype_id, int> &moncam : branch.moncams ) {
         add_moncam( moncam );
     }
 
@@ -662,7 +662,7 @@ void Character::mutation_loss_effect( const trait_id &mut )
         recalculate_bodyparts();
     }
 
-    for( std::pair<mtype_id, int> moncam : branch.moncams ) {
+    for( const std::pair<mtype_id, int> &moncam : branch.moncams ) {
         remove_moncam( moncam.first );
     }
 

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -628,7 +628,7 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
         return true;
     } );
 
-    for( const std::pair<mtype_id, int> &moncam : branch.moncams ) {
+    for( const std::pair<const mtype_id, int> &moncam : branch.moncams ) {
         add_moncam( moncam );
     }
 

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -679,7 +679,7 @@ void mutation_branch::check_consistency()
                 debugmsg( "mutation %s transform uses undefined target %s", mid.c_str(), tid.c_str() );
             }
         }
-        for( const std::pair<species_id, int> &elem : an_id ) {
+        for( const std::pair<const species_id, int> &elem : an_id ) {
             if( !elem.first.is_valid() ) {
                 debugmsg( "mutation %s refers to undefined species id %s", mid.c_str(), elem.first.c_str() );
             }

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -679,7 +679,7 @@ void mutation_branch::check_consistency()
                 debugmsg( "mutation %s transform uses undefined target %s", mid.c_str(), tid.c_str() );
             }
         }
-        for( const std::pair<species_id, int> elem : an_id ) {
+        for( const std::pair<species_id, int> &elem : an_id ) {
             if( !elem.first.is_valid() ) {
                 debugmsg( "mutation %s refers to undefined species id %s", mid.c_str(), elem.first.c_str() );
             }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2375,7 +2375,7 @@ static std::string assemble_profession_details( const avatar &u, const input_con
     // Profession spells
     if( !sorted_profs[cur_id]->spells().empty() ) {
         assembled += "\n" + colorize( _( "Profession spells:" ), COL_HEADER ) + "\n";
-        for( const std::pair<spell_id, int> &spell_pair : sorted_profs[cur_id]->spells() ) {
+        for( const std::pair<const spell_id, int> &spell_pair : sorted_profs[cur_id]->spells() ) {
             assembled += string_format( _( "%s level %d" ), spell_pair.first->name, spell_pair.second ) + "\n";
         }
     }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2783,7 +2783,7 @@ static std::string assemble_hobby_details( const avatar &u, const input_context 
     // Background spells
     if( !sorted_hobbies[cur_id]->spells().empty() ) {
         assembled += "\n" + colorize( _( "Background spells:" ), COL_HEADER ) + "\n";
-        for( const std::pair<spell_id, int> &spell_pair : sorted_hobbies[cur_id]->spells() ) {
+        for( const std::pair<const spell_id, int> &spell_pair : sorted_hobbies[cur_id]->spells() ) {
             assembled += string_format( _( "%s level %d" ), spell_pair.first->name, spell_pair.second ) + "\n";
         }
     }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2375,7 +2375,7 @@ static std::string assemble_profession_details( const avatar &u, const input_con
     // Profession spells
     if( !sorted_profs[cur_id]->spells().empty() ) {
         assembled += "\n" + colorize( _( "Profession spells:" ), COL_HEADER ) + "\n";
-        for( const std::pair<spell_id, int> spell_pair : sorted_profs[cur_id]->spells() ) {
+        for( const std::pair<spell_id, int> &spell_pair : sorted_profs[cur_id]->spells() ) {
             assembled += string_format( _( "%s level %d" ), spell_pair.first->name, spell_pair.second ) + "\n";
         }
     }
@@ -2783,7 +2783,7 @@ static std::string assemble_hobby_details( const avatar &u, const input_context 
     // Background spells
     if( !sorted_hobbies[cur_id]->spells().empty() ) {
         assembled += "\n" + colorize( _( "Background spells:" ), COL_HEADER ) + "\n";
-        for( const std::pair<spell_id, int> spell_pair : sorted_hobbies[cur_id]->spells() ) {
+        for( const std::pair<spell_id, int> &spell_pair : sorted_hobbies[cur_id]->spells() ) {
             assembled += string_format( _( "%s level %d" ), spell_pair.first->name, spell_pair.second ) + "\n";
         }
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -703,7 +703,7 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     // Add martial arts
     learn_ma_styles_from_traits();
     // Add spells for magiclysm mod
-    for( const std::pair<spell_id, int> &spell_pair : myclass->_starting_spells ) {
+    for( const std::pair<const spell_id, int> &spell_pair : myclass->_starting_spells ) {
         this->magic->learn_spell( spell_pair.first, *this, true );
         spell &sp = this->magic->get_spell( spell_pair.first );
         while( sp.get_level() < spell_pair.second && !sp.is_max_level( *this ) ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -703,7 +703,7 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     // Add martial arts
     learn_ma_styles_from_traits();
     // Add spells for magiclysm mod
-    for( std::pair<spell_id, int> spell_pair : myclass->_starting_spells ) {
+    for( const std::pair<spell_id, int> &spell_pair : myclass->_starting_spells ) {
         this->magic->learn_spell( spell_pair.first, *this, true );
         spell &sp = this->magic->get_spell( spell_pair.first );
         while( sp.get_level() < spell_pair.second && !sp.is_max_level( *this ) ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2404,7 +2404,7 @@ struct mutable_overmap_phase_remainder {
     ) const {
         int context_mandatory_joins_shortfall = 0;
 
-        for( const mutable_overmap_piece_candidate piece : rule.pieces( origin, dir ) ) {
+        for( const mutable_overmap_piece_candidate &piece : rule.pieces( origin, dir ) ) {
             if( !overmap::inbounds( piece.pos ) ) {
                 return std::nullopt;
             }
@@ -2421,7 +2421,7 @@ struct mutable_overmap_phase_remainder {
 
         std::vector<om_pos_dir> suppressed_joins;
 
-        for( const std::pair<om_pos_dir, const mutable_overmap_terrain_join *> p :
+        for( const std::pair<om_pos_dir, const mutable_overmap_terrain_join *> &p :
              rule.outward_joins( origin, dir ) ) {
             const om_pos_dir &pos_d = p.first;
             const mutable_overmap_terrain_join &ter_join = *p.second;
@@ -2800,7 +2800,7 @@ struct mutable_overmap_special_data : overmap_special_data {
             if( rule ) {
                 const tripoint_om_omt &satisfy_origin = satisfy_result.origin;
                 om_direction::type rot = satisfy_result.dir;
-                for( const mutable_overmap_piece_candidate piece : rule->pieces( satisfy_origin, rot ) ) {
+                for( const mutable_overmap_piece_candidate &piece : rule->pieces( satisfy_origin, rot ) ) {
                     const mutable_overmap_terrain &ter = *piece.overmap;
                     add_ter( ter, piece.pos, piece.rot, satisfy_result.suppressed_joins );
                 }
@@ -6610,7 +6610,7 @@ void overmap::connect_closest_points( const std::vector<point_om_omt> &points, i
     // track which subgraph each point belongs to
     std::vector<int> subgraphs( points.size(), -1 );
 
-    for( edge candidate : edges ) {
+    for( const edge &candidate : edges ) {
         const size_t i = candidate.second.first;
         const size_t j = candidate.second.second;
         bool connect = false;

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -732,7 +732,7 @@ std::map<spell_id, int> profession::spells() const
 
 void profession::learn_spells( avatar &you ) const
 {
-    for( const std::pair<spell_id, int> &spell_pair : spells() ) {
+    for( const std::pair<const spell_id, int> &spell_pair : spells() ) {
         you.magic->learn_spell( spell_pair.first, you, true );
         spell &sp = you.magic->get_spell( spell_pair.first );
         while( sp.get_level() < spell_pair.second && !sp.is_max_level( you ) ) {

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -732,7 +732,7 @@ std::map<spell_id, int> profession::spells() const
 
 void profession::learn_spells( avatar &you ) const
 {
-    for( const std::pair<spell_id, int> spell_pair : spells() ) {
+    for( const std::pair<spell_id, int> &spell_pair : spells() ) {
         you.magic->learn_spell( spell_pair.first, you, true );
         spell &sp = you.magic->get_spell( spell_pair.first );
         while( sp.get_level() < spell_pair.second && !sp.is_max_level( you ) ) {

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -633,16 +633,16 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
             if( boo_hoo ) {
                 cpu.get_name() = string_format( pgettext( "vehicle turret", "The %s" ), pt.name() );
                 // check if the player can see or hear then print chooses a message accordingly
-                if( u_see & u_hear ) {
+                if( u_see && u_hear ) {
                     add_msg( m_warning, n_gettext( "%s points in your direction and emits an IFF warning beep.",
                                                    "%s points in your direction and emits %d annoyed sounding beeps.",
                                                    boo_hoo ),
                              cpu.get_name(), boo_hoo );
-                } else if( !u_see & u_hear ) {
+                } else if( !u_see && u_hear ) {
                     add_msg( m_warning, n_gettext( "You hear a warning beep.",
                                                    "You hear %d annoyed sounding beeps.",
                                                    boo_hoo ), boo_hoo );
-                } else if( u_see & !u_hear ) {
+                } else if( u_see && !u_hear ) {
                     add_msg( m_warning, _( "%s points in your direction." ), cpu.get_name() );
                 }
             }

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -362,7 +362,7 @@ static void finalize_item_counts( std::unordered_map<itype_id, float> &item_coun
                 }
             }
         }
-        for( std::pair<const itype_id, int> demographics : category.second.item_weights ) {
+        for( const std::pair<const itype_id, int> &demographics : category.second.item_weights ) {
             item_counts[demographics.first] = 0.0;
         }
     }

--- a/tests/vehicle_export_test.cpp
+++ b/tests/vehicle_export_test.cpp
@@ -24,7 +24,7 @@ static bool operator==( const vehicle_prototype::part_def &l, const vehicle_prot
 
 static bool operator==( const vehicle_item_spawn &l, const vehicle_item_spawn &r )
 {
-    return l.pos == r.pos && l.chance == r.chance && l.with_ammo == r.with_ammo &&
+    return l.pos == r.pos && l.chance == r.chance &&
            l.with_ammo == r.with_ammo && l.with_magazine == r.with_magazine && l.item_ids == r.item_ids &&
            // NOLINTNEXTLINE(misc-redundant-expression)
            l.variant_ids == r.variant_ids && l.item_groups == r.item_groups;

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -137,7 +137,7 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
     // Shift skill levels by one to ensure successful crafting
     // after the change in https://github.com/CleverRaven/Cataclysm-DDA/pull/61985
     character.set_skill_level( recipe.skill_used, recipe.difficulty + 1 );
-    for( const std::pair<skill_id, int> &req : recipe.required_skills ) {
+    for( const std::pair<const skill_id, int> &req : recipe.required_skills ) {
         character.set_skill_level( req.first, req.second + 1 );
     }
     for( const recipe_proficiency &prof : recipe.proficiencies ) {

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -137,7 +137,7 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
     // Shift skill levels by one to ensure successful crafting
     // after the change in https://github.com/CleverRaven/Cataclysm-DDA/pull/61985
     character.set_skill_level( recipe.skill_used, recipe.difficulty + 1 );
-    for( const std::pair<skill_id, int> req : recipe.required_skills ) {
+    for( const std::pair<skill_id, int> &req : recipe.required_skills ) {
         character.set_skill_level( req.first, req.second + 1 );
     }
     for( const recipe_proficiency &prof : recipe.proficiencies ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Silence a bunch of compiler warnings (with the rather futile hope to one day reach a state where the appearance of a warning means it's something you've just caused, and thus needs to deal with).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Silenced a template type conversion complaint fouling the compile log with a bunch of references every compilation by turning an implicit conversion into an explicit on.
- Changed obviously incorrect && into || (being different from at least one of two flags will always be true). Cannot guarantee the change is the correct one, but looks reasonable.
- Changed bitwise comparisons into the boolean ones they probably were meant to be.
- Changed a whole lot of loop variables into const & ones (const sometimes present already) after checking if they seems to actually be assigned (found none in my checks).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Also trying to silence many of the complaints about switch fallthroughs. It appears C++17 has the `[[fallthrough]];` directive the compiler can interpret (rather than the various human produced comments present in a lot of cases).
Haven't tried to do it as I'm not completely certain that will work for all compilers used by the project.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded save, walked up ramp, jumped into car, ran through hay bales, ran over a turkey, smashed into a stationary vehicle. Didn't see anything odd.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There are a lot of warnings about:
- Access via null pointers (some reasoning being incorrect, such as assuming casting of a Creature into an npc resulting in a nullptr must mean casting into a monster also has to result in a nullptr). Many may be relevant, though.
- Stack footprint of operations being excessive.
- Use of a moved from object.
- Stuff in imgui and flatbuffer, but I assume they're "as is" and shouldn't be touched, as they're marked as third party.
- Some odd bits and ends, some of which seems to be the compiler making assumptions it cannot logically make with the information available.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
