### PR TITLE
mics eoc changes

### DIFF
--- a/data/json/effects_on_condition/computer_eocs.json
+++ b/data/json/effects_on_condition/computer_eocs.json
@@ -48,13 +48,7 @@
     "type": "effect_on_condition",
     "id": "EOC_CHECK_MAP_CACHE",
     "//": "todo: make it not reveal fungal towers and such? would require edits in reveal_map code, to accept blacklist of locations?",
-    "condition": {
-      "or": [
-        { "compare_string": [ "has", { "npc_val": "map_cache" } ] },
-        { "compare_string": [ "lack", { "npc_val": "map_cache" } ] },
-        { "compare_string": [ "read", { "npc_val": "map_cache" } ] }
-      ]
-    },
+    "condition": { "or": [ { "compare_string": [ { "npc_val": "map_cache" }, "has", "lack", "read" ] } ] },
     "false_effect": [ { "npc_add_var": "map_cache", "possible_values": [ "has", "lack" ] }, { "run_eocs": "EOC_CHECK_MAP_CACHE" } ],
     "effect": [
       {

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -1335,18 +1335,23 @@
         { "u_has_items": { "item": "nre_recorder", "charges": 1 } },
         {
           "or": [
-            { "compare_string": [ "mon_hound_tindalos", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_darkman", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_zombie_phase_shrike", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_swarm_structure", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_better_half", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_hallucinator", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_archunk_strong", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_void_spider", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_XEDRA_officer", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_eigenspectre_3", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_eigenspectre_4", { "context_val": "victim_type" } ] },
-            { "compare_string": [ "mon_living_vector", { "context_val": "victim_type" } ] }
+            {
+              "compare_string": [
+                { "context_val": "victim_type" },
+                "mon_hound_tindalos",
+                "mon_darkman",
+                "mon_zombie_phase_shrike",
+                "mon_swarm_structure",
+                "mon_better_half",
+                "mon_hallucinator",
+                "mon_archunk_strong",
+                "mon_void_spider",
+                "mon_XEDRA_officer",
+                "mon_eigenspectre_3",
+                "mon_eigenspectre_4",
+                "mon_living_vector"
+              ]
+            }
           ]
         }
       ]

--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -22,9 +22,14 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_vitrified_farm_entry",
+    "id": "EOC_vitrified_farm_entry_event",
     "eoc_type": "EVENT",
     "required_event": "avatar_enters_omt",
+    "effect": [ { "run_eocs": "EOC_vitrified_farm_entry" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_vitrified_farm_entry",
     "condition": {
       "and": [
         { "or": [ { "u_at_om_location": "unvitrified_farm_0" }, { "u_at_om_location": "unvitrified_orchard" } ] },
@@ -41,6 +46,12 @@
         }
       ]
     },
+    "false_effect": [
+      {
+        "if": { "not": { "u_has_trait": "NOT_GLASS" } },
+        "then": { "run_eocs": [ "EOC_vitrified_farm_entry" ], "time_in_future": "1 seconds" }
+      }
+    ],
     "effect": [
       {
         "place_override": { "global_val": "place_name", "default_str": "Quiet Farmhouse" },

--- a/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
@@ -386,20 +386,23 @@
     "eoc_type": "EVENT",
     "required_event": "avatar_moves",
     "condition": "u_is_underwater",
+    "//": "I would assume that Mycus spores are a bit sticky to keep them from coming off, so this has a chance to be removed instead of a guarantee.",
     "effect": [
       {
-        "run_eocs": {
-          "id": "EOC_REMOVE_HARD_THINGS_CHECK",
-          "global": false,
-          "eoc_type": "EVENT",
-          "required_event": "avatar_moves",
-          "condition": { "x_in_y_chance": { "x": 1, "y": 10 } },
-          "//": "I would assume that Mycus spores are a bit sticky to keep them from coming off, so this has a chance to be removed instead of a garuntee.",
-          "effect": [ { "u_lose_effect": "spores" } ]
-        }
+        "if": { "and": [ { "u_has_effect": "spores" }, { "x_in_y_chance": { "x": 1, "y": 10 } } ] },
+        "then": [
+          { "u_message": "You scrub your body extensively, and spores are finally gone.", "type": "good" },
+          { "u_lose_effect": "spores" }
+        ]
       },
-      { "u_lose_effect": "boomered" },
-      { "u_lose_effect": "corroding" }
+      {
+        "if": { "u_has_effect": "boomered" },
+        "then": [ { "u_message": "You wash the bile from your face.", "type": "good" }, { "u_lose_effect": "boomered" } ]
+      },
+      {
+        "if": { "u_has_effect": "corroding" },
+        "then": [ { "u_message": "You wash the acid from your body.", "type": "good" }, { "u_lose_effect": "corroding" } ]
+      }
     ]
   },
   {

--- a/data/mods/TEST_DATA/effect_on_condition.json
+++ b/data/mods/TEST_DATA/effect_on_condition.json
@@ -163,5 +163,48 @@
       { "set_string_var": "mixin fail alpha", "target_var": { "global_val": "alpha_name" } },
       { "set_string_var": "mixin fail beta", "target_var": { "global_val": "beta_name" } }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_compare_string_test",
+    "effect": [
+      { "if": { "compare_string": [ "yes", "yes" ] }, "then": { "math": [ "eoc_compare_string_test_1", "++" ] } },
+      { "if": { "compare_string": [ "yes", "no" ] }, "else": { "math": [ "eoc_compare_string_test_2", "++" ] } },
+      {
+        "if": { "compare_string": [ "yes", "yes", "yes" ] },
+        "then": { "math": [ "eoc_compare_string_test_3", "++" ] }
+      },
+      {
+        "if": { "compare_string": [ "yes", "yes", "no" ] },
+        "then": { "math": [ "eoc_compare_string_test_4", "++" ] }
+      },
+      { "if": { "compare_string": [ "yes", "no", "eh" ] }, "else": { "math": [ "eoc_compare_string_test_5", "++" ] } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_compare_string_match_all_test",
+    "effect": [
+      {
+        "if": { "compare_string_match_all": [ "yes", "yes" ] },
+        "then": { "math": [ "eoc_compare_string_match_all_test_1", "++" ] }
+      },
+      {
+        "if": { "compare_string_match_all": [ "yes", "no" ] },
+        "else": { "math": [ "eoc_compare_string_match_all_test_2", "++" ] }
+      },
+      {
+        "if": { "compare_string_match_all": [ "yes", "yes", "yes" ] },
+        "then": { "math": [ "eoc_compare_string_match_all_test_3", "++" ] }
+      },
+      {
+        "if": { "compare_string_match_all": [ "yes", "yes", "no" ] },
+        "else": { "math": [ "eoc_compare_string_match_all_test_4", "++" ] }
+      },
+      {
+        "if": { "compare_string_match_all": [ "yes", "no", "eh" ] },
+        "else": { "math": [ "eoc_compare_string_match_all_test_5", "++" ] }
+      }
+    ]
   }
 ]

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -555,8 +555,8 @@ checks this var exists
 ```
 
 ### `compare_string`
-- type: pair of strings or [variable objects](#variable-object)
-- Compare two strings, and return true if strings are equal
+- type: array of strings or [variable objects](#variable-object)
+- Compare all strings, and return true if at least two of them match
 
 #### Examples
 checks if `victim_type` is `mon_zombie_phase_shrike`
@@ -567,6 +567,42 @@ checks if `victim_type` is `mon_zombie_phase_shrike`
 checks is `victim_type` has `zombie` faction
 ```json
 { "compare_string": [ "zombie", { "mutator": "mon_faction", "mtype_id": { "context_val": "victim_type" } } ] }
+```
+
+Check if victim_type is any in the list
+```json
+"compare_string": [
+  { "context_val": "victim_type" },
+  "mon_hound_tindalos",
+  "mon_darkman",
+  "mon_zombie_phase_shrike",
+  "mon_swarm_structure",
+  "mon_better_half",
+  "mon_hallucinator",
+  "mon_archunk_strong",
+  "mon_void_spider",
+  "mon_XEDRA_officer",
+  "mon_eigenspectre_3",
+  "mon_eigenspectre_4",
+  "mon_living_vector"
+]
+```
+
+Check if `map_cache` contain value `has`, `lack` or `read`
+```json
+{ "compare_string": [ { "npc_val": "map_cache" }, "has", "lack", "read" ] }
+```
+
+### `compare_string_match_all`
+- type: array of strings or [variable objects](#variable-object)
+- Compare all strings, and return true if all of them match
+- For two strings the check is same as compare_string
+
+#### Examples
+
+Check if two variables are `yes`
+```json
+"compare_string": [ "yes", { "context_val": "some_context_should_be_yes" }, { "context_val": "some_another_context_also_should_be_yes" } ]
 ```
 
 ### `u_profession`
@@ -1358,7 +1394,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | activates_mininuke | Triggers when any character arms a mininuke | { "character", `character_id` } | character / NONE |
 | administers_mutagen |  | { "character", `character_id` },<br/> { "technique", `mutagen_technique` }, | character / NONE |
 | angers_amigara_horrors | Triggers when amigara horrors are spawned as part of a mine finale | NONE | avatar / NONE |
-| avatar_enters_omt |  | { "pos", `tripoint` },<br/> { "oter_id", `oter_id` }, | avatar / NONE |
+| avatar_enters_omt | Triggers when player crosses the overmap boundary, including when player spawns | { "pos", `tripoint` },<br/> { "oter_id", `oter_id` }, | avatar / NONE |
 | avatar_moves |  | { "mount", `mtype_id` },<br/> { "terrain", `ter_id` },<br/> { "movement_mode", `move_mode_id` },<br/> { "underwater", `bool` },<br/> { "z", `int` }, | avatar / NONE |
 | avatar_dies |  | NONE | avatar / NONE |
 | awakes_dark_wyrms | Triggers when `pedestal_wyrm` examine action is used | NONE | avatar / NONE |

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1838,7 +1838,7 @@ conditional_t::func f_compare_string( const JsonObject &jo, std::string_view mem
 
     return [values]( const_dialogue const & d ) {
         std::unordered_set<std::string> seen_values;
-        for( const str_or_var &val : values ) { 
+        for( const str_or_var &val : values ) {
             std::string evaluated_value = val.evaluate( d );
             if( seen_values.count( evaluated_value ) > 0 ) {
                 return true;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -34,6 +34,10 @@ static const effect_on_condition_id effect_on_condition_EOC_attack_test( "EOC_at
 static const effect_on_condition_id
 effect_on_condition_EOC_combat_mutator_test( "EOC_combat_mutator_test" );
 static const effect_on_condition_id
+effect_on_condition_EOC_compare_string_test( "EOC_compare_string_test" );
+static const effect_on_condition_id
+effect_on_condition_EOC_compare_string_match_all_test( "EOC_compare_string_match_all_test" );
+static const effect_on_condition_id
 effect_on_condition_EOC_increment_var_var( "EOC_increment_var_var" );
 static const effect_on_condition_id
 effect_on_condition_EOC_item_activate_test( "EOC_item_activate_test" );
@@ -1412,6 +1416,49 @@ TEST_CASE( "EOC_string_test", "[eoc]" )
     CHECK( get_avatar().get_value( "key1" ) == "nest2" );
     CHECK( get_avatar().get_value( "key2" ) == "nest3" );
     CHECK( get_avatar().get_value( "key3" ) == "nest4" );
+}
+
+TEST_CASE( "EOC_compare_string_test", "[eoc]" )
+{
+    clear_avatar();
+    clear_map();
+
+    dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+    global_variables &globvars = get_globals();
+    globvars.clear_global_values();
+
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_test_1" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_test_2" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_test_3" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_test_4" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_test_5" ).empty() );
+
+    CHECK( effect_on_condition_EOC_compare_string_test->activate( d ) );
+
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_test_1" ) ) == Approx( 1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_test_2" ) ) == Approx( 1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_test_3" ) ) == Approx( 1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_test_4" ) ) == Approx( 1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_test_5" ) ) == Approx( 1 ) );
+
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_match_all_test_1" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_match_all_test_2" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_match_all_test_3" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_match_all_test_4" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_match_all_test_5" ).empty() );
+
+    CHECK( effect_on_condition_EOC_compare_string_match_all_test->activate( d ) );
+
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_match_all_test_1" ) ) == Approx(
+               1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_match_all_test_2" ) ) == Approx(
+               1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_match_all_test_3" ) ) == Approx(
+               1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_match_all_test_4" ) ) == Approx(
+               1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_match_all_test_5" ) ) == Approx(
+               1 ) );
 }
 
 TEST_CASE( "EOC_run_eocs", "[eoc]" )

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -34,9 +34,9 @@ static const effect_on_condition_id effect_on_condition_EOC_attack_test( "EOC_at
 static const effect_on_condition_id
 effect_on_condition_EOC_combat_mutator_test( "EOC_combat_mutator_test" );
 static const effect_on_condition_id
-effect_on_condition_EOC_compare_string_test( "EOC_compare_string_test" );
-static const effect_on_condition_id
 effect_on_condition_EOC_compare_string_match_all_test( "EOC_compare_string_match_all_test" );
+static const effect_on_condition_id
+effect_on_condition_EOC_compare_string_test( "EOC_compare_string_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_increment_var_var( "EOC_increment_var_var" );
 static const effect_on_condition_id


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Few random EoC fixes here and there
#### Describe the solution
added ability for compare_string to compare more than 1 string; use it in a few instances for simpler syntax; added unit test to confirm it won't break silently
fix vitrified farm not triggering asap, as it was intended - it was caused by eoc triggering on overmap boundary cross, and aborting because the condition "you stand on terrain X" failing; now it queue itself until it can teleport you properly
fix EOC_DIVING_INTO_WATER_CHECK trying to run event eoc - it doesn't work like this, so i simplified it, and added messages to signalize you indeed scrub away stuff
#### Testing
CI, also visited the quiet farm to confirm it works correctly