### PR TITLE
tests/eoc: use standard NPC in the EOC_run_eocs test

### DIFF
--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -1457,18 +1457,14 @@ TEST_CASE( "EOC_run_eocs", "[eoc]" )
     clear_avatar();
     clear_map();
     clear_npcs();
-    shared_ptr_fast<npc> guy = make_shared_fast<npc>();
-    guy->normalize();
-    overmap_buffer.insert_npc( guy );
-    guy->spawn_at_precise( u.get_location() + tripoint_east );
-    g->load_npcs();
+    npc &guy = spawn_npc( u.pos_bub().xy() + point_east, "thug" );
     tripoint_abs_ms mon_loc = u.get_location() + tripoint_west;
     monster *zombie = g->place_critter_at( mon_zombie, get_map().bub_from_abs( mon_loc ) );
     REQUIRE( zombie != nullptr );
 
     item hammer( "hammer" );
-    item_location hammer_loc( map_cursor{ guy->get_location() }, &hammer );
-    dialogue d2( get_talker_for( *guy ), get_talker_for( hammer_loc ) );
+    item_location hammer_loc( map_cursor{ guy.get_location() }, &hammer );
+    dialogue d2( get_talker_for( guy ), get_talker_for( hammer_loc ) );
     talker *alpha_talker = d2.actor( false );
     talker *beta_talker = d2.actor( true );
 
@@ -1485,10 +1481,10 @@ TEST_CASE( "EOC_run_eocs", "[eoc]" )
     CHECK( globvars.get_global_value( "beta_name" ) == alpha_talker->get_name() );
 
     d2.set_value( "alpha_var", "avatar" );
-    d2.set_value( "beta_var", std::to_string( guy->getID().get_value() ) );
+    d2.set_value( "beta_var", std::to_string( guy.getID().get_value() ) );
     CHECK( effect_on_condition_run_eocs_talker_mixes->activate( d2 ) );
     CHECK( globvars.get_global_value( "alpha_name" ) == get_avatar().get_name() );
-    CHECK( globvars.get_global_value( "beta_name" ) == guy->get_name() );
+    CHECK( globvars.get_global_value( "beta_name" ) == guy.get_name() );
 
     d2.set_value( "alpha_var", std::string{} );
     d2.set_value( "beta_var", std::string{} );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
The `EOC_run_eocs` test uses a dummy npc with no id that breaks assumptions in other parts of the code, as seen [in this job run](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/11877612096/job/33097305312?pr=77934#step:18:160): that mission is assigned with no ID, but when this dummy NPC dies it fails the mission because its ID matches, then the (pointless) debug message shows up because we've already cleared missions on the avatar.

#### Describe the solution
Use a standard test NPC

#### Describe alternatives you've considered
Robustify test infra to ensure there's no stale state for any test unit?

#### Testing

`../build_lto/cata_test --rng-seed 1731840727 "~[slow] ~[.],starting_items"` doesn't trigger the error

Wait for LTO job to finish.

#### Additional context
Perfect example of why we need LTO and ASan jobs to run earlier. It would have taken me <5 minutes to track this down (instead of 2 hours) if CI had run the LTO job for #77359
