### PR TITLE
Fix: Show consistent healing quality

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1759,8 +1759,8 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
 
         // Force intensity if it is duration based
         if( e.get_int_dur_factor() != 0_turns ) {
-            // + 1 here so that the lowest is intensity 1, not 0
-            e.set_intensity( e.get_duration() / e.get_int_dur_factor() + 1 );
+            const int intensity = std::ceil( e.get_duration() / e.get_int_dur_factor() );
+            e.set_intensity( std::max( 1, intensity ) );
         }
         // Bound new effect intensity by [1, max intensity]
         if( e.get_intensity() < 1 ) {

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1083,8 +1083,8 @@ void effect::set_duration( const time_duration &dur, bool alert )
 
     // Force intensity if it is duration based
     if( eff_type->int_dur_factor != 0_turns ) {
-        // + 1 here so that the lowest is intensity 1, not 0
-        set_intensity( duration / eff_type->int_dur_factor + 1, alert );
+        const int intensity = std::ceil( duration / eff_type->int_dur_factor );
+        set_intensity( std::max( 1, intensity ), alert );
     }
 
     add_msg_debug( debugmode::DF_EFFECT, "ID: %s, Duration %s", get_id().c_str(),

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3588,19 +3588,19 @@ int heal_actor::finish_using( Character &healer, Character &patient, item &it,
 
     // apply healing over time effects
     if( bandages_power > 0 ) {
-        int bandages_intensity = get_bandaged_level( healer );
+        int bandages_intensity = std::max( 1, get_bandaged_level( healer ) );
         patient.add_effect( effect_bandaged, 1_turns, healed );
         effect &e = patient.get_effect( effect_bandaged, healed );
-        e.set_duration( e.get_int_dur_factor() * ( bandages_intensity + 0.5f ) );
+        e.set_duration( e.get_int_dur_factor() * bandages_intensity );
         patient.set_part_damage_bandaged( healed,
                                           patient.get_part_hp_max( healed ) - patient.get_part_hp_cur( healed ) );
         practice_amount += 2 * bandages_intensity;
     }
     if( disinfectant_power > 0 ) {
-        int disinfectant_intensity = get_disinfected_level( healer );
+        int disinfectant_intensity = std::max( 1, get_disinfected_level( healer ) );
         patient.add_effect( effect_disinfected, 1_turns, healed );
         effect &e = patient.get_effect( effect_disinfected, healed );
-        e.set_duration( e.get_int_dur_factor() * ( disinfectant_intensity + 0.5f ) );
+        e.set_duration( e.get_int_dur_factor() * disinfectant_intensity );
         patient.set_part_damage_disinfected( healed,
                                              patient.get_part_hp_max( healed ) - patient.get_part_hp_cur( healed ) );
         practice_amount += 2 * disinfectant_intensity;

--- a/tests/effect_test.cpp
+++ b/tests/effect_test.cpp
@@ -111,12 +111,12 @@ TEST_CASE( "effect_duration", "[effect][duration]" )
     //
     // "id": "drunk",
     // "name": [ "Tipsy", "Drunk", "Trashed", "Wasted" ],
-    // "max_intensity": 4,
+    // "max_intensity": 3,
     // "apply_message": "You feel lightheaded.",
     // "int_dur_factor": 1000,
     //
     // It has "int_dur_factor": 1000, meaning that its intensity will always be equal to its duration /
-    // 1000 rounded up, and it has "max_intensity": 4 meaning the highest its intensity will go is 4 at
+    // 1000 rounded up, and it has "max_intensity": 3 meaning the highest its intensity will go is 3 at
     // a duration of 3000 or higher.
     SECTION( "set_duration modifies intensity if effect is duration-based" ) {
         effect eff_intense( effect_source::empty(), &effect_intensified.obj(), 1_turns, body_part_bp_null,
@@ -127,16 +127,24 @@ TEST_CASE( "effect_duration", "[effect][duration]" )
         eff_intense.set_duration( 0_seconds );
         CHECK( eff_intense.get_intensity() == 1 );
 
-        // At duration == int_dur_factor, intensity is 2
+        // At duration == int_dur_factor, intensity is 1
         eff_intense.set_duration( 1_minutes );
+        CHECK( eff_intense.get_intensity() == 1 );
+
+        // At duration == 2 * int_dur_factor, intensity is 2
+        eff_intense.set_duration( 2_minutes );
         CHECK( eff_intense.get_intensity() == 2 );
 
-        // At duration == 2 * int_dur_factor, intensity is 3
-        eff_intense.set_duration( 2_minutes );
+        // At duration == (2m1s) * int_dur_factor, intensity is 3 (rounds up)
+        eff_intense.set_duration( 2_minutes + 1_seconds );
         CHECK( eff_intense.get_intensity() == 3 );
 
         // At duration == 3 * int_dur_factor, intensity is still 3
         eff_intense.set_duration( 3_minutes );
+        CHECK( eff_intense.get_intensity() == 3 );
+
+        // At duration == 4 * int_dur_factor, intensity is still 3
+        eff_intense.set_duration( 4_minutes );
         CHECK( eff_intense.get_intensity() == 3 );
     }
 }


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Show consistent healing quality"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes an issue where healing qualities shown when applying a bandage was different than the applied quality. Fixes #75736 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This is a continuation of the nice investigation that was done in #75857 .

The problem before was:
* For example, applying an adhesive bandage with "wound care" proficiency should give bandaging intensity 2, as returned from `get_bandaged_level` - this is correct.
* The `bandaged` effect as defined in `effects.json` specifies `int_dur_factor=6h`, so the intensity of this effect should be defined by setting its duration as multiples of `int_dur_factor`.
* When calculating the duration for the created effect, the code previously added `0.5f` to the desired intensity, likely to prevent it from getting 0. <- This was one part of the previous problem.
* In `effect::set_duration`, the intensity is calculated from how many multiples of `int_dur_factor` that the desired `duration` is. That calulation added 1 to the desired intensity, likely to also prevent it from being 0. <- This was the second problem before.
* In effect, instead of applying intensity 2 for an adhesive bandage, the code previously applied intensity 3.5 .

With this commit, we instead use `std::max(1, intensity)` to prevent intensity from being 0. This commit also adds a debugmsg if the calculation of intensity based on the duration would start to differ from the expected values some time in the future.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Applied adhesive bandage. Now shows the same bandage quality when choosing body part as the applied quality. ✓
* Applied bandage. Now shows the same bandage quality when choosing body part as the applied quality. ✓
* Applied antiseptic. Now shows the same disinfection quality when choosing body part as the applied quality. ✓
* Debug-spawned some flaming eyes. Had a staring contest. Threw up. Effect "touched mind" and "badly touched mind" is still applied as expected (to verify that other effects still work). ✓

![consistent-healing-quality](https://github.com/user-attachments/assets/3970ae58-4771-47ea-80e1-fba519f1cdcc)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
