### PR TITLE
Add storage space to bras

### DIFF
--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -550,12 +550,14 @@
       "pocket_type": "CONTAINER",
       "max_contains_volume": "200 ml",
       "max_contains_weight": "400 g",
+      "max_item_length": "19 cm",
       "moves": 80
     },
     {
       "pocket_type": "CONTAINER",
       "max_contains_volume": "200 ml",
       "max_contains_weight": "400 g",
+      "max_item_length": "19 cm",
       "moves": 80
      }
   ],

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -546,21 +546,21 @@
     "looks_like": "tank_top",
     "color": "white",
     "pocket_data": [
-    {
-      "pocket_type": "CONTAINER",
-      "max_contains_volume": "200 ml",
-      "max_contains_weight": "400 g",
-      "max_item_length": "19 cm",
-      "moves": 80
-    },
-    {
-      "pocket_type": "CONTAINER",
-      "max_contains_volume": "200 ml",
-      "max_contains_weight": "400 g",
-      "max_item_length": "19 cm",
-      "moves": 80
-     }
-  ],
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "200 ml",
+        "max_contains_weight": "400 g",
+        "max_item_length": "19 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "200 ml",
+        "max_contains_weight": "400 g",
+        "max_item_length": "19 cm",
+        "moves": 80
+      }
+    ],
     "warmth": 5,
     "material_thickness": 0.1,
     "flags": [ "VARSIZE", "SKINTIGHT" ],

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -545,6 +545,20 @@
     "symbol": "[",
     "looks_like": "tank_top",
     "color": "white",
+    "pocket_data": [
+    {
+      "pocket_type": "CONTAINER",
+      "max_contains_volume": "200 ml",
+      "max_contains_weight": "400 g",
+      "moves": 80
+    },
+    {
+      "pocket_type": "CONTAINER",
+      "max_contains_volume": "200 ml",
+      "max_contains_weight": "400 g",
+      "moves": 80
+     }
+  ],
     "warmth": 5,
     "material_thickness": 0.1,
     "flags": [ "VARSIZE", "SKINTIGHT" ],


### PR DESCRIPTION
#### Summary
Features "Allow storing items in bras"

#### Purpose of change

It is not unheard of for those who wear bras to tuck small items away in them. This simply replicates such utility in game.

#### Describe the solution

Added in two pockets to the bra, one for each cup. Roughly the size of a smartphone in a case so it could hold items of similar quality.

#### Describe alternatives you've considered

None, other than not implementing the change.

#### Testing

Booted world and spawned in a bra with the changes implemented. Was able to hold a smartphone with a case in one cup and a pack of cigarettes in the other. Was not able to fit two smartphones in a single cup. Spawned in obviously large items like a bowling ball to rule out the possibility of them fitting in a cup. They were not able to fit.

#### Additional context

Files changed: Undergarment.json

I cant exactly post pictures of occurrences of people using bras in such a fashion. It would just be pictures of women's busts. I trust the application happens enough and is simple to accomplish so as to warrant simulation in the game.