### PR TITLE
Add Portuguese (Portugal) to options menu

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -331,6 +331,8 @@ static void AddGlyphRangesFromCLDR( ImFontGlyphRangesBuilder *b, const std::stri
     } else if( lang == "pl" ) {
         AddGlyphRangesFromCLDRForPL( b );
     } else if( lang == "pt_BR" ) {
+        AddGlyphRangesFromCLDRForPL( b );
+    } else if( lang == "pt_PT" ) {
         AddGlyphRangesFromCLDRForPT( b );
     } else if( lang == "ru" ) {
         AddGlyphRangesFromCLDRForRU( b );

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -331,7 +331,7 @@ static void AddGlyphRangesFromCLDR( ImFontGlyphRangesBuilder *b, const std::stri
     } else if( lang == "pl" ) {
         AddGlyphRangesFromCLDRForPL( b );
     } else if( lang == "pt_BR" ) {
-        AddGlyphRangesFromCLDRForPL( b );
+        AddGlyphRangesFromCLDRForPT( b );
     } else if( lang == "pt_PT" ) {
         AddGlyphRangesFromCLDRForPT( b );
     } else if( lang == "ru" ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1338,7 +1338,7 @@ std::vector<options_manager::id_and_option> options_manager::get_lang_options()
         { "", to_translation( "System language" ) },
     };
 
-    constexpr std::array<std::pair<const char *, const char *>, 25> language_names = {{
+    constexpr std::array<std::pair<const char *, const char *>, 26> language_names = {{
             // Note: language names are in their own language and are *not* translated at all.
             // Note: Somewhere in Github PR was better link to msdn.microsoft.com with language names.
             // http://en.wikipedia.org/wiki/List_of_language_names

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1361,6 +1361,7 @@ std::vector<options_manager::id_and_option> options_manager::get_lang_options()
             { "nl", R"(Nederlands)" },
             { "pl", R"(Polski)" },
             { "pt_BR", R"(Português (Brasil))" },
+            { "pt_PT", R"(Português (Portugal))" },
             { "ru", R"(Русский)" },
             { "sr", R"(Српски)" },
             { "tr", R"(Türkçe)" },

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4246,6 +4246,8 @@ void options_manager::update_global_locale()
             std::locale::global( std::locale( "pl_PL.UTF-8" ) );
         } else if( lang == "pt_BR" ) {
             std::locale::global( std::locale( "pt_BR.UTF-8" ) );
+        } else if( lang == "pt_PT" ) {
+            std::locale::global( std::locale( "pt_PT.UTF-8" ) );
         } else if( lang == "ru" ) {
             std::locale::global( std::locale( "ru_RU.UTF-8" ) );
         } else if( lang == "sr" ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Allow Portuguese language to be selected in game"

#### Purpose of change
 As of now, the Portuguese (Portugal) translation file is included in the compiled game, but is not selectable due to lacking entries in options.cpp and cata_imgui.cpp. This fixes that.

#### Describe the solution
Modify options.cpp and cata_imgui.cpp to include Portuguese (Portugal) in their lists of languages.

#### Testing
Admittedly, I have not tested this, as I have not compiled the game myself, but the code changes are trivial. I'm just following the existing pattern and structure in each list, and referencing IBM's list of valid locales to make sure that there were no typos.

#### Additional context
This is my very first PR! I hope that I have followed all procedures properly.
