### PR TITLE
Obsolete OM_MOVE

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
@@ -475,7 +475,8 @@
   },
   {
     "type": "effect_on_condition",
-    "eoc_type": "OM_MOVE",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_enters_omt",
     "id": "EOC_HAVE_U_BEEN_TO_MIGOS",
     "condition": {
       "or": [

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -38,7 +38,7 @@ An effect_on_condition is an object allowing the combination of dialog condition
 | `false_effect`        | effect     | The effect(s) caused if `condition` returns false upon activation.  See the "Dialogue Effects" section of [NPCs](NPCs.md) for the full syntax.
 | `global`              | bool       | If this is true, this recurring eoc will be run on the player and every npc from a global queue.  Deactivate conditions will work based on the avatar. If it is false the avatar and every character will have their own copy and their own deactivated list. Defaults to false.
 | `run_for_npcs`        | bool       | Can only be true if global is true. If false the EOC will only be run against the avatar. If true the eoc will be run against the avatar and all npcs.  Defaults to false.
-| `EOC_TYPE`            | string     | Can be one of `ACTIVATION`, `RECURRING`, `SCENARIO_SPECIFIC`, `AVATAR_DEATH`, `NPC_DEATH`, `OM_MOVE`, `PREVENT_DEATH`, `EVENT` (see details below). It defaults to `ACTIVATION` unless `recurrence` is provided in which case it defaults to `RECURRING`.
+| `EOC_TYPE`            | string     | Can be one of `ACTIVATION`, `RECURRING`, `SCENARIO_SPECIFIC`, `AVATAR_DEATH`, `NPC_DEATH`, `PREVENT_DEATH`, `EVENT` (see details below). It defaults to `ACTIVATION` unless `recurrence` is provided in which case it defaults to `RECURRING`.
 
  ### EOC types
 
@@ -49,7 +49,6 @@ An effect_on_condition is an object allowing the combination of dialog condition
 * `SCENARIO_SPECIFIC` - automatically invoked once on scenario start.
 * `AVATAR_DEATH` - automatically invoked whenever the current avatar dies (it will be run with the avatar as `u`), if after it the player is no longer dead they will not die, if there are multiple EOCs they all be run until the player is not dead.
 * `NPC_DEATH` - EOCs can only be assigned to run on the death of an npc, in which case u will be the dying npc and npc will be the killer. If after it npc is no longer dead they will not die, if there are multiple they all be run until npc is not dead.
-* `OM_MOVE` - EOCs trigger when the player moves overmap tiles
 * `PREVENT_DEATH` - whenever the current avatar dies it will be run with the avatar as `u`, if after it the player is no longer dead they will not die, if there are multiple they all be run until the player is not dead.
 * `EVENT` - EOCs trigger when a specific event given by "required_event" takes place. 
 

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -42,7 +42,6 @@ namespace io
         case eoc_type::SCENARIO_SPECIFIC: return "SCENARIO_SPECIFIC";
         case eoc_type::AVATAR_DEATH: return "AVATAR_DEATH";
         case eoc_type::NPC_DEATH: return "NPC_DEATH";
-        case eoc_type::OM_MOVE: return "OM_MOVE";
         case eoc_type::PREVENT_DEATH: return "PREVENT_DEATH";
         case eoc_type::EVENT: return "EVENT";
         case eoc_type::NUM_EOC_TYPES: break;
@@ -462,17 +461,6 @@ void effect_on_conditions::avatar_death()
     dialogue d( get_talker_for( get_avatar() ), klr == nullptr ? nullptr : get_talker_for( klr ) );
     for( const effect_on_condition &eoc : effect_on_conditions::get_all() ) {
         if( eoc.type == eoc_type::AVATAR_DEATH ) {
-            eoc.activate( d );
-        }
-    }
-}
-
-void effect_on_conditions::om_move()
-{
-    avatar &player_character = get_avatar();
-    dialogue d( get_talker_for( player_character ), nullptr );
-    for( const effect_on_condition &eoc : effect_on_conditions::get_all() ) {
-        if( eoc.type == eoc_type::OM_MOVE ) {
             eoc.activate( d );
         }
     }

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -32,7 +32,6 @@ enum eoc_type {
     SCENARIO_SPECIFIC,
     AVATAR_DEATH,
     NPC_DEATH,
-    OM_MOVE,
     PREVENT_DEATH,
     EVENT,
     NUM_EOC_TYPES
@@ -114,8 +113,6 @@ void write_global_eocs_to_file();
 void prevent_death();
 /** Run all avatar death eocs */
 void avatar_death();
-/** Run all OM_MOVE eocs */
-void om_move();
 } // namespace effect_on_conditions
 
 template<>

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13927,7 +13927,6 @@ void avatar_moves( const tripoint &old_abs_pos, const avatar &u, const map &m )
         const oter_id &past_ter = overmap_buffer.ter( old_abs_omt );
         get_event_bus().send<event_type::avatar_enters_omt>( new_abs_omt.raw(), cur_ter );
         // if the player has moved omt then might trigger an EOC for that OMT
-        effect_on_conditions::om_move();
         if( !past_ter->get_exit_EOC().is_null() ) {
             dialogue d( get_talker_for( get_avatar() ), nullptr );
             effect_on_condition_id eoc = cur_ter->get_exit_EOC();


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
There are two ways to run eoc when character crosses some boundary: eoc of type OM_MOVE, or eoc hooked to avatar_enters_omt event;
First one is barely used, second one used widely and allow using of additional context vars. Supreme way, i'd say. Let's stick to it
#### Describe the solution
Remove OM_MOVE type
#### Testing
No changes, the game compiles and loads properly
#### Additional context
Fun fact: both events run at the same time, and both events run event before actually stepping onto said OM