### PR TITLE
Monsters spawned via `place_critter_within` now gain ammo on spawn

### DIFF
--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1634,13 +1634,10 @@ void computer_session::failure_manhacks()
 
 void computer_session::failure_secubots()
 {
-    int num_robots = 1;
     const tripoint_range<tripoint> range =
         get_map().points_in_radius( get_player_character().pos(), 3 );
-    for( int i = 0; i < num_robots; i++ ) {
-        if( g->place_critter_within( mon_secubot, range ) ) {
-            add_msg( m_warning, _( "Secubots emerge from compartments in the floor." ) );
-        }
+    if( g->place_critter_within( mon_secubot, range ) ) {
+        add_msg( m_warning, _( "Secubot emerge from compartment in the floor." ) );
     }
 }
 

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1637,7 +1637,7 @@ void computer_session::failure_secubots()
     const tripoint_range<tripoint> range =
         get_map().points_in_radius( get_player_character().pos(), 3 );
     if( g->place_critter_within( mon_secubot, range ) ) {
-        add_msg( m_warning, _( "Secubot emerge from compartment in the floor." ) );
+        add_msg( m_warning, _( "Secubot emerges from compartment in the floor." ) );
     }
 }
 

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1637,7 +1637,7 @@ void computer_session::failure_secubots()
     const tripoint_range<tripoint> range =
         get_map().points_in_radius( get_player_character().pos(), 3 );
     if( g->place_critter_within( mon_secubot, range ) ) {
-        add_msg( m_warning, _( "Secubot emerges from compartment in the floor." ) );
+        add_msg( m_warning, _( "A secubot emerges from a compartment in the floor." ) );
     }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5104,7 +5104,9 @@ monster *game::place_critter_within( const mtype_id &id, const tripoint_range<tr
     if( id.is_null() ) {
         return nullptr;
     }
-    return place_critter_within( make_shared_fast<monster>( id ), range );
+    shared_ptr_fast<monster> mon = make_shared_fast<monster>( id );
+    mon->ammo = mon->type->starting_ammo;
+    return place_critter_within( mon, range );
 }
 
 monster *game::place_critter_within( const shared_ptr_fast<monster> &mon,


### PR DESCRIPTION
#### Summary
Bugfixes "Monsters spawned via 'place_critter_within' now gain ammo on spawn"

#### Purpose of change
* Closes #49088.

#### Describe the solution
Similar to #42331, just for `place_critter_within`.
Also, while I'm here, I removed the senseless 1-cycle loop since `failure_secubots` spawns only 1 secubot, and updated message to reflect 1 bot rather than several ones.

#### Describe alternatives you've considered
Increase number of bots spawned to match the message?

#### Testing
At `bank_1` vault, tried to hack the computer, waited for secubot to appear. Checked that it started shooting at me.

#### Additional context
None.