### PR TITLE
Increase helicopter autotravel speed

### DIFF
--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -152,6 +152,8 @@ static constexpr int NUM_ORIENTATIONS = 360 / TURNING_INCREMENT;
 // min and max speed in tiles/s
 static constexpr int MIN_SPEED_TPS = 1;
 static constexpr int MAX_SPEED_TPS = 3;
+// 16 tiles/s is roughly 55 knots, helicopter efficiency is greatest around 50-70 knots.
+static constexpr int MAX_AIR_SPEED_TPS = 16;
 static constexpr int VMIPH_PER_TPS = static_cast<int>( vehicles::vmiph_per_tile );
 
 /**
@@ -301,6 +303,7 @@ struct auto_navigation_data {
     bool land_ok;
     bool water_ok;
     bool air_ok;
+    bool is_flying;
     // the maximum speed to consider driving at, in tiles/s
     int max_speed_tps;
     // max acceleration
@@ -928,7 +931,11 @@ void vehicle::autodrive_controller::precompute_data()
         data.land_ok = driven_veh.valid_wheel_config();
         data.water_ok = driven_veh.can_float();
         data.air_ok = driven_veh.has_sufficient_rotorlift();
-        data.max_speed_tps = std::min( MAX_SPEED_TPS, driven_veh.safe_velocity() / VMIPH_PER_TPS );
+        data.is_flying = driven_veh.is_rotorcraft() && driven_veh.is_flying_in_air();
+        data.max_speed_tps = std::min(
+                                 data.is_flying ? MAX_AIR_SPEED_TPS : MAX_SPEED_TPS,
+                                 driven_veh.safe_velocity() / VMIPH_PER_TPS
+                             );
         data.acceleration.resize( data.max_speed_tps );
         for( int speed_tps = 0; speed_tps < data.max_speed_tps; speed_tps++ ) {
             data.acceleration[speed_tps] = driven_veh.acceleration( true, speed_tps * VMIPH_PER_TPS );
@@ -1199,7 +1206,7 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
     }
     for( const point &p : collision_zone ) {
         const tripoint_bub_ms next = data.adjust_z( veh_pos + p );
-        if( !driver.sees( next ) ) {
+        if( !data.is_flying && !driver.sees( next ) ) {
             return collision_check_result::slow_down;
         }
         if( !check_drivable( next ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Increase helicopter autotravel speed"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Helicopter autotravel was restricted to the same 19 kph (3 tiles / second) as land or water vehicles, even though the main reason for restricting the speed (obstacle avoidance) largely does not apply to flying vehicles since at sufficient z-levels, there are very few obstacles to collide with.
For non-flying vehicles, the relatively low speed is fine, but for helicopters this leads to unmanageable fuel consumption, which makes it practically impossible to use autotravel while flying.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The autotravel speed is increased for helicopters to 102 kph (16 tiles / second, 55 knots) without addressing any potential pathfinding issues. This specific maximum speed was chosen due to being close to the maximum efficiency speed for helicopters (50 - 70 knots), while being low enough to have manageable speed oscillations when turning.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Manually flying at high speeds, but this becomes tedious when traversing large distances (100s of OMTs). Additionally, each turn takes quite a long time to process at those speeds, so the wall time to manually fly 100 OMTs at 360 kph can be longer than autotraveling at 19 kph.

Addressing obstacle avoidance at high speeds, but this would be really difficult.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Autotraveled in a helicopter at high enough z-levels to avoid any obstacles. Autotraveled in a car to make sure that nothing changed for regular autotravel.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
No z-level changes are possible while autotraveling with a helicopter. Resuming a route from another z-level doesn't work, but that would be unchanged by this PR. ~~It's very possible to crash the helicopter when not going high enough before beginning autotravel, due to the obstacle avoidance not really being built for such high speeds~~ (Turns out this is not actually the case).

When autotravelling in a straight line (N, E, S, W), a stable speed is maintained, but when the omt path is diagonal, the speed oscillates mainly between 102 and 51 kph. Could be looked into, but it's way less annoying than ground vehicles before #70780 and the fuel consumption is already enormous for helicopters, so the constant ac-/deceleration is less of a problem here.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
