### PR TITLE
fix macos experimental build release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Install build dependencies (mac)
         if: runner.os == 'macOS'
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install gettext ccache parallel dylibbundler
+          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install gettext ccache parallel dylibbundler freetype2
           pip3 install dmgbuild biplist
       - name: Create VERSION.TXT
         shell: bash


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The root cause of the experimental build errors AFAICT is that freetype2 is not installed as build lib, only as headers, leading to lacking symbols

#### Describe the solution
Add necessary deps

#### Describe alternatives you've considered
NONE

#### Testing
Well, wait for the build on my branch and see the results

#### Additional context
Followup of #77413
