### PR TITLE
Aftershock: Nerf spawn % of broken cyborg in basement_bionic

### DIFF
--- a/data/mods/Aftershock/maps/mapgen/basement_bionic.json
+++ b/data/mods/Aftershock/maps/mapgen/basement_bionic.json
@@ -72,7 +72,7 @@
         { "item": "stereo", "x": 2, "y": 13, "chance": 50 }
       ],
       "items": { "?": { "item": "autodoc_supplies", "chance": 100 } },
-      "place_monster": [ { "monster": "mon_broken_cyborg", "x": 14, "y": 3, "chance": 100 } ]
+      "place_monster": [ { "monster": "mon_broken_cyborg", "x": 14, "y": 3, "chance": 25 } ]
     }
   }
 ]


### PR DESCRIPTION
#### Summary
Balance "Aftershock: Reduce spawn chance of broken cyborgs in bionic basements"

#### Purpose of change
 I feel like bionic_basement shouldn't have a 100% chance of spawning a broken cyborg. You know, because then you always know there's going to be a broken cyborg in it, meaning you can prepare for it in a way that I don't think was intended.

"It's a basement though, so how would yo-"

` You hear "PLEASE GOD KILL ME AAAAAAAAAAAAAAAAAA" from 8 tiles away and below!`

You know it's a bionic basement possibly before you even enter the house.

#### Describe the solution
Reduce the spawn chance of the broken cyborg in bionic basements from 100% to 25%.

#### Describe alternatives you've considered

Reducing it lower, keeping it higher, not changing it at all.

#### Testing
N/A: It's a single integer change.

#### Additional context
25% just feels right in my head, as I feel like there's a good chance that the cyborg resident holed up in a basement with no food would have wandered out into the world by the time the player arrives. However, I am completely down for discussing raising or lowering the number further if you think I'm off.

Side note, but the No Hope mod uses this basement as well and contains the same issue. I submitted a separate PR #77898 to perform the same nerf to it. This way, both sets of maintainers can make independent decisions on if they want to accept this change.
