### PR TITLE
Simple cloth quiver for holding various ammo

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -540,7 +540,7 @@
     "id": "quiver_simple_cloth",
     "type": "ARMOR",
     "name": { "str": "simple cloth quiver" },
-    "description": "A simple quiver made out of cloth that can be adjusted to hold various types of arrows, bolts and spears of different lengths.  Takes slightly longer to pull ammunition from than a regular quiver.  Use insert to store arrows, bolts, fishing spears or atlatl spears.",
+    "description": "A simple quiver made out of cloth that can be adjusted to hold various types of arrows, bolts, and spears of different lengths.  Takes slightly longer to pull ammunition from than a regular quiver.  Use insert to store arrows, bolts, fishing spears, or atlatl spears.",
     "weight": "200 g",
     "volume": "500 ml",
     "price": "5 USD",

--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -537,6 +537,25 @@
     "melee_damage": { "bash": 12 }
   },
   {
+    "id": "quiver_simple_cloth",
+    "type": "ARMOR",
+    "name": { "str": "simple cloth quiver" },
+    "description": "A simple quiver made out of cloth that can be adjusted to hold various types of arrows, bolts and spears of different lengths.  Takes slightly longer to pull ammunition from than a regular quiver.  Use insert to store arrows, bolts, fishing spears or atlatl spears.",
+    "weight": "200 g",
+    "volume": "500 ml",
+    "price": "5 USD",
+    "price_postapoc": "1 USD",
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "looks_like": "quiver",
+    "color": "white",
+    "sided": true,
+    "material_thickness": 1,
+    "pocket_data": [ { "ammo_restriction": { "arrow": 30, "bolt": 30, "atlatl": 5, "fishspear": 5 }, "moves": 30 } ],
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": [ { "encumbrance": 6, "coverage": 30, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
+  },
+  {
     "id": "quiver_takedown_bow",
     "type": "ARMOR",
     "//": "Based on: https://www.amazon.com/XTACER-Multi-Function-4-Tubes-Training-Takedown/dp/B072K4537K",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -1578,6 +1578,19 @@
     "components": [ [ [ "rope_natural", 1, "LIST" ] ], [ [ "duct_tape", 30 ] ], [ [ "pipe", 3 ] ] ]
   },
   {
+    "result": "quiver_simple_cloth",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "tailor",
+    "difficulty": 1,
+    "skills_required": [ "survival", 1 ],
+    "time": "45 m",
+    "autolearn": true,
+    "using": [ [ "tailoring_cotton_patchwork_simple", 1 ], [ "strap_small", 2 ] ]
+  },
+  {
     "result": "ragpouch",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -2503,7 +2503,8 @@
       "quiver_large_birchbark",
       "nylon_quiver",
       "pipe_quiver",
-      "pipe_quiver_large"
+      "pipe_quiver_large",
+      "quiver_simple_cloth"
     ],
     "difficulty": 3
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Simple cloth quiver for holding various ammo"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

When I was trying out a standard survivor evac start I noticed that you had everything you needed to make and atlatl except somewhere to store it. It looks as if you can store it in a single point sling and other items, but you can't. See #77773. 

There aren't any good storage solutions for atlatl spears. 

#### Describe the solution

Make a simple cloth quiver that can store atlatl spears and various other arrow, bolt and spear like items. 

Based on this: https://www.wikihow.com/Make-a-Quiver-for-Arrows

The design looks similar to medieval arrow bags: https://www.google.com/search?q=medieval+arrow+bag&udm=2

A potential concern is if it would need some reinforcement padding in the bottom.

I used the large pipe quiver as a base for the item, and it has the line: `sided": true,`. I'm not sure what sided does for back quivers, but I kept it. 

Ammo for comparison:

| Item | Length | Volume | Weight |
| ---- | ---- | ---- | ---- | 
| 5 atlatl spear | 90 cm | 2.9 L | 1.15 kg (5) |
| 30 arrow | 76 cm | 2.7 L | 0.96 kg (5) |
| 30 bolt | 30 cm | 2.55 L | 0.81 kg |
| 5 fishing spear | 120 cm | 0.31 L |  0.09 kg |

The stats for the fishing spear looks a bit wonky. If I used the same volume/weight it would fit 40 in the quiver which seems a bit much.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Changing all back quivers to be able to hold atlatl spears. But as the recipes are found in fletching books and you need archery skill to craft them I was hesitant to do it. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Works as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![image](https://github.com/user-attachments/assets/390ab206-1757-4666-9338-04eba7f13ce3)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
