### PR TITLE
Lead Acid Battery breaks_into Audit

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -818,9 +818,11 @@
     "description": "A car battery wired into a static power grid.",
     "item": "battery_car",
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 6, 9 ] },
-      { "item": "steel_chunk", "count": [ 6, 9 ] },
-      { "item": "scrap", "count": [ 6, 9 ] }
+      { "item": "lead", "charges": [ 1680, 2380 ] },
+      { "item": "chem_sulphuric_acid", "count": [ 5, 8 ], "container-item": "null" },
+      { "item": "plastic_chunk", "count": [ 14, 20 ] },
+      { "item": "scrap", "charges": [ 2, 3 ] },
+      { "item": "shredded_rubber", "charges": [ 10, 14 ] }
     ],
     "durability": 120,
     "requirements": { "removal": { "time": "6 m" } },

--- a/data/json/vehicleparts/battery.json
+++ b/data/json/vehicleparts/battery.json
@@ -12,9 +12,11 @@
     "description": "A battery for storing electrical power, and discharging it to power electrical devices built into the vehicle.",
     "folded_volume": "10 L",
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 6, 9 ] },
-      { "item": "steel_chunk", "count": [ 6, 9 ] },
-      { "item": "scrap", "count": [ 6, 9 ] }
+      { "item": "lead", "charges": [ 1680, 2380 ] },
+      { "item": "chem_sulphuric_acid", "count": [ 5, 8 ], "container-item": "null" },
+      { "item": "plastic_chunk", "count": [ 14, 20 ] },
+      { "item": "scrap", "charges": [ 2, 3 ] },
+      { "item": "shredded_rubber", "charges": [ 10, 14 ] }
     ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "50 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
@@ -34,9 +36,11 @@
     "durability": 100,
     "folded_volume": "1500 ml",
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 7 ] },
-      { "item": "steel_chunk", "count": [ 4, 7 ] },
-      { "item": "scrap", "count": [ 4, 7 ] }
+      { "item": "lead", "charges": [ 252, 357 ] },
+      { "item": "chem_sulphuric_acid", "count": [ 0, 1 ], "container-item": "null" },
+      { "item": "plastic_chunk", "count": [ 2, 3 ] },
+      { "item": "scrap", "charges": [ 0, 1 ] },
+      { "item": "shredded_rubber", "charges": [ 1, 2 ] }
     ]
   },
   {
@@ -48,9 +52,11 @@
     "durability": 30,
     "folded_volume": "750 ml",
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 7 ] },
-      { "item": "steel_chunk", "count": [ 4, 7 ] },
-      { "item": "scrap", "count": [ 4, 7 ] }
+      { "item": "lead", "charges": [ 126, 178 ] },
+      { "item": "chem_sulphuric_acid", "count": [ 0, 1 ], "container-item": "null" },
+      { "item": "plastic_chunk" },
+      { "item": "scrap", "charges": [ 0, 1 ] },
+      { "item": "shredded_rubber", "charges": [ 0, 1 ] }
     ]
   },
   {


### PR DESCRIPTION

#### Summary
Balance "Audit Lead Acid Batteries breaks_into"

#### Purpose of change

I recently added motorbike batteries as place-able to be used with the appliance system.  #77901 While doing this, I set up a spreadsheet to determine their breaks_into materials.  What I realized is that breaks_into for these vehicle parts/other car battery appliances, is that they mostly just drop steel, despite this not being the materials found in a car battery.

IE: For a car battery, which is primarily lead and acid by weight, it actually breaks_into 6-9 lumps, 6-9 chunks, and 6-9 scrap metal.  This is all steel, clearly not designed to be accurate given they all have the same drop numbers and that batteries are not 100% steel.

Anyway, so there are issues for car batteries, motorbike batteries, etc.

#### Describe the solution

Yeah, so I made a spreadsheet for the breaks_into of the appliance version of the motorbike batteries.  It's by no means perfect, but it's a hell of a lot better than just giant piles of steel.

So, I plugged in all the lead-acid batteries I saw, adjusting their appliance breaks_into and their vehicle part breaks_into.  I will provide the spreadsheet if github allows posting files, if not there will be screen shots below.

The basic breakdown is as follows: 

Lead = 70% (primary material, grids, electrodes)
Acid = 22% (electrolyte/acid)
Plastic = 6% (case, separators, structure)
steel = 1% (terminals and connectors, battery only, where it sits in the vehicle is the frame not the battery)
rubber = token value <1% (barely any, tiny bit for rubber seals)

These are obviously not exact, I could not find exact values for these sort of batteries and they do actually vary in their design despite being very similar.  This is an approximation, and honestly the lead% is a little too high, I basically figured for the other parts FIRST because lead is the dominant component, and then dumped a few extra percent into lead to balance it.  In my opinion this is the smartest way to do this, since that's the highest portion and also a low value material, so it's hard to go wrong overdoing it. IE: makes a lot more sense for lead to be a little too high than for it to dump way too much acid or whatever.

These values/materials are determined by their mass.

And then for the actual min/max I went with 60% min 85% max.  Ultimately, we are tracking very small pieces of material (small volume/weight pieces of lead, plastic chunks, etc) and you would generally be able to salvage nearly 100% of materials.  However, most of our breaks_into/bash do NOT give 100% materials, presuming some is lost.  Well, to be honest most breaks_into either gives wrong components (like these batteries giving steel instead of lead, acid, etc. before this change), way too little, or WAY too much.  So it's all fucked and 60-85% is better than being absurdly wrong so take that as you will.

Acid is the outlier here, it's the only thing with a large volume/mass (compared to plastic chunks or scrap metal, I mean.  It's still small, just not nearly that small).  

Anyway, changes made:

- Motorbike battery vehicle part breaks_into (matches my previous PR for their appliance)
- Small Motorbike battery vehicle part breaks_into (matches my previous PR for their appliance)
- Car Battery vehicle part breaks_into (new)
- Car Battery appliance breaks_into (new, same as vehicle part)
- Notes: 
     - Other batteries can be installed in vehicles but are not lead-acid batteries and thus don't get this treatment.
     - Did not look at or adjust disassembly recipes for the item versions of these batteries.

#### Describe alternatives you've considered

Not including acid due to the creation of acid puddles, but ultimately acid is a large % of the battery.

I actually debated adding a separate 'truck' battery or similar heavy duty lead-acid battery.  While we have the ubiquitous 'car battery' and we have many 'storage batteries' we don't have a larger lead-acid battery for larger trucks.  However, in my research it appears that larger trucks often just have multiple regular 12V batteries.  I'm unsure if this is correct, or if that's reflected somewhere in the game, once I saw that I stopped investigating because I lost interest x_x

#### Testing

Well, I ironed out issues with charges in the last PR, so really I just plugged everything in and copy-pasted, changing the relevant values, then verifying they're in the game by smashing the relevant parts.  Pretty straight forward.  Everything works, notes about my distaste for smash results/the acid placement in additional info.

#### Additional context

It annoys me that smashing things creates such a large radius of debris, but also stacks the items together.  IE: you might find materials 3 tiles in each direction, but the lead will land in a perfect stack of 2000 on one tile.  I hate this, but ultimately it's out of scope/my knowledge.

Regarding acid: The high amount of acid in a car battery means that there actually is enough to justify having it create acid tiles on the ground (which it does, I have no actual control over this, pools do not seem to have intensity based on input volume, it just IS an acid tile) however, due to the way smashing works, this can create multiple tiles.  In my testing with the car battery, this was about 2-3 tiles on average, which seems... not great, but acceptable.  The fact that it can spawn MORE than 3 is problematic but I have no idea what to do about this.

The motorbike batteries drop 0-1 tiles, which is a bit overboard for how little acid there is, especially for the small battery, but again I have no control over this, the only option would be to remove the acid drop completely, which does not make sense given the acid is a significant portion of the battery's weight.

SPREADSHEET:
[BatteryAudit.ods](https://github.com/user-attachments/files/17788271/BatteryAudit.ods)

I've included the file in case it's relevant to someone in the future/if they want an already set up spreadsheet to tweak if they'd want to.

Here is a screenshot, though this obviously doesn't show the math in the cells like the file would:
![image](https://github.com/user-attachments/assets/9587f31c-20a4-4b40-aa09-53924060965f)

