### PR TITLE
typified vehicle stuff

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1699,6 +1699,7 @@ void Character::process_bionic( bionic &bio )
                                _( "Your %s activates and you feel your throat open up and air filling your lungs!" ),
                                bio.info().name );
             remove_effect( effect_asthma );
+            mod_power_level( -trigger_cost );
         }
     } else if( bio.id == bio_evap ) {
         if( is_underwater() ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1693,7 +1693,8 @@ void Character::process_bionic( bionic &bio )
             mod_power_level( -trigger_cost );
         }
     } else if( bio.id == bio_gills ) {
-        if( has_effect( effect_asthma ) ) {
+        const units::energy trigger_cost = bio.info().power_trigger / 8;
+        if( has_effect( effect_asthma ) && get_power_level() >= trigger_cost ) {
             add_msg_if_player( m_good,
                                _( "You feel your throat open up and air filling your lungs!" ) );
             remove_effect( effect_asthma );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1693,13 +1693,10 @@ void Character::process_bionic( bionic &bio )
             mod_power_level( -trigger_cost );
         }
     } else if( bio.id == bio_gills ) {
-        const units::energy trigger_cost = bio.info().power_trigger / 8;
-        if( has_effect( effect_asthma ) && get_power_level() >= trigger_cost ) {
+        if( has_effect( effect_asthma ) ) {
             add_msg_if_player( m_good,
-                               _( "Your %s activates and you feel your throat open up and air filling your lungs!" ),
-                               bio.info().name );
+                               _( "You feel your throat open up and air filling your lungs!" ) );
             remove_effect( effect_asthma );
-            mod_power_level( -trigger_cost );
         }
     } else if( bio.id == bio_evap ) {
         if( is_underwater() ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1696,7 +1696,8 @@ void Character::process_bionic( bionic &bio )
         const units::energy trigger_cost = bio.info().power_trigger / 8;
         if( has_effect( effect_asthma ) && get_power_level() >= trigger_cost ) {
             add_msg_if_player( m_good,
-                               _( "You feel your throat open up and air filling your lungs!" ) );
+                               _( "Your %s activates and you feel your throat open up and air filling your lungs!" ),
+                               bio.info().name );
             remove_effect( effect_asthma );
         }
     } else if( bio.id == bio_evap ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3084,7 +3084,7 @@ std::vector<item_location> Character::nearby( const
         } );
     }
 
-    for( const vehicle_cursor &cur : vehicle_selector( pos(), radius ) ) {
+    for( const vehicle_cursor &cur : vehicle_selector( pos_bub(), radius ) ) {
         cur.visit_items( [&]( const item * e, const item * parent ) {
             if( func( e, parent ) ) {
                 res.emplace_back( cur, const_cast<item *>( e ) );
@@ -3213,7 +3213,7 @@ units::mass Character::best_nearby_lifting_assist( const tripoint &world_pos ) c
     }
     int lift_quality = std::max( { this->max_quality( qual_LIFT ), mech_lift,
                                    map_selector( this->pos_bub(), PICKUP_RANGE ).max_quality( qual_LIFT ),
-                                   vehicle_selector( world_pos, 4, true, true ).max_quality( qual_LIFT )
+                                   vehicle_selector( tripoint_bub_ms( world_pos ), 4, true, true ).max_quality( qual_LIFT )
                                  } );
     return lifting_quality_to_mass( lift_quality );
 }

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -118,7 +118,7 @@ std::vector<item_location> Character::find_ammo( const item &obj, bool empty, in
         for( map_cursor &cursor : map_selector( pos_bub(), radius ) ) {
             find_ammo_helper( cursor, obj, empty, std::back_inserter( res ), false );
         }
-        for( vehicle_cursor &cursor : vehicle_selector( pos(), radius ) ) {
+        for( vehicle_cursor &cursor : vehicle_selector( pos_bub(), radius ) ) {
             find_ammo_helper( cursor, obj, empty, std::back_inserter( res ), false );
         }
     }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1408,7 +1408,7 @@ void zone_manager::add( const std::string &name, const zone_type_id &type, const
                     return;
                 }
 
-                create_vehicle_loot_zone( vp->vehicle(), vp->mount(), new_zone, pmap );
+                create_vehicle_loot_zone( vp->vehicle(), vp->mount_pos().raw(), new_zone, pmap );
                 return;
             }
         }
@@ -1791,7 +1791,7 @@ void zone_manager::revert_vzones()
         const tripoint_bub_ms pos = here.bub_from_abs( zone.get_start_point() );
         if( const std::optional<vpart_reference> vp = here.veh_at( pos ).cargo() ) {
             zone.set_is_vehicle( true );
-            vp->vehicle().loot_zones.emplace( vp->mount(), zone );
+            vp->vehicle().loot_zones.emplace( vp->mount_pos(), zone );
             here.register_vehicle_zone( &vp->vehicle(), here.get_abs_sub().z() );
             cache_vzones();
         }

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -654,7 +654,7 @@ void editmap::draw_main_ui_overlay()
                                                false );
                     }
                     if( const optional_vpart_position ovp = tmpmap.veh_at( tmp_p ) ) {
-                        const vpart_display vd = ovp->vehicle().get_display_of_tile( ovp->mount() );
+                        const vpart_display vd = ovp->vehicle().get_display_of_tile( ovp->mount_pos() );
                         char part_mod = 0;
                         if( vd.is_open ) {
                             part_mod = 1;
@@ -662,7 +662,8 @@ void editmap::draw_main_ui_overlay()
                             part_mod = 2;
                         }
                         const units::angle veh_dir = ovp->vehicle().face.dir();
-                        g->draw_vpart_override( map_p, vpart_id( vd.id ), part_mod, veh_dir, vd.has_cargo, ovp->mount() );
+                        g->draw_vpart_override( map_p, vpart_id( vd.id ), part_mod, veh_dir, vd.has_cargo,
+                                                ovp->mount_pos().raw() );
                     } else {
                         g->draw_vpart_override( map_p, vpart_id::NULL_ID(), 0, 0_degrees, false, point_zero );
                     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1059,11 +1059,11 @@ bool game::start_game()
             std::string search = std::string( "helicopter" );
             if( name.find( search ) != std::string::npos ) {
                 for( const vpart_reference &vp : v.v->get_any_parts( VPFLAG_CONTROLS ) ) {
-                    const tripoint pos = vp.pos();
+                    const tripoint_bub_ms pos = vp.pos_bub();
                     u.setpos( pos );
 
                     // Delete the items that would have spawned here from a "corpse"
-                    for( const int sp : v.v->parts_at_relative( vp.mount(), true ) ) {
+                    for( const int sp : v.v->parts_at_relative( vp.mount_pos(), true ) ) {
                         vpart_reference( *v.v, sp ).items().clear();
                     }
 
@@ -1225,7 +1225,7 @@ vehicle *game::place_vehicle_nearby(
                 point_sm_ms remainder;
                 std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( abs_local );
                 veh->sm_pos = quotient.raw();
-                veh->pos = remainder.raw();
+                veh->pos = remainder;
 
                 veh->unlock();          // always spawn unlocked
                 veh->toggle_tracking(); // always spawn tracked
@@ -5555,7 +5555,7 @@ void game::save_cyborg( item *cyborg, const tripoint &couch_pos, Character &inst
 
 void game::exam_appliance( vehicle &veh, const point &c )
 {
-    player_activity act = veh_app_interact::run( veh, c );
+    player_activity act = veh_app_interact::run( veh, point_rel_ms( c ) );
     if( act ) {
         u.set_moves( 0 );
         u.assign_activity( act );
@@ -5568,7 +5568,7 @@ void game::exam_vehicle( vehicle &veh, const point &c )
         add_msg( m_info, _( "This is your %s" ), veh.name );
         return;
     }
-    player_activity act = veh_interact::run( veh, c );
+    player_activity act = veh_interact::run( veh, point_rel_ms( c ) );
     if( act ) {
         u.set_moves( 0 );
         u.assign_activity( act );
@@ -5627,8 +5627,8 @@ void game::control_vehicle()
     vehicle *veh = nullptr;
     if( const optional_vpart_position vp = m.veh_at( u.pos_bub() ) ) {
         veh = &vp->vehicle();
-        const int controls_idx = veh->avail_part_with_feature( vp->mount(), "CONTROLS" );
-        const int reins_idx = veh->avail_part_with_feature( vp->mount(), "CONTROL_ANIMAL" );
+        const int controls_idx = veh->avail_part_with_feature( vp->mount_pos(), "CONTROLS" );
+        const int reins_idx = veh->avail_part_with_feature( vp->mount_pos(), "CONTROL_ANIMAL" );
         const bool controls_ok = controls_idx >= 0; // controls available to "drive"
         const bool reins_ok = reins_idx >= 0 // reins + animal available to "drive"
                               && veh->has_engine_type( fuel_type_animal, false )
@@ -6055,7 +6055,7 @@ void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
             if( !vp->vehicle().is_appliance() ) {
                 vp->vehicle().interact_with( examp, with_pickup );
             } else {
-                g->exam_appliance( vp->vehicle(), vp->mount() );
+                g->exam_appliance( vp->vehicle(), vp->mount_pos().raw() );
             }
             return;
         } else {
@@ -10856,7 +10856,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
 
     if( grabbed_vehicle ) {
         // Vehicle might be at different z level than the grabbed part.
-        u.grab_point.z() = vp_grab->pos().z - u.posz();
+        u.grab_point.z() = vp_grab->pos_bub().z() - u.posz();
     }
 
     if( pulling ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -752,7 +752,7 @@ static void grab()
                 return;
             }
             get_player_character().pause();
-            vp->vehicle().separate_from_grid( vp.value().mount() );
+            vp->vehicle().separate_from_grid( vp.value().mount_pos() );
             if( const optional_vpart_position &split_vp = here.veh_at( grabp ) ) {
                 veh_name = split_vp->vehicle().name;
             } else {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13654,7 +13654,7 @@ std::string item::link_name() const
 
 ret_val<void> item::link_to( const optional_vpart_position &linked_vp, link_state link_type )
 {
-    return linked_vp ? link_to( linked_vp->vehicle(), linked_vp->mount(), link_type ) :
+    return linked_vp ? link_to( linked_vp->vehicle(), linked_vp->mount_pos(), link_type ) :
            ret_val<void>::make_failure();
 }
 
@@ -13665,11 +13665,12 @@ ret_val<void> item::link_to( const optional_vpart_position &first_linked_vp,
         return ret_val<void>::make_failure();
     }
     // Link up the second vehicle first so, if it's a tow cable, the first vehicle will tow the second.
-    ret_val<void> result = link_to( second_linked_vp->vehicle(), second_linked_vp->mount(), link_type );
+    ret_val<void> result = link_to( second_linked_vp->vehicle(), second_linked_vp->mount_pos(),
+                                    link_type );
     if( !result.success() ) {
         return result;
     }
-    return link_to( first_linked_vp->vehicle(), first_linked_vp->mount(), link_type );
+    return link_to( first_linked_vp->vehicle(), first_linked_vp->mount_pos(), link_type );
 }
 
 ret_val<void> item::link_to( vehicle &veh, const point &mount, link_state link_type )

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -508,7 +508,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
                 debugmsg( "item in vehicle part without cargo storage" );
             }
             if( ch ) {
-                res += " " + direction_suffix( ch->pos(), part_pos.pos() );
+                res += " " + direction_suffix( ch->pos_bub().raw(), part_pos.pos_bub().raw() );
             }
             return res;
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4896,7 +4896,7 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
 
     const auto can_link = [&here, &to_ports]( const tripoint & point ) {
         const optional_vpart_position ovp = here.veh_at( point );
-        return ovp && ovp->vehicle().avail_linkable_part( ovp->mount(), to_ports ) != -1;
+        return ovp && ovp->vehicle().avail_linkable_part( ovp->mount_pos(), to_ports ) != -1;
     };
     const std::optional<tripoint> pnt_ = choose_adjacent_highlight( _( "Attach the cable where?" ),
                                          "", can_link, false, false );
@@ -4939,7 +4939,7 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
         }
 
         // Get the part name for the connection message, using the vehicle name as a fallback.
-        const int part_index = sel_vp->vehicle().avail_linkable_part( sel_vp->mount(), to_ports );
+        const int part_index = sel_vp->vehicle().avail_linkable_part( sel_vp->mount_pos(), to_ports );
         const std::string sel_vp_name = part_index == -1 ? sel_vp->vehicle().name :
                                         sel_vp->vehicle().part( part_index ).name( false );
 

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -413,7 +413,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
                     } else {
                         m.place_spawns( GROUP_MIL_PASSENGER, 1, pos.xy(), pos.xy(), pos.z(), 1, true );
                     }
-                    delete_items_at_mount( *wreckage, vp.mount() ); // delete corpse items
+                    delete_items_at_mount( *wreckage, vp.mount_pos().raw() ); // delete corpse items
                 }
                 break;
             case 4:
@@ -427,7 +427,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
                     } else {
                         m.place_spawns( GROUP_MIL_WEAK, 2, pos.xy(), pos.xy(), pos.z(), 1, true );
                     }
-                    delete_items_at_mount( *wreckage, vp.mount() ); // delete corpse items
+                    delete_items_at_mount( *wreckage, vp.mount_pos().raw() ); // delete corpse items
                 }
                 break;
             case 6:
@@ -435,7 +435,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
                 for( const vpart_reference &vp : wreckage->get_any_parts( VPFLAG_CONTROLS ) ) {
                     const tripoint_bub_ms pos = vp.pos_bub();
                     m.place_spawns( GROUP_MIL_PILOT, 1, pos.xy(), pos.xy(), pos.z(), 1, true );
-                    delete_items_at_mount( *wreckage, vp.mount() ); // delete corpse items
+                    delete_items_at_mount( *wreckage, vp.mount_pos().raw() ); // delete corpse items
                 }
                 break;
             case 7:

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2686,10 +2686,10 @@ static inclusive_rectangle<point> vehicle_bounds( const vehicle_prototype &vp )
     cata_assert( !vp.parts.empty() );
 
     for( const vehicle_prototype::part_def &part : vp.parts ) {
-        min.x = std::min( min.x, part.pos.x );
-        max.x = std::max( max.x, part.pos.x );
-        min.y = std::min( min.y, part.pos.y );
-        max.y = std::max( max.y, part.pos.y );
+        min.x = std::min( min.x, part.pos.x() );
+        max.x = std::max( max.x, part.pos.x() );
+        min.y = std::min( min.y, part.pos.y() );
+        max.y = std::max( max.y, part.pos.y() );
     }
 
     return { min, max };
@@ -6907,7 +6907,7 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, cons
     point_sm_ms remainder;
     std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( p_ms );
     veh->sm_pos = quotient.raw();
-    veh->pos = remainder.raw();
+    veh->pos = remainder;
     veh->init_state( *this, veh_fuel, veh_status );
     veh->place_spawn_items();
     veh->face.init( dir );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1790,9 +1790,9 @@ void npc::execute_action( npc_action action )
 
             // Try to find the last destination
             // This is mount point, not actual position
-            point last_dest( INT_MIN, INT_MIN );
+            point_rel_ms last_dest( INT_MIN, INT_MIN );
             if( !path.empty() && veh_pointer_or_null( here.veh_at( path[path.size() - 1] ) ) == veh ) {
-                last_dest = vp->mount();
+                last_dest = vp->mount_pos();
             }
 
             // Prioritize last found path, then seats
@@ -1821,7 +1821,7 @@ void npc::execute_action( npc_action action )
 
                 int priority = 0;
 
-                if( vp.mount() == last_dest ) {
+                if( vp.mount_pos() == last_dest ) {
                     // Shares mount point with last known path
                     // We probably wanted to go there in the last turn
                     priority = 4;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1338,7 +1338,7 @@ std::vector<options_manager::id_and_option> options_manager::get_lang_options()
         { "", to_translation( "System language" ) },
     };
 
-    constexpr std::array<std::pair<const char *, const char *>, 26> language_names = {{
+    constexpr std::array<std::pair<const char *, const char *>, 25> language_names = {{
             // Note: language names are in their own language and are *not* translated at all.
             // Note: Somewhere in Github PR was better link to msdn.microsoft.com with language names.
             // http://en.wikipedia.org/wiki/List_of_language_names

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1338,7 +1338,7 @@ std::vector<options_manager::id_and_option> options_manager::get_lang_options()
         { "", to_translation( "System language" ) },
     };
 
-    constexpr std::array<std::pair<const char *, const char *>, 25> language_names = {{
+    constexpr std::array<std::pair<const char *, const char *>, 26> language_names = {{
             // Note: language names are in their own language and are *not* translated at all.
             // Note: Somewhere in Github PR was better link to msdn.microsoft.com with language names.
             // http://en.wikipedia.org/wiki/List_of_language_names

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -87,7 +87,7 @@ SDL_Color get_map_color_at( const tripoint &p )
 {
     const map &here = get_map();
     if( const optional_vpart_position vp = here.veh_at( p ) ) {
-        const vpart_display vd = vp->vehicle().get_display_of_tile( vp->mount() );
+        const vpart_display vd = vp->vehicle().get_display_of_tile( vp->mount_pos() );
         return curses_color_to_SDL( vd.color );
     }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3343,8 +3343,8 @@ void vehicle::deserialize( const JsonObject &data )
     int mdir = 0;
 
     data.read( "type", type );
-    data.read( "posx", pos.x );
-    data.read( "posy", pos.y );
+    data.read( "posx", pos.x() );
+    data.read( "posy", pos.y() );
     data.read( "om_id", om_id );
     data.read( "faceDir", fdir );
     data.read( "moveDir", mdir );
@@ -3461,8 +3461,8 @@ void vehicle::serialize( JsonOut &json ) const
 {
     json.start_object();
     json.member( "type", type );
-    json.member( "posx", pos.x );
-    json.member( "posy", pos.y );
+    json.member( "posx", pos.x() );
+    json.member( "posy", pos.y() );
     json.member( "om_id", om_id );
     json.member( "faceDir", std::lround( to_degrees( face.dir() ) ) );
     json.member( "moveDir", std::lround( to_degrees( move.dir() ) ) );

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -259,9 +259,9 @@ void submap::rotate( int turns )
     }
 
     for( auto &elem : vehicles ) {
-        const point_sm_ms new_pos = point_sm_ms( rotate_point( elem->pos ) );
+        const point_sm_ms new_pos = point_sm_ms( rotate_point( elem->pos.raw() ) );
 
-        elem->pos = new_pos.raw();
+        elem->pos = new_pos;
         // turn the steering wheel, vehicle::turn does not actually
         // move the vehicle.
         elem->turn( turns * 90_degrees );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -317,15 +317,9 @@ void suffer::while_underwater( Character &you )
         you.oxygen += 12;
     }
     if( you.oxygen <= 5 ) {
-        if( you.has_bionic( bio_gills ) ) {
-            if( you.get_power_level() >= bio_gills->power_trigger ) {
-                you.oxygen += 5;
-                you.mod_power_level( -bio_gills->power_trigger );
-            } else {
-                you.add_msg_if_player( m_bad,
-                                       _( "You don't have enough bionic power for activation of your Respirator, so you're drowning!" ) );
-                you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
-            }
+        if( you.has_bionic( bio_gills ) && you.get_power_level() >= bio_gills->power_trigger ) {
+            you.oxygen += 5;
+            you.mod_power_level( -bio_gills->power_trigger );
         } else {
             you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
             you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -127,7 +127,7 @@ bool place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
     return true;
 }
 
-player_activity veh_app_interact::run( vehicle &veh, const point &p )
+player_activity veh_app_interact::run( vehicle &veh, const point_rel_ms &p )
 {
     veh_app_interact ap( veh, p );
     ap.app_loop();
@@ -135,7 +135,7 @@ player_activity veh_app_interact::run( vehicle &veh, const point &p )
 }
 
 // Registers general appliance actions from keybindings
-veh_app_interact::veh_app_interact( vehicle &veh, const point &p )
+veh_app_interact::veh_app_interact( vehicle &veh, const point_rel_ms &p )
     : a_point( p ), veh( &veh ), ctxt( "APP_INTERACT", keyboard_mode::keycode )
 {
     ctxt.register_directions();
@@ -408,10 +408,10 @@ void veh_app_interact::refill()
         }
         act.values.push_back( here.getglobal( veh->pos_bub() ).x() + q.x() );
         act.values.push_back( here.getglobal( veh->pos_bub() ).y() + q.y() );
-        act.values.push_back( a_point.x );
-        act.values.push_back( a_point.y );
-        act.values.push_back( -a_point.x );
-        act.values.push_back( -a_point.y );
+        act.values.push_back( a_point.x() );
+        act.values.push_back( a_point.y() );
+        act.values.push_back( -a_point.x() );
+        act.values.push_back( -a_point.y() );
         act.values.push_back( veh->index_of_part( pt ) );
     }
 }
@@ -460,7 +460,7 @@ void veh_app_interact::rename()
 void veh_app_interact::remove()
 {
     map &here = get_map();
-    const tripoint a_point_bub( veh->mount_to_tripoint( a_point ) );
+    const tripoint_bub_ms a_point_bub( veh->mount_to_tripoint( a_point ) );
 
     vehicle_part *vp;
     if( auto sel_part = here.veh_at( a_point_bub ).part_with_feature( VPFLAG_APPLIANCE, false ) ) {
@@ -498,10 +498,10 @@ void veh_app_interact::remove()
         const tripoint a_point_abs( here.getglobal( a_point_bub ).raw() );
         act.values.push_back( a_point_abs.x );
         act.values.push_back( a_point_abs.y );
-        act.values.push_back( a_point.x );
-        act.values.push_back( a_point.y );
-        act.values.push_back( -a_point.x );
-        act.values.push_back( -a_point.y );
+        act.values.push_back( a_point.x() );
+        act.values.push_back( a_point.y() );
+        act.values.push_back( -a_point.x() );
+        act.values.push_back( -a_point.y() );
         act.values.push_back( veh->index_of_part( vp ) );
     }
 }
@@ -538,7 +538,7 @@ void veh_app_interact::populate_app_actions()
 {
     map &here = get_map();
     vehicle_part *vp;
-    const tripoint a_point_bub( veh->mount_to_tripoint( a_point ) );
+    const tripoint_bub_ms a_point_bub( veh->mount_to_tripoint( a_point ) );
     if( auto sel_part = here.veh_at( a_point_bub ).part_with_feature( VPFLAG_APPLIANCE, false ) ) {
         vp = &sel_part->part();
     } else {
@@ -597,7 +597,7 @@ void veh_app_interact::populate_app_actions()
 
     /*************** Get part-specific actions ***************/
     veh_menu menu( veh, "IF YOU SEE THIS IT IS A BUG" );
-    veh->build_interact_menu( menu, veh->mount_to_tripoint( a_point ), false );
+    veh->build_interact_menu( menu, veh->mount_to_tripoint( a_point ).raw(), false );
     const std::vector<veh_menu_item> items = menu.get_items();
     for( size_t i = 0; i < items.size(); i++ ) {
         const veh_menu_item &it = items[i];

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -2,6 +2,8 @@
 #ifndef CATA_SRC_VEH_APPLIANCE_H
 #define CATA_SRC_VEH_APPLIANCE_H
 
+#include "coordinates.h"
+#include "coordinate_constants.h"
 #include "input_context.h"
 #include "player_activity.h"
 
@@ -37,14 +39,14 @@ class veh_app_interact
          * @returns An activity to assign to the player (ACT_VEHICLE),
          * or a null activity if no further action is required.
         */
-        static player_activity run( vehicle &veh, const point &p = point_zero );
+        static player_activity run( vehicle &veh, const point_rel_ms &p = point_rel_ms_zero );
 
     private:
-        explicit veh_app_interact( vehicle &veh, const point &p );
+        explicit veh_app_interact( vehicle &veh, const point_rel_ms &p );
         ~veh_app_interact() = default;
 
         // The player's point of interaction on the appliance.
-        point a_point = point_zero;
+        point_rel_ms a_point = point_rel_ms_zero;
         // The vehicle representing the appliance.
         vehicle *veh;
         // An input context to contain registered actions from the APP_INTERACT category.

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -136,8 +136,8 @@ player_activity veh_interact::serialize_activity()
     if( sel_cmd == 'p' ) {
         if( !parts_here.empty() ) {
             const vpart_reference part_here( *veh, parts_here[0] );
-            const vpart_reference displayed_part( *veh, veh->part_displayed_at( part_here.mount() ) );
-            return veh_shape( *veh ).start( tripoint_bub_ms( displayed_part.pos() ) );
+            const vpart_reference displayed_part( *veh, veh->part_displayed_at( part_here.mount_pos() ) );
+            return veh_shape( *veh ).start( displayed_part.pos_bub() );
         }
         return player_activity();
     }
@@ -182,10 +182,10 @@ player_activity veh_interact::serialize_activity()
     }
     res.values.push_back( here.getglobal( veh->pos_bub() ).x() + q.x() );   // values[0]
     res.values.push_back( here.getglobal( veh->pos_bub() ).y() + q.y() );   // values[1]
-    res.values.push_back( dd.x );   // values[2]
-    res.values.push_back( dd.y );   // values[3]
-    res.values.push_back( -dd.x );   // values[4]
-    res.values.push_back( -dd.y );   // values[5]
+    res.values.push_back( dd.x() );   // values[2]
+    res.values.push_back( dd.y() );   // values[3]
+    res.values.push_back( -dd.x() );   // values[4]
+    res.values.push_back( -dd.y() );   // values[5]
     res.values.push_back( veh->index_of_part( vpt ) ); // values[6]
     res.str_values.emplace_back( vp->id.str() );
     res.str_values.emplace_back( "" ); // previously stored the part variant, now obsolete
@@ -195,7 +195,7 @@ player_activity veh_interact::serialize_activity()
 }
 
 void orient_part( vehicle *veh, const vpart_info &vpinfo, int partnum,
-                  const std::optional<point> &part_placement )
+                  const std::optional<point_rel_ms> &part_placement )
 {
 
     avatar &player_character = get_avatar();
@@ -205,8 +205,8 @@ void orient_part( vehicle *veh, const vpart_info &vpinfo, int partnum,
     tripoint_bub_ms offset = veh->pos_bub();
     // Appliances are one tile so the part placement there is always point_zero
     if( part_placement ) {
-        point copied_placement = *part_placement ;
-        offset += copied_placement ;
+        point_rel_ms copied_placement = *part_placement;
+        offset = offset + copied_placement;
     }
     player_character.view_offset = offset - player_character.pos_bub();
 
@@ -232,7 +232,7 @@ void orient_part( vehicle *veh, const vpart_info &vpinfo, int partnum,
     veh->part( partnum ).direction = dir;
 }
 
-player_activity veh_interact::run( vehicle &veh, const point &p )
+player_activity veh_interact::run( vehicle &veh, const point_rel_ms &p )
 {
     veh_interact vehint( veh, p );
     vehint.do_main_loop();
@@ -268,7 +268,7 @@ std::optional<vpart_reference> veh_interact::select_part( const vehicle &veh,
 /**
  * Creates a blank veh_interact window.
  */
-veh_interact::veh_interact( vehicle &veh, const point &p )
+veh_interact::veh_interact( vehicle &veh, const point_rel_ms &p )
     : dd( p ), veh( &veh ), main_context( "VEH_INTERACT", keyboard_mode::keycode )
 {
     main_context.register_directions();
@@ -302,7 +302,7 @@ veh_interact::veh_interact( vehicle &veh, const point &p )
     count_durability();
     cache_tool_availability();
     // Initialize info of selected parts
-    move_cursor( point_zero );
+    move_cursor( point_rel_ms_zero );
 }
 
 veh_interact::~veh_interact() = default;
@@ -513,7 +513,7 @@ void veh_interact::do_main_loop()
         const std::string action = main_context.handle_input();
         msg.reset();
         if( const std::optional<tripoint> vec = main_context.get_direction( action ) ) {
-            move_cursor( vec->xy() );
+            move_cursor( point_rel_ms( vec->xy() ) );
         } else if( action == "QUIT" ) {
             finish = true;
         } else if( action == "INSTALL" ) {
@@ -587,13 +587,13 @@ void veh_interact::do_main_loop()
         } else if( action == "OVERVIEW_UP" ) {
             move_overview_line( -1 );
         } else if( action == "DESC_LIST_DOWN" ) {
-            move_cursor( point_zero, 1 );
+            move_cursor( point_rel_ms_zero, 1 );
         } else if( action == "DESC_LIST_UP" ) {
-            move_cursor( point_zero, -1 );
+            move_cursor( point_rel_ms_zero, -1 );
         } else if( action == "PAGE_DOWN" ) {
-            move_cursor( point_zero, description_scroll_lines );
+            move_cursor( point_rel_ms_zero, description_scroll_lines );
         } else if( action == "PAGE_UP" ) {
-            move_cursor( point_zero, -description_scroll_lines );
+            move_cursor( point_rel_ms_zero, -description_scroll_lines );
         }
         if( sel_cmd != ' ' ) {
             finish = true;
@@ -606,21 +606,21 @@ void veh_interact::cache_tool_availability()
     Character &player_character = get_player_character();
     crafting_inv = &player_character.crafting_inventory();
 
-    cache_tool_availability_update_lifting( player_character.pos() );
+    cache_tool_availability_update_lifting( player_character.pos_bub() );
     int mech_jack = 0;
     if( player_character.is_mounted() ) {
         mech_jack = player_character.mounted_creature->mech_str_addition() + 10;
     }
     int max_quality = std::max( { player_character.max_quality( qual_JACK ), mech_jack,
                                   map_selector( player_character.pos_bub(), PICKUP_RANGE ).max_quality( qual_JACK ),
-                                  vehicle_selector( player_character.pos(), 2, true, *veh ).max_quality( qual_JACK )
+                                  vehicle_selector( player_character.pos_bub(), 2, true, *veh ).max_quality( qual_JACK )
                                 } );
     max_jack = lifting_quality_to_mass( max_quality );
 }
 
-void veh_interact::cache_tool_availability_update_lifting( const tripoint &world_cursor_pos )
+void veh_interact::cache_tool_availability_update_lifting( const tripoint_bub_ms &world_cursor_pos )
 {
-    max_lift = get_player_character().best_nearby_lifting_assist( world_cursor_pos );
+    max_lift = get_player_character().best_nearby_lifting_assist( world_cursor_pos.raw() );
 }
 
 /**
@@ -854,7 +854,7 @@ bool veh_interact::update_part_requirements()
             }
         }
 
-        if( !axles.empty() && axles.count( -dd.x ) == 0 ) {
+        if( !axles.empty() && axles.count( -dd.x() ) == 0 ) {
             // Installing more than one steerable axle is hard
             // (but adding a wheel to an existing axle isn't)
             dif_steering = axles.size() + 5;
@@ -2154,9 +2154,9 @@ std::pair<bool, std::string> veh_interact::calc_lift_requirements( const vpart_i
  * @param d The coordinates, relative to the viewport's 0-point (?)
  * @return The first vehicle part at the specified coordinates.
  */
-int veh_interact::part_at( const point &d )
+int veh_interact::part_at( const point_rel_ms &d )
 {
-    const point vd = -dd + d.rotate( 1 );
+    const point_rel_ms vd{ -dd + d.rotate( 1 ) };
     return veh->part_displayed_at( vd );
 }
 
@@ -2190,19 +2190,19 @@ bool veh_interact::can_potentially_install( const vpart_info &vpart )
  * @param d How far to move the cursor.
  * @param dstart_at How far to change the start position for vehicle part descriptions
  */
-void veh_interact::move_cursor( const point &d, int dstart_at )
+void veh_interact::move_cursor( const point_rel_ms &d, int dstart_at )
 {
     dd += d.rotate( 3 );
-    if( d != point_zero ) {
+    if( d != point_rel_ms_zero ) {
         start_limit = 0;
     } else {
         start_at += dstart_at;
     }
 
     // Update the current active component index to the new position.
-    cpart = part_at( point_zero );
-    const point vd = -dd;
-    const point q = veh->coord_translate( vd );
+    cpart = part_at( point_rel_ms_zero );
+    const point_rel_ms vd = -dd;
+    const point_rel_ms q = veh->coord_translate( vd );
     const tripoint_bub_ms vehp = veh->pos_bub() + q;
     const bool has_critter = get_creature_tracker().creature_at( vehp );
     map &here = get_map();
@@ -2252,7 +2252,7 @@ void veh_interact::move_cursor( const point &d, int dstart_at )
     }
 
     /* Update the lifting quality to be the that is available for this newly selected tile */
-    cache_tool_availability_update_lifting( vehp.raw() );
+    cache_tool_availability_update_lifting( vehp );
 }
 
 void veh_interact::display_grid()
@@ -2318,18 +2318,18 @@ void veh_interact::display_veh()
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         mvwprintz( w_disp, point( 0, 1 ), c_red,   "Pivot %d,%d", pivot.x(), pivot.y() );
 
-        const point com_s = ( com.raw() + dd ).rotate( 3 ) + h_size;
-        const point pivot_s = ( pivot.raw() + dd ).rotate( 3 ) + h_size;
+        const point_rel_ms com_s = ( com + dd ).rotate( 3 ) + h_size;
+        const point_rel_ms pivot_s = ( pivot + dd ).rotate( 3 ) + h_size;
 
-        mvwhline( w_disp, point( 0, com_s.y ), c_green, LINE_OXOX, std::min( getmaxx( w_disp ),
-                  com_s.x + 1 ) );
-        mvwvline( w_disp, point( com_s.x, 0 ), c_green, LINE_XOXO, std::min( getmaxy( w_disp ),
-                  com_s.y + 1 ) );
+        mvwhline( w_disp, point( 0, com_s.y() ), c_green, LINE_OXOX, std::min( getmaxx( w_disp ),
+                  com_s.x() + 1));
+        mvwvline( w_disp, point( com_s.x(), 0), c_green, LINE_XOXO, std::min(getmaxy(w_disp),
+                  com_s.y() + 1));
 
-        mvwhline( w_disp, point( std::max( 0, pivot_s.x ), pivot_s.y ), c_red, LINE_OXOX,
-                  getmaxx( w_disp ) - std::max( 0, pivot_s.x ) + 1 );
-        mvwvline( w_disp, point( pivot_s.x, std::max( 0, pivot_s.y ) ), c_red, LINE_XOXO,
-                  getmaxy( w_disp ) - std::max( 0, pivot_s.y ) + 1 );
+        mvwhline( w_disp, point( std::max( 0, pivot_s.x() ), pivot_s.y() ), c_red, LINE_OXOX,
+                  getmaxx( w_disp ) - std::max( 0, pivot_s.x() ) + 1 );
+        mvwvline( w_disp, point( pivot_s.x(), std::max(0, pivot_s.y())), c_red, LINE_XOXO,
+                  getmaxy( w_disp ) - std::max( 0, pivot_s.y() ) + 1 );
     }
 
     // Draw guidelines to make current selection point more visible.
@@ -2343,10 +2343,10 @@ void veh_interact::display_veh()
     for( const int structural_part_idx : veh->all_parts_at_location( "structure" ) ) {
         const vehicle_part &vp = veh->part( structural_part_idx );
         const vpart_display vd = veh->get_display_of_tile( vp.mount, false, false );
-        const point q = ( vp.mount.raw() + dd ).rotate( 3 );
+        const point_rel_ms q = ( vp.mount + dd ).rotate( 3 );
 
-        if( q != point_zero ) { // cursor is not on this part
-            mvwputch( w_disp, h_size + q, vd.color, vd.symbol_curses );
+        if( q != point_rel_ms_zero ) { // cursor is not on this part
+            mvwputch( w_disp, h_size + q.raw(), vd.color, vd.symbol_curses );
             continue;
         }
         cpart = structural_part_idx;
@@ -3130,7 +3130,7 @@ void veh_interact::complete_vehicle( Character &you )
             if( vpinfo.has_flag( VPFLAG_CONE_LIGHT ) ||
                 vpinfo.has_flag( VPFLAG_WIDE_CONE_LIGHT ) ||
                 vpinfo.has_flag( VPFLAG_HALF_CIRCLE_LIGHT ) ) {
-                orient_part( &veh, vpinfo, partnum, q.raw() );
+                orient_part( &veh, vpinfo, partnum, q );
             }
 
             const tripoint_bub_ms vehp = veh.pos_bub() + tripoint_rel_ms( q, 0 );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2322,13 +2322,13 @@ void veh_interact::display_veh()
         const point_rel_ms pivot_s = ( pivot + dd ).rotate( 3 ) + h_size;
 
         mvwhline( w_disp, point( 0, com_s.y() ), c_green, LINE_OXOX, std::min( getmaxx( w_disp ),
-                  com_s.x() + 1));
-        mvwvline( w_disp, point( com_s.x(), 0), c_green, LINE_XOXO, std::min(getmaxy(w_disp),
-                  com_s.y() + 1));
+                  com_s.x() + 1 ) );
+        mvwvline( w_disp, point( com_s.x(), 0 ), c_green, LINE_XOXO, std::min( getmaxy( w_disp ),
+                  com_s.y() + 1 ) );
 
         mvwhline( w_disp, point( std::max( 0, pivot_s.x() ), pivot_s.y() ), c_red, LINE_OXOX,
                   getmaxx( w_disp ) - std::max( 0, pivot_s.x() ) + 1 );
-        mvwvline( w_disp, point( pivot_s.x(), std::max(0, pivot_s.y())), c_red, LINE_XOXO,
+        mvwvline( w_disp, point( pivot_s.x(), std::max( 0, pivot_s.y() ) ), c_red, LINE_XOXO,
                   getmaxy( w_disp ) - std::max( 0, pivot_s.y() ) + 1 );
     }
 

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -12,12 +12,13 @@
 #include <vector>
 
 #include "color.h"
+#include "coordinates.h"
+#include "coordinate_constants.h"
 #include "cursesdef.h"
 #include "input_context.h"
 #include "item_location.h"
 #include "mapdata.h"
 #include "player_activity.h"
-#include "point.h"
 #include "type_id.h"
 #include "units_fwd.h"
 
@@ -51,7 +52,7 @@ class veh_interact
         using part_selector = std::function<bool( const vehicle_part &pt )>;
 
     public:
-        static player_activity run( vehicle &veh, const point &p );
+        static player_activity run( vehicle &veh, const point_rel_ms &p );
 
         /** Prompt for a part matching the selector function */
         static std::optional<vpart_reference> select_part( const vehicle &veh, const part_selector &sel,
@@ -60,10 +61,10 @@ class veh_interact
         static void complete_vehicle( Character &you );
 
     private:
-        explicit veh_interact( vehicle &veh, const point &p = point_zero );
+        explicit veh_interact( vehicle &veh, const point_rel_ms &p = point_rel_ms_zero );
         ~veh_interact();
 
-        point dd = point_zero;
+        point_rel_ms dd = point_rel_ms_zero;
         /* starting offset for vehicle parts description display and max offset for scrolling */
         int start_at = 0;
         int start_limit = 0;
@@ -139,8 +140,8 @@ class veh_interact
         bool format_reqs( std::string &msg, const requirement_data &reqs,
                           const std::map<skill_id, int> &skills, time_duration time ) const;
 
-        int part_at( const point &d );
-        void move_cursor( const point &d, int dstart_at = 0 );
+        int part_at( const point_rel_ms &d );
+        void move_cursor( const point_rel_ms &d, int dstart_at = 0 );
         task_reason cant_do( char mode );
         bool can_potentially_install( const vpart_info &vpart );
         /** Move index (parameter pos) according to input action:
@@ -284,7 +285,7 @@ class veh_interact
         void allocate_windows();
         void do_main_loop();
 
-        void cache_tool_availability_update_lifting( const tripoint &world_cursor_pos );
+        void cache_tool_availability_update_lifting( const tripoint_bub_ms &world_cursor_pos );
 
         /** Returns true if the vehicle has a jack powerful enough to lift itself installed */
         bool can_self_jack();
@@ -293,6 +294,6 @@ class veh_interact
 void act_vehicle_siphon( vehicle *veh );
 
 void orient_part( vehicle *veh, const vpart_info &vpinfo, int partnum,
-                  const std::optional<point> &part_placement = std::nullopt );
+                  const std::optional<point_rel_ms> &part_placement = std::nullopt );
 
 #endif // CATA_SRC_VEH_INTERACT_H

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -23,7 +23,7 @@ player_activity veh_shape::start( const tripoint_bub_ms &pos )
 
     cursor_allowed.clear();
     for( const vpart_reference &part : veh.get_all_parts() ) {
-        cursor_allowed.insert( tripoint_bub_ms( part.pos() ) );
+        cursor_allowed.insert( part.pos_bub() );
     }
 
     if( !set_cursor_pos( pos ) ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1276,7 +1276,7 @@ void vehicle_prototype::load( const JsonObject &jo, std::string_view )
     vgroups[vgroup_id( id.str() )].add_vehicle( id, 100 );
     optional( jo, was_loaded, "name", name );
 
-    const auto add_part_obj = [&]( const JsonObject & part, point pos ) {
+    const auto add_part_obj = [&]( const JsonObject & part, point_rel_ms pos ) {
         const auto [id, variant] = get_vpart_str_variant( part.get_string( "part" ) );
         part_def pt;
         pt.part = vpart_id( id );
@@ -1292,7 +1292,7 @@ void vehicle_prototype::load( const JsonObject &jo, std::string_view )
         parts.emplace_back( pt );
     };
 
-    const auto add_part_string = [&]( const std::string & part, point pos ) {
+    const auto add_part_string = [&]( const std::string & part, point_rel_ms pos ) {
         const auto [id, variant] = get_vpart_str_variant( part );
         part_def pt;
         pt.part = vpart_id( id );
@@ -1307,7 +1307,7 @@ void vehicle_prototype::load( const JsonObject &jo, std::string_view )
     }
 
     for( JsonObject part : jo.get_array( "parts" ) ) {
-        point pos = point( part.get_int( "x" ), part.get_int( "y" ) );
+        point_rel_ms pos{ part.get_int( "x" ), part.get_int( "y" ) };
 
         if( part.has_string( "part" ) ) {
             add_part_obj( part, pos );
@@ -1328,13 +1328,13 @@ void vehicle_prototype::load( const JsonObject &jo, std::string_view )
 
     for( JsonObject spawn_info : jo.get_array( "items" ) ) {
         vehicle_item_spawn next_spawn;
-        next_spawn.pos.x = spawn_info.get_int( "x" );
-        next_spawn.pos.y = spawn_info.get_int( "y" );
+        next_spawn.pos.x() = spawn_info.get_int( "x" );
+        next_spawn.pos.y() = spawn_info.get_int( "y" );
 
         next_spawn.chance = spawn_info.get_int( "chance" );
         if( next_spawn.chance <= 0 || next_spawn.chance > 100 ) {
             debugmsg( "Invalid spawn chance in %s (%d, %d): %d%%",
-                      name, next_spawn.pos.x, next_spawn.pos.y, next_spawn.chance );
+                      name, next_spawn.pos.x(), next_spawn.pos.y(), next_spawn.chance );
         }
 
         // constrain both with_magazine and with_ammo to [0-100]
@@ -1371,7 +1371,7 @@ void vehicle_prototype::load( const JsonObject &jo, std::string_view )
         zone_type_id zone_type( jzi.get_member( "type" ).get_string() );
         std::string name;
         std::string filter;
-        point pt( jzi.get_member( "x" ).get_int(), jzi.get_member( "y" ).get_int() );
+        point_rel_ms pt( jzi.get_member( "x" ).get_int(), jzi.get_member( "y" ).get_int() );
 
         if( jzi.has_string( "name" ) ) {
             name = jzi.get_string( "name" );
@@ -1504,8 +1504,8 @@ void vehicle_prototype::save_vehicle_as_prototype( const vehicle &veh, JsonOut &
         const vehicle_stack &stack = veh.get_items( vp.part() );
         if( !stack.empty() ) {
             json.start_object();
-            json.member( "x", vp.mount().x );
-            json.member( "y", vp.mount().y );
+            json.member( "x", vp.mount_pos().x() );
+            json.member( "y", vp.mount_pos().y() );
             json.member( "chance", 100 );
             json.member( "items" );
             json.start_array();
@@ -1522,8 +1522,8 @@ void vehicle_prototype::save_vehicle_as_prototype( const vehicle &veh, JsonOut &
     json.start_array();
     for( auto const &z : veh.loot_zones ) {
         json.start_object();
-        json.member( "x", z.first.x );
-        json.member( "y", z.first.y );
+        json.member( "x", z.first.x() );
+        json.member( "y", z.first.y() );
         json.member( "type", z.second.get_type().str() );
         json.end_object();
     }
@@ -1540,7 +1540,7 @@ void vehicles::finalize_prototypes()
     vehicle_prototype_factory.finalize();
     for( const vehicle_prototype &const_proto : vehicles::get_all_prototypes() ) {
         vehicle_prototype &proto = const_cast<vehicle_prototype &>( const_proto );
-        std::unordered_set<point> cargo_spots;
+        std::unordered_set<point_rel_ms> cargo_spots;
 
         // Calling the constructor with empty vproto_id as parameter
         // makes constructor bypass copying the (non-existing) blueprint.
@@ -1566,7 +1566,7 @@ void vehicles::finalize_prototypes()
             if( part_idx < 0 ) {
                 debugmsg( "init_vehicles: '%s' part '%s'(%d) can't be installed to %d,%d",
                           blueprint.name, pt.part.c_str(),
-                          blueprint.part_count(), pt.pos.x, pt.pos.y );
+                          blueprint.part_count(), pt.pos.x(), pt.pos.y() );
             } else {
                 vehicle_part &vp = blueprint.part( part_idx );
                 const vpart_info &vpi = vp.info();
@@ -1657,7 +1657,7 @@ void vehicles::finalize_prototypes()
         for( vehicle_item_spawn &i : proto.item_spawns ) {
             if( cargo_spots.count( i.pos ) == 0 ) {
                 debugmsg( "Invalid spawn location (no CARGO vpart) in %s (%d, %d): %d%%",
-                          proto.name, i.pos.x, i.pos.y, i.chance );
+                          proto.name, i.pos.x(), i.pos.y(), i.chance );
             }
             for( auto &j : i.item_ids ) {
                 if( !item::type_is_defined( j ) ) {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -18,8 +18,8 @@
 #include "calendar.h"
 #include "color.h"
 #include "compatibility.h"
+#include "coordinates.h"
 #include "damage.h"
-#include "point.h"
 #include "requirements.h"
 #include "translations.h"
 #include "type_id.h"
@@ -465,7 +465,7 @@ class vpart_info
 };
 
 struct vehicle_item_spawn {
-    point pos;
+    point_rel_ms pos;
     int chance = 0;
     /** Chance [0-100%] for items to spawn with ammo (plus default magazine if necessary) */
     int with_ammo = 0;
@@ -484,7 +484,7 @@ struct vehicle_item_spawn {
 struct vehicle_prototype {
     public:
         struct part_def {
-            point pos;
+            point_rel_ms pos;
             vpart_id part;
             std::string variant;
             int with_ammo = 0;
@@ -498,7 +498,7 @@ struct vehicle_prototype {
             zone_type_id zone_type;
             std::string name;
             std::string filter;
-            point pt;
+            point_rel_ms pt;
         };
 
         vproto_id id;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -141,8 +141,8 @@ static const std::string flag_WIRING( "WIRING" );
 //~ Name for an array of electronic power grid appliances, like batteries and solar panels
 static const translation power_grid_name = to_translation( "power grid" );
 
-static bool is_sm_tile_outside( const tripoint &real_global_pos );
-static bool is_sm_tile_over_water( const tripoint &real_global_pos );
+static bool is_sm_tile_outside( const tripoint_abs_ms &real_global_pos );
+static bool is_sm_tile_over_water( const tripoint_abs_ms &real_global_pos );
 
 static const int MAX_WIRE_VEHICLE_SIZE = 24;
 
@@ -262,7 +262,7 @@ bool vehicle::player_in_control( const Character &p ) const
     const optional_vpart_position vp = get_map().veh_at( p.pos_bub() );
     if( vp && &vp->vehicle() == this &&
         p.controlling_vehicle &&
-        ( ( part_with_feature( vp->mount(), "CONTROL_ANIMAL", true ) >= 0 &&
+        ( ( part_with_feature( vp->mount_pos(), "CONTROL_ANIMAL", true ) >= 0 &&
             has_engine_type( fuel_type_animal, false ) && get_harnessed_animal() ) ||
           ( part_with_feature( vp->part_index(), VPFLAG_CONTROLS, false ) >= 0 ) )
       ) {
@@ -302,7 +302,7 @@ bool vehicle::remote_controlled( const Character &p ) const
     }
 
     for( const vpart_reference &vp : get_avail_parts( "REMOTE_CONTROLS" ) ) {
-        if( rl_dist( p.pos(), vp.pos() ) <= 40 ) {
+        if( rl_dist( p.pos_bub(), vp.pos_bub() ) <= 40 ) {
             return true;
         }
     }
@@ -465,7 +465,7 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
         }
     }
 
-    std::optional<point> blood_inside_pos;
+    std::optional<point_rel_ms> blood_inside_pos;
     for( const vpart_reference &vp : get_all_parts() ) {
         const size_t p = vp.part_index();
         vehicle_part &pt = vp.part();
@@ -545,7 +545,7 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
             * the "front" of the vehicle (since the driver's seat is at (0, 0).
             * We'll be generous with the blood, since some may disappear before
             * the player gets a chance to see the vehicle. */
-            if( blood_covered && vp.mount().x > 0 ) {
+            if( blood_covered && vp.mount_pos().x() > 0 ) {
                 if( one_in( 3 ) ) {
                     //Loads of blood. (200 = completely red vehicle part)
                     pt.blood = rng( 200, 600 );
@@ -559,14 +559,14 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
                 // blood is splattered around (blood_inside_pos),
                 // coordinates relative to mount point; the center is always a seat
                 if( blood_inside_pos ) {
-                    const int distSq = std::pow( blood_inside_pos->x - vp.mount().x, 2 ) +
-                                       std::pow( blood_inside_pos->y - vp.mount().y, 2 );
+                    const int distSq = std::pow( blood_inside_pos->x() - vp.mount_pos().x(), 2 ) +
+                                       std::pow( blood_inside_pos->y() - vp.mount_pos().y(), 2 );
                     if( distSq <= 1 ) {
                         pt.blood = rng( 200, 400 ) - distSq * 100;
                     }
                 } else if( vp.has_feature( "SEAT" ) ) {
                     // Set the center of the bloody mess inside
-                    blood_inside_pos.emplace( vp.mount() );
+                    blood_inside_pos.emplace( vp.mount_pos() );
                 }
             }
         }
@@ -727,8 +727,8 @@ std::set<point_abs_ms> vehicle::immediate_path( const units::angle &rotate )
     return points_to_check;
 }
 
-static int get_turn_from_angle( const units::angle &angle, const tripoint &vehpos,
-                                const tripoint &target, bool reverse = false )
+static int get_turn_from_angle( const units::angle &angle, const tripoint_abs_ms &vehpos,
+                                const tripoint_abs_ms &target, bool reverse = false )
 {
     if( angle > 10.0_degrees && angle <= 45.0_degrees ) {
         return reverse ? 4 : 1;
@@ -775,7 +775,7 @@ void vehicle::drive_to_local_target( const tripoint_abs_ms &target, bool follow_
         stop_autodriving();
         return;
     }
-    int turn_x = get_turn_from_angle( angle, vehpos.raw(), target.raw() );
+    int turn_x = get_turn_from_angle( angle, vehpos, target );
     int accel_y = 0;
     // best to cruise around at a safe velocity or 40mph, whichever is lowest
     // accelerate when it doesn't need to turn.
@@ -788,12 +788,12 @@ void vehicle::drive_to_local_target( const tripoint_abs_ms &target, bool follow_
     if( follow_protocol ) {
         if( ( ( turn_x > 0 || turn_x < 0 ) && velocity > safe_player_follow_speed ) ||
             rl_dist( vehpos, here.getglobal( player_character.pos_bub() ) ) < 7 + ( (
-                        mount_max.y * 3 ) + 4 ) ) {
+                        mount_max.y() * 3 ) + 4 ) ) {
             accel_y = 1;
         }
         if( ( velocity < std::min( safe_velocity(), safe_player_follow_speed ) && turn_x == 0 &&
               rl_dist( vehpos, here.getglobal( player_character.pos_bub() ) ) > 8 + ( (
-                          mount_max.y * 3 ) + 4 ) ) ||
+                          mount_max.y() * 3 ) + 4 ) ) ||
             velocity < 100 ) {
             accel_y = -1;
         }
@@ -1173,11 +1173,6 @@ int vehicle::power_to_energy_bat( const units::power power, const time_duration 
     units::energy produced = power * d;
     int produced_kj = roll_remainder( units::to_millijoule( produced ) / 1000000.0 );
     return produced_kj;
-}
-
-bool vehicle::has_structural_part( const point &dp ) const
-{
-    return vehicle::has_structural_part( point_rel_ms( dp ) );
 }
 
 bool vehicle::has_structural_part( const point_rel_ms &dp ) const
@@ -1643,7 +1638,7 @@ std::vector<vehicle::rackable_vehicle> vehicle::find_vehicles_to_rack( int rack 
 
         for( const point &offset : four_cardinal_directions ) {
             vehicle *veh_matched = nullptr;
-            std::set<tripoint> parts_matched;
+            std::set<tripoint_bub_ms> parts_matched;
             for( const int &rack_part : filtered_rack ) {
                 const tripoint_bub_ms search_pos = bub_part_pos( rack_part ) + offset;
                 const optional_vpart_position ovp = get_map().veh_at( search_pos );
@@ -1655,12 +1650,12 @@ std::vector<vehicle::rackable_vehicle> vehicle::find_vehicles_to_rack( int rack 
                     veh_matched = test_veh;
                     parts_matched.clear();
                 }
-                parts_matched.insert( search_pos.raw() );
+                parts_matched.insert( search_pos );
 
-                std::set<tripoint> test_veh_points;
+                std::set<tripoint_bub_ms> test_veh_points;
                 for( const vpart_reference &vpr : test_veh->get_all_parts() ) {
                     if( !vpr.part().removed && !vpr.part().is_fake ) {
-                        test_veh_points.insert( vpr.pos() );
+                        test_veh_points.insert( vpr.pos_bub() );
                     }
                 }
 
@@ -1784,10 +1779,10 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
         int rack_part = 0;
 
         // the mount point we are going to add to the vehicle with the rack
-        point carry_mount;
+        point_rel_ms carry_mount;
 
         // the mount point on the old vehicle (carry_veh) that will be destroyed
-        point old_mount;
+        point_rel_ms old_mount;
     };
     remove_fake_parts( /* cleanup = */ false );
     invalidate_towing( true );
@@ -1846,8 +1841,8 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
                 point_rel_ms old_mount = carry_veh->parts[ carry_part ].mount;
                 carry_map.carry_parts_here = carry_veh->parts_at_relative( old_mount, true );
                 carry_map.rack_part = rack_part;
-                carry_map.carry_mount = carry_mount.raw();
-                carry_map.old_mount = old_mount.raw();
+                carry_map.carry_mount = carry_mount;
+                carry_map.old_mount = old_mount;
                 carry_data.push_back( carry_map );
                 merged_part = true;
                 break;
@@ -1869,9 +1864,9 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
             for( const int &carry_part : carry_map.carry_parts_here ) {
                 parts.push_back( carry_veh->parts[ carry_part ] );
                 vehicle_part &carried_part = parts.back();
-                carried_part.mount = point_rel_ms( carry_map.carry_mount );
+                carried_part.mount = carry_map.carry_mount;
                 carried_part.carried_stack.push( {
-                    tripoint_rel_ms( carry_map.old_mount.x, carry_map.old_mount.y, 0 ),
+                    tripoint_rel_ms( carry_map.old_mount.x(), carry_map.old_mount.y(), 0 ),
                     relative_dir,
                     carry_veh->name
                 } );
@@ -1890,9 +1885,9 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
                 parts[ carry_map.rack_part ].set_flag( vp_flag::carrying_flag );
             }
 
-            const std::pair<std::unordered_multimap<point, zone_data>::iterator, std::unordered_multimap<point, zone_data>::iterator>
-            zones_on_point = carry_veh->loot_zones.equal_range( carry_map.old_mount );
-            for( std::unordered_multimap<point, zone_data>::const_iterator it = zones_on_point.first;
+            const std::pair<std::unordered_multimap<point_rel_ms, zone_data>::iterator, std::unordered_multimap<point_rel_ms, zone_data>::iterator>
+            zones_on_point = carry_veh->loot_zones.equal_range( point_rel_ms( carry_map.old_mount ) );
+            for( std::unordered_multimap<point_rel_ms, zone_data>::const_iterator it = zones_on_point.first;
                  it != zones_on_point.second; ++it ) {
                 new_zones.emplace( carry_map.carry_mount, it->second );
             }
@@ -1900,7 +1895,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
 
         for( auto &new_zone : new_zones ) {
             zone_manager::get_manager().create_vehicle_loot_zone(
-                *this, new_zone.first, new_zone.second );
+                *this, new_zone.first.raw(), new_zone.second );
         }
 
         // Now that we've added zones to this vehicle, we need to make sure their positions
@@ -2115,11 +2110,11 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
 
     // Unboard any entities standing on removed boardable parts
     if( vpi.has_flag( "BOARDABLE" ) && vp.has_flag( vp_flag::passenger_flag ) ) {
-        handler.unboard( part_loc.raw() );
+        handler.unboard( part_loc );
     }
 
     for( const item &it : vp.tools ) {
-        handler.add_item_or_charges( part_loc.raw(), it, false );
+        handler.add_item_or_charges( part_loc, it, false );
     }
 
     // If `p` has flag `parent_flag`, remove child with flag `child_flag`
@@ -2131,7 +2126,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
             return false;
         }
         vehicle_part &vp_dep = parts[dep];
-        handler.add_item_or_charges( part_loc.raw(), part_to_item( vp_dep ), false );
+        handler.add_item_or_charges( part_loc, part_to_item( vp_dep ), false );
         remove_part( vp_dep, handler );
         return true;
     };
@@ -2153,7 +2148,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
     // Release any animal held by the part
     if( vp.has_flag( vp_flag::animal_flag ) ) {
         item base = vp.get_base();
-        handler.spawn_animal_from_part( base, part_loc.raw() );
+        handler.spawn_animal_from_part( base, part_loc );
         vp.set_base( std::move( base ) );
         vp.remove_flag( vp_flag::animal_flag );
     }
@@ -2180,13 +2175,13 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
     }
 
     //Remove loot zone if Cargo was removed.
-    const auto lz_iter = loot_zones.find( vp.mount.raw() );
+    const auto lz_iter = loot_zones.find( vp.mount );
     const bool no_zone = lz_iter != loot_zones.end();
 
     if( no_zone && vpi.has_flag( VPFLAG_CARGO ) ) {
         // Using the key here (instead of the iterator) will remove all zones on
         // this mount points regardless of how many there are
-        loot_zones.erase( vp.mount.raw() );
+        loot_zones.erase( vp.mount );
         zones_dirty = true;
     }
     vp.removed = true;
@@ -2213,7 +2208,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
             // so we pass true here to cause such points to be clamped to the
             // valid bounds without printing an error (as would normally
             // occur).
-            handler.add_item_or_charges( dest.raw(), i, true );
+            handler.add_item_or_charges( dest, i, true );
         }
     }
     refresh( false );
@@ -2486,7 +2481,7 @@ void vehicle::relocate_passengers( const std::vector<Character *> &passengers ) 
     for( Character *passenger : passengers ) {
         for( const vpart_reference &vp : boardables ) {
             if( vp.part().passenger_id == passenger->getID() ) {
-                passenger->setpos( vp.pos() );
+                passenger->setpos( vp.pos_bub() );
             }
         }
     }
@@ -2610,15 +2605,16 @@ bool vehicle::split_vehicles( map &here,
                 new_labels.insert( label( new_mount, label_str ) );
             }
             // Prepare the zones to be moved to the new vehicle
-            const std::pair<std::unordered_multimap<point, zone_data>::iterator, std::unordered_multimap<point, zone_data>::iterator>
-            zones_on_point = loot_zones.equal_range( cur_mount.raw() );
-            for( std::unordered_multimap<point, zone_data>::const_iterator lz_iter = zones_on_point.first;
+            const std::pair<std::unordered_multimap<point_rel_ms, zone_data>::iterator, std::unordered_multimap<point_rel_ms, zone_data>::iterator>
+            zones_on_point = loot_zones.equal_range( cur_mount );
+            for( std::unordered_multimap<point_rel_ms, zone_data>::const_iterator lz_iter =
+                     zones_on_point.first;
                  lz_iter != zones_on_point.second; ++lz_iter ) {
                 new_zones.emplace( new_mount.raw(), lz_iter->second );
             }
 
             // Erasing on the key removes all the zones from the point at once
-            loot_zones.erase( cur_mount.raw() );
+            loot_zones.erase( cur_mount );
 
             // The zone manager will be updated when we next interact with it through get_vehicle_zones
             zones_dirty = true;
@@ -2635,8 +2631,8 @@ bool vehicle::split_vehicles( map &here,
         // We want to create the vehicle zones after we've setup the parts
         // because we need only to move the zone once per mount, not per part. If we move per
         // part, we will end up with duplicates of the zone per part on the same mount
-        for( std::pair<point, zone_data> zone : new_zones ) {
-            zone_manager::get_manager().create_vehicle_loot_zone( *new_vehicle, zone.first, zone.second );
+        for( std::pair<point_rel_ms, zone_data> zone : new_zones ) {
+            zone_manager::get_manager().create_vehicle_loot_zone( *new_vehicle, zone.first.raw(), zone.second );
         }
 
         // create_vehicle_loot_zone marks the vehicle as not dirty but since we got these zones
@@ -2689,36 +2685,7 @@ item_group::ItemList vehicle_part::pieces_for_broken_part() const
 std::vector<int> vehicle::parts_at_relative( const point &dp, const bool use_cache,
         bool include_fake ) const
 {
-    std::vector<int> res;
-    if( !use_cache ) {
-        if( include_fake ) {
-            for( const vpart_reference &vp : get_all_parts_with_fakes() ) {
-                if( vp.mount() == dp && !vp.part().removed ) {
-                    res.push_back( static_cast<int>( vp.part_index() ) );
-                }
-            }
-        } else {
-            for( const vpart_reference &vp : get_all_parts() ) {
-                if( vp.mount() == dp && !vp.part().removed ) {
-                    res.push_back( static_cast<int>( vp.part_index() ) );
-                }
-            }
-        }
-    } else {
-        const auto &iter = relative_parts.find( dp );
-        if( iter != relative_parts.end() ) {
-            if( include_fake ) {
-                return iter->second;
-            } else {
-                for( const int vp : iter->second ) {
-                    if( !parts.at( vp ).is_fake ) {
-                        res.push_back( vp );
-                    }
-                }
-            }
-        }
-    }
-    return res;
+    return vehicle::parts_at_relative( point_rel_ms( dp ), use_cache, include_fake );
 }
 
 std::vector<int> vehicle::parts_at_relative( const point_rel_ms &dp, const bool use_cache,
@@ -2740,7 +2707,7 @@ std::vector<int> vehicle::parts_at_relative( const point_rel_ms &dp, const bool 
             }
         }
     } else {
-        const auto &iter = relative_parts.find( dp.raw() );
+        const auto &iter = relative_parts.find( dp );
         if( iter != relative_parts.end() ) {
             if( include_fake ) {
                 return iter->second;
@@ -2772,7 +2739,7 @@ std::optional<vpart_reference> vpart_position::obstacle_at_part() const
 
 std::optional<vpart_reference> vpart_position::part_displayed() const
 {
-    int part_id = vehicle().part_displayed_at( mount(), true );
+    int part_id = vehicle().part_displayed_at( mount_pos(), true );
     if( part_id == -1 ) {
         return std::nullopt;
     }
@@ -2781,7 +2748,7 @@ std::optional<vpart_reference> vpart_position::part_displayed() const
 
 std::optional<vpart_reference> vpart_position::part_with_tool( const itype_id &tool_type ) const
 {
-    for( const int idx : vehicle().parts_at_relative( mount(), false ) ) {
+    for( const int idx : vehicle().parts_at_relative( mount_pos(), false ) ) {
         const vpart_reference vp( vehicle(), idx );
         if( vp.part().is_broken() ) {
             continue;
@@ -2800,7 +2767,7 @@ std::optional<vpart_reference> vpart_position::part_with_tool( const itype_id &t
 std::map<item, int> vpart_position::get_tools() const
 {
     std::map<item, int> res;
-    for( const int part_idx : this->vehicle().parts_at_relative( this->mount(), false ) ) {
+    for( const int part_idx : this->vehicle().parts_at_relative( this->mount_pos(), false ) ) {
         const vehicle_part &vp = this->vehicle().part( part_idx );
         if( vp.is_broken() ) {
             continue;
@@ -2820,7 +2787,7 @@ std::optional<vpart_reference> vpart_position::cargo() const
 std::optional<vpart_reference> vpart_position::part_with_feature( const std::string &f,
         bool unbroken, bool include_fake ) const
 {
-    const int i = vehicle().part_with_feature( mount(), f, unbroken, include_fake );
+    const int i = vehicle().part_with_feature( mount_pos(), f, unbroken, include_fake );
     if( i < 0 ) {
         return std::nullopt;
     }
@@ -2840,7 +2807,7 @@ std::optional<vpart_reference> vpart_position::part_with_feature( const vpart_bi
 std::optional<vpart_reference> vpart_position::avail_part_with_feature(
     const std::string &f ) const
 {
-    const int i = vehicle().avail_part_with_feature( mount(), f );
+    const int i = vehicle().avail_part_with_feature( mount_pos(), f );
     return i >= 0 ? vpart_reference( vehicle(), i ) : std::optional<vpart_reference>();
 }
 
@@ -2909,7 +2876,7 @@ std::vector<std::string> optional_vpart_position::extended_description() const
     ret.emplace_back( string_format( _( "%s (%s)" ), v.name, v.owner->name ) );
     ret.emplace_back( "--" );
 
-    for( int idx : v.parts_at_relative( value().mount(), true ) ) {
+    for( int idx : v.parts_at_relative( value().mount_pos(), true ) ) {
         ret.emplace_back( v.part( idx ).name() );
     }
 
@@ -2975,11 +2942,6 @@ int vehicle::avail_part_with_feature( int part, vpart_bitflags flag ) const
     return -1;
 }
 
-int vehicle::avail_part_with_feature( const point &pt, const std::string &flag ) const
-{
-    return vehicle::avail_part_with_feature( point_rel_ms( pt ), flag );
-}
-
 int vehicle::avail_part_with_feature( const point_rel_ms &pt, const std::string &flag ) const
 {
     const int part_a = part_with_feature( pt, flag, true );
@@ -2987,11 +2949,6 @@ int vehicle::avail_part_with_feature( const point_rel_ms &pt, const std::string 
         return part_a;
     }
     return -1;
-}
-
-int vehicle::avail_linkable_part( const point &pt, bool to_ports ) const
-{
-    return vehicle::avail_linkable_part( point_rel_ms( pt ), to_ports );
 }
 
 int vehicle::avail_linkable_part( const point_rel_ms &pt, bool to_ports ) const
@@ -3059,13 +3016,6 @@ bool vehicle::has_part( const tripoint_bub_ms &pos, const std::string &flag, boo
         }
     }
     return false;
-}
-
-// NOLINTNEXTLINE(readability-make-member-function-const)
-std::vector<vehicle_part *> vehicle::get_parts_at( const tripoint &pos, const std::string &flag,
-        const part_status_flag condition )
-{
-    return vehicle::get_parts_at( tripoint_bub_ms( pos ), flag, condition );
 }
 
 // NOLINTNEXTLINE(readability-make-member-function-const)
@@ -3461,12 +3411,6 @@ int vehicle::index_of_part( const vehicle_part *part, bool include_removed ) con
  * @param roof Include roof parts.
  * @return The index of the part that will be displayed.
  */
-int vehicle::part_displayed_at( const point &dp, bool include_fake, bool below_roof,
-                                bool roof ) const
-{
-    return vehicle::part_displayed_at( point_rel_ms( dp ), include_fake, below_roof, roof );
-}
-
 int vehicle::part_displayed_at( const point_rel_ms &dp, bool include_fake, bool below_roof,
                                 bool roof ) const
 {
@@ -3534,15 +3478,6 @@ point_rel_ms vehicle::coord_translate( const point_rel_ms &p ) const
     return q.xy();
 }
 
-void vehicle::coord_translate( const units::angle &dir, const point &pivot, const point &p,
-                               tripoint &q ) const
-{
-    tileray tdir( dir );
-    tdir.advance( p.x - pivot.x );
-    q.x = tdir.dx() + tdir.ortho_dx( p.y - pivot.y );
-    q.y = tdir.dy() + tdir.ortho_dy( p.y - pivot.y );
-}
-
 void vehicle::coord_translate( const units::angle &dir, const point_rel_ms &pivot,
                                const point_rel_ms &p,
                                tripoint_rel_ms &q ) const
@@ -3575,15 +3510,9 @@ tripoint_bub_ms vehicle::mount_to_tripoint( const point_rel_ms &mount ) const
 tripoint_bub_ms vehicle::mount_to_tripoint( const point_rel_ms &mount,
         const point_rel_ms &offset ) const
 {
-    tripoint mnt_translated;
-    coord_translate( pivot_rotation[0], pivot_anchor[0], mount.raw() + offset.raw(), mnt_translated );
+    tripoint_rel_ms mnt_translated;
+    coord_translate( pivot_rotation[0], pivot_anchor[0], mount + offset, mnt_translated );
     return pos_bub() + mnt_translated;
-}
-
-void vehicle::precalc_mounts( int idir, const units::angle &dir,
-                              const point &pivot )
-{
-    vehicle::precalc_mounts( idir, dir, point_rel_ms( pivot ) );
 }
 
 void vehicle::precalc_mounts( int idir, const units::angle &dir,
@@ -3606,7 +3535,7 @@ void vehicle::precalc_mounts( int idir, const units::angle &dir,
             p.precalc[idir] = q->second;
         }
     }
-    pivot_anchor[idir] = pivot.raw();
+    pivot_anchor[idir] = pivot;
     pivot_rotation[idir] = dir;
 }
 
@@ -3626,7 +3555,7 @@ std::vector<rider_data> vehicle::get_riders() const
     std::vector<rider_data> res;
     creature_tracker &creatures = get_creature_tracker();
     for( const vpart_reference &vp : get_avail_parts( VPFLAG_BOARDABLE ) ) {
-        Creature *rider = creatures.creature_at( vp.pos() );
+        Creature *rider = creatures.creature_at( vp.pos_bub() );
         if( rider ) {
             rider_data r;
             r.prt = vp.part_index();
@@ -3697,7 +3626,7 @@ tripoint_abs_omt vehicle::global_omt_location() const
 
 tripoint_bub_ms vehicle::pos_bub() const
 {
-    return coords::project_to<coords::ms>( tripoint_bub_sm( sm_pos ) ) + pos;
+    return coords::project_to<coords::ms>( tripoint_bub_sm( sm_pos ) ) + rebase_rel( pos );
 }
 
 tripoint_bub_ms vehicle::bub_part_pos( const int index ) const
@@ -3776,7 +3705,7 @@ point_rel_ms vehicle::pivot_displacement() const
 
     // rotate the old pivot point around the new pivot point with the old rotation angle
     tripoint_rel_ms dp;
-    coord_translate( pivot_rotation[0], pivot_anchor[1], pivot_anchor[0], dp.raw() );
+    coord_translate( pivot_rotation[0], pivot_anchor[1], pivot_anchor[0], dp );
     return dp.xy();
 }
 
@@ -4276,7 +4205,7 @@ void vehicle::spew_field( double joules, int part, field_type_id type, int inten
         return;
     }
     intensity = std::max( joules / 10000, static_cast<double>( intensity ) );
-    const tripoint_bub_ms dest = tripoint_bub_ms( exhaust_dest( part ) );
+    const tripoint_bub_ms dest = exhaust_dest( part );
     get_map().mod_field_intensity( dest, type, intensity );
 }
 
@@ -4442,8 +4371,8 @@ double vehicle::coeff_air_drag() const
     constexpr double rotor_height = 0.6;
 
     std::vector<int> structure_indices = all_parts_at_location( part_location_structure );
-    int width = mount_max.y - mount_min.y + 1;
-    int length = mount_max.x - mount_min.x + 1;
+    int width = mount_max.y() - mount_min.y() + 1;
+    int length = mount_max.x() - mount_min.x() + 1;
     // a mess of lambdas to make the next bit slightly easier to read
     const auto d_exposed = [&]( const vehicle_part & p ) {
         // if it's not inside, it's a center location, and it doesn't need a roof, it's exposed
@@ -4463,10 +4392,10 @@ double vehicle::coeff_air_drag() const
         }
     };
     const auto d_check_min = [&]( int &value, const vehicle_part & p, bool test ) {
-        value = std::min( value, test ? p.mount.x() - mount_min.x : maxrow );
+        value = std::min( value, test ? p.mount.x() - mount_min.x() : maxrow );
     };
     const auto d_check_max = [&]( int &value, const vehicle_part & p, bool test ) {
-        value = std::max( value, test ? p.mount.x() - mount_min.x : minrow );
+        value = std::max( value, test ? p.mount.x() - mount_min.x() : minrow );
     };
 
     // raycast down each column. the least drag vehicle has halfboard, windshield, seat with roof,
@@ -4477,7 +4406,7 @@ double vehicle::coeff_air_drag() const
         if( parts[ p ].removed || parts[ p ].is_fake ) {
             continue;
         }
-        int col = parts[ p ].mount.y() - mount_min.y;
+        int col = parts[ p ].mount.y() - mount_min.y();
         std::vector<int> parts_at = parts_at_relative( parts[ p ].mount, true );
         d_check_min( drag[ col ].pro, parts[ p ], d_protrusion( parts_at ) );
         for( int pa_index : parts_at ) {
@@ -4792,7 +4721,7 @@ double vehicle::coeff_water_drag() const
     }
     double hull_coverage = static_cast<double>( floating.size() ) / structural_part_count;
 
-    int tile_width = mount_max.y - mount_min.y + 1;
+    int tile_width = mount_max.y() - mount_min.y() + 1;
     double width_m = tile_to_width( tile_width );
 
     // actual area of the hull in m^2 (handles non-rectangular shapes)
@@ -5379,7 +5308,7 @@ units::power vehicle::total_solar_epower() const
     for( const int p : solar_panels ) {
         const vehicle_part &vp = parts[p];
         const tripoint_bub_ms pos = bub_part_pos( vp );
-        if( vp.is_unavailable() || !is_sm_tile_outside( here.getglobal( pos ).raw() ) ) {
+        if( vp.is_unavailable() || !is_sm_tile_outside( here.getglobal( pos ) ) ) {
             continue;
         }
 
@@ -5402,7 +5331,7 @@ units::power vehicle::total_wind_epower() const
     for( const int p : wind_turbines ) {
         const vehicle_part &vp = parts[p];
         const tripoint_bub_ms pos = bub_part_pos( vp );
-        if( vp.is_unavailable() || !is_sm_tile_outside( here.getglobal( pos ).raw() ) ) {
+        if( vp.is_unavailable() || !is_sm_tile_outside( here.getglobal( pos ) ) ) {
             continue;
         }
 
@@ -5423,7 +5352,7 @@ units::power vehicle::total_water_wheel_epower() const
     for( const int p : water_wheels ) {
         const vehicle_part &vp = parts[p];
         const tripoint_bub_ms pos = bub_part_pos( vp );
-        if( vp.is_unavailable() || !is_sm_tile_over_water( here.getglobal( pos ).raw() ) ) {
+        if( vp.is_unavailable() || !is_sm_tile_over_water( here.getglobal( pos ) ) ) {
             continue;
         }
 
@@ -5639,8 +5568,7 @@ vehicle *vehicle::find_vehicle( const tripoint_abs_ms &where )
 
     for( const auto &elem : sm->vehicles ) {
         vehicle *found_veh = elem.get();
-        // TODO: fix point types
-        if( veh_in_sm.raw() == found_veh->pos ) {
+        if( veh_in_sm == found_veh->pos ) {
             return found_veh;
         }
     }
@@ -5666,7 +5594,6 @@ vehicle *vehicle::find_vehicle_using_parts( const tripoint_abs_ms &where )
 
     for( const auto &elem : sm->vehicles ) {
         vehicle *found_veh = elem.get();
-        // TODO: fix point types
         for( const vpart_reference &vp : found_veh->get_all_parts() ) {
             point_sm_ms_ib vp_in_sm;
             tripoint_bub_sm vp_sm;
@@ -6301,7 +6228,7 @@ void vehicle::place_spawn_items()
     for( const vehicle_item_spawn &spawn : type->item_spawns ) {
         int part = part_with_feature( spawn.pos, "CARGO", false );
         if( part < 0 ) {
-            debugmsg( "No CARGO parts at (%d, %d) of %s!", spawn.pos.x, spawn.pos.y, name );
+            debugmsg( "No CARGO parts at (%d, %d) of %s!", spawn.pos.x(), spawn.pos.y(), name );
         } else {
             vehicle_part &vp = parts[part];
             const bool broken = vp.is_broken();
@@ -6374,7 +6301,7 @@ void vehicle::place_zones( map &pmap ) const
         return;
     }
     for( vehicle_prototype::zone_def const &d : type->zone_defs ) {
-        tripoint_abs_ms const pt = pmap.getglobal( tripoint_bub_ms( point_bub_ms( pos + d.pt ),
+        tripoint_abs_ms const pt = pmap.getglobal( tripoint_bub_ms( rebase_bub( pos.raw() + d.pt ),
                                    pmap.get_abs_sub().z() ) );
         mapgen_place_zone( pt.raw(), pt.raw(), d.zone_type, get_owner(), d.name, d.filter, &pmap );
     }
@@ -6499,7 +6426,7 @@ void vehicle::refresh_active_item_cache()
         auto it = vs.begin();
         auto end = vs.end();
         for( ; it != end; ++it ) {
-            active_items.add( *it, point_rel_ms( vp.mount() ) );
+            active_items.add( *it, vp.mount_pos() );
         }
     }
 }
@@ -6553,10 +6480,10 @@ void vehicle::refresh( const bool remove_fakes )
         }
     } svpv = { this };
 
-    mount_min.x = 123;
-    mount_min.y = 123;
-    mount_max.x = -123;
-    mount_max.y = -123;
+    mount_min.x() = 123;
+    mount_min.y() = 123;
+    mount_max.x() = -123;
+    mount_max.y() = -123;
 
     int railwheel_xmin = INT_MAX;
     int railwheel_ymin = INT_MAX;
@@ -6578,11 +6505,11 @@ void vehicle::refresh( const bool remove_fakes )
         refresh_done = true;
 
         // Build map of point -> all parts in that point
-        const point pt = vp.mount();
-        mount_min.x = std::min( mount_min.x, pt.x );
-        mount_min.y = std::min( mount_min.y, pt.y );
-        mount_max.x = std::max( mount_max.x, pt.x );
-        mount_max.y = std::max( mount_max.y, pt.y );
+        const point_rel_ms pt{vp.mount_pos()};
+        mount_min.x() = std::min( mount_min.x(), pt.x() );
+        mount_min.y() = std::min( mount_min.y(), pt.y() );
+        mount_max.x() = std::max( mount_max.x(), pt.x() );
+        mount_max.y() = std::max( mount_max.y(), pt.y() );
 
         // This will keep the parts at point pt sorted
         std::vector<int>::iterator vii = std::lower_bound( relative_parts[pt].begin(),
@@ -6657,10 +6584,10 @@ void vehicle::refresh( const bool remove_fakes )
                 all_wheels_on_one_axis = false;
             }
 
-            railwheel_xmin = std::min( railwheel_xmin, pt.x );
-            railwheel_ymin = std::min( railwheel_ymin, pt.y );
-            railwheel_xmax = std::max( railwheel_xmax, pt.x );
-            railwheel_ymax = std::max( railwheel_ymax, pt.y );
+            railwheel_xmin = std::min( railwheel_xmin, pt.x() );
+            railwheel_ymin = std::min( railwheel_ymin, pt.y() );
+            railwheel_xmax = std::max( railwheel_xmax, pt.x() );
+            railwheel_ymax = std::max( railwheel_ymax, pt.y() );
         }
         if( ( vpi.has_flag( "STEERABLE" ) && part_with_feature( pt, "STEERABLE", true ) != -1 ) ||
             vpi.has_flag( "TRACKED" ) ) {
@@ -6706,12 +6633,12 @@ void vehicle::refresh( const bool remove_fakes )
 
     rail_wheel_bounding_box.p1 = point_rel_ms( railwheel_xmin, railwheel_ymin );
     rail_wheel_bounding_box.p2 = point_rel_ms( railwheel_xmax, railwheel_ymax );
-    front_left.x = mount_max.x;
-    front_left.y = mount_min.y;
+    front_left.x() = mount_max.x();
+    front_left.y() = mount_min.y();
     front_right = mount_max;
 
     if( !refresh_done ) {
-        mount_min = mount_max = point_zero;
+        mount_min = mount_max = point_rel_ms_zero;
         rail_wheel_bounding_box.p1 = point_rel_ms_zero;
         rail_wheel_bounding_box.p2 = point_rel_ms_zero;
     }
@@ -6737,7 +6664,7 @@ void vehicle::refresh( const bool remove_fakes )
             vehicle_part &part_real = parts.at( real_index );
             if( part_real.has_fake &&
                 static_cast<size_t>( part_real.fake_part_at ) < parts.size() ) {
-                relative_parts[ parts[ part_real.fake_part_at ].mount.raw()].push_back(
+                relative_parts[ parts[ part_real.fake_part_at ].mount].push_back(
                     part_real.fake_part_at );
                 return;
             }
@@ -6747,7 +6674,7 @@ void vehicle::refresh( const bool remove_fakes )
             part_fake.fake_part_to = real_index;
             part_fake.mount += edge_info.is_left_edge() ? point_north : point_south;
             if( part_real.info().has_flag( "PROTRUSION" ) ) {
-                for( const int vp : relative_parts.at( part_real.mount.raw() ) ) {
+                for( const int vp : relative_parts.at( part_real.mount ) ) {
                     if( parts.at( vp ).is_fake ) {
                         part_fake.fake_protrusion_on = vp;
                         break;
@@ -6757,7 +6684,7 @@ void vehicle::refresh( const bool remove_fakes )
             int fake_index = parts.size();
             part_real.fake_part_at = fake_index;
             fake_parts.push_back( fake_index );
-            relative_parts[ part_fake.mount.raw()].push_back( fake_index );
+            relative_parts[ part_fake.mount].push_back( fake_index );
             edges.emplace( real_mount, edge_info );
             parts.push_back( std::move( part_fake ) );
         }
@@ -6766,7 +6693,7 @@ void vehicle::refresh( const bool remove_fakes )
     // guarantee that the fake parts were removed before being added
     if( remove_fakes && !has_tag( "wreckage" ) && !is_appliance() ) {
         // add all the obstacles first
-        for( const std::pair <const point, std::vector<int>> &rp : relative_parts ) {
+        for( const std::pair <const point_rel_ms, std::vector<int>> &rp : relative_parts ) {
             add_fake_part( point_rel_ms( rp.first ), "OBSTACLE" );
         }
         // then add protrusions that hanging on top of fake obstacles.
@@ -6777,11 +6704,11 @@ void vehicle::refresh( const bool remove_fakes )
         }
 
         // add fake camera parts so vision isn't blocked by fake parts
-        for( const std::pair <const point, std::vector<int>> &rp : relative_parts ) {
+        for( const std::pair <const point_rel_ms, std::vector<int>> &rp : relative_parts ) {
             add_fake_part( point_rel_ms( rp.first ), "CAMERA" );
         }
         // add fake curtains so vision is correctly blocked
-        for( const std::pair <const point, std::vector<int>> &rp : relative_parts ) {
+        for( const std::pair <const point_rel_ms, std::vector<int>> &rp : relative_parts ) {
             add_fake_part( point_rel_ms( rp.first ), "CURTAIN" );
         }
     } else {
@@ -6790,7 +6717,7 @@ void vehicle::refresh( const bool remove_fakes )
             if( parts[fake_index].removed ) {
                 continue;
             }
-            point pt = parts[fake_index].mount.raw();
+            point_rel_ms pt = parts[fake_index].mount;
             relative_parts[pt].push_back( fake_index );
         }
     }
@@ -6820,25 +6747,25 @@ vpart_edge_info vehicle::get_edge_info( const point_rel_ms &mount ) const
     int r_index = -1;
     bool left_side = false;
     bool right_side = false;
-    if( relative_parts.find( forward.raw() ) != relative_parts.end() &&
-        !parts.at( relative_parts.at( forward.raw() ).front() ).is_fake ) {
-        f_index = relative_parts.at( forward.raw() ).front();
+    if( relative_parts.find( forward ) != relative_parts.end() &&
+        !parts.at( relative_parts.at( forward ).front() ).is_fake ) {
+        f_index = relative_parts.at( forward ).front();
     }
-    if( relative_parts.find( aft.raw() ) != relative_parts.end() &&
-        !parts.at( relative_parts.at( aft.raw() ).front() ).is_fake ) {
-        a_index = relative_parts.at( aft.raw() ).front();
+    if( relative_parts.find( aft ) != relative_parts.end() &&
+        !parts.at( relative_parts.at( aft ).front() ).is_fake ) {
+        a_index = relative_parts.at( aft ).front();
     }
-    if( relative_parts.find( left.raw() ) != relative_parts.end() &&
-        !parts.at( relative_parts.at( left.raw() ).front() ).is_fake ) {
-        l_index = relative_parts.at( left.raw() ).front();
-        if( parts.at( relative_parts.at( left.raw() ).front() ).info().has_flag( "PROTRUSION" ) ) {
+    if( relative_parts.find( left ) != relative_parts.end() &&
+        !parts.at( relative_parts.at( left ).front() ).is_fake ) {
+        l_index = relative_parts.at( left ).front();
+        if( parts.at( relative_parts.at( left ).front() ).info().has_flag( "PROTRUSION" ) ) {
             left_side = true;
         }
     }
-    if( relative_parts.find( right.raw() ) != relative_parts.end() &&
-        !parts.at( relative_parts.at( right.raw() ).front() ).is_fake ) {
-        r_index = relative_parts.at( right.raw() ).front();
-        if( parts.at( relative_parts.at( right.raw() ).front() ).info().has_flag( "PROTRUSION" ) ) {
+    if( relative_parts.find( right ) != relative_parts.end() &&
+        !parts.at( relative_parts.at( right ).front() ).is_fake ) {
+        r_index = relative_parts.at( right ).front();
+        if( parts.at( relative_parts.at( right ).front() ).info().has_flag( "PROTRUSION" ) ) {
             right_side = true;
         }
     }
@@ -7020,7 +6947,7 @@ void vehicle::do_towing_move()
     const bool reverse = towed_veh->tow_data.tow_direction == TOW_BACK;
     int accel_y = 0;
     tripoint_abs_ms vehpos = global_square_location();
-    int turn_x = get_turn_from_angle( towing_veh_angle, vehpos.raw(), tower_tow_point.raw(), reverse );
+    int turn_x = get_turn_from_angle( towing_veh_angle, vehpos, tower_tow_point, reverse );
     if( rl_dist( towed_tow_point, tower_tow_point ) < 6 ) {
         accel_y = reverse ? -1 : 1;
     }
@@ -7128,10 +7055,11 @@ bool vehicle::has_tow_attached() const
 
 void vehicle::set_tow_directions()
 {
-    const int length = mount_max.x - mount_min.x + 1;
+    const int length = mount_max.x() - mount_min.x() + 1;
     const point_rel_ms mount_of_tow = parts[get_tow_part()].mount;
-    const point_rel_ms normalized_tow_mount = point_rel_ms( std::abs( mount_of_tow.x() - mount_min.x ),
-            std::abs( mount_of_tow.y() - mount_min.y ) );
+    const point_rel_ms normalized_tow_mount = point_rel_ms( std::abs( mount_of_tow.x() -
+            mount_min.x() ),
+            std::abs( mount_of_tow.y() - mount_min.y() ) );
     if( length >= 3 ) {
         const int trisect = length / 3;
         if( normalized_tow_mount.x() <= trisect ) {
@@ -7356,13 +7284,6 @@ void vehicle::shed_loose_parts( const trinary shed_cables, const tripoint_bub_ms
         }
         remove_part( vp_loose );
     }
-}
-
-void vehicle::unlink_cables( const point &mount, Character &remover,
-                             bool unlink_items, bool unlink_tow_cables, bool unlink_power_cords )
-{
-    vehicle::unlink_cables( point_rel_ms( mount ), remover, unlink_items, unlink_tow_cables,
-                            unlink_power_cords );
 }
 
 void vehicle::unlink_cables( const point_rel_ms &mount, Character &remover,
@@ -7593,11 +7514,6 @@ void vehicle::damage_all( int dmg1, int dmg2, const damage_type_id &type,
  * (0, 0) part is always present.
  * @param delta How much to shift along each axis
  */
-void vehicle::shift_parts( map &here, const point &delta )
-{
-    vehicle::shift_parts( here, point_rel_ms( delta ) );
-}
-
 void vehicle::shift_parts( map &here, const point_rel_ms &delta )
 {
     // Don't invalidate the active item cache's location!
@@ -7641,7 +7557,7 @@ bool vehicle::shift_if_needed( map &here )
         if( vp.info().location == "structure"
             && !vp.has_feature( "PROTRUSION" )
             && !vp.part().removed ) {
-            shift_parts( here, vp.mount() );
+            shift_parts( here, vp.mount_pos() );
             refresh();
             return true;
         }
@@ -7649,7 +7565,7 @@ bool vehicle::shift_if_needed( map &here )
     // There are only parts with PROTRUSION left, choose one of them.
     for( const vpart_reference &vp : get_all_parts() ) {
         if( !vp.part().removed ) {
-            shift_parts( here, vp.mount() );
+            shift_parts( here, vp.mount_pos() );
             refresh();
             return true;
         }
@@ -8090,7 +8006,7 @@ const std::set<tripoint_bub_ms> &vehicle::get_points( const bool force_refresh,
         occupied_cache_pos = pos_bub();
         occupied_cache_direction = face.dir();
         occupied_points.clear();
-        for( const std::pair<const point, std::vector<int>> &part_location : relative_parts ) {
+        for( const std::pair<const point_rel_ms, std::vector<int>> &part_location : relative_parts ) {
             if( no_fake && part( part_location.second.front() ).is_fake ) {
                 continue;
             }
@@ -8158,7 +8074,8 @@ std::list<item> vehicle::use_charges( const vpart_position &vp, const itype_id &
     }
 
     if( const std::optional<vpart_reference> cargo_vp = vp.cargo() ) {
-        std::list<item> tmp = cargo_vp->items().use_charges( type, quantity, vp.pos(), filter, in_tools );
+        std::list<item> tmp = cargo_vp->items().use_charges( type, quantity, vp.pos_bub().raw(), filter,
+                              in_tools );
         ret.splice( ret.end(), tmp );
         if( quantity <= 0 ) {
             return ret;
@@ -8196,11 +8113,6 @@ bool vpart_position::operator<( const vpart_position &other ) const
     return std::make_pair( v1, part_index_ ) < std::make_pair( v2, other.part_index_ );
 }
 
-point vpart_position::mount() const
-{
-    return vpart_position::mount_pos().raw();
-}
-
 point_rel_ms vpart_position::mount_pos() const
 {
     return vehicle().part( part_index() ).mount;
@@ -8209,10 +8121,6 @@ point_rel_ms vpart_position::mount_pos() const
 tripoint_bub_ms vpart_position::pos_bub() const
 {
     return vehicle().bub_part_pos( part_index() );
-}
-tripoint vpart_position::pos() const
-{
-    return pos_bub().raw();
 }
 
 bool vpart_reference::has_feature( const std::string &f ) const
@@ -8225,12 +8133,11 @@ bool vpart_reference::has_feature( const vpart_bitflags f ) const
     return info().has_flag( f );
 }
 
-static bool is_sm_tile_over_water( const tripoint &real_global_pos )
+static bool is_sm_tile_over_water( const tripoint_abs_ms &real_global_pos )
 {
     tripoint_abs_sm smp;
     point_sm_ms_ib p;
-    // TODO: fix point types
-    std::tie( smp, p ) = project_remain<coords::sm>( tripoint_abs_ms( real_global_pos ) );
+    std::tie( smp, p ) = project_remain<coords::sm>( real_global_pos );
     const submap *sm = MAPBUFFER.lookup_submap( smp );
     if( sm == nullptr ) {
         debugmsg( "is_sm_tile_over_water(): couldn't find submap %s", smp.to_string() );
@@ -8242,17 +8149,15 @@ static bool is_sm_tile_over_water( const tripoint &real_global_pos )
         return false;
     }
 
-    // TODO: fix point types
     return ( sm->get_ter( p ).obj().has_flag( ter_furn_flag::TFLAG_CURRENT ) ||
              sm->get_furn( p ).obj().has_flag( ter_furn_flag::TFLAG_CURRENT ) );
 }
 
-static bool is_sm_tile_outside( const tripoint &real_global_pos )
+static bool is_sm_tile_outside( const tripoint_abs_ms &real_global_pos )
 {
     tripoint_abs_sm smp;
     point_sm_ms_ib p;
-    // TODO: fix point types
-    std::tie( smp, p ) = project_remain<coords::sm>( tripoint_abs_ms( real_global_pos ) );
+    std::tie( smp, p ) = project_remain<coords::sm>( real_global_pos );
     const submap *sm = MAPBUFFER.lookup_submap( smp );
     if( sm == nullptr ) {
         debugmsg( "is_sm_tile_outside(): couldn't find submap %s", smp.to_string() );
@@ -8264,7 +8169,6 @@ static bool is_sm_tile_outside( const tripoint &real_global_pos )
         return false;
     }
 
-    // TODO: fix point types
     return !( sm->get_ter( p ).obj().has_flag( ter_furn_flag::TFLAG_INDOORS ) ||
               sm->get_furn( p ).obj().has_flag( ter_furn_flag::TFLAG_INDOORS ) );
 }
@@ -8308,7 +8212,7 @@ void vehicle::update_time( const time_point &update_to )
         const vehicle_part &pt = parts[idx];
 
         // we need an unbroken funnel mounted on the exterior of the vehicle
-        if( pt.is_unavailable() || !is_sm_tile_outside( here.getglobal( bub_part_pos( pt ) ).raw() ) ) {
+        if( pt.is_unavailable() || !is_sm_tile_outside( here.getglobal( bub_part_pos( pt ) ) ) ) {
             continue;
         }
 
@@ -8346,7 +8250,7 @@ void vehicle::update_time( const time_point &update_to )
         for( const int p : solar_panels ) {
             const vehicle_part &vp = parts[p];
             const tripoint_bub_ms pos = bub_part_pos( vp );
-            if( vp.is_unavailable() || !is_sm_tile_outside( here.getglobal( pos ).raw() ) ) {
+            if( vp.is_unavailable() || !is_sm_tile_outside( here.getglobal( pos ) ) ) {
                 continue;
             }
             epower += part_epower( vp );
@@ -8426,8 +8330,8 @@ void vehicle::calc_mass_center( bool use_precalc ) const
             xf += vp.part().precalc[0].x() * m_part;
             yf += vp.part().precalc[0].y() * m_part;
         } else {
-            xf += vp.mount().x * m_part;
-            yf += vp.mount().y * m_part;
+            xf += vp.mount_pos().x() * m_part;
+            yf += vp.mount_pos().y() * m_part;
         }
 
         m_total += m_part;
@@ -8464,6 +8368,7 @@ bounding_box vehicle::get_bounding_box( bool use_precalc, bool no_fake )
         point_rel_ms pt;
         if( use_precalc ) {
             const int i_use = 0;
+            // TODO: Check if this is correct. part_at takes a vehicle relative position, not a bub one...
             int part_idx = part_at( p.xy().raw() );
             if( part_idx < 0 ) {
                 continue;
@@ -8546,8 +8451,9 @@ std::vector<std::reference_wrapper<const vehicle_part>> vehicle::real_parts() co
     }
     return ret;
 }
-std::set<int> vehicle::advance_precalc_mounts( const point &new_pos, const tripoint &src,
-        const tripoint &dp, int ramp_offset, const bool adjust_pos,
+std::set<int> vehicle::advance_precalc_mounts( const point_sm_ms &new_pos,
+        const tripoint_bub_ms &src,
+        const tripoint_rel_ms &dp, int ramp_offset, const bool adjust_pos,
         std::set<int> parts_to_move )
 {
     map &here = get_map();
@@ -8580,20 +8486,20 @@ std::set<int> vehicle::advance_precalc_mounts( const point &new_pos, const tripo
     for( vehicle_part &prt : parts ) {
         index += 1;
         if( prt.is_real_or_active_fake() ) {
-            here.clear_vehicle_point_from_cache( this, tripoint_bub_ms( src ) + prt.precalc[0] );
+            here.clear_vehicle_point_from_cache( this, src + prt.precalc[0] );
         }
         // no parts means this is a normal horizontal or vertical move
         if( parts_to_move.empty() ) {
             prt.precalc[0] = prt.precalc[1];
             // partial part movement means we're zero-ing out after missing a ramp
         } else if( adjust_pos && parts_to_move.find( index ) == parts_to_move.end() ) {
-            prt.precalc[0].z() -= dp.z;
+            prt.precalc[0].z() -= dp.z();
         } else if( !adjust_pos &&  parts_to_move.find( index ) != parts_to_move.end() ) {
-            prt.precalc[0].z() += dp.z;
+            prt.precalc[0].z() += dp.z();
         }
-        if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, src + dp + prt.precalc[0].raw() ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, src + dp + prt.precalc[0] ) ) {
             prt.precalc[0].z() += 1;
-        } else if( here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, src + dp + prt.precalc[0].raw() ) ) {
+        } else if( here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, src + dp + prt.precalc[0] ) ) {
             prt.precalc[0].z() -= 1;
         }
         prt.precalc[0].z() -= ramp_offset;
@@ -8663,7 +8569,7 @@ bool vehicle::refresh_zones()
             const int part_idx = part_with_feature( z.first, "CARGO", false );
             if( part_idx == -1 ) {
                 debugmsg( "Could not find cargo part at %d,%d on vehicle %s for loot zone.  Removing loot zone.",
-                          z.first.x, z.first.y, this->name );
+                          z.first.x(), z.first.y(), this->name );
 
                 // If this loot zone refers to a part that no longer exists at this location, then its unattached somehow.
                 // By continuing here and not adding to new_zones, we effectively remove it
@@ -8699,16 +8605,11 @@ std::pair<int, double> vehicle::get_exhaust_part() const
     return std::make_pair( exhaust_part, muffle );
 }
 
-tripoint vehicle::exhaust_dest( int part ) const
-{
-    return vehicle::exhaust_dest_bub( part ).raw();
-}
-
-tripoint_bub_ms vehicle::exhaust_dest_bub( int part ) const
+tripoint_bub_ms vehicle::exhaust_dest( int part ) const
 {
     point_rel_ms p = parts[part].mount;
     // Move back from engine/muffler until we find an open space
-    while( relative_parts.find( p.raw() ) != relative_parts.end() ) {
+    while( relative_parts.find( p ) != relative_parts.end() ) {
         p.x() += ( velocity < 0 ? 1 : -1 );
     }
     point_rel_ms q = coord_translate( p );
@@ -8758,14 +8659,14 @@ bool vehicle_part_with_fakes_range::matches( const size_t part ) const
 }
 
 void MapgenRemovePartHandler::add_item_or_charges(
-    const tripoint &loc, item it, bool permit_oob )
+    const tripoint_bub_ms &loc, item it, bool permit_oob )
 {
     if( !m.inbounds( loc ) ) {
         if( !permit_oob ) {
             debugmsg( "Tried to put item %s on invalid tile %s during mapgen!",
                       it.tname(), loc.to_string() );
         }
-        tripoint copy = loc;
+        tripoint_bub_ms copy = loc;
         m.clip_to_bounds( copy );
         cata_assert( m.inbounds( copy ) ); // prevent infinite recursion
         add_item_or_charges( copy, std::move( it ), false );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -807,8 +807,6 @@ class vpart_display
 class vehicle
 {
     private:
-        // TODO: Get rid of untyped overload.
-        bool has_structural_part( const point &dp ) const;
         bool has_structural_part( const point_rel_ms &dp ) const;
         bool is_structural_part_removed() const;
         void open_or_close( int part_index, bool opening );
@@ -1246,8 +1244,6 @@ class vehicle
         *  @param unbroken if true also requires the part to be !is_broken
         *  @returns part index or -1
         */
-        // TODO: Get rid of untyped overload.
-        int avail_part_with_feature( const point &pt, const std::string &f ) const;
         int avail_part_with_feature( const point_rel_ms &pt, const std::string &f ) const;
         /**
         *  Returns \p p or part index at mount point \p pt which has given \p f flag
@@ -1268,8 +1264,6 @@ class vehicle
         *  Either way, will also look for APPLIANCE
         *  @returns part index or -1
         */
-        // TODO: Get rid of untyped overload.
-        int avail_linkable_part( const point &pt, bool to_ports ) const;
         int avail_linkable_part( const point_rel_ms &pt, bool to_ports ) const;
 
         /**
@@ -1309,9 +1303,6 @@ class vehicle
          *  @param flag if set only flags with this part will be considered
          *  @param condition enum to include unabled, unavailable, and broken parts
          */
-        // TODO: Get rid of untyped overload.
-        std::vector<vehicle_part *> get_parts_at( const tripoint &pos, const std::string &flag,
-                part_status_flag condition );
         std::vector<vehicle_part *> get_parts_at( const tripoint_bub_ms &pos, const std::string &flag,
                 part_status_flag condition );
         std::vector<const vehicle_part *> get_parts_at( const tripoint_bub_ms &pos,
@@ -1382,9 +1373,6 @@ class vehicle
         point_rel_ms coord_translate( const point_rel_ms &p ) const;
 
         // Translate mount coordinates "p" into tile coordinates "q" using given pivot direction and anchor
-        // TODO: Get rid of untyped overload.
-        void coord_translate( const units::angle &dir, const point &pivot, const point &p,
-                              tripoint &q ) const;
         void coord_translate( const units::angle &dir, const point_rel_ms &pivot, const point_rel_ms &p,
                               tripoint_rel_ms &q ) const;
         // Translate mount coordinates "p" into tile coordinates "q" using given tileray and anchor
@@ -1401,9 +1389,6 @@ class vehicle
         // TODO: Get rid of untyped overload.
         int part_at( const point &dp ) const;
         int part_at( const point_rel_ms &dp ) const;
-        // TODO: Get rid of untyped overload.
-        int part_displayed_at( const point &dp, bool include_fake = false,
-                               bool below_roof = true, bool roof = true ) const;
         int part_displayed_at( const point_rel_ms &dp, bool include_fake = false,
                                bool below_roof = true, bool roof = true ) const;
         int roof_at_part( int p ) const;
@@ -1418,9 +1403,6 @@ class vehicle
         // @param below_roof if true parts below roof are included
         // @param roof if true roof parts are included
         // @returns filled vpart_display struct or default constructed if no part displayed
-        // TODO: Get rid of untyped overload.
-        vpart_display get_display_of_tile( const point &dp, bool rotate = true, bool include_fake = true,
-                                           bool below_roof = true, bool roof = true ) const;
         vpart_display get_display_of_tile( const point_rel_ms &dp, bool rotate = true,
                                            bool include_fake = true,
                                            bool below_roof = true, bool roof = true ) const;
@@ -1447,8 +1429,6 @@ class vehicle
 
         // Pre-calculate mount points for (idir=0) - current direction or
         // (idir=1) - next turn direction
-        // TODO: Get rid of untyped overload.
-        void precalc_mounts( int idir, const units::angle &dir, const point &pivot );
         void precalc_mounts( int idir, const units::angle &dir, const point_rel_ms &pivot );
 
         // get a list of part indices where is a passenger inside
@@ -1942,8 +1922,6 @@ class vehicle
         void damage_all( int dmg1, int dmg2, const damage_type_id &type, const point_rel_ms &impact );
 
         //Shifts the coordinates of all parts and moves the vehicle in the opposite direction.
-        // TODO: Get rid of untyped overload.
-        void shift_parts( map &here, const point &delta );
         void shift_parts( map &here, const point_rel_ms &delta );
         bool shift_if_needed( map &here );
 
@@ -1964,9 +1942,6 @@ class vehicle
          * @param unlink_tow_cables If tow cables should be unlinked.
          * @param unlink_power_cords If power grid cables (power_cord) should be unlinked.
          */
-        // TODO: Get rid of untyped overload.
-        void unlink_cables( const point &mount, Character &remover, bool unlink_items = false,
-                            bool unlink_tow_cables = false, bool unlink_power_cords = false );
         void unlink_cables( const point_rel_ms &mount, Character &remover, bool unlink_items = false,
                             bool unlink_tow_cables = false, bool unlink_power_cords = false );
 
@@ -2262,8 +2237,8 @@ class vehicle
 
         // Updates the internal precalculated mount offsets after the vehicle has been displaced
         // used in map::displace_vehicle()
-        std::set<int> advance_precalc_mounts( const point &new_pos, const tripoint &src,
-                                              const tripoint &dp, int ramp_offset,
+        std::set<int> advance_precalc_mounts( const point_sm_ms &new_pos, const tripoint_bub_ms &src,
+                                              const tripoint_rel_ms &dp, int ramp_offset,
                                               bool adjust_pos, std::set<int> parts_to_move );
         // make sure the vehicle is supported across z-levels or on the same z-level
         bool level_vehicle();
@@ -2307,14 +2282,14 @@ class vehicle
          */
         vproto_id type;
         // parts_at_relative(dp) is used a lot (to put it mildly)
-        std::map<point, std::vector<int>> relative_parts; // NOLINT(cata-serialize)
+        std::map<point_rel_ms, std::vector<int>> relative_parts; // NOLINT(cata-serialize)
         std::set<label> labels;            // stores labels
         std::set<std::string> tags;        // Properties of the vehicle
         // After fuel consumption, this tracks the remainder of fuel < 1, and applies it the next time.
         // The value is negative.
         std::map<itype_id, units::energy> fuel_remainder;
         std::map<itype_id, units::energy> fuel_used_last_turn;
-        std::unordered_multimap<point, zone_data> loot_zones;
+        std::unordered_multimap<point_rel_ms, zone_data> loot_zones;
         active_item_cache active_items; // NOLINT(cata-serialize)
         // a magic vehicle, powered by magic.gif
         bool magic = false;
@@ -2338,8 +2313,8 @@ class vehicle
         /*
          * The co-ordinates of the bounding box of the vehicle's mount points
          */
-        mutable point mount_max; // NOLINT(cata-serialize)
-        mutable point mount_min; // NOLINT(cata-serialize)
+        mutable point_rel_ms mount_max; // NOLINT(cata-serialize)
+        mutable point_rel_ms mount_min; // NOLINT(cata-serialize)
         mutable point_rel_ms mass_center_precalc; // NOLINT(cata-serialize)
         mutable point_rel_ms mass_center_no_precalc; // NOLINT(cata-serialize)
         tripoint_abs_ms autodrive_local_target =
@@ -2373,7 +2348,7 @@ class vehicle
          * Note that vehicles are "moved" by map::displace_vehicle. You should not
          * set them directly, except when initializing the vehicle or during mapgen.
          */
-        point pos = point_zero;
+        point_sm_ms pos = point_sm_ms_zero;
         // vehicle current velocity, mph * 100
         int velocity = 0;
         /**
@@ -2405,11 +2380,11 @@ class vehicle
         std::array<units::angle, 2> pivot_rotation = { { 0_degrees, 0_degrees } };
 
         bounding_box rail_wheel_bounding_box; // NOLINT(cata-serialize)
-        point front_left; // NOLINT(cata-serialize)
-        point front_right; // NOLINT(cata-serialize)
+        point_rel_ms front_left; // NOLINT(cata-serialize)
+        point_rel_ms front_right; // NOLINT(cata-serialize)
         towing_data tow_data;
         // points used for rotation of mount precalc values
-        std::array<point, 2> pivot_anchor;
+        std::array<point_rel_ms, 2> pivot_anchor;
         // frame direction
         tileray face;
         // direction we are moving
@@ -2479,13 +2454,11 @@ class vehicle
         std::pair<int, double> get_exhaust_part() const;
 
         // destination for exhaust emissions
-        // TODO: Get rid of untyped "overload".
-        tripoint exhaust_dest( int part ) const;
-        tripoint_bub_ms exhaust_dest_bub( int part ) const;
+        tripoint_bub_ms exhaust_dest( int part ) const;
 
         // Returns debug data to overlay on the screen, a vector of {map tile position
         // relative to vehicle pos, color and text}.
-        std::vector<std::tuple<point, int, std::string>> get_debug_overlay_data() const;
+        std::vector<std::tuple<point_rel_ms, int, std::string>> get_debug_overlay_data() const;
 };
 
 // For reference what each function is supposed to do, see their implementation in
@@ -2496,12 +2469,12 @@ class RemovePartHandler
     public:
         virtual ~RemovePartHandler() = default;
 
-        virtual void unboard( const tripoint &loc ) = 0;
-        virtual void add_item_or_charges( const tripoint &loc, item it, bool permit_oob ) = 0;
+        virtual void unboard( const tripoint_bub_ms &loc ) = 0;
+        virtual void add_item_or_charges( const tripoint_bub_ms &loc, item it, bool permit_oob ) = 0;
         virtual void set_transparency_cache_dirty( int z ) = 0;
         virtual void set_floor_cache_dirty( int z ) = 0;
         virtual void removed( vehicle &veh, int part ) = 0;
-        virtual void spawn_animal_from_part( item &base, const tripoint &loc ) = 0;
+        virtual void spawn_animal_from_part( item &base, const tripoint_bub_ms &loc ) = 0;
         virtual map &get_map_ref() = 0;
 };
 
@@ -2510,10 +2483,10 @@ class DefaultRemovePartHandler : public RemovePartHandler
     public:
         ~DefaultRemovePartHandler() override = default;
 
-        void unboard( const tripoint &loc ) override {
-            get_map().unboard_vehicle( tripoint_bub_ms( loc ) );
+        void unboard( const tripoint_bub_ms &loc ) override {
+            get_map().unboard_vehicle( loc );
         }
-        void add_item_or_charges( const tripoint &loc, item it, bool /*permit_oob*/ ) override {
+        void add_item_or_charges( const tripoint_bub_ms &loc, item it, bool /*permit_oob*/ ) override {
             get_map().add_item_or_charges( loc, std::move( it ) );
         }
         void set_transparency_cache_dirty( const int z ) override {
@@ -2525,8 +2498,8 @@ class DefaultRemovePartHandler : public RemovePartHandler
             get_map().set_floor_cache_dirty( z );
         }
         void removed( vehicle &veh, int part ) override;
-        void spawn_animal_from_part( item &base, const tripoint &loc ) override {
-            base.release_monster( loc, 1 );
+        void spawn_animal_from_part( item &base, const tripoint_bub_ms &loc ) override {
+            base.release_monster( loc.raw(), 1 );
         }
         map &get_map_ref() override {
             return get_map();
@@ -2543,12 +2516,12 @@ class MapgenRemovePartHandler : public RemovePartHandler
 
         ~MapgenRemovePartHandler() override = default;
 
-        void unboard( const tripoint &/*loc*/ ) override {
+        void unboard( const tripoint_bub_ms &/*loc*/ ) override {
             debugmsg( "Tried to unboard during mapgen!" );
             // Ignored. Will almost certainly not be called anyway, because
             // there are no creatures that could have been mounted during mapgen.
         }
-        void add_item_or_charges( const tripoint &loc, item it, bool permit_oob ) override;
+        void add_item_or_charges( const tripoint_bub_ms &loc, item it, bool permit_oob ) override;
         void set_transparency_cache_dirty( const int /*z*/ ) override {
             // Ignored for now. We don't initialize the transparency cache in mapgen anyway.
         }
@@ -2559,7 +2532,7 @@ class MapgenRemovePartHandler : public RemovePartHandler
             // TODO: check if this is necessary, it probably isn't during mapgen
             m.dirty_vehicle_list.insert( &veh );
         }
-        void spawn_animal_from_part( item &/*base*/, const tripoint &/*loc*/ ) override {
+        void spawn_animal_from_part( item &/*base*/, const tripoint_bub_ms &/*loc*/ ) override {
             debugmsg( "Tried to spawn animal from vehicle part during mapgen!" );
             // Ignored. The base item will not be changed and will spawn as is:
             // still containing the animal.

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -56,12 +56,6 @@ std::string vpart_display::get_tileset_id() const
     return res;
 }
 
-vpart_display vehicle::get_display_of_tile( const point &dp, bool rotate, bool include_fake,
-        bool below_roof, bool roof ) const
-{
-    return vehicle::get_display_of_tile( point_rel_ms( dp ), rotate, include_fake, below_roof, roof );
-}
-
 vpart_display vehicle::get_display_of_tile( const point_rel_ms &dp, bool rotate, bool include_fake,
         bool below_roof, bool roof ) const
 {

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -38,9 +38,9 @@ const VehicleGroup &string_id<VehicleGroup>::obj() const
     return iter->second;
 }
 
-point VehicleLocation::pick_point() const
+point_bub_ms VehicleLocation::pick_point() const
 {
-    return point( x.get(), y.get() );
+    return point_bub_ms( x.get(), y.get() );
 }
 
 /** @relates string_id */
@@ -155,10 +155,10 @@ void VehicleFunction_json::apply( map &m, const std::string &terrain_name ) cons
                 debugmsg( "vehiclefunction_json: unable to get location to place vehicle." );
                 return;
             }
-            const tripoint_bub_ms pos{ point_bub_ms( loc->pick_point() ), m.get_abs_sub().z() };
+            const tripoint_bub_ms pos{ loc->pick_point(), m.get_abs_sub().z() };
             m.add_vehicle( vehicle->pick(), pos, loc->pick_facing(), fuel, status );
         } else {
-            const tripoint_bub_ms pos{ point_bub_ms( location->pick_point() ), m.get_abs_sub().z()};
+            const tripoint_bub_ms pos{ location->pick_point(), m.get_abs_sub().z()};
             m.add_vehicle( vehicle->pick(), pos, location->pick_facing(), fuel, status );
         }
     }

--- a/src/vehicle_group.h
+++ b/src/vehicle_group.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "coords_fwd.h"
 #include "mapgen.h"
 #include "memory_fast.h"
 #include "rng.h"
@@ -71,7 +72,7 @@ struct VehicleLocation {
         return facings.pick();
     }
 
-    point pick_point() const;
+    point_bub_ms pick_point() const;
 
     jmapgen_int x;
     jmapgen_int y;

--- a/src/vehicle_selector.cpp
+++ b/src/vehicle_selector.cpp
@@ -6,11 +6,11 @@
 #include "point.h"
 #include "vpart_position.h"
 
-vehicle_selector::vehicle_selector( const tripoint &pos, int radius, bool accessible,
+vehicle_selector::vehicle_selector( const tripoint_bub_ms &pos, int radius, bool accessible,
                                     bool visibility_only )
 {
     map &here = get_map();
-    for( const tripoint &e : closest_points_first( pos, radius ) ) {
+    for( const tripoint_bub_ms &e : closest_points_first( pos, radius ) ) {
         if( !accessible ||
             ( visibility_only ? here.sees( pos, e, radius ) : here.clear_path( pos, e, radius, 1, 100 ) ) ) {
             if( const optional_vpart_position vp = here.veh_at( e ) ) {
@@ -20,11 +20,11 @@ vehicle_selector::vehicle_selector( const tripoint &pos, int radius, bool access
     }
 }
 
-vehicle_selector::vehicle_selector( const tripoint &pos, int radius, bool accessible,
+vehicle_selector::vehicle_selector( const tripoint_bub_ms &pos, int radius, bool accessible,
                                     const vehicle &ignore )
 {
     map &here = get_map();
-    for( const tripoint &e : closest_points_first( pos, radius ) ) {
+    for( const tripoint_bub_ms &e : closest_points_first( pos, radius ) ) {
         if( !accessible || here.clear_path( pos, e, radius, 1, 100 ) ) {
             if( const optional_vpart_position vp = here.veh_at( e ) ) {
                 data.emplace_back( vp->vehicle(), vp->part_index(), &vp->vehicle() == &ignore );

--- a/src/vehicle_selector.h
+++ b/src/vehicle_selector.h
@@ -8,6 +8,7 @@
 #include <list>
 #include <vector>
 
+#include "coords_fwd.h"
 #include "type_id.h"
 #include "visitable.h"
 
@@ -50,7 +51,7 @@ class vehicle_selector : public visitable
          *  @param accessible whether found items must be accessible from pos to be considered
          *  @param visibility_only accessibility based on line of sight, not walkability
          */
-        explicit vehicle_selector( const tripoint &pos, int radius = 0, bool accessible = true,
+        explicit vehicle_selector( const tripoint_bub_ms &pos, int radius = 0, bool accessible = true,
                                    bool visibility_only = false );
 
         /**
@@ -60,7 +61,7 @@ class vehicle_selector : public visitable
          *  @param accessible whether found items must be accessible from pos to be considered
          *  @param ignore don't include this vehicle as part of the selection
          */
-        vehicle_selector( const tripoint &pos, int radius, bool accessible, const vehicle &ignore );
+        vehicle_selector( const tripoint_bub_ms &pos, int radius, bool accessible, const vehicle &ignore );
 
         // similar to item_location you are not supposed to store this class between turns
         vehicle_selector( const vehicle_selector &that ) = delete;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -852,7 +852,7 @@ void vehicle::honk_horn() const
             honked = true;
         }
         //Get global position of horn
-        const tripoint horn_pos = vp.pos();
+        const tripoint_bub_ms horn_pos = vp.pos_bub();
         //Determine sound
         if( horn_type.bonus >= 110 ) {
             //~ Loud horn sound
@@ -928,7 +928,8 @@ void vehicle::beeper_sound() const
         }
 
         //~ Beeper sound
-        sounds::sound( vp.pos(), vp.info().bonus, sounds::sound_t::alarm, _( "beep!" ), false, "vehicle",
+        sounds::sound( vp.pos_bub(), vp.info().bonus, sounds::sound_t::alarm, _( "beep!" ), false,
+                       "vehicle",
                        "rear_beeper" );
     }
 }
@@ -937,7 +938,7 @@ void vehicle::play_music() const
 {
     Character &player_character = get_player_character();
     for( const vpart_reference &vp : get_enabled_parts( "STEREO" ) ) {
-        iuse::play_music( &player_character, vp.pos(), 15, 30 );
+        iuse::play_music( &player_character, vp.pos_bub().raw(), 15, 30 );
     }
 }
 
@@ -948,7 +949,7 @@ void vehicle::play_chimes() const
     }
 
     for( const vpart_reference &vp : get_enabled_parts( "CHIMES" ) ) {
-        sounds::sound( vp.pos(), 40, sounds::sound_t::music,
+        sounds::sound( vp.pos_bub(), 40, sounds::sound_t::music,
                        _( "a simple melody blaring from the loudspeakers." ), false, "vehicle", "chimes" );
     }
 }
@@ -1866,7 +1867,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .hotkey( "EXAMINE_VEHICLE" )
         .on_submit( [this, vp] {
             const vpart_position non_fake( *this, get_non_fake_part( vp.part_index() ) );
-            const point start_pos = non_fake.mount().rotate( 2 );
+            const point start_pos = non_fake.mount_pos().raw().rotate( 2 );
             g->exam_vehicle( *this, start_pos );
         } );
 
@@ -2085,7 +2086,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .skip_locked_check()
         .hotkey( "DISCONNECT_CABLES" )
         .on_submit( [this, vp] {
-            unlink_cables( vp.mount(), get_player_character(), true, true, true );
+            unlink_cables( vp.mount_pos(), get_player_character(), true, true, true );
             get_player_character().pause();
         } );
     }
@@ -2096,7 +2097,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .skip_locked_check()
         .hotkey( "DISCONNECT_CABLES" )
         .on_submit( [this, vp] {
-            unlink_cables( vp.mount(), get_player_character(), true, true, false );
+            unlink_cables( vp.mount_pos(), get_player_character(), true, true, false );
             get_player_character().pause();
         } );
     }

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -104,16 +104,12 @@ class vpart_position
          * `g->m.veh_at( this->pos() )` (there is a vehicle there)
          * `g->m.veh_at( this->pos() )->vehicle() == this->vehicle()` (it's this one)
          */
-        // Name chosen to match Creature::pos
         tripoint_bub_ms pos_bub() const;
-        tripoint pos() const; // TODO: Get rid of this untyped operation
         /**
          * Returns the mount point: the point in the vehicles own coordinate system.
          * This system is independent of movement / rotation.
          */
         // TODO: change to return tripoint.
-        // TODO: Get rid of untyped overload.
-        point mount() const;
         point_rel_ms mount_pos() const;
 
         // implementation required for using as std::map key

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -274,7 +274,7 @@ static bool tally_items( std::unordered_map<itype_id, float> &global_item_count,
         }
         if( const optional_vpart_position ovp = tm.veh_at( p ) ) {
             vehicle *const veh = &ovp->vehicle();
-            for( const int elem : veh->parts_at_relative( ovp->mount(), true ) ) {
+            for( const int elem : veh->parts_at_relative( ovp->mount_pos(), true ) ) {
                 const vehicle_part &vp = veh->part( elem );
                 for( item &i : veh->get_items( vp ) ) {
                     std::unordered_map<itype_id, float>::iterator iter = global_item_count.find( i.typeId() );

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -415,11 +415,12 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
         CAPTURE( you.pos() );
         REQUIRE( veh->can_close( vp.part_index(), you ) );
         REQUIRE( veh->can_close( fake_door.part_index(), you ) );
-        you.setpos( vp.pos() );
+        you.setpos( vp.pos_bub() );
         CHECK( !veh->can_close( vp.part_index(), you ) );
         CHECK( !veh->can_close( fake_door.part_index(), you ) );
         // Move to the location of the fake part and repeat the assetion
-        you.setpos( fake_door.pos() );
+        you.setpos( fake_door.pos_bub() );
+        you.setpos( fake_door.pos_bub() );
         CHECK( !veh->can_close( vp.part_index(), you ) );
         CHECK( !veh->can_close( fake_door.part_index(), you ) );
         you.setpos( prev_player_pos );

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -239,7 +239,7 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
     for( int i = 0; i < water_charges; i++ ) {
         CAPTURE( i, veh.fuel_left( itype_water_clean ) );
         menu.reset();
-        veh.build_interact_menu( menu, faucet->pos(), false );
+        veh.build_interact_menu( menu, faucet->pos_bub().raw(), false );
         const std::vector<veh_menu_item> items = menu.get_items();
         const bool stomach_should_be_full = i == water_charges - 1;
         const auto drink_item_it = std::find_if( items.begin(), items.end(),

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -68,13 +68,13 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
         tripoint_abs_ms target_global = here.getglobal( target );
         const vpart_id vpid( cord.typeId().str() );
 
-        point vcoords = source_vp->mount();
+        point_rel_ms vcoords = source_vp->mount_pos();
         vehicle_part source_part( vpid, item( cord ) );
         source_part.target.first = target_global;
         source_part.target.second = target_veh->global_square_location();
         source_veh->install_part( vcoords, std::move( source_part ) );
 
-        vcoords = target_vp->mount();
+        vcoords = target_vp->mount_pos();
         vehicle_part target_part( vpid, item( cord ) );
         tripoint_bub_ms source_global( cord.get_var( "source_x", 0 ),
                                        cord.get_var( "source_y", 0 ),

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -156,17 +156,17 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
             if( vp.info().location != "structure" ) {
                 continue;
             }
-            const point &pmount = vp.mount();
+            const point_rel_ms &pmount = vp.mount_pos();
             CAPTURE( pmount );
-            const tripoint &ppos = vp.pos();
+            const tripoint_bub_ms &ppos = vp.pos_bub();
             CAPTURE( ppos );
-            if( cycles > ( transition_cycle - pmount.x ) ) {
-                CHECK( ppos.z == target_z );
+            if( cycles > ( transition_cycle - pmount.x() ) ) {
+                CHECK( ppos.z() == target_z );
             } else {
-                CHECK( ppos.z == 0 );
+                CHECK( ppos.z() == 0 );
             }
-            if( pmount.x == 0 && pmount.y == 0 ) {
-                CHECK( player_character.pos() == ppos );
+            if( pmount.x() == 0 && pmount.y() == 0 ) {
+                CHECK( player_character.pos_bub() == ppos );
             }
         }
         vpts = veh.get_points();

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -334,7 +334,7 @@ static void check_folded_item_to_parts_damage_transfer( const folded_item_damage
 
     // don't actually need point_north but damage_all filters out direct damage
     // do some damage so it is transferred when folding
-    ovp->vehicle().damage_all( 100, 100, damage_pure, ovp->mount() + point_rel_ms_north );
+    ovp->vehicle().damage_all( 100, 100, damage_pure, ovp->mount_pos() + point_rel_ms_north );
 
     // fold vehicle into an item
     complete_activity( u, vehicle_folding_activity_actor( ovp->vehicle() ) );

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -444,7 +444,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
             v->add_item( vp->part(), obj );
         }
 
-        vehicle_selector sel( p.pos_bub().raw(), 1 );
+        vehicle_selector sel( p.pos_bub(), 1 );
 
         REQUIRE( count_items( sel, container_id ) == count );
         REQUIRE( count_items( sel, liquid_id ) == count );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Replace untyped coordinate usage with typed usage.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Go through the remainder of vehicle.h, sweep over vehicle.cpp, and go through the rest of the vehicle related .h files to update operation, duplicate ones that still depend on untyped usage, and replace unused untyped operation. This process involves some modification to usages.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Try to fix this section of vehicle.cpp:
```
            // TODO: Check if this is correct. part_at takes a vehicle relative position, not a bub one...
            int part_idx = part_at( p.xy().raw() );
```
but decided to leave it as a turd for later clean up. Didn't find any operation that actually took bubble coordinates, so fixing this would require subtracting the vehicle coordinates from the bubble one to actually check the correct location.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded a save, walked up a ramp, jumped into a car, drove through some hay bales, ran over a zombie corpse that had stuff in the inventory, ran over a turkey, and smashed into a stationary vehicle. Didn't see anything odd (the changes should not change any functionality).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Had a local environment corruption, so it had to be rebuilt. This involved downloading the latest master, creating a branch, and copy the modified files based on a previous master over it to recover the work done. This means that version tags and things like that may be wrong, However, the test was performed after recovery, so at least it's consistent internally.

Also note that typification PRs tend to mess with a lot of places, so there's a significant risk of a merge clash if this PR is merged concurrently with other code PRs.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
