### PR TITLE
Fix map items categorization

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9750,7 +9750,8 @@ std::string item::get_book_skill() const
 
 bool item::is_map() const
 {
-    return get_category_shallow().get_id() == item_category_maps;
+    return get_category_shallow().get_id() == item_category_maps ||
+           type->use_methods.count( "reveal_map" );
 }
 
 bool item::seal()


### PR DESCRIPTION
#### Summary
Bugfixes "Trail guides and similar things won't change their home town anymore"

#### Purpose of change

Fixes #61214

#### Describe the solution

Put all items with "reveal_map" in maps category.