### PR TITLE
Allow safecracking prof to identify safe mechanisms

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -221,6 +221,7 @@ static const npc_class_id NC_ROBOFAC_INTERCOM( "NC_ROBOFAC_INTERCOM" );
 
 static const proficiency_id proficiency_prof_disarming( "prof_disarming" );
 static const proficiency_id proficiency_prof_parkour( "prof_parkour" );
+static const proficiency_id proficiency_prof_safecracking( "prof_safecracking" );
 static const proficiency_id proficiency_prof_traps( "prof_traps" );
 static const proficiency_id proficiency_prof_trapsetting( "prof_trapsetting" );
 
@@ -1805,15 +1806,28 @@ void iexamine::safe( Character &you, const tripoint_bub_ms &examp )
         // The dialing procedures for safes vary, I'm estimating 5 procedures.
         // See https://hoogerhydesafe.com/resources/combination-lock-dialing-procedures/
         // At the end of the day, that means a 1 / 80,000 chance per attempt.
-        // If someone is interested, they can feel free to add a proficiency for
-        // "safe recognition" to mitigate or eliminate this 2x and 5x factor.
-        if( one_in( 80000 ) ) {
-            you.add_msg_if_player( m_good, _( "You mess with the dial for a little bit… and it opens!" ) );
-            get_map().furn_set( examp, furn_f_safe_o );
-            return;
+        // If the player has the safecracking proficiency, they know the procedure.
+
+        // With the proficiency, there's a 50% chance to open after 15.4 hours of attempts.
+        // Without the proficiency, there's a 50% chance to open after 154 hours of attempts.
+        if( you.has_proficiency( proficiency_prof_safecracking ) ) {
+            if( one_in( 8000 ) ) {
+                you.add_msg_if_player( m_good, _( "You carefully dial a combination… and it opens!" ) );
+                get_map().furn_set( examp, furn_f_safe_o );
+                return;
+            } else {
+                you.add_msg_if_player( m_info, _( "You carefully dial a combination." ) );
+                return;
+            }
         } else {
-            you.add_msg_if_player( m_info, _( "You mess with the dial for a little bit." ) );
-            return;
+            if( one_in( 80000 ) ) {
+                you.add_msg_if_player( m_good, _( "You mess with the dial for a little bit… and it opens!" ) );
+                get_map().furn_set( examp, furn_f_safe_o );
+                return;
+            } else {
+                you.add_msg_if_player( m_info, _( "You mess with the dial for a little bit." ) );
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Features "Safe crackers guess combinations more accurately"

#### Purpose of change

Guessing safe combinations is based on the number of possible combinations and assumes you can try one such combination in 10 seconds:

> assume a 3 digit 100-number code. many safes allow adjacent + 1 dial locations to match, so 1/20^3, or 1/8,000 odds.
> additionally, safes can be left-handed or right-handed, doubling the problem space.
> the dialing procedures for safes vary, i'm estimating 5 procedures.
> see https://hoogerhydesafe.com/resources/combination-lock-dialing-procedures/
> at the end of the day, that means a 1 / 80,000 chance per attempt.
> If someone is interested, they can feel free to add a proficiency for "safe recognition" to mitigate or eliminate this 2x and 5x factor.
> -- Kevin

I'm interested so I've made it so the safe cracking proficiency allows you to know the mechanism of how a safe combination should be entered. It's still much slower than proper safe cracking with a tool, of course!

#### Describe the solution

If you have the proficiency, you only have to check the 1/8,000 odds.

#### Describe alternatives you've considered

- Make the safe cracking activity take a variable amount of time to simulate how long it takes to stumble across the correct combination.
- Give safecrackers one attempt at more like 1/50 to represent them trying the factory default combination before moving on to 1/8000.
- Make safe cracking proficiency less effective.  It's still so unlikely to open a safe that I think it's fine even if it's overestimating the ability to identify the safe mechanism.
- Extract odds and message to variables assigned within the proficiency check and interpolating the conditional values. Doubling the code seemed fine since it's all in one place.

#### Testing

![image](https://github.com/user-attachments/assets/a314bb93-8f06-4271-8d57-502c8b362c9b)
Tried to crack a safe before and after having the safe cracking proficiency.

#### Additional Context
https://github.com/CleverRaven/Cataclysm-DDA/pull/44958

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->