### PR TITLE
Camp crafting uses the normal crafting GUI

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -5152,5 +5152,15 @@
     "id": "a_winner_is_u",
     "name": [ "Winning!" ],
     "//": "Used to display the winning screen upon winning like a winner."
+  },
+  {
+    "type": "effect_type",
+    "//": "Horrible hack to apply vision flag. Set in C++ basecamp::start_crafting()",
+    "id": "HACK_camp_vision_for_npc",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "good",
+    "flags": [ "EFFECT_LIMB_SCORE_MOD", "CRAFT_IN_DARKNESS", "READ_IN_DARKNESS" ],
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 10 } ]
   }
 ]

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -412,7 +412,7 @@ std::vector<basecamp_upgrade> basecamp::available_upgrades( const point &dir )
 std::unordered_set<recipe_id> basecamp::recipe_deck_all() const
 {
     std::unordered_set<recipe_id> known_recipes;
-    for( npc_ptr guy : assigned_npcs ) {
+    for( const npc_ptr &guy : assigned_npcs ) {
         if( guy.get() ) {
             for( const recipe *rec : guy->get_learned_recipes() ) {
                 known_recipes.insert( rec->ident() );
@@ -420,10 +420,10 @@ std::unordered_set<recipe_id> basecamp::recipe_deck_all() const
         }
     }
 
-    for( auto exp_iter = expansions.begin(); exp_iter != expansions.end(); exp_iter++ ) {
-        for( const auto &provides : exp_iter->second.provides ) {
+    for( const auto &exp_data_pair : expansions ) {
+        for( const auto &provides : exp_data_pair.second.provides ) {
             const auto &test_s = recipe_group::get_recipes_by_id( provides.first );
-            for( std::pair<const recipe_id, translation> rec_list : test_s ) {
+            for( const std::pair<const recipe_id, translation> &rec_list : test_s ) {
                 known_recipes.insert( rec_list.first );
             }
         }

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -409,10 +409,34 @@ std::vector<basecamp_upgrade> basecamp::available_upgrades( const point &dir )
     return ret_data;
 }
 
+std::unordered_set<recipe_id> basecamp::recipe_deck_all() const
+{
+    std::unordered_set<recipe_id> known_recipes;
+    for( npc_ptr guy : assigned_npcs ) {
+        if( guy.get() ) {
+            for( const recipe *rec : guy->get_learned_recipes() ) {
+                known_recipes.insert( rec->ident() );
+            }
+        }
+    }
+
+    for( auto exp_iter = expansions.begin(); exp_iter != expansions.end(); exp_iter++ ) {
+        for( const auto &provides : exp_iter->second.provides ) {
+            const auto &test_s = recipe_group::get_recipes_by_id( provides.first );
+            for( std::pair<const recipe_id, translation> rec_list : test_s ) {
+                known_recipes.insert( rec_list.first );
+            }
+        }
+    }
+
+    return known_recipes;
+}
+
 // recipes and craft support functions
 std::map<recipe_id, translation> basecamp::recipe_deck( const point &dir ) const
 {
     std::map<recipe_id, translation> recipes;
+
     const auto &e = expansions.find( dir );
     if( e == expansions.end() ) {
         return recipes;

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -284,6 +284,8 @@ class basecamp
         std::map<recipe_id, translation> recipe_deck( const point &dir ) const;
         // from a building
         std::map<recipe_id, translation> recipe_deck( const std::string &bldg ) const;
+        // All recipes known by NPCs stationed here + all recipes provided by all expansions
+        std::unordered_set<recipe_id> recipe_deck_all() const;
         int recipe_batch_max( const recipe &making ) const;
         void form_crafting_inventory();
         void form_crafting_inventory( map &target_map );
@@ -332,7 +334,7 @@ class basecamp
 
         // mission description functions
         void add_available_recipes( mission_data &mission_key, mission_kind kind, const point &dir,
-                                    const std::map<recipe_id, translation> &craft_recipes );
+                                    const std::unordered_set<recipe_id> &craft_recipes );
 
         std::string recruit_description( int npc_count ) const;
         /// Provides a "guess" for some of the things your gatherers will return with

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -367,7 +367,7 @@ class basecamp
                                bool must_feed, const std::string &desc, bool group,
                                const std::vector<item *> &equipment, float exertion_level,
                                const std::map<skill_id, int> &required_skills = {},
-                               npc_ptr preselected_choice = nullptr );
+                               const npc_ptr &preselected_choice = nullptr );
         comp_list start_multi_mission( const mission_id &miss_id,
                                        bool must_feed, const std::string &desc,
                                        // const std::vector<item*>& equipment, //  No support for extracting equipment from recipes currently..

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -333,8 +333,7 @@ class basecamp
         void place_results( const item &result );
 
         // mission description functions
-        void add_available_recipes( mission_data &mission_key, mission_kind kind, const point &dir,
-                                    const std::unordered_set<recipe_id> &craft_recipes );
+        void add_available_recipes( mission_data &mission_key, mission_kind kind, const point &dir );
 
         std::string recruit_description( int npc_count ) const;
         /// Provides a "guess" for some of the things your gatherers will return with
@@ -367,7 +366,8 @@ class basecamp
         npc_ptr start_mission( const mission_id &miss_id, time_duration duration,
                                bool must_feed, const std::string &desc, bool group,
                                const std::vector<item *> &equipment, float exertion_level,
-                               const std::map<skill_id, int> &required_skills = {} );
+                               const std::map<skill_id, int> &required_skills = {},
+                               npc_ptr preselected_choice = nullptr );
         comp_list start_multi_mission( const mission_id &miss_id,
                                        bool must_feed, const std::string &desc,
                                        // const std::vector<item*>& equipment, //  No support for extracting equipment from recipes currently..
@@ -382,7 +382,9 @@ class basecamp
         void start_menial_labor();
         void worker_assignment_ui();
         void job_assignment_ui();
-        void start_crafting( const std::string &type, const mission_id &miss_id );
+        // Assembles a dummy NPC with all available recipes and uses player input on the regular crafting GUI to
+        // determine what to make, batch size, who to assign to making it, etc.
+        void start_crafting( const mission_id &miss_id );
 
         /// Called when a companion is sent to cut logs
         void start_cut_logs( const mission_id &miss_id, float exertion_level );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -214,10 +214,12 @@ static bool cannot_gain_skill_or_prof( const Character &crafter, const recipe &r
 namespace
 {
 struct availability {
-        explicit availability( Character &_crafter, const recipe *r, int batch_size = 1 ) :
+        explicit availability( Character &_crafter, const recipe *r, int batch_size = 1,
+                               bool camp_crafting = false, inventory *inventory_override = nullptr ) :
             crafter( _crafter ) {
             rec = r;
-            const inventory &inv = crafter.crafting_inventory();
+            inv_override = inventory_override;
+            const inventory &inv = camp_crafting ? *inv_override : crafter.crafting_inventory();
             auto all_items_filter = r->get_component_filter( recipe_filter_flags::none );
             auto no_rotten_filter = r->get_component_filter( recipe_filter_flags::no_rotten );
             auto no_favorite_filter = r->get_component_filter( recipe_filter_flags::no_favorite );
@@ -229,7 +231,7 @@ struct availability {
                                         >= static_cast<int>( rec->get_difficulty( crafter ) * 0.8f );
             has_proficiencies = r->character_has_required_proficiencies( crafter );
             std::string reason;
-            if( crafter.is_npc() && !r->npc_can_craft( reason ) ) {
+            if( crafter.is_npc() && !r->npc_can_craft( reason ) && !camp_crafting ) {
                 can_craft = false;
             } else if( r->is_nested() ) {
                 can_craft = check_can_craft_nested( _crafter, *r );
@@ -264,6 +266,7 @@ struct availability {
         bool has_proficiencies;
         bool has_all_skills;
         bool is_nested_category;
+        inventory *inv_override;
     private:
         const recipe *rec;
         mutable float proficiency_time_maluses = -1.0f;
@@ -457,7 +460,7 @@ static std::vector<std::string> recipe_info(
                           recp.has_flag( flag_BLIND_HARD ) ? _( "Hard" ) :
                           _( "Impossible" ) );
 
-    const inventory &crafting_inv = guy.crafting_inventory();
+    const inventory &crafting_inv = avail.inv_override ? *avail.inv_override : guy.crafting_inventory();
     if( recp.result() ) {
         const int nearby_amount = crafting_inv.count_item( recp.result() );
         std::string nearby_string;
@@ -1207,7 +1210,8 @@ static bool selection_ok( const std::vector<const recipe *> &list, const int cur
 }
 
 std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &batch_size_out,
-        const recipe_id &goto_recipe, Character *crafter, std::string filterstring )
+        const recipe_id &goto_recipe, Character *crafter, std::string filterstring, bool camp_crafting,
+        inventory *inventory_override )
 {
     if( crafter == nullptr ) {
         return {nullptr, nullptr};
@@ -1344,7 +1348,10 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                           crafter ) - crafting_group.begin();
 
     // Get everyone's recipes
-    const recipe_subset &available_recipes = crafter->get_group_available_recipes();
+    // WTF? If called with dummy npc, we have to do this. Why? Why doesn't Character::get_group_available_recipes()
+    // already include get_learned_recipes()?
+    const recipe_subset &available_recipes = camp_crafting ? crafter->get_learned_recipes() :
+            crafter->get_group_available_recipes();
     std::map<character_id, std::map<const recipe *, availability>> guy_availability_cache;
     // next line also inserts empty cache for crafter->getID()
     std::map<const recipe *, availability> *availability_cache =
@@ -1636,7 +1643,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 // cache recipe availability on first display
                 for( const recipe *e : current ) {
                     if( !availability_cache->count( e ) ) {
-                        availability_cache->emplace( e, availability( *crafter, e ) );
+                        availability_cache->emplace( e, availability( *crafter, e, 1, camp_crafting, inventory_override ) );
                     }
                 }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1589,7 +1589,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 current.clear();
                 for( int i = 1; i <= 50; i++ ) {
                     current.push_back( chosen );
-                    available.emplace_back( *crafter, chosen, i );
+                    available.emplace_back( *crafter, chosen, i, camp_crafting, inventory_override );
                 }
                 indent.assign( current.size(), 0 );
             } else {

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -9,6 +9,7 @@
 #include "type_id.h"
 
 class Character;
+class inventory;
 class JsonObject;
 class recipe;
 
@@ -21,7 +22,8 @@ class recipe;
  * Return: if recipe * is not nullptr, then Character * is not nullptr either.
  */
 std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &batch_size_out,
-        const recipe_id &goto_recipe, Character *crafter, std::string filterstring = "" );
+        const recipe_id &goto_recipe, Character *crafter, std::string filterstring = "",
+        bool camp_crafting = false, inventory *inventory_override = nullptr );
 
 void load_recipe_category( const JsonObject &jsobj, const std::string &src );
 void reset_recipe_categories();

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1984,7 +1984,7 @@ npc_ptr basecamp::start_mission( const mission_id &miss_id, time_duration durati
 npc_ptr basecamp::start_mission( const mission_id &miss_id, time_duration duration,
                                  bool must_feed, const std::string &desc, bool /*group*/,
                                  const std::vector<item *> &equipment, float exertion_level,
-                                 const std::map<skill_id, int> &required_skills, npc_ptr preselected_choice )
+                                 const std::map<skill_id, int> &required_skills, const npc_ptr &preselected_choice )
 {
     if( must_feed && fac()->food_supply.kcal() < time_to_food( duration, exertion_level ) ) {
         popup( _( "You don't have enough food stored to feed your companion." ) );
@@ -3512,10 +3512,10 @@ void basecamp::start_crafting( const mission_id &miss_id )
 {
     int num_to_make = 1;
     npc dummy;
-    for( auto &some_known_recipe : recipe_deck_all() ) {
+    for( const recipe_id &some_known_recipe : recipe_deck_all() ) {
         dummy.learn_recipe( &*some_known_recipe );
     }
-    for( npc_ptr guy : assigned_npcs ) {
+    for( const npc_ptr &guy : assigned_npcs ) {
         if( guy.get() ) {
             // give the dummy a combination of all their skills
             for( auto &skill_level_pair : guy->get_all_skills() ) {
@@ -3547,7 +3547,7 @@ void basecamp::start_crafting( const mission_id &miss_id )
     uilist choose_crafter;
     choose_crafter.title = _( "Choose a NPC to craft" );
     int i = 0;
-    for( npc_ptr guy : assigned_npcs ) {
+    for( const npc_ptr &guy : assigned_npcs ) {
         if( guy.get() ) {
             const recipe *r = crafter_recipe_pair.second;
             bool has_skills = r->skill_used.is_null() ||

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1297,9 +1297,10 @@ npc_ptr talk_function::individual_mission( npc &p, const std::string &desc,
 npc_ptr talk_function::individual_mission( const tripoint_abs_omt &omt_pos,
         const std::string &role_id, const std::string &desc,
         const mission_id &miss_id, bool group, const std::vector<item *> &equipment,
-        const std::map<skill_id, int> &required_skills, bool silent_failure )
+        const std::map<skill_id, int> &required_skills, bool silent_failure, npc_ptr preselected_choice )
 {
-    npc_ptr comp = companion_choose( required_skills, silent_failure );
+    npc_ptr comp = preselected_choice ? preselected_choice : companion_choose( required_skills,
+                   silent_failure );
     if( comp == nullptr ) {
         return comp;
     }

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1297,7 +1297,8 @@ npc_ptr talk_function::individual_mission( npc &p, const std::string &desc,
 npc_ptr talk_function::individual_mission( const tripoint_abs_omt &omt_pos,
         const std::string &role_id, const std::string &desc,
         const mission_id &miss_id, bool group, const std::vector<item *> &equipment,
-        const std::map<skill_id, int> &required_skills, bool silent_failure, npc_ptr preselected_choice )
+        const std::map<skill_id, int> &required_skills, bool silent_failure,
+        const npc_ptr &preselected_choice )
 {
     npc_ptr comp = preselected_choice ? preselected_choice : companion_choose( required_skills,
                    silent_failure );

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -185,7 +185,7 @@ npc_ptr individual_mission( const tripoint_abs_omt &omt_pos, const std::string &
                             const std::string &desc, const mission_id &miss_id,
                             bool group = false, const std::vector<item *> &equipment = {},
                             const std::map<skill_id, int> &required_skills = {}, bool silent_failure = false,
-                            npc_ptr preselected_choice = nullptr );
+                            const npc_ptr &preselected_choice = nullptr );
 
 ///All of these missions are associated with the ranch camp and need to be updated/merged into the new ones
 void caravan_return( npc &p, const std::string &dest, const mission_id &miss_id );

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -184,7 +184,8 @@ npc_ptr individual_mission( npc &p, const std::string &desc, const mission_id &m
 npc_ptr individual_mission( const tripoint_abs_omt &omt_pos, const std::string &role_id,
                             const std::string &desc, const mission_id &miss_id,
                             bool group = false, const std::vector<item *> &equipment = {},
-                            const std::map<skill_id, int> &required_skills = {}, bool silent_failure = false );
+                            const std::map<skill_id, int> &required_skills = {}, bool silent_failure = false,
+                            npc_ptr preselected_choice = nullptr );
 
 ///All of these missions are associated with the ranch camp and need to be updated/merged into the new ones
 void caravan_return( npc &p, const std::string &dest, const mission_id &miss_id );


### PR DESCRIPTION
#### Summary
Interface "Camp crafting uses the normal crafting GUI"

#### Purpose of change
Camp crafting is problematic in many ways. Accessing the recipes, manipulating them, seeing if they're available, etc.

![image](https://github.com/user-attachments/assets/e39ac973-8693-4c54-b80a-65e179398573)

We have a perfectly good crafting GUI already, why not use it?

#### Describe the solution
Use the existing crafting GUI.

We shove all the recipes and proficiencies from our camp's NPCs into a dummy, give them access to the camp inventory, and put them into the crafting window. We wait for the return value and instead of doing a normal crafting activity we craft like camps always used to, by off-mapping a chosen NPC.

Essentially we are borrowing the crafting GUI, with a few little changes to make it work for us.

#### Describe alternatives you've considered
Making the mission window searchable/filterable :^)

#### Testing
**DRAFT**


https://github.com/user-attachments/assets/c2d5def9-3153-4bba-ae34-f9a2d70ec967



The draft as posted does not work ~~(inventory is not properly tallied, somehow) and~~ it does not do anything with the recipe selected in the crafting window.

#### Additional context

Known issues:
The flow of recipe selection --> crafter selection is maybe not ideal

Can't see kcal display until after you select a recipe

Descriptions for camp-provided recipes are still loaded and sent for translation, but we don't use them
