### PR TITLE
Replace the old pathfinding_settings with two new classes

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -784,7 +784,7 @@ void avatar::grab( object_type grab_type_new, const tripoint_rel_ms &grab_point_
     // eliminate ghost vehicles/furnitures/etc.
     update_memory( grab_type, grab_point, /* erase = */ true );
 
-    path_settings->avoid_rough_terrain = grab_type != object_type::NONE;
+    path_settings->set_avoid_rough_terrain( grab_type != object_type::NONE );
 }
 
 object_type avatar::get_grab_type() const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -483,7 +483,14 @@ Character::Character() :
     name.clear();
     custom_profession.clear();
 
-    *path_settings = pathfinding_settings{ {}, 1000, 1000, 0, true, true, true, true, false, true, creature_size::medium };
+    PathfindingSettings pf_settings; 
+    pf_settings.set_avoid_bashing(true);
+    pf_settings.set_max_distance(1000);
+    pf_settings.set_max_cost(1000 * 50);
+    pf_settings.set_avoid_dangerous_traps(true);
+    pf_settings.set_avoid_sharp(true);
+    pf_settings.set_size_restriction(creature_size::medium);
+    *path_settings = pf_settings;
 
     move_mode = move_mode_walk;
     next_expected_position = std::nullopt;
@@ -5729,7 +5736,7 @@ std::function<bool( const tripoint_bub_ms & )> Character::get_path_avoid() const
     };
 }
 
-const pathfinding_settings &Character::get_pathfinding_settings() const
+const PathfindingSettings &Character::get_pathfinding_settings() const
 {
     return *path_settings;
 }

--- a/src/character.h
+++ b/src/character.h
@@ -112,7 +112,7 @@ struct itype;
 struct mutation_branch;
 struct mutation_category_trait;
 struct mutation_variant;
-struct pathfinding_settings;
+class PathfindingSettings;
 struct projectile;
 struct requirement_data;
 struct tool_comp;
@@ -3367,7 +3367,7 @@ class Character : public Creature, public visitable
         /** Returns the player's modified base movement cost */
         int run_cost( int base_cost, bool diag = false ) const;
 
-        const pathfinding_settings &get_pathfinding_settings() const override;
+        const PathfindingSettings &get_pathfinding_settings() const override;
         std::function<bool( const tripoint_bub_ms & )> get_path_avoid() const override;
         /**
          * Get all hostile creatures currently visible to this player.
@@ -4126,7 +4126,7 @@ class Character : public Creature, public visitable
          * Cache for pathfinding settings.
          * Most of it isn't changed too often, hence mutable.
          */
-        mutable pimpl<pathfinding_settings> path_settings;
+        mutable pimpl<PathfindingSettings> path_settings;
 
         // faction API versions
         // 2 - allies are in your_followers faction; NPCATT_FOLLOW is follower but not an ally

--- a/src/creature.h
+++ b/src/creature.h
@@ -64,7 +64,7 @@ class window;
 }  // namespace catacurses
 struct dealt_projectile_attack;
 struct field_immunity_data;
-struct pathfinding_settings;
+class PathfindingSettings;
 struct projectile;
 struct projectile_attack_results;
 struct trap;
@@ -976,7 +976,7 @@ class Creature : public viewer
         virtual units::mass weight_capacity() const;
 
         /** Returns settings for pathfinding. */
-        virtual const pathfinding_settings &get_pathfinding_settings() const = 0;
+        virtual const PathfindingSettings &get_pathfinding_settings() const = 0;
         /** Returns a set of points we do not want to path through. */
         virtual std::function<bool( const tripoint_bub_ms & )> get_path_avoid() const = 0;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3632,7 +3632,12 @@ Creature *game::is_hostile_within( int distance, bool dangerous )
                     return critter;
                 }
 
-                const pathfinding_settings pf_settings = pathfinding_settings{ {{{ damage_bash, 8}}}, distance, distance * 2, 4, true, true, false, true, false, false };
+                PathfindingSettings pf_settings;
+                pf_settings.set_bash_strength( damage_bash, 8 );
+                pf_settings.set_max_distance( distance );
+                pf_settings.set_max_cost( distance * 2 * 50 );
+                pf_settings.set_climb_cost( 4 );
+
                 const pathfinding_target pf_t = pathfinding_target::point( critter->pos_bub() );
                 if( !get_map().route( u.pos_bub(), pf_t, pf_settings ).empty() ) {
                     return critter;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5394,8 +5394,15 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
         const int max_dist = 2;
         std::vector<tripoint_bub_ms> tiles = closest_points_first( pos, 1, max_dist );
         const int max_path_length = 4 * max_dist;
-        const pathfinding_settings setting( {}, max_dist, max_path_length, 0, false, false, true, false,
-                                            false, false );
+        PathfindingSettings setting;
+        setting.set_avoid_bashing( true );
+        setting.set_max_distance( max_dist );
+        setting.set_max_cost( max_path_length * 50 );
+        setting.set_avoid_opening_doors( true );
+        setting.set_avoid_unlocking_doors( true );
+        setting.set_avoid_dangerous_traps( true );
+        setting.set_avoid_climb_stairway( true );
+
         for( const tripoint_bub_ms &e : tiles ) {
             if( copies_remaining <= 0 ) {
                 break;

--- a/src/map.h
+++ b/src/map.h
@@ -97,7 +97,7 @@ class map;
 
 enum class ter_furn_flag : int;
 struct pathfinding_cache;
-struct pathfinding_settings;
+class PathfindingSettings;
 struct pathfinding_target;
 template<typename T>
 struct weighted_int_list;
@@ -724,7 +724,7 @@ class map
          * @param pre_closed Never path through those points. They can still be the source or the destination.
          */
         std::vector<tripoint_bub_ms> route( const tripoint_bub_ms &f, const pathfinding_target &target,
-                                            const pathfinding_settings &settings,
+                                            const PathfindingSettings &settings,
         const std::function<bool( const tripoint_bub_ms & )> &avoid = []( const tripoint_bub_ms & ) {
             return false;
         } ) const;
@@ -745,17 +745,17 @@ class map
         // Pathfinding cost helper that computes the cost of moving into |p| from |cur|.
         // Includes climbing, bashing and opening doors.
         int cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
-                          const pathfinding_settings &settings,
+                          const PathfindingSettings &settings,
                           PathfindingFlags p_special ) const;
         // Pathfinding cost helper that computes the cost of moving into |p|
         // from |cur| based on perceived danger.
         // Includes moving through traps.
         int cost_to_avoid( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
-                           const pathfinding_settings &settings,
+                           const PathfindingSettings &settings,
                            PathfindingFlags p_special ) const;
         // Sum of cost_to_pass and cost_to_avoid.
         int extra_cost( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
-                        const pathfinding_settings &settings,
+                        const PathfindingSettings &settings,
                         PathfindingFlags p_special ) const;
     public:
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1512,8 +1512,15 @@ bool mattack::triffid_heartbeat( monster *z )
     const tripoint_bub_ms z_pos = z->pos_bub( here );
 
     creature_tracker &creatures = get_creature_tracker();
-    static pathfinding_settings root_pathfind( {{damage_bash, 10}}, 20, 50, 0, false, false, false,
-    false, false, false );
+    // TODO: Move this to a separate initialiser.
+    static PathfindingSettings root_pathfind;
+    root_pathfind.set_bash_strength( damage_bash, 10 );
+    root_pathfind.set_max_distance( 20 );
+    root_pathfind.set_max_cost( 50 * 50 );
+    root_pathfind.set_avoid_opening_doors( true );
+    root_pathfind.set_avoid_unlocking_doors( true );
+    root_pathfind.set_avoid_climb_stairway( true );
+
     const pathfinding_target pf_t = pathfinding_target::point( z_pos );
     if( rl_dist( z_pos, pos ) > 5 &&
         !here.route( pos, pf_t, root_pathfind ).empty() ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -210,10 +210,10 @@ bool monster::know_danger_at( map *here, const tripoint_bub_ms &p ) const
 
     bool avoid_fire = avoid_simple || has_flag( mon_flag_PATH_AVOID_FIRE );
     bool avoid_fall = avoid_simple || has_flag( mon_flag_PATH_AVOID_FALL );
-    bool avoid_sharp = avoid_simple || get_pathfinding_settings().avoid_sharp;
+    bool avoid_sharp = avoid_simple || get_pathfinding_settings().avoid_sharp();
 
-    bool avoid_dangerous_fields = get_pathfinding_settings().avoid_dangerous_fields;
-    bool avoid_traps = get_pathfinding_settings().avoid_traps;
+    bool avoid_dangerous_fields = get_pathfinding_settings().avoid_dangerous_fields();
+    bool avoid_traps = get_pathfinding_settings().avoid_dangerous_traps();
 
     // technically this will shortcut in evaluation from fire or fall
     // before hitting simple or complex but this is more explicit
@@ -1049,8 +1049,8 @@ void monster::move()
                 path.erase( path.begin() );
             }
 
-            const pathfinding_settings &pf_settings = get_pathfinding_settings();
-            if( pf_settings.max_dist >= rl_dist( pos_abs(), get_dest() ) &&
+            const PathfindingSettings &pf_settings = get_pathfinding_settings();
+            if( pf_settings.max_distance() >= rl_dist( pos_abs(), get_dest() ) &&
                 ( path.empty() || rl_dist( pos_bub(), path.front() ) >= 2 || path.back() != local_dest ) ) {
                 // We need a new path
                 if( can_pathfind() ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -215,6 +215,8 @@ static const trait_id trait_PHEROMONE_MAMMAL( "PHEROMONE_MAMMAL" );
 static const trait_id trait_TERRIFYING( "TERRIFYING" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
 
+class PathfindingSettings;
+
 // Limit the number of iterations for next upgrade_time calculations.
 // This also sets the percentage of monsters that will never upgrade.
 // The rough formula is 2^(-x), e.g. for x = 5 it's 0.03125 (~ 3%).
@@ -1562,8 +1564,8 @@ bool monster::has_intelligence() const
            has_flag( mon_flag_PATH_AVOID_FIRE ) ||
            has_flag( mon_flag_PATH_AVOID_DANGER ) ||
            has_flag( mon_flag_PRIORITIZE_TARGETS ) ||
-           get_pathfinding_settings().avoid_sharp ||
-           get_pathfinding_settings().avoid_traps;
+           type->path_settings.avoid_sharp() ||
+           type->path_settings.avoid_dangerous_traps();
 }
 
 std::vector<material_id> monster::get_absorb_material() const
@@ -4193,7 +4195,7 @@ void monster::on_load()
                    name(), to_turns<int>( dt ), healed, healed_speed );
 }
 
-const pathfinding_settings &monster::get_pathfinding_settings() const
+const PathfindingSettings &monster::get_pathfinding_settings() const
 {
     return type->path_settings;
 }

--- a/src/monster.h
+++ b/src/monster.h
@@ -34,6 +34,7 @@ class JsonOut;
 class effect_source;
 class item;
 class map;
+class PathfindingSettings;
 enum class mon_trigger : int;
 enum class phase_id : int;
 struct monster_plan;
@@ -631,7 +632,7 @@ class monster : public Creature
          */
         void on_load();
 
-        const pathfinding_settings &get_pathfinding_settings() const override;
+        const PathfindingSettings &get_pathfinding_settings() const override;
         std::function<bool( const tripoint_bub_ms & )> get_path_avoid() const override;
         std::vector<std::pair<std::string, std::string>> get_overlay_ids() const;
     private:

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -591,19 +591,19 @@ void MonsterGenerator::apply_species_attributes( mtype &mon )
 
 void MonsterGenerator::finalize_pathfinding_settings( mtype &mon )
 {
-    if( mon.path_settings.max_length < 0 ) {
-        mon.path_settings.max_length = mon.path_settings.max_dist * 5;
+    if( mon.path_settings.max_cost() / 50 < 0 ) {
+        mon.path_settings.set_max_cost( mon.path_settings.max_distance() * 5 * 50 ) ;
     }
 
-    if( mon.path_settings.bash_strength.empty() ) {
-        mon.path_settings.bash_strength = mon.bash_skill;
+    if( mon.path_settings.bash_strength().empty() ) {
+        mon.path_settings.set_bash_strength( mon.bash_skill );
     }
 
     if( mon.move_skills.climb.has_value() ) {
-        mon.path_settings.climb_cost = move_skills_data::max_movemod_penalty -
-                                       ( mon.move_skills.climb.value() * ( move_skills_data::max_movemod_penalty / 10 ) );
+        mon.path_settings.set_climb_cost( move_skills_data::max_movemod_penalty -
+                                          ( mon.move_skills.climb.value() * ( move_skills_data::max_movemod_penalty / 10 ) ) );
     } else if( mon.has_flag( mon_flag_CLIMBS ) ) {
-        mon.path_settings.climb_cost = 3;
+        mon.path_settings.set_climb_cost( 3 );
     }
 }
 
@@ -1178,14 +1178,33 @@ void mtype::load( const JsonObject &jo, const std::string_view src )
     if( jo.has_member( "path_settings" ) ) {
         JsonObject jop = jo.get_object( "path_settings" );
         // Here rather than in pathfinding.cpp because we want monster-specific defaults and was_loaded
-        optional( jop, was_loaded, "max_dist", path_settings.max_dist, 0 );
-        optional( jop, was_loaded, "max_length", path_settings.max_length, -1 );
-        optional( jop, was_loaded, "bash_strength", path_settings.bash_strength );
-        optional( jop, was_loaded, "allow_open_doors", path_settings.allow_open_doors, false );
-        optional( jop, was_loaded, "avoid_traps", path_settings.avoid_traps, false );
-        optional( jop, was_loaded, "allow_climb_stairs", path_settings.allow_climb_stairs, true );
-        optional( jop, was_loaded, "avoid_sharp", path_settings.avoid_sharp, false );
-        optional( jop, was_loaded, "avoid_dangerous_fields", path_settings.avoid_dangerous_fields, false );
+        int max_dist;
+        int bash_strength;
+        int max_length;
+        bool allow_open_doors;
+        bool avoid_traps;
+        bool allow_climb_stairs;
+        bool avoid_sharp;
+        bool avoid_dangerous_fields;
+
+        optional( jop, was_loaded, "max_dist", max_dist, 0 );
+        optional( jop, was_loaded, "max_length", max_length, -1 );
+        optional( jop, was_loaded, "bash_strength", bash_strength );
+        optional( jop, was_loaded, "allow_open_doors", allow_open_doors, false );
+        optional( jop, was_loaded, "avoid_traps", avoid_traps, false );
+        optional( jop, was_loaded, "allow_climb_stairs", allow_climb_stairs, true );
+        optional( jop, was_loaded, "avoid_sharp", avoid_sharp, false );
+        optional( jop, was_loaded, "avoid_dangerous_fields", avoid_dangerous_fields, false );
+
+        path_settings = PathfindingSettings();
+        path_settings.set_max_distance( max_dist );
+        path_settings.set_bash_strength( damage_bash, bash_strength );
+        // FIXME: cost -> length conversion is a stopgap before the new pathfinding system is added.
+        path_settings.set_max_cost( max_length * 50 );
+        path_settings.set_avoid_opening_doors( !allow_open_doors );
+        path_settings.set_avoid_dangerous_traps( !avoid_traps );
+        path_settings.set_avoid_climb_stairway( !allow_climb_stairs );
+        path_settings.set_avoid_dangerous_fields( avoid_dangerous_fields );
     }
 }
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -552,7 +552,7 @@ struct mtype {
         // Monster biosignature variables
         std::optional<time_duration> biosig_timer;
 
-        pathfinding_settings path_settings;
+        PathfindingSettings path_settings;
 
         // All the bools together for space efficiency
         //

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -571,7 +571,7 @@ void Character::recalculate_size()
             size_class = creature_size::medium;
         }
     }
-    path_settings->size = size_class;
+    path_settings->set_size_restriction( size_class );
 }
 
 void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_override )

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -264,8 +264,16 @@ npc::npc()
     patience = 0;
     attitude = NPCATT_NULL;
 
-    *path_settings = pathfinding_settings( {}, 1000, 1000, 10, true, true, true, true, false, true,
-                                           get_size() );
+    PathfindingSettings pf_settings;
+    pf_settings.set_avoid_bashing( true );
+    pf_settings.set_max_distance( 1000 );
+    pf_settings.set_max_cost( 1000 * 50 );
+    pf_settings.set_climb_cost( 10 );
+    pf_settings.set_avoid_dangerous_traps( true );
+    pf_settings.set_avoid_sharp( true );
+    pf_settings.set_size_restriction( get_size() );
+    *path_settings = pf_settings;
+
     for( direction threat_dir : npc_threat_dir ) {
         ai_cache.threat_map[ threat_dir ] = 0.0f;
     }
@@ -3490,26 +3498,28 @@ bool npc::will_accept_from_player( const item &it ) const
     return true;
 }
 
-const pathfinding_settings &npc::get_pathfinding_settings() const
+const PathfindingSettings &npc::get_pathfinding_settings() const
 {
     return get_pathfinding_settings( false );
 }
 
-const pathfinding_settings &npc::get_pathfinding_settings( bool no_bashing ) const
+const PathfindingSettings &npc::get_pathfinding_settings( bool no_bashing ) const
 {
-    path_settings->bash_strength = !no_bashing ? smash_ability() : std::map<damage_type_id, int>();
-    if( has_trait( trait_NO_BASH ) ) {
-        path_settings->bash_strength = {};
+    if( no_bashing || has_trait( trait_NO_BASH ) ) {
+        path_settings->set_bash_strength( {} );
+    } else {
+        path_settings->set_bash_strength( smash_ability() );
     }
+
     // TODO: Extract climb skill
     const int climb = std::min( 20, get_dex() );
     if( climb > 1 ) {
         // Success is !one_in(dex), so 0%, 50%, 66%, 75%...
         // Penalty for failure chance is 1/success = 1/(1-failure) = 1/(1-(1/dex)) = dex/(dex-1)
-        path_settings->climb_cost = ( 10 - climb / 5.0f ) * climb / ( climb - 1 );
+        path_settings->set_climb_cost( ( 10 - climb / 5.0f ) * climb / ( climb - 1 ) );
     } else {
         // Climbing at this dexterity will always fail
-        path_settings->climb_cost = 0;
+        path_settings->set_climb_cost( 0 );
     }
 
     return *path_settings;

--- a/src/npc.h
+++ b/src/npc.h
@@ -76,7 +76,7 @@ class window;
 }  // namespace catacurses
 class gun_mode;
 struct overmap_location;
-struct pathfinding_settings;
+class PathfindingSettings;
 
 using overmap_location_str_id = string_id<overmap_location>;
 
@@ -1195,8 +1195,8 @@ class npc : public Character
 
         void set_movement_mode( const move_mode_id &mode ) override;
 
-        const pathfinding_settings &get_pathfinding_settings() const override;
-        const pathfinding_settings &get_pathfinding_settings( bool no_bashing ) const;
+        const PathfindingSettings &get_pathfinding_settings() const override;
+        const PathfindingSettings &get_pathfinding_settings( bool no_bashing ) const;
         std::function<bool( const tripoint_bub_ms & )> get_path_avoid() const override;
 
         // Item discovery and fetching

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -139,38 +139,6 @@ static bool vertical_move_destination( const map &m, ter_furn_flag flag, tripoin
     return false;
 }
 
-template<class Set1, class Set2>
-static bool is_disjoint( const Set1 &set1, const Set2 &set2 )
-{
-    if( set1.empty() || set2.empty() ) {
-        return true;
-    }
-
-    typename Set1::const_iterator it1 = set1.begin();
-    typename Set1::const_iterator it1_end = set1.end();
-
-    typename Set2::const_iterator it2 = set2.begin();
-    typename Set2::const_iterator it2_end = set2.end();
-
-    if( *set2.rbegin() < *it1 || *set1.rbegin() < *it2 ) {
-        return true;
-    }
-
-    while( it1 != it1_end && it2 != it2_end ) {
-        if( *it1 == *it2 ) {
-            return false;
-        }
-        if( *it1 < *it2 ) {
-            it1++;
-        } else {
-            it2++;
-        }
-    }
-
-    return true;
-}
-
-
 void PathfindingSettings::set_size_restriction( std::optional<creature_size> size_restriction )
 {
     size_restriction_mask_.clear();

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -210,37 +210,6 @@ void PathfindingSettings::set_size_restriction( std::optional<creature_size> siz
     size_restriction_ = size_restriction;
 }
 
-int PathfindingSettings::bash_rating_from_range( int min, int max ) const
-{
-    if( avoid_bashing_ ) {
-        return 0;
-    }
-    // TODO: Move all the bash stuff to map so this logic isn't duplicated.
-    ///\EFFECT_STR increases smashing damage
-    if( bash_strength_ < min ) {
-        return 0;
-    } else if( bash_strength_ >= max ) {
-        return 10;
-    }
-    const double ret = ( 10.0 * ( bash_strength_ - min ) ) / ( max - min );
-    // Round up to 1, so that desperate NPCs can try to bash down walls
-    return std::max( ret, 1.0 );
-}
-
-std::vector<tripoint> map::straight_route( const tripoint &f, const tripoint &t ) const
-{
-    const std::vector<tripoint_bub_ms> temp = map::straight_route( tripoint_bub_ms( f ),
-            tripoint_bub_ms( t ) );
-    std::vector<tripoint> result;
-    result.reserve( temp.size() );
-
-    for( const tripoint_bub_ms pt : temp ) {
-        result.push_back( pt.raw() );
-    }
-
-    return result;
-}
-
 std::vector<tripoint_bub_ms> map::straight_route( const tripoint_bub_ms &f,
         const tripoint_bub_ms &t ) const
 {
@@ -741,19 +710,6 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
     }
 
     return ret;
-}
-
-std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoint_bub_ms &t,
-        const PathfindingSettings &settings,
-        const std::function<bool( const tripoint & )> &avoid ) const
-{
-    std::vector<tripoint> raw_result = route( f.raw(), t.raw(), settings, avoid );
-    std::vector<tripoint_bub_ms> result;
-    std::transform( raw_result.begin(), raw_result.end(), std::back_inserter( result ),
-    []( const tripoint & p ) {
-        return tripoint_bub_ms( p );
-    } );
-    return result;
 }
 
 bool pathfinding_target::contains( const tripoint_bub_ms &p ) const

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -170,6 +170,109 @@ static bool is_disjoint( const Set1 &set1, const Set2 &set2 )
     return true;
 }
 
+
+void PathfindingSettings::set_size_restriction( std::optional<creature_size> size_restriction )
+{
+    size_restriction_mask_.clear();
+    if( size_restriction ) {
+        switch( *size_restriction ) {
+            case creature_size::tiny:
+                size_restriction_mask_ = PathfindingFlag::RestrictTiny;
+                break;
+            case creature_size::small:
+                size_restriction_mask_ = PathfindingFlag::RestrictSmall;
+                break;
+            case creature_size::medium:
+                size_restriction_mask_ = PathfindingFlag::RestrictMedium;
+                break;
+            case creature_size::large:
+                size_restriction_mask_ = PathfindingFlag::RestrictLarge;
+                break;
+            case creature_size::huge:
+                size_restriction_mask_ = PathfindingFlag::RestrictHuge;
+                break;
+            default:
+                break;
+        }
+    }
+    size_restriction_ = size_restriction;
+}
+
+//int PathfindingSettings::bash_rating_from_range( int min, int max ) const
+//{
+//    if( avoid_bashing_ ) {
+//        return 0;
+//    }
+//    // TODO: Move all the bash stuff to map so this logic isn't duplicated.
+//    ///\EFFECT_STR increases smashing damage
+//    if( bash_strength_ < min ) {
+//        return 0;
+//    } else if( bash_strength_ >= max ) {
+//        return 10;
+//    }
+//    const double ret = ( 10.0 * ( bash_strength_ - min ) ) / ( max - min );
+//    // Round up to 1, so that desperate NPCs can try to bash down walls
+//    return std::max( ret, 1.0 );
+//}
+
+void PathfindingSettings::set_size_restriction( std::optional<creature_size> size_restriction )
+{
+    size_restriction_mask_.clear();
+    if( size_restriction ) {
+        switch( *size_restriction ) {
+            case creature_size::tiny:
+                size_restriction_mask_ = PathfindingFlag::RestrictTiny;
+                break;
+            case creature_size::small:
+                size_restriction_mask_ = PathfindingFlag::RestrictSmall;
+                break;
+            case creature_size::medium:
+                size_restriction_mask_ = PathfindingFlag::RestrictMedium;
+                break;
+            case creature_size::large:
+                size_restriction_mask_ = PathfindingFlag::RestrictLarge;
+                break;
+            case creature_size::huge:
+                size_restriction_mask_ = PathfindingFlag::RestrictHuge;
+                break;
+            default:
+                break;
+        }
+    }
+    size_restriction_ = size_restriction;
+}
+
+int PathfindingSettings::bash_rating_from_range( int min, int max ) const
+{
+    if( avoid_bashing_ ) {
+        return 0;
+    }
+    // TODO: Move all the bash stuff to map so this logic isn't duplicated.
+    ///\EFFECT_STR increases smashing damage
+    if( bash_strength_ < min ) {
+        return 0;
+    } else if( bash_strength_ >= max ) {
+        return 10;
+    }
+    const double ret = ( 10.0 * ( bash_strength_ - min ) ) / ( max - min );
+    // Round up to 1, so that desperate NPCs can try to bash down walls
+    return std::max( ret, 1.0 );
+}
+
+std::vector<tripoint> map::straight_route( const tripoint &f, const tripoint &t ) const
+{
+    const std::vector<tripoint_bub_ms> temp = map::straight_route( tripoint_bub_ms( f ),
+            tripoint_bub_ms( t ) );
+    std::vector<tripoint> result;
+    result.reserve( temp.size() );
+
+    for( const tripoint_bub_ms pt : temp ) {
+        result.push_back( pt.raw() );
+    }
+
+    return result;
+}
+
 std::vector<tripoint_bub_ms> map::straight_route( const tripoint_bub_ms &f,
         const tripoint_bub_ms &t ) const
 {
@@ -187,10 +290,7 @@ std::vector<tripoint_bub_ms> map::straight_route( const tripoint_bub_ms &f,
         const pathfinding_cache &pf_cache = get_pathfinding_cache_ref( f.z() );
         // Check all points for any special case (including just hard terrain)
         if( std::any_of( ret.begin(), ret.end(), [&pf_cache]( const tripoint_bub_ms & p ) {
-        constexpr PathfindingFlags non_normal = PathfindingFlag::Slow |
-                                                PathfindingFlag::Obstacle | PathfindingFlag::Vehicle | PathfindingFlag::DangerousTrap |
-                                                PathfindingFlag::Sharp;
-        return pf_cache.special[p.x()][p.y()] & non_normal;
+        return pf_cache.special[p.x()][p.y()] & PathfindingSettings::RoughTerrain;
         } ) ) {
             ret.clear();
         }
@@ -201,38 +301,43 @@ std::vector<tripoint_bub_ms> map::straight_route( const tripoint_bub_ms &f,
 static constexpr int PF_IMPASSABLE = -1;
 static constexpr int PF_IMPASSABLE_FROM_HERE = -2;
 int map::cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
-                       const pathfinding_settings &settings,
+                       const PathfindingSettings &settings,
                        PathfindingFlags p_special ) const
 {
-    constexpr PathfindingFlags non_normal = PathfindingFlag::Slow |
-                                            PathfindingFlag::Obstacle | PathfindingFlag::Vehicle | PathfindingFlag::DangerousTrap |
-                                            PathfindingFlag::Sharp;
+    constexpr PathfindingFlags non_normal = PathfindingSettings::RoughTerrain;
+
+    // FIXME: This check is strictly false.
     if( !( p_special & non_normal ) ) {
         // Boring flat dirt - the most common case above the ground
         return 2;
     }
 
-    if( settings.avoid_rough_terrain ) {
+    if( settings.avoid_rough_terrain() ) {
         return PF_IMPASSABLE;
     }
 
-    if( settings.avoid_sharp && ( p_special & PathfindingFlag::Sharp ) ) {
+    if( settings.avoid_sharp() && ( p_special & PathfindingFlag::Sharp ) ) {
         return PF_IMPASSABLE;
     }
 
     // RestrictTiny isn't checked since it's unclear how it would actually work as there's no category smaller than tiny
-    if( settings.size && (
-            ( p_special & PathfindingFlag::RestrictSmall && settings.size > creature_size::tiny ) ||
-            ( p_special & PathfindingFlag::RestrictMedium && settings.size > creature_size::small ) ||
-            ( p_special & PathfindingFlag::RestrictLarge && settings.size > creature_size::medium ) ||
-            ( p_special & PathfindingFlag::RestrictHuge && settings.size > creature_size::large ) ) ) {
+    // FIXME: Make this more ergonomic.
+    if( ( p_special & PathfindingSettings::AnySizeRestriction ) && settings.size_restriction() && (
+            ( p_special & PathfindingFlag::RestrictSmall &&
+              settings.size_restriction() > creature_size::tiny ) ||
+            ( p_special & PathfindingFlag::RestrictMedium &&
+              settings.size_restriction() > creature_size::small ) ||
+            ( p_special & PathfindingFlag::RestrictLarge &&
+              settings.size_restriction() > creature_size::medium ) ||
+            ( p_special & PathfindingFlag::RestrictHuge &&
+              settings.size_restriction() > creature_size::large ) ) ) {
         return PF_IMPASSABLE;
     }
 
-    const std::map<damage_type_id, int> &bash = settings.bash_strength;
-    const bool allow_open_doors = settings.allow_open_doors;
-    const bool allow_unlock_doors = settings.allow_unlock_doors;
-    const int climb_cost = settings.climb_cost;
+    const std::map<damage_type_id, int> &bash = settings.bash_strength();
+    const bool allow_open_doors = !settings.avoid_opening_doors();
+    const bool allow_unlock_doors = !settings.avoid_unlocking_doors();
+    const int climb_cost = settings.climb_cost();
 
     int part = -1;
     const const_maptile &tile = maptile_at_internal( p );
@@ -302,12 +407,12 @@ int map::cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
     }
 
     // If terrain/furniture is openable but we can't fit through the open version, ignore the tile
-    if( settings.size && allow_open_doors &&
+    if( settings.size_restriction() && allow_open_doors &&
         ( ( terrain.open && terrain.open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ||
           ( furniture.open && furniture.open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ||
           // Windows with curtains need to be opened twice
           ( terrain.open->open && terrain.open->open->has_flag( ter_furn_flag::TFLAG_SMALL_PASSAGE ) ) ) &&
-        settings.size > creature_size::medium
+        settings.size_restriction() > creature_size::medium
       ) {
         return PF_IMPASSABLE;
     }
@@ -348,9 +453,9 @@ int map::cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
 }
 
 int map::cost_to_avoid( const tripoint_bub_ms & /*cur*/, const tripoint_bub_ms &p,
-                        const pathfinding_settings &settings, PathfindingFlags p_special ) const
+                        const PathfindingSettings &settings, PathfindingFlags p_special ) const
 {
-    if( settings.avoid_traps && ( p_special & PathfindingFlag::DangerousTrap ) ) {
+    if( settings.avoid_dangerous_traps() && ( p_special & PathfindingFlag::DangerousTrap ) ) {
         const const_maptile &tile = maptile_at_internal( p );
         const ter_t &terrain = tile.get_ter_t();
         const trap &ter_trp = terrain.trap.obj();
@@ -362,7 +467,8 @@ int map::cost_to_avoid( const tripoint_bub_ms & /*cur*/, const tripoint_bub_ms &
         }
     }
 
-    if( settings.avoid_dangerous_fields && ( p_special & PathfindingFlag::DangerousField ) ) {
+    if( settings.avoid_dangerous_fields() &&
+        ( p_special & PathfindingFlag::DangerousField ) ) {
         // We'll walk through even known-dangerous fields if we absolutely have to.
         return 500;
     }
@@ -371,7 +477,7 @@ int map::cost_to_avoid( const tripoint_bub_ms & /*cur*/, const tripoint_bub_ms &
 }
 
 int map::extra_cost( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
-                     const pathfinding_settings &settings,
+                     const PathfindingSettings &settings,
                      PathfindingFlags p_special ) const
 {
     int pass_cost = cost_to_pass( tripoint_bub_ms( cur ), tripoint_bub_ms( p ), settings, p_special );
@@ -394,7 +500,7 @@ std::vector<tripoint_bub_ms> map::route( const Creature &who,
 
 std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
         const pathfinding_target &target,
-        const pathfinding_settings &settings,
+        const PathfindingSettings &settings,
         const std::function<bool( const tripoint_bub_ms & )> &avoid ) const
 {
     /* TODO: If the origin or destination is out of bound, figure out the closest
@@ -437,11 +543,12 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
     }
 
     // If expected path length is greater than max distance, allow only line path, like above
-    if( rl_dist( f, t ) > settings.max_dist ) {
+    if( rl_dist( f, t ) > settings.max_distance() ) {
         return ret;
     }
 
-    const int max_length = settings.max_length;
+    // FIXME: Temporary number while migration is ongoing.
+    const int max_length = settings.max_cost() / 50;
 
     const int pad = 16;  // Should be much bigger - low value makes pathfinders dumb!
     tripoint_bub_ms min( std::min( f.x(), t.x() ) - pad, std::min( f.y(), t.y() ) - pad,
@@ -522,7 +629,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
             // Special case: pathfinders that avoid traps can avoid ledges by
             // climbing down. This can't be covered by |extra_cost| because it
             // can add a new point to the search.
-            if( settings.avoid_traps && ( p_special & PathfindingFlag::DangerousTrap ) ) {
+            if( settings.avoid_dangerous_traps() && ( p_special & PathfindingFlag::DangerousTrap ) ) {
                 const const_maptile &tile = maptile_at_internal( p );
                 const ter_t &terrain = tile.get_ter_t();
                 const trap &ter_trp = terrain.trap.obj();
@@ -552,7 +659,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
 
         // TODO: We should be able to go up ramps even if we can't climb stairs.
         if( !( cur_special & ( PathfindingFlag::GoesUp | PathfindingFlag::GoesDown ) ) ||
-            !settings.allow_climb_stairs ) {
+            settings.avoid_climb_stairway() ) {
             // The part below is only for z-level pathing
             continue;
         }
@@ -560,7 +667,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
         bool rope_ladder = false;
         const const_maptile &parent_tile = maptile_at_internal( cur );
         const ter_t &parent_terrain = parent_tile.get_ter_t();
-        if( settings.allow_climb_stairs && cur.z() > min.z() &&
+        if( !settings.avoid_climb_stairway() && cur.z() > min.z() &&
             parent_terrain.has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) ) {
             std::optional<tripoint_bub_ms> opt_dest = g->find_or_make_stairs( get_map(),
                     cur.z() - 1, rope_ladder, false, cur );
@@ -578,7 +685,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
                               cur, dest );
             }
         }
-        if( settings.allow_climb_stairs && cur.z() < max.z() &&
+        if( !settings.avoid_climb_stairway() && cur.z() < max.z() &&
             parent_terrain.has_flag( ter_furn_flag::TFLAG_GOES_UP ) ) {
             std::optional<tripoint_bub_ms> opt_dest = g->find_or_make_stairs( get_map(),
                     cur.z() + 1, rope_ladder, false, cur );
@@ -666,6 +773,19 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
     }
 
     return ret;
+}
+
+std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoint_bub_ms &t,
+        const PathfindingSettings &settings,
+        const std::function<bool( const tripoint & )> &avoid ) const
+{
+    std::vector<tripoint> raw_result = route( f.raw(), t.raw(), settings, avoid );
+    std::vector<tripoint_bub_ms> result;
+    std::transform( raw_result.begin(), raw_result.end(), std::back_inserter( result ),
+    []( const tripoint & p ) {
+        return tripoint_bub_ms( p );
+    } );
+    return result;
 }
 
 bool pathfinding_target::contains( const tripoint_bub_ms &p ) const

--- a/src/pathfinding.h
+++ b/src/pathfinding.h
@@ -7,7 +7,9 @@
 #include <optional>
 #include <unordered_set>
 
-#include "coordinates.h"
+#include "creature.h"
+#include "coords_fwd.h"
+#include "game_constants.h"
 #include "mdarray.h"
 #include "point.h"
 #include "type_id.h"
@@ -23,12 +25,15 @@ enum class PathfindingFlag : uint8_t {
     Swimmable,      // Can swim in
     Air,            // Empty air
     Unsheltered,    // Outside and above ground level
-    Obstacle,       // Something stopping us, might be bashable.
+    Obstacle,       // Something stopping us, might be bashable, climbable, diggable, or openable.
     Bashable,       // Something bashable.
     Impassable,     // Impassable obstacle.
     Vehicle,        // Vehicle tile (passable or not)
     DangerousField, // Dangerous field
     DangerousTrap,  // Dangerous trap (i.e. not flagged benign)
+
+    // TODO: Rename these to StairsUp and StairsDown.
+    // TODO: Handle ladders, elevators, etc.
     GoesUp,         // Valid stairs up
     GoesDown,       // Valid stairs down
     RampUp,         // Valid ramp up
@@ -136,37 +141,337 @@ struct pathfinding_cache {
     cata::mdarray<PathfindingFlags, point_bub_ms> special;
 };
 
-struct pathfinding_settings {
-    std::map<damage_type_id, int> bash_strength;
-    int max_dist = 0;
-    // At least 2 times the above, usually more
-    int max_length = 0;
 
-    // Expected terrain cost (2 is flat ground) of climbing a wire fence
-    // 0 means no climbing
-    int climb_cost = 0;
+// Settings that affect either parameters of the pathfinding algorithm
+// or fundamental assumptions about movement, e.g. vertical / horizontal movement.
+// TODO: Support burrowing as a way to change Z-levels.
+// TODO: Allow climbing as a way to change Z-levels.
+// TODO: Support swimming as a way to change Z-levels.
+// TODO: Support the CLIMB_FLYING flag (e.g. #75515).
+class RealityBubblePathfindingSettings
+{
+    public:
+        bool allow_flying() const {
+            return allow_flying_;
+        }
+        void set_allow_flying( bool v = true ) {
+            allow_flying_ = v;
+        }
 
-    bool allow_open_doors = false;
-    bool allow_unlock_doors = false;
-    bool avoid_traps = false;
-    bool allow_climb_stairs = true;
-    bool avoid_rough_terrain = false;
-    bool avoid_sharp = false;
-    bool avoid_dangerous_fields = false;
+        bool allow_falling() const {
+            return allow_falling_;
+        }
+        void set_allow_falling( bool v = true ) {
+            allow_falling_ = v;
+        }
 
-    std::optional<creature_size> size = std::nullopt;
+        bool allow_stairways() const {
+            return allow_stairways_;
+        }
+        void set_allow_stairways( bool v = true ) {
+            allow_stairways_ = v;
+        }
 
-    pathfinding_settings() = default;
-    pathfinding_settings( const pathfinding_settings & ) = default;
+        int max_cost() const {
+            return max_cost_;
+        }
+        void set_max_cost( int v = 0 ) {
+            max_cost_ = v;
+        }
 
-    pathfinding_settings( const std::map<damage_type_id, int> &bs, int md, int ml, int cc, bool aod,
-                          bool aud, bool at, bool acs,
-                          bool art, bool as, std::optional<creature_size> sz = std::nullopt )
-        : bash_strength( bs ), max_dist( md ), max_length( ml ), climb_cost( cc ),
-          allow_open_doors( aod ), allow_unlock_doors( aud ), avoid_traps( at ), allow_climb_stairs( acs ),
-          avoid_rough_terrain( art ), avoid_sharp( as ), size( sz )  {}
+        const tripoint_rel_ms &padding() const {
+            return padding_;
+        }
+        void set_padding( const tripoint_rel_ms &v ) {
+            padding_ = v;
+        }
 
-    pathfinding_settings &operator=( const pathfinding_settings & ) = default;
+    private:
+        bool allow_flying_ = false;
+        bool allow_falling_ = false;
+        bool allow_stairways_ = false;
+        int max_cost_ = 0;
+        tripoint_rel_ms padding_ = tripoint_rel_ms( 16, 16, 1 );
+};
+
+
+// Characteristics of pathfinding as they relate to how an individual creature
+// reacts to an individual terrain tile. Attributes that relate to how a creature
+// may react to movement that affects Z-Levels, or that act on parameters of the
+// pathfinding algorithm (e.g. max_cost_ or padding), belong in RealityBubblePathfindingSettings.
+//
+// For example, a creature may want to avoid lava, unsheltered terrain, etc.
+// Under the hood, a PathfindingFlags instance is used. This allows us to avoid
+// any tile with an attribute corresponding to a PathfindingFlag.
+//
+// All values except avoid impassible initialise to false.
+class PathfindingSettings
+{
+    public:
+        static constexpr PathfindingFlags RoughTerrain = PathfindingFlag::Slow | PathfindingFlag::Obstacle |
+                PathfindingFlag::Vehicle | PathfindingFlag::Sharp | PathfindingFlag::DangerousTrap;
+        static constexpr PathfindingFlags AnySizeRestriction = PathfindingFlag::RestrictTiny |
+                PathfindingFlag::RestrictSmall |
+                PathfindingFlag::RestrictMedium | PathfindingFlag::RestrictLarge | PathfindingFlag::RestrictHuge;
+
+        bool avoid_falling() const {
+            return !rb_settings_.allow_falling();
+        }
+        void set_avoid_falling( bool v = true ) {
+            rb_settings_.set_allow_falling( !v );
+        }
+
+        bool avoid_unsheltered() const {
+            return is_set( PathfindingFlag::Unsheltered );
+        }
+        void set_avoid_unsheltered( bool v = true ) {
+            set( PathfindingFlag::Unsheltered, v );
+        }
+
+        bool avoid_swimming() const {
+            return is_set( PathfindingFlag::Swimmable );
+        }
+        void set_avoid_swimming( bool v = true ) {
+            set( PathfindingFlag::Swimmable, v );
+        }
+
+        bool avoid_ground() const {
+            return is_set( PathfindingFlag::Ground );
+        }
+        void set_avoid_ground( bool v = true ) {
+            set( PathfindingFlag::Ground, v );
+        }
+
+        bool avoid_vehicle() const {
+            return is_set( PathfindingFlag::Vehicle );
+        }
+        void set_avoid_vehicle( bool v = true ) {
+            set( PathfindingFlag::Vehicle, v );
+        }
+
+        // This refers to climbing within the context of moving on the same
+        // z-level, e.g. over a fence.
+        bool avoid_climbing() const {
+            return avoid_climbing_;
+        }
+        void set_avoid_climbing( bool v = true ) {
+            avoid_climbing_ = v;
+            maybe_set_avoid_obstacle();
+        }
+
+        bool avoid_climb_stairway() const {
+            return !rb_settings_.allow_stairways();
+        }
+        void set_avoid_climb_stairway( bool v = true ) {
+            rb_settings_.set_allow_stairways( !v );
+        }
+
+        bool avoid_deep_water() const {
+            return is_set( PathfindingFlag::DeepWater );
+        }
+        void set_avoid_deep_water( bool v = true ) {
+            set( PathfindingFlag::DeepWater, v );
+        }
+
+        std::optional<creature_size> size_restriction() const {
+            return size_restriction_;
+        }
+        PathfindingFlags size_restriction_mask() const {
+            return size_restriction_mask_;
+        }
+        void set_size_restriction( std::optional<creature_size> size_restriction = std::nullopt );
+
+        bool avoid_pits() const {
+            return is_set( PathfindingFlag::Pit );
+        }
+        void set_avoid_pits( bool v = true ) {
+            set( PathfindingFlag::Pit, v );
+        }
+
+        bool avoid_opening_doors() const {
+            return avoid_opening_doors_;
+        }
+        void set_avoid_opening_doors( bool v = true ) {
+            avoid_opening_doors_ = v;
+            maybe_set_avoid_obstacle();
+        }
+
+        bool avoid_unlocking_doors() const {
+            return avoid_unlocking_doors_;
+        }
+        void set_avoid_unlocking_doors( bool v = true ) {
+            avoid_unlocking_doors_ = v;
+        }
+
+        bool avoid_rough_terrain() const {
+            return is_set( RoughTerrain );
+        }
+        void set_avoid_rough_terrain( bool v = true ) {
+            set( RoughTerrain, v );
+        }
+
+        bool avoid_dangerous_traps() const {
+            return is_set( PathfindingFlag::DangerousTrap );
+        }
+        void set_avoid_dangerous_traps( bool v ) {
+            set( PathfindingFlag::DangerousTrap, v );
+        }
+
+        bool avoid_sharp() const {
+            return is_set( PathfindingFlag::Sharp );
+        }
+        void set_avoid_sharp( bool v = true ) {
+            set( PathfindingFlag::Sharp, v );
+        }
+
+        bool avoid_lava() const {
+            return is_set( PathfindingFlag::Lava );
+        }
+        void set_avoid_lava( bool v = true ) {
+            set( PathfindingFlag::Lava, v );
+        }
+
+        bool avoid_hard_ground() const {
+            return is_set( PathfindingFlag::HardGround );
+        }
+        void set_avoid_hard_ground( bool v = true ) {
+            set( PathfindingFlag::HardGround, v );
+        }
+
+        bool avoid_dangerous_fields() const {
+            return is_set( PathfindingFlag::DangerousField );
+        }
+        void set_avoid_dangerous_fields( bool v = true ) {
+            set( PathfindingFlag::DangerousField, v );
+        }
+
+        const std::function<bool( const tripoint_bub_ms & )> &maybe_avoid_fn() const {
+            return maybe_avoid_fn_;
+        }
+        void set_maybe_avoid_fn( std::function<bool( const tripoint_bub_ms & )> fn = nullptr ) {
+            maybe_avoid_fn_ = std::move( fn );
+        }
+
+        int max_distance() const {
+            return max_distance_;
+        }
+        void set_max_distance( int v = 0 ) {
+            max_distance_ = v;
+        }
+
+        // TODO: For now, max cost is often set as max_dist * 50. This should be audited.
+        int max_cost() const {
+            return rb_settings_.max_cost();
+        }
+        void set_max_cost( int v = 0 ) {
+            rb_settings_.set_max_cost( v );
+        }
+
+        int climb_cost() const {
+            return climb_cost_;
+        }
+        void set_climb_cost( int v = 0 ) {
+            climb_cost_ = v;
+            maybe_set_avoid_obstacle();
+        }
+
+        bool is_digging() const {
+            return is_digging_;
+        }
+        void set_is_digging( bool v = true ) {
+            is_digging_ = v;
+            maybe_set_avoid_obstacle();
+        }
+
+        bool is_flying() const {
+            return rb_settings_.allow_flying();
+        }
+        void set_is_flying( bool v = true ) {
+            rb_settings_.set_allow_flying( v );
+        }
+
+        PathfindingFlags avoid_mask() const {
+            return avoid_mask_;
+        }
+
+        bool avoid_bashing() const {
+            return avoid_bashing_;
+        }
+        void set_avoid_bashing( bool v = true ) {
+            avoid_bashing_ = v;
+            maybe_set_avoid_obstacle();
+        }
+
+        std::map<damage_type_id, int> bash_strength() const {
+            return bash_strength_;
+        }
+        void set_bash_strength( damage_type_id damage_type, int strength ) {
+            bash_strength_.insert( {damage_type, strength } );
+            if( strength <= 0 && bash_strength_.empty() ) {
+                set_avoid_bashing( true );
+            }
+            maybe_set_avoid_obstacle();
+        }
+
+        void set_bash_strength( std::map<damage_type_id, int> bash_strength ) {
+            bash_strength_ = bash_strength;
+            if( bash_strength_.empty() ||
+            std::all_of( bash_strength_.begin(), bash_strength_.end(), []( const auto & p ) {
+            return p.second <= 0;
+        } ) ) {
+                set_avoid_bashing( true );
+            }
+
+            maybe_set_avoid_obstacle();
+        }
+
+
+        // TODO: Is this function useful?
+        //int bash_rating_from_range( int min, int max ) const;
+
+    protected:
+        const RealityBubblePathfindingSettings &rb_settings() const {
+            return rb_settings_;
+        }
+
+    private:
+        bool is_set( PathfindingFlags flag ) const {
+            return avoid_mask_.is_set( flag );
+        }
+        // Set the corresponding flags to true if v, and false if not v.
+        void set( PathfindingFlags flags, bool v ) {
+            if( v ) {
+                avoid_mask_.set_union( flags );
+            } else {
+                avoid_mask_.set_clear( flags );
+            }
+        }
+
+        void maybe_set_avoid_obstacle() {
+            // Check if we can short circuit checking obstacles. Significantly faster if so.
+            set( PathfindingFlag::Obstacle, !is_digging() && ( climb_cost() <= 0 || avoid_climbing() ) &&
+                 avoid_opening_doors() && ( avoid_bashing() || bash_strength().empty() ) );
+        }
+
+        PathfindingFlags avoid_mask_ = PathfindingFlag::Impassable;
+
+        std::optional<creature_size> size_restriction_;
+        PathfindingFlags size_restriction_mask_;
+        int max_distance_ = 0;
+
+        bool avoid_bashing_ = false;
+        std::map<damage_type_id, int> bash_strength_;
+
+        // Expected terrain cost (2 is flat ground) of climbing a wire fence, 0 means no climbing
+        bool avoid_climbing_ = false;
+        int climb_cost_ = 0;
+
+        bool is_digging_ = false;
+        RealityBubblePathfindingSettings rb_settings_;
+
+        bool avoid_opening_doors_ = false;
+        bool avoid_unlocking_doors_ = false;
+        std::function<bool( const tripoint_bub_ms & )> maybe_avoid_fn_;
 };
 
 struct pathfinding_target {


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Work towards finishing #75945.

#### Describe the solution

`PathfindingSettings` is the direct replacement for the old struct. It stores how the creature will react to a given terrain, and what actions they can take. `RealityBubblePathfindingSettings` contains settings that govern z-level movement and parameters related to pathfinding, such as the maximum path cost.

Currently the extra features of these two classes are completely unused, as they are intended for integration with the new pathfinder.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
