### PR TITLE
Several tweaks to Respirator bionic

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1022,7 +1022,7 @@
     "id": "bio_gills",
     "type": "bionic",
     "name": { "str": "Respirator" },
-    "description": "A complex respiration augmentation system.  Improves respiration ability in air and allows breathing water.  Will automatically turn on when drowning.  Turn on to recharge stamina faster, at moderate power cost.  Asthmatics may also use it to stop asthma attacks.",
+    "description": "A complex respiration augmentation system.  Improves respiration ability in air and allows breathing water.  Will automatically activate when drowning.  Turn on to recharge stamina faster, at moderate power cost.  Asthmatics may also use it to stop asthma attacks.",
     "occupied_bodyparts": [ [ "torso", 8 ], [ "head", 2 ], [ "mouth", 2 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
     "trigger_cost": "25 kJ"

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1693,10 +1693,13 @@ void Character::process_bionic( bionic &bio )
             mod_power_level( -trigger_cost );
         }
     } else if( bio.id == bio_gills ) {
-        if( has_effect( effect_asthma ) ) {
+        const units::energy trigger_cost = bio.info().power_trigger / 8;
+        if( has_effect( effect_asthma ) && get_power_level() >= trigger_cost ) {
             add_msg_if_player( m_good,
-                               _( "You feel your throat open up and air filling your lungs!" ) );
+                               _( "Your %s activates and you feel your throat open up and air filling your lungs!" ),
+                               bio.info().name );
             remove_effect( effect_asthma );
+            mod_power_level( -trigger_cost );
         }
     } else if( bio.id == bio_evap ) {
         if( is_underwater() ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -317,9 +317,15 @@ void suffer::while_underwater( Character &you )
         you.oxygen += 12;
     }
     if( you.oxygen <= 5 ) {
-        if( you.has_bionic( bio_gills ) && you.get_power_level() >= bio_gills->power_trigger ) {
-            you.oxygen += 5;
-            you.mod_power_level( -bio_gills->power_trigger );
+        if( you.has_bionic( bio_gills ) ) {
+            if( you.get_power_level() >= bio_gills->power_trigger ) {
+                you.oxygen += 5;
+                you.mod_power_level( -bio_gills->power_trigger );
+            } else {
+                you.add_msg_if_player( m_bad,
+                                       _( "You don't have enough bionic power for activation of your Respirator, so you're drowning!" ) );
+                you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
+            }
         } else {
             you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
             you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );


### PR DESCRIPTION
#### Summary
Bugfixes "Several tweaks to Respirator bionic"

#### Purpose of change
1. When Respirator activates during asthma attack, it cleared the effect for no cost.
2. Description of bionic states that it automatically "turns on" when drowning when actually it just triggers its effect, not turning on.
3. Close #49095.

#### Describe the solution
1. Consume bionic power when Respirator activates during "regular" asthma attacks (not the ones that occur while you're sleeping). The cost is `trigger_cost / 8`, the same as cost of bionic activating when you're sleeping. Also updated message that occurs when bionic clears the effect of asthma to clearly state that it's precisely thanks to the Respirator you're now able to breathe again.
2. Changed description of bionic to make it clear that it only silently activates its effect when drowning, not turns on.
3. When drowning and doesn't have enough power to activate the Respirator, give player a message that bionic is unpowered.

#### Describe alternatives you've considered
None.

#### Testing
Got `Asthmatic` trait. Got `Respirator` bionic. Activated the bionic. Waited for some time until asthma attack happens. Checked that it correctly consumed ~3 kJ of bionic power to clear the effect of asthma.
Made it so my character has 0 units of bionic power. Dived underwater. Waited for my oxygen to run out. Noticed message about my unpowered bionic.

#### Additional context
None.