### PR TITLE
[MOM] Adjust Electron Overflow EOC logic to allow charging values above 5

### DIFF
--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -328,7 +328,11 @@
         ]
       },
       {
-        "math": [ "u_electrokin_personal_battery_power_count", "=", "( (u_spell_level('electrokinetic_personal_battery') / 5) + 1) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling" ]
+        "math": [
+          "u_electrokin_personal_battery_power_count",
+          "=",
+          "( (u_spell_level('electrokinetic_personal_battery') / 5) + 1) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+        ]
       },
       { "u_message": "begin with val:<u_val:electrokin_personal_battery_power_count>" },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT" }
@@ -344,8 +348,16 @@
       { "math": [ "u_electrokin_personal_battery_item_count", "=", "0" ] },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_GET_ITEM_COUNT" },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_AMMEND_ITEM_COUNT" },
-      { "math": [ "u_electrokin_personal_battery_max_indv_power", "=", "floor(u_electrokin_personal_battery_power_count / u_electrokin_personal_battery_item_count)" ] },
-      { "u_message": "u_electrokin_personal_battery_max_indv_power=<u_val:electrokin_personal_battery_max_indv_power>" },
+      {
+        "math": [
+          "u_electrokin_personal_battery_max_indv_power",
+          "=",
+          "floor(u_electrokin_personal_battery_power_count / u_electrokin_personal_battery_item_count)"
+        ]
+      },
+      {
+        "u_message": "u_electrokin_personal_battery_max_indv_power=<u_val:electrokin_personal_battery_max_indv_power>"
+      },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS" }
     ]
   },
@@ -353,7 +365,12 @@
     "type": "effect_on_condition",
     "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS",
     "//": "power uncharged items",
-    "condition": { "and": [ { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_item_count", ">=", "1" ] } ] },
+    "condition": {
+      "and": [
+        { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] },
+        { "math": [ "u_electrokin_personal_battery_item_count", ">=", "1" ] }
+      ]
+    },
     "effect": [
       { "u_message": "pb power" },
       {
@@ -363,27 +380,51 @@
           {
             "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS_DISTRIBUTION",
             "//": "if there is enough power to be distributed to many items",
-            "condition": { "and": [ { "math": [ "n_val('power')", "<", "n_val('power_max')" ] }, { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_max_indv_power", ">=", "1" ] } ] },
+            "condition": {
+              "and": [
+                { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
+                { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] },
+                { "math": [ "u_electrokin_personal_battery_max_indv_power", ">=", "1" ] }
+              ]
+            },
             "effect": [
               { "u_message": "pb power distribute ind" },
               {
-                "math": [ "u_electrokin_personal_battery_power_count_used", "=", "min( n_val('power_max') - n_val('power'), u_electrokin_personal_battery_max_indv_power )" ]
+                "math": [
+                  "u_electrokin_personal_battery_power_count_used",
+                  "=",
+                  "min( n_val('power_max') - n_val('power'), u_electrokin_personal_battery_max_indv_power )"
+                ]
               },
               { "math": [ "n_val('power')", "+=", "u_electrokin_personal_battery_power_count_used" ] },
-              { "math": [ "u_electrokin_personal_battery_power_count", "-=", "u_electrokin_personal_battery_power_count_used" ] }
+              {
+                "math": [ "u_electrokin_personal_battery_power_count", "-=", "u_electrokin_personal_battery_power_count_used" ]
+              }
             ]
           },
           {
             "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS_SINGLE",
             "//": "if there is not enough power to distribute to many items but enough power for a single item",
-            "condition": { "and": [ { "math": [ "n_val('power')", "<", "n_val('power_max')" ] }, { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_max_indv_power", "<", "1" ] } ] },
+            "condition": {
+              "and": [
+                { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
+                { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] },
+                { "math": [ "u_electrokin_personal_battery_max_indv_power", "<", "1" ] }
+              ]
+            },
             "effect": [
               { "u_message": "pb power single ind" },
               {
-                "math": [ "u_electrokin_personal_battery_power_count_used", "=", "min( n_val('power_max') - n_val('power'), u_electrokin_personal_battery_power_count )" ]
+                "math": [
+                  "u_electrokin_personal_battery_power_count_used",
+                  "=",
+                  "min( n_val('power_max') - n_val('power'), u_electrokin_personal_battery_power_count )"
+                ]
               },
               { "math": [ "n_val('power')", "+=", "u_electrokin_personal_battery_power_count_used" ] },
-              { "math": [ "u_electrokin_personal_battery_power_count", "-=", "u_electrokin_personal_battery_power_count_used" ] }
+              {
+                "math": [ "u_electrokin_personal_battery_power_count", "-=", "u_electrokin_personal_battery_power_count_used" ]
+              }
             ]
           }
         ]
@@ -415,14 +456,24 @@
     "type": "effect_on_condition",
     "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_AMMEND_ITEM_COUNT",
     "//": "Reduce item count if the total chargeable power / uncharged item count is less than 1.",
-    "condition": { "and": [ { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_item_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_power_count / u_electrokin_personal_battery_item_count", "<", "1" ] } ] },
+    "condition": {
+      "and": [
+        { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] },
+        { "math": [ "u_electrokin_personal_battery_item_count", ">=", "1" ] },
+        {
+          "math": [ "u_electrokin_personal_battery_power_count / u_electrokin_personal_battery_item_count", "<", "1" ]
+        }
+      ]
+    },
     "effect": [
       { "math": [ "u_electrokin_personal_battery_item_count", "--" ] },
       { "u_message": "pb ammend item count to <u_val:electrokin_personal_battery_item_count>" },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_AMMEND_ITEM_COUNT" }
     ],
     "false_effect": [
-      { "u_message": "pb ammend item count false power_count:<u_val:electrokin_personal_battery_power_count>, <u_val:electrokin_personal_battery_item_count>" }
+      {
+        "u_message": "pb ammend item count false power_count:<u_val:electrokin_personal_battery_power_count>, <u_val:electrokin_personal_battery_item_count>"
+      }
     ]
   },
   {

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -338,7 +338,7 @@
     "type": "effect_on_condition",
     "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT",
     "//": "recursively runs until available power is < 1 or all items are charged",
-    "condition": { "math": [ "u_electrokin_personal_battery_power_count", ">", "0" ] },
+    "condition": { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] },
     "effect": [
       { "u_message": "pb effect" },
       { "math": [ "u_electrokin_personal_battery_item_count", "=", "0" ] },
@@ -415,110 +415,14 @@
     "type": "effect_on_condition",
     "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_AMMEND_ITEM_COUNT",
     "//": "Reduce item count if the total chargeable power / uncharged item count is less than 1.",
-    "condition": { "and": [ { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }, { "math": [ "electrokin_personal_battery_item_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_power_count / u_electrokin_personal_battery_count", "<", "1" ] } ] },
+    "condition": { "and": [ { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_item_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_power_count / u_electrokin_personal_battery_item_count", "<", "1" ] } ] },
     "effect": [
       { "math": [ "u_electrokin_personal_battery_item_count", "--" ] },
-      { "u_message": "pb ammend item count at <u_val:u_electrokin_personal_battery_item_count>" },
+      { "u_message": "pb ammend item count to <u_val:electrokin_personal_battery_item_count>" },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_AMMEND_ITEM_COUNT" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER",
-    "condition": { "u_has_effect": "effect_electrokin_personal_battery" },
-    "effect": [
-      {
-        "queue_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER",
-        "time_in_future": [
-          {
-            "math": [
-              "max( ( 60 - ( ( (u_spell_level('electrokinetic_personal_battery') * 2.5 ) * scaling_factor(u_val('intelligence')  ) * u_nether_attunement_power_scaling ) ) ), 5)"
-            ]
-          },
-          {
-            "math": [
-              "max( ( 240 - ( (  (u_spell_level('electrokinetic_personal_battery') * 5 ) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling ) ) ), 10)"
-            ]
-          }
-        ]
-      },
-      { "math": [ "u_electrokin_personal_battery_count", "=", "0" ] },
-      {
-        "u_run_inv_eocs": "all",
-        "search_data": [ { "uses_energy": true } ],
-        "true_eocs": [
-          {
-            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_COUNTER",
-            "condition": { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
-            "effect": [ { "math": [ "u_electrokin_personal_battery_count", "++" ] } ]
-          }
-        ]
-      },
-      { "queue_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_FINALIZATION", "time_in_future": 1 }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_FINALIZATION",
-    "//": "The one that actually does the charging",
-    "condition": { "u_has_effect": "effect_electrokin_personal_battery" },
-    "effect": [
-      {
-        "u_run_inv_eocs": "all",
-        "search_data": [ { "uses_energy": true } ],
-        "true_eocs": [
-          {
-            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_VALUE_ADDED",
-            "condition": { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
-            "effect": [
-              {
-                "if": { "math": [ "u_electrokin_personal_battery_count", ">", "0" ] },
-                "then": {
-                  "math": [
-                    "n_electrokin_charging_value_counter",
-                    "+=",
-                    "( ( (u_spell_level('electrokinetic_personal_battery') / 5) + 1) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling) / u_electrokin_personal_battery_count"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_CHARGER",
-            "condition": { "math": [ "n_electrokin_charging_value_counter", ">=", "1" ] },
-            "effect": [
-              {
-                "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "5" ] },
-                "then": [ { "math": [ "n_val('power')", "+=", "5" ] }, { "math": [ "n_electrokin_charging_value_counter", "-=", "5" ] } ],
-                "else": [
-                  {
-                    "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "4" ] },
-                    "then": [ { "math": [ "n_val('power')", "+=", "4" ] }, { "math": [ "n_electrokin_charging_value_counter", "-=", "4" ] } ],
-                    "else": [
-                      {
-                        "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "3" ] },
-                        "then": [ { "math": [ "n_val('power')", "+=", "3" ] }, { "math": [ "n_electrokin_charging_value_counter", "-=", "3" ] } ],
-                        "else": [
-                          {
-                            "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "2" ] },
-                            "then": [ { "math": [ "n_val('power')", "+=", "2" ] }, { "math": [ "n_electrokin_charging_value_counter", "-=", "2" ] } ],
-                            "else": [
-                              {
-                                "if": { "math": [ "n_electrokin_charging_value_counter", ">=", "1" ] },
-                                "then": [ { "math": [ "n_val('power')", "+=", "1" ] }, { "math": [ "n_electrokin_charging_value_counter", "-=", "1" ] } ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
+    ],
+    "false_effect": [
+      { "u_message": "pb ammend item count false power_count:<u_val:electrokin_personal_battery_power_count>, <u_val:electrokin_personal_battery_item_count>" }
     ]
   },
   {

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -364,7 +364,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS",
-    "//": "power uncharged items",
+    "//": "power uncharged items and calls the main eoc to deal with any remaining power left over",
     "condition": {
       "and": [
         { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] },
@@ -379,46 +379,36 @@
         "true_eocs": [
           {
             "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS_DISTRIBUTION",
-            "//": "if there is enough power to be distributed to many items",
             "condition": {
               "and": [
                 { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
-                { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] },
-                { "math": [ "u_electrokin_personal_battery_max_indv_power", ">=", "1" ] }
+                { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }
               ]
             },
             "effect": [
               { "u_message": "pb power distribute ind" },
               {
+                "if": { "math": [ "u_electrokin_personal_battery_max_indv_power", ">=", "1" ] },
+                "then": {
+                  "math": [
+                    "u_electrokin_personal_battery_power_count_used",
+                    "=",
+                    "min( n_val('power_max') - n_val('power'), u_electrokin_personal_battery_max_indv_power )"
+                  ]
+                },
+                "else": {
+                  "math": [
+                    "u_electrokin_personal_battery_power_count_used",
+                    "=",
+                    "min( n_val('power_max') - n_val('power'), u_electrokin_personal_battery_power_count )"
+                  ]
+                }
+              },
+              {
                 "math": [
                   "u_electrokin_personal_battery_power_count_used",
                   "=",
                   "min( n_val('power_max') - n_val('power'), u_electrokin_personal_battery_max_indv_power )"
-                ]
-              },
-              { "math": [ "n_val('power')", "+=", "u_electrokin_personal_battery_power_count_used" ] },
-              {
-                "math": [ "u_electrokin_personal_battery_power_count", "-=", "u_electrokin_personal_battery_power_count_used" ]
-              }
-            ]
-          },
-          {
-            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS_SINGLE",
-            "//": "if there is not enough power to distribute to many items but enough power for a single item",
-            "condition": {
-              "and": [
-                { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
-                { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] },
-                { "math": [ "u_electrokin_personal_battery_max_indv_power", "<", "1" ] }
-              ]
-            },
-            "effect": [
-              { "u_message": "pb power single ind" },
-              {
-                "math": [
-                  "u_electrokin_personal_battery_power_count_used",
-                  "=",
-                  "min( n_val('power_max') - n_val('power'), u_electrokin_personal_battery_power_count )"
                 ]
               },
               { "math": [ "n_val('power')", "+=", "u_electrokin_personal_battery_power_count_used" ] },

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -281,7 +281,7 @@
     "effect": [
       { "u_message": "The hair on your body stands up on end.", "type": "good" },
       { "u_add_effect": "effect_electrokin_personal_battery", "duration": "PERMANENT" },
-      { "run_eocs": [ "EOC_POWER_MAINTENANCE_PLUS_ONE", "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER" ] },
+      { "run_eocs": [ "EOC_POWER_MAINTENANCE_PLUS_ONE", "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_BEGIN" ] },
       {
         "queue_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_DRAIN",
         "time_in_future": [
@@ -305,6 +305,122 @@
     "id": "EOC_ELECTROKIN_REMOVE_PERSONAL_BATTERY",
     "condition": { "u_has_effect": "effect_electrokin_personal_battery" },
     "effect": [ { "u_lose_effect": "effect_electrokin_personal_battery" }, { "run_eocs": "EOC_POWER_MAINTENANCE_MINUS_ONE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_BEGIN",
+    "condition": { "u_has_effect": "effect_electrokin_personal_battery" },
+    "effect": [
+      { "u_message": "pb begin" },
+      {
+        "queue_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_BEGIN",
+        "time_in_future": [
+          {
+            "math": [
+              "max( ( 60 - ( ( (u_spell_level('electrokinetic_personal_battery') * 2.5 ) * scaling_factor(u_val('intelligence')  ) * u_nether_attunement_power_scaling ) ) ), 5)"
+            ]
+          },
+          {
+            "math": [
+              "max( ( 240 - ( (  (u_spell_level('electrokinetic_personal_battery') * 5 ) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling ) ) ), 10)"
+            ]
+          }
+        ]
+      },
+      {
+        "math": [ "u_electrokin_personal_battery_power_count", "=", "( (u_spell_level('electrokinetic_personal_battery') / 5) + 1) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling" ]
+      },
+      { "u_message": "begin with val:<u_val:electrokin_personal_battery_power_count>" },
+      { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT",
+    "//": "recursively runs until available power is < 1 or all items are charged",
+    "condition": { "math": [ "u_electrokin_personal_battery_power_count", ">", "0" ] },
+    "effect": [
+      { "u_message": "pb effect" },
+      { "math": [ "u_electrokin_personal_battery_item_count", "=", "0" ] },
+      { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_GET_ITEM_COUNT" },
+      { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_AMMEND_ITEM_COUNT" },
+      { "math": [ "u_electrokin_personal_battery_max_indv_power", "=", "floor(u_electrokin_personal_battery_power_count / u_electrokin_personal_battery_item_count)" ] },
+      { "u_message": "u_electrokin_personal_battery_max_indv_power=<u_val:electrokin_personal_battery_max_indv_power>" },
+      { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS",
+    "//": "power uncharged items",
+    "condition": { "and": [ { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_item_count", ">=", "1" ] } ] },
+    "effect": [
+      { "u_message": "pb power" },
+      {
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "uses_energy": true } ],
+        "true_eocs": [
+          {
+            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS_DISTRIBUTION",
+            "//": "if there is enough power to be distributed to many items",
+            "condition": { "and": [ { "math": [ "n_val('power')", "<", "n_val('power_max')" ] }, { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_max_indv_power", ">=", "1" ] } ] },
+            "effect": [
+              { "u_message": "pb power distribute ind" },
+              {
+                "math": [ "u_electrokin_personal_battery_power_count_used", "=", "min( n_val('power_max') - n_val('power'), u_electrokin_personal_battery_max_indv_power )" ]
+              },
+              { "math": [ "n_val('power')", "+=", "u_electrokin_personal_battery_power_count_used" ] },
+              { "math": [ "u_electrokin_personal_battery_power_count", "-=", "u_electrokin_personal_battery_power_count_used" ] }
+            ]
+          },
+          {
+            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS_SINGLE",
+            "//": "if there is not enough power to distribute to many items but enough power for a single item",
+            "condition": { "and": [ { "math": [ "n_val('power')", "<", "n_val('power_max')" ] }, { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_max_indv_power", "<", "1" ] } ] },
+            "effect": [
+              { "u_message": "pb power single ind" },
+              {
+                "math": [ "u_electrokin_personal_battery_power_count_used", "=", "min( n_val('power_max') - n_val('power'), u_electrokin_personal_battery_power_count )" ]
+              },
+              { "math": [ "n_val('power')", "+=", "u_electrokin_personal_battery_power_count_used" ] },
+              { "math": [ "u_electrokin_personal_battery_power_count", "-=", "u_electrokin_personal_battery_power_count_used" ] }
+            ]
+          }
+        ]
+      },
+      { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_GET_ITEM_COUNT",
+    "//": "get total items without max power",
+    "effect": [
+      { "u_message": "pb get item count" },
+      {
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "uses_energy": true } ],
+        "true_eocs": [
+          {
+            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_COUNTER_3",
+            "condition": { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
+            "effect": [ { "math": [ "u_electrokin_personal_battery_item_count", "++" ] } ]
+          }
+        ]
+      },
+      { "u_message": "pb item count=<u_val:electrokin_personal_battery_item_count>" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_AMMEND_ITEM_COUNT",
+    "//": "Reduce item count if the total chargeable power / uncharged item count is less than 1.",
+    "condition": { "and": [ { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] }, { "math": [ "electrokin_personal_battery_item_count", ">=", "1" ] }, { "math": [ "u_electrokin_personal_battery_power_count / u_electrokin_personal_battery_count", "<", "1" ] } ] },
+    "effect": [
+      { "math": [ "u_electrokin_personal_battery_item_count", "--" ] },
+      { "u_message": "pb ammend item count at <u_val:u_electrokin_personal_battery_item_count>" },
+      { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_AMMEND_ITEM_COUNT" }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -311,7 +311,6 @@
     "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_BEGIN",
     "condition": { "u_has_effect": "effect_electrokin_personal_battery" },
     "effect": [
-      { "u_message": "pb begin" },
       {
         "queue_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_BEGIN",
         "time_in_future": [
@@ -334,7 +333,6 @@
           "( (u_spell_level('electrokinetic_personal_battery') / 5) + 1) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
         ]
       },
-      { "u_message": "begin with val:<u_val:electrokin_personal_battery_power_count>" },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT" }
     ]
   },
@@ -344,7 +342,6 @@
     "//": "recursively runs until available power is < 1 or all items are charged",
     "condition": { "math": [ "u_electrokin_personal_battery_power_count", ">=", "1" ] },
     "effect": [
-      { "u_message": "pb effect" },
       { "math": [ "u_electrokin_personal_battery_item_count", "=", "0" ] },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_GET_ITEM_COUNT" },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_AMMEND_ITEM_COUNT" },
@@ -354,9 +351,6 @@
           "=",
           "floor(u_electrokin_personal_battery_power_count / u_electrokin_personal_battery_item_count)"
         ]
-      },
-      {
-        "u_message": "u_electrokin_personal_battery_max_indv_power=<u_val:electrokin_personal_battery_max_indv_power>"
       },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS" }
     ]
@@ -372,7 +366,6 @@
       ]
     },
     "effect": [
-      { "u_message": "pb power" },
       {
         "u_run_inv_eocs": "all",
         "search_data": [ { "uses_energy": true } ],
@@ -386,7 +379,6 @@
               ]
             },
             "effect": [
-              { "u_message": "pb power distribute ind" },
               {
                 "if": { "math": [ "u_electrokin_personal_battery_max_indv_power", ">=", "1" ] },
                 "then": {
@@ -427,7 +419,6 @@
     "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_GET_ITEM_COUNT",
     "//": "get total items without max power",
     "effect": [
-      { "u_message": "pb get item count" },
       {
         "u_run_inv_eocs": "all",
         "search_data": [ { "uses_energy": true } ],
@@ -438,8 +429,7 @@
             "effect": [ { "math": [ "u_electrokin_personal_battery_item_count", "++" ] } ]
           }
         ]
-      },
-      { "u_message": "pb item count=<u_val:electrokin_personal_battery_item_count>" }
+      }
     ]
   },
   {
@@ -457,13 +447,7 @@
     },
     "effect": [
       { "math": [ "u_electrokin_personal_battery_item_count", "--" ] },
-      { "u_message": "pb ammend item count to <u_val:electrokin_personal_battery_item_count>" },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_AMMEND_ITEM_COUNT" }
-    ],
-    "false_effect": [
-      {
-        "u_message": "pb ammend item count false power_count:<u_val:electrokin_personal_battery_power_count>, <u_val:electrokin_personal_battery_item_count>"
-      }
     ]
   },
   {
@@ -492,8 +476,7 @@
           }
         ]
       }
-    ],
-    "false_effect": [  ]
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -424,7 +424,7 @@
         "search_data": [ { "uses_energy": true } ],
         "true_eocs": [
           {
-            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_COUNTER_3",
+            "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_GET_ITEM_COUNT_2",
             "condition": { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
             "effect": [ { "math": [ "u_electrokin_personal_battery_item_count", "++" ] } ]
           }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Adjust electron overflow to allow charging values above 5"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently, electron overflow is capped at charging individual items at 5 power units per 'charge cycle'.  This can waste a lot of potential power if a psion is trying to charge a single item at a sufficiently strong power calculation.
Also, I think the new logic should help evenly distribute charge amongst many items by adding a little more calculations.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rework the charging eoc's with some sub EOCs.
Logic Path:
- 1) Calculate total available charge (same number as prior)
- 2) Calculate total number of items that need charging
- 3) If the available charge and chargeable items would result in each item getting < 1 power, start reducing the item count until the distributed charge is at least 1
- 4) Calculate the new amount of power that will go to each selected chargeable item
- 5) For each chargeable item, give it the calculated individual power or less depending on how much power it actually needs. If there isn't an even distribution of at least 1 power but still enough power to charge things, instead give it that power amount (again only up to how much power it truly needs).  Subtract the power used from the total charge calculated in step 1.
- 6) Return to step two with the remaining total available charge

Recursive breaks:
ammend eoc:
- function will end either when a >1 charge distribution is calculated or when the number of chargeable items is adjusted to below 0.  Since every call always reduces the number of chargeable items, the recursive loop is guaranteed to break eventually. (likely will end normally upon an even charge distribution though)

effect->power dual eoc loop:
- loop will end when either the remaining available power is < 1 or the remaining chargeable items are < 1.
- if there are chargeable items, a loop iteration will always consume available power, guaranteeing that the loop will either end due to lack of chargeable items or lack of available power.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with various amounts of uncharged items and no uncharged items.
No chargeable items worked correctly, no infinite loops or similar
Items were correctly charged
High power electron overflow was able to charge items faster than 5 charge per iteration
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This was to uncap the effectiveness of high int, power level, and nether attunements on the power that the eoc logic had.  However, the normal effectiveness of the power seems a tad weak regardless.  For example, a 10 Int psion with the power at level 10 at nether attunement 1 will trigger the effect between every 35 - 190 seconds.  Say an average of 112.5 seconds.  Every 112.5 seconds they will generate 3 power.  This results in about 0.03 total charge per second from an average electrokinetic.  Since this 0.03 charge per second is now split between all devices rather than per device, it feels like the numbers could use a bit of a buff to make up for it.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
