### PR TITLE
Add missing clause id in Aftershock mod

### DIFF
--- a/data/mods/Aftershock/ui.json
+++ b/data/mods/Aftershock/ui.json
@@ -298,6 +298,7 @@
     "style": "text",
     "clauses": [
       {
+        "id": "danger",
         "text": "  ☢DNGR☢",
         "color": "red",
         "condition": { "and": [ { "math": [ "u_shield_ratio", "<", "25" ] }, { "math": [ "u_shield_ratio", ">=", "0" ] } ] }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix translation extraction script error (e.g. see - https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/11853444759/job/33033586569?pr=77868)