### PR TITLE
Crafting GUI Search: cancel the search with ESC

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1589,7 +1589,12 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 static_popup popup;
                 std::chrono::steady_clock::time_point last_update = std::chrono::steady_clock::now();
                 static constexpr std::chrono::milliseconds update_interval( 500 );
-
+                // Get a key description for the cancel button.
+                // Rather than propagating the context, create a new one here as a one-off.
+                // See register_action( "QUIT" ) in recipe_dictionary.cpp (line 289 when this was commited).
+                input_context dummy;
+                dummy.register_action( "QUIT" );
+                std::string cancel_btn = dummy.get_button_text( "QUIT", _( "Cancel" ) );
                 std::function<void( size_t, size_t )> progress_callback =
                 [&]( size_t at, size_t out_of ) {
                     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
@@ -1598,7 +1603,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                     }
                     last_update = now;
                     double percent = 100.0 * at / out_of;
-                    popup.message( _( "Searching… %3.0f%%\n" ), percent );
+                    popup.message( _( "Searching… %3.0f%%\n%s\n" ), percent, cancel_btn );
                     ui_manager::redraw();
                     refresh_display();
                     inp_mngr.pump_events();

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -1,6 +1,7 @@
 #include "recipe_dictionary.h"
 
 #include <algorithm>
+#include <chrono>
 #include <iterator>
 #include <memory>
 #include <unordered_map>
@@ -286,10 +287,13 @@ std::vector<const recipe *> recipe_subset::search(
     std::vector<const recipe *> res;
     size_t i = 0;
     ctxt.register_action( "QUIT" );
-    ctxt.set_timeout( 10 );
+    std::chrono::steady_clock::time_point next_input_check = std::chrono::steady_clock::now();
     for( const recipe *r : recipes ) {
-        if( ctxt.handle_input() == "QUIT" ) {
-            return res;
+        if( std::chrono::steady_clock::now() > next_input_check ) {
+            next_input_check = std::chrono::steady_clock::now() + std::chrono::milliseconds( 250 );
+            if( ctxt.handle_input( 1 ) == "QUIT" ) {
+                return res;
+            }
         }
         if( progress_callback ) {
             progress_callback( i, recipes.size() );

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -285,7 +285,12 @@ std::vector<const recipe *> recipe_subset::search(
 
     std::vector<const recipe *> res;
     size_t i = 0;
+    ctxt.register_action( "QUIT" );
+    ctxt.set_timeout( 10 );
     for( const recipe *r : recipes ) {
+        if( ctxt.handle_input() == "QUIT" ) {
+            return res;
+        }
         if( progress_callback ) {
             progress_callback( i, recipes.size() );
         }

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -12,6 +12,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "input_context.h"
 #include "recipe.h"
 #include "type_id.h"
 
@@ -205,6 +206,7 @@ class recipe_subset
         std::map<const recipe *, int> difficulties;
         std::map<crafting_category_id, std::set<const recipe *>> category;
         std::map<itype_id, std::set<const recipe *>> component;
+        mutable input_context ctxt;
 };
 
 void serialize( const recipe_subset &value, JsonOut &jsout );


### PR DESCRIPTION
#### Summary
Interface "Crafting GUI Search: cancel the search with ESC"

#### Purpose of change
 - Fixes part of #63091

#### Describe the solution

- Add context and register QUIT action in it.
- Every 250ms (non-blocking), check for input for 1ms (blocking).
- If the user presses ESC, return what we have found so far.

To be done
- [x] show in the Searching... popup the ESC to cancel.
  - ![image](https://github.com/user-attachments/assets/7b7632f9-68f1-4c08-9aac-f13446608955)
- [x] Credit ~@ Snup~ @mqrause who helped me with the initial commit on Discord. [Their patch](https://discord.com/channels/598523535169945603/598535827169083403/1297828320746143755).


#### Describe alternatives you've considered

 - Make it multithreaded. It is forbidden in CDDA codebase, see [FREQUENTLY_MADE_SUGGESTIONS.md](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/FREQUENTLY_MADE_SUGGESTIONS.md#improving-performance-via-multithreading-not-just-no-but-hell-no).
- Rewrite `handle_input` in `input_context` to handle 0ms delay input. I didn't try it. I assume it would be a bit slower than my approach. I was too lazy to try and implement it. Would it be better?
- Make a proper button, not just a hint. Too lazy. Also, I believe the complexity of this change would rise, as it would have to be passed into the `progress_callback`. But it would be a bit better.

#### Testing

I tested the speed of this change for two prompts. ~The testing isn't rigorous and the speeds might differ.~ Also, on master, the function is optimized away, making it a bit harder to point to specific slowdowns. But the same lanes were tested.
1. `c:plank` a fast prompt. Before 66ms, after 88ms. The purpose is to check that simple prompts don't suddenly take 6 seconds.
<details>
<summary>
before
</summary>

![play_plank](https://github.com/user-attachments/assets/1547e01f-4a31-4c8a-9dde-0aa5f99f9dab)
</details>


<details>
<summary>
after
</summary>

![plank_fast](https://github.com/user-attachments/assets/77ae20a1-ae13-449c-b5b0-b159697859e9)
</details>

2. `d:close` the slow prompt. Tested thrice in a row. Before 1min11sec, 1min13sec, 1min10sec after 1min15sec, 1min15sec, 1min14sec. Before: freeze for that duration. After: can cancel anytime!

<details>
<summary>
before
</summary>

![close_to_skin_play](https://github.com/user-attachments/assets/9837d537-9142-44a0-b71f-7dcda4907e56)
</details>


<details>
<summary>
after
</summary>

![close_to_skin_fast](https://github.com/user-attachments/assets/b3532174-4bcb-4b07-9227-3edd86913305)
</details>

#### Additional context
