### PR TITLE
[Xedra Evolved] Cryptid missions hang ups

### DIFF
--- a/data/mods/Xedra_Evolved/missions.json
+++ b/data/mods/Xedra_Evolved/missions.json
@@ -68,9 +68,7 @@
     "destination": "cabin_sevenoclock",
     "difficulty": 1,
     "value": 0,
-    "start": {
-      "assign_mission_target": { "om_terrain": "cabin_sevenoclock", "om_special": "cabin_sevenoclock", "search_range": 1800 }
-    },
+    "start": { "assign_mission_target": { "om_terrain": "cabin_sevenoclock", "om_special": "old cabin", "search_range": 1800 } },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
     "dialogue": {
@@ -93,7 +91,9 @@
     "destination": "field_deathworm",
     "difficulty": 1,
     "value": 0,
-    "start": { "assign_mission_target": { "om_terrain": "field_deathworm", "om_special": "field_deathworm", "search_range": 1800 } },
+    "start": {
+      "assign_mission_target": { "om_terrain": "field_deathworm", "om_special": "acid-scarred field", "search_range": 1800 }
+    },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
     "dialogue": {

--- a/data/mods/Xedra_Evolved/missions.json
+++ b/data/mods/Xedra_Evolved/missions.json
@@ -93,9 +93,7 @@
     "destination": "field_deathworm",
     "difficulty": 1,
     "value": 0,
-    "start": {
-      "assign_mission_target": { "om_terrain": "field_deathworm", "om_special": "field_deathworm", "search_range": 1800 }
-    },
+    "start": { "assign_mission_target": { "om_terrain": "field_deathworm", "om_special": "field_deathworm", "search_range": 1800 } },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
     "dialogue": {

--- a/data/mods/Xedra_Evolved/missions.json
+++ b/data/mods/Xedra_Evolved/missions.json
@@ -69,7 +69,7 @@
     "difficulty": 1,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_terrain": "cabin_sevenoclock_north", "om_special": "cabin_sevenoclock", "search_range": 1800 }
+      "assign_mission_target": { "om_terrain": "cabin_sevenoclock", "om_special": "cabin_sevenoclock", "search_range": 1800 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
@@ -94,7 +94,7 @@
     "difficulty": 1,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_terrain": "field_deathworm_north", "om_special": "field_deathworm", "search_range": 1800 }
+      "assign_mission_target": { "om_terrain": "field_deathworm", "om_special": "field_deathworm", "search_range": 1800 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,


### PR DESCRIPTION

#### Summary
Mods "Make the cryptid mission assigning less likely to hang"


#### Purpose of change
Recently, i played as a cryptid hunter in XE. There's this map where it leads ya to the cryptid's place, but it hangs out every time i activate it.

After some time of being unable to figure out why, @Procyonae told me that the mission json that assigns the mission specified the rotation of the om_terrain, which it should not. So this pr fixes it.

#### Describe the solution

Delete the `_north` on the om_terrain field.

#### Describe alternatives you've considered

None.
#### Testing

Activating the map to the cryptid before the change, it hangs my game up.

After deleting the `_north`, it successfully placed the mission and the marker.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
