### PR TITLE
Aftershock: Make UICA share public goods.

### DIFF
--- a/data/mods/Aftershock/npcs/factions.json
+++ b/data/mods/Aftershock/npcs/factions.json
@@ -96,6 +96,7 @@
     "fac_food_supply": { "calories": 62500000000000, "vitamins": { "iron": 2000000000, "calcium": 2000000000, "vitC": 2000000000 } },
     "wealth": 75000,
     "relations": {
+      "your_followers": { "share public goods": true, "lets you in": true, "knows your voice": true },
       "free_merchants": {
         "kill on sight": false,
         "watch your back": false,


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Fix examination of the map being illegal on the Space Station."

#### Purpose of change
Both the bug and the solution were reported on discord.

#### Describe the solution
Make UICA share public goods with the players faction.

#### Testing
Spawned and interacted with the ATM.