### PR TITLE
Remove thousands separators

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3768,7 +3768,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     const double cur_total_moves = cached_cur_total_moves;
 
     // item_counter represents the percent progress relative to the base batch time
-    // stored precise to 5 decimal places ( e.g. 67.32 percent would be stored as 6'732'000 )
+    // stored precise to 5 decimal places ( e.g. 67.32 percent would be stored as 6732000 )
     const int old_counter = craft.item_counter;
 
     // Delta progress in moves adjusted for current crafting speed /
@@ -3777,21 +3777,21 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
                           exertion_level() );
     const double delta_progress = spent_moves * base_total_moves / cur_total_moves;
     // Current progress in moves
-    const double current_progress = craft.item_counter * base_total_moves / 10'000'000.0 +
+    const double current_progress = craft.item_counter * base_total_moves / 10000000.0 +
                                     delta_progress;
     // Current progress as a percent of base_total_moves to 2 decimal places
-    craft.item_counter = std::round( current_progress / base_total_moves * 10'000'000.0 );
+    craft.item_counter = std::round( current_progress / base_total_moves * 10000000.0 );
     crafter.set_moves( 0 );
 
     // This is to ensure we don't over count skill steps
-    craft.item_counter = std::min( craft.item_counter, 10'000'000 );
+    craft.item_counter = std::min( craft.item_counter, 10000000 );
 
     // This nominal craft time is also how many practice ticks to perform
     // spread out evenly across the actual duration.
     const double total_practice_ticks = rec.time_to_craft_moves( crafter,
                                         recipe_time_flag::ignore_proficiencies ) / 100.0;
 
-    const int ticks_per_practice = 10'000'000.0 / total_practice_ticks;
+    const int ticks_per_practice = 10000000.0 / total_practice_ticks;
     int num_practice_ticks = craft.item_counter / ticks_per_practice -
                              old_counter / ticks_per_practice;
     bool level_up = false;
@@ -3799,7 +3799,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         level_up |= crafter.craft_skill_gain( craft, num_practice_ticks );
     }
     // Proficiencies and tools are gained/consumed after every 5% progress
-    int five_percent_steps = craft.item_counter / 500'000 - old_counter / 500'000;
+    int five_percent_steps = craft.item_counter / 500000 - old_counter / 500000;
     if( five_percent_steps > 0 ) {
         // Divide by 100 for seconds, 20 for 5%
         const time_duration pct_time = time_duration::from_seconds( base_total_moves / 2000 );
@@ -3811,14 +3811,14 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     }
 
     // Unlike skill, tools are consumed once at the start and should not be consumed at the end
-    if( craft.item_counter >= 10'000'000 ) {
+    if( craft.item_counter >= 10000000 ) {
         --five_percent_steps;
     }
 
     if( five_percent_steps > 0 ) {
         if( !crafter.craft_consume_tools( craft, five_percent_steps, false ) ) {
             // So we don't skip over any tool comsuption
-            craft.item_counter -= craft.item_counter % 500'000 + 1;
+            craft.item_counter -= craft.item_counter % 500000 + 1;
             craft.erase_var( "crafter" );
             crafter.cancel_activity();
             return;
@@ -3826,7 +3826,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     }
 
     // if item_counter has reached 100% or more
-    if( craft.item_counter >= 10'000'000 ) {
+    if( craft.item_counter >= 10000000 ) {
         if( rec.is_practice() && !is_long && craft.get_making_batch_size() == 1 ) {
             if( query_yn( _( "Keep practicing until proficiency increases?" ) ) ) {
                 is_long = true;
@@ -5328,15 +5328,15 @@ void disassemble_activity_actor::do_turn( player_activity &act, Character &who )
     }
 
     if( moves_total == 0 ) {
-        craft.item_counter = 10'000'000;
+        craft.item_counter = 10000000;
     } else {
         const int spent_moves = who.get_moves() * who.exertion_adjusted_move_multiplier( exertion_level() );
-        craft.item_counter += std::round( spent_moves * crafting_speed * 10'000'000.0 / moves_total );
-        craft.item_counter = std::min( craft.item_counter, 10'000'000 );
+        craft.item_counter += std::round( spent_moves * crafting_speed * 10000000.0 / moves_total );
+        craft.item_counter = std::min( craft.item_counter, 10000000 );
         who.set_moves( 0 );
     }
 
-    if( craft.item_counter >= 10'000'000 ) {
+    if( craft.item_counter >= 10000000 ) {
         who.complete_disassemble( target );
     }
 }

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -50,7 +50,7 @@ class basic_animation
 {
     public:
         explicit basic_animation( const int scale ) :
-            delay( get_option<int>( "ANIMATION_DELAY" ) * scale * 1'000'000L ) {
+            delay( get_option<int>( "ANIMATION_DELAY" ) * scale * 1000000L ) {
         }
 
         void draw() const {
@@ -71,7 +71,7 @@ class basic_animation
             do {
                 const auto sleep_for = std::min( sleep_till - std::chrono::steady_clock::now(),
                                                  // Pump events every 100 ms
-                                                 std::chrono::nanoseconds( 100'000'000 ) );
+                                                 std::chrono::nanoseconds( 100000000 ) );
                 if( sleep_for > std::chrono::nanoseconds( 0 ) ) {
                     std::this_thread::sleep_for( sleep_for );
                     inp_mngr.pump_events();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -582,10 +582,10 @@ Character::Character() :
     update_type_of_scent( true );
     pkill = 0;
     // 55 Mcal or 55k kcal
-    healthy_calories = 55'000'000;
+    healthy_calories = 55000000;
     base_cardio_acc = 1000;
     // this makes sure characters start with normal bmi
-    stored_calories = healthy_calories - 1'000'000;
+    stored_calories = healthy_calories - 1000000;
     initialize_stomach_contents();
 
     name.clear();

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3034,7 +3034,7 @@ std::pair<float, float> repair_item_actor::repair_chance(
             break;
         default:
             // 5 is obsoleted reinforcing, remove after 0.H
-            action_difficulty = 1'000'000; // ensure failure
+            action_difficulty = 1000000; // ensure failure
             break;
     }
 

--- a/src/iuse_software_kitten.cpp
+++ b/src/iuse_software_kitten.cpp
@@ -288,11 +288,11 @@ void robot_finds_kitten::process_input()
                 refresh_display();
                 // Sleep for 1 s
                 const auto sleep_till = std::chrono::steady_clock::now()
-                                        + std::chrono::nanoseconds( 1'000'000'000 );
+                                        + std::chrono::nanoseconds( 1000000000 );
                 do {
                     const auto sleep_for = std::min( sleep_till - std::chrono::steady_clock::now(),
                                                      // Pump events every 100 ms
-                                                     std::chrono::nanoseconds( 100'000'000 ) );
+                                                     std::chrono::nanoseconds( 100000000 ) );
                     if( sleep_for > std::chrono::nanoseconds( 0 ) ) {
                         std::this_thread::sleep_for( sleep_for );
                         inp_mngr.pump_events();

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -32,7 +32,7 @@ static const float kill_modifier = 1.5f;
 static const int base_time_penalty = 3;
 // we want this out of our hands, pronto.
 // give a large buff to the attack value so it prioritizes this
-static const int base_throw_now = 10'000;
+static const int base_throw_now = 10000;
 } // namespace npc_attack_constants
 
 // TODO: make a better, more generic "check if this projectile is blocked" function

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -20,7 +20,7 @@ using mass = units::quantity<int, units::mass_in_microgram_tag>;
 
 constexpr mass microgram = units::quantity<int, units::mass_in_microgram_tag>( 1, {} );
 constexpr mass milligram = units::quantity<int, units::mass_in_microgram_tag>( 1000, {} );
-constexpr mass gram = units::quantity<int, units::mass_in_microgram_tag>( 1'000'000, {} );
+constexpr mass gram = units::quantity<int, units::mass_in_microgram_tag>( 1000000, {} );
 const std::vector<std::pair<std::string, mass>> mass_units = { {
         { "ug", microgram },
         { "μg", microgram },

--- a/src/units_utility.cpp
+++ b/src/units_utility.cpp
@@ -171,12 +171,12 @@ int convert_length( const units::length &length )
     int ret = to_millimeter( length );
     const bool metric = get_option<std::string>( "DISTANCE_UNITS" ) == "metric";
     if( metric ) {
-        if( ret % 1'000'000 == 0 ) {
+        if( ret % 1000000 == 0 ) {
             // kilometers
-            ret /= 1'000'000;
-        } else if( ret % 1'000 == 0 ) {
+            ret /= 1000000;
+        } else if( ret % 1000 == 0 ) {
             // meters
-            ret /= 1'000;
+            ret /= 1000;
         } else if( ret % 10 == 0 ) {
             // centimeters
             ret /= 10;
@@ -201,10 +201,10 @@ std::string length_units( const units::length &length )
     int length_mm = to_millimeter( length );
     const bool metric = get_option<std::string>( "DISTANCE_UNITS" ) == "metric";
     if( metric ) {
-        if( length_mm % 1'000'000 == 0 ) {
+        if( length_mm % 1000000 == 0 ) {
             //~ kilometers
             return _( "km" );
-        } else if( length_mm % 1'000 == 0 ) {
+        } else if( length_mm % 1000 == 0 ) {
             //~ meters
             return _( "m" );
         } else if( length_mm % 10 == 0 ) {
@@ -251,12 +251,12 @@ double convert_length_approx( const units::length &length, bool &display_as_inte
     double ret = static_cast<double>( to_millimeter( length ) );
     const bool metric = get_option<std::string>( "DISTANCE_UNITS" ) == "metric";
     if( metric ) {
-        if( ret > 500'000 ) {
+        if( ret > 500000 ) {
             // kilometers
-            ret /= 1'000'000.0;
+            ret /= 1000000.0;
         } else {
             // meters
-            ret /= 1'000.0;
+            ret /= 1000.0;
             display_as_integer = true;
         }
     } else {
@@ -279,7 +279,7 @@ std::string length_units_approx( const units::length &length )
     int length_mm = to_millimeter( length );
     const bool metric = get_option<std::string>( "DISTANCE_UNITS" ) == "metric";
     if( metric ) {
-        if( length_mm > 500'000 ) {
+        if( length_mm > 500000 ) {
             //~ kilometers
             return _( "km" );
         } else {
@@ -327,13 +327,13 @@ std::pair<std::string, std::string> weight_to_string( const
         units::quantity<int, units::mass_in_microgram_tag> &weight )
 {
     using high_res_mass = units::quantity<int, units::mass_in_microgram_tag>;
-    static const high_res_mass gram = high_res_mass( 1'000'000, {} );
-    static const high_res_mass milligram = high_res_mass( 1'000, {} );
+    static const high_res_mass gram = high_res_mass( 1000000, {} );
+    static const high_res_mass milligram = high_res_mass( 1000, {} );
 
     if( weight > gram ) {
-        return {string_format( "%.0f", weight.value() / 1'000'000.f ), "g"};
+        return {string_format( "%.0f", weight.value() / 1000000.f ), "g"};
     } else if( weight > milligram ) {
-        return {string_format( "%.0f", weight.value() / 1'000.f ), "mg"};
+        return {string_format( "%.0f", weight.value() / 1000.f ), "mg"};
     }
     return {string_format( "%d", weight.value() ), "μg"};
 }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1727,7 +1727,7 @@ std::pair<const itype_id &, int> vehicle::tool_ammo_available( const itype_id &t
         return { itype_id::NULL_ID(), 0 };
     }
     // 2 bil ought to be enough for everyone, and hopefully not overflow int
-    const int64_t max = 2'000'000'000;
+    const int64_t max = 2000000000;
     if( ft->ammo->type == ammo_battery ) {
         return { ft, static_cast<int>( std::min<int64_t>( battery_left(), max ) ) };
     } else {

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -555,7 +555,7 @@ TEST_CASE( "proficiency_gain_short_crafts", "[crafting][proficiency]" )
     REQUIRE( ch.get_proficiency_practice( proficiency_prof_carving ) == 0.0f );
 
     int turns_taken = 0;
-    const int max_turns = 100'000;
+    const int max_turns = 100000;
 
     float time_malus = rec->proficiency_time_maluses( ch );
 
@@ -594,8 +594,8 @@ TEST_CASE( "proficiency_gain_long_craft", "[crafting][proficiency]" )
     // Check exactly one 5% tick has passed
     // 500k counter = 5% progress
     // If counter is 0, this means the craft finished before we gained the proficiency
-    CHECK( craft->item_counter >= 500'000 );
-    CHECK( craft->item_counter < 501'000 );
+    CHECK( craft->item_counter >= 500000 );
+    CHECK( craft->item_counter < 501000 );
 }
 
 static float craft_aggregate_fail_chance( const recipe_id &rid )

--- a/tests/units_test.cpp
+++ b/tests/units_test.cpp
@@ -404,12 +404,12 @@ TEST_CASE( "Specific_energy", "[temperature]" )
 TEST_CASE( "energy_display", "[units][nogame]" )
 {
     CHECK( units::display( units::from_millijoule( 1 ) ) == "1 mJ" );
-    CHECK( units::display( units::from_millijoule( 1'000 ) ) == "1 J" );
-    CHECK( units::display( units::from_millijoule( 1'001 ) ) == "1001 mJ" );
-    CHECK( units::display( units::from_millijoule( 1'000'000 ) ) == "1 kJ" );
-    CHECK( units::display( units::from_millijoule( 1'000'001 ) ) == "1 kJ" );
-    CHECK( units::display( units::from_millijoule( 1'001'000 ) ) == "1001 J" );
-    CHECK( units::display( units::from_millijoule( 1'001'001 ) ) == "1001001 mJ" );
-    CHECK( units::display( units::from_millijoule( 2'147'483'648LL ) ) == "2147483648 mJ" );
-    CHECK( units::display( units::from_millijoule( 4'294'967'296LL ) ) == "4294967296 mJ" );
+    CHECK( units::display( units::from_millijoule( 1000 ) ) == "1 J" );
+    CHECK( units::display( units::from_millijoule( 1001 ) ) == "1001 mJ" );
+    CHECK( units::display( units::from_millijoule( 1000000 ) ) == "1 kJ" );
+    CHECK( units::display( units::from_millijoule( 1000001 ) ) == "1 kJ" );
+    CHECK( units::display( units::from_millijoule( 1001000 ) ) == "1001 J" );
+    CHECK( units::display( units::from_millijoule( 1001001 ) ) == "1001001 mJ" );
+    CHECK( units::display( units::from_millijoule( 2147483648LL ) ) == "2147483648 mJ" );
+    CHECK( units::display( units::from_millijoule( 4294967296LL ) ) == "4294967296 mJ" );
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix warnings in translation extraction script:

```
src/activity_actor.cpp:3821: warning: unterminated character constant
src/iuse_software_kitten.cpp:291: warning: unterminated character constant
src/npc_attack.cpp:35: warning: unterminated character constant
src/units_utility.cpp:177: warning: unterminated character constant
src/units_utility.cpp:179: warning: unterminated character constant
src/units_utility.cpp:207: warning: unterminated character constant
src/units_utility.cpp:254: warning: unterminated character constant
src/units_utility.cpp:259: warning: unterminated character constant
src/units_utility.cpp:282: warning: unterminated character constant
src/units_utility.cpp:331: warning: unterminated character constant
src/units_utility.cpp:336: warning: unterminated character constant
src/vehicle_use.cpp:1730: warning: unterminated character constant
```

#### Describe the solution

Remove thousands separators.
