### PR TITLE
Abstractify basic walls

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -16,27 +16,106 @@
   },
   {
     "type": "terrain",
-    "id": "t_wall",
-    "name": "wall",
-    "description": "A standard wall consisting of a wooden support structure filled with insulation and drywalled.  Painted a neutral off-white or cream color, it could use some more vibrant paint.  Looks flammable.",
-    "symbol": "#",
+    "abstract": "t_abstract_column",
+    "name": { "str": "abstract column", "//~": "NO_I18N" },
+    "description": "Encompasses rock columns.  If you see this in-game, it's a bug.",
     "color": "light_gray",
+    "symbol": "1",
     "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
+    "coverage": 80,
     "connect_groups": "WALL",
     "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
+    "flags": [ "WALL", "PERMEABLE", "MINEABLE" ]
+  },
+  {
+    "type": "terrain",
+    "abstract": "t_abstract_wall",
+    "name": { "str": "abstract wall", "//~": "NO_I18N" },
+    "description": {
+      "str": "Encompasses most undamaged natural and building-grade artificial walls.  SUPPORTS_ROOF, but the roof field must be defined in child terrain.  If you see this in-game, it's a bug.",
+      "//~": "NO_I18N"
+    },
+    "color": "light_gray",
+    "symbol": "#",
+    "move_cost": 0,
+    "coverage": 100,
+    "connect_groups": "WALL",
+    "connects_to": "WALL",
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND", "MINEABLE" ]
+  },
+  {
+    "type": "terrain",
+    "abstract": "t_abstract_wall_wood",
+    "copy-from": "t_abstract_wall",
+    "name": { "str": "abstract wooden wall", "//~": "NO_I18N" },
+    "description": "Encompasses most wood-like walls.  If you see this in-game, it's a bug.",
+    "roof": "t_wood_roof",
+    "extend": { "flags": [ "FLAMMABLE" ] }
+  },
+  {
+    "type": "terrain",
+    "abstract": "t_abstract_wall_concrete",
+    "copy-from": "t_abstract_wall",
+    "name": { "str": "abstract concrete wall", "//~": "NO_I18N" },
+    "description": "Encompasses most concrete-like walls.  If you see this in-game, it's a bug.",
+    "roof": "t_concrete_roof",
+    "color": "light_gray"
+  },
+  {
+    "type": "terrain",
+    "abstract": "t_abstract_wall_brick",
+    "copy-from": "t_abstract_wall",
+    "name": { "str": "abstract brick wall", "//~": "NO_I18N" },
+    "description": "Encompasses most brick-like walls.  If you see this in-game, it's a bug.",
+    "roof": "t_brick_roof",
+    "color": "brown"
+  },
+  {
+    "type": "terrain",
+    "abstract": "t_abstract_wall_stone",
+    "copy-from": "t_abstract_wall",
+    "name": { "str": "abstract stone wall", "//~": "NO_I18N" },
+    "description": "Encompasses most stone-like walls.  If you see this in-game, it's a bug.",
+    "color": "light_gray",
+    "roof": "t_rock_roof"
+  },
+  {
+    "type": "terrain",
+    "abstract": "t_abstract_wall_metal",
+    "copy-from": "t_abstract_wall",
+    "name": { "str": "abstract metal wall", "//~": "NO_I18N" },
+    "description": "Encompasses most metal-like walls.  If you see this in-game, it's a bug.",
+    "color": "cyan",
+    "roof": "t_metal_flat_roof"
+  },
+  {
+    "type": "terrain",
+    "abstract": "t_abstract_wall_earthen",
+    "copy-from": "t_abstract_wall",
+    "name": { "str": "abstract earthen wall", "//~": "NO_I18N" },
+    "description": "Encompasses most below-ground walls.  If you see this in-game, it's a bug.",
+    "color": "brown"
+  },
+  {
+    "type": "terrain",
+    "abstract": "t_abstract_wall_glass",
+    "copy-from": "t_abstract_wall",
+    "name": { "str": "abstract glass wall", "//~": "NO_I18N" },
+    "description": "Encompasses most wall-sized glass panes.  If you see this in-game, it's a bug.",
+    "color": "cyan",
+    "roof": "t_flat_roof",
+    "coverage": 0,
+    "extend": { "flags": [ "TRANSPARENT" ] },
+    "delete": { "flags": [ "SUPPORTS_ROOF" ] }
+  },
+  {
+    "type": "terrain",
+    "id": "t_wall",
+    "copy-from": "t_abstract_wall_wood",
+    "name": "wall",
+    "description": "A standard wall consisting of a wooden support structure filled with insulation and drywalled.  Painted a neutral off-white or cream color, it could use some more vibrant paint.  Looks flammable.",
+    "roof": "t_flat_roof",
+    "extend": { "flags": [ "WIRED_WALL" ] },
     "bash": {
       "str_min": 30,
       "str_max": 210,
@@ -45,6 +124,14 @@
       "ter_set": "t_null",
       "items": "wall_bash_results"
     }
+  },
+  {
+    "type": "terrain",
+    "abstract": "t_wall_color",
+    "copy-from": "t_wall",
+    "name": { "str": "abstract colored wall", "//~": "NO_I18N" },
+    "description": "An abstract for t_wall color variants.  If you see this in-game, it's a bug.",
+    "extend": { "flags": [ "CHIP" ] }
   },
   {
     "type": "terrain",
@@ -99,1575 +186,616 @@
   },
   {
     "type": "terrain",
+    "id": "t_wall_wood",
+    "copy-from": "t_abstract_wall_wood",
+    "name": "wooden wall",
+    "looks_like": "t_wall",
+    "description": "A finished wall of planks and support beams, capable of supporting an upper level or roof.  Highly flammable.",
+    "color": "light_red",
+    "roof": "t_wood_roof",
+    "delete": { "flags": [ "MINEABLE" ] },
+    "bash": {
+      "str_min": 12,
+      "str_max": 150,
+      "sound": "crunch!",
+      "sound_fail": "whump!",
+      "ter_set": "t_wall_wood_chipped",
+      "items": [
+        { "item": "2x4", "count": [ 0, 3 ] },
+        { "item": "wood_panel", "count": [ 0, 2 ] },
+        { "item": "nail", "charges": [ 1, 5 ] },
+        { "item": "splinter", "count": [ 1, 4 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_concrete_wall",
+    "copy-from": "t_abstract_wall_concrete",
+    "name": "concrete wall",
+    "looks_like": "t_rock",
+    "description": "An aesthetically pleasing design with simple lines, this type of concrete was used with a weaker chemical mixture in order to have faster setting times.  Not ideal for multi-story buildings, but still capable of supporting a roof.",
+    "color": "dark_gray",
+    "bash": {
+      "str_min": 70,
+      "str_max": 300,
+      "sound": "crash!",
+      "sound_fail": "whump!",
+      "ter_set": "t_reb_cage",
+      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_sconc_wall",
+    "copy-from": "t_abstract_wall_concrete",
+    "name": "simple concrete wall",
+    "looks_like": "t_concrete_wall",
+    "description": "A durable and uniform concrete wall, quite drab without decoration.  More than capable of supporting a roof, as well as keeping out most anything, save for vehicles.",
+    "bash": {
+      "str_min": 90,
+      "str_max": 350,
+      "sound": "crash!",
+      "sound_fail": "whump!",
+      "ter_set": "t_pit_shallow",
+      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_strconc_wall",
+    "copy-from": "t_abstract_wall_concrete",
+    "name": "reinforced concrete wall",
+    "looks_like": "t_concrete_wall",
+    "description": "An extremely resilient wall, filled with concrete and rebar.  Best suited for supporting multi-level buildings, only serious explosives and high-speed impacts would be capable of damaging this wall.",
+    "bash": {
+      "str_min": 120,
+      "str_max": 460,
+      "sound": "scrrrash!",
+      "sound_fail": "whump!",
+      "ter_set": "t_reb_cage",
+      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_wall_r",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "red wall",
     "description": "A wall, painted red.",
-    "symbol": "#",
-    "color": "red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "red"
   },
   {
     "type": "terrain",
     "id": "t_wall_w",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "white wall",
     "description": "A wall, painted white.",
-    "symbol": "#",
-    "color": "white",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "white"
   },
   {
     "type": "terrain",
     "id": "t_wall_b",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "blue wall",
     "description": "A wall, painted blue.",
-    "symbol": "#",
-    "color": "blue",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "blue"
   },
   {
     "type": "terrain",
     "id": "t_wall_g",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "green wall",
     "description": "A wall, painted green.",
-    "symbol": "#",
-    "color": "green",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "green"
   },
   {
     "type": "terrain",
     "id": "t_wall_y",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "yellow wall",
     "description": "A wall, painted yellow.",
-    "symbol": "#",
-    "color": "yellow",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "yellow"
   },
   {
     "type": "terrain",
     "id": "t_wall_P",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "pink wall",
     "description": "A wall, painted pink.",
-    "symbol": "#",
-    "color": "pink",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "pink"
   },
   {
     "type": "terrain",
     "id": "t_wall_p",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "purple wall",
     "description": "A wall, painted purple.",
-    "symbol": "#",
-    "color": "magenta",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "magenta"
   },
   {
     "type": "terrain",
     "id": "t_wall_orange",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "orange wall",
     "description": "A wall, painted orange.",
-    "symbol": "#",
-    "color": "light_red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "light_red"
   },
   {
     "type": "terrain",
     "id": "t_wall_gray",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "gray wall",
     "description": "A wall, painted gray.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "light_gray"
   },
   {
     "type": "terrain",
     "id": "t_wall_brown",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "brown wall",
     "description": "A wall, painted brown.",
-    "symbol": "#",
-    "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "brown"
   },
   {
     "type": "terrain",
     "id": "t_wall_cyan",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "cyan wall",
     "description": "A wall, painted cyan.",
-    "symbol": "#",
-    "color": "cyan",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "cyan"
   },
   {
     "type": "terrain",
     "id": "t_wall_black",
+    "copy-from": "t_wall_color",
     "looks_like": "t_wall",
     "name": "black wall",
     "description": "A wall, painted black.",
-    "symbol": "#",
-    "color": "yellow",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "CHIP",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "WIRED_WALL"
-    ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_null",
-      "items": "wall_bash_results"
-    }
+    "color": "yellow"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_b",
+    "copy-from": "t_wall_wood",
     "name": "blue wood wall",
     "looks_like": "t_wall_b",
     "description": "A wooden wall, painted blue.",
-    "symbol": "#",
-    "color": "blue",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "blue"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_g",
+    "copy-from": "t_wall_wood",
     "name": "green wood wall",
     "looks_like": "t_wall_g",
     "description": "A wooden wall, painted green.",
-    "symbol": "#",
-    "color": "green",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "green"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_r",
+    "copy-from": "t_wall_wood",
     "name": "red wood wall",
     "looks_like": "t_wall_r",
     "description": "A wooden wall, painted red.",
-    "symbol": "#",
-    "color": "red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "red"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_w",
+    "copy-from": "t_wall_wood",
     "name": "white wood wall",
     "looks_like": "t_wall_w",
     "description": "A wooden wall, painted white.",
-    "symbol": "#",
-    "color": "white",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "white"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_p",
+    "copy-from": "t_wall_wood",
     "name": "purple wood wall",
     "looks_like": "t_wall_p",
     "description": "A wooden wall, painted purple.",
-    "symbol": "#",
-    "color": "magenta",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "magenta"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_P",
+    "copy-from": "t_wall_wood",
     "name": "pink wood wall",
     "looks_like": "t_wall_P",
     "description": "A wooden wall, painted pink.",
-    "symbol": "#",
-    "color": "pink",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "pink"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_y",
+    "copy-from": "t_wall_wood",
     "name": "yellow wood wall",
     "looks_like": "t_wall_y",
     "description": "A wooden wall, painted yellow.",
-    "symbol": "#",
-    "color": "yellow",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "yellow"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_orange",
+    "copy-from": "t_wall_wood",
     "name": "orange wood wall",
     "looks_like": "t_wall_orange",
     "description": "A wooden wall, painted orange.",
-    "symbol": "#",
-    "color": "light_red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "light_red"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_gray",
+    "copy-from": "t_wall_wood",
     "name": "gray wood wall",
     "looks_like": "t_wall_gray",
     "description": "A wooden wall, painted gray.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "light_gray"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_brown",
+    "copy-from": "t_wall_wood",
     "name": "brown wood wall",
     "looks_like": "t_wall_brown",
     "description": "A wooden wall, painted brown.",
-    "symbol": "#",
-    "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "brown"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_cyan",
+    "copy-from": "t_wall_wood",
     "name": "cyan wood wall",
     "looks_like": "t_wall_cyan",
     "description": "A wooden wall, painted cyan.",
-    "symbol": "#",
-    "color": "cyan",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "cyan"
   },
   {
     "type": "terrain",
     "id": "t_wood_wall_black",
+    "copy-from": "t_wall_wood",
     "name": "black wood wall",
     "looks_like": "t_wall_black",
     "description": "A wooden wall, painted black.",
-    "symbol": "#",
-    "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
+    "color": "dark_gray"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_b",
+    "copy-from": "t_concrete_wall",
     "name": "blue concrete wall",
     "looks_like": "t_wall_b",
     "description": "A concrete wall, painted blue.",
-    "symbol": "#",
-    "color": "blue",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "blue"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_g",
+    "copy-from": "t_concrete_wall",
     "name": "green concrete wall",
     "looks_like": "t_wall_g",
     "description": "A concrete wall, painted green.",
-    "symbol": "#",
-    "color": "green",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "green"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_r",
+    "copy-from": "t_concrete_wall",
     "name": "red concrete wall",
     "looks_like": "t_wall_r",
     "description": "A concrete wall, painted red.",
-    "symbol": "#",
-    "color": "red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "red"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_w",
+    "copy-from": "t_concrete_wall",
     "name": "white concrete wall",
     "looks_like": "t_wall_w",
     "description": "A concrete wall, painted white.",
-    "symbol": "#",
-    "color": "white",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "white"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_p",
+    "copy-from": "t_concrete_wall",
     "name": "purple concrete wall",
     "looks_like": "t_wall_p",
     "description": "A concrete wall, painted purple.",
-    "symbol": "#",
-    "color": "magenta",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "magenta"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_P",
+    "copy-from": "t_concrete_wall",
     "name": "pink concrete wall",
     "looks_like": "t_wall_P",
     "description": "A concrete wall, painted pink.",
-    "symbol": "#",
-    "color": "pink",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "pink"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_y",
+    "copy-from": "t_concrete_wall",
     "name": "yellow concrete wall",
     "looks_like": "t_wall_y",
     "description": "A concrete wall, painted yellow.",
-    "symbol": "#",
-    "color": "yellow",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "yellow"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_orange",
+    "copy-from": "t_concrete_wall",
     "name": "orange concrete wall",
     "looks_like": "t_wall_orange",
     "description": "A concrete wall, painted orange.",
-    "symbol": "#",
-    "color": "light_red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "light_red"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_gray",
+    "copy-from": "t_concrete_wall",
     "name": "gray concrete wall",
     "looks_like": "t_wall_gray",
     "description": "A concrete wall, painted gray.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "light_gray"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_brown",
+    "copy-from": "t_concrete_wall",
     "name": "brown concrete wall",
     "looks_like": "t_wall_brown",
     "description": "A concrete wall, painted brown.",
-    "symbol": "#",
-    "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "brown"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_cyan",
+    "copy-from": "t_concrete_wall",
     "name": "cyan concrete wall",
     "looks_like": "t_wall_cyan",
     "description": "A concrete wall, painted cyan.",
-    "symbol": "#",
-    "color": "cyan",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "cyan"
   },
   {
     "type": "terrain",
     "id": "t_concrete_wall_black",
+    "copy-from": "t_concrete_wall",
     "name": "black concrete wall",
     "looks_like": "t_wall_p",
     "description": "A concrete wall, painted black.",
-    "symbol": "#",
-    "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "dark_gray"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_b",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced blue concrete wall",
     "looks_like": "t_wall_b",
     "description": "A reinforced concrete wall, painted blue.",
-    "symbol": "#",
-    "color": "blue",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "blue"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_g",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced green concrete wall",
     "looks_like": "t_wall_g",
     "description": "A reinforced concrete wall, painted green.",
-    "symbol": "#",
-    "color": "green",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "green"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_r",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced red concrete wall",
     "looks_like": "t_wall_r",
     "description": "A reinforced concrete wall, painted red.",
-    "symbol": "#",
-    "color": "red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "red"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_w",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced white concrete wall",
     "looks_like": "t_wall_w",
     "description": "A reinforced concrete wall, painted white.",
-    "symbol": "#",
-    "color": "white",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "white"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_p",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced purple concrete wall",
     "looks_like": "t_wall_p",
     "description": "A reinforced concrete wall, painted purple.",
-    "symbol": "#",
-    "color": "magenta",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "magenta"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_P",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced pink concrete wall",
     "looks_like": "t_wall_P",
     "description": "A reinforced concrete wall, painted pink.",
-    "symbol": "#",
-    "color": "pink",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "pink"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_y",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced yellow concrete wall",
     "looks_like": "t_wall_y",
     "description": "A reinforced concrete wall, painted yellow.",
-    "symbol": "#",
-    "color": "yellow",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "yellow"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_orange",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced orange concrete wall",
     "looks_like": "t_wall_orange",
     "description": "A reinforced concrete wall, painted orange.",
-    "symbol": "#",
-    "color": "light_red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "light_red"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_gray",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced gray concrete wall",
     "looks_like": "t_wall_gray",
     "description": "A reinforced concrete wall, painted gray.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "light_gray"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_brown",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced brown concrete wall",
     "looks_like": "t_wall_brown",
     "description": "Reinforced concrete wall painted brown.",
-    "symbol": "#",
-    "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "brown"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_cyan",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced cyan concrete wall",
     "looks_like": "t_wall_cyan",
     "description": "A reinforced concrete wall, painted cyan.",
-    "symbol": "#",
-    "color": "cyan",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "cyan"
   },
   {
     "type": "terrain",
     "id": "t_strconc_wall_black",
+    "copy-from": "t_strconc_wall",
     "name": "reinforced black concrete wall",
     "looks_like": "t_wall_black",
     "description": "A reinforced concrete wall, painted black.",
-    "symbol": "#",
-    "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "dark_gray"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_b",
+    "copy-from": "t_sconc_wall",
     "name": "simple blue concrete wall",
     "looks_like": "t_wall_b",
     "description": "A simple concrete wall, painted blue.",
-    "symbol": "#",
-    "color": "blue",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "blue"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_g",
+    "copy-from": "t_sconc_wall",
     "name": "simple green concrete wall",
     "looks_like": "t_wall_g",
     "description": "A simple concrete wall, painted green.",
-    "symbol": "#",
-    "color": "green",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "green"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_r",
+    "copy-from": "t_sconc_wall",
     "name": "simple red concrete wall",
     "looks_like": "t_wall_r",
     "description": "A simple concrete wall, painted red.",
-    "symbol": "#",
-    "color": "red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "red"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_w",
+    "copy-from": "t_sconc_wall",
     "name": "simple white concrete wall",
     "looks_like": "t_wall_w",
     "description": "A simple concrete wall, painted white.",
-    "symbol": "#",
-    "color": "white",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "white"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_p",
+    "copy-from": "t_sconc_wall",
     "name": "simple purple concrete wall",
     "looks_like": "t_wall_p",
     "description": "A simple concrete wall, painted purple.",
-    "symbol": "#",
-    "color": "magenta",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "magenta"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_P",
+    "copy-from": "t_sconc_wall",
     "name": "simple pink concrete wall",
     "looks_like": "t_wall_P",
     "description": "A simple concrete wall, painted pink.",
-    "symbol": "#",
-    "color": "pink",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "pink"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_y",
+    "copy-from": "t_sconc_wall",
     "name": "simple yellow concrete wall",
     "looks_like": "t_wall_y",
     "description": "A simple concrete wall, painted yellow.",
-    "symbol": "#",
-    "color": "yellow",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "yellow"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_orange",
+    "copy-from": "t_sconc_wall",
     "name": "simple orange concrete wall",
     "looks_like": "t_wall_orange",
     "description": "A simple concrete wall, painted orange.",
-    "symbol": "#",
-    "color": "light_red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "light_red"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_gray",
+    "copy-from": "t_sconc_wall",
     "name": "simple gray concrete wall",
     "looks_like": "t_wall_gray",
     "description": "A simple concrete wall, painted gray.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "light_gray"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_brown",
+    "copy-from": "t_sconc_wall",
     "name": "simple brown concrete wall",
     "looks_like": "t_wall_brown",
     "description": "A simple concrete wall, painted brown.",
-    "symbol": "#",
-    "color": "red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "red"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_cyan",
+    "copy-from": "t_sconc_wall",
     "name": "simple cyan concrete wall",
     "looks_like": "t_wall_cyan",
     "description": "A simple concrete wall, painted cyan.",
-    "symbol": "#",
-    "color": "cyan",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "cyan"
   },
   {
     "type": "terrain",
     "id": "t_sconc_wall_black",
+    "copy-from": "t_sconc_wall",
     "name": "simple black concrete wall",
     "looks_like": "t_wall_p",
     "description": "A simple concrete wall, painted black.",
-    "symbol": "#",
-    "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "color": "dark_gray"
   },
   {
     "type": "terrain",
@@ -1692,16 +820,9 @@
   {
     "type": "terrain",
     "id": "t_brick_wall",
+    "copy-from": "t_abstract_wall_brick",
     "name": "brick wall",
     "description": "A solid brick wall, sturdy enough to support a roof with enough walls and to keep out any unwanted visitors.",
-    "symbol": "#",
-    "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_brick_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 60,
       "str_max": 160,
@@ -1714,17 +835,10 @@
   {
     "type": "terrain",
     "id": "t_rock_wall",
+    "copy-from": "t_abstract_wall_stone",
     "name": "stone wall",
     "looks_like": "t_rock",
     "description": "A sturdy stone wall.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_rock_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 80,
       "str_max": 300,
@@ -1737,17 +851,10 @@
   {
     "type": "terrain",
     "id": "t_stone_masonry_wall_whitewashed",
+    "copy-from": "t_abstract_wall_stone",
     "name": "whitewashed stone masonry wall",
     "looks_like": "t_rock_wall",
     "description": "A wall of carefully cut and laid stones, joined with mortar.  The exterior has been finished with plaster and whitewashed.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_rock_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 80,
       "str_max": 300,
@@ -1782,18 +889,12 @@
   {
     "type": "terrain",
     "id": "t_rock_smooth",
+    "copy-from": "t_abstract_wall_stone",
     "name": "smoothed rock",
     "looks_like": "t_rock",
     "description": "A block of stone that's been smoothed and shaped, commonly granite or marble for funerary chapels and mausoleums.",
-    "symbol": "#",
     "//": "use pillars, 't_column', as a compliment.",
     "color": "white",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_rock_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 120,
       "str_max": 400,
@@ -1826,17 +927,10 @@
   {
     "type": "terrain",
     "id": "t_adobe_brick_wall",
+    "copy-from": "t_abstract_wall_brick",
     "name": "adobe wall",
     "description": "A solid adobe brick wall that's both sturdy enough to support a roof and keep out any unwanted visitors.",
-    "symbol": "#",
-    "color": "brown",
     "looks_like": "t_brick_wall",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_brick_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 40,
       "str_max": 120,
@@ -1848,41 +942,13 @@
   },
   {
     "type": "terrain",
-    "id": "t_concrete_wall",
-    "name": "concrete wall",
-    "looks_like": "t_rock",
-    "description": "An aesthetically pleasing design with simple lines, this type of concrete was used with a weaker chemical mixture in order to have faster setting times.  Not ideal for multi-story buildings, but still capable of supporting a roof.",
-    "symbol": "#",
-    "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 70,
-      "str_max": 300,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
-  },
-  {
-    "type": "terrain",
     "id": "t_concrete_wall_rope",
+    "copy-from": "t_concrete_wall",
     "name": "concrete wall with ropes",
-    "looks_like": "t_rock",
     "description": "A boxlike wall of concrete with ropes attached to the exterior edges.",
-    "symbol": "#",
-    "color": "dark_gray",
     "move_cost": 10,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND", "MOUNTABLE" ],
+    "extend": { "flags": [ "MOUNTABLE" ] },
+    "delete": { "flags": [ "SUPPORTS_ROOF" ] },
     "bash": {
       "str_min": 70,
       "str_max": 300,
@@ -1895,16 +961,9 @@
   {
     "type": "terrain",
     "id": "t_wall_metal",
+    "copy-from": "t_abstract_wall_metal",
     "name": "metal wall",
     "description": "An industrially fabricated thick sheet carefully positioned and joined seamlessly with perimeter sealant, this wall is capable of resisting extreme elements as well as hostile forces.  Blast load rated and extremely fire-retardant, breaching it will require specialized tools or an industrial vehicle.",
-    "symbol": "#",
-    "color": "cyan",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_metal_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "oxytorch": {
       "result": "t_scrap_wall_halfway",
       "duration": "14 seconds",
@@ -1926,17 +985,10 @@
   {
     "type": "terrain",
     "id": "t_wall_metal_corrugated",
+    "copy-from": "t_abstract_wall_metal",
     "name": "corrugated metal wall",
     "description": "A wall made from a thin sheet of corrugated steel held in a frame, weather- and windproof but not very insulating or durable.",
     "looks_like": "t_wall_metal",
-    "symbol": "#",
-    "color": "cyan",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_metal_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 30,
       "str_max": 210,
@@ -1949,52 +1001,12 @@
   {
     "type": "terrain",
     "id": "t_wall_bulkhead",
+    "copy-from": "t_abstract_wall_metal",
+    "//": "identical to t_wall_metal, but gray and cannot be oxytorched",
     "name": "bulkhead",
     "description": "An industrially fabricated thick sheet carefully positioned, this wall is capable of resisting extreme elements as well as hostile forces.",
-    "symbol": "#",
     "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "looks_like": "t_wall_metal",
-    "roof": "t_metal_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 200,
-      "str_max": 600,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "ter_set": "t_null",
-      "items": [
-        { "item": "steel_lump", "count": [ 1, 4 ] },
-        { "item": "steel_chunk", "count": [ 3, 12 ] },
-        { "item": "scrap", "count": [ 9, 36 ] }
-      ]
-    }
-  },
-  {
-    "type": "terrain",
-    "id": "t_sconc_wall",
-    "name": "simple concrete wall",
-    "looks_like": "t_concrete_wall",
-    "description": "A durable and uniform concrete wall, quite drab without decoration.  More than capable of supporting a roof, as well as keeping out most anything, save for vehicles.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 90,
-      "str_max": 350,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "looks_like": "t_wall_metal"
   },
   {
     "type": "terrain",
@@ -2016,29 +1028,6 @@
       "sound_fail": "whump!",
       "ter_set": "t_pit_shallow",
       "items": [ { "item": "rock", "count": [ 5, 11 ] } ]
-    }
-  },
-  {
-    "type": "terrain",
-    "id": "t_strconc_wall",
-    "name": "reinforced concrete wall",
-    "looks_like": "t_concrete_wall",
-    "description": "An extremely resilient wall, filled with concrete and rebar.  Best suited for supporting multi-level buildings, only serious explosives and high-speed impacts would be capable of damaging this wall.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_concrete_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 460,
-      "sound": "scrrrash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
     }
   },
   {
@@ -2097,17 +1086,11 @@
   {
     "type": "terrain",
     "id": "t_scrap_wall",
+    "copy-from": "t_abstract_wall_metal",
     "name": "simple metal wall",
     "looks_like": "t_wall_metal",
     "description": "A relatively simple wall made of cobbled-together scrap metal.  It's still capable of blocking intruders and supporting a roof with adjacent walls.",
-    "symbol": "#",
     "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_metal_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "REDUCE_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 80,
       "str_max": 200,
@@ -2139,46 +1122,13 @@
   },
   {
     "type": "terrain",
-    "id": "t_wall_wood",
-    "name": "wooden wall",
-    "looks_like": "t_wall",
-    "description": "A finished wall of planks and support beams, capable of supporting an upper level or roof.  Highly flammable.",
-    "symbol": "#",
-    "color": "light_red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whump!",
-      "ter_set": "t_wall_wood_chipped",
-      "items": [
-        { "item": "2x4", "count": [ 0, 3 ] },
-        { "item": "wood_panel", "count": [ 0, 2 ] },
-        { "item": "nail", "charges": [ 1, 5 ] },
-        { "item": "splinter", "count": [ 1, 4 ] }
-      ]
-    }
-  },
-  {
-    "type": "terrain",
     "id": "t_wall_wood_chipped",
+    "copy-from": "t_wall_wood",
     "name": "chipped wood wall",
     "looks_like": "t_wall_wood",
     "description": "A wall of aligned planks that's starting to crack and break open.  Some replacement wood and a number of nails could patch this up quick.",
-    "symbol": "#",
-    "color": "light_red",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "REDUCE_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
+    "extend": { "flags": [ "REDUCE_SCENT" ] },
+    "delete": { "flags": [ "NO_SCENT" ] },
     "bash": {
       "str_min": 8,
       "str_max": 150,
@@ -2246,17 +1196,12 @@
   {
     "type": "terrain",
     "id": "t_wall_log",
+    "copy-from": "t_abstract_wall_wood",
     "name": "log wall",
     "looks_like": "t_wall_wood",
     "description": "A tall wall of timber suitable for housing and insulating from the weather.  Quite flammable.",
-    "symbol": "#",
     "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
     "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 60,
       "str_max": 180,
@@ -2269,17 +1214,11 @@
   {
     "type": "terrain",
     "id": "t_wall_log_chipped",
+    "copy-from": "t_wall_log",
     "name": "chipped log wall",
-    "looks_like": "t_wall_log",
     "description": "A moderately damaged log wall, it could probably be patched up with some planks and nails.",
-    "symbol": "#",
-    "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_wood_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "WALL", "REDUCE_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
+    "extend": { "flags": [ "REDUCE_SCENT" ] },
+    "delete": { "flags": [ "NO_SCENT" ] },
     "bash": {
       "str_min": 40,
       "str_max": 160,
@@ -2336,14 +1275,14 @@
   {
     "id": "t_wall_wattle",
     "type": "terrain",
+    "copy-from": "t_abstract_wall_wood",
     "name": "wattle-and-daub wall",
     "looks_like": "t_wall_wood",
     "description": "A relatively primitive wall made by daubing together a lattice of wooden strips using some combination of wet soil, clay, sand, animal dung, and straw.",
-    "symbol": "#",
     "color": "light_red",
-    "move_cost": 0,
-    "coverage": 100,
     "roof": "t_thatch_roof",
+    "extend": { "flags": [ "FLAMMABLE_HARD" ] },
+    "delete": { "flags": [ "FLAMMABLE", "MINEABLE" ] },
     "bash": {
       "str_min": 10,
       "str_max": 140,
@@ -2351,10 +1290,7 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "items": [ { "item": "2x4", "count": [ 0, 3 ] }, { "item": "splinter", "count": [ 0, 6 ] } ]
-    },
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE_HARD", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ]
+    }
   },
   {
     "id": "t_wall_wattle_broken",
@@ -2428,17 +1364,11 @@
   {
     "type": "terrain",
     "id": "t_wall_rammed_earth",
+    "copy-from": "t_abstract_wall_earthen",
     "name": "rammed earth wall",
     "looks_like": "t_rock",
     "description": "A solid wall of compressed dirt, sturdy enough to support a roof with enough walls and to keep out some unwanted visitors.",
-    "symbol": "#",
-    "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
     "roof": "t_dirt",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 60,
       "str_max": 200,
@@ -2451,17 +1381,11 @@
   {
     "type": "terrain",
     "id": "t_wall_dirt",
+    "copy-from": "t_abstract_wall_earthen",
     "name": "smooth dirt wall",
     "looks_like": "t_wall_rammed_earth",
     "description": "A solid wall of compressed dirt, mixed with… something to keep it stable.  Its surface glistens slightly, and it smells like rotten milk.",
-    "symbol": "#",
-    "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
     "roof": "t_dirt",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 30,
       "str_max": 200,
@@ -2509,18 +1433,13 @@
   {
     "type": "terrain",
     "id": "t_wall_glass",
+    "copy-from": "t_abstract_wall_glass",
     "name": "glass wall",
     "looks_like": "t_window",
     "description": "A barrier made of glass, it's nothing complicated, and looks extremely fragile.  Some contain glass break sensors or window sensors that trigger an alarm if the glass is damaged.",
-    "symbol": "#",
-    "color": "light_cyan",
-    "move_cost": 0,
     "coverage": 30,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "TRANSPARENT", "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
     "rotates_to": "INDOORFLOOR",
+    "delete": { "flags": [ "MINEABLE" ] },
     "bash": {
       "str_min": 4,
       "str_max": 12,
@@ -2536,43 +1455,18 @@
   {
     "type": "terrain",
     "id": "t_wall_glass_alarm",
-    "looks_like": "t_wall_glass",
+    "copy-from": "t_wall_glass",
     "name": "glass wall",
     "description": "A barrier made of glass, it's nothing complicated, and looks extremely fragile.  Some contain glass break sensors or window sensors that trigger an alarm if the glass is damaged.",
-    "symbol": "#",
-    "color": "light_cyan",
-    "move_cost": 0,
-    "coverage": 30,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "TRANSPARENT", "ALARMED", "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
-    "rotates_to": "INDOORFLOOR",
-    "bash": {
-      "str_min": 4,
-      "str_max": 12,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 42, 84 ] } ]
-    },
-    "shoot": { "reduce_damage": [ 1, 8 ], "reduce_damage_laser": [ 0, 5 ], "destroy_damage": [ 2, 8 ], "no_laser_destroy": true }
+    "extend": { "flags": [ "ALARMED" ] }
   },
   {
     "type": "terrain",
     "id": "t_laminated_glass",
+    "copy-from": "t_abstract_wall_glass",
     "name": "laminated glass",
     "looks_like": "t_reinforced_glass",
     "description": "A laminated glass barrier, composed of layers of glass and plastic held together by an interlayer.",
-    "symbol": "#",
-    "color": "light_cyan",
-    "move_cost": 0,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "TRANSPARENT", "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 100,
       "str_max": 180,
@@ -2588,16 +1482,10 @@
   {
     "type": "terrain",
     "id": "t_ballistic_glass",
+    "copy-from": "t_abstract_wall_glass",
     "name": "ballistic glass",
     "looks_like": "t_reinforced_glass",
     "description": "A ballistic glass barrier, consisting of layers of laminated glass.",
-    "symbol": "#",
-    "color": "light_cyan",
-    "move_cost": 0,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "TRANSPARENT", "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 200,
       "str_max": 400,
@@ -2618,15 +1506,9 @@
   {
     "type": "terrain",
     "id": "t_reinforced_glass",
+    "copy-from": "t_abstract_wall_glass",
     "name": "reinforced glass",
     "description": "A thicker pane of glass with thin metal wires embedded throughout, strengthening the structural properties.  Still weaker than other types of walls, and not made to support a roof either.",
-    "symbol": "#",
-    "color": "light_cyan",
-    "move_cost": 0,
-    "roof": "t_flat_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "TRANSPARENT", "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 40,
       "str_max": 210,
@@ -2797,11 +1679,6 @@
     "type": "terrain",
     "id": "t_paper_brood",
     "copy-from": "t_paper",
-    "symbol": "#",
-    "color": "white",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "FLAMMABLE_ASH", "NOITEM", "WALL", "NO_SCENT" ],
     "bash": {
       "str_min": 1,
       "str_max": 6,
@@ -2810,8 +1687,7 @@
       "sound_vol": 8,
       "sound_fail_vol": 4,
       "ter_set": "t_floor_paper_noroof"
-    },
-    "shoot": { "reduce_damage": [ 2, 12 ], "reduce_damage_laser": [ 4, 16 ], "destroy_damage": [ 10, 40 ] }
+    }
   },
   {
     "type": "terrain",
@@ -2839,17 +1715,11 @@
   {
     "type": "terrain",
     "id": "t_root_wall",
+    "copy-from": "t_abstract_wall_earthen",
     "name": "root wall",
     "looks_like": "t_rock",
     "description": "A dirt wall covered with roots.",
-    "symbol": "#",
-    "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_dirt",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT" ],
+    "delete": { "flags": [ "MINEABLE", "BLOCK_WIND" ] },
     "bash": {
       "str_min": 12,
       "str_max": 150,
@@ -2884,15 +1754,10 @@
   {
     "type": "terrain",
     "id": "t_soil",
+    "copy-from": "t_abstract_wall_earthen",
     "name": "solid earth",
     "description": "A wall of solid earth.",
-    "symbol": "#",
-    "color": "brown",
-    "move_cost": 0,
-    "coverage": 100,
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "MINEABLE", "BLOCK_WIND" ],
+    "delete": { "flags": [ "AUTO_WALL_SYMBOL" ] },
     "roof": "t_dirt",
     "bash": {
       "str_min": 100,
@@ -2907,15 +1772,11 @@
   {
     "type": "terrain",
     "id": "t_rock",
+    "copy-from": "t_abstract_wall_earthen",
     "name": "solid rock",
     "description": "A wall of solid rock, could be full of all kinds of interesting things.  Best grab your pickaxe or equivalent digging implement, and strike the earth!",
-    "symbol": "#",
     "color": "white",
-    "move_cost": 0,
-    "coverage": 100,
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "MINEABLE", "BLOCK_WIND" ],
+    "delete": { "flags": [ "AUTO_WALL_SYMBOL" ] },
     "roof": "t_rock_floor_no_roof",
     "bash": {
       "str_min": 100,
@@ -2990,16 +1851,12 @@
   {
     "type": "terrain",
     "id": "t_little_column",
+    "copy-from": "t_abstract_column",
     "name": "little column",
     "looks_like": "t_column",
     "description": "A small support column.",
-    "symbol": "1",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 80,
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "WALL", "PERMEABLE", "TRANSPARENT" ],
+    "extend": { "flags": [ "TRANSPARENT" ] },
+    "delete": { "flags": [ "MINEABLE" ] },
     "bash": {
       "str_min": 40,
       "str_max": 200,
@@ -3033,16 +1890,10 @@
   {
     "type": "terrain",
     "id": "t_column",
+    "copy-from": "t_abstract_column",
     "name": "column",
     "looks_like": "t_rock_wall",
     "description": "A concrete column.",
-    "symbol": "1",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 80,
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "WALL", "PERMEABLE", "MINEABLE" ],
     "bash": {
       "str_min": 120,
       "str_max": 200,
@@ -3149,17 +2000,10 @@
   {
     "type": "terrain",
     "id": "t_drystone_wall",
+    "copy-from": "t_abstract_wall_stone",
     "name": "field stone wall",
     "looks_like": "t_rock_wall",
     "description": "A sturdy, dry stone wall.  Just rocks fitted together without mortar.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "roof": "t_rock_roof",
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "WALL", "SUPPORTS_ROOF", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
       "str_min": 50,
       "str_max": 200,
@@ -3194,23 +2038,8 @@
   {
     "type": "terrain",
     "id": "t_pillar",
+    "copy-from": "t_column",
     "name": "pillar",
-    "looks_like": "t_column",
-    "description": "A concrete column that helps keep the mine's ceiling and walls from collapsing.",
-    "symbol": "1",
-    "color": "light_gray",
-    "move_cost": 0,
-    "coverage": 80,
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "WALL", "PERMEABLE", "MINEABLE" ],
-    "bash": {
-      "str_min": 120,
-      "str_max": 200,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
-    }
+    "description": "A concrete column that helps keep the mine's ceiling and walls from collapsing."
   }
 ]

--- a/lang/string_extractor/parsers/terrain.py
+++ b/lang/string_extractor/parsers/terrain.py
@@ -4,8 +4,9 @@ from .examine_action import parse_examine_action
 
 
 def parse_terrain(json, origin):
-    name = get_singular_name(json.get("name", json["id"]))
+    name = ""
     if "name" in json:
+        name = get_singular_name(json["name"])
         write_text(json["name"], origin, comment="Terrain name")
     if "description" in json:
         write_text(json["description"], origin,

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1042,7 +1042,7 @@ bool ter_t::is_null() const
 void ter_t::load( const JsonObject &jo, const std::string &src )
 {
     map_data_common_t::load( jo, src );
-    mandatory( jo, was_loaded, "move_cost", movecost );
+    optional( jo, was_loaded, "move_cost", movecost );
     assign( jo, "max_volume", max_volume, src == "dda" );
     optional( jo, was_loaded, "trap", trap_id_str );
     optional( jo, was_loaded, "heat_radiation", heat_radiation );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -39,18 +39,23 @@ connect_group get_connect_group( const std::string &name );
 template <typename E> struct enum_traits;
 
 struct map_common_bash_info { //TODO: Half of this shouldn't be common
-        int str_min;            // min str(*) required to bash
-        int str_max;            // max str required: bash succeeds if str >= random # between str_min & str_max
-        int str_min_blocked;    // same as above; alternate values for has_adjacent_furniture(...) == true
-        int str_max_blocked;
-        int str_min_supported;  // Alternative values for floor supported by something from below
-        int str_max_supported;
-        int explosive;          // Explosion on destruction
-        int sound_vol;          // sound volume of breaking terrain/furniture
-        int sound_fail_vol;     // sound volume on fail
-        int collapse_radius;    // Radius of the tent supported by this tile
-        bool destroy_only;      // Only used for destroying, not normally bashable
-        bool bash_below;        // This terrain is the roof of the tile below it, try to destroy that too
+        // min str(*) required to bash
+        int str_min = -1;
+        // max str required: bash succeeds if str >= random # between str_min & str_max
+        int str_max = -1;
+        // same as above; alternate values for has_adjacent_furniture(...) == true
+        int str_min_blocked = -1;
+        int str_max_blocked = -1;
+        // Alternative values for floor supported by something from below
+        int str_min_supported = -1;
+        int str_max_supported = -1;
+        int explosive = -1;          // Explosion on destruction
+        int sound_vol = -1;          // sound volume of breaking terrain/furniture
+        int sound_fail_vol = -1;     // sound volume on fail
+        int collapse_radius = 1;     // Radius of the tent supported by this tile
+        bool destroy_only = false;   // Only used for destroying, not normally bashable
+        // This terrain is the roof of the tile below it, try to destroy that too
+        bool bash_below = false;
         item_group_id drop_group; // item group of items that are dropped when the object is bashed
         translation sound;      // sound made on success ('You hear a "smash!"')
         translation sound_fail; // sound made on fail
@@ -61,20 +66,22 @@ struct map_common_bash_info { //TODO: Half of this shouldn't be common
         virtual ~map_common_bash_info() = default;
 };
 struct map_ter_bash_info : map_common_bash_info {
-    ter_str_id ter_set;    // terrain to set
-    ter_str_id ter_set_bashed_from_above; // terrain to set if bashed from above (defaults to ter_set)
+    ter_str_id ter_set = ter_str_id::NULL_ID();    // terrain to set
+    // terrain to set if bashed from above (defaults to ter_set)
+    ter_str_id ter_set_bashed_from_above = ter_str_id::NULL_ID();
     map_ter_bash_info() = default;
     void load( const JsonObject &jo, bool was_loaded, const std::string &context );
     void check( const std::string &id ) const;
 };
 struct map_furn_bash_info : map_common_bash_info {
-    furn_str_id furn_set;   // furniture to set (only used by furniture, not terrain)
+    // furniture to set (only used by furniture, not terrain)
+    furn_str_id furn_set = furn_str_id::NULL_ID();
     map_furn_bash_info() = default;
     void load( const JsonObject &jo, bool was_loaded, const std::string &context );
     void check( const std::string &id ) const;
 };
 struct map_fd_bash_info : map_common_bash_info {
-    int fd_bash_move_cost; // cost to bash a field
+    int fd_bash_move_cost = 100; // cost to bash a field
     translation field_bash_msg_success; // message upon successfully bashing a field
     map_fd_bash_info() = default;
     void load( const JsonObject &jo, bool was_loaded, const std::string &context );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "abstractify basic walls"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Colored wall bloat is egregious, as is redefining the same flags over and over

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Set up a simple wall hierarchy by material

Also, defined values for fields in map_common_bash_info and related structs' constructors. `copy-from` uses the default constructor, and unset fields default to values inconsistent with the default `optional` values from load() functions, so copying from an abstract terrain didn't work.

I didn't do half-walls here because they have differences that seemed questionable

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Can burn t_wall but not t_concrete_wall
- Can destroy t_wall with a pickaxe but not t_concrete_wall
- Can mine t_wall and t_concrete_wall with a pickaxe
- t_wall_glass is still transparent
- Can remove paint from t_wall_blue with a paint chipper
- Deconstructed a table
- Deconstructed t_wall
- Blew up the side of a TCLF without errors
 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Let me know if I misplaced anything. I'd like to do this with windows, but they need extra work for `copy-from`

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
