### PR TITLE
`BIO_OP_DISARM` tweak

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4297,7 +4297,10 @@ bool mattack::bio_op_disarm( monster *z )
 
     if( my_roll >= their_roll && !it->has_flag( flag_NO_UNWIELD ) ) {
         target->add_msg_if_player( m_bad, _( "and throws it to the ground!" ) );
-        const tripoint_bub_ms tp = foe->pos_bub() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
+        tripoint_bub_ms tp = foe->pos_bub() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
+        if( !get_map().can_put_items( tp ) ) {
+            tp = foe->pos_bub();
+        }
         get_map().add_item_or_charges( tp, foe->i_rem( &*it ) );
     } else {
         target->add_msg_if_player( m_good, _( "but you break its grip!" ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #48403.

#### Describe the solution
If there isn't any free space at the randomly-selected point, put it in the square of the monster.

#### Describe alternatives you've considered
None.

#### Testing
In a world with Mind over Matter, debug-spawned feral adept and encircled it with walls, like this:
![изображение](https://github.com/user-attachments/assets/bb6a6089-130a-4e18-ba3e-78807683417b)

Waited for feral adept to trigger its BIO_OP_DISARM attack, checked that my gun is placed under feet of feral adept.

#### Additional context
None.