### PR TITLE
Audit some more of the aztec stuff

### DIFF
--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -587,7 +587,7 @@
         ],
         "covers": [ "head" ],
         "specifically_covers": [ "head_forehead", "head_crown", "head_ear_l", "head_ear_r" ],
-        "encumbrance": 5,
+        "encumbrance": 50,
         "coverage": 100
       },
       {

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -348,12 +348,13 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "fabrication",
     "difficulty": 1,
-    "time": "10 m",
+    "time": "150 m",
     "reversible": true,
     "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "proficiencies": [ { "proficiency": "prof_carving" } ],
+    "qualities": [ { "id": "CUT", "level": 2 } ],
     "using": [ [ "adhesive", 5 ] ],
-    "components": [ [ [ "rock", 20 ], [ "flint", 20 ] ], [ [ "2x4", 1 ] ] ]
+    "components": [ [ [ "sharp_rock", 6 ], [ "flint", 6 ] ], [ [ "2x4", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Where there's smoke there's fire

Here's the wooden aztec helmet compared to a modern tactical helmet 
![image](https://github.com/user-attachments/assets/28d6a916-2cac-40b7-9ae2-7bdc6afa2956)


#### Describe the solution
Nerf the helmet's encumbrance by a lot. I specifically picked the 50 number to make it close to some other helmet, but now I can't remember which. 

Fix up some truly bizarre recipe where you apparently glue 20 normal rocks onto a plank (??????????) and it turns into a weapon. Made the rocks at least have to be sharp, and used a more reasonable amount of them instead of **thirteen kilograms of rocks**. Also require the carving proficiency, because you need to at least glue those rocks into carved pits and make your handle.


#### Describe alternatives you've considered
Embrace wood meta. Make body armor out of wood. Glue steel to my planks. Become god.

#### Testing
Loads without error

#### Additional context
