### PR TITLE
Reserve space for vectors before allocating in a loop.

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7372,14 +7372,18 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
         if( const std::optional<vpart_reference> ovp = here.veh_at( src_loc ).cargo() ) {
             src_veh = &ovp->vehicle();
             src_part = ovp->part_index();
-            for( item &it : ovp->items() ) {
+            vehicle_stack vp_items = ovp->items();
+            items.reserve( vp_items.size() );
+            for( item &it : vp_items ) {
                 items.emplace_back( &it, true );
             }
         } else {
             src_veh = nullptr;
             src_part = -1;
         }
-        for( item &it : here.i_at( src_loc ) ) {
+        map_stack map_items = here.i_at( src_loc );
+        items.reserve( items.size() + map_items.size() );
+        for( item &it : map_items ) {
             items.emplace_back( &it, false );
         }
 
@@ -7954,11 +7958,13 @@ void wash_activity_actor::finish( player_activity &act, Character &p )
     }
 
     std::vector<item_comp> comps;
+    comps.reserve( 2 );
     comps.emplace_back( itype_water, requirements.water );
     comps.emplace_back( itype_water_clean, requirements.water );
     p.consume_items( comps, 1, is_liquid_crafting_component );
 
     std::vector<item_comp> comps1;
+    comps1.reserve( 3 );
     comps1.emplace_back( itype_soap, requirements.cleanser );
     comps1.emplace_back( itype_detergent, requirements.cleanser );
     comps1.emplace_back( itype_liquid_soap, requirements.cleanser );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1189,6 +1189,8 @@ bool advanced_inventory::move_all_items()
     } else if( dpane.get_area() == AIM_INVENTORY ) {
         std::vector<item_location> target_items;
         std::vector<int> quantities;
+        target_items.reserve( pane_items.size() );
+        quantities.reserve( pane_items.size() );
         for( const drop_or_stash_item_info &drop : pane_items ) {
             target_items.emplace_back( drop.loc() );
             // quantity of 0 means move all
@@ -1207,6 +1209,8 @@ bool advanced_inventory::move_all_items()
 
         std::vector<item_location> target_items;
         std::vector<int> quantities;
+        target_items.reserve( pane_items.size() );
+        quantities.reserve( pane_items.size() );
         for( const drop_or_stash_item_info &drop : pane_items ) {
             target_items.emplace_back( drop.loc() );
             // quantity of 0 means move all

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -769,6 +769,7 @@ void game::draw_line( const tripoint &p, const tripoint &center,
     }
 
     std::vector<tripoint_bub_ms> temp;
+    temp.reserve( points.size() );
     for( const tripoint &it : points ) {
         const tripoint_bub_ms tmp = tripoint_bub_ms( it );
         temp.push_back( tmp );

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -333,6 +333,7 @@ std::vector<std::pair<std::string, std::string>> collect_protection_subvalues(
             const bool display_median, const damage_type_id &type )
 {
     std::vector<std::pair<std::string, std::string>> subvalues;
+    subvalues.reserve( 2 + ( display_median ? 1 : 0 ) );
     subvalues.emplace_back( _( "Worst:" ), string_format( "%.2f",
                             worst_res.type_resist( type ) ) );
     if( display_median ) {

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -1015,7 +1015,7 @@ void basecamp_action_components::consume_components()
     map &target_map = base_.get_camp_map();
     avatar &player_character = get_avatar();
     std::vector<tripoint> src;
-    src.resize( base_.src_set.size() );
+    src.reserve( base_.src_set.size() );
     for( const tripoint_abs_ms &p : base_.src_set ) {
         src.emplace_back( target_map.bub_from_abs( p ).raw() );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1810,6 +1810,7 @@ void Character::forced_dismount()
         mon->mounted_player = nullptr;
     }
     std::vector<tripoint_bub_ms> valid;
+    valid.reserve( 8 );
     for( const tripoint_bub_ms &jk : get_map().points_in_radius( pos_bub(), 1 ) ) {
         if( g->is_empty( jk ) ) {
             valid.push_back( jk );
@@ -7530,6 +7531,7 @@ void Character::vomit()
 tripoint Character::adjacent_tile() const
 {
     std::vector<tripoint> ret;
+    ret.reserve( 4 );
     int dangerous_fields = 0;
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -525,6 +525,7 @@ std::vector<item_location> Character::all_items_loc()
 std::vector<item_location> outfit::top_items_loc( Character &guy )
 {
     std::vector<item_location> ret;
+    ret.reserve( worn.size() );
     for( item &worn_it : worn ) {
         item_location worn_loc( guy, &worn_it );
         ret.push_back( worn_loc );
@@ -625,6 +626,8 @@ void Character::pick_up( const drop_locations &what )
     //todo: refactor pickup_activity_actor to just use drop_locations, also rename drop_locations
     std::vector<item_location> items;
     std::vector<int> quantities;
+    items.reserve( what.size() );
+    quantities.reserve( what.size() );
     for( const drop_location &dl : what ) {
         items.emplace_back( dl.first );
         quantities.emplace_back( dl.second );

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -839,6 +839,7 @@ void color_manager::show_gui()
     point iOffset;
 
     std::vector<int> vLines;
+    vLines.reserve( 2 );
     vLines.push_back( -1 );
     vLines.push_back( 48 );
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -545,6 +545,7 @@ static void monster_ammo_edit( monster &mon )
     char hotkey = 'a';
     const auto &ammo_map = mon.type->starting_ammo;
     std::vector<itype_id> ammos;
+    ammos.reserve( ammo_map.size() );
     for( const std::pair<const itype_id, int> &pair : ammo_map ) {
         ammos.emplace_back( pair.first );
         const itype *display_type = item::find_type( pair.first );

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -891,6 +891,7 @@ std::string effect::disp_desc( bool reduced ) const
     std::vector<std::string> uncommon;
     std::vector<std::string> rare;
     std::vector<desc_freq> values;
+    values.reserve( 9 ); // Pre-allocate space for each value.
     // Add various desc_freq structs to values. If more effects wish to be placed in the descriptions this is the
     // place to add them.
     int val = 0;

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -598,7 +598,6 @@ struct event_transformation_impl : public event_transformation::impl {
         // Need to use list here rather than vector because
         // updatable_value_constraint is not movable.
         std::list<updatable_value_constraint> result;
-        result.resize( constraints_.size() );
         for( const auto &p : constraints_ ) {
             result.emplace_back( p, st, stats );
         }

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -598,6 +598,7 @@ struct event_transformation_impl : public event_transformation::impl {
         // Need to use list here rather than vector because
         // updatable_value_constraint is not movable.
         std::list<updatable_value_constraint> result;
+        result.resize( constraints_.size() );
         for( const auto &p : constraints_ ) {
             result.emplace_back( p, st, stats );
         }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1616,6 +1616,7 @@ void basecamp::choose_new_leader()
         return;
     }
     std::vector<std::string> choices;
+    choices.reserve( 3 );
     int choice = 0;
     choices.emplace_back _( "autocratic" );
     choices.emplace_back _( "sortition" );
@@ -4405,6 +4406,7 @@ void basecamp::recruit_return( const mission_id &miss_id, int score )
         description += _( "Select an option:" );
 
         std::vector<std::string> rec_options;
+        rec_options.reserve( 4 );
         rec_options.emplace_back( _( "Increase Food" ) );
         rec_options.emplace_back( _( "Decrease Food" ) );
         rec_options.emplace_back( _( "Make Offer" ) );
@@ -5077,6 +5079,7 @@ void om_range_mark( const tripoint_abs_omt &origin, int range, bool add_notes,
             note_pts.emplace_back( pos );
         }
     } else {
+        note_pts.reserve( range * 4 - 4 );
         //North Limit
         for( int x = origin.x() - range; x < origin.x() + range + 1; x++ ) {
             note_pts.emplace_back( x, origin.y() - range, origin.z() );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7905,6 +7905,7 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
         }
     }
 
+    ret.reserve( item_order.size() );
     for( auto &elem : item_order ) {
         ret.push_back( temp_items[elem] );
     }
@@ -8166,6 +8167,7 @@ void game::reset_item_list_state( const catacurses::window &window, int height, 
     shortcut_print( window, point( getmaxx( window ) - letters, 0 ), c_white, c_light_green, sSort );
 
     std::vector<std::string> tokens;
+    tokens.reserve( 5 + ( !sFilter.empty() ? 1 : 0 ) );
     if( !sFilter.empty() ) {
         tokens.emplace_back( _( "<R>eset" ) );
     }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -133,6 +133,7 @@ inventory::inventory() = default;
 invslice inventory::slice()
 {
     invslice stacks;
+    stacks.reserve( items.size() );
     for( auto &elem : items ) {
         stacks.push_back( &elem );
     }
@@ -142,6 +143,7 @@ invslice inventory::slice()
 const_invslice inventory::const_slice() const
 {
     const_invslice stacks;
+    stacks.reserve( items.size() );
     for( const auto &item : items ) {
         stacks.push_back( &item );
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4390,6 +4390,7 @@ std::optional<int> iuse::vibe( Character *p, item *it, const tripoint & )
 std::optional<int> iuse::vortex( Character *p, item *it, const tripoint & )
 {
     std::vector<point> spawn;
+    spawn.reserve( 28 );
     for( int i = -3; i <= 3; i++ ) {
         spawn.emplace_back( -3, i );
         spawn.emplace_back( +3, i );
@@ -5813,6 +5814,7 @@ std::optional<int> iuse::einktabletpc( Character *p, item *it, const tripoint & 
                 return std::nullopt;
             }
             std::vector<item_location> targets;
+            targets.reserve( locs.size() );
             for( const auto& [item_loc, count] : locs ) {
                 targets.emplace_back( item_loc );
             }
@@ -9144,6 +9146,7 @@ std::optional<int> iuse::ebooksave( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
     std::vector<item_location> books;
+    books.reserve( to_scan.size() );
     for( const auto &pair : to_scan ) {
         books.push_back( pair.first );
     }

--- a/src/iuse_software_sokoban.cpp
+++ b/src/iuse_software_sokoban.cpp
@@ -246,6 +246,7 @@ int sokoban_game::start_game()
         draw_border( w_sokoban, BORDER_COLOR, _( "Sokoban" ), hilite( c_white ) );
 
         std::vector<std::string> shortcuts;
+        shortcuts.reserve( 5 );
         shortcuts.emplace_back( _( "<+> next" ) ); // '+': next
         shortcuts.emplace_back( _( "<-> prev" ) ); // '-': prev
         shortcuts.emplace_back( _( "<r>eset" ) ); // 'r': reset

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1826,6 +1826,7 @@ std::string spell::list_targeted_monster_names() const
         return "";
     }
     std::vector<std::string> all_valid_monster_names;
+    all_valid_monster_names.reserve( type->targeted_monster_ids.size() );
     for( const mtype_id &mon_id : type->targeted_monster_ids ) {
         all_valid_monster_names.emplace_back( mon_id->nname() );
     }
@@ -1842,6 +1843,7 @@ std::string spell::list_targeted_species_names() const
         return "";
     }
     std::vector<std::string> all_valid_species_names;
+    all_valid_species_names.reserve( type->targeted_species_ids.size() );
     for( const species_id &specie_id : type->targeted_species_ids ) {
         all_valid_species_names.emplace_back( specie_id.str() );
     }
@@ -1858,6 +1860,7 @@ std::string spell::list_ignored_species_names() const
         return "";
     }
     std::vector<std::string> all_valid_species_names;
+    all_valid_species_names.reserve( type->ignored_species_ids.size() );
     for( const species_id &species_id : type->ignored_species_ids ) {
         all_valid_species_names.emplace_back( species_id.str() );
     }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1349,6 +1349,8 @@ static void burned_ground_parser( map &m, const tripoint &loc )
     VehicleList vehs = m.get_vehicles();
     std::vector<vehicle *> vehicles;
     std::vector<tripoint_bub_ms> points;
+    vehicles.reserve( vehs.size() );
+    points.reserve( vehs.size() ); // Each vehicle is at least one point.
     for( wrapped_vehicle vehicle : vehs ) {
         vehicles.push_back( vehicle.v );
         // Important that this loop excludes fake parts, because those can be
@@ -1506,6 +1508,8 @@ static bool mx_burned_ground( map &m, const tripoint &abs_sub )
     VehicleList vehs = m.get_vehicles();
     std::vector<vehicle *> vehicles;
     std::vector<tripoint_bub_ms> points;
+    vehicles.reserve( vehs.size() );
+    points.reserve( vehs.size() ); // Each vehicle is at least one point.
     for( wrapped_vehicle vehicle : vehs ) {
         vehicles.push_back( vehicle.v );
         std::set<tripoint_bub_ms> occupied = vehicle.v->get_points();

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -196,6 +196,8 @@ void mapbuffer::save_quad(
 {
     std::vector<point> offsets;
     std::vector<tripoint_abs_sm> submap_addrs;
+    offsets.reserve( 4 );
+    submap_addrs.reserve( 4 );
     offsets.push_back( point_zero );
     offsets.push_back( point_south );
     offsets.push_back( point_east );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -5845,6 +5845,7 @@ void map::draw_lab( mapgendata &dat )
                             }
                             if( is_ot_match( "stairs", terrain_type, ot_match_type::contains ) ) { // Stairs going down
                                 std::vector<point> stair_points;
+                                stair_points.reserve( 8 );
                                 if( tw != 0 ) {
                                     stair_points.emplace_back( SEEX - 1, 2 );
                                     stair_points.emplace_back( SEEX - 1, 2 );

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -504,7 +504,9 @@ bool string_id<martialart>::is_valid() const
 std::vector<matype_id> all_martialart_types()
 {
     std::vector<matype_id> result;
-    for( const martialart &ma : martialarts.get_all() ) {
+    std::vector<martialart> martial_arts = martialarts.get_all();
+    result.reserve( martial_arts.size() );
+    for( const martialart &ma : martial_arts ) {
         result.push_back( ma.id );
     }
     return result;

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -406,6 +406,7 @@ void mission::wrap_up()
                 items, grp_type, matches,
                 container, itype_null, specific_container_required );
 
+            comps.reserve( matches.size() );
             for( std::pair<const itype_id, int> &cnt : matches ) {
                 comps.emplace_back( cnt.first, cnt.second );
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1593,6 +1593,7 @@ static std::vector<tripoint> get_bashing_zone( const tripoint &bashee, const tri
         int maxdepth )
 {
     std::vector<tripoint> direction;
+    direction.reserve( 2 );
     direction.push_back( bashee );
     direction.push_back( basher );
     // Draw a line from the target through the attacker.

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1085,6 +1085,10 @@ void monster::print_info_imgui() const
 std::vector<std::string> monster::extended_description() const
 {
     std::vector<std::string> tmp;
+    // Reserve the number of elements we know we will need.
+    // Likely we will need more, but it's best to leave that to
+    // exponential growth.
+    tmp.reserve( 12 );
 
     tmp.emplace_back( get_origin( type->src ) );
     tmp.emplace_back( "--" );

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -701,6 +701,7 @@ void player_morale::display( int focus_eq, int pain_penalty, int sleepiness_pena
     }
 
     std::vector<morale_line> bottom_lines;
+    bottom_lines.reserve( 3 ); // We need at least 3 lines.
     bottom_lines.emplace_back( morale_line::separation_line {} );
     bottom_lines.emplace_back(
         _( "Total morale:" ), get_level(),

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1493,6 +1493,7 @@ bool Character::mutation_selector( const std::vector<trait_id> &prospective_trai
 static std::vector<trait_id> get_all_mutation_prereqs( const trait_id &id )
 {
     std::vector<trait_id> ret;
+    ret.reserve( id->prereqs.size() + id->prereqs2.size() ); // Lower bound on size.
     for( const trait_id &it : id->prereqs ) {
         ret.push_back( it );
         std::vector<trait_id> these_prereqs = get_all_mutation_prereqs( it );

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -1150,6 +1150,7 @@ shared_ptr_fast<Trait_group> mutation_branch::get_group( const
 std::vector<trait_group::Trait_group_tag> mutation_branch::get_all_group_names()
 {
     std::vector<trait_group::Trait_group_tag> rval;
+    rval.reserve( trait_groups.size() );
     for( auto &group : trait_groups ) {
         rval.push_back( group.first );
     }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4145,6 +4145,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
 
         werase( w_stats );
         std::vector<std::string> vStatNames;
+        vStatNames.reserve( 4 );
         mvwprintz( w_stats, point_zero, COL_HEADER, _( "Stats:" ) );
         vStatNames.emplace_back( _( "Strength:" ) );
         vStatNames.emplace_back( _( "Dexterity:" ) );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -880,6 +880,7 @@ void starting_clothes( npc &who, const npc_class_id &type, bool male )
     if( item_group::group_is_defined( type->worn_override ) ) {
         ret = item_group::items_from( type->worn_override );
     } else {
+        ret.reserve( 18 );
         ret.push_back( get_clothing_item( type, "pants", male ) );
         ret.push_back( get_clothing_item( type, "shirt", male ) );
         ret.push_back( get_clothing_item( type, "underwear_top", male ) );

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -400,6 +400,7 @@ void Pickup::autopickup( const tripoint &p )
     // which items are we grabbing?
     std::vector<item_stack::iterator> here;
     const map_stack mapitems = local.i_at( p );
+    here.reserve( mapitems.size() );
     for( item_stack::iterator it = mapitems.begin(); it != mapitems.end(); ++it ) {
         here.push_back( it );
     }
@@ -432,6 +433,8 @@ void Pickup::autopickup( const tripoint &p )
     // At this point we've selected our items, register an activity to pick them up.
     std::vector<int> quantities;
     std::vector<item_location> target_items;
+    target_items.reserve( selected_items.size() );
+    quantities.reserve( selected_items.size() );
     for( drop_location selected : selected_items ) {
         item *it = selected.first.get_item();
         target_items.push_back( selected.first );

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -509,6 +509,7 @@ time_duration proficiency_set::training_time_needed( const proficiency_id &query
 std::vector<proficiency_id> proficiency_set::known_profs() const
 {
     std::vector<proficiency_id> ret;
+    ret.reserve( known.size() );
     for( const proficiency_id &knows : known ) {
         ret.push_back( knows );
     }

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -836,6 +836,7 @@ std::vector<std::string> requirement_data::get_folded_tools_list( int width, nc_
         const read_only_visitable &crafting_inv, int batch ) const
 {
     std::vector<std::string> output_buffer;
+    output_buffer.reserve( 2 );
     output_buffer.push_back( colorize( _( "Tools required:" ), col ) );
     if( tools.empty() && qualities.empty() ) {
         output_buffer.push_back( colorize( "> ", col ) + colorize( _( "NONE" ), c_green ) );

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -373,7 +373,9 @@ void scen_blacklist::load( const JsonObject &jo, const std::string_view )
 void scen_blacklist::finalize()
 {
     std::vector<string_id<scenario>> all_scens;
-    for( const scenario &scen : scenario::get_all() ) {
+    std::vector<scenario> all_scenarios = scenario::get_all();
+    all_scens.reserve( all_scenarios.size() );
+    for( const scenario &scen : all_scenarios ) {
         all_scens.emplace_back( scen.ident() );
     }
     for( const string_id<scenario> &sc : sc_blacklist.scenarios ) {

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -1266,6 +1266,7 @@ std::vector<std::tuple<point, int, std::string>> vehicle::get_debug_overlay_data
 {
     static const std::vector<std::string> debug_what = { "valid_position", "omt" };
     std::vector<std::tuple<point, int, std::string>> ret;
+    ret.reserve( collision_check_points.size() );
 
     const tripoint_abs_ms veh_pos = global_square_location();
     if( autodrive_local_target != tripoint_abs_ms_zero ) {

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -71,6 +71,7 @@ bool string_id<VehiclePlacement>::is_valid() const
 std::vector<vproto_id> VehicleGroup::all_possible_results() const
 {
     std::vector<vproto_id> result;
+    result.reserve( vehicles.size() );
     for( const weighted_object<int, vproto_id> &wo : vehicles ) {
         result.push_back( wo.obj );
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1118,6 +1118,7 @@ void vehicle::operate_scoop()
         sounds::sound( bub_part_pos( scoop ), rng( 20, 35 ), sounds::sound_t::combat,
                        random_entry_ref( sound_msgs ), false, "vehicle", "scoop" );
         std::vector<tripoint_bub_ms> parts_points;
+        parts_points.reserve( 8 );
         for( const tripoint_bub_ms &current :
              here.points_in_radius( bub_part_pos( scoop ), 1 ) ) {
             parts_points.push_back( current );


### PR DESCRIPTION

#### Summary
None

#### Purpose of change

Pre-allocating saves doing multiple allocations when we know exactly what size structure we need.

#### Describe the solution

Manually search through the code base for all `push_back` and reserve space if applicable.

#### Describe alternatives you've considered

clang-tidy has a lint for this, but I don't really understand how it's configured for this project plus it's configured for linux. It was easier to do a find than to try and mess with the build settings.

#### Testing
Ran the game before and after. No noticeable performance changes. There are no functionality changes, so nothing should break.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
