### PR TITLE
Add raw() to point and tripoint.

### DIFF
--- a/src/point.h
+++ b/src/point.h
@@ -68,7 +68,7 @@ struct point {
     // Dummy implementation of raw() to allow reasoning about
     // abstract generic points.
     constexpr point raw() const {
-        return point( x, y );
+        return this;
     }
 
     /**
@@ -212,7 +212,7 @@ struct tripoint {
     // Dummy implementation of raw() to allow reasoning about
     // abstract generic points.
     constexpr tripoint raw() const {
-        return tripoint( x, y, z );
+        return this;
     }
 
     /**

--- a/src/point.h
+++ b/src/point.h
@@ -68,7 +68,7 @@ struct point {
     // Dummy implementation of raw() to allow reasoning about
     // abstract generic points.
     constexpr point raw() const {
-        return this;
+        return *this;
     }
 
     /**
@@ -212,7 +212,7 @@ struct tripoint {
     // Dummy implementation of raw() to allow reasoning about
     // abstract generic points.
     constexpr tripoint raw() const {
-        return this;
+        return *this;
     }
 
     /**

--- a/src/point.h
+++ b/src/point.h
@@ -66,7 +66,7 @@ struct point {
     }
 
     // Dummy implementation of raw() to allow reasoning about
-    // abstract generic points.
+    // generic points.
     constexpr point raw() const {
         return *this;
     }

--- a/src/point.h
+++ b/src/point.h
@@ -65,6 +65,12 @@ struct point {
         return point( std::abs( x ), std::abs( y ) );
     }
 
+    // Dummy implementation of raw() to allow reasoning about
+    // abstract generic points.
+    constexpr point raw() const {
+        return point( x, y );
+    }
+
     /**
      * Rotate point clockwise @param turns times, 90 degrees per turn,
      * around the center of a rectangle with the dimensions specified
@@ -201,6 +207,12 @@ struct tripoint {
 
     constexpr point xy() const {
         return point( x, y );
+    }
+
+    // Dummy implementation of raw() to allow reasoning about
+    // abstract generic points.
+    constexpr tripoint raw() const {
+        return tripoint( x, y, z );
     }
 
     /**


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

This makes it possible to reason about a generic point object that may be a raw point / tripoint or a typed coordinate. This came up in #75961.

In particular, the change would allow expressing the following line:
```c++
const Point next = Point{ ( center + p).raw() };
```
for which there is currently no way to express. This would also allow getting rid of some overloads in favour of generic implementations (e.g. the `closest_point_first` overloads in coordinates.h)

#### Describe the solution

Add `raw()` methods to point and tripoint that create a new object with the same details.

#### Describe alternatives you've considered

Adding `raw` at callsites.  This means that points have to be converted to the correct type system at the callsite, which is less than ideal.

Using `template<typename Point, coords::origin Origin, coords::scale Scale>`. However, I don't think this works with raw points, so they would have to be converted.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
