### PR TITLE
Make enchantment influence dps shown in item

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2293,6 +2293,7 @@ double item::effective_dps( const Character &guy, Creature &mon ) const
         guy.roll_all_damage( crit, base_damage, true, *this, attack_vector_vector_null,
                              sub_body_part_sub_limb_debug, &mon, bp );
         damage_instance dealt_damage = base_damage;
+        dealt_damage = guy.modify_damage_dealt_with_enchantments( dealt_damage );
         // TODO: Modify DPS calculation to consider weakpoints.
         resistances r = resistances( *static_cast<monster *>( temp_mon ) );
         for( damage_unit &dmg_unit : dealt_damage.damage_units ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Item DPS field is a field that already reflect you using this weapon against different enemies; it is influenced by both item properties, and character stats and effects: strength, pain and similar
There is little reason to omit possible enchantments if they are presented
#### Describe the solution
Add modify_damage_dealt_with_enchantments() to dps calculations in UI
#### Testing
Default character with skill 5
![image](https://github.com/user-attachments/assets/8d51e44d-c056-4d4a-8ecf-92b9681d243a)
Default character with skill 5, and 1000 additional bash damage added
![image](https://github.com/user-attachments/assets/31e99a43-60c6-4881-895f-554a8bb21a80)
#### Additional context
once #77662 will be merged, someone need to run across all melee enchantments, and if it's an item, replace said enchantment with damage, specified in item definition (unless it utilizes math or similar properties, it would be tricky then)