### PR TITLE
Allow Placement of Motorbike Batteries as Appliances

### DIFF
--- a/data/json/construction/appliances.json
+++ b/data/json/construction/appliances.json
@@ -157,6 +157,30 @@
   },
   {
     "type": "construction",
+    "id": "app_battery_motorbike",
+    "group": "place_motorbike_battery",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "electronics", 1 ] ],
+    "time": "6 m",
+    "components": [ [ [ "battery_motorbike", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_special": "done_appliance",
+    "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
+    "id": "app_battery_motorbike_small",
+    "group": "place_motorbike_small_battery",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "electronics", 1 ] ],
+    "time": "6 m",
+    "components": [ [ [ "battery_motorbike_small", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_special": "done_appliance",
+    "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
     "id": "app_battery_large",
     "group": "place_large_battery",
     "category": "APPLIANCE",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1467,6 +1467,16 @@
   },
   {
     "type": "construction_group",
+    "id": "place_motorbike_battery",
+    "name": "Place Motorbike Battery"
+  },
+  {
+    "type": "construction_group",
+    "id": "place_motorbike_small_battery",
+    "name": "Place Small Motorbike Battery"
+  },
+  {
+    "type": "construction_group",
     "id": "place_washing_machine",
     "name": "Place Washing Machine"
   },

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -828,6 +828,48 @@
   },
   {
     "type": "vehicle_part",
+    "id": "ap_battery_motorbike",
+    "name": { "str": "motorbike grid battery" },
+    "categories": [ "energy" ],
+    "looks_like": "battery_motorbike",
+    "color": "red",
+    "flags": [ "OBSTACLE", "APPLIANCE" ],
+    "description": "A motorbike battery wired into a static power grid.",
+    "item": "battery_motorbike",
+    "breaks_into": [
+      { "item": "lead", "charges": [ 252, 357 ] },
+      { "item": "chem_sulphuric_acid", "count": [ 0, 1 ], "container-item": "null" },
+      { "item": "plastic_chunk", "count": [ 2, 3 ] },
+      { "item": "scrap", "charges": [ 0, 1 ] },
+      { "item": "shredded_rubber", "charges": [ 1, 2 ] }
+    ],
+    "durability": 100,
+    "requirements": { "removal": { "time": "6 m" } },
+    "variants": [ { "symbols": "B", "symbols_broken": "#" } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_battery_motorbike_small",
+    "name": { "str": "small motorbike grid battery" },
+    "categories": [ "energy" ],
+    "looks_like": "battery_motorbike_small",
+    "color": "red",
+    "flags": [ "OBSTACLE", "APPLIANCE" ],
+    "description": "A small motorbike battery wired into a static power grid.",
+    "item": "battery_motorbike_small",
+    "breaks_into": [
+      { "item": "lead", "charges": [ 126, 178 ] },
+      { "item": "chem_sulphuric_acid", "count": [ 0, 1 ], "container-item": "null" },
+      { "item": "plastic_chunk" },
+      { "item": "scrap", "charges": [ 0, 1 ] },
+      { "item": "shredded_rubber", "charges": [ 0, 1 ] }
+    ],
+    "durability": 30,
+    "requirements": { "removal": { "time": "6 m" } },
+    "variants": [ { "symbols": "B", "symbols_broken": "#" } ]
+  },
+  {
+    "type": "vehicle_part",
     "id": "ap_washing_machine",
     "looks_like": "f_washer",
     "flags": [ "OBSTACLE", "APPLIANCE", "WASHING_MACHINE", "CARGO", "COVERED", "ENABLED_DRAINS_EPOWER" ],


### PR DESCRIPTION
#### Summary
Content "Allow Motorbike Battery Appliances"

#### Purpose of change
#77816 mentioned the lack of powergrid placement for motorbike batteries. While these batteries are smaller and significantly less useful than our other batteries, they are basically identical in function/form to other vehicle batteries.  Thus, they should probably be place-able from a realism perspective, even if they are niche or less useful.


#### Describe the solution
Make both the motorbike batter and the small motorbike battery place-able as appliances to use the power grid system.

- Create construction groups, one for motorbike battery, one for small motorbike battery.
- Create appliance construction entry, one for each battery.
- Create appliances themselves in furniture/terrain for each battery.
     - Copied car battery entries, but tweaked breaks_into, which was apparently based on the vehicle part drops (which are absurd, IE: 1.5kg battery produces up to 7-8x weight in steel).  Amended to be more reasonable, added lead drops to reflect the deconstruction producing lead.  
	~~- Adjust the breaks_into for the battery vehicle parts themselves to reflect my changes above for the same reasonings.~~ I have decided this is best left for a separate PR, so that if I were going to audit them, I could do all of them at the same time and it's out of scope for this PR, no reason to do this here.

#### Describe alternatives you've considered
I debated if this was even worth it.  Motorbike batteries are substantially smaller than car batteries (especially the small motorbike battery).  However, they are functionally identical to car batteries in terms of how they could easily be hooked into our appliance system.  

While these are generally 'not worth' using when car batteries are so readily available, using realism as guidance, these should be placeable.  Hence, I have made both place-able.

I also debated splitting this into two PR's, in case people don't like the small battery being made placeable, but really, like I said, there's no real reason they shouldn't be, in my opinion.

#### Testing
Ensured they appear in construction menu, are constructable/place-able using only the battery and electronics 1, checked that it functions as a battery/has charges, and then verified the breaks_into by smashing them to bits.

#### Additional context

breaks_into is fucked for most vehicle parts, this extends to appliances which at least the battery place-ables seem to use the vehicle part breaks_into as a reference rather than actually making them accurate to the materials that would be gained.

I may attempt to audit this, or at least to audit the battery appliances/vehicle parts, depending on how my apathy plays out.


General math for battery breaks_into:
While I found it difficult to find exact ratios of materials typically found in car batteries/motorbike batteries, etc. I do know that what is on many of the batteries (all steel) is complete nonsense.

So, for determining breaks_into for the appliances, I used the following ratios based on the materials weight to determine the 'maximum' dropped value:

Lead = 70% (primary material, grids, electrodes)
Acid = 22% (electrolyte/acid)
Plastic = 6% (case, separators, structure)
steel = 1% (terminals and connectors, battery only, where it sits in the vehicle is the frame not the battery)
rubber = token value <1% (barely any, tiny bit for rubber seals)

All I can really say is that if I used the existing values for the car batteries/vehicle parts, these batteries would break down into a huge amount of steel, which is complete nonsense.  So, in my opinion, even if I am wrong, this is still much more accurate than the alternative.

These are just rough values, I absolutely do not know the exact breakdown of any given battery, this was research from several websites, although who tf knows what's true on the internet, and I also asked chat-gpt which gave me similar values to what I found through random googling and forum threads.  Please don't hate me if this is wrong.

Spreadsheet showing the breakdown of each of these batteries breaks_into/how I arrived at those values:
![image](https://github.com/user-attachments/assets/0a48fa0f-e3c6-49bf-a3de-882e3269d6e6)

I sure hope all this made sense and that I didn't make some glaring mistake.

closes #77816 
