### PR TITLE
Riemann Shields

### DIFF
--- a/data/mods/Aftershock/flags.json
+++ b/data/mods/Aftershock/flags.json
@@ -19,6 +19,11 @@
     "info": "You are immune to telepathy."
   },
   {
+    "id": "SHIELD_GENERATOR",
+    "type": "json_flag",
+    "info": "This item is capable of projecting a Riemann protective shield."
+  },
+  {
     "id": "HIVE_MIND",
     "type": "monster_flag",
     "//": "This monster is part of a hive mind"

--- a/data/mods/Aftershock/itemgroups/clothing/armor_sets.json
+++ b/data/mods/Aftershock/itemgroups/clothing/armor_sets.json
@@ -64,7 +64,8 @@
         "distribution": [ { "item": "tac_fullhelmet_uicas", "prob": 20 }, { "item": "tac_helmet_uicas", "prob": 1 } ],
         "prob": 40
       },
-      { "item": "afs_military_cloak", "prob": 40 }
+      { "item": "afs_military_cloak", "prob": 40 },
+      { "item": "afs_backpack_shieldgen", "prob": 1 }
     ]
   },
   {

--- a/data/mods/Aftershock/items/armor/energy_shield.json
+++ b/data/mods/Aftershock/items/armor/energy_shield.json
@@ -1,0 +1,283 @@
+[
+  {
+    "id": "afs_energy_shield",
+    "type": "TOOL_ARMOR",
+    "name": { "str": "Riemann shell" },
+    "description": "A thin shell of altered reality containing enormous electromagnetic potential, such that it might behave as a solid object under certain conditions.  A Riemann shell can defend against a wide variety of physical and energy attacks, but can be overwhelmed and forced to collapse into deadly radiation with prolonged assault.",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "symbol": "o",
+    "color": "blue",
+    "material": [ "riemann_space" ],
+    "environmental_protection": 20,
+    "material_thickness": 5.0,
+    "max_energy_shield_hp": 1200,
+    "flags": [
+      "AURA",
+      "ENERGY_SHIELD",
+      "OVERSIZE",
+      "ONLY_ONE",
+      "TRADER_AVOID",
+      "NO_TAKEOFF",
+      "NONCONDUCTIVE",
+      "SPAWN_ACTIVE",
+      "ALLOWS_NATURAL_ATTACKS",
+      "SEMITANGIBLE",
+      "UNRESTRICTED"
+    ],
+    "tick_action": {
+      "type": "effect_on_conditions",
+      "effect_on_conditions": [ { "id": "_afs_energy_shield", "effect": { "run_eocs": "EOC_afs_do_shield" } } ]
+    },
+    "armor": [
+      {
+        "encumbrance": 0,
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+      }
+    ]
+  },
+  {
+    "id": "afs_backpack_shieldgen",
+    "type": "TOOL_ARMOR",
+    "name": { "str": "SHD-1k Riemann Shield Generator" },
+    "description": "A backpack mounted shield generator for infantry use, capable of fully protecting its user during prolonged bursts of kinetic and energy attacks.  Standard issue for UICA breaching teams.\n\nIts high energy consumption and weight make it unsuitable for long-term use.  Powered with energy cartridges.",
+    "weight": "10 kg",
+    "volume": "18000 ml",
+    "price": "120 kUSD",
+    "price_postapoc": "120 kUSD",
+    "ammo": [ "battery" ],
+    "material": [ "nylon", "aluminum" ],
+    "symbol": "[",
+    "looks_like": "backpack",
+    "color": "brown",
+    "warmth": 10,
+    "charges_per_use": 400,
+    "material_thickness": 2,
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "magazine_well": "75 ml",
+        "item_restriction": [ "afs_cartridge", "afs_bootleg_cartridge", "afs_archeotech_cartridge" ]
+      }
+    ],
+    "flags": [ "BELTED", "WATERPROOF", "ONLY_ONE" ],
+    "use_action": {
+      "type": "effect_on_conditions",
+      "ammo_scale": 1,
+      "menu_text": "Activate",
+      "effect_on_conditions": [
+        {
+          "id": "afs_backpack_shieldgen_activate",
+          "effect": {
+            "run_eoc_with": "EOC_start_shield",
+            "variables": {
+              "transform_target": "afs_backpack_shieldgen_on",
+              "shield_max_hp": "600",
+              "shield_regen": "1",
+              "shield_regen_rate": "1",
+              "bionic": "0",
+              "turn_cost": "1",
+              "success_message": "a",
+              "failure_message": "b"
+            }
+          }
+        }
+      ]
+    },
+    "armor": [
+      {
+        "encumbrance": [ 3, 12 ],
+        "volume_encumber_modifier": 0,
+        "coverage": 100,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_hanging_back", "torso_waist" ]
+      }
+    ]
+  },
+  {
+    "id": "afs_backpack_shieldgen_on",
+    "type": "TOOL_ARMOR",
+    "name": { "str": "SHD-1k Riemann Shield Generator (active)", "str_pl": "SHD-1k Riemann Shield Generators (active)" },
+    "copy-from": "afs_backpack_shieldgen",
+    "description": "A backpack mounted shield generator for infantry use, capable of fully protecting its user during prolonged bursts of kinetic and energy attacks.  Standard issue for UICA breaching teams.\n\nIts high energy consumption and weight make it unsuitable for long-term use.  Powered with energy cartridges.",
+    "power_draw": "100000 mW",
+    "revert_to": "afs_backpack_shieldgen",
+    "extend": { "flags": [ "SHIELD_GENERATOR" ] },
+    "use_action": {
+      "type": "effect_on_conditions",
+      "ammo_scale": 0,
+      "menu_text": "Deactivate",
+      "effect_on_conditions": [
+        {
+          "id": "afs_backpack_shieldgen_deactivate",
+          "effect": { "run_eoc_with": "EOC_stop_shield", "variables": { "transform_target": "afs_backpack_shieldgen" } }
+        }
+      ]
+    },
+    "tick_action": {
+      "type": "effect_on_conditions",
+      "effect_on_conditions": [
+        {
+          "id": "afs_backpack_shieldgen_tick",
+          "condition": "has_alpha",
+          "effect": { "math": [ "u_shield_power_ratio", "=", "n_val('power_percentage')" ] },
+          "false_effect": { "transform_item": "afs_backpack_shieldgen" }
+        }
+      ]
+    }
+  },
+  {
+    "id": "spawn_shield",
+    "type": "SPELL",
+    "name": "Spawn Riemann Shield",
+    "description": "Creates a shield.",
+    "valid_targets": [ "self" ],
+    "flags": [ "VERBAL", "NO_FAIL", "CONCENTRATE", "SOMATIC", "PERMANENT_ALL_LEVELS", "NO_EXPLOSION_SFX" ],
+    "min_range": 0,
+    "max_range": 0,
+    "min_damage": 1,
+    "max_damage": 1,
+    "effect": "spawn_item",
+    "effect_str": "afs_energy_shield",
+    "shape": "blast",
+    "max_level": 1
+  },
+  {
+    "id": "EOC_start_shield",
+    "type": "effect_on_condition",
+    "effect": [
+      {
+        "if": "has_ammo",
+        "then": [
+          { "turn_cost": { "context_val": "turn_cost" } },
+          { "u_cast_spell": { "id": "spawn_shield", "hit_self": true } },
+          { "u_message": { "context_val": "success_message" } },
+          { "transform_item": { "context_val": "transform_target" }, "active": true },
+          { "math": [ "_shield_uid", "=", "rand(1200)" ] },
+          { "math": [ "n_shield_gen_uid", "=", "_shield_uid" ] },
+          {
+            "if": { "math": [ "_is_bionic" ] },
+            "then": [ { "math": [ "u_shield_power_ratio", "=", "u_val('power_percentage')" ] } ],
+            "else": [ { "math": [ "u_shield_power_ratio", "=", "n_val('power_percentage')" ] } ]
+          },
+          {
+            "u_run_inv_eocs": "all",
+            "search_data": [ { "id": [ "afs_energy_shield" ] } ],
+            "true_eocs": [
+              {
+                "id": "_SHIELD_SETUP",
+                "effect": [
+                  { "math": [ "n_shield_uid", "=", "_shield_uid" ] },
+                  { "math": [ "n_shield_turn", "=", "0" ] },
+                  { "math": [ "n_SHIELD_REGEN", "=", "0" ] },
+                  { "math": [ "n_SHIELD_REGEN_RATE", "=", "0" ] },
+                  { "math": [ "n_ENERGY_SHIELD_HP", "=", "_shield_max_hp*0.1" ] },
+                  { "math": [ "n_ENERGY_SHIELD_MAX_HP", "=", "_shield_max_hp" ] },
+                  { "math": [ "n_SHIELD_REGEN", "=", "_shield_regen" ] },
+                  { "math": [ "n_SHIELD_REGEN_RATE", "=", "shield_regen_rate" ] },
+                  { "math": [ "u_shield_ratio", "=", "n_ENERGY_SHIELD_HP/n_ENERGY_SHIELD_MAX_HP" ] }
+                ]
+              }
+            ]
+          }
+        ],
+        "else": { "u_message": { "context_val": "failure_message" } }
+      }
+    ]
+  },
+  {
+    "id": "EOC_afs_do_shield",
+    "type": "effect_on_condition",
+    "effect": [
+      { "math": [ "u_proceed_shield", "=", "0" ] },
+      { "math": [ "_shield_uid", "=", "n_shield_uid" ] },
+      { "math": [ "u_shield_ratio", "=", "n_ENERGY_SHIELD_HP/n_ENERGY_SHIELD_MAX_HP*100" ] },
+      {
+        "//": "We check if the shield generator that made this shield is still active.",
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "worn_only": true, "flags": [ "SHIELD_GENERATOR" ] } ],
+        "true_eocs": [
+          {
+            "id": "_afs_actually_do_shield",
+            "condition": { "math": [ "_shield_uid", "==", "n_shield_gen_uid" ] },
+            "effect": [ { "math": [ "u_proceed_shield", "=", "1" ] } ]
+          }
+        ]
+      },
+      {
+        "if": { "math": [ "u_proceed_shield", "==", "1" ] },
+        "then": [
+          { "math": [ "n_shield_turn", "++" ] },
+          {
+            "if": {
+              "and": [ { "math": [ "n_SHIELD_REGEN", "!=", "0" ] }, { "math": [ "n_shield_turn/n_SHIELD_REGEN_RATE", ">", "1" ] } ]
+            },
+            "then": [
+              { "math": [ "n_shield_turn", "=", "0" ] },
+              { "math": [ "n_ENERGY_SHIELD_HP", "+=", "n_SHIELD_REGEN" ] },
+              {
+                "math": [
+                  "n_ENERGY_SHIELD_HP",
+                  "=",
+                  "n_ENERGY_SHIELD_HP > n_ENERGY_SHIELD_MAX_HP ? n_ENERGY_SHIELD_MAX_HP : n_ENERGY_SHIELD_HP"
+                ]
+              }
+            ]
+          }
+        ],
+        "else": [ { "u_remove_item_with": "afs_energy_shield" }, { "math": [ "u_shield_ratio", "=", "-1" ] } ]
+      }
+    ]
+  },
+  {
+    "id": "EOC_stop_shield",
+    "type": "effect_on_condition",
+    "effect": [
+      { "transform_item": { "context_val": "transform_target" } },
+      { "u_remove_item_with": "afs_energy_shield" },
+      { "math": [ "u_shield_ratio", "=", "-1" ] }
+    ]
+  },
+  {
+    "//": "This bit is only here to do a final update of the UI when a generator is dropped.",
+    "id": "EOC_check_drop_shield_gen",
+    "type": "effect_on_condition",
+    "eoc_type": "EVENT",
+    "required_event": "character_finished_activity",
+    "condition": {
+      "and": [
+        { "compare_string": [ "ACT_DROP", { "context_val": "activity" } ] },
+        { "math": [ "u_shield_power_ratio", ">=", "0" ] }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_shield_power_ratio", "=", "-1" ] },
+      {
+        "//": "We check if we have another shield generator to update the UI power gauge.",
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "worn_only": true, "flags": [ "SHIELD_GENERATOR" ] } ],
+        "true_eocs": [
+          {
+            "id": "_afs_drop_update_power",
+            "effect": [ { "math": [ "u_shield_power_ratio", "=", "n_val('power_percentage')" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "EOC_detonate_shield",
+    "type": "effect_on_condition",
+    "eoc_type": "EVENT",
+    "required_event": "character_armor_destroyed",
+    "condition": { "and": [ { "compare_string": [ "afs_energy_shield", { "context_val": "itype" } ] } ] },
+    "effect": [
+      { "math": [ "u_shield_ratio", "=", "-1" ] },
+      { "u_emit": "heavy_rad_glimmer", "chance_mult": 2 },
+      { "u_message": "The shield blasts you with radiation as it dissipates.", "type": "bad" }
+    ]
+  }
+]

--- a/data/mods/Aftershock/items/armor/energy_shield.json
+++ b/data/mods/Aftershock/items/armor/energy_shield.json
@@ -72,7 +72,7 @@
         {
           "id": "afs_backpack_shieldgen_activate",
           "effect": {
-            "run_eoc_with": "EOC_start_shield",
+            "run_eocs": "EOC_start_shield",
             "variables": {
               "transform_target": "afs_backpack_shieldgen_on",
               "shield_max_hp": "600",
@@ -113,7 +113,7 @@
       "effect_on_conditions": [
         {
           "id": "afs_backpack_shieldgen_deactivate",
-          "effect": { "run_eoc_with": "EOC_stop_shield", "variables": { "transform_target": "afs_backpack_shieldgen" } }
+          "effect": { "run_eocs": "EOC_stop_shield", "variables": { "transform_target": "afs_backpack_shieldgen" } }
         }
       ]
     },

--- a/data/mods/Aftershock/items/materials.json
+++ b/data/mods/Aftershock/items/materials.json
@@ -73,6 +73,23 @@
   },
   {
     "type": "material",
+    "id": "riemann_space",
+    "name": "Riemann space",
+    "density": 1,
+    "specific_heat_liquid": 0.52,
+    "specific_heat_solid": 0.52,
+    "latent_heat": 5200,
+    "chip_resist": 100,
+    "breathability": "SECOND_SKIN",
+    "dmg_adj": [ "resonating", "cascading", "unraveling", "fractal" ],
+    "bash_dmg_verb": "agitated",
+    "cut_dmg_verb": "agitated",
+    "soft": true,
+    "//": "Impenetrable to all damage types.  The material energy shields are made of.",
+    "resist": { "bash": 1000, "cut": 1000, "acid": 1000, "heat": 1000, "bullet": 1000, "afs_plasma": 1000, "electric": 1000 }
+  },
+  {
+    "type": "material",
     "id": "clearcrete",
     "name": "Clearcrete",
     "density": 40,

--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_outfitter.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_outfitter.json
@@ -81,7 +81,11 @@
     "subtype": "distribution",
     "ammo": 100,
     "magazine": 100,
-    "items": [ { "group": "afs_armor_military_infantry_g", "prob": 90 }, { "item": "afs_backpack_rockets", "prob": 10 } ]
+    "items": [
+      { "group": "afs_armor_military_infantry_g", "prob": 85 },
+      { "item": "afs_backpack_rockets", "prob": 10 },
+      { "item": "afs_backpack_shieldgen", "prob": 5 }
+    ]
   },
   {
     "type": "npc",

--- a/data/mods/Aftershock/ui.json
+++ b/data/mods/Aftershock/ui.json
@@ -255,7 +255,7 @@
       },
       {
         "id": "full6",
-        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇      </color>",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇        </color>",
         "condition": { "math": [ "u_shield_power_ratio", ">=", "50" ] }
       },
       {

--- a/data/mods/Aftershock/ui.json
+++ b/data/mods/Aftershock/ui.json
@@ -216,12 +216,12 @@
       {
         "id": "full1",
         "text": "<color_light_red>▂                  </color>",
-        "condition": { "math": [ "u_shield_ratio", ">=", "0.00" ] }
+        "condition": { "math": [ "u_shield_ratio", ">", "0.00" ] }
       },
       {
         "id": "empty",
         "text": "<color_red>      OFFLINE      </color>",
-        "condition": { "math": [ "u_shield_ratio", "<", "0.00" ] }
+        "condition": { "math": [ "u_shield_ratio", "<=", "0.00" ] }
       }
     ],
     "flags": [ "W_NO_PADDING" ]

--- a/data/mods/Aftershock/ui.json
+++ b/data/mods/Aftershock/ui.json
@@ -1,0 +1,325 @@
+[
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_classic_sidebar",
+    "type": "widget",
+    "id": "legacy_classic_sidebar",
+    "extend": { "widgets": [ "shield_layout" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_compact_sidebar",
+    "type": "widget",
+    "id": "legacy_compact_sidebar",
+    "extend": { "widgets": [ "shield_layout" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_labels_narrow_sidebar",
+    "type": "widget",
+    "id": "legacy_labels_narrow_sidebar",
+    "extend": { "widgets": [ "shield_layout" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_labels_sidebar",
+    "type": "widget",
+    "id": "legacy_labels_sidebar",
+    "extend": { "widgets": [ "shield_layout" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "structured_sidebar",
+    "type": "widget",
+    "id": "structured_sidebar",
+    "extend": { "widgets": [ "shield_layout" ] }
+  },
+  {
+    "id": "shield_layout",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "minimum_columns",
+    "label": "SHIELD",
+    "label_align": "right",
+    "text_align": "right",
+    "widgets": [ "shield_layout_1", "shield_layout_2" ],
+    "flags": [ "W_NO_PADDING" ]
+  },
+  {
+    "id": "shield_layout_2",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "rows",
+    "label": "SHIELD",
+    "widgets": [ "shield_empty", "shield_rad_warning" ]
+  },
+  {
+    "id": "shield_layout_1",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "rows",
+    "label": "SHIELD",
+    "widgets": [ "shield_title", "shield_gauge", "shield_power_gauge" ]
+  },
+  {
+    "id": "shield_gauge",
+    "type": "widget",
+    "style": "text",
+    "label": "INTGR",
+    "width": 19,
+    "clauses": [
+      {
+        "id": "full30",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇</color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "96.67" ] }
+      },
+      {
+        "id": "full29",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▅</color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "93.33" ] }
+      },
+      {
+        "id": "full28",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▂</color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "90.00" ] }
+      },
+      {
+        "id": "full27",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "86.67" ] }
+      },
+      {
+        "id": "full26",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▅  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "83.33" ] }
+      },
+      {
+        "id": "full25",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▂  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "80.00" ] }
+      },
+      {
+        "id": "full24",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇    </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "76.67" ] }
+      },
+      {
+        "id": "full23",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▅    </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "73.33" ] }
+      },
+      {
+        "id": "full22",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▂    </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "70.00" ] }
+      },
+      {
+        "id": "full21",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▇      </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "66.67" ] }
+      },
+      {
+        "id": "full20",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▅      </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "63.33" ] }
+      },
+      {
+        "id": "full19",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇ ▂      </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "60.00" ] }
+      },
+      {
+        "id": "full18",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▇        </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "56.67" ] }
+      },
+      {
+        "id": "full17",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▅        </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "53.33" ] }
+      },
+      {
+        "id": "full16",
+        "text": "<color_light_cyan>▇ ▇ ▇ ▇ ▇ ▂        </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "50.00" ] }
+      },
+      {
+        "id": "full15",
+        "text": "<color_yellow>▇ ▇ ▇ ▇ ▇          </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "46.67" ] }
+      },
+      {
+        "id": "full14",
+        "text": "<color_yellow>▇ ▇ ▇ ▇ ▅          </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "43.33" ] }
+      },
+      {
+        "id": "full13",
+        "text": "<color_yellow>▇ ▇ ▇ ▇ ▂          </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "40.00" ] }
+      },
+      {
+        "id": "full12",
+        "text": "<color_yellow>▇ ▇ ▇ ▇            </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "36.67" ] }
+      },
+      {
+        "id": "full11",
+        "text": "<color_yellow>▇ ▇ ▇ ▅            </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "33.33" ] }
+      },
+      {
+        "id": "full10",
+        "text": "<color_yellow>▇ ▇ ▇ ▂            </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "30.00" ] }
+      },
+      {
+        "id": "full9",
+        "text": "<color_yellow>▇ ▇ ▇              </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "26.67" ] }
+      },
+      {
+        "id": "full8",
+        "text": "<color_light_red>▇ ▇ ▅              </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "23.33" ] }
+      },
+      {
+        "id": "full7",
+        "text": "<color_light_red>▇ ▇ ▂              </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "20.00" ] }
+      },
+      {
+        "id": "full6",
+        "text": "<color_light_red>▇ ▇                </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "16.67" ] }
+      },
+      {
+        "id": "full5",
+        "text": "<color_light_red>▇ ▅                </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "13.33" ] }
+      },
+      {
+        "id": "full4",
+        "text": "<color_light_red>▇ ▂                </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "10.00" ] }
+      },
+      {
+        "id": "full3",
+        "text": "<color_light_red>▇                  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "6.67" ] }
+      },
+      {
+        "id": "full2",
+        "text": "<color_light_red>▅                  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "3.33" ] }
+      },
+      {
+        "id": "full1",
+        "text": "<color_light_red>▂                  </color>",
+        "condition": { "math": [ "u_shield_ratio", ">=", "0.00" ] }
+      },
+      {
+        "id": "empty",
+        "text": "<color_red>      OFFLINE      </color>",
+        "condition": { "math": [ "u_shield_ratio", "<", "0.00" ] }
+      }
+    ],
+    "flags": [ "W_NO_PADDING" ]
+  },
+  {
+    "id": "shield_power_gauge",
+    "type": "widget",
+    "style": "text",
+    "label": "POWER",
+    "width": 19,
+    "clauses": [
+      {
+        "id": "full10",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇</color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "90" ] }
+      },
+      {
+        "id": "full9",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇  </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "80" ] }
+      },
+      {
+        "id": "full8",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇    </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "70" ] }
+      },
+      {
+        "id": "full7",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇      </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "60" ] }
+      },
+      {
+        "id": "full6",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇      </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "50" ] }
+      },
+      {
+        "id": "full5",
+        "text": "<color_red>▇ ▇ ▇ ▇ ▇          </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "40" ] }
+      },
+      {
+        "id": "full4",
+        "text": "<color_red>▇ ▇ ▇ ▇            </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "30" ] }
+      },
+      {
+        "id": "full3",
+        "text": "<color_red>▇ ▇ ▇              </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "20" ] }
+      },
+      {
+        "id": "full2",
+        "text": "<color_red>▇ ▇                </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">=", "10" ] }
+      },
+      {
+        "id": "full1",
+        "text": "<color_red>▇                  </color>",
+        "condition": { "math": [ "u_shield_power_ratio", ">", "0" ] }
+      },
+      {
+        "id": "empty",
+        "text": "<color_red>      OFFLINE      </color>",
+        "condition": { "math": [ "u_shield_power_ratio", "<=", "0" ] }
+      }
+    ],
+    "flags": [ "W_NO_PADDING" ]
+  },
+  {
+    "id": "shield_rad_warning",
+    "type": "widget",
+    "width": 8,
+    "style": "text",
+    "clauses": [
+      {
+        "text": "  ☢DNGR☢",
+        "color": "red",
+        "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_ratio", ">=", "0" ] } ] }
+      }
+    ],
+    "default_clause": { "text": "  ☢DNGR☢", "color": "dark_gray" },
+    "flags": [ "W_LABEL_NONE", "W_NO_PADDING" ]
+  },
+  {
+    "id": "shield_title",
+    "type": "widget",
+    "width": 8,
+    "style": "text",
+    "string": "SHIELDING:",
+    "flags": [ "W_LABEL_NONE", "W_NO_PADDING" ]
+  },
+  {
+    "id": "shield_empty",
+    "type": "widget",
+    "width": 8,
+    "style": "text",
+    "string": "",
+    "flags": [ "W_LABEL_NONE", "W_NO_PADDING" ]
+  }
+]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Add personal shield generators"

#### Purpose of change
Energy Shields are a staple of Sci-fi and somewhat necessary if we want to continue adding high danger ranged enemies.


#### Describe the solution
This adds a single High power wearable shield generator the "SHD-1 Riemann Shield Generator". When activated it creates a shield armor piece that is linked to the generator through EOCs.  The shield will resist 600 points of damage and regens one point of damage every turn. If completely broken by damage it will release a deadly flash of radiation, its intended that all Aftershock shields will fail in this manner.

Includes some generic EOCs to handle activating shield items and for their active processing.

Includes an UI widget displaying the shield's hp and the shield generator's power as well as the current risk of radiation.

![image](https://github.com/user-attachments/assets/c2712d83-0206-4599-bef0-9512f4ae260d)


#### Testing
Got the shield destroyed, got the generator destroyed, dropped the active generator, verified the shield took damage and that the shield turned off when the generator ran out of juice.

Also made sure the UI properly updated for all those cases.

#### Additional context
Still need to migrate the other forcefield bionics and exosuit modules to this system, but this PR was too large to do it here.

It would have probably been easier to do this on C++ but I was already in too deep by the time I realized this.