### PR TITLE
Increased volume of pillows, body-pillow, and volume capacity of pillowcase

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2942,7 +2942,7 @@
     "material": [ "cotton" ],
     "weight": "514 g",
     "container": "pillowcase",
-    "volume": "1 L",
+    "volume": "40 L",
     "flags": [ "SLEEP_AID" ],
     "category": "other"
   },
@@ -2958,7 +2958,7 @@
     "material": [ "paper" ],
     "weight": "514 g",
     "container": "pillowcase",
-    "volume": "1 L",
+    "volume": "40 L",
     "flags": [ "SLEEP_AID" ],
     "category": "other"
   },
@@ -2973,7 +2973,7 @@
     "price_postapoc": "1 USD",
     "material": [ "cotton" ],
     "weight": "774 g",
-    "volume": "1750 ml",
+    "volume": "70 L",
     "flags": [ "SLEEP_AID" ],
     "variant_type": "generic",
     "variants": [
@@ -3069,7 +3069,7 @@
     "material": [ "cotton" ],
     "weight": "514 g",
     "container": "pillowcase",
-    "volume": "1 L",
+    "volume": "40 L",
     "flags": [ "SLEEP_AID" ],
     "category": "other"
   },

--- a/data/json/items/generic/bedding.json
+++ b/data/json/items/generic/bedding.json
@@ -13,7 +13,7 @@
     "to_hit": { "grip": "none", "length": "short", "surface": "any", "balance": "clumsy" },
     "material": [ "cotton" ],
     "flags": [ "SLEEP_AID_CONTAINER" ],
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "15 L", "max_contains_weight": "15 kg", "moves": 400 } ],
+    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "42 L", "max_contains_weight": "15 kg", "moves": 400 } ],
     "symbol": ")",
     "color": "white",
     "//": "Based on https://www.amazon.com/dp/B01MUDQUN9"


### PR DESCRIPTION
#### Summary
Bugfixes "Increased volume of pillows, body-pillow, and capacity of pillowcase"

#### Purpose of change
* Closes #48606.

#### Describe the solution
Based on https://github.com/CleverRaven/Cataclysm-DDA/issues/48606#issuecomment-2471147003, I increased volume of all pillows to 40 liters, bodypillow to 70 liters, and volume capacity of pillowcase to 42 liters.

#### Describe alternatives you've considered
None.

#### Testing
Started game with no errors, found pillow in some house, checked its volume.

#### Additional context
None.