### PR TITLE
Afs shield items

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2294,6 +2294,11 @@
     "inherit": false
   },
   {
+    "id": "ENERGY_SHIELD",
+    "type": "json_flag",
+    "info": "This piece of armor is an energy barrier and will break after absorbing a certain amount of damage."
+  },
+  {
     "id": "ROBOFAC_ROBOT_MEDIUM",
     "type": "json_flag",
     "info": "A medium drone sold by Hub 01."

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -25,6 +25,36 @@
     ]
   },
   {
+    "id": "debug_energy_shield",
+    "type": "ARMOR",
+    "name": { "str": "weak energy shield" },
+    "description": "A weak energy shield that protects against ballistic damage.",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "symbol": "o",
+    "color": "blue",
+    "material": [ "ballistic_shield" ],
+    "material_thickness": 0.3,
+    "max_energy_shield_hp": 4,
+    "flags": [
+      "AURA",
+      "ENERGY_SHIELD",
+      "OVERSIZE",
+      "ONLY_ONE",
+      "TRADER_AVOID",
+      "NO_TAKEOFF",
+      "NONCONDUCTIVE",
+      "ALLOWS_NATURAL_ATTACKS"
+    ],
+    "armor": [
+      {
+        "encumbrance": 0,
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+      }
+    ]
+  },
+  {
     "id": "pride_flag",
     "type": "ARMOR",
     "name": { "str": "pride flag" },

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2265,6 +2265,21 @@
   },
   {
     "type": "material",
+    "id": "ballistic_shield",
+    "name": "Ballistic Barrier",
+    "density": 1,
+    "specific_heat_liquid": 0.52,
+    "specific_heat_solid": 0.52,
+    "latent_heat": 5200,
+    "chip_resist": 100,
+    "breathability": "SECOND_SKIN",
+    "dmg_adj": [ "resonating", "cascading", "unraveling", "fractal" ],
+    "bash_dmg_verb": "agitated",
+    "cut_dmg_verb": "agitated",
+    "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 100 }
+  },
+  {
+    "type": "material",
     "id": "monolith_heavy",
     "name": "Monolith",
     "density": 400,

--- a/data/mods/Aftershock/flags.json
+++ b/data/mods/Aftershock/flags.json
@@ -19,6 +19,11 @@
     "info": "You are immune to telepathy."
   },
   {
+    "id": "SHIELD_GENERATOR",
+    "type": "json_flag",
+    "info": "This item is capable of projecting a Riemann protective shield."
+  },
+  {
     "id": "HIVE_MIND",
     "type": "monster_flag",
     "//": "This monster is part of a hive mind"

--- a/data/mods/Aftershock/items/armor/energy_shield.json
+++ b/data/mods/Aftershock/items/armor/energy_shield.json
@@ -38,25 +38,9 @@
     ]
   },
   {
-    "id": "spawn_shield",
-    "type": "SPELL",
-    "name": "Spawn Riemann Shield",
-    "description": "Creates a shield.",
-    "valid_targets": [ "self" ],
-    "flags": [ "VERBAL", "NO_FAIL", "CONCENTRATE", "SOMATIC", "PERMANENT_ALL_LEVELS", "NO_EXPLOSION_SFX" ],
-    "min_range": 0,
-    "max_range": 0,
-    "min_damage": 1,
-    "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "afs_energy_shield",
-    "shape": "blast",
-    "max_level": 1
-  },
-  {
     "id": "afs_backpack_shieldgen",
     "type": "TOOL_ARMOR",
-    "name": { "str": "SHD-1k Riemman Generator" },
+    "name": { "str": "SHD-1k Riemman Shield Generator" },
     "description": "A backpack mounted shield generator for infantry use, capable of fully protecting its user during prolonged bursts of kinetic and energy attacks.  Standard issue for UICA breaching teams.\n\nIts high energy consuption and weight make it unsuitable for long-term use.  Powered with energy cartridges.",
     "weight": "10 kg",
     "volume": "18000 ml",
@@ -68,7 +52,7 @@
     "looks_like": "backpack",
     "color": "brown",
     "warmth": 10,
-    "charges_per_use": 1,
+    "charges_per_use": 400,
     "material_thickness": 2,
     "pocket_data": [
       {
@@ -94,6 +78,7 @@
               "shield_max_hp": "600",
               "shield_regen": "1",
               "shield_regen_rate": "1",
+              "bionic": "0",
               "turn_cost": "1",
               "success_message": "a",
               "failure_message": "b"
@@ -115,7 +100,7 @@
   {
     "id": "afs_backpack_shieldgen_on",
     "type": "TOOL_ARMOR",
-    "name": { "str": "SHD-1k Riemman Generator (ACTIVE)" },
+    "name": { "str": "SHD-1k Riemman Shield Generator (active)", "str_pl": "SHD-1k Riemman Shield Generators (active)" },
     "copy-from": "afs_backpack_shieldgen",
     "description": "A backpack mounted shield generator for infantry use, capable of fully protecting its user during prolonged bursts of kinetic and energy attacks.  Standard issue for UICA breaching teams.\n\nIts high energy consumption and weight make it unsuitable for long-term use.  Powered with energy cartridges.",
     "power_draw": "100000 mW",
@@ -137,10 +122,28 @@
       "effect_on_conditions": [
         {
           "id": "afs_backpack_shieldgen_tick",
-          "effect": { "math": [ "u_shield_power_ratio", "=", "n_val('power_percentage')" ] }
+          "condition": "has_alpha",
+          "effect": { "math": [ "u_shield_power_ratio", "=", "n_val('power_percentage')" ] },
+          "false_effect": { "transform_item": "afs_backpack_shieldgen" }
         }
       ]
     }
+  },
+  {
+    "id": "spawn_shield",
+    "type": "SPELL",
+    "name": "Spawn Riemann Shield",
+    "description": "Creates a shield.",
+    "valid_targets": [ "self" ],
+    "flags": [ "VERBAL", "NO_FAIL", "CONCENTRATE", "SOMATIC", "PERMANENT_ALL_LEVELS", "NO_EXPLOSION_SFX" ],
+    "min_range": 0,
+    "max_range": 0,
+    "min_damage": 1,
+    "max_damage": 1,
+    "effect": "spawn_item",
+    "effect_str": "afs_energy_shield",
+    "shape": "blast",
+    "max_level": 1
   },
   {
     "id": "EOC_start_shield",
@@ -155,7 +158,11 @@
           { "transform_item": { "context_val": "transform_target" }, "active": true },
           { "math": [ "_shield_uid", "=", "rand(1200)" ] },
           { "math": [ "n_shield_gen_uid", "=", "_shield_uid" ] },
-          { "math": [ "u_shield_power_ratio", "=", "n_val('power_percentage')" ] },
+          {
+            "if": { "math": [ "_is_bionic" ] },
+            "then": [ { "math": [ "u_shield_power_ratio", "=", "u_val('power_percentage')" ] } ],
+            "else": [ { "math": [ "u_shield_power_ratio", "=", "n_val('power_percentage')" ] } ]
+          },
           {
             "u_run_inv_eocs": "all",
             "search_data": [ { "id": [ "afs_energy_shield" ] } ],
@@ -167,7 +174,7 @@
                   { "math": [ "n_shield_turn", "=", "0" ] },
                   { "math": [ "n_SHIELD_REGEN", "=", "0" ] },
                   { "math": [ "n_SHIELD_REGEN_RATE", "=", "0" ] },
-                  { "math": [ "n_ENERGY_SHIELD_HP", "=", "_shield_max_hp" ] },
+                  { "math": [ "n_ENERGY_SHIELD_HP", "=", "_shield_max_hp*0.1" ] },
                   { "math": [ "n_ENERGY_SHIELD_MAX_HP", "=", "_shield_max_hp" ] },
                   { "math": [ "n_SHIELD_REGEN", "=", "_shield_regen" ] },
                   { "math": [ "n_SHIELD_REGEN_RATE", "=", "shield_regen_rate" ] },
@@ -232,6 +239,45 @@
       { "transform_item": { "context_val": "transform_target" } },
       { "u_remove_item_with": "afs_energy_shield" },
       { "math": [ "u_shield_ratio", "=", "-1" ] }
+    ]
+  },
+  {
+    "//": "This bit is only here to do a final update of the UI when a generator is dropped.",
+    "id": "EOC_check_drop_shield_gen",
+    "type": "effect_on_condition",
+    "eoc_type": "EVENT",
+    "required_event": "character_finished_activity",
+    "condition": {
+      "and": [
+        { "compare_string": [ "ACT_DROP", { "context_val": "activity" } ] },
+        { "math": [ "u_shield_power_ratio", ">=", "0" ] }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_shield_power_ratio", "=", "-1" ] },
+      {
+        "//": "We check if we have another shield generator to update the UI power gauge.",
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "worn_only": true, "flags": [ "SHIELD_GENERATOR" ] } ],
+        "true_eocs": [
+          {
+            "id": "_afs_drop_update_power",
+            "effect": [ { "math": [ "u_shield_power_ratio", "=", "n_val('power_percentage')" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "EOC_detonate_shield",
+    "type": "effect_on_condition",
+    "eoc_type": "EVENT",
+    "required_event": "character_armor_destroyed",
+    "condition": { "and": [ { "compare_string": [ "afs_energy_shield", { "context_val": "itype" } ] } ] },
+    "effect": [
+      { "math": [ "u_shield_ratio", "=", "-1" ] },
+      { "u_emit": "heavy_rad_glimmer", "chance_mult": 2 },
+      { "u_message": "The shield blasts you with radiation as it dissipates.", "type": "bad" }
     ]
   }
 ]

--- a/data/mods/Aftershock/items/armor/energy_shield.json
+++ b/data/mods/Aftershock/items/armor/energy_shield.json
@@ -1,0 +1,237 @@
+[
+  {
+    "id": "afs_energy_shield",
+    "type": "TOOL_ARMOR",
+    "name": { "str": "Riemann shell" },
+    "description": "A thin shell of altered reality containing enormous electromagnetic potential, such that it might behave as a solid object under certain conditions.  A Riemann shell can defend against a wide variety of physical and energy attacks, but can be overwhelmed and forced to collapse into deadly radiation with prolonged assault.",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "symbol": "o",
+    "color": "blue",
+    "material": [ "riemmann_space" ],
+    "environmental_protection": 20,
+    "material_thickness": 5.0,
+    "max_energy_shield_hp": 1200,
+    "flags": [
+      "AURA",
+      "ENERGY_SHIELD",
+      "OVERSIZE",
+      "ONLY_ONE",
+      "TRADER_AVOID",
+      "NO_TAKEOFF",
+      "NONCONDUCTIVE",
+      "SPAWN_ACTIVE",
+      "ALLOWS_NATURAL_ATTACKS",
+      "SEMITANGIBLE",
+      "UNRESTRICTED"
+    ],
+    "tick_action": {
+      "type": "effect_on_conditions",
+      "effect_on_conditions": [ { "id": "_afs_energy_shield", "effect": { "run_eocs": "EOC_afs_do_shield" } } ]
+    },
+    "armor": [
+      {
+        "encumbrance": 0,
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+      }
+    ]
+  },
+  {
+    "id": "spawn_shield",
+    "type": "SPELL",
+    "name": "Spawn Riemann Shield",
+    "description": "Creates a shield.",
+    "valid_targets": [ "self" ],
+    "flags": [ "VERBAL", "NO_FAIL", "CONCENTRATE", "SOMATIC", "PERMANENT_ALL_LEVELS", "NO_EXPLOSION_SFX" ],
+    "min_range": 0,
+    "max_range": 0,
+    "min_damage": 1,
+    "max_damage": 1,
+    "effect": "spawn_item",
+    "effect_str": "afs_energy_shield",
+    "shape": "blast",
+    "max_level": 1
+  },
+  {
+    "id": "afs_backpack_shieldgen",
+    "type": "TOOL_ARMOR",
+    "name": { "str": "SHD-1k Riemman Generator" },
+    "description": "A backpack mounted shield generator for infantry use, capable of fully protecting its user during prolonged bursts of kinetic and energy attacks.  Standard issue for UICA breaching teams.\n\nIts high energy consuption and weight make it unsuitable for long-term use.  Powered with energy cartridges.",
+    "weight": "10 kg",
+    "volume": "18000 ml",
+    "price": "120 kUSD",
+    "price_postapoc": "120 kUSD",
+    "ammo": [ "battery" ],
+    "material": [ "nylon", "aluminum" ],
+    "symbol": "[",
+    "looks_like": "backpack",
+    "color": "brown",
+    "warmth": 10,
+    "charges_per_use": 1,
+    "material_thickness": 2,
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "magazine_well": "75 ml",
+        "item_restriction": [ "afs_cartridge", "afs_bootleg_cartridge", "afs_archeotech_cartridge" ]
+      }
+    ],
+    "flags": [ "BELTED", "WATERPROOF", "ONLY_ONE" ],
+    "use_action": {
+      "type": "effect_on_conditions",
+      "ammo_scale": 1,
+      "menu_text": "Activate",
+      "effect_on_conditions": [
+        {
+          "id": "afs_backpack_shieldgen_activate",
+          "effect": {
+            "run_eoc_with": "EOC_start_shield",
+            "variables": {
+              "transform_target": "afs_backpack_shieldgen_on",
+              "shield_max_hp": "600",
+              "shield_regen": "1",
+              "shield_regen_rate": "1",
+              "turn_cost": "1",
+              "success_message": "a",
+              "failure_message": "b"
+            }
+          }
+        }
+      ]
+    },
+    "armor": [
+      {
+        "encumbrance": [ 3, 12 ],
+        "volume_encumber_modifier": 0,
+        "coverage": 100,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_hanging_back", "torso_waist" ]
+      }
+    ]
+  },
+  {
+    "id": "afs_backpack_shieldgen_on",
+    "type": "TOOL_ARMOR",
+    "name": { "str": "SHD-1k Riemman Generator (ACTIVE)" },
+    "copy-from": "afs_backpack_shieldgen",
+    "description": "A backpack mounted shield generator for infantry use, capable of fully protecting its user during prolonged bursts of kinetic and energy attacks.  Standard issue for UICA breaching teams.\n\nIts high energy consumption and weight make it unsuitable for long-term use.  Powered with energy cartridges.",
+    "power_draw": "100000 mW",
+    "revert_to": "afs_backpack_shieldgen",
+    "extend": { "flags": [ "SHIELD_GENERATOR" ] },
+    "use_action": {
+      "type": "effect_on_conditions",
+      "ammo_scale": 0,
+      "menu_text": "Deactivate",
+      "effect_on_conditions": [
+        {
+          "id": "afs_backpack_shieldgen_deactivate",
+          "effect": { "run_eoc_with": "EOC_stop_shield", "variables": { "transform_target": "afs_backpack_shieldgen" } }
+        }
+      ]
+    },
+    "tick_action": {
+      "type": "effect_on_conditions",
+      "effect_on_conditions": [
+        {
+          "id": "afs_backpack_shieldgen_tick",
+          "effect": { "math": [ "u_shield_power_ratio", "=", "n_val('power_percentage')" ] }
+        }
+      ]
+    }
+  },
+  {
+    "id": "EOC_start_shield",
+    "type": "effect_on_condition",
+    "effect": [
+      {
+        "if": "has_ammo",
+        "then": [
+          { "turn_cost": { "context_val": "turn_cost" } },
+          { "u_cast_spell": { "id": "spawn_shield", "hit_self": true } },
+          { "u_message": { "context_val": "success_message" } },
+          { "transform_item": { "context_val": "transform_target" }, "active": true },
+          { "math": [ "_shield_uid", "=", "rand(1200)" ] },
+          { "math": [ "n_shield_gen_uid", "=", "_shield_uid" ] },
+          { "math": [ "u_shield_power_ratio", "=", "n_val('power_percentage')" ] },
+          {
+            "u_run_inv_eocs": "all",
+            "search_data": [ { "id": [ "afs_energy_shield" ] } ],
+            "true_eocs": [
+              {
+                "id": "_SHIELD_SETUP",
+                "effect": [
+                  { "math": [ "n_shield_uid", "=", "_shield_uid" ] },
+                  { "math": [ "n_shield_turn", "=", "0" ] },
+                  { "math": [ "n_SHIELD_REGEN", "=", "0" ] },
+                  { "math": [ "n_SHIELD_REGEN_RATE", "=", "0" ] },
+                  { "math": [ "n_ENERGY_SHIELD_HP", "=", "_shield_max_hp" ] },
+                  { "math": [ "n_ENERGY_SHIELD_MAX_HP", "=", "_shield_max_hp" ] },
+                  { "math": [ "n_SHIELD_REGEN", "=", "_shield_regen" ] },
+                  { "math": [ "n_SHIELD_REGEN_RATE", "=", "shield_regen_rate" ] },
+                  { "math": [ "u_shield_ratio", "=", "n_ENERGY_SHIELD_HP/n_ENERGY_SHIELD_MAX_HP" ] }
+                ]
+              }
+            ]
+          }
+        ],
+        "else": { "u_message": { "context_val": "failure_message" } }
+      }
+    ]
+  },
+  {
+    "id": "EOC_afs_do_shield",
+    "type": "effect_on_condition",
+    "effect": [
+      { "math": [ "u_proceed_shield", "=", "0" ] },
+      { "math": [ "_shield_uid", "=", "n_shield_uid" ] },
+      { "math": [ "u_shield_ratio", "=", "n_ENERGY_SHIELD_HP/n_ENERGY_SHIELD_MAX_HP*100" ] },
+      {
+        "//": "We check if the shield generator that made this shield is still active.",
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "worn_only": true, "flags": [ "SHIELD_GENERATOR" ] } ],
+        "true_eocs": [
+          {
+            "id": "_afs_actually_do_shield",
+            "condition": { "math": [ "_shield_uid", "==", "n_shield_gen_uid" ] },
+            "effect": [ { "math": [ "u_proceed_shield", "=", "1" ] } ]
+          }
+        ]
+      },
+      {
+        "if": { "math": [ "u_proceed_shield", "==", "1" ] },
+        "then": [
+          { "math": [ "n_shield_turn", "++" ] },
+          {
+            "if": {
+              "and": [ { "math": [ "n_SHIELD_REGEN", "!=", "0" ] }, { "math": [ "n_shield_turn/n_SHIELD_REGEN_RATE", ">", "1" ] } ]
+            },
+            "then": [
+              { "math": [ "n_shield_turn", "=", "0" ] },
+              { "math": [ "n_ENERGY_SHIELD_HP", "+=", "n_SHIELD_REGEN" ] },
+              {
+                "math": [
+                  "n_ENERGY_SHIELD_HP",
+                  "=",
+                  "n_ENERGY_SHIELD_HP > n_ENERGY_SHIELD_MAX_HP ? n_ENERGY_SHIELD_MAX_HP : n_ENERGY_SHIELD_HP"
+                ]
+              }
+            ]
+          }
+        ],
+        "else": [ { "u_remove_item_with": "afs_energy_shield" }, { "math": [ "u_shield_ratio", "=", "-1" ] } ]
+      }
+    ]
+  },
+  {
+    "id": "EOC_stop_shield",
+    "type": "effect_on_condition",
+    "effect": [
+      { "transform_item": { "context_val": "transform_target" } },
+      { "u_remove_item_with": "afs_energy_shield" },
+      { "math": [ "u_shield_ratio", "=", "-1" ] }
+    ]
+  }
+]

--- a/data/mods/Aftershock/items/materials.json
+++ b/data/mods/Aftershock/items/materials.json
@@ -73,6 +73,23 @@
   },
   {
     "type": "material",
+    "id": "riemmann_space",
+    "name": "Riemann space",
+    "density": 1,
+    "specific_heat_liquid": 0.52,
+    "specific_heat_solid": 0.52,
+    "latent_heat": 5200,
+    "chip_resist": 100,
+    "breathability": "SECOND_SKIN",
+    "dmg_adj": [ "resonating", "cascading", "unraveling", "fractal" ],
+    "bash_dmg_verb": "agitated",
+    "cut_dmg_verb": "agitated",
+    "soft": true,
+    "//": "Impenetrable to all damage types.  The material energy shields are made of.",
+    "resist": { "bash": 1000, "cut": 1000, "acid": 1000, "heat": 1000, "bullet": 1000, "afs_plasma": 1000, "electric": 1000 }
+  },
+  {
+    "type": "material",
     "id": "clearcrete",
     "name": "Clearcrete",
     "density": 40,

--- a/data/mods/Aftershock/ui.json
+++ b/data/mods/Aftershock/ui.json
@@ -42,8 +42,16 @@
     "label": "SHIELD",
     "label_align": "right",
     "text_align": "right",
-    "widgets": [ "shield_layout_1", "shield_rad_warning" ],
+    "widgets": [ "shield_layout_1", "shield_layout_2" ],
     "flags": [ "W_NO_PADDING" ]
+  },
+  {
+    "id": "shield_layout_2",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "rows",
+    "label": "SHIELD",
+    "widgets": [ "shield_empty", "shield_rad_warning" ]
   },
   {
     "id": "shield_layout_1",
@@ -51,7 +59,7 @@
     "style": "layout",
     "arrange": "rows",
     "label": "SHIELD",
-    "widgets": [ "shield_gauge", "shield_power_gauge" ]
+    "widgets": [ "shield_title", "shield_gauge", "shield_power_gauge" ]
   },
   {
     "id": "shield_gauge",
@@ -292,32 +300,26 @@
       {
         "text": "  ☢DNGR☢",
         "color": "red",
-        "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
+        "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_ratio", ">=", "0" ] } ] }
       }
     ],
-    "default_clause": {
-      "text": "  ☢DNGR☢",
-      "color": "dark_gray",
-      "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
-    },
+    "default_clause": { "text": "  ☢DNGR☢", "color": "dark_gray" },
     "flags": [ "W_LABEL_NONE", "W_NO_PADDING" ]
   },
   {
-    "id": "shield_heat_warning",
+    "id": "shield_title",
     "type": "widget",
+    "width": 8,
     "style": "text",
-    "clauses": [
-      {
-        "text": "  !HEAT!",
-        "color": "red",
-        "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
-      }
-    ],
-    "default_clause": {
-      "text": "  !HEAT!",
-      "color": "dark_gray",
-      "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
-    },
+    "string": "SHIELDING:",
+    "flags": [ "W_LABEL_NONE", "W_NO_PADDING" ]
+  },
+  {
+    "id": "shield_empty",
+    "type": "widget",
+    "width": 8,
+    "style": "text",
+    "string": "",
     "flags": [ "W_LABEL_NONE", "W_NO_PADDING" ]
   }
 ]

--- a/data/mods/Aftershock/ui.json
+++ b/data/mods/Aftershock/ui.json
@@ -38,12 +38,20 @@
     "id": "shield_layout",
     "type": "widget",
     "style": "layout",
+    "arrange": "minimum_columns",
+    "label": "SHIELD",
+    "label_align": "right",
+    "text_align": "right",
+    "widgets": [ "shield_layout_1", "shield_rad_warning" ],
+    "flags": [ "W_NO_PADDING" ]
+  },
+  {
+    "id": "shield_layout_1",
+    "type": "widget",
+    "style": "layout",
     "arrange": "rows",
     "label": "SHIELD",
-    "width": 19,
-    "label_align": "center",
-    "text_align": "left",
-    "widgets": [ "shield_rad_warning", "shield_gauge", "shield_power_gauge" ]
+    "widgets": [ "shield_gauge", "shield_power_gauge" ]
   },
   {
     "id": "shield_gauge",
@@ -208,7 +216,7 @@
         "condition": { "math": [ "u_shield_ratio", "<", "0.00" ] }
       }
     ],
-    "padding": 0
+    "flags": [ "W_NO_PADDING" ]
   },
   {
     "id": "shield_power_gauge",
@@ -273,25 +281,26 @@
         "condition": { "math": [ "u_shield_power_ratio", "<=", "0" ] }
       }
     ],
-    "padding": 0
+    "flags": [ "W_NO_PADDING" ]
   },
   {
     "id": "shield_rad_warning",
     "type": "widget",
+    "width": 8,
     "style": "text",
     "clauses": [
       {
-        "text": "☢DNGR☢",
+        "text": "  ☢DNGR☢",
         "color": "red",
         "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
       }
     ],
     "default_clause": {
-      "text": "☢DNGR☢",
+      "text": "  ☢DNGR☢",
       "color": "dark_gray",
       "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
     },
-    "flags": [ "W_LABEL_NONE" ]
+    "flags": [ "W_LABEL_NONE", "W_NO_PADDING" ]
   },
   {
     "id": "shield_heat_warning",
@@ -299,16 +308,16 @@
     "style": "text",
     "clauses": [
       {
-        "text": "!HEAT!",
+        "text": "  !HEAT!",
         "color": "red",
         "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
       }
     ],
     "default_clause": {
-      "text": "!HEAT!",
+      "text": "  !HEAT!",
       "color": "dark_gray",
       "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
     },
-    "flags": [ "W_LABEL_NONE" ]
+    "flags": [ "W_LABEL_NONE", "W_NO_PADDING" ]
   }
 ]

--- a/data/mods/Aftershock/ui.json
+++ b/data/mods/Aftershock/ui.json
@@ -1,0 +1,314 @@
+[
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_classic_sidebar",
+    "type": "widget",
+    "id": "legacy_classic_sidebar",
+    "extend": { "widgets": [ "shield_layout" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_compact_sidebar",
+    "type": "widget",
+    "id": "legacy_compact_sidebar",
+    "extend": { "widgets": [ "shield_layout" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_labels_narrow_sidebar",
+    "type": "widget",
+    "id": "legacy_labels_narrow_sidebar",
+    "extend": { "widgets": [ "shield_layout" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_labels_sidebar",
+    "type": "widget",
+    "id": "legacy_labels_sidebar",
+    "extend": { "widgets": [ "shield_layout" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "structured_sidebar",
+    "type": "widget",
+    "id": "structured_sidebar",
+    "extend": { "widgets": [ "shield_layout" ] }
+  },
+  {
+    "id": "shield_layout",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "rows",
+    "label": "SHIELD",
+    "width": 19,
+    "label_align": "center",
+    "text_align": "left",
+    "widgets": [ "shield_rad_warning", "shield_gauge", "shield_power_gauge" ]
+  },
+  {
+    "id": "shield_gauge",
+    "type": "widget",
+    "style": "text",
+    "label": "INTGR",
+    "width": 19,
+    "clauses": [
+      {
+        "id": "full30",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇</color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "96.67" ] }
+      },
+      {
+        "id": "full29",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▅</color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "93.33" ] }
+      },
+      {
+        "id": "full28",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▂</color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "90.00" ] }
+      },
+      {
+        "id": "full27",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "86.67" ] }
+      },
+      {
+        "id": "full26",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▅  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "83.33" ] }
+      },
+      {
+        "id": "full25",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▂  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "80.00" ] }
+      },
+      {
+        "id": "full24",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇    </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "76.67" ] }
+      },
+      {
+        "id": "full23",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▅    </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "73.33" ] }
+      },
+      {
+        "id": "full22",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▂    </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "70.00" ] }
+      },
+      {
+        "id": "full21",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇      </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "66.67" ] }
+      },
+      {
+        "id": "full20",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▅      </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "63.33" ] }
+      },
+      {
+        "id": "full19",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▂      </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "60.00" ] }
+      },
+      {
+        "id": "full18",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇        </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "56.67" ] }
+      },
+      {
+        "id": "full17",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▅        </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "53.33" ] }
+      },
+      {
+        "id": "full16",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▂        </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "50.00" ] }
+      },
+      {
+        "id": "full15",
+        "text": "<color_yellow>▇ ▇ ▇ ▇ ▇          </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "46.67" ] }
+      },
+      {
+        "id": "full14",
+        "text": "<color_yellow>▇ ▇ ▇ ▇ ▅          </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "43.33" ] }
+      },
+      {
+        "id": "full13",
+        "text": "<color_yellow>▇ ▇ ▇ ▇ ▂          </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "40.00" ] }
+      },
+      {
+        "id": "full12",
+        "text": "<color_yellow>▇ ▇ ▇ ▇            </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "36.67" ] }
+      },
+      {
+        "id": "full11",
+        "text": "<color_yellow>▇ ▇ ▇ ▅            </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "33.33" ] }
+      },
+      {
+        "id": "full10",
+        "text": "<color_yellow>▇ ▇ ▇ ▂            </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "30.00" ] }
+      },
+      {
+        "id": "full9",
+        "text": "<color_yellow>▇ ▇ ▇              </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "26.67" ] }
+      },
+      {
+        "id": "full8",
+        "text": "<color_light_red>▇ ▇ ▅              </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "23.33" ] }
+      },
+      {
+        "id": "full7",
+        "text": "<color_light_red>▇ ▇ ▂              </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "20.00" ] }
+      },
+      {
+        "id": "full6",
+        "text": "<color_light_red>▇ ▇                </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "16.67" ] }
+      },
+      {
+        "id": "full5",
+        "text": "<color_light_red>▇ ▅                </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "13.33" ] }
+      },
+      {
+        "id": "full4",
+        "text": "<color_light_red>▇ ▂                </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "10.00" ] }
+      },
+      {
+        "id": "full3",
+        "text": "<color_light_red>▇                  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "6.67" ] }
+      },
+      {
+        "id": "full2",
+        "text": "<color_light_red>▅                  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "3.33" ] }
+      },
+      {
+        "id": "full1",
+        "text": "<color_light_red>▂                  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "0.00" ] }
+      },
+      {
+        "id": "empty",
+        "text": "<color_red>      OFFLINE      </color>",
+        "condition": { "math": [ "u_shield_ratio", "<", "0.00" ] }
+      }
+    ],
+    "padding": 0
+  },
+  {
+    "id": "shield_power_gauge",
+    "type": "widget",
+    "style": "text",
+    "label": "POWER",
+    "width": 19,
+    "clauses": [
+      {
+        "id": "full10",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇</color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "90" ] }
+      },
+      {
+        "id": "full9",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇  </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "80" ] }
+      },
+      {
+        "id": "full8",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇    </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "70" ] }
+      },
+      {
+        "id": "full7",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇      </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "60" ] }
+      },
+      {
+        "id": "full6",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇      </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "50" ] }
+      },
+      {
+        "id": "full5",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇          </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "40" ] }
+      },
+      {
+        "id": "full4",
+        "text": "<color_red>▇ ▇ ▇ ▇            </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "30" ] }
+      },
+      {
+        "id": "full3",
+        "text": "<color_red>▇ ▇ ▇              </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "20" ] }
+      },
+      {
+        "id": "full2",
+        "text": "<color_red>▇ ▇                </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "10" ] }
+      },
+      {
+        "id": "full1",
+        "text": "<color_red>▇                  </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">", "0" ] }
+      },
+      {
+        "id": "empty",
+        "text": "<color_red>      OFFLINE      </color>",
+        "condition": { "math": [ "u_shield_power_ratio", "<=", "0" ] }
+      }
+    ],
+    "padding": 0
+  },
+  {
+    "id": "shield_rad_warning",
+    "type": "widget",
+    "style": "text",
+    "clauses": [
+      {
+        "text": "☢DNGR☢",
+        "color": "red",
+        "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
+      }
+    ],
+    "default_clause": {
+      "text": "☢DNGR☢",
+      "color": "dark_gray",
+      "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
+    },
+    "flags": [ "W_LABEL_NONE" ]
+  },
+  {
+    "id": "shield_heat_warning",
+    "type": "widget",
+    "style": "text",
+    "clauses": [
+      {
+        "text": "!HEAT!",
+        "color": "red",
+        "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
+      }
+    ],
+    "default_clause": {
+      "text": "!HEAT!",
+      "color": "dark_gray",
+      "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_rad_fails", "==", "1" ] } ] }
+    },
+    "flags": [ "W_LABEL_NONE" ]
+  }
+]

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1398,6 +1398,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | character_falls_asleep | triggers in the moment character actually falls asleep; trigger includes cases where character sleep for a short time because of sleepiness or drugs; duration of the sleep can be changed mid sleep because of hurt/noise/light/pain thresholds and another factors | { "character", `character_id` }, { "duration", `int_` (in seconds) } | character / NONE |
 | character_wields_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wield |
 | character_wears_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear |
+| character_armor_destroyed | triggers when a worn armor is set to be destroyed from damage. The armor still exists but will be destroyed immediately after the EOCs finish running. | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear |
 | consumes_marloss_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
 | crosses_marloss_threshold | | { "character", `character_id` } | character / NONE |
 | crosses_mutation_threshold | | { "character", `character_id` },<br/> { "category", `mutation_category_id` }, | character / NONE |

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -186,6 +186,7 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```DEAF``` Makes the player deaf.
 - ```DECAY_EXPOSED_ATMOSPHERE``` Consumable will go bad once exposed to the atmosphere (such as MREs).
 - ```ELECTRIC_IMMUNE``` This gear completely protects you from electric discharges.
+- ```ENERGY_SHIELD``` Marks a piece of armor as an energy shield. Energy shields do not suffer degradation from attacks and instead have an hp pool `ENERGY_SHIELD_HP` and `ENERGY_SHIELD_MAX_HP` that is depleted by blocked attacks.  When the hp pool is depleted, the shield is destroyed. The fields `ENERGY SHIELD_HP` and `ENERGY_SHIELD_MAX_HP` are dialogue variables stored in the item, and can be modified through effects on condition.
 - ```EXTRA_PLATING``` Item can be worn over some armors, as additional layer of protection (like armor above brigandine); specifically can be put in pocket for armor with this flag restriction.
 - ```FANCY``` Wearing this clothing gives a morale bonus if the player has the `Stylish` trait.
 - ```FIN``` This item is swim fins aka diving fins aka flippets, and provide speed boost when you swim.

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -186,7 +186,7 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```DEAF``` Makes the player deaf.
 - ```DECAY_EXPOSED_ATMOSPHERE``` Consumable will go bad once exposed to the atmosphere (such as MREs).
 - ```ELECTRIC_IMMUNE``` This gear completely protects you from electric discharges.
-- ```ENERGY_SHIELD``` Marks a piece of armor as an energy shield. Energy shields do not suffer degradation from attacks and instead have an hp pool `ENERGY_SHIELD_HP` and `ENERGY_SHIELD_MAX_HP` that is depleted by blocked attacks.  When the hp pool is depleted, the shield is destroyed. The fields `ENERGY SHIELD_HP` and `ENERGY_SHIELD_MAX_HP` are dialogue variables stored in the item, and can be modified through effects on condition.
+- ```ENERGY_SHIELD``` Marks a piece of armor as an energy shield. Energy shields do not suffer degradation from attacks and instead have an hp pool defined by the dialogue variable `ENERGY_SHIELD_HP`that is depleted by blocked attacks and a second variable `ENERGY_SHIELD_MAX_HP` which just stores the max hp of the shield in case its needed for EOC manipulation.  When the hp pool is depleted, the shield is destroyed. The fields `ENERGY SHIELD_HP` and `ENERGY_SHIELD_MAX_HP` are dialogue variables stored in the item, and can be modified through effects on condition.
 - ```EXTRA_PLATING``` Item can be worn over some armors, as additional layer of protection (like armor above brigandine); specifically can be put in pocket for armor with this flag restriction.
 - ```FANCY``` Wearing this clothing gives a morale bonus if the player has the `Stylish` trait.
 - ```FIN``` This item is swim fins aka diving fins aka flippets, and provide speed boost when you swim.

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3671,6 +3671,7 @@ Armor can be defined like this:
 "cover_vitals": 10,                 // What percentage of critical hit damage is mitigated
 "material_thickness" : 1,           // Thickness of material, in millimeter units (approximately).  Ordinary clothes range from 0.1 to 0.5. Particularly rugged cloth may reach as high as 1-2mm, and armor or protective equipment can range as high as 10 or rarely more.
 "power_armor" : false,              // If this is a power armor item (those are special).
+"energy_shield_max_hp" : false,     // Determines the inital value for the `ENERGY_SHIELD_HP` and `ENERGY_SHIELD_MAX_HP` item variables used by energy shields. The field has no effect for armor pieces without the `ENERGY_SHIELD` flag.
 "non_functional" : "destroyed",     //this is the itype_id of an item that this turns into when destroyed. Currently only works for ablative armor.
 "damage_verb": "makes a crunch, something has shifted", // if an item uses non-functional this will be the description when it turns into its non functional variant.
 "valid_mods" : ["steel_padded"],    // List of valid clothing mods. Note that if the clothing mod doesn't have "restricted" listed, this isn't needed.

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -285,18 +285,23 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
         armor.energy_consume( units::from_kilojoule( du.amount ),
                               pos(), nullptr );
     }
+    // We copy the damage unit here since it will be mutated by mitigate_damage()
+    damage_unit pre_mitigation = du;
+
     // reduce the damage
     // -1 is passed as roll so that each material is rolled individually
     armor.mitigate_damage( du, sbp, -1 );
 
     // check if the armor was damaged
-    item::armor_status damaged = armor.damage_armor_durability( du, bp, calculate_by_enchantment( 1,
-                                 enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
+    item::armor_status damaged = armor.damage_armor_durability( du, pre_mitigation, bp,
+                                 calculate_by_enchantment( 1,
+                                         enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
 
     // describe what happened if the armor took damage
     if( damaged == item::armor_status::DAMAGED || damaged == item::armor_status::DESTROYED ) {
         describe_damage( du, armor );
     }
+
     return damaged == item::armor_status::DESTROYED;
 }
 
@@ -318,18 +323,23 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
         armor.energy_consume( units::from_kilojoule( du.amount ),
                               pos(), nullptr );
     }
+    // We copy the damage unit here since it will be mutated by mitigate_damage()
+    damage_unit pre_mitigation = du;
+
     // reduce the damage
     // -1 is passed as roll so that each material is rolled individually
     armor.mitigate_damage( du, bp, -1 );
 
     // check if the armor was damaged
-    item::armor_status damaged = armor.damage_armor_durability( du, bp, calculate_by_enchantment( 1,
-                                 enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
+    item::armor_status damaged = armor.damage_armor_durability( du, pre_mitigation, bp,
+                                 calculate_by_enchantment( 1,
+                                         enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
 
     // describe what happened if the armor took damage
     if( damaged == item::armor_status::DAMAGED || damaged == item::armor_status::DESTROYED ) {
         describe_damage( du, armor );
     }
+
     return damaged == item::armor_status::DESTROYED;
 }
 
@@ -361,8 +371,9 @@ bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_b
                     damaged = ablative_armor.damage_armor_transforms( pre_mitigation, calculate_by_enchantment( 1,
                               enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
                 } else {
-                    damaged = ablative_armor.damage_armor_durability( du, bp->parent, calculate_by_enchantment( 1,
-                              enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
+                    damaged = ablative_armor.damage_armor_durability( du, pre_mitigation, bp->parent,
+                              calculate_by_enchantment( 1,
+                                                        enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
                 }
 
                 if( damaged == item::armor_status::TRANSFORMED ) {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1963,11 +1963,16 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
             destroyed_armor_msg( guy, pre_damage_name );
             armor_destroyed = true;
             armor.on_takeoff( guy );
+
+            item_location loc = item_location( guy, &armor );
+            cata::event e = cata::event::make<event_type::character_armor_destroyed>( guy.getID() ,armor.typeId() );
+            get_event_bus().send_with_talker( &guy, &loc, e );
+            
             for( const item *it : armor.all_items_top( pocket_type::CONTAINER ) ) {
                 worn_remains.push_back( *it );
             }
             // decltype is the type name of the iterator, note that reverse_iterator::base returns the
-            // iterator to the next element, not the one the revers_iterator points to.
+            // iterator to the next element, not the one the revers_iterator points to. 
             // http://stackoverflow.com/questions/1830158/how-to-call-erase-with-a-reverse-iterator
             iter = decltype( iter )( worn.erase( --iter.base() ) );
         } else {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1950,7 +1950,7 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
             // if not already destroyed to an armor absorb
             destroy = guy.armor_absorb( elem, armor, bp, sbp, roll );
             // for the torso we also need to consider if it hits anything hanging off the character or their neck
-            if( secondary_sbp != sub_bodypart_id() ) {
+            if( secondary_sbp != sub_bodypart_id() && !destroy ) {
                 destroy = guy.armor_absorb( elem, armor, bp, secondary_sbp, roll );
             }
         }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -57,6 +57,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::character_attempt_to_fall_asleep: return "character_attempt_to_fall_asleep";
         case event_type::character_wakes_up: return "character_wakes_up";
         case event_type::character_wears_item: return "character_wears_item";
+         case event_type::character_armor_destroyed: return "character_armor_destroyed";
         case event_type::character_wields_item: return "character_wields_item";
         case event_type::consumes_marloss_item: return "consumes_marloss_item";
         case event_type::crosses_marloss_threshold: return "crosses_marloss_threshold";
@@ -144,7 +145,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 105,
+static_assert( static_cast<int>( event_type::num_event_types ) == 106,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );

--- a/src/event.h
+++ b/src/event.h
@@ -66,6 +66,7 @@ enum class event_type : int {
     character_wakes_up,
     character_wields_item,
     character_wears_item,
+    character_armor_destroyed,
     consumes_marloss_item,
     crosses_marloss_threshold,
     crosses_mutation_threshold,
@@ -189,7 +190,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 105,
+static_assert( static_cast<int>( event_type::num_event_types ) == 106,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -528,6 +529,9 @@ struct event_spec<event_type::character_butchered_corpse> {
 
 template<>
 struct event_spec<event_type::character_wears_item> : event_spec_character_item {};
+
+template<>
+struct event_spec<event_type::character_armor_destroyed> : event_spec_character_item {};
 
 template<>
 struct event_spec<event_type::character_wields_item> : event_spec_character_item {};

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -103,6 +103,7 @@ const flag_id flag_EFFECT_LIMB_SCORE_MOD( "EFFECT_LIMB_SCORE_MOD" );
 const flag_id flag_EFFECT_LIMB_SCORE_MOD_LOCAL( "EFFECT_LIMB_SCORE_MOD_LOCAL" );
 const flag_id flag_ELECTRIC_IMMUNE( "ELECTRIC_IMMUNE" );
 const flag_id flag_ELECTRONIC( "ELECTRONIC" );
+const flag_id flag_ENERGY_SHIELD( "ENERGY_SHIELD" );
 const flag_id flag_ETHEREAL_ITEM( "ETHEREAL_ITEM" );
 const flag_id flag_EXO_ARM_PLATE( "EXO_ARM_PLATE" );
 const flag_id flag_EXO_BOOT_PLATE( "EXO_BOOT_PLATE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -111,6 +111,7 @@ extern const flag_id flag_EFFECT_LIMB_SCORE_MOD;
 extern const flag_id flag_EFFECT_LIMB_SCORE_MOD_LOCAL;
 extern const flag_id flag_ELECTRIC_IMMUNE;
 extern const flag_id flag_ELECTRONIC;
+extern const flag_id flag_ENERGY_SHIELD;
 extern const flag_id flag_ETHEREAL_ITEM;
 extern const flag_id flag_EXO_ARM_PLATE;
 extern const flag_id flag_EXO_BOOT_PLATE;

--- a/src/item.h
+++ b/src/item.h
@@ -1402,7 +1402,8 @@ class item : public visitable
          * This version is for items with durability
          * @return the state of the armor
          */
-        armor_status damage_armor_durability( damage_unit &du, const bodypart_id &bp,
+        armor_status damage_armor_durability( damage_unit &du, damage_unit &premitigated,
+                                              const bodypart_id &bp,
                                               double enchant_multiplier = 1 );
 
         /**

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2032,6 +2032,9 @@ void Item_factory::check_definitions() const
         if( !type->category_force.is_valid() ) {
             msg += "undefined category " + type->category_force.str() + "\n";
         }
+        if( type->has_flag( flag_ENERGY_SHIELD ) && !type->armor ) {
+            msg += "has ENERGY_SHIELD flag specified but the item isn't armor";
+        }
 
         if( type->armor ) {
             cata::flat_set<bodypart_str_id> observed_bps;
@@ -3111,6 +3114,7 @@ void islot_armor::load( const JsonObject &jo )
     optional( jo, was_loaded, "non_functional", non_functional, itype_id() );
     optional( jo, was_loaded, "damage_verb", damage_verb );
     optional( jo, was_loaded, "power_armor", power_armor, false );
+    optional( jo, was_loaded, "max_energy_shield_hp", max_energy_shield_hp, 0 );
     optional( jo, was_loaded, "valid_mods", valid_mods );
 }
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -402,6 +402,12 @@ struct islot_armor {
          */
         int warmth = 0;
         /**
+         * The max health of an energy shield type armor.  Value is completely ignored if the
+         * ENERGY_SHIELD flag is not set.  This value and "energy_shield_hp" are then stored
+         * through item variables so that they might be manipulated with EOCS and magic.
+         */
+        int max_energy_shield_hp = 0;
+        /**
          * Whether this is a power armor item.
          */
         bool power_armor = false;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2086,7 +2086,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
 
             if( source != nullptr && !source->is_hallucination() ) {
                 for( damage_unit &du : dam.damage_units ) {
-                    shield->damage_armor_durability( du, bp_hit, calculate_by_enchantment( 1,
+                    shield->damage_armor_durability( du, du, bp_hit, calculate_by_enchantment( 1,
                                                      enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
                 }
             }

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -1135,6 +1135,7 @@ void memorial_logger::notify( const cata::event &e )
         case event_type::character_radioactively_mutates:
         case event_type::character_wears_item:
         case event_type::character_wields_item:
+        case event_type::character_armor_destroyed:
         case event_type::character_casts_spell:
         case event_type::cuts_tree:
         case event_type::opens_spellbook:


### PR DESCRIPTION

#### Summary
Mods "Aftershock: Add personal shield generators"

#### Purpose of change
Energy Shields are a staple of Sci-fi and somewhat necessary if we want to continue adding high danger ranged enemies.


#### Describe the solution
This adds a single High power wearable shield generator the "SHD-1 Riemann Shield Generator". When activated it creates a shield armor piece that is linked to the generator through EOCs.  The shield will resist 600 points of damage and regens 1 for one point of damage every turn. If completely broken by damage it will release a deadly flash of radiation, its intended that all Aftershock shields will fail in this manner.

Includes some generic EOCs to handle activating shield items and for their active processing.

Includes an UI widget displaying the shield's hp and the shield generator's power as well as the current risk of radiation.

![image](https://github.com/user-attachments/assets/c2712d83-0206-4599-bef0-9512f4ae260d)


#### Testing
Got the shield destroyed, got the generator destroyed, dropped the active generator, verified the shield took damage and that the shield turned off when the generator ran out of juice.

Also made sure the UI properly updated for all those cases.

#### Additional context
Still need to migrate the other forcefield bionics and exosuit modules to this system, but this PR was too large to do it here.

It would have probably been easier to do this on C++ but I was already in too deep by the time I realized this.