### PR TITLE
Allow a heavy training dummy in place of light

### DIFF
--- a/data/json/recipes/practice/melee.json
+++ b/data/json/recipes/practice/melee.json
@@ -297,7 +297,7 @@
       { "proficiency": "prof_unarmed_familiar", "required": true },
       { "proficiency": "prof_unarmed_pro", "time_multiplier": 2, "skill_penalty": 0 }
     ],
-    "tools": [ [ "pseudo_training_dummy_light", "pseudo_punching_bag" ] ]
+    "tools": [ [ "pseudo_training_dummy_light", "pseudo_training_dummy_heavy", "pseudo_punching_bag" ] ]
   },
   {
     "id": "prac_cutting_beg_long_sword",
@@ -814,7 +814,7 @@
       { "proficiency": "prof_shivs_familiar", "required": true },
       { "proficiency": "prof_shivs_pro", "time_multiplier": 2, "skill_penalty": 0 }
     ],
-    "tools": [ [ [ "real_shivs", 1, "LIST" ] ], [ "pseudo_training_dummy_light" ] ]
+    "tools": [ [ [ "real_shivs", 1, "LIST" ] ], [ "pseudo_training_dummy_light", "pseudo_training_dummy_heavy" ] ]
   },
   {
     "id": "prac_bashing_beg_baton",


### PR DESCRIPTION
#### Summary
Content "Allow using a heavy training dummy where a light one will suffice"

#### Purpose of change

The standard training dummy is made of wood, nails, and duct tape, along with some markings. The armored training dummy is the same thing with some scrap metal armor on top.  I think that if you're practicing how to aim your strikes with a weapon, the armored dummy should suffice.  I don't think that the training consists of punching or shivving a hunk of wood with force because that would damage your limbs or break your shiv, so since the training doesn't involve hard contact, the armored dummy should work.

#### Describe the solution

Add `pseudo_training_dummy_heavy` to the couple of places that have `pseudo_training_dummy_light` without it.

#### Describe alternatives you've considered

Leaving it alone. Changing the shiv practice to consume many shivs and possibly try to make the unarmed practice inflict damage.

#### Testing

I don't have a functional dev environment for CDDA, but as you can see the JSON change is trivial.

#### Additional context

Upgrading your training dummy without finishing training shivs or unarmed creates a chore without any particular purpose.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
