### PR TITLE
New scenario: Moonlit Night

### DIFF
--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -308,5 +308,11 @@
     "update_mapgen_id": "SCENARIO_SMOKE",
     "method": "json",
     "object": { "place_fields": [ { "field": "fd_smoke", "x": [ 3, 20 ], "y": [ 3, 20 ], "intensity": [ 1, 3 ], "repeat": 60 } ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_scenario_clear_weather",
+    "eoc_type": "SCENARIO_SPECIFIC",
+    "effect": [ { "math": [ "weather('humidity')", "=", "0" ] }, { "math": [ "weather('pressure')", "=", "1050" ] }, "next_weather" ]
   }
 ]

--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -321,17 +321,14 @@
     "type": "effect_on_condition",
     "eoc_type": "ACTIVATION",
     "id": "EOC_deactivate_moonlit",
-    "effect": [
-      { "math": [ "is_moonlit_scenario", "=", "0" ] },
-      "next_weather"
-    ]
+    "effect": [ { "math": [ "is_moonlit_scenario", "=", "0" ] }, "next_weather" ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_scenario_clear_weather",
     "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
-      { "u_message": "The moon shines brightly." }, 
+      { "u_message": "The moon shines brightly." },
       { "math": [ "is_moonlit_scenario", "=", "1" ] },
       "next_weather",
       { "run_eocs": "EOC_deactivate_moonlit", "time_in_future": "4 hours" }

--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -310,9 +310,31 @@
     "object": { "place_fields": [ { "field": "fd_smoke", "x": [ 3, 20 ], "y": [ 3, 20 ], "intensity": [ 1, 3 ], "repeat": 60 } ] }
   },
   {
+    "id": "moonlit_scenario_weather",
+    "copy-from": "sunny",
+    "type": "weather_type",
+    "name": "Moonlit",
+    "priority": 999,
+    "condition": { "math": [ "is_moonlit_scenario", "==", "1" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "eoc_type": "ACTIVATION",
+    "id": "EOC_deactivate_moonlit",
+    "effect": [
+      { "math": [ "is_moonlit_scenario", "=", "0" ] },
+      "next_weather"
+    ]
+  },
+  {
     "type": "effect_on_condition",
     "id": "EOC_scenario_clear_weather",
     "eoc_type": "SCENARIO_SPECIFIC",
-    "effect": [ { "math": [ "weather('humidity')", "=", "0" ] }, { "math": [ "weather('pressure')", "=", "1050" ] }, "next_weather" ]
+    "effect": [
+      { "u_message": "The moon shines brightly." }, 
+      { "math": [ "is_moonlit_scenario", "=", "1" ] },
+      "next_weather",
+      { "run_eocs": "EOC_deactivate_moonlit", "time_in_future": "4 hours" }
+    ]
   }
 ]

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -1353,5 +1353,20 @@
     "requirement": "achievement_kill_10_monsters",
     "map_extra": "mx_laststand",
     "flags": [ "CITY_START", "LONE_START" ]
+  },
+  {
+    "type": "scenario",
+    "id": "a_moonlit_night_start",
+    "name": "A Moonlight Night",
+    "points": 0,
+    "description": "You've been holed up in your basement ever since the Cataclysm happened a little over a week ago, but now you've run out of food and have been forced to go on a supply run on this fateful moonlit night.  You see zombies all around you, but thankfully, most of them can't seem to see as well in moonlight as you do.",
+    "start_name": "In the Middle of Town",
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 23, "day": 72, "season": "spring", "year": 1 },
+    "allowed_locs": [ "sloc_town_in_the_open" ],
+    "eoc": [ "EOC_scenario_clear_weather" ],
+    "requirement": "achievement_survive_one_day",
+    "flags": [ "CITY_START", "LONE_START", "SUR_START" ],
+    "surround_groups": [ [ "GROUP_BLACK_ROAD", 70.0 ] ]
   }
 ]

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -825,5 +825,16 @@
     "name": "Intersection",
     "terrain": [ { "om_terrain": "road_nesw_manhole", "om_terrain_match_type": "PREFIX" } ],
     "flags": [ "ALLOW_OUTSIDE" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_town_in_the_open",
+    "name": "Town, in the open",
+    "terrain": [
+      { "om_terrain": "road", "om_terrain_match_type": "TYPE" },
+      { "om_terrain": "playground", "om_terrain_match_type": "TYPE" },
+      { "om_terrain": "park", "om_terrain_match_type": "TYPE" }
+    ],
+    "flags": [ "ALLOW_OUTSIDE" ]
   }
 ]

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -831,7 +831,7 @@
     "id": "sloc_town_in_the_open",
     "name": "Town, in the open",
     "terrain": [
-      { "om_terrain": "road", "om_terrain_match_type": "TYPE" },
+      { "om_terrain": "road_nesw_manhole", "om_terrain_match_type": "PREFIX" },
       { "om_terrain": "playground", "om_terrain_match_type": "TYPE" },
       { "om_terrain": "park", "om_terrain_match_type": "TYPE" }
     ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "New scenario: Moonlit Night"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

A new scenario that offers a new type of challenge: to navigate through a group of zombies on a moonlit night where you have the benefit of vision but the monsters don't. 

Also features a game mechanic maybe not all new players know about and teaches the importance of vision and aggro. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* Set start date to the beginning of a full moon phase.
* Add SCENARIO_SPECIFIC EOC to ensure clear weather and benefit of moonlight. 

~~Not sure why my clear weather EOC isn't working, tried to follow the procedure outlined by [Ramza13](https://github.com/Ramza13) in #63444, which to my understanding was to set conditions with `weather( s )` to where only clear sky is possible and then call `next_weather`.~~

EDIT; Weather EOC fixed by creating a custom weather.

- [x] Fix clear weather EOC 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Works except for the clear weather EOC. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
