### PR TITLE
Query the player on whether he really want to cut other people's stuff

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1824,22 +1824,7 @@ static bool query_consume_ownership( item &target, Character &p )
         if( p.get_value( "THIEF_MODE" ) == "THIEF_HONEST" || !choice ) {
             return false;
         }
-        std::vector<npc *> witnesses;
-        for( npc &elem : g->all_npcs() ) {
-            if( rl_dist( elem.pos(), p.pos() ) < MAX_VIEW_DISTANCE && elem.sees( p.pos_bub() ) ) {
-                witnesses.push_back( &elem );
-            }
-        }
-        for( npc *elem : witnesses ) {
-            elem->say( "<witnessed_thievery>", 7 );
-        }
-        if( !witnesses.empty() && target.is_owned_by( p, true ) ) {
-            if( p.add_faction_warning( target.get_owner() ) ) {
-                for( npc *elem : witnesses ) {
-                    elem->make_angry();
-                }
-            }
-        }
+        g->on_witness_theft( target );
     }
     return true;
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2659,23 +2659,7 @@ bool Character::disassemble( item_location target, bool interactive, bool disass
             return false;
         } else {
             if( obj.get_owner() ) {
-                std::vector<npc *> witnesses;
-                for( npc &elem : g->all_npcs() ) {
-                    if( rl_dist( elem.pos_bub(), player_character.pos_bub() ) < MAX_VIEW_DISTANCE &&
-                        elem.get_faction() &&
-                        obj.is_owned_by( elem ) && elem.sees( player_character.pos_bub() ) ) {
-                        elem.say( "<witnessed_thievery>", 7 );
-                        npc *npc_to_add = &elem;
-                        witnesses.push_back( npc_to_add );
-                    }
-                }
-                if( !witnesses.empty() ) {
-                    if( player_character.add_faction_warning( obj.get_owner() ) ) {
-                        for( npc *elem : witnesses ) {
-                            elem->make_angry();
-                        }
-                    }
-                }
+                g->on_witness_theft( obj );
             }
         }
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1271,6 +1271,29 @@ void game::load_npcs()
     npcs_dirty = false;
 }
 
+void game::on_witness_theft( const item &target )
+{
+    Character &p = get_player_character();
+    std::vector<npc *> witnesses;
+    for( npc &elem : g->all_npcs() ) {
+        if( rl_dist( elem.pos(), p.pos() ) < MAX_VIEW_DISTANCE && elem.sees( p.pos_bub() ) &&
+            target.is_owned_by( elem ) ) {
+            witnesses.push_back( &elem );
+        }
+    }
+    for( npc *elem : witnesses ) {
+        elem->say( "<witnessed_thievery>", 7 );
+    }
+    if( !witnesses.empty() ) {
+        if( p.add_faction_warning( target.get_owner() ) ||
+            target.get_owner() == faction_id( "no_faction" ) ) {
+            for( npc *elem : witnesses ) {
+                elem->make_angry();
+            }
+        }
+    }
+}
+
 void game::unload_npcs()
 {
     for( const auto &npc : critter_tracker->active_npc ) {

--- a/src/game.h
+++ b/src/game.h
@@ -544,6 +544,10 @@ class game
         npc *find_npc_by_unique_id( const std::string &unique_id );
         /** Makes any nearby NPCs on the overmap active. */
         void load_npcs();
+
+        /** NPCs who saw player interacting with their stuff (disassembling, cutting etc)
+        * will notify the player that thievery was witnessed and make angry at the player. */
+        void on_witness_theft( const item &target );
     private:
         /** Unloads all NPCs.
          *

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1515,6 +1515,18 @@ std::optional<int> salvage_actor::use( Character *p, item &cutter, const tripoin
         return std::nullopt;
     }
 
+    const item &to_cut = *item_loc;
+    if( !to_cut.is_owned_by( *p, true ) ) {
+        if( !query_yn( _( "Cutting the %s may anger the people who own it, continue?" ),
+                       to_cut.tname() ) ) {
+            return false;
+        } else {
+            if( to_cut.get_owner() ) {
+                g->on_witness_theft( to_cut );
+            }
+        }
+    }
+
     return salvage_actor::try_to_cut_up( *p, cutter, item_loc );
 }
 


### PR DESCRIPTION
#### Summary
Features "Query the player on whether he really want to cut other people's stuff"

#### Purpose of change
1. Disassembling other people's stuff used almost exact copy of code for witness check from `query_consume_ownership`.
2. Witness check triggered only when you tried to disassemble stuff belonging to NPCs from some faction, so you could safely disassemble stuff belonging to factionless NPCs.
3. You could safely cut (salvage) other people's stuff.

#### Describe the solution
1. Extracted "witnessed thievery" function from `query_consume_ownership` and applied it to disassembling check to eliminate duplicating the code.
2. In "witness check" added check for factionless NPC, so they make angry at you when you start disassembling their stuff.
3. Added "witness check" to `salvage_actor::use`.

#### Describe alternatives you've considered
None.

#### Testing
Tried to disassemble prisoners' stuff at island prison type B. Got a prompt. Answered no, answered yes.
Tried to cut prisoners' stuff at island prison type B. Got a prompt. Answered no, answered yes.
Tried to disassemble veterinarian's stuff at animal shelter. Got a prompt. Answered no, answered yes.
Tried to cut veterinarian's stuff at animal shelter. Got a prompt. Answered no, answered yes.

#### Additional context
I also wanted to mention that trying to disassemble/cut factionless NPC's stuff triggers immediate hostile attitude from that NPC, contrary to trying to disassemble/cut faction stuff, which allows you to do it three (!) times before they turn hostile towards you. Their faction opinion towards you will lower every time, but still. I personally find immediate reaction much more "natural", and I wanted to change faction reaction to be immediate too, but I wanted to hear other opinions too, or maybe even open an issue regarding that.