### PR TITLE
Give "bodysuit_lycra" a fallback sprite of "jumpsuit"

### DIFF
--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -34,6 +34,7 @@
     "price_postapoc": "80 cent",
     "material": [ "lycra" ],
     "symbol": "[",
+    "looks_like": "jumpsuit",
     "color": "blue",
     "warmth": 15,
     "material_thickness": 1,


### PR DESCRIPTION
#### Summary
Features "Assign bodysuit_lycra a fallback sprite"

#### Purpose of change
"Bodysuit_lycra", as well as its dozen or so variants, lack dedicated sprites in at least Ultica. However, "jumpsuit" more than suffices as a fallback.

#### Describe the solution
Add a "looks_like" field to "bodysuit_lycra" and assigned "jumpsuit" as the value.

#### Describe alternatives you've considered
Not doing this.

#### Testing
Spawned "black infiltration bodysuit", a lycra bodysuit variant, before making change. No sprite assigned.
Made change, it now has the jumpsuit sprite correctly loaded.
![cataclysm-tiles_OlhJuNlnGG](https://github.com/user-attachments/assets/8a9435cd-4ae6-4bdb-aba2-f8c35e349029)

#### Additional context
This was done at the request of somebody in the Devcord, who brought up the issue in the first place. It seemed trivial to fix, so I did so.