### PR TITLE
Items salvaged from cutting will now be placed in vehicle, if you're cutting them in vehicle

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1789,7 +1789,6 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
     // Force an encumbrance update in case they were wearing that item.
     p.calc_encumbrance();
 
-    map &here = get_map();
     for( const auto &salvaged_mat : salvage ) {
         item result( salvaged_mat.first, calendar::turn );
         int amount = salvaged_mat.second;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1809,7 +1809,7 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
                 p.i_add_or_drop( result, amount );
             } else {
                 for( int i = 0; i < amount; i++ ) {
-                    here.add_item_or_charges( pos, result );
+                    put_into_vehicle_or_drop( p, item_drop_reason::deliberate, { result }, pos );
                 }
             }
         } else {


### PR DESCRIPTION
#### Summary
Features "Items salvaged from cutting will now be placed in vehicle, if you're cutting them in vehicle"

#### Purpose of change
* Closes #45228.

#### Describe the solution
Replaced placing directly on the ground through `add_item_or_charges` with `put_into_vehicle_or_drop`.

#### Describe alternatives you've considered
None.

#### Testing
Got a car with an empty trunk. Put a backpack in the trunk. Cut the backpack with my multitool. Salvaged items were placed in the trunk.

#### Additional context
![изображение](https://github.com/user-attachments/assets/552c67e9-11fe-41a0-b4bb-393be59b6a87)