### PR TITLE
Show the power draw of battery chargers

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5854,7 +5854,8 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
             }
 
             if( is_running ) {
-                cur_veh.recharge_epower_this_turn -= units::from_watt( recharge_part.info().bonus );
+                cur_veh.recharge_epower_this_turn -= units::from_watt( static_cast<std::int64_t>
+                                                     ( recharge_part.info().bonus ) );
             }
 
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5789,7 +5789,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
         recharge_part.last_charged = calendar::turn;
 
         if( !recharge_part.removed && recharge_part.enabled  && ( turns_elapsed > 0 ) &&
-            cur_veh.connected_battery_power_level().first ) {
+            cur_veh.is_battery_available() ) {
 
             int dischargeable = turns_elapsed * recharge_part.info().bonus;
             // Convert to kilojoule

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5788,13 +5788,22 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
         int turns_elapsed = to_turns<int>( calendar::turn - recharge_part.last_charged );
         recharge_part.last_charged = calendar::turn;
 
-        if( !recharge_part.removed && recharge_part.enabled  && ( turns_elapsed > 0 ) ) {
+        if( !recharge_part.removed && recharge_part.enabled  && ( turns_elapsed > 0 ) &&
+            cur_veh.connected_battery_power_level().first ) {
+
             int dischargeable = turns_elapsed * recharge_part.info().bonus;
             // Convert to kilojoule
             dischargeable = ( dischargeable / 1000 ) + x_in_y( dischargeable % 1000, 1000 );
+
+            bool is_running = false;
+
             for( item &n : cur_veh.get_items( vp ) ) {
 
-                if( dischargeable <= 0 ) {
+                // "dischargeable" could be 0 even if the battery charger is actually running,
+                // because of the rounding when the power is below a kilojoule. Before breaking,
+                // I need to know if there is at least a non-full battery, for the purpose of
+                // displaying the correct power draw.
+                if( is_running && dischargeable <= 0 ) {
                     break;
                 }
 
@@ -5809,6 +5818,13 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                                             n.energy_remaining( nullptr ) ) );
                 } else if( n.ammo_capacity( ammo_battery ) ) {
                     chargeable = n.ammo_capacity( ammo_battery ) - n.ammo_remaining();
+                }
+
+                if( !is_running && chargeable > 0 ) {
+                    is_running = true;
+                    if( dischargeable <= 0 ) {
+                        break;
+                    }
                 }
 
                 if( chargeable > 0 ) {
@@ -5836,6 +5852,11 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                 }
 
             }
+
+            if( is_running ) {
+                cur_veh.recharge_epower_this_turn -= units::from_watt( recharge_part.info().bonus );
+            }
+
         }
     }
 }

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -295,6 +295,13 @@ void veh_app_interact::draw_info()
     }
 
     // Other power output
+    if( veh->has_part( "RECHARGE" ) ) {
+        units::power rate = veh->recharge_epower_this_turn;
+        print_charge( _( "Appliance power consumption: " ), rate, row );
+        row++;
+    }
+
+    // Other power output
     if( !veh->accessories.empty() ) {
         units::power rate = veh->total_accessory_epower();
         print_charge( _( "Appliance power consumption: " ), rate, row );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -295,15 +295,8 @@ void veh_app_interact::draw_info()
     }
 
     // Other power output
-    if( veh->has_part( "RECHARGE" ) ) {
-        units::power rate = veh->recharge_epower_this_turn;
-        print_charge( _( "Appliance power consumption: " ), rate, row );
-        row++;
-    }
-
-    // Other power output
-    if( !veh->accessories.empty() ) {
-        units::power rate = veh->total_accessory_epower();
+    if( !veh->accessories.empty() || veh->has_part( "RECHARGE" ) ) {
+        units::power rate = veh->total_accessory_epower() + veh->recharge_epower_this_turn;
         print_charge( _( "Appliance power consumption: " ), rate, row );
         row++;
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5465,7 +5465,8 @@ units::power vehicle::net_battery_charge_rate( bool include_reactors ) const
 {
     return total_engine_epower() + total_alternator_epower() + total_accessory_epower() +
            total_solar_epower() + total_wind_epower() + total_water_wheel_epower() +
-           linked_item_epower_this_turn + ( include_reactors ? active_reactor_epower() : 0_W );
+           linked_item_epower_this_turn + recharge_epower_this_turn + ( include_reactors ?
+                   active_reactor_epower() : 0_W );
 }
 
 units::power vehicle::active_reactor_epower() const
@@ -6003,6 +6004,7 @@ void vehicle::idle( bool on_map )
     }
 
     linked_item_epower_this_turn = 0_W;
+    recharge_epower_this_turn = 0_W;
     smart_controller_handle_turn();
 
     if( !on_map ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5844,6 +5844,20 @@ static void distribute_charge_evenly( const std::map<vpart_reference, float> &ba
     }
 }
 
+bool vehicle::is_battery_available() const
+{
+    for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles() ) {
+        const vehicle &veh = *pair.first;
+        for( const int part_idx : veh.batteries ) {
+            const vehicle_part &vp = veh.parts[part_idx];
+            if( vp.ammo_remaining() > 0 ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 int64_t vehicle::battery_left( bool apply_loss ) const
 {
     int64_t ret = 0;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1564,6 +1564,11 @@ class vehicle
         std::pair<int, int> connected_battery_power_level() const;
 
         /**
+        * @return true if at least one of the connected batteries has any charge left
+        */
+        bool is_battery_available() const;
+
+        /**
         * @param apply_loss if true apply wire loss when charge crosses vehicle power cables
         * @return battery charge in kJ from all connected batteries
         */

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1544,6 +1544,8 @@ class vehicle
         units::power total_accessory_epower() const;
         // Total power draw from all cable-connected devices. Is cleared every turn during idle().
         units::power linked_item_epower_this_turn; // NOLINT(cata-serialize)
+        // Total power draw from all battery chargers. Is cleared every turn during idle().
+        units::power recharge_epower_this_turn; // NOLINT(cata-serialize)
         // Net power draw or drain on batteries.
         units::power net_battery_charge_rate( bool include_reactors ) const;
         // Maximum available power available from all reactors. Power from


### PR DESCRIPTION
#### Summary
Interface "Display the power draw of battery chargers"

#### Purpose of change
Unlike other vehicle parts, battery chargers consume power on demand when the items it contains are processed. This means that their power consumption isn't fixed when they are enabled, and because of that it isn't displayed like with other vehicle parts. This pull request adds custom code to show the power consumption.

#### Describe the solution
I used as a reference the vehicle/item link code, which has an analogous feature. When the battery charger is processed, we check if it is enabled, if there is any power available in the grid and if it contains any battery that isn't completely charged. If all this conditions are true,  `cur_veh.recharge_epower_this_turn` gets updated by adding the nominal power consumption of the battery charger. `recharge_epower_this_turn` is then used where relevant to show the correct power consumption, and it's reset to 0 every time vehicle::idle is called (which means once every turn).

#### Describe alternatives you've considered
The way this is implemented, there is a 1-turn lag between the conditions changing and the power draw being updated.
There are two ways to fix this (that I know of): either checking the conditions every time the power draw has to be shown, or updating `recharge_epower_this_turn` manually every time something that could change the conditions happens. The link system seems to use the second approach, but in this case even moving/removing a battery from the charger storage can change the power draw. Checking if the source or the destination is a battery charger every time an item is being moved seems excessively expensive to me (but I've not looked into it).

#### Testing
Make a test world, build a vehicle a charged battery and a battery charger, turn the latter on and put an empty battery inside. You can do an analogous test for the appliance version.

#### Additional context
![immagine](https://github.com/user-attachments/assets/c9143402-a216-45d9-882b-8c229529e4d1)

![immagine](https://github.com/user-attachments/assets/ca83b5c4-827e-4dc6-9ab1-3f6eb0583acc)
