### PR TITLE
Revert the horizontal separator color back to dark-gray

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -1089,7 +1089,7 @@ void cataimgui::init_colors()
     style.Colors[ImGuiCol_Header]                 = c_blue;
     style.Colors[ImGuiCol_HeaderHovered]          = c_black;
     style.Colors[ImGuiCol_HeaderActive]           = c_dark_gray;
-    style.Colors[ImGuiCol_Separator]              = c_blue;
+    style.Colors[ImGuiCol_Separator]              = c_dark_gray;
     style.Colors[ImGuiCol_SeparatorHovered]       = c_white;
     style.Colors[ImGuiCol_SeparatorActive]        = c_white;
     style.Colors[ImGuiCol_ResizeGrip]             = c_light_gray;


### PR DESCRIPTION
#### Summary
Interface "Revert horizontal separator color back to dark gray"

#### Purpose of change
#77842 made the imgui colors inherit from player-chosen colors, but it used blue as the color for horizontal separator in item description screen and the like instead of dark gray. I assume, accidentally, since there is no mention of  such intent in the PR.
In the default fresh install the blue color is extremely bright  and high contrast. It pulls attention towards itself and makes it hard [for me] to look at the item description pane for prolonged time.

This change reverts the horizontal separator color back to what it was pre-#77842 

Images:
before #77842 
![20241117-014826-cataclysm-tiles](https://github.com/user-attachments/assets/b3eab26c-8261-4c7c-861e-bd627e114fcb)
current master:
![20241117-014522-cataclysm-tiles](https://github.com/user-attachments/assets/b71d5260-8b33-402c-939c-e85d340cdade)
with this PR in place:
![20241117-014649-cataclysm-tiles](https://github.com/user-attachments/assets/c9a56e06-9677-4d2f-93b8-90e01a4a0f92)

(sidenote: I'm not sure what's going on with the fonts and why the switched to monospace now, but that's out of scope)

#### Describe the solution
Change the separator default color from `c_blue` to `c_dark_gray`

#### Describe alternatives you've considered
N/A
(Well, i did consider making it much easier to customize imgui, and unbinding the "separator color" from the pre-defined colors we have in color config, but realized that it might be a task beyond my abilities atm. Besides, this PR is just a simple bugfix)

#### Testing
Opened item description pane, took screenshot (above), was happy with the result.

#### Additional context
This will likely conflict with #77928 since we both touch the same file (i'm not sure how PR conflicts are handled in this project and if i need to do anything special here. cc @mqrause  just in case)
