### PR TITLE
Imgui input popups

### DIFF
--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -14,6 +14,7 @@
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
 #include "input_context.h"
+#include "input_popup.h"
 #include "json.h"
 #include "map_extras.h"
 #include "options.h"
@@ -21,7 +22,6 @@
 #include "path_info.h"
 #include "point.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translation.h"
 #include "translations.h"
 #include "ui.h"
@@ -510,16 +510,13 @@ void auto_note_manager_gui::show()
             entry.second = false;
             ( bCharacter ? charwasChanged : globalwasChanged ) = true;
         } else if( action == "CHANGE_MAPEXTRA_CHARACTER" ) {
-            string_input_popup custom_symbol_popup;
-            custom_symbol_popup
-            .title( _( "Enter a map extra custom symbol (empty to unset):" ) )
-            .width( 2 )
-            .query_string();
+            string_input_popup_imgui custom_symbol_popup( 0 );
+            custom_symbol_popup.set_label( _( "Enter a map extra custom symbol (empty to unset):" ) );
+            custom_symbol_popup.set_max_input_length( 1 );
+            const std::string &custom_symbol_str = custom_symbol_popup.query();
 
-            if( !custom_symbol_popup.canceled() ) {
-                const std::string &custom_symbol_str = custom_symbol_popup.text();
+            if( !custom_symbol_popup.cancelled() ) {
                 if( custom_symbol_str.empty() ) {
-
                     ( bCharacter ? char_custom_symbol_cache : global_custom_symbol_cache ).erase( currentItem );
                 } else {
                     uilist ui_colors;

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -21,6 +21,7 @@
 #include "flexbuffer_json-inl.h"
 #include "flexbuffer_json.h"
 #include "input_context.h"
+#include "input_popup.h"
 #include "item.h"
 #include "item_factory.h"
 #include "item_location.h"
@@ -35,7 +36,6 @@
 #include "path_info.h"
 #include "point.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "type_id.h"
 #include "ui.h"
@@ -517,45 +517,24 @@ void user_interface::show()
             ui_manager::redraw();
 
             if( bLeftColumn || action == "ADD_RULE" ) {
-                ui_adaptor help_ui;
-                catacurses::window w_help;
-                const auto init_help_window = [&]( ui_adaptor & help_ui ) {
-                    const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                                         TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
-                    w_help = catacurses::newwin( FULL_SCREEN_HEIGHT / 2 + 2,
-                                                 FULL_SCREEN_WIDTH * 3 / 4,
-                                                 iOffset + point( 19 / 2, 7 + FULL_SCREEN_HEIGHT / 2 / 2 ) );
-                    help_ui.position_from_window( w_help );
-                };
-                init_help_window( help_ui );
-                help_ui.on_screen_resize( init_help_window );
-
-                help_ui.on_redraw( [&]( const ui_adaptor & ) {
-                    // NOLINTNEXTLINE(cata-use-named-point-constants)
-                    fold_and_print( w_help, point( 1, 1 ), 999, c_white,
-                                    _(
-                                        "* is used as a Wildcard.  A few Examples:\n"
-                                        "\n"
-                                        "wooden arrow    matches the itemname exactly\n"
-                                        "wooden ar*      matches items beginning with wood ar\n"
-                                        "*rrow           matches items ending with rrow\n"
-                                        "*avy fle*fi*arrow     multiple * are allowed\n"
-                                        "heAVY*woOD*arrOW      case insensitive search\n"
-                                        "\n"
-                                        "Pickup based on item materials:\n"
-                                        "m:kevlar        matches items made of Kevlar\n"
-                                        "M:copper        matches items made purely of copper\n"
-                                        "M:steel,iron    multiple materials allowed (OR search)" )
-                                  );
-
-                    draw_border( w_help );
-                    wnoutrefresh( w_help );
-                } );
-                const std::string r = string_input_popup()
-                                      .title( _( "Pickup Rule:" ) )
-                                      .width( 30 )
-                                      .text( cur_rules[iLine].sRule )
-                                      .query_string();
+                string_input_popup_imgui popup( 60, cur_rules[iLine].sRule );
+                popup.set_label( _( "Pickup Rule:" ) );
+                std::string description = _(
+                                              "* is used as a Wildcard.  A few Examples:\n"
+                                              "\n"
+                                              "wooden arrow    matches the itemname exactly\n"
+                                              "wooden ar*      matches items beginning with wood ar\n"
+                                              "*rrow           matches items ending with rrow\n"
+                                              "*avy fle*fi*arrow     multiple * are allowed\n"
+                                              "heAVY*woOD*arrOW      case insensitive search\n"
+                                              "\n"
+                                              "Pickup based on item materials:\n"
+                                              "m:kevlar        matches items made of Kevlar\n"
+                                              "M:copper        matches items made purely of copper\n"
+                                              "M:steel,iron    multiple materials allowed (OR search)"
+                                          );
+                popup.set_description( description, c_white, true );
+                const std::string r = popup.query();
                 // If r is empty, then either (1) The player ESC'ed from the window (changed their mind), or
                 // (2) Explicitly entered an empty rule- which isn't allowed since "*" should be used
                 // to include/exclude everything

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -1027,6 +1027,14 @@ void cataimgui::window::clear_filter()
     }
 }
 
+bool cataimgui::InputFloat( const char *label, float *v, float step, float step_fast,
+                            const char *format, ImGuiInputTextFlags flags )
+{
+    return ImGui::InputScalar( label, ImGuiDataType_Float, static_cast<void *>( v ),
+                               static_cast<void *>( step > 0.0f ? &step : nullptr ),
+                               static_cast<void *>( step_fast > 0.0f ? &step_fast : nullptr ), format, flags );
+}
+
 void cataimgui::PushGuiFont()
 {
 #ifdef TILES

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -7,6 +7,7 @@
 
 class nc_color;
 struct input_event;
+using ImGuiInputTextFlags = int;
 
 #if defined(IMTUI) || !(defined(WIN32) || defined(TILES))
 #   define TUI
@@ -149,6 +150,10 @@ class window
 void init_pair( int p, int f, int b );
 void load_colors();
 #endif
+
+// drops the ImGuiInputTextFlags_CharsScientific flag from regular imgui InputFloat because it doesn't allow commas
+bool InputFloat( const char *label, float *v, float step = 0.0f, float step_fast = 0.0f,
+                 const char *format = "%.3f", ImGuiInputTextFlags flags = 0 );
 
 void PushGuiFont();
 void PushMonoFont();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -113,6 +113,7 @@
 #include "input.h"
 #include "input_context.h"
 #include "input_enums.h"
+#include "input_popup.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_category.h"
@@ -8626,15 +8627,12 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             recalc_unread = highlight_unread_items;
         } else if( action == "FILTER" ) {
             ui.invalidate_ui();
-            string_input_popup()
-            .title( _( "Filter:" ) )
-            .width( 55 )
-            .description( item_filter_rule_string( item_filter_type::FILTER ) + "\n\n"
-                          + list_items_filter_history_help() )
-            .desc_color( c_white )
-            .identifier( "item_filter" )
-            .max_length( 256 )
-            .edit( sFilter );
+            string_input_popup_imgui imgui_popup( 70, sFilter, _( "Filter items" ) );
+            imgui_popup.set_label( _( "Filter:" ) );
+            imgui_popup.set_description( item_filter_rule_string( item_filter_type::FILTER ) + "\n\n" +
+                                         list_items_filter_history_help(), c_white, true );
+            imgui_popup.set_identifier( "item_filter" );
+            sFilter = imgui_popup.query();
             refilter = true;
             addcategory = !sort_radius;
             uistate.list_item_filter_active = !sFilter.empty();

--- a/src/input_popup.cpp
+++ b/src/input_popup.cpp
@@ -1,0 +1,365 @@
+#include "input_popup.h"
+
+#include "cata_utility.h"
+#include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"
+#include "imgui/imgui_stdlib.h"
+#include "ui.h"
+#include "uistate.h"
+#include "ui_manager.h"
+
+input_popup::input_popup( int width, const std::string &title, const point &pos,
+                          ImGuiWindowFlags flags ) :
+    cataimgui::window( title, ImGuiWindowFlags_NoNavInputs | flags | ( title.empty() ?
+                       ImGuiWindowFlags_NoTitleBar : 0 ) | ImGuiWindowFlags_AlwaysAutoResize ),
+    pos( pos ),
+    width( width )
+{
+    ctxt = input_context( "STRING_INPUT", keyboard_mode::keychar );
+    ctxt.register_action( "TEXT.CONFIRM" );
+    ctxt.register_action( "TEXT.QUIT" );
+    ctxt.register_action( "TEXT.CLEAR" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.set_timeout( 10 );
+}
+
+void input_popup::set_description( const std::string &desc, const nc_color &default_color,
+                                   bool monofont )
+{
+    description = desc;
+    description_default_color = default_color;
+    description_monofont = monofont;
+}
+
+void input_popup::set_label( const std::string &label, const nc_color &default_color )
+{
+    this->label = label;
+    label_default_color = default_color;
+}
+
+void input_popup::set_max_input_length( int length )
+{
+    max_input_length = length;
+}
+
+static void register_input( input_context &ctxt, const callback_input &input )
+{
+    if( input.description ) {
+        ctxt.register_action( input.action, *input.description );
+    } else {
+        ctxt.register_action( input.action );
+    }
+}
+
+void input_popup::add_callback( const callback_input &input,
+                                const std::function<bool()> &callback_func )
+{
+    if( !input.action.empty() ) {
+        register_input( ctxt, input );
+    }
+    callbacks.emplace_back( input, callback_func );
+}
+
+bool input_popup::cancelled() const
+{
+    return is_cancelled;
+}
+
+cataimgui::bounds input_popup::get_bounds()
+{
+    return {
+        pos.x < 0 ? -1.f : str_width_to_pixels( pos.x ),
+        pos.y < 0 ? -1.f : str_height_to_pixels( pos.y ),
+        width <= 0 ? -1.f : str_width_to_pixels( width ),
+        -1.f
+    };
+}
+
+void input_popup::draw_controls()
+{
+    if( !description.empty() ) {
+        if( description_monofont ) {
+            cataimgui::PushMonoFont();
+        }
+        // todo: you should not have to manually split text to print it as paragraphs
+        uint64_t offset = 0;
+        uint64_t pos = 0;
+        while( pos != std::string::npos ) {
+            pos = description.find( '\n', offset );
+            std::string str = description.substr( offset, pos - offset );
+            cataimgui::TextColoredParagraph( description_default_color, str );
+            ImGui::NewLine();
+            offset = pos + 1;
+        }
+        if( description_monofont ) {
+            ImGui::PopFont();
+        }
+    }
+
+    if( !label.empty() ) {
+        ImGui::AlignTextToFramePadding();
+        cataimgui::draw_colored_text( label, c_light_red );
+        ImGui::SameLine();
+    }
+
+    // make sure the cursor is in the input field when we regain focus
+    if( !ImGui::IsWindowFocused() ) {
+        set_focus = true;
+    }
+
+    if( set_focus && ImGui::IsWindowFocused() ) {
+        ImGui::SetKeyboardFocusHere();
+        set_focus = false;
+    }
+    draw_input_control();
+}
+
+bool input_popup::handle_custom_callbacks( const std::string &action )
+{
+
+    input_event ev = ctxt.get_raw_input();
+    int key = ev.get_first_input();
+
+    bool next_loop = false;
+    for( const auto &cb : callbacks ) {
+        if( cb.first == callback_input( action, key ) && cb.second() ) {
+            next_loop = true;
+            break;
+        }
+    }
+
+    return next_loop;
+}
+
+string_input_popup_imgui::string_input_popup_imgui( int width, const std::string &old_input,
+        const std::string &title, const point &pos, ImGuiWindowFlags flags ) :
+    input_popup( width, title, pos, flags ),
+    text( old_input ),
+    old_input( old_input )
+{
+    ctxt.register_action( "TEXT.UP" );
+    ctxt.register_action( "TEXT.DOWN" );
+}
+
+void string_input_popup_imgui::draw_input_control()
+{
+    // shrink width of input field if we only allow short inputs
+    float input_width = str_width_to_pixels( max_input_length + 1 );
+    if( input_width > 0 && input_width < ImGui::CalcItemWidth() ) {
+        ImGui::SetNextItemWidth( input_width );
+    }
+
+    std::string input_label = "##string_input_" + label;
+    ImGui::InputText( input_label.c_str(), &text );
+}
+
+void string_input_popup_imgui::set_identifier( const std::string &ident )
+{
+    identifier = ident;
+}
+
+void string_input_popup_imgui::set_text( const std::string &txt )
+{
+    text = txt;
+}
+
+void string_input_popup_imgui::show_history()
+{
+    if( identifier.empty() ) {
+        return;
+    }
+    std::vector<std::string> &hist = uistate.gethistory( identifier );
+    uilist hmenu;
+    hmenu.title = _( "d: delete history" );
+    hmenu.allow_anykey = true;
+    for( size_t h = 0; h < hist.size(); h++ ) {
+        hmenu.addentry( h, true, -2, hist[h] );
+    }
+    if( !text.empty() && ( hmenu.entries.empty() ||
+                           hmenu.entries[hist.size() - 1].txt != text ) ) {
+        hmenu.addentry( hist.size(), true, -2, text );
+    }
+
+    if( !hmenu.entries.empty() ) {
+        hmenu.selected = hmenu.entries.size() - 1;
+
+        bool finished = false;
+        do {
+            hmenu.query();
+            if( hmenu.ret >= 0 && hmenu.entries[hmenu.ret].txt != text ) {
+                set_text( hmenu.entries[hmenu.ret].txt );
+                if( static_cast<size_t>( hmenu.ret ) < hist.size() ) {
+                    hist.erase( hist.begin() + hmenu.ret );
+                    add_to_history( text );
+                }
+                finished = true;
+            } else if( hmenu.ret == UILIST_UNBOUND && hmenu.ret_evt.get_first_input() == 'd' ) {
+                hist.clear();
+                finished = true;
+            } else if( hmenu.ret != UILIST_UNBOUND ) {
+                finished = true;
+            }
+        } while( !finished );
+    }
+}
+
+void string_input_popup_imgui::update_input_history( bool up )
+{
+    if( identifier.empty() ) {
+        return;
+    }
+
+    std::vector<std::string> &hist = uistate.gethistory( identifier );
+
+    if( hist.empty() ) {
+        return;
+    }
+
+    if( hist.size() >= max_history_size ) {
+        hist.erase( hist.begin(), hist.begin() + ( hist.size() - max_history_size ) );
+    }
+
+    if( up ) {
+        if( history_index >= static_cast<int>( hist.size() ) ) {
+            return;
+        } else if( history_index == 0 ) {
+            session_input = text;
+
+            //avoid showing the same result twice (after reopen filter window without reset)
+            if( hist.size() > 1 && session_input == hist.back() ) {
+                history_index += 1;
+            }
+        }
+    } else {
+        if( history_index == 1 ) {
+            set_text( session_input );
+            //show initial string entered and 'return'
+            history_index = 0;
+            return;
+        } else if( history_index == 0 ) {
+            return;
+        }
+    }
+
+    history_index += up ? 1 : -1;
+    set_text( hist[hist.size() - history_index] );
+}
+
+void string_input_popup_imgui::add_to_history( const std::string &value ) const
+{
+    if( !identifier.empty() && !value.empty() ) {
+        std::vector<std::string> &hist = uistate.gethistory( identifier );
+        if( hist.empty() || hist[hist.size() - 1] != value ) {
+            hist.push_back( value );
+        }
+    }
+}
+
+std::string string_input_popup_imgui::query()
+{
+    is_cancelled = false;
+
+    while( true ) {
+        ui_manager::redraw_invalidated();
+
+        std::string action = ctxt.handle_input();
+        if( handle_custom_callbacks( action ) ) {
+            continue;
+        }
+
+        if( action == "TEXT.CONFIRM" ) {
+            add_to_history( text );
+            return text;
+        } else if( action == "TEXT.QUIT" ) {
+            break;
+        } else if( action == "TEXT.UP" ) {
+            if( is_uilist_history ) {
+                show_history();
+            } else {
+                update_input_history( true );
+            }
+        } else if( action == "TEXT.DOWN" && !is_uilist_history ) {
+            update_input_history( false );
+        } else if( action == "TEXT.CLEAR" ) {
+            text.clear();
+        }
+
+        // mouse click on x to close leads here
+        if( !get_is_open() ) {
+            break;
+        }
+    }
+
+    is_cancelled = true;
+    return old_input;
+}
+
+void string_input_popup_imgui::use_uilist_history( bool use_uilist )
+{
+    is_uilist_history = use_uilist;
+}
+
+template<typename T>
+number_input_popup<T>::number_input_popup( int width, T old_value, const std::string &title,
+        const point &pos, ImGuiWindowFlags flags ) :
+    input_popup( width, title, pos, flags ),
+    value( old_value ),
+    old_value( old_value )
+{
+    // potentially register context keys
+}
+
+template<>
+void number_input_popup<int>::draw_input_control()
+{
+    // todo: maybe set width of input field, default is fairly long
+    // step size default values are imgui defaults
+    ImGui::InputInt( "##number_input", &value, step_size.value_or( 1 ),
+                     fast_step_size.value_or( 100 ) );
+}
+
+template<>
+void number_input_popup<float>::draw_input_control()
+{
+    // todo: maybe set width of input field, default is fairly long
+    // step size default values are imgui defaults
+    cataimgui::InputFloat( "##number_input", &value, step_size.value_or( 0.f ),
+                           fast_step_size.value_or( 0.f ) );
+}
+
+template<typename T>
+T number_input_popup<T>::query()
+{
+
+    while( true ) {
+        ui_manager::redraw_invalidated();
+        std::string action = ctxt.handle_input();
+
+        if( handle_custom_callbacks( action ) ) {
+            continue;
+        }
+
+        if( action == "TEXT.CONFIRM" ) {
+            return value;
+        } else if( action == "TEXT.QUIT" ) {
+            break;
+        }
+
+        // mouse click on x to close leads here
+        if( !get_is_open() ) {
+            break;
+        }
+    }
+
+    return old_value;
+}
+
+template<typename T>
+void number_input_popup<T>::set_step_size( std::optional<T> step, std::optional<T> fast_step )
+{
+    step_size = step;
+    fast_step_size = fast_step;
+}
+
+template class number_input_popup<int>;
+template class number_input_popup<float>;

--- a/src/input_popup.h
+++ b/src/input_popup.h
@@ -18,7 +18,7 @@ struct callback_input {
                     std::optional<translation> description = std::nullopt ) : action( action ), key( key ),
         description( std::move( description ) ) {};
     explicit callback_input( const std::string &action,
-                    std::optional<translation> description = std::nullopt ) : action( action ),
+                             std::optional<translation> description = std::nullopt ) : action( action ),
         description( std::move( description ) ) {};
     explicit callback_input( int key,
                              std::optional<translation> description = std::nullopt ) : key( key ),
@@ -34,13 +34,14 @@ class input_popup : public cataimgui::window
 {
     public:
         explicit input_popup( int width, const std::string &title = "", const point &pos = point::min,
-                     ImGuiWindowFlags flags = ImGuiWindowFlags_None );
+                              ImGuiWindowFlags flags = ImGuiWindowFlags_None );
 
         // todo: monofont is a hack for easy support of old descriptions and should be replaced by a more universal solution
         void set_description( const std::string &desc, const nc_color &default_color = c_green,
                               bool monofont = false );
         void set_label( const std::string &label, const nc_color &default_color = c_light_red );
         void set_max_input_length( int length );
+        int get_max_input_length() const;
         void add_callback( const callback_input &input, const std::function<bool()> &callback_func );
         bool cancelled() const;
 
@@ -73,8 +74,8 @@ class string_input_popup_imgui : public input_popup
 {
     public:
         explicit string_input_popup_imgui( int width, const std::string &old_input = "",
-                                  const std::string &title = "", const point &pos = point::min,
-                                  ImGuiWindowFlags flags = ImGuiWindowFlags_None );
+                                           const std::string &title = "", const point &pos = point::min,
+                                           ImGuiWindowFlags flags = ImGuiWindowFlags_None );
 
         std::string query();
         void set_identifier( const std::string &ident );
@@ -102,7 +103,7 @@ class number_input_popup : public input_popup
 {
     public:
         explicit number_input_popup( int width, T old_value = 0, const std::string &title = "",
-                            const point &pos = point::min, ImGuiWindowFlags flags = ImGuiWindowFlags_None );
+                                     const point &pos = point::min, ImGuiWindowFlags flags = ImGuiWindowFlags_None );
         T query();
         void set_step_size( std::optional<T> step, std::optional<T> fast_step );
     protected:

--- a/src/input_popup.h
+++ b/src/input_popup.h
@@ -1,0 +1,116 @@
+#pragma once
+#ifndef CATA_SRC_INPUT_POPUP_H
+#define CATA_SRC_INPUT_POPUP_H
+
+#include <type_traits>
+
+#include "cata_imgui.h"
+#include "color.h"
+#include "imgui/imgui.h"
+#include "input_context.h"
+
+struct callback_input {
+    std::string action;
+    int key = INT_MIN;
+    std::optional<translation> description;
+
+    callback_input( const std::string &action, int key,
+                    std::optional<translation> description = std::nullopt ) : action( action ), key( key ),
+        description( std::move( description ) ) {};
+    explicit callback_input( const std::string &action,
+                    std::optional<translation> description = std::nullopt ) : action( action ),
+        description( std::move( description ) ) {};
+    explicit callback_input( int key,
+                             std::optional<translation> description = std::nullopt ) : key( key ),
+        description( std::move( description ) ) {};
+
+    bool operator==( const callback_input &rhs ) const {
+        return ( !action.empty() && action == rhs.action ) ||
+               ( key != INT_MIN && key == rhs.key );
+    }
+};
+
+class input_popup : public cataimgui::window
+{
+    public:
+        explicit input_popup( int width, const std::string &title = "", const point &pos = point::min,
+                     ImGuiWindowFlags flags = ImGuiWindowFlags_None );
+
+        // todo: monofont is a hack for easy support of old descriptions and should be replaced by a more universal solution
+        void set_description( const std::string &desc, const nc_color &default_color = c_green,
+                              bool monofont = false );
+        void set_label( const std::string &label, const nc_color &default_color = c_light_red );
+        void set_max_input_length( int length );
+        void add_callback( const callback_input &input, const std::function<bool()> &callback_func );
+        bool cancelled() const;
+
+    protected:
+        virtual void draw_input_control() = 0;
+        void draw_controls() override;
+        cataimgui::bounds get_bounds() override;
+
+        bool handle_custom_callbacks( const std::string &action );
+
+        input_context ctxt;
+        std::string label;
+        nc_color label_default_color = c_light_red;
+        int max_input_length = 0;
+        // set focus on startup, ability to set focus on other occasions
+        bool set_focus = true;
+        bool is_cancelled = false;
+        std::vector<std::pair<callback_input, std::function<bool()>>> callbacks;
+
+    private:
+        std::string description;
+        nc_color description_default_color = c_green;
+
+        point pos;
+        int width;
+        bool description_monofont = false;
+};
+
+class string_input_popup_imgui : public input_popup
+{
+    public:
+        explicit string_input_popup_imgui( int width, const std::string &old_input = "",
+                                  const std::string &title = "", const point &pos = point::min,
+                                  ImGuiWindowFlags flags = ImGuiWindowFlags_None );
+
+        std::string query();
+        void set_identifier( const std::string &ident );
+        void set_text( const std::string &txt );
+        void use_uilist_history( bool use_uilist );
+    protected:
+        void draw_input_control() override;
+    private:
+        void add_to_history( const std::string &value ) const;
+        void update_input_history( bool up );
+        void show_history();
+        std::string text;
+        // currently entered input for history handling
+        std::string session_input;
+        std::string old_input;
+        std::string identifier;
+        bool is_uilist_history = true;
+        uint64_t max_history_size = 100;
+        int history_index = 0;
+};
+
+// todo: make generic for any numeric type?
+template<typename T>
+class number_input_popup : public input_popup
+{
+    public:
+        explicit number_input_popup( int width, T old_value = 0, const std::string &title = "",
+                            const point &pos = point::min, ImGuiWindowFlags flags = ImGuiWindowFlags_None );
+        T query();
+        void set_step_size( std::optional<T> step, std::optional<T> fast_step );
+    protected:
+        void draw_input_control() override;
+    private:
+        T value;
+        T old_value;
+        std::optional<T> step_size = std::nullopt;
+        std::optional<T> fast_step_size = std::nullopt;
+};
+#endif // CATA_SRC_INPUT_POPUP_H

--- a/src/input_popup.h
+++ b/src/input_popup.h
@@ -80,11 +80,11 @@ class string_input_popup_imgui : public input_popup
         void set_identifier( const std::string &ident );
         void set_text( const std::string &txt );
         void use_uilist_history( bool use_uilist );
+        void update_input_history( ImGuiInputTextCallbackData *data );
     protected:
         void draw_input_control() override;
     private:
         void add_to_history( const std::string &value ) const;
-        void update_input_history( bool up );
         void show_history();
         std::string text;
         // currently entered input for history handling

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -19,6 +19,7 @@
 #include "game_constants.h"
 #include "generic_factory.h"
 #include "input_context.h"
+#include "input_popup.h"
 #include "json.h"
 #include "lang_stats.h"
 #include "line.h"
@@ -3755,33 +3756,16 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
                     current_opt.setNext();
                 } else {
                     const bool is_int = current_opt.getType() == "int";
-                    const bool is_float = current_opt.getType() == "float";
-                    const std::string old_opt_val = current_opt.getValueName();
-                    const std::string opt_val = string_input_popup()
-                                                .title( current_opt.getMenuText() )
-                                                .width( 10 )
-                                                .text( old_opt_val )
-                                                .only_digits( is_int )
-                                                .query_string();
-                    if( !opt_val.empty() && opt_val != old_opt_val ) {
-                        if( is_float ) {
-                            std::istringstream ssTemp( opt_val );
-                            // This uses the current locale, to allow the users
-                            // to use their own decimal format.
-                            float tmpFloat;
-                            ssTemp >> tmpFloat;
-                            if( ssTemp ) {
-                                current_opt.setValue( tmpFloat );
-
-                            } else {
-                                popup( _( "Invalid input: not a number" ) );
-                            }
-                        } else {
-                            // option is of type "int": string_input_popup
-                            // has taken care that the string contains
-                            // only digits, parsing is done in setValue
-                            current_opt.setValue( opt_val );
-                        }
+                    if( is_int ) {
+                        number_input_popup<int> popup( 0, current_opt.value_as<int>() );
+                        popup.set_label( current_opt.getMenuText() );
+                        int num = popup.query();
+                        current_opt.setValue( num );
+                    } else {
+                        number_input_popup<float> popup( 0, current_opt.value_as<float>() );
+                        popup.set_label( current_opt.getMenuText() );
+                        float num = popup.query();
+                        current_opt.setValue( num );
                     }
                 }
             }

--- a/src/ui.h
+++ b/src/ui.h
@@ -41,7 +41,7 @@ const int UILIST_TIMEOUT = -1028;
 const int UILIST_ADDITIONAL = -1029;
 const int MENU_AUTOASSIGN = -1;
 
-class string_input_popup;
+class string_input_popup_imgui;
 class uilist_impl;
 
 catacurses::window new_centered_win( int nlines, int ncols );
@@ -472,7 +472,7 @@ class uilist // NOLINT(cata-xy)
 
         weak_ptr_fast<uilist_impl> ui;
 
-        std::unique_ptr<string_input_popup> filter_popup;
+        std::unique_ptr<string_input_popup_imgui> filter_popup;
         std::string filter;
 
         int max_entry_len = 0;

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -10,6 +10,7 @@
 
 #include "enums.h"
 #include "flat_set.h"
+#include "item_location.h"
 #include "json.h"
 #include "omdata.h"
 #include "type_id.h"

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -20,6 +20,7 @@
 #include "enums.h"
 #include "filesystem.h"
 #include "input_context.h"
+#include "input_popup.h"
 #include "json.h"
 #include "json_loader.h"
 #include "mod_manager.h"
@@ -183,21 +184,21 @@ WORLD *worldfactory::make_new_world( bool show_prompt, const std::string &world_
 static std::optional<std::string> prompt_world_name( const std::string &title,
         const std::string &cur_worldname )
 {
-    string_input_popup popup;
-    popup.max_length( max_worldname_len ).title( title ).text( cur_worldname );
+    string_input_popup_imgui popup( 50, cur_worldname );
+    popup.set_max_input_length( max_worldname_len );
+    popup.set_label( title );
 
     input_context ctxt( "STRING_INPUT" );
-    popup.description( string_format(
-                           _( "Press [<color_c_yellow>%s</color>] to randomize the world name." ),
-                           ctxt.get_desc( "PICK_RANDOM_WORLDNAME", 1U ) ) );
+    popup.set_description( string_format(
+                               _( "Press [<color_c_yellow>%s</color>] to randomize the world name." ),
+                               ctxt.get_desc( "PICK_RANDOM_WORLDNAME", 1U ) ) );
 
-    popup.custom_actions.emplace_back( "PICK_RANDOM_WORLDNAME", translation() );
-    popup.add_callback( "PICK_RANDOM_WORLDNAME", [&popup]() {
-        popup.text( get_next_valid_worldname() );
+    popup.add_callback( callback_input{ "PICK_RANDOM_WORLDNAME" }, [&popup]() {
+        popup.set_text( get_next_valid_worldname() );
         return true;
     } );
-    std::string message = popup.query_string();
-    return !popup.canceled() ? std::optional<std::string>( message ) : std::optional<std::string>();
+    std::string message = popup.query();
+    return message;
 }
 
 int worldfactory::show_worldgen_advanced( WORLD *world )


### PR DESCRIPTION
#### Summary
Infrastructure "Imgui input popups"

#### Purpose of change

General imgui migration and I need this for #55503.
Fixes #75676

#### Describe the solution

Make new classes for string and number input popups. The number input is templated to work on any number type (in theory, need to learn more template magic to really enforce that without having to implement `number_input_popup::draw_input_control` for every type we want). Some places don't use `string_input_popup` as a popup but as an integrated element, so I can't simply replace it completely.

When using non-uilist input history, I had to use imgui callback input handling instead of our usual input_context, because imgui's input fields reset the buffer when redrawing while they're the focused element. This is kinda ugly because it mixed two methods of input handling, but I don't see a better solution right now.

notable string input features:
 - description can be forced to monospace (so I can avoid redesigning how descriptions are set and the offending descriptions themselves)
 - can have an actual title bar (but doesn't have to)

notable number input features:
 - +/- buttons, which offer two different step sizes (click or ctrl-click), uses default values from imgui, which is 1/100 for int and disabled for float

Issues that probably won't be addressed in this PR unless required:
- float input always uses system decimal separator instead of the one from the language settings
- a ton of instances left to be migrated
- extra keybinds such as `*` for randomization in world creation world name popup only register when the input field is unfocused

#### Describe alternatives you've considered

Mirroring the code style of the old popup for easier transitioning. But it's the only place in the code base where that style is used and nobody insisted I keep it.

#### Testing

Int and float input is implemented in the settings menu and tested there.
String input is implemented in a few places, mostly tested in world creation world name and V menu item filtering.
Input length limiting tested in auto note menu.

**Not** tested with CJK characters.

#### Additional context

Screenshots slightly outdated since style updates.

float input:
![grafik](https://github.com/user-attachments/assets/ebb41902-0a45-4411-8d9d-f019379985d3)

int input:
![grafik](https://github.com/user-attachments/assets/6766816f-8b7a-4c48-a7de-30eaa6872080)

item filter input:
![grafik](https://github.com/user-attachments/assets/a23ce924-508b-411b-945f-21f00fba04da)