### PR TITLE
Enable Multiple Anvils for Isherwood Mission

### DIFF
--- a/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
@@ -327,10 +327,17 @@
     "id": "MISSION_ISHERWOOD_CARLOS_1",
     "type": "mission_definition",
     "name": { "str": "Find an anvil" },
-    "goal": "MGOAL_FIND_ITEM",
+    "goal": "MGOAL_CONDITION",
     "difficulty": 5,
     "value": 50000,
-    "item": "anvil",
+    "goal_condition": {
+      "or": [
+        { "u_has_item": "anvil" },
+        { "u_has_item": "anvil_crude" },
+        { "u_has_item": "anvil_heavy" },
+        { "u_has_item": "anvil_bronze" }
+      ]
+    },
     "count": 1,
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,

--- a/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
@@ -349,6 +349,19 @@
     "end": {
       "opinion": { "trust": 1, "value": 1 },
       "effect": [
+        {
+          "if": { "u_has_item": "anvil" },
+          "then": { "u_consume_item": "anvil", "popup": true },
+          "else": {
+            "if": { "u_has_item": "anvil_crude" },
+            "then": { "u_consume_item": "anvil_crude", "popup": true },
+            "else": {
+              "if": { "u_has_item": "anvil_heavy" },
+              "then": { "u_consume_item": "anvil_heavy", "popup": true },
+              "else": { "u_consume_item": "anvil_bronze", "popup": true }
+            }
+          }
+        },
         { "u_spawn_item": "leather_armor_horse", "count": 1 },
         { "npc_add_var": "carlos_has_anvil", "value": "yes" },
         { "math": [ "timer_carlos_has_anvil", "=", "time('now')" ] }


### PR DESCRIPTION
#### Summary
Bugfixes "Enable Other Anvils for Isherwood Quest"

#### Purpose of change
#77908 

TLDR: Missions asks for an anvil, dialogue suggests that you can use a crafted one.  However, it only accepted the regular anvil.  It was requested that this change to accommodate other anvils.

#### Describe the solution
Restructure mission using if then logic to allow for the anvil, crude anvil, bronze anvil, or heavy anvil.

#### Describe alternatives you've considered
Removing the dialogue suggesting craft-able anvils are acceptable and leaving it as anvil only.

#### Testing
Ensured no syntax errors.  Verified that all anvils are acceptable/complete the mission (though it requires you to wield that larger anvils/have them in your inventory to complete, this is a flaw with the removal command, I can't fix that).  Verified the anvil is removed before giving the reward, I don't know if this matters, but it makes more sense that way and figured it was safer that way.

#### Additional context

Okay, so a few issues.  Firstly, all anvils have anvil 3 or better, making them suitable for the purpose of this quest.  Therefore, I feel they should be acceptable.  However, part of this mission updates the mapgen to include that anvil as furniture IN the map.  I looked into changing this to accommodate which anvil you received, however I could not find an example of "then" using the update mapgen command.  When attempting to do this I got various errors about it not being a valid entry for this.  I don't know if I was doing it wrong or if the infrastructure isn't there.

TLDR: TODO: Figure out how to change the mapgen update to reflect which anvil is turned in for the quest.

Additionally, it was unclear to me if the bronze anvil should be valid, but seeing as we assign them the same anvil quality, presumably it is fine.
closes #77908 

Screenshots:
![image](https://github.com/user-attachments/assets/8d2e195f-391d-4a9c-8db1-4e65dc725bae)
![image](https://github.com/user-attachments/assets/317acc88-db3f-4e92-ad45-fdbed53be5bd)
![image](https://github.com/user-attachments/assets/da792381-7cf2-42e4-8c16-be5fcf6e588e)


