### PR TITLE
Items with "POST_UP" use_action can be put up on walls 

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -592,6 +592,11 @@
     "info": "You could probably <color_brown>plant</color> these."
   },
   {
+    "id": "POSTABLE",
+    "type": "json_flag",
+    "info": "This item can be put up on a wall."
+  },
+  {
     "id": "MELTS",
     "type": "json_flag",
     "info": "This food <neutral>melts when not in a very cold climate</neutral>, and tastes much <good>better</good> when <color_light_cyan>frozen</color>."

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -592,9 +592,9 @@
     "info": "You could probably <color_brown>plant</color> these."
   },
   {
-    "id": "POSTABLE",
+    "id": "POST_UP",
     "type": "json_flag",
-    "info": "This item can be put up on a wall."
+    "info": "This item can be put up on a wall, like a poster."
   },
   {
     "id": "MELTS",

--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -691,7 +691,7 @@
   },
   {
     "type": "item_action",
-    "id": "POSTABLE",
+    "id": "POST_UP",
     "name": { "str": "Put up" }
   },
   {

--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -691,6 +691,11 @@
   },
   {
     "type": "item_action",
+    "id": "POSTABLE",
+    "name": { "str": "Put up" }
+  },
+  {
+    "type": "item_action",
     "id": "PROZAC",
     "name": { "str": "Take" }
   },

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -16,7 +16,7 @@
     "material_thickness": 0.3,
     "environmental_protection": 1,
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS" ],
-    "use_action": [ "POSTABLE" ],
+    "use_action": [ "POST_UP" ],
     "armor": [
       {
         "encumbrance": 50,

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -16,6 +16,7 @@
     "material_thickness": 0.3,
     "environmental_protection": 1,
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS" ],
+    "use_action": [ "POSTABLE" ],
     "armor": [
       {
         "encumbrance": 50,

--- a/doc/DEVELOPER_FAQ.md
+++ b/doc/DEVELOPER_FAQ.md
@@ -72,8 +72,9 @@ Specifically to ablative plates, some transform when damaged instead of damaging
 ## Adding an iuse function.
 
 1. Add the new item use code to `iuse.cpp` and `iuse.h`.
-2. Add the new json_flag to your item. And link it to the iuse function in `item_factory.cpp`.
-3. Document the new flag in `JSON_FLAGS.md`.
+2. Add a new json_flag to `flags.json`, and add the flag to your item(s) and to an `item_actions.json` entry. 
+3. Link the flag to the iuse function in `item_factory.cpp`.
+4. Document the new flag in `JSON_FLAGS.md`.
 
 ## Acid resistance
 

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -832,7 +832,7 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```PAPER_SHAPED``` This item is shaped in form of thin paper sheet, and can be stored in leather journal.
 - ```PERFECT_LOCKPICK``` Item is a perfect lockpick.  Takes only 5 seconds to pick a lock and never fails, but using it grants only a small amount of lock picking xp.  The item should have `LOCKPICK` quality of at least 1.
 - ```PLANTABLE_SEED``` This item is a seed, and you can plant it.
-- ```POSTABLE``` This item can be placed on terrain/furniture with the WALL flag.
+- ```POST_UP``` This item can be placed on terrain/furniture with the WALL flag.
 - ```PRESERVE_SPAWN_OMT``` This item will store the OMT that it spawns in, in the `spawn_location_omt` item var.
 - ```PROVIDES_TECHNIQUES``` This item will provide martial arts techniques when worn/in the character's inventory, in addition to those provided by the weapon and martial art.
 - ```PSEUDO``` Used internally to mark items that are referred to in the crafting inventory but are not actually items.  They can be used as tools, but not as components.  Implies `TRADER_AVOID`.

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -832,6 +832,7 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```PAPER_SHAPED``` This item is shaped in form of thin paper sheet, and can be stored in leather journal.
 - ```PERFECT_LOCKPICK``` Item is a perfect lockpick.  Takes only 5 seconds to pick a lock and never fails, but using it grants only a small amount of lock picking xp.  The item should have `LOCKPICK` quality of at least 1.
 - ```PLANTABLE_SEED``` This item is a seed, and you can plant it.
+- ```POSTABLE``` This item can be placed on terrain/furniture with the WALL flag.
 - ```PRESERVE_SPAWN_OMT``` This item will store the OMT that it spawns in, in the `spawn_location_omt` item var.
 - ```PROVIDES_TECHNIQUES``` This item will provide martial arts techniques when worn/in the character's inventory, in addition to those provided by the weapon and martial art.
 - ```PSEUDO``` Used internally to mark items that are referred to in the crafting inventory but are not actually items.  They can be used as tools, but not as components.  Implies `TRADER_AVOID`.

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -34,6 +34,7 @@ class JsonObject;
 class pixel_minimap;
 
 extern void set_displaybuffer_rendertarget();
+using ter_str_id = string_id<ter_t>;
 
 /** Structures */
 struct tile_type {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1854,6 +1854,7 @@ void Item_factory::init()
     add_iuse( "POISON", &iuse::poison );
     add_iuse( "PORTABLE_GAME", &iuse::portable_game );
     add_iuse( "PORTAL", &iuse::portal );
+    add_iuse( "POSTABLE", &iuse::postable );
     add_iuse( "PROZAC", &iuse::prozac );
     add_iuse( "PURIFY_SMART", &iuse::purify_smart );
     add_iuse( "RADGLOVE", &iuse::radglove );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1854,7 +1854,7 @@ void Item_factory::init()
     add_iuse( "POISON", &iuse::poison );
     add_iuse( "PORTABLE_GAME", &iuse::portable_game );
     add_iuse( "PORTAL", &iuse::portal );
-    add_iuse( "POSTABLE", &iuse::postable );
+    add_iuse( "POST_UP", &iuse::post_up );
     add_iuse( "PROZAC", &iuse::prozac );
     add_iuse( "PURIFY_SMART", &iuse::purify_smart );
     add_iuse( "RADGLOVE", &iuse::radglove );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8811,6 +8811,31 @@ std::optional<int> iuse::disassemble( Character *p, item *it, const tripoint & )
     return 0;
 }
 
+std::optional<int> iuse::postable( Character *p, item *it, const tripoint & )
+{
+    map &here = get_map();
+
+    //arbitrary limit of 10 postable items per wall
+    const std::function<bool( const tripoint_bub_ms & )> f = [&here]( const tripoint_bub_ms & pnt ) {
+        return here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, pnt ) && here.i_at( pnt ).size() < 10;
+    };
+
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Post to which wall?" ), _( "There is no applicable wall nearby." ), f, false );
+    if( !pnt_ ) {
+        return std::nullopt;
+    }
+
+    //copy and place used item and remove the used item from inventory
+    item_location original_item( *p, it );
+    item copy_item( *original_item );
+    here.add_item( *pnt_, copy_item );
+    original_item.remove_item();
+    p->add_msg_if_player( m_good, _( "You put up the %s." ), copy_item.tname() );
+
+    return 0;
+}
+
 std::optional<int> iuse::melatonin_tablet( Character *p, item *it, const tripoint & )
 {
     p->add_msg_if_player( _( "You pop a %s." ), it->tname() );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8811,7 +8811,7 @@ std::optional<int> iuse::disassemble( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::postable( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::post_up( Character *p, item *it, const tripoint & )
 {
     map &here = get_map();
 

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -222,7 +222,7 @@ std::optional<int> craft( Character *, item *, const tripoint & );
 
 std::optional<int> disassemble( Character *, item *, const tripoint & );
 
-std::optional<int> postable( Character *, item *, const tripoint & );
+std::optional<int> post_up( Character *, item *, const tripoint & );
 
 // Helper functions for other iuse functions
 void cut_log_into_planks( Character & );

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -222,6 +222,8 @@ std::optional<int> craft( Character *, item *, const tripoint & );
 
 std::optional<int> disassemble( Character *, item *, const tripoint & );
 
+std::optional<int> postable( Character *, item *, const tripoint & );
+
 // Helper functions for other iuse functions
 void cut_log_into_planks( Character & );
 void play_music( Character *p, const tripoint &source, int volume, int max_morale,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "items with POST_UP use_action can be put up on walls "
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Closes #60405

I disagree; decoration is something this game needs

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Take an item with the "POST_UP" use_action, stand next to terrain/furniture with the "WALL" flag (functionally only terrain, as far as I'm aware), and put it up on the wall for some nice decoration. The item occupies the terrain's space and can still be taken down with 'g'rab, but not with the advanced inventory manager.

For testing purposes, `american_flag` was provided with "POST_UP" for this PR. Providing a variant in e.g. `gfx\UltimateCataclysm\layering.json` for the "WALL" flag like so:
```json
{
  "context": [ "WALL" ],
  "item_variants": [
    {
      "item": "american_flag",
      "sprite": [ { "id": "american_flag_hoisted", "weight": 1 } ],
      "layer": 90,
      "offset_x": 0,
      "offset_y": 0
    }
  ]
},
```
will let the flag have a different sprite when it's on terrain with the "WALL" flag.


Notes on implementation:
- There is no error checking for wall orientation. The appearance of a posted item not making sense on a certain wall orientation is contextual to the tileset's POV, not the game. If you don't want a flag on a vertical wall, don't put it there. It goes without saying that this PR doesn't affect ASCII.
- There is no error checking for which side of the wall you're on when you take down or put up an item because we don't handle "sides" of a single tile (to my knowledge). Because of this, items with the "POST_UP" flag should be mainly cosmetic and not actually something you'd benefit from phasing through a wall.
- There's an arbitrary limit of 10 items per "WALL" tile.
- Putting "POST_UP" items up is free, but if we absolutely want a required stapler or something, make a new PR.
- There isn't a corresponding PR for UltimateCataclysm, but I'll get to it soon.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Passed tests locally (not really applicable here)
- Put flag up and took it down
- Put multiple flags up and took them down
- Made sure flag could only be put on "WALL" terrain
- Made sure that fields and items still draw

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Putting up `american_flag` -- note the sprite difference
![flag1](https://github.com/user-attachments/assets/d134232d-2cc1-4aa0-945d-60452c74a117)
![flag2](https://github.com/user-attachments/assets/c32f5357-2ede-4428-94f9-98c771ac030c)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
