### PR TITLE
fix popup messages that show up the wrong size until the next input

### DIFF
--- a/src/action.h
+++ b/src/action.h
@@ -480,7 +480,7 @@ std::optional<tripoint_bub_ms> choose_adjacent_bub( const std::string &message,
 std::optional<tripoint> choose_adjacent( const tripoint &pos, const std::string &message,
         bool allow_vertical = false );
 std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
-        const std::string &message, bool allow_vertical = false, int timeout = -1,
+        const std::string &message, bool allow_vertical = false, int timeout = 50,
         const std::function<std::pair<bool, std::optional<tripoint_bub_ms>>(
             const input_context &ctxt, const std::string &action )> &action_cb = nullptr );
 
@@ -509,7 +509,7 @@ std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
 std::optional<tripoint> choose_direction( const std::string &message,
         bool allow_vertical = false );
 std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &message,
-        bool allow_vertical = false, bool allow_mouse = false, int timeout = -1,
+        bool allow_vertical = false, bool allow_mouse = false, int timeout = 50,
         const std::function<std::pair<bool, std::optional<tripoint_rel_ms>>(
             const input_context &ctxt, const std::string &action )> &action_cb = nullptr );
 

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -714,7 +714,9 @@ bool do_turn()
 
             // Avoid redrawing the main UI every time due to invalidation
             ui_adaptor dummy( ui_adaptor::disable_uis_below {} );
-            g->wait_popup = std::make_unique<static_popup>();
+            if( !g->wait_popup ) {
+                g->wait_popup = std::make_unique<static_popup>();
+            }
             g->wait_popup->on_top( true ).wait_message( "%s", wait_message );
             ui_manager::redraw();
             refresh_display();

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -317,16 +317,13 @@ query_popup::result query_popup::query_once()
     if( cancel ) {
         ctxt.register_action( "QUIT" );
     }
-#if defined(WIN32) || defined(TILES)
-    ctxt.set_timeout( 50 );
-#endif
 
     result res;
     // Assign outside construction of `res` to ensure execution order
     res.wait_input = !anykey;
     do {
         ui_manager::redraw();
-        res.action = ctxt.handle_input();
+        res.action = ctxt.handle_input( 50 );
         res.evt = ctxt.get_raw_input();
 
         // If we're tracking mouse movement


### PR DESCRIPTION
#### Summary
Bugfixes "popup messages should show up at the correct size (such as when sleeping, waiting, etc)"

#### Purpose of change

Fixes #77487

#### Describe the solution

ImGui windows either need to be given an exact size up front or they need to be redrawn at a regular frame rate. (The autoresize logic uses the size of the window content from the previous frame to determine the window size for the current frame, so everything that is autoresized needs at least two frames to show up correctly.)

And also `do_turn` shouldn’t throw away the game’s `wait_popup` every frame and create a new one, because that causes similar problems.

#### Testing

Sleep, wait, or do some other activity that passes time. The popup that tells you that the activity is in progress should be the right size, and should not be overlapped with a second popup which is the wrong size.

Go to a building that has two doors or windows adjacent to each other, and open one of them. The popup that asks you which one to open should be the right size.

There may yet be other popups in the game that need to be tested, but at least the really common ones are fixed.