### PR TITLE
Do not access overmap during character creation

### DIFF
--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -126,7 +126,9 @@ void memorial_logger::add( const std::string_view male_msg,
         return;
     }
 
-    const oter_id &cur_ter = overmap_buffer.ter( player_character.global_omt_location() );
+    const oter_id &cur_ter = overmap_buffer.get_overmap_count() == 0 ?
+                             oter_id() :
+                             overmap_buffer.ter( player_character.global_omt_location() );
     const oter_type_str_id cur_oter_type = cur_ter->get_type_id();
     const std::string &oter_name = cur_ter->get_name( om_vision_level::full );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #77570

#### Describe the solution

Do not access overmap during character creation