### PR TITLE
[Magiclysm] Fix demonic possession causing starvation penalties

### DIFF
--- a/data/mods/Magiclysm/Spells/attunements/Blood_Mage.json
+++ b/data/mods/Magiclysm/Spells/attunements/Blood_Mage.json
@@ -46,7 +46,7 @@
             "DEMON_CLAWS",
             "DEMON_SKIN",
             "DEMON_TAIL",
-            "HUGE_OK",
+            "DEMON_HUGE",
             "NOPAIN",
             "FACIAL_HAIR_GOATEE"
           ]
@@ -59,12 +59,12 @@
     "type": "SPELL",
     "name": "Demonic Possession",
     "description": "You allow a demon to possess your body for a short time, giving you great combat abilities.  You still retain control, though lose your spellcasting abilities temporarily.",
-    "valid_targets": [ "none" ],
+    "valid_targets": [ "self" ],
     "flags": [ "CONJURATION_SPELL", "SOMATIC", "NO_LEGS", "MUST_HAVE_CLASS_TO_LEARN" ],
     "extra_effects": [ { "id": "eoc_summon_setup", "hit_self": true } ],
-    "effect": "spawn_item",
+    "effect": "effect_on_condition",
     "shape": "blast",
-    "effect_str": "demon_possession_aura",
+    "effect_str": "EOC_DEMON_POSSESSION",
     "min_damage": 1,
     "max_damage": 1,
     "min_duration": 360000,
@@ -76,5 +76,74 @@
     "base_casting_time": 800,
     "base_energy_cost": 5,
     "energy_source": "HP"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEMON_POSSESSION",
+    "condition": { "and": [ { "not": { "u_has_trait": "HUGE" } }, { "not": { "u_has_trait": "HUGE_OK" } } ] },
+    "effect": [
+      { "u_message": "Your body swells and warps as your size increases!", "type": "good" },
+      { "math": [ "u_preshift_size", "=", "u_val('size')" ] },
+      {
+        "switch": { "math": [ "u_preshift_size" ] },
+        "cases": [
+          { "case": 1, "effect": [ { "math": [ "u_calories('dont_affect_weariness': true)", "*=", "12" ] } ] },
+          { "case": 2, "effect": [ { "math": [ "u_calories('dont_affect_weariness': true)", "*=", "6" ] } ] },
+          { "case": 3, "effect": [ { "math": [ "u_calories('dont_affect_weariness': true)", "*=", "2" ] } ] },
+          { "case": 4, "effect": [ { "math": [ "u_calories('dont_affect_weariness': true)", "*=", "1.5" ] } ] },
+          { "case": 5, "effect": [  ] }
+        ]
+      },
+      { "u_cast_spell": { "id": "demonic_possession_real" } },
+      {
+        "run_eocs": "EOC_DEMON_POSSESSION_REMOVE",
+        "time_in_future": { "math": [ "(u_spell_level('demonic_possession') * 309) + 3600" ] }
+      }
+    ],
+    "false_effect": [
+      { "u_message": "Your body fills with demonic power!", "type": "good" },
+      { "u_cast_spell": { "id": "demonic_possession_real" } },
+      {
+        "run_eocs": "EOC_DEMON_POSSESSION_REMOVE",
+        "time_in_future": { "math": [ "(u_spell_level('demonic_possession') * 309) + 3600" ] }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEMON_POSSESSION_REMOVE",
+    "effect": [
+      { "u_message": "Your body shrinks and warps as your size decreases!", "type": "bad" },
+      {
+        "switch": { "math": [ "u_preshift_size" ] },
+        "cases": [
+          { "case": 1, "effect": [ { "math": [ "u_calories('dont_affect_weariness': true)", "/=", "12" ] } ] },
+          { "case": 2, "effect": [ { "math": [ "u_calories('dont_affect_weariness': true)", "/=", "6" ] } ] },
+          { "case": 3, "effect": [ { "math": [ "u_calories('dont_affect_weariness': true)", "/=", "2" ] } ] },
+          { "case": 4, "effect": [ { "math": [ "u_calories('dont_affect_weariness': true)", "/=", "1.5" ] } ] },
+          { "case": 5, "effect": [  ] }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "demonic_possession_real",
+    "type": "SPELL",
+    "name": "Demonic Possession Real",
+    "description": "Grants the aura that gives the demon traits.  You're not supposed to see this.",
+    "valid_targets": [ "self" ],
+    "flags": [ "CONJURATION_SPELL", "SOMATIC", "NO_LEGS", "MUST_HAVE_CLASS_TO_LEARN", "SILENT", "NO_EXPLOSION_SFX" ],
+    "extra_effects": [ { "id": "eoc_summon_setup", "hit_self": true } ],
+    "effect": "spawn_item",
+    "shape": "blast",
+    "effect_str": "demon_possession_aura",
+    "min_damage": 1,
+    "max_damage": 1,
+    "min_duration": { "math": [ "(u_spell_level('demonic_possession') * 30900) + 360000" ] },
+    "max_duration": { "math": [ "(u_spell_level('demonic_possession') * 30900) + 360000" ] },
+    "spell_class": "BLOOD_MAGE",
+    "difficulty": 5,
+    "max_level": 35,
+    "base_casting_time": 0
   }
 ]

--- a/data/mods/Magiclysm/traits/temporary_demon_traits.json
+++ b/data/mods/Magiclysm/traits/temporary_demon_traits.json
@@ -64,6 +64,33 @@
   },
   {
     "type": "mutation",
+    "id": "DEMON_HUGE",
+    "//": "Identical to HUGE_OK but uses the flag for temporary sizeshifting.",
+    "//2": "I am not using the biomancer version, as it has more bonuses than HUGE_OK and I want to keep the spell's balance identical while fixing the bug.",
+    "flags": [ "TEMPORARY_SHAPESHIFT", "SHAPESHIFT_SIZE_HUGE" ],
+    "name": { "str": "Huge" },
+    "points": 2,
+    "visibility": 4,
+    "ugliness": 3,
+    "valid": false,
+    "starting_trait": false,
+    "mixed_effect": true,
+    "description": "Your cardiovascular system has caught up with your muscular physique, so who needs pathetic human cars?  Strength +4.",
+    "types": [ "SIZE" ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": 4 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 1 },
+          { "value": "CARRY_WEIGHT", "multiply": 0.1 }
+        ]
+      }
+    ],
+    "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
+    "destroys_gear": true
+  },
+  {
+    "type": "mutation",
     "id": "DEMON_CLAWS",
     "name": { "str": "Demon Claws" },
     "points": 2,


### PR DESCRIPTION
#### Summary
Mods  "[Magiclysm] Fix demonic possession causing starvation penalties"

#### Purpose of change

The blood mage's demonic possession grants huge size but didn't change calories, making what is supposed to be a buff mostly cause penalties from not having enough calories for your size

#### Describe the solution

Add a EOC that changes the calories that runs as the spell is casted. The player-visible spells triggers the EOC that changes the calories and cast the real spell.
Also use a demon version of HUGE_OK to use the temporary shapeshifting flags.

#### Describe alternatives you've considered

#### Testing

Used demonic possession without the fix on a starting character: goes from overweight to emaciated

Used demonic possession with the fix on a starting character: starts at overweight, stays at overweight

#### Additional context