### PR TITLE
Fix placement of the aftershock landing pad

### DIFF
--- a/data/mods/Aftershock/maps/overmap_specials.json
+++ b/data/mods/Aftershock/maps/overmap_specials.json
@@ -13,7 +13,7 @@
     "type": "overmap_special",
     "id": "landing_pad",
     "locations": [ "land", "swamp" ],
-    "city_distance": [ -1, -1 ],
+    "city_distance": [ 0, -1 ],
     "city_sizes": [ 0, -1 ],
     "occurrences": [ 1, 1 ],
     "overmaps": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Aftershock: fix placement of the landing pad"

#### Purpose of change
Bug reported through discord.

#### Describe the solution
Turns out `city_sizing: [-1,-1]` can cause issues with placement.

#### Testing
Made three characters to no errors compared with always getting the error without this change.

