### PR TITLE
Fix mining using a pickaxe always causes an error

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1870,7 +1870,7 @@ void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
     here.destroy( pos, true );
     if( !act->targets.empty() ) {
         item &it = *act->targets.front();
-        if( it.is_null() || it.charges <= 0 ) {
+        if( it.is_null() || ( it.count_by_charges() && it.charges <= 0 ) ) {
             debugmsg( "pickaxe expired during mining" );
             return;
         }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1869,12 +1869,10 @@ void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
                                 _( "<npcname> finishes digging." ) );
     here.destroy( pos, true );
     if( !act->targets.empty() ) {
-        item &it = *act->targets.front();
-        if( it.is_null() || ( it.count_by_charges() && it.charges <= 0 ) ) {
-            debugmsg( "pickaxe expired during mining" );
-            return;
+        item_location it = act->targets.front();
+        if( it ) {
+            you->consume_charges( *it, it->ammo_required() );
         }
-        you->consume_charges( it, it.ammo_required() );
     } else {
         debugmsg( "pickaxe activity targets empty" );
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix mining using a pickaxe always causes an error"
#### Purpose of change
Fix #77865 
#### Describe the solution
Use a better way by andrei8l to check if the tool disappered during mining.
#### Testing
Loaded the save from #76783 , game did not crash when earthshaper's pickaxe expired during mining.
Using normal pickaxes and jackhammers also didn't cause an error.
#### Additional context