### PR TITLE
[Xedra Evolved] Add more wilderness spooky messages

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effect_on_condition.json
+++ b/data/mods/Xedra_Evolved/effects/effect_on_condition.json
@@ -16,8 +16,9 @@
     "id": "xe_night_messages",
     "recurrence": [ "8 hours", "72 hours" ],
     "condition": { "and": [ { "one_in_chance": 6 }, { "not": "is_day" }, "u_can_see", "u_is_outside" ] },
-    "effect": [ 
-      { "if": { "or": [ { "is_weather": "clear" }, { "is_weather": "sunny" } ] },
+    "effect": [
+      {
+        "if": { "or": [ { "is_weather": "clear" }, { "is_weather": "sunny" } ] },
         "then": { "u_message": "XE_NIGHT_MESSAGES_CLEAR_1", "snippet": true },
         "else": { "u_message": "XE_NIGHT_MESSAGES_CLOUDY_1", "snippet": true }
       }

--- a/data/mods/Xedra_Evolved/effects/effect_on_condition.json
+++ b/data/mods/Xedra_Evolved/effects/effect_on_condition.json
@@ -17,11 +17,9 @@
     "recurrence": [ "8 hours", "72 hours" ],
     "condition": { "and": [ { "one_in_chance": 6 }, { "not": "is_day" }, "u_can_see", "u_is_outside" ] },
     "effect": [ 
-      { "if": { "or": [ { "is_weather": "clear" }, { "is_weather": "sunny" } ],
-        "then": { "u_message": "XE_NIGHT_MESSAGES_CLEAR_1", "snippet": true } 
-      },
-      { "if": { "is_weather": "cloudy" },
-        "then": { "u_message": "XE_NIGHT_MESSAGES_CLOUDY_1", "snippet": true } 
+      { "if": { "or": [ { "is_weather": "clear" }, { "is_weather": "sunny" } ] },
+        "then": { "u_message": "XE_NIGHT_MESSAGES_CLEAR_1", "snippet": true },
+        "else": { "u_message": "XE_NIGHT_MESSAGES_CLOUDY_1", "snippet": true }
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/effects/effect_on_condition.json
+++ b/data/mods/Xedra_Evolved/effects/effect_on_condition.json
@@ -15,8 +15,15 @@
     "type": "effect_on_condition",
     "id": "xe_night_messages",
     "recurrence": [ "8 hours", "72 hours" ],
-    "condition": { "and": [ { "one_in_chance": 6 }, { "not": "is_day" }, "u_can_see", { "is_weather": "clear" }, "u_is_outside" ] },
-    "effect": [ { "u_message": "XE_NIGHT_MESSAGES_1", "snippet": true } ]
+    "condition": { "and": [ { "one_in_chance": 6 }, { "not": "is_day" }, "u_can_see", "u_is_outside" ] },
+    "effect": [ 
+      { "if": { "or": [ { "is_weather": "clear" }, { "is_weather": "sunny" } ],
+        "then": { "u_message": "XE_NIGHT_MESSAGES_CLEAR_1", "snippet": true } 
+      },
+      { "if": { "is_weather": "cloudy" },
+        "then": { "u_message": "XE_NIGHT_MESSAGES_CLOUDY_1", "snippet": true } 
+      }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/snippets/effect_on_condition.json
+++ b/data/mods/Xedra_Evolved/snippets/effect_on_condition.json
@@ -23,14 +23,15 @@
       "<XE_NIGHT_MESSAGES_GENERAL_1>",
       "<XE_NIGHT_MESSAGES_GENERAL_1>",
       "<XE_NIGHT_MESSAGES_GENERAL_1>",
-      "Winged shadows cross the ground, but when you look into the sky you can't seem to see any movement or shapes at all.",
+      "<XE_NIGHT_MESSAGES_GENERAL_1>",
+      "<XE_NIGHT_MESSAGES_GENERAL_1>",
+      "Winged shadows cross the ground, but when you look into the sky you can't see any movement or shapes.",
       "There is a bright red star with a dark heart that looks like a pupil, staring down on you from the sky above.  Is that star in the sky every night?  Is it coming closer to the planet?",
       "A helicopter passes by overhead.  All its running lights have been blacked out and you suspect the rotors have been muffled.  If it hadn't passed right over you, you'd have never known it was there.",
       "Something passes across the moon for a moment, completely blotting it out.",
       "A shooting star flashes across the sky.",
       "A pair of owls flies by, so close that they're almost wingtip to wingtip.",
-      ""
-    
+      "For a moment, all the stars turn a dim reddish color."
     ]
   },
   {
@@ -40,11 +41,14 @@
       "<XE_NIGHT_MESSAGES_GENERAL_1>",
       "<XE_NIGHT_MESSAGES_GENERAL_1>",
       "<XE_NIGHT_MESSAGES_GENERAL_1>",
+      "<XE_NIGHT_MESSAGES_GENERAL_1>",
       "A single raindrop falls on your exposed skin.  You look up, but no further droplets fall.",
       "Something above the clouds glows, creating a hazy patch of light.  It stays in place for a few moments before speeding away to the <random_direction>.",
       "You see the vague outlines of a humanoid figure in the distance.  As soon as you catch sight of it, there is a blur of motion and it vanishes.",
-      "Your step splashes in a small puddle, but when you bend down to look, there's nothing there."
-    
+      "You step in a small puddle, but when you bend down to look, there's nothing there.",
+      "You feel something tap on your shoulder but when you spin around to look, there's no one there.",
+      "You hear a slithering sound in the distance.  It's far enough away that whatever is making it must be very large.",
+      "You hear a cracking sound and then the night falls totally silent."
     ]
   },
   {
@@ -59,7 +63,10 @@
       "A single shot fires in the distance then silence.",
       "The birds are no longer singing here.  It's quiet, scary quiet.",
       "A rare plane leaves contrails high in the sky.  You wonder where it could be coming from and where it could possibly be going.",
-      "The sunlight seems to dim for a moment.  When you blink, it's as bright as it was before."
+      "The sunlight seems to dim for a moment.  When you blink, it's as bright as it was before.",
+      "Your footstep suddenly crunch loudly.  When you look down, the ground beneath you is carpeted with dead insects.",
+      "The grass nearby is trampled down in a sinuous pattern.",
+      "The air suddenly smells sickly sweet."
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/snippets/effect_on_condition.json
+++ b/data/mods/Xedra_Evolved/snippets/effect_on_condition.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "snippet",
-    "category": "XE_NIGHT_MESSAGES_GENERAL_1",
+    "category": "<XE_NIGHT_MESSAGES_GENERAL_1>",
     "text": [
       "The clopping of hooves pass you by with a swift breeze, yet you did not see anything except for local flora brushed by the wind.",
       "As you are walking you suddenly hear a woman singing mournfully.  As you look around trying to see where the sound is coming from you slowly realize that if you take more than a step and a half in any direction the song fades away.  Eventually you are unable to find it again.",

--- a/data/mods/Xedra_Evolved/snippets/effect_on_condition.json
+++ b/data/mods/Xedra_Evolved/snippets/effect_on_condition.json
@@ -1,15 +1,50 @@
 [
   {
     "type": "snippet",
-    "category": "XE_NIGHT_MESSAGES_1",
+    "category": "XE_NIGHT_MESSAGES_GENERAL_1",
     "text": [
       "The clopping of hooves pass you by with a swift breeze, yet you did not see anything except for local flora brushed by the wind.",
       "As you are walking you suddenly hear a woman singing mournfully.  As you look around trying to see where the sound is coming from you slowly realize that if you take more than a step and a half in any direction the song fades away.  Eventually you are unable to find it again.",
+      "Something roars in the night, similar sounding to one of the Kaiju you heard destroying a nearby town during the Cataclysm.",
+      "The night suddenly goes dead silent.",
+      "You hear a wolf howl in the distance, swiftly joined by several others.  After a moment of silence, you hear another series of howls, and then another.  It's only after the third set fades that you realize the howls were all in exactly the same pattern; two long, three short.",
+      "You hear a scream in the distance.  Probably a deer or a bobcat, but it sure sounded like a human.",
+      "Disturbed by your approach, a small animal darts away into the underbrush.  It's only after it disappears that you realize it had six legs.",
+      "Your ears pop, leaving behind a high-pitched whine that fades as normal sounds slowly return.",
+      "For a moment, the air smells so strongly metallic that you can almost taste it.",
+      "You hear a rush of unfelt wind.",
+      "The wind makes a low murmur that sounds almost like words.  When you stop to pay attention to it, it falls silent."
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "XE_NIGHT_MESSAGES_CLEAR_1",
+    "text": [
+      "<XE_NIGHT_MESSAGES_GENERAL_1>",
+      "<XE_NIGHT_MESSAGES_GENERAL_1>",
+      "<XE_NIGHT_MESSAGES_GENERAL_1>",
       "Winged shadows cross the ground, but when you look into the sky you can't seem to see any movement or shapes at all.",
       "There is a bright red star with a dark heart that looks like a pupil, staring down on you from the sky above.  Is that star in the sky every night?  Is it coming closer to the planet?",
-      "A helicopter passes by overhead.  All it's running lights have been blacked out and you suspect the rotors have been muffled.  If it hadn't passed right over you, you'd have never known it was there.",
-      "Something roars in the night, similar sounding to one of the Kaiju you heard destroying a nearby town during the Cataclysm.",
-      "The night suddenly goes dead silent."
+      "A helicopter passes by overhead.  All its running lights have been blacked out and you suspect the rotors have been muffled.  If it hadn't passed right over you, you'd have never known it was there.",
+      "Something passes across the moon for a moment, completely blotting it out.",
+      "A shooting star flashes across the sky.",
+      "A pair of owls flies by, so close that they're almost wingtip to wingtip.",
+      ""
+    
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "XE_NIGHT_MESSAGES_CLOUDY_1",
+    "text": [
+      "<XE_NIGHT_MESSAGES_GENERAL_1>",
+      "<XE_NIGHT_MESSAGES_GENERAL_1>",
+      "<XE_NIGHT_MESSAGES_GENERAL_1>",
+      "A single raindrop falls on your exposed skin.  You look up, but no further droplets fall.",
+      "Something above the clouds glows, creating a hazy patch of light.  It stays in place for a few moments before speeding away to the <random_direction>.",
+      "You see the vague outlines of a humanoid figure in the distance.  As soon as you catch sight of it, there is a blur of motion and it vanishes.",
+      "Your step splashes in a small puddle, but when you bend down to look, there's nothing there."
+    
     ]
   },
   {
@@ -23,7 +58,8 @@
       "You hear a distant explosion.  You can't tell if it came from one of the tendrils of smoke at the edge of your vision or if it's new.",
       "A single shot fires in the distance then silence.",
       "The birds are no longer singing here.  It's quiet, scary quiet.",
-      "A rare plane leaves contrails high in the sky.  You wonder where it could be coming from and where it could possibly be going."
+      "A rare plane leaves contrails high in the sky.  You wonder where it could be coming from and where it could possibly be going.",
+      "The sunlight seems to dim for a moment.  When you blink, it's as bright as it was before."
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Add more wilderness spooky messages"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I thought it might be neat to have the occasional message play about a spooky occurrence when you're out wandering around in XE and, to my surprise, I found that such messages already exist. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add more snippets.

Divide the existing night snippets into clear, cloudy, and general categories.  Clear and cloudy both pull from general as well. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Set recurrence to 1 and ran around, saw a lot of messages.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
