### PR TITLE
Swap colors for imgui window title bars

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -1072,9 +1072,9 @@ void cataimgui::init_colors()
     style.Colors[ImGuiCol_FrameBg]                = c_dark_gray;
     style.Colors[ImGuiCol_FrameBgHovered]         = c_black;
     style.Colors[ImGuiCol_FrameBgActive]          = c_dark_gray;
-    style.Colors[ImGuiCol_TitleBg]                = c_blue;
-    style.Colors[ImGuiCol_TitleBgActive]          = c_dark_gray;
-    style.Colors[ImGuiCol_TitleBgCollapsed]       = c_blue;
+    style.Colors[ImGuiCol_TitleBg]                = c_dark_gray;
+    style.Colors[ImGuiCol_TitleBgActive]          = c_blue;
+    style.Colors[ImGuiCol_TitleBgCollapsed]       = c_dark_gray;
     style.Colors[ImGuiCol_MenuBarBg]              = c_black;
     style.Colors[ImGuiCol_ScrollbarBg]            = c_black;
     style.Colors[ImGuiCol_ScrollbarGrab]          = c_dark_gray;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

This looks like it was a mistake. At the very least grey for active and blue for inactive is very counterintuitive.

#### Describe the solution

Swap the colors.

#### Describe alternatives you've considered

Not swapping `ImGuiCol_TitleBgCollapsed`.

#### Testing

Old, "test" is the active window:
![grafik](https://github.com/user-attachments/assets/0fef02de-bd20-4259-8b9d-a1636d372f6e)

New, "test" is the active window:
![grafik](https://github.com/user-attachments/assets/d2a6eb20-82f2-47f5-a769-a317b2c62732)


#### Additional context

Tbh the default style being the old terminal-like style is kinda awful. But I'm absolutely not the person to develop styles.