### PR TITLE
Sanity pass on the fungal acidic zombie

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -1725,6 +1725,13 @@
     }
   },
   {
+    "id": "zombie_humanoid_mushroom_acid",
+    "type": "harvest",
+    "copy-from": "zombie_humanoid_mushroom",
+    "delete": { "entries": [ { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.1 } ] },
+    "extend": { "entries": [ { "drop": "blood_acid", "type": "blood", "mass_ratio": 0.1 } ] }
+  },
+  {
     "id": "zombie_animal_mushroom",
     "//": "moldy animal zombie - fungus chunks replace a part of the innards",
     "type": "harvest",

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -567,26 +567,6 @@
     "max_field_intensity": 2
   },
   {
-    "type": "SPELL",
-    "id": "spread_fungal_acid",
-    "name": { "str": "Spread Hallucinogenic Acid", "//~": "NO_I18N" },
-    "description": { "str": "Splatters hallucinogenic acid in the air in blasts.", "//~": "NO_I18N" },
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "NO_EXPLOSION_SFX" ],
-    "min_aoe": 2,
-    "max_aoe": 3,
-    "base_casting_time": 100,
-    "min_range": 1,
-    "max_range": 1,
-    "effect": "attack",
-    "effect_str": "emit_hallucinogenic_spores_blast",
-    "shape": "blast",
-    "field_id": "fd_hallucinogenic_spores",
-    "field_chance": 2,
-    "min_field_intensity": 1,
-    "max_field_intensity": 2
-  },
-  {
     "type": "effect_on_condition",
     "id": "EOC_random_mutate",
     "condition": { "and": [ { "math": [ "_proj_damage + _damage > 0" ] }, "npc_is_character", "has_beta" ] },

--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -702,7 +702,7 @@
     "id": "mon_zombie_fungus_acidic",
     "type": "MONSTER",
     "name": { "str": "acidic fungal zombie" },
-    "description": "The air around this stumbling fungal coated corpse seems to constantly warp and shift; colors and shapes visibly distort, making it impossible to discern finer details of what's causing this anomaly.  Your nose clogs as the smell of damp carpet and mold assaults it, even from afar.",
+    "description": "A grotesque fusion of rot and mycelium, this zombie's flesh is pocked with open sores that lazily drool a strange yellow-green acid.  Pale fungal stalks have burst through its corroded skin, their slimy caps dripping with what seems to be the same fluid.  The air around it is thick with the scent of rot and acrid chemicals.",
     "default_faction": "fungus",
     "bodytype": "human",
     "species": [ "FUNGUS" ],

--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -701,7 +701,7 @@
   {
     "id": "mon_zombie_fungus_acidic",
     "type": "MONSTER",
-    "name": { "str": "day tripper" },
+    "name": { "str": "acidic fungal zombie" },
     "description": "The air around this stumbling fungal coated corpse seems to constantly warp and shift; colors and shapes visibly distort, making it impossible to discern finer details of what's causing this anomaly.  Your nose clogs as the smell of damp carpet and mold assaults it, even from afar.",
     "default_faction": "fungus",
     "bodytype": "human",
@@ -720,22 +720,14 @@
     "melee_dice": 2,
     "melee_dice_sides": 3,
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
-    "dodge": 2,
     "bleed_rate": 0,
     "vision_day": 5,
     "vision_night": 3,
     "weakpoint_sets": [ "wps_humanoid_body" ],
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_wp_zombie" ],
-    "harvest": "zombie_humanoid_mushroom",
-    "special_attacks": [
-      {
-        "type": "spell",
-        "spell_data": { "id": "spread_fungal_acid", "min_level": 1 },
-        "cooldown": 3,
-        "monster_message": "the %s spews hallucinogenic gas!"
-      }
-    ],
-    "emit_fields": [ { "emit_id": "emit_hallucinogenic_spores", "delay": "2 s" } ],
+    "harvest": "zombie_humanoid_mushroom_acid",
+    "special_attacks": [ [ "ACID_BARF", 10 ] ],
+    "death_function": { "message": "The %s's body leaks acid.", "effect": { "id": "death_acid", "hit_self": true } },
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_scorched",
     "flags": [
@@ -747,6 +739,7 @@
       "GROUP_BASH",
       "POISON",
       "NO_FUNG_DMG",
+      "ACID_BLOOD",
       "ACIDPROOF",
       "NO_BREATHE",
       "PUSH_MON",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
So the acidic fungal zombie - the Day Tripper. Because acid? And acid is drug, also, in one of the meanings? And hallucinogenic mushroom drug too? Yeah no.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Removed all of its hallucinogenic gas - it turning from having corrosive blood to suddenly spitting hallucinogenic spores makes no sense
- Added a new harvestlist for fungal zombies with acid blood
- Added a flag that gives it acid blood
- Added an acid blood death effect
- Removed the dodge that's a remnant of our base acid zombies being dodgy in the past
- Renamed
- New description - written by @themaster567 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Consider this an offshoot of #77321 that I opted to split since it changed too much even for that PR
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
