### PR TITLE
shorten `memorize` hint in crafting GUI search

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1067,7 +1067,7 @@ static const std::vector<SearchPrefix> prefixes = {
     { 's', to_translation( "food handling" ), to_translation( "<color_cyan>any skill</color> used to craft" ) },
     { 'Q', to_translation( "fine bolt turning" ), to_translation( "<color_cyan>quality</color> required to craft" ) },
     { 't', to_translation( "soldering iron" ), to_translation( "<color_cyan>tool</color> required to craft" ) },
-    { 'm', to_translation( "yes" ), to_translation( "recipes which are <color_cyan>memorized</color> or not (hides nested)" ) },
+    { 'm', to_translation( "yes" ), to_translation( "recipe <color_cyan>memorized</color> (or not)" ) },
     { 'P', to_translation( "Blacksmithing" ), to_translation( "<color_cyan>proficiency</color> used to craft" ) },
     { 'l', to_translation( "5" ), to_translation( "<color_cyan>difficulty</color> of the recipe as a number or range" ) },
     { 'r', to_translation( "buttermilk" ), to_translation( "recipe's (<color_cyan>by</color>)<color_cyan>products</color>; use * as wildcard" ) },


### PR DESCRIPTION
#### Summary
Interface "shorten `memorize` hint in crafting GUI search"

#### Purpose of change

 - Fixes part of #64626

The hint was hideously over multiple lines. (It still could be broken in other languages).

before
![image](https://github.com/user-attachments/assets/6bed6b6b-c5e5-4868-8a26-f96a9913677e)

after
![image](https://github.com/user-attachments/assets/f3dfca15-d3c2-40dc-9de5-2cc3b70366b0)

#### Describe the solution

 - Shorten the hint.
 - Remove (hides nested) added in #64627. I don't think the player cares for that piece of info.

#### Describe alternatives you've considered

 - Do nice wrapping - fix it for all languages. That would be a lot of work.
 - Change `m:yes` to `m:no` Which is a more used use-case, I think. But that wouldn't go with the rest of the hints (Implying `m:no` shows memorized recipes).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Look at it.

#### Additional context


