### PR TITLE
Return a few persk that were removed by accident

### DIFF
--- a/data/mods/Defense_Mode/mod_interactions/bombastic_perks/perks.json
+++ b/data/mods/Defense_Mode/mod_interactions/bombastic_perks/perks.json
@@ -32,6 +32,49 @@
     "name": { "str": "Knifey" },
     "points": 0,
     "description": "You're very in tune with the ways of stabbing somebody.",
-    "enchantments": [ { "melee_damage_bonus": [ { "type": "stab", "add": 5 } ] } ]
+    "enchantments": [ { "melee_damage_bonus": [ { "type": "stab", "add": 5 } ] } ],
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_melee_master",
+    "name": { "str": "Melee Master" },
+    "points": 0,
+    "description": "You've become a master of melee, and are skilled with melee weapons.",
+    "enchantments": [
+      {
+        "condition": { "not": "u_has_weapon" },
+        "melee_damage_bonus": [ { "type": "cut", "add": 10 }, { "type": "stab", "add": 10 }, { "type": "bash", "add": 10 } ]
+      }
+    ],
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_gymrat_king",
+    "name": { "str": "Gym Rat King" },
+    "points": 0,
+    "description": "Your time exercising has gotten you used to being winded, and has vastly expanded your stamina.  You can go for longer and harder now.",
+    "category": [ "perk" ],
+    "enchantments": [ { "values": [ { "value": "CARDIO_MULTIPLIER", "multiply": 0.8 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_extra_life",
+    "name": { "str": "Living on a Prayer" },
+    "points": 0,
+    "description": "You're like a cat, and it always seemed to you like you've had nine lives.  When things get rough, by pure luck or divine intervention, you can get out of it.",
+    "category": [ "perk" ],
+    "processed_eocs": [ { "id": "extra_life_addup", "effect": { "math": [ "revivication_counter", "++" ] } } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_mysterious_stranger",
+    "name": { "str": "Mysterious Stranger" },
+    "points": 0,
+    "description": "Someone must be watching over you!  Whenever you're in combat, you can call for the help of a stranger for a short amount of time.",
+    "category": [ "perk" ],
+    "active": true,
+    "activated_eocs": [ "mysterious_stranger_activate" ]
   }
 ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
After merging #77662, i by accident spot that i somehow removed a few perks from defence mode/bombastic perks interaction
I have no idea how it happened
#### Describe the solution
Return them back