### PR TITLE
[CR] Stop warning the player about harmless critters

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4537,7 +4537,8 @@ void game::mon_info_update( )
                                       mon_dist,
                                       u.controlling_vehicle ) == rule_state::BLACKLISTED;
             } else {
-                need_processing =  MATT_ATTACK == matt || MATT_FOLLOW == matt;
+                need_processing =  MATT_ATTACK == matt || ( MATT_FOLLOW == matt &&
+                                   critter.get_dest() == u.get_location() );
             }
             if( need_processing ) {
                 if( index < 8 && critter.sees( get_player_character() ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Safe mode only default warns about aggressive creatures that are actually targeting you"

#### Purpose of change
You see a black rat! Stop driving?

You see a painted turtle! Stop driving?

#### Describe the solution
MATT_FOLLOW is only considered dangerous if they're following *you*

Prevents e.g. bear cubs following their mother triggering safemode

#### Describe alternatives you've considered
Just removing these animals/toning down their aggression values because it doesn't really serve any useful purpose

#### Testing
I honestly don't know a good way to thoroughly test this.

I don't know when MATT_FOLLOW is usually set, so this might not be a good idea.

#### Additional context
Putting this up as draft before I lose it in the shuffle