### PR TITLE
'Fix' Small Squeeze Tube Description

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -700,7 +700,7 @@
     "type": "GENERIC",
     "category": "container",
     "name": { "str": "small squeeze tube" },
-    "description": "A small squeeze tube, holds 3 mL of liquid.  It cannot be refilled after it's empty.",
+    "description": "A small squeeze tube, holds 4 mL of liquid.  It cannot be refilled after it's empty.",
     "ascii_picture": "bottle_plastic_small",
     "weight": "2 g",
     "volume": "11 ml",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

#77710 pointed out that the tube holds 4ml but the description say 3ml. 

#### Describe the solution

I changed the description to match the pocket data's 4ml.  Nothing functional/gameplay wise was affected.

#### Describe alternatives you've considered

Screaming at idlesol to stop making issues for things they could fix themselves in about 40 seconds, less time than it takes to write the issue.

#### Testing
None testing. It one character. 

#### Additional context
closes #77710
In all seriousness... idlesol... come on.
