### PR TITLE
[Perf] Improve efficiency of vehicle code.

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3040,7 +3040,7 @@ tiny_bitset vehicle::has_parts( const std::vector<std::string> &flags, bool enab
         vehicle_part &part = vpr.part();
         if( !part.removed && ( !enabled || part.enabled ) && !part.is_broken() ) {
             // Check whether the part has any of the flags we are looking for
-            for( int i = 0; i < flags.size(); i++ ) {
+            for( size_t i = 0; i < flags.size(); i++ ) {
                 const std::string &flag = flags[i];
                 if( part.info().has_flag( flag ) ) {
                     ret.set( i );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -21,6 +21,7 @@
 
 #include "active_item_cache.h"
 #include "calendar.h"
+#include "cata_bitset.h"
 #include "character_id.h"
 #include "clzones.h"
 #include "colony.h"
@@ -1288,6 +1289,19 @@ class vehicle
          *  @param enabled if set part must also be enabled to be considered
          */
         bool has_part( const tripoint &pos, const std::string &flag, bool enabled = false ) const;
+
+        /**
+         *  Check if vehicle has at least one unbroken part with each of the specified flags
+         *
+         *  e.g. has_parts({"F1", "F2", "F3"}), the first bit will hold whether the vehicle has
+         *      F1, the second F2, and so on.
+         *
+         *  @param flags Specified flags to search parts for. This should be <= 56 entries long.
+         *  @param enabled if set part must also be enabled to be considered
+         *  @returns true if part is found for each flag. The index of the resultant bitset is the
+         *      same as in flags.
+         */
+        tiny_bitset has_parts( const std::vector<std::string> &flags, bool enabled = false ) const;
 
         /**
          *  Get all enabled, available, unbroken vehicle parts at specified position

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -291,7 +291,7 @@ void vehicle::build_electronics_menu( veh_menu &menu )
         .on_submit( [this] { control_doors(); } );
     }
 
-    if( camera_on || ( has_part( "CAMERA" ) && has_part( "CAMERA_CONTROL" ) ) ) {
+    if( camera_on || ( has_parts( {"CAMERA", "CAMERA_CONTROL"} ).all() ) ) {
         menu.add( camera_on
                   ? colorize( _( "Turn off camera system" ), c_pink )
                   : _( "Turn on camera system" ) )
@@ -1842,7 +1842,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
 
     const bool remote = g->remoteveh() == this;
     const bool has_electronic_controls = remote
-                                         ? has_part( "CTRL_ELECTRONIC" ) || has_part( "REMOTE_CONTROLS" )
+                                         ? has_parts( {"CTRL_ELECTRONIC", "REMOTE_CONTROL"} ).any()
                                          : has_part_here( "CTRL_ELECTRONIC" );
     const bool controls_here = has_part_here( "CONTROLS" );
     const bool player_is_driving = get_player_character().controlling_vehicle;


### PR DESCRIPTION
#### Summary
Performance "Vehicles are slightly more efficient"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Performance.

#### Describe the solution

* Add a new function, has_parts() which takes a list of flags and checks if the vehicle has parts which have them. Equivalent to calling has_part multiple times, but more performant.
* Replace get_all_parts() with boarded_parts() in vehicle::get_driver(). Each part would check all the parts that its mounted to to see whether they had a passenger, requiring a lot of redundant checks.

#### Describe alternatives you've considered

None.

#### Testing

- [ ] Compiled game, drove a car around. Checked that music played correctly.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
