### PR TITLE
Fix compiling with HEADERPOPULARITY=1

### DIFF
--- a/src/text.cpp
+++ b/src/text.cpp
@@ -1,6 +1,6 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
-#include "third-party/imgui/imgui.h"
-#include "third-party/imgui/imgui_internal.h"
+#include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"
 #undef IMGUI_DEFINE_MATH_OPERATORS
 
 #include "color.h"

--- a/src/third-party/imgui/imgui.h
+++ b/src/third-party/imgui/imgui.h
@@ -47,9 +47,6 @@ Index of this file:
 */
 
 #pragma once
-// NOLINTBEGIN
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
 
 // Configuration file with compile-time options
 // (edit imconfig.h or '#define IMGUI_USER_CONFIG "myfilename.h" from your build system')
@@ -3174,5 +3171,3 @@ enum ImGuiModFlags_ { ImGuiModFlags_None = 0, ImGuiModFlags_Ctrl = ImGuiMod_Ctrl
 #endif
 
 #endif // #ifndef IMGUI_DISABLE
-#pragma GCC diagnostic pop
-// NOLINTEND

--- a/src/third-party/imgui/imgui_impl_sdl2.h
+++ b/src/third-party/imgui/imgui_impl_sdl2.h
@@ -18,10 +18,6 @@
 #pragma once
 #include "imgui.h"      // IMGUI_IMPL_API
 
-// NOLINTBEGIN
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-
 struct SDL_Window;
 struct SDL_Renderer;
 typedef union SDL_Event SDL_Event;
@@ -38,6 +34,3 @@ IMGUI_IMPL_API bool     ImGui_ImplSDL2_ProcessEvent(const SDL_Event* event);
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 static inline void ImGui_ImplSDL2_NewFrame(SDL_Window*) { ImGui_ImplSDL2_NewFrame(); } // 1.84: removed unnecessary parameter
 #endif
-
-#pragma GCC diagnostic pop
-// NOLINTEND

--- a/src/third-party/imgui/imgui_impl_sdlrenderer2.h
+++ b/src/third-party/imgui/imgui_impl_sdlrenderer2.h
@@ -15,10 +15,6 @@
 #include <functional>
 #include "imgui.h"      // IMGUI_IMPL_API
 
-// NOLINTBEGIN
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-
 struct SDL_Renderer;
 
 IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer2_Init(SDL_Renderer* renderer);
@@ -32,6 +28,3 @@ IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer2_CreateFontsTexture();
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer2_DestroyFontsTexture();
 IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer2_CreateDeviceObjects();
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer2_DestroyDeviceObjects();
-
-#pragma GCC diagnostic pop
-// NOLINTEND

--- a/src/third-party/imgui/imgui_internal.h
+++ b/src/third-party/imgui/imgui_internal.h
@@ -42,9 +42,6 @@ Index of this file:
 */
 
 #pragma once
-// NOLINTBEGIN
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
 
 #ifndef IMGUI_DISABLE
 
@@ -3312,5 +3309,3 @@ extern const char*  ImGuiTestEngine_FindItemDebugLabel(ImGuiContext* ctx, ImGuiI
 #endif
 
 #endif // #ifndef IMGUI_DISABLE
-#pragma GCC diagnostic pop
-// NOLINTEND

--- a/src/third-party/imgui/imstb_rectpack.h
+++ b/src/third-party/imgui/imstb_rectpack.h
@@ -70,10 +70,6 @@
 #ifndef STB_INCLUDE_STB_RECT_PACK_H
 #define STB_INCLUDE_STB_RECT_PACK_H
 
-// NOLINTBEGIN
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-
 #define STB_RECT_PACK_VERSION  1
 
 #ifdef STBRP_STATIC
@@ -629,6 +625,3 @@ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ------------------------------------------------------------------------------
 */
-
-#pragma GCC diagnostic pop
-// NOLINTEND

--- a/src/third-party/imgui/imstb_textedit.h
+++ b/src/third-party/imgui/imstb_textedit.h
@@ -277,10 +277,6 @@
 #ifndef INCLUDE_STB_TEXTEDIT_H
 #define INCLUDE_STB_TEXTEDIT_H
 
-// NOLINTBEGIN
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-
 ////////////////////////////////////////////////////////////////////////
 //
 //     STB_TexteditState
@@ -1439,6 +1435,3 @@ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ------------------------------------------------------------------------------
 */
-
-#pragma GCC diagnostic pop
-// NOLINTEND

--- a/src/third-party/imgui/imstb_truetype.h
+++ b/src/third-party/imgui/imstb_truetype.h
@@ -271,10 +271,6 @@
 //   Inline sort     :  6.54 s     5.65 s
 //   New rasterizer  :  5.63 s     5.00 s
 
-// NOLINTBEGIN
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 ////
@@ -5087,6 +5083,3 @@ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ------------------------------------------------------------------------------
 */
-
-#pragma GCC diagnostic pop
-// NOLINTEND


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

#76513 added includes to third-party files in a way that caused some issues.

#### Describe the solution

Fix the includes and remove the lint changes from imgui files that I also assume aren't needed anymore.

#### Describe alternatives you've considered



#### Testing

Compiled with ```make -j$((`nproc`+0)) CCACHE=1 RELEASE=1 MSYS2=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=0 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 TESTS=0 HEADERPOPULARITY=1``` with MSYS2 without errors.

#### Additional context

