### PR TITLE
Updates for melee enchantment bonuses

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1622,6 +1622,11 @@
     "type": "json_flag"
   },
   {
+    "id": "RELIC_PINK",
+    "//": "For items that do not have relic data, but intended to be magical; changes the color of item to pink",
+    "type": "json_flag"
+  },
+  {
     "id": "MUTAGEN_SAMPLE",
     "type": "json_flag",
     "info": "Used in the <neutral>creation of mutagenic drugs</neutral>."

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3610,7 +3610,7 @@
     "vitamin_cost": 160,
     "visibility": 8,
     "ugliness": 4,
-    "enchantments": [ { "melee_damage_bonus": [ { "type": "stab", "add": 2 } ] } ],
+    "enchantments": [ { "condition": { "not": "u_has_weapon" }, "melee_damage_bonus": [ { "type": "stab", "add": 2 } ] } ],
     "description": "Your skin is covered in small, woody thorns.  Whenever an unarmed opponent strikes a part of your body that is not covered by clothing, they will receive minor damage.  Your punches may also deal extra damage.",
     "prereqs": [ "BARK", "BARK2_a", "BARK2_b", "BARK2_c" ],
     "category": [ "PLANT" ]
@@ -3804,7 +3804,12 @@
     "points": 1,
     "vitamin_cost": 60,
     "visibility": 1,
-    "enchantments": [ { "melee_damage_bonus": [ { "type": "stab", "add": 0.5 } ] } ],
+    "enchantments": [
+      {
+        "condition": { "and": [ { "not": "u_has_weapon" }, { "math": [ "u_encumbrance('hand_l') + u_encumbrance('hand_r') <= 0" ] } ] },
+        "melee_damage_bonus": [ { "type": "stab", "add": 0.5 } ]
+      }
+    ],
     "description": "Your fingernails are long and sharp.  If you aren't wearing gloves, your unarmed attacks deal a minor amount of cutting damage.",
     "types": [ "CLAWS" ],
     "changes_to": [ "CLAWS", "TALONS" ],
@@ -4195,7 +4200,7 @@
     "vitamin_cost": 60,
     "visibility": 5,
     "ugliness": 4,
-    "enchantments": [ { "melee_damage_bonus": [ { "type": "acid", "add": { "math": [ "rng(2, 3)" ] } } ] } ],
+    "enchantments": [ { "condition": { "not": "u_has_weapon" }, "melee_damage_bonus": [ { "type": "acid", "add": 3 } ] } ],
     "description": "The skin on your hands is now a mucous membrane that produces a thick, acrid slime.  Attacks using your hand will cause minor acid damage.  Slightly increases wet benefits.",
     "prereqs": [ "SLIMY" ],
     "category": [ "SLIME" ],

--- a/data/mods/Defense_Mode/mod_interactions/bombastic_perks/perks.json
+++ b/data/mods/Defense_Mode/mod_interactions/bombastic_perks/perks.json
@@ -14,7 +14,7 @@
     "name": { "str": "Slice n' Dice" },
     "points": 0,
     "description": "You've become very skilled with cutting weapons of all sorts, and know how to use them better.",
-    "enchantments": [ { "condition": { "not": "u_has_weapon" }, "melee_damage_bonus": [ { "type": "cut", "add": 5 } ] } ],
+    "enchantments": [ { "condition": { "math": [ "u_melee_damage('cut') > 1" ] }, "melee_damage_bonus": [ { "type": "cut", "add": 5 } ] } ],
     "category": [ "perk" ]
   },
   {
@@ -23,7 +23,9 @@
     "name": { "str": "Bash n' Mash" },
     "points": 0,
     "description": "You've become very skilled with blunt instruments of all sorts, and know how to use them better.",
-    "enchantments": [ { "condition": { "not": "u_has_weapon" }, "melee_damage_bonus": [ { "type": "bash", "add": 5 } ] } ],
+    "enchantments": [
+      { "condition": { "math": [ "u_melee_damage('bash') > 1" ] }, "melee_damage_bonus": [ { "type": "bash", "add": 5 } ] }
+    ],
     "category": [ "perk" ]
   },
   {
@@ -32,7 +34,9 @@
     "name": { "str": "Knifey" },
     "points": 0,
     "description": "You're very in tune with the ways of stabbing somebody.",
-    "enchantments": [ { "melee_damage_bonus": [ { "type": "stab", "add": 5 } ] } ],
+    "enchantments": [
+      { "condition": { "math": [ "u_melee_damage('stab') > 1" ] }, "melee_damage_bonus": [ { "type": "stab", "add": 5 } ] }
+    ],
     "category": [ "perk" ]
   },
   {

--- a/data/mods/Magiclysm/Spells/attunements/Crusader.json
+++ b/data/mods/Magiclysm/Spells/attunements/Crusader.json
@@ -120,14 +120,20 @@
     "material": [ "concentrated_mana" ],
     "weapon_category": [ "LONG_SWORDS", "GREAT_SWORDS" ],
     "techniques": [ "RSTRIKE", "WBLOCK_2", "BRUTAL", "RAPID" ],
-    "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID", "SHEATH_SWORD" ],
+    "flags": [
+      "UNBREAKABLE_MELEE",
+      "NONCONDUCTIVE",
+      "NO_REPAIR",
+      "NO_SALVAGE",
+      "MAGIC_FOCUS",
+      "TRADER_AVOID",
+      "SHEATH_SWORD",
+      "RELIC_PINK"
+    ],
     "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
     "weight": "1067 g",
     "volume": "2750 ml",
     "longest_side": "120cm",
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "pure", "add": 10 } ] } ]
-    },
     "use_action": [
       {
         "target": "dagger_judgement",
@@ -147,7 +153,16 @@
     "color": "light_gray",
     "looks_like": "kris",
     "description": "A short blade made of glowing, radiant fire.  It explodes with radiance when striking enemies.",
-    "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID", "SHEATH_KNIFE" ],
+    "flags": [
+      "UNBREAKABLE_MELEE",
+      "NONCONDUCTIVE",
+      "NO_REPAIR",
+      "NO_SALVAGE",
+      "MAGIC_FOCUS",
+      "TRADER_AVOID",
+      "SHEATH_KNIFE",
+      "RELIC_PINK"
+    ],
     "to_hit": { "grip": "weapon", "length": "hand", "surface": "line", "balance": "good" },
     "weight": "328 g",
     "volume": "750 ml",
@@ -155,9 +170,6 @@
     "material": "concentrated_mana",
     "techniques": [ "RSTRIKE", "WBLOCK_1", "RAPID" ],
     "weapon_category": [ "KNIVES" ],
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "pure", "add": 5 } ] } ]
-    },
     "use_action": [
       {
         "target": "zwei_judgement",
@@ -186,7 +198,8 @@
       "NO_SALVAGE",
       "MAGIC_FOCUS",
       "TRADER_AVOID",
-      "SHEATH_SWORD"
+      "SHEATH_SWORD",
+      "RELIC_PINK"
     ],
     "weight": "1868 g",
     "volume": "3250 ml",
@@ -195,9 +208,6 @@
     "techniques": [ "RSTRIKE", "WBLOCK_1", "WIDE", "BRUTAL", "SWEEP" ],
     "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
     "weapon_category": [ "GREAT_SWORDS" ],
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "pure", "add": 15 } ] } ]
-    },
     "use_action": [
       {
         "target": "qiang_judgement",
@@ -226,7 +236,8 @@
       "NO_SALVAGE",
       "MAGIC_FOCUS",
       "TRADER_AVOID",
-      "SHEATH_SPEAR"
+      "SHEATH_SPEAR",
+      "RELIC_PINK"
     ],
     "weight": "822 g",
     "volume": "2500 ml",
@@ -235,9 +246,6 @@
     "techniques": [ "RSTRIKE", "WBLOCK_1", "IMPALE" ],
     "weapon_category": [ "POLEARMS", "SPEARS" ],
     "to_hit": { "grip": "weapon", "length": "long", "surface": "point", "balance": "neutral" },
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "pure", "add": 11 } ] } ]
-    },
     "use_action": [
       {
         "target": "mace_judgement",
@@ -257,7 +265,16 @@
     "color": "light_gray",
     "looks_like": "mace",
     "description": "A short and hefty mace glowing with radiant fire.  It explodes with radiance when striking enemies.",
-    "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID", "BELT_CLIP" ],
+    "flags": [
+      "UNBREAKABLE_MELEE",
+      "NONCONDUCTIVE",
+      "NO_REPAIR",
+      "NO_SALVAGE",
+      "MAGIC_FOCUS",
+      "TRADER_AVOID",
+      "BELT_CLIP",
+      "RELIC_PINK"
+    ],
     "to_hit": { "grip": "weapon", "length": "short", "surface": "any", "balance": "neutral" },
     "weight": "882 g",
     "volume": "1250 ml",
@@ -265,9 +282,6 @@
     "material": "concentrated_mana",
     "techniques": [ "RSTRIKE", "WBLOCK_1", "SWEEP" ],
     "weapon_category": [ "MACES" ],
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "pure", "add": 13 } ] } ]
-    },
     "use_action": [
       {
         "target": "longsword_judgement",

--- a/data/mods/Magiclysm/items/enchanted_unarmed.json
+++ b/data/mods/Magiclysm/items/enchanted_unarmed.json
@@ -30,10 +30,7 @@
     "weight": "970 g",
     "price_postapoc": "1 kUSD 240 USD",
     "qualities": [ [ "HAMMER", 1 ] ],
-    "flags": [ "ONLY_ONE", "DURABLE_MELEE", "NONCONDUCTIVE", "FLAMING" ],
-    "relic_data": {
-      "passive_effects": [ { "has": "WORN", "condition": { "not": "u_has_weapon" }, "melee_damage_bonus": [ { "type": "heat", "add": 7 } ] } ]
-    },
+    "flags": [ "ONLY_ONE", "DURABLE_MELEE", "NONCONDUCTIVE", "FLAMING", "RELIC_PINK" ],
     "armor": [
       {
         "material": [
@@ -53,7 +50,7 @@
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ]
       }
     ],
-    "melee_damage": { "bash": 2 }
+    "melee_damage": { "bash": 2, "heat": 7 }
   },
   {
     "type": "GENERIC",
@@ -61,10 +58,7 @@
     "copy-from": "flaming_fist",
     "looks_like": "flaming_fist",
     "name": { "str": "flaming fist +1", "str_pl": "flaming fists +1" },
-    "proportional": { "price": 3.0, "weight": 0.9, "melee_damage": { "all": 1.1 } },
-    "relic_data": {
-      "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "heat", "add": 11 } ] } ]
-    },
+    "proportional": { "price": 3.0, "weight": 0.9, "melee_damage": { "all": 1.5 } },
     "relative": { "to_hit": 1 }
   },
   {
@@ -73,10 +67,7 @@
     "copy-from": "flaming_fist",
     "looks_like": "flaming_fist",
     "name": { "str": "flaming fist +2", "str_pl": "flaming fists +2" },
-    "proportional": { "price": 6.0, "weight": 0.8, "melee_damage": { "all": 1.2 } },
-    "relic_data": {
-      "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "heat", "add": 15 } ] } ]
-    },
+    "proportional": { "price": 6.0, "weight": 0.8, "melee_damage": { "all": 2 } },
     "relative": { "to_hit": 2 }
   },
   {

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -237,7 +237,7 @@
     "volume": "1500 ml",
     "longest_side": "40 cm",
     "material": [ "concentrated_mana" ],
-    "techniques": [ "PRECISE", "WIDE", "SWEEP" ],
+    "techniques": [ "PRECISE", "WIDE", "SWEEP", "RELIC_PINK" ],
     "flags": [
       "REACH_ATTACK",
       "REACH3",
@@ -254,11 +254,8 @@
       "FIRE"
     ],
     "to_hit": 3,
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "heat", "add": 30 } ] } ]
-    },
     "category": "weapons",
-    "melee_damage": { "cut": 6 }
+    "melee_damage": { "cut": 6, "heat": 30 }
   },
   {
     "id": "fleshpouch",
@@ -664,10 +661,7 @@
     "weight": "900 g",
     "volume": "1250 ml",
     "longest_side": "100 cm",
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "heat", "add": 28 } ] } ]
-    },
-    "melee_damage": { "bash": 12, "cut": 2 }
+    "melee_damage": { "bash": 12, "cut": 2, "heat": 28 }
   },
   {
     "id": "decaying_boneclub",
@@ -685,10 +679,7 @@
     "volume": "800 ml",
     "longest_side": "70 cm",
     "to_hit": 3,
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "biological", "add": 8 } ] } ]
-    },
-    "melee_damage": { "bash": 12 }
+    "melee_damage": { "bash": 12, "biological": 8 }
   },
   {
     "id": "impactsling",
@@ -920,10 +911,7 @@
     ],
     "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID" ],
     "qualities": [ [ "CONTAIN", 1 ], [ "BOIL", 1 ] ],
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "pure", "add": 3 } ] } ]
-    },
-    "melee_damage": { "bash": 1 }
+    "melee_damage": { "bash": 1, "pure": 3 }
   },
   {
     "id": "longsword_holy",
@@ -1428,10 +1416,7 @@
     ],
     "qualities": [ [ "WELD", 2 ] ],
     "to_hit": { "grip": "weapon", "length": "hand", "surface": "any", "balance": "neutral" },
-    "melee_damage": { "bash": 2 },
-    "relic_data": {
-      "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "electric", "add": 6 } ] } ]
-    }
+    "melee_damage": { "bash": 2, "electric": 6 }
   },
   {
     "type": "GENERIC",
@@ -1747,9 +1732,6 @@
     ],
     "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "TRADER_AVOID" ],
     "qualities": [ [ "CONTAIN", 1 ] ],
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "pure", "add": 0 } ] } ]
-    },
     "melee_damage": { "bash": 1 }
   },
   {

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -237,7 +237,7 @@
     "volume": "1500 ml",
     "longest_side": "40 cm",
     "material": [ "concentrated_mana" ],
-    "techniques": [ "PRECISE", "WIDE", "SWEEP", "RELIC_PINK" ],
+    "techniques": [ "PRECISE", "WIDE", "SWEEP" ],
     "flags": [
       "REACH_ATTACK",
       "REACH3",
@@ -251,7 +251,8 @@
       "FIRESTARTER",
       "LIGHT_8",
       "FLAMING",
-      "FIRE"
+      "FIRE",
+      "RELIC_PINK"
     ],
     "to_hit": 3,
     "category": "weapons",

--- a/data/mods/Xedra_Evolved/items/ethereal_items.json
+++ b/data/mods/Xedra_Evolved/items/ethereal_items.json
@@ -87,13 +87,19 @@
     "color": "light_gray",
     "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 9 ] ],
-    "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID", "SHEATH_SWORD" ],
+    "flags": [
+      "UNBREAKABLE_MELEE",
+      "NONCONDUCTIVE",
+      "NO_REPAIR",
+      "NO_SALVAGE",
+      "MAGIC_FOCUS",
+      "TRADER_AVOID",
+      "SHEATH_SWORD",
+      "RELIC_PINK"
+    ],
     "weapon_category": [ "FENCING_WEAPONRY" ],
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "cold", "add": 10 } ] } ]
-    },
     "category": "weapons",
-    "melee_damage": { "bash": 2, "stab": 31 }
+    "melee_damage": { "bash": 2, "stab": 31, "cold": 10 }
   },
   {
     "id": "dagger_dreamdross",
@@ -375,9 +381,6 @@
     ],
     "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "TRADER_AVOID" ],
     "qualities": [ [ "CONTAIN", 1 ], [ "BOIL", 1 ] ],
-    "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "melee_damage_bonus": [ { "type": "pure", "add": 0 } ] } ]
-    },
     "melee_damage": { "bash": 1 }
   },
   {

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -539,6 +539,7 @@
     "weight": "300 g",
     "longest_side": "25 cm",
     "ammo": [ "battery" ],
+    "melee_damage": { "electric": 10 },
     "flags": [ "MORPHIC", "ONLY_ONE", "TRADER_AVOID", "MUNDANE", "INVENTOR_CRAFTED" ],
     "use_action": [
       {
@@ -565,12 +566,7 @@
     ],
     "relic_data": {
       "passive_effects": [
-        {
-          "has": "WORN",
-          "condition": "ACTIVE",
-          "hit_you_effect": [ { "id": "inventor_electric_fist_spell", "once_in": 6 } ],
-          "melee_damage_bonus": [ { "type": "electric", "add": 10 } ]
-        }
+        { "has": "WORN", "condition": "ACTIVE", "hit_you_effect": [ { "id": "inventor_electric_fist_spell", "once_in": 6 } ] }
       ]
     },
     "material_thickness": 0.3,

--- a/data/mods/Xedra_Evolved/items/melee.json
+++ b/data/mods/Xedra_Evolved/items/melee.json
@@ -48,15 +48,10 @@
     "name": { "str": "frostrimed estoc" },
     "copy-from": "mirror_march_estoc",
     "description": "This sword is covered in shifting frost and seems to move of its own volition in your hands.",
+    "extend": { "flags": [ "RELIC_PINK" ] },
+    "relative": { "melee_damage": { "cold": 9 } },
     "relic_data": {
-      "passive_effects": [
-        {
-          "has": "WIELD",
-          "condition": "ALWAYS",
-          "melee_damage_bonus": [ { "type": "cold", "add": 9 } ],
-          "values": [ { "value": "ATTACK_SPEED", "add": -20 } ]
-        }
-      ]
+      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "values": [ { "value": "ATTACK_SPEED", "add": -20 } ] } ]
     }
   },
   {

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -843,6 +843,7 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```REBREATHER``` If you wear this item, your oxygen won't fall lower than 12 (default is ~50).
 - ```REDUCED_BASHING``` Gunmod flag; reduces the item's bashing damage by 50%.
 - ```REDUCED_WEIGHT``` Gunmod flag; reduces the item's base weight by 25%.
+- ```RELIC_PINK``` - Changes the color of item to pink, same as any another item with magical properties
 - ```REQUIRES_TINDER``` Requires tinder to be present on the tile this item tries to start a fire on.
 - ```ROBOFAC_ROBOT_MEDIUM``` This item is a medium-size Hub 01 drone, and you can store it in specific slot in drone-tech harness.
 - ```ROBOFAC_ROBOT_SMALL``` This item is a small-size Hub 01 drone, and you can store it in specific slot in drone-tech harness.

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -287,6 +287,7 @@ const flag_id flag_REBREATHER( "REBREATHER" );
 const flag_id flag_RECHARGE( "RECHARGE" );
 const flag_id flag_REDUCED_BASHING( "REDUCED_BASHING" );
 const flag_id flag_REDUCED_WEIGHT( "REDUCED_WEIGHT" );
+const flag_id flag_RELIC_PINK( "RELIC_PINK" );
 const flag_id flag_RELOAD_AND_SHOOT( "RELOAD_AND_SHOOT" );
 const flag_id flag_RELOAD_EJECT( "RELOAD_EJECT" );
 const flag_id flag_RELOAD_ONE( "RELOAD_ONE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -292,6 +292,7 @@ extern const flag_id flag_REBREATHER;
 extern const flag_id flag_RECHARGE;
 extern const flag_id flag_REDUCED_BASHING;
 extern const flag_id flag_REDUCED_WEIGHT;
+extern const flag_id flag_RELIC_PINK;
 extern const flag_id flag_RELOAD_AND_SHOOT;
 extern const flag_id flag_RELOAD_EJECT;
 extern const flag_id flag_RELOAD_ONE;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5458,11 +5458,9 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
 
     std::map<damage_type_id, int> dmg_types;
     for( const damage_type &dt : damage_type::get_all() ) {
-        if( dt.physical && dt.melee_only ) {
-            int val = damage_melee( dt.id );
-            if( val ) {
-                dmg_types.emplace( dt.id, val );
-            }
+        int val = damage_melee( dt.id );
+        if( val ) {
+            dmg_types.emplace( dt.id, val );
         }
     }
 
@@ -5474,9 +5472,6 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
             info.emplace_back( "BASE", _( "<bold>Melee damage</bold>: " ), "", iteminfo::no_newline );
         }
         for( const auto &dmg_type : dmg_types ) {
-            if( !dmg_type.first->melee_only ) {
-                continue;
-            }
             info.emplace_back( "BASE", sep + uppercase_first_letter( dmg_type.first->name.translated() ) + ": ",
                                "", iteminfo::no_newline, dmg_type.second );
             sep = space;
@@ -6368,7 +6363,7 @@ nc_color item::color_in_inventory( const Character *const ch ) const
         ret = c_red;
     } else if( is_filthy() || has_own_flag( flag_DIRTY ) ) {
         ret = c_brown;
-    } else if( is_relic() && !has_flag( flag_MUNDANE ) ) {
+    } else if( ( is_relic() && !has_flag( flag_MUNDANE ) ) || has_flag( flag_RELIC_PINK ) ) {
         ret = c_pink;
     } else if( is_bionic() ) {
         if( player_character.is_installable( this, false ).success() &&


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
#77662 was merged, so i decided to do a little sanity sweep around it
Close #48674
#### Describe the solution
If possible, bonus for melee is moved from enchantment to be direclty applied to the melee weapon itself
Few stuff got conditions updated, like bombastic perks `Slice n' Dice`, `Bash n' Mash` and `Knifey` now work only when your own melee damage of related type is higher than 1
New flag RELIC_PINK is added, to handle the fact this items are not highlighted in purple without relic_data
UI now shows all damage types item has, not only physical; Vaniila won't be affected because items here do not deal elemental damage, and mods suffer from presenting incorrect information
#### Testing
![image](https://github.com/user-attachments/assets/5fbbbb2a-35cb-473b-b931-895b30b188c6)
![image](https://github.com/user-attachments/assets/d532d2e4-af17-427c-8fb6-6fef313a6d09)
#### Additional context
I wonder how mad it would be to implement dbl_or_var for items