### PR TITLE
Cannibals are pariahs

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/ref_center_beggar_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/ref_center_beggar_npc_eocs.json
@@ -1,0 +1,36 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BEGGAR_TEST_IF_FOOD_CANNIBAL",
+    "effect": [
+      {
+        "npc_run_inv_eocs": "random",
+        "search_data": [ { "condition": { "math": [ "n_vitamin('human_flesh_vitamin') >= 1" ] } } ],
+        "true_eocs": [
+          {
+            "id": "EOC_GAVE_BEGGAR_CANNIBAL_PROOF",
+            "effect": [
+              { "math": [ "faction_like('free_merchants')", "=", "-100" ] },
+              { "math": [ "faction_like('lobby_beggars')", "=", "-100" ] },
+              { "math": [ "u_npc_anger()", "=", "100" ] },
+              { "math": [ "u_npc_trust()", "=", "-100" ] },
+              { "message": "They know what you've done.", "type": "bad", "popup": true }
+            ]
+          }
+        ],
+        "false_eocs": [
+          {
+            "id": "EOC_GAVE_BEGGAR_FOOD",
+            "effect": [
+              { "npc_add_effect": "beggar_has_eaten", "duration": 3600 },
+              { "math": [ "n_npc_trust()", "+=", "1" ] },
+              { "math": [ "n_npc_value()", "+=", "1" ] },
+              { "math": [ "n_npc_fear()", "+=", "-1" ] },
+              { "math": [ "n_npc_anger()", "+=", "-1" ] }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_1_Reena_Sandhu.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_1_Reena_Sandhu.json
@@ -149,11 +149,7 @@
     "repeat_responses": [
       {
         "for_category": [ "food" ],
-        "response": {
-          "text": "Here, you can have this <topic_item>.",
-          "topic": "TALK_REFUGEE_BEGGAR_1_GAVE_FOOD",
-          "opinion": { "trust": 1, "value": 1, "fear": -1, "anger": -1, "owed": 1 }
-        }
+        "response": { "text": "Here, you can have this <topic_item>.", "topic": "TALK_REFUGEE_BEGGAR_1_GAVE_FOOD" }
       }
     ]
   },
@@ -161,10 +157,10 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_1_GAVE_FOOD",
     "dynamic_line": "This is wonderful of you, I really appreciate it.",
-    "speaker_effect": [ { "effect": { "npc_add_effect": "beggar_has_eaten", "duration": 3600 } } ],
+    "speaker_effect": [ { "effect": { "u_bulk_donate": 1 } }, { "effect": { "run_eocs": [ "EOC_BEGGAR_TEST_IF_FOOD_CANNIBAL" ] } } ],
     "responses": [
-      { "text": "What are you doing here?", "topic": "TALK_REFUGEE_BEGGAR_1_INTRO", "effect": { "u_bulk_donate": 1 } },
-      { "text": "No problem.  <end_talking_leave>", "topic": "TALK_DONE", "effect": { "u_bulk_donate": 1 } }
+      { "text": "What are you doing here?", "topic": "TALK_REFUGEE_BEGGAR_1_INTRO" },
+      { "text": "No problem.  <end_talking_leave>", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -129,10 +129,10 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_2_GAVE_FOOD",
     "dynamic_line": "I can tell when it has stuff in it, it's got a sandy texture.  But this doesn't.  Thanks again.",
-    "speaker_effect": [ { "effect": { "npc_add_effect": "beggar_has_eaten", "duration": 3600 } } ],
+    "speaker_effect": [ { "effect": { "u_bulk_donate": 1 } }, { "effect": { "run_eocs": [ "EOC_BEGGAR_TEST_IF_FOOD_CANNIBAL" ] } } ],
     "responses": [
-      { "text": "What are you doing here?", "topic": "TALK_REFUGEE_BEGGAR_2", "effect": { "u_bulk_donate": 1 } },
-      { "text": "No problem.  <end_talking_bye>", "topic": "TALK_DONE", "effect": { "u_bulk_donate": 1 } }
+      { "text": "What are you doing here?", "topic": "TALK_REFUGEE_BEGGAR_2" },
+      { "text": "No problem.  <end_talking_bye>", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_3_Luo_Meizhen.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_3_Luo_Meizhen.json
@@ -189,11 +189,7 @@
     "repeat_responses": [
       {
         "for_category": [ "food" ],
-        "response": {
-          "text": "Here, you can have this <topic_item>.",
-          "topic": "TALK_REFUGEE_BEGGAR_3_GAVE_FOOD",
-          "opinion": { "trust": 1, "value": 1, "fear": -1, "anger": -1, "owed": 1 }
-        }
+        "response": { "text": "Here, you can have this <topic_item>.", "topic": "TALK_REFUGEE_BEGGAR_3_GAVE_FOOD" }
       }
     ]
   },
@@ -201,10 +197,10 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_3_GAVE_FOOD",
     "dynamic_line": "Thanks, I really appreciate this.",
-    "speaker_effect": [ { "effect": { "npc_add_effect": "beggar_has_eaten", "duration": 3600 } } ],
+    "speaker_effect": [ { "effect": { "u_bulk_donate": 1 } }, { "effect": { "run_eocs": [ "EOC_BEGGAR_TEST_IF_FOOD_CANNIBAL" ] } } ],
     "responses": [
-      { "text": "What are you doing here?", "topic": "TALK_REFUGEE_BEGGAR_3_INTRO", "effect": { "u_bulk_donate": 1 } },
-      { "text": "No problem.  <end_talking_leave>", "topic": "TALK_DONE", "effect": { "u_bulk_donate": 1 } }
+      { "text": "What are you doing here?", "topic": "TALK_REFUGEE_BEGGAR_3_INTRO" },
+      { "text": "No problem.  <end_talking_leave>", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_4_Brandon_Garder.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_4_Brandon_Garder.json
@@ -131,11 +131,7 @@
     "repeat_responses": [
       {
         "for_category": [ "food" ],
-        "response": {
-          "text": "Here, you can have this <topic_item>.",
-          "topic": "TALK_REFUGEE_BEGGAR_4_GAVE_FOOD",
-          "opinion": { "trust": 1, "value": 1, "fear": -1, "anger": -1, "owed": 2 }
-        }
+        "response": { "text": "Here, you can have this <topic_item>.", "topic": "TALK_REFUGEE_BEGGAR_4_GAVE_FOOD" }
       }
     ]
   },
@@ -143,10 +139,10 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_4_GAVE_FOOD",
     "dynamic_line": "It's good to know there are still people like you in the world, it really is.",
-    "speaker_effect": [ { "effect": { "npc_add_effect": "beggar_has_eaten", "duration": 3600 } } ],
+    "speaker_effect": [ { "effect": { "u_bulk_donate": 1 } }, { "effect": { "run_eocs": [ "EOC_BEGGAR_TEST_IF_FOOD_CANNIBAL" ] } } ],
     "responses": [
-      { "text": "What are you up to?", "topic": "TALK_REFUGEE_BEGGAR_4_TALK1", "effect": { "u_bulk_donate": 1 } },
-      { "text": "No problem.  <end_talking_leave>", "topic": "TALK_DONE", "effect": { "u_bulk_donate": 1 } }
+      { "text": "What are you up to?", "topic": "TALK_REFUGEE_BEGGAR_4_TALK1" },
+      { "text": "No problem.  <end_talking_leave>", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1653,7 +1653,11 @@ diag_eval_dbl_f vitamin_eval( char scope, std::vector<diag_value> const &params,
         if( Character const *const chr = actor->get_const_character(); chr != nullptr ) {
             return chr->vitamin_get( vitamin_id( id.str( d ) ) );
         }
-        debugmsg( "Tried to access vitamins of a non-Character talker" );
+        if( item_location const *const itm = actor->get_const_item(); itm != nullptr ) {
+            const nutrients &nutrient_data = default_character_compute_effective_nutrients( *itm->get_item() );
+            return static_cast<int>( nutrient_data.vitamins().count( vitamin_id( id.str( d ) ) ) );
+        }
+        debugmsg( "Tried to access vitamins of a non-Character/non-item talker" );
         return 0;
     };
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
People bragging about feeding butchered humans to the beggars 🙄 

#### Describe the solution
Giving them any cannibal food will instantly ostracize you from the entire refugee center, forever.

Moved this check into a EOC run when the GAVE_FOOD topic is reached. Also moved when bulk_donate's effect is activated to make it somewhat more sensible.

#### Describe alternatives you've considered
Nothing that wouldn't require rewriting all their dialogue or making it incredibly, awfully clunky

#### Testing
Gave beggar normal food, confirmed they got the beggar_has_eaten effect and their opinion of me improved.

Gave beggar cannibal food, got the entire refugee center angry at me.

#### Additional context
SIDE EFFECTS:
Giving them food no longer changes your "owed" value, because owed is not exposed to eoc (only via the `opinion` effect). The amount was miniscule, and the value couldn't be 'cashed in', so its removal has no practical effect. 

Dino dave now likes you slightly more when you give him food, because he previously did not get an 'opinion' change. Again, no practical effect because dave isn't recruitable.

Known issues:
When I refactored u_bulk_donate some months ago I added a confirmation/last chance to back out screen, because you might be trading over containers of liquid items. You can cancel the bulk donate, but it doesn't influence the return type(void) so it always act as if you completed the donation. For trades this works fine, but for donations you can say you'll give them food, back out, and not actually give them anything.
