### PR TITLE
Lower Stream Item Spawns

### DIFF
--- a/data/json/mapgen_palettes/stream.json
+++ b/data/json/mapgen_palettes/stream.json
@@ -35,12 +35,12 @@
     "items": {
       "1": [
         { "item": "trash", "chance": 5, "repeat": 2 },
-        { "item": "creek_bed", "chance": 50, "repeat": 3 },
+        { "item": "creek_bed", "chance": 30, "repeat": 2 },
         { "item": "wheels", "chance": 1 }
       ],
       "2": [
-        { "item": "trash", "chance": 25, "repeat": 2 },
-        { "item": "creek_bed", "chance": 40, "repeat": 5 },
+        { "item": "trash", "chance": 3, "repeat": 2 },
+        { "item": "creek_bed", "chance": 15, "repeat": 3 },
         { "item": "wheels", "chance": 1 }
       ]
     }


### PR DESCRIPTION
#### Summary
Balance "Lower Stream Item Spawns"

#### Purpose of change

Streams spawned excessive items, mentioned in #77780 this was caused by two main issues.  Firstly, the itemgroup "trash" had too high of a chance to spawn.

Example: Every 1 in these image has a 5% chance to spawn from this group, every 2 has a 25% chance to spawn from this group.  This image is ONE segment of stream. Remember, each stream is made up of a lot of these segments, and thus spawns hundreds of items total.

![image](https://github.com/user-attachments/assets/6f414314-b1a8-480a-ac8b-cfd7c1840c57)
In this image there are 
1: 24 total, 5% spawn chance, average of 1.2 spawns in this map segment. Repeated 2x so 2.4.  Great, reasonable.
2: 144 total, 25% spawn chance, average of 36 spawns. Repeated 2x so 72 spawns.

Keep in mind this is ONE segment of map.  I randomly revealed map and found a stream here and this is frankly very small compared to other streams I found:
![image](https://github.com/user-attachments/assets/bc9e9266-2251-4746-8165-aed54ab5c8af)

Assuming this math holds, it means this little baby stream would contain around 1190.4 spawns on average JUST from trash.  I live in a small town, see lots of creeks and streams, and no, not even close to being accurate in my opinion.  And that's JUST trash, it also has a huge % chance to spawn branches, sticks, stones, etc. which are less problematic but raise the number of item spawns even further.  Like.  THOUSANDS of sticks and rocks.

Anyway that was long-winded af. TLDR: Stream spawn too much trash.

The other smaller issue here is that the trash itemgroup used causes some issues, I'll mentioned that in the additional information segment below.

#### Describe the solution
Reduce the spawns.
- adjust stream palette, reducing the chance of spawning the "trash" itemgroup for each `2`, reducing it from 25% to 3% (still 2x repeat).  This is ultimately an arbitrary number, my plan to reduce it by more than 80%
- adjust stream palette, reducing chance to spawn creek_bed items for both the `1` and `2` tiles. I have reduced the 1 from 50% repeating 3 times to a 30% chance repeating 2 times.  For the `2` tiles, it went from 40% chance repeating 5 times, to 15% chance repeating 3 times.  These are also arbitrary but should reduce the overall spawns substantially, while still providing an enormous amount of these resources.

#### Describe alternatives you've considered
A bunch of different numbers.  I really want to axe them much much harder than this, even a small stream is still spawning thousands of rocks, sticks, and random trash.

Other alternative was to hit the itemgroups, making a bespoke trash group for the stream to eliminate things that don't make a ton of sense or spawn in weird amounts (like 4+ kilos of glass shards at once)

#### Testing

Just nerfed it, walked around, checked the numbers.  Reduced it slightly more, etc, until I felt it was tolerable.

#### Additional context
Okay, lots to go here.

<details>

<summary>Images illustrating the before and after</summary>

BEFORE IMAGES:
![image](https://github.com/user-attachments/assets/b5da2c3d-30b1-4cef-bbe5-45250f8dfc15)
![image](https://github.com/user-attachments/assets/4c67120c-f94c-4ed8-9752-37ab94324795)

AFTER IMAGES:
![image](https://github.com/user-attachments/assets/c3e25248-730a-4825-b886-54427776d0c2)
![image](https://github.com/user-attachments/assets/22fdef59-4b02-4ff2-a1fc-e9232c5653fb)
Still too dang cluttered imo...

</details>

<details>

<summary>Rambling thoughts regarding the issues with the itemgroups</summary>

The trash itemgroup was not made specifically for these streams, and is problematic for that reason.  Example: it spawns loose marbles in groups of 1-20, however they are in a stream, and so it doesn't make a ton of sense for 20 marbles to be clustered together.  There was a similar issue with glass shards, spawning up to 4.2 kilos of glass shards at once, which is, let's be honest, a bit silly.

I did not thoroughly check what's nested within it, so I don't know if all items are even appropriate to spawn in a stream.  Also, to be honest, a stream is not a dump site, and while people are gross and throw their trash everywhere, I live in a rural area with hillbillies and our streams look nothing like that.

In my opinion, the majority of this trash would either be buried within the soil of the stream and thus vanish (IE: a marble) or would not spawn in huge clusters like this.

HOWEVER, this itemgroup is used many other places -- it's the trash itemgroup for, you know, trash.  So I cannot edit this itemgroup to be appropriate for the stream.  The correct solution is to handcraft a new trash group just for streams, but alas, I'm not going to do this in this PR, I may do that later, I'd like to but I don't know if I'll follow through.

And then finally, the creek_bed group (containing sticks and rocks) spawns in huge amounts here.  This results in thousands of rocks and sticks.  While I think this is ridiculous and out of control, it's a stream, I don't know what the right amount is, here, and so went pretty light on my nerf in this PR.  However, I think tracking 1000+ stones and sticks is a bit overkill compared to literally everywhere else in the game (including forests), and so I've reduced these spawns as well, though I personally think they should be reduced even more significantly.  The problem is it's not unrealistic so I didn't feel like I 'had the right' to do that.

</details>

And then finally, I also feel that the wheels that spawn here (1% chance on every 1 and 2 shown in the image of the stream map) are too frequent.  While they are a 1% chance, there are dozens of tiles in these map segments that can spawn them, and I frequently found 1-3 wheels in my vision radius as I walked around.  I understand that people dump things, but it's a stream, and it's a tad ridiculous.  I could not fix this currently without making an itemgroup for it, which I decided I would do if I got around to making the above mentioned itemgroup, so it just goes here in additional information.

I'm not sure if this counts as closing #77780 or not, because it's not really the full reworking that I feel is needed, but it at least will solve the majority of the problem.

Anyway, I think that's everything, I'm too verbose for what is ultimately like four digit changes.