### PR TITLE
Fix nunez bullet trailer appearing out of nowhere

### DIFF
--- a/data/json/furniture_and_terrain/special_use/bullet_trailer.json
+++ b/data/json/furniture_and_terrain/special_use/bullet_trailer.json
@@ -12,6 +12,13 @@
   },
   {
     "type": "terrain",
+    "id": "t_bullettrailer_roof",
+    "name": "bullet trailer roof",
+    "description": "A smooth roof of gleaming chrome, slightly dusty from the road.",
+    "copy-from": "t_metal_flat_roof"
+  },
+  {
+    "type": "terrain",
     "id": "t_bullettrailer_nwall_westcorner",
     "name": "bullet trailer exterior wall",
     "copy-from": "t_scrap_wall",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Pablo_Nunez.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Pablo_Nunez.json
@@ -244,7 +244,7 @@
         { "npc_location_variable": { "context_val": "refcenter_nunez_departure" } },
         { "math": [ "_travel_time", "=", "time_since('cataclysm', 'unit': 'days') + 2" ] },
         {
-          "run_eocs": [ "EOC_Nunez_Travel" ],
+          "run_eocs": [ "EOC_Nunez_Travel_To_Tacoma" ],
           "time_in_future": { "context_val": "travel_time" },
           "variables": {
             "refcenter_nunez_departure": { "context_val": "refcenter_nunez_departure" },

--- a/data/json/npcs/tacoma_ranch/Nunez/Arrival_code.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/Arrival_code.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "EOC_Nunez_Travel",
+    "id": "EOC_Nunez_Travel_To_Tacoma",
     "type": "effect_on_condition",
     "effect": [
       { "math": [ "u_counter_refugee_center_refugee_happiness", "++" ] },

--- a/data/json/npcs/tacoma_ranch/Nunez/Arrival_code.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/Arrival_code.json
@@ -30,14 +30,7 @@
     "update_mapgen_id": "tacoma_nunez_trailer_arrive",
     "method": "json",
     "//": "In addition to basic mapgen, adds some point variables in the hopes that I can add some passive movement animations for pablo and dana.",
-    "object": {
-      "place_nested": [ { "chunks": [ "nunez_trailer" ], "x": 0, "y": 17 } ],
-      "place_npcs": [ { "class": "tacoma_DanaNunez", "x": 4, "y": 19 }, { "class": "tacoma_PabloNunez", "x": 4, "y": 20 } ],
-      "set": [
-        { "point": "variable", "id": "Pablo_relax", "x": 4, "y": 20 },
-        { "point": "variable", "id": "Dana_baking", "x": 4, "y": 19 }
-      ]
-    }
+    "object": { "flags": [ "NO_UNDERLYING_ROTATE" ], "place_nested": [ { "chunks": [ "nunez_trailer" ], "x": 5, "y": 15 } ] }
   },
   {
     "type": "mapgen",
@@ -45,8 +38,9 @@
     "nested_mapgen_id": "nunez_trailer",
     "//": "Nunez bakery inside a silver bullet trailer.",
     "object": {
-      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN", "NO_UNDERLYING_ROTATE" ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "mapgensize": [ 6, 6 ],
+      "rotation": [ 0 ],
       "rows": [
         "ABCDE ",
         "123456",
@@ -99,7 +93,32 @@
         "c": "f_bullettrailer_bed_head",
         "d": "f_bullettrailer_toilet",
         "i": "f_bullettrailer_sign_danabakery"
-      }
+      },
+      "place_npcs": [ { "class": "tacoma_DanaNunez", "x": 4, "y": 2 }, { "class": "tacoma_PabloNunez", "x": 4, "y": 3 } ],
+      "set": [
+        { "point": "variable", "id": "Pablo_relax", "x": 4, "y": 3 },
+        { "point": "variable", "id": "Dana_baking", "x": 4, "y": 2 }
+      ],
+      "place_nested": [ { "chunks": [ "nunez_trailer_roof" ], "x": 0, "y": 0, "z": 1 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nunez_trailer_roof",
+    "object": {
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0 ],
+      "rows": [
+        "      ",
+        "......",
+        "......",
+        "......",
+        "......",
+        "      "
+      ],
+      "terrain": { ".": "t_bullettrailer_roof" }
     }
   }
 ]

--- a/data/json/obsoletion_and_migration_0.I/obsolete_eoc.json
+++ b/data/json/obsoletion_and_migration_0.I/obsolete_eoc.json
@@ -30,5 +30,9 @@
   {
     "type": "effect_on_condition",
     "id": "eoc_conjunctivitis_itch"
+  },
+  {
+    "id": "EOC_Nunez_Travel",
+    "type": "effect_on_condition"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix nunez bullet trailer appearing out of nowhere"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #77877
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Obsoletes the old EoC that was stored in memory bc it was recurrance
Renames the new EoC
Fixes bullet trailer rotating
Adds a roof to the bullet trailer
Stops the bullet trailer spawning in the fence for two ranch_camp_55 rotations
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Changing the cursed palette of the trailer proper
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Simplified the EoC to test it on all rotations
```json
  {
    "id": "EOC_Nunez_Travel_To_Tacoma",
    "type": "effect_on_condition",
    "effect": [
      {
        "mapgen_update": "tacoma_nunez_trailer_arrive",
        "om_terrain": "ranch_camp_55"
      }
    ]
  },
```
resulting in
![image](https://github.com/user-attachments/assets/d8709138-40b5-4ba8-a290-d102d88413e8)
![image](https://github.com/user-attachments/assets/5db08d39-688e-4892-818a-4df65725c912)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
