### PR TITLE
Severely up rock volume from mined tiles, add limestone to digging results

### DIFF
--- a/data/json/itemgroups/misc.json
+++ b/data/json/itemgroups/misc.json
@@ -174,6 +174,7 @@
       { "item": "rock", "count": [ 1, 4 ], "prob": 10 },
       { "item": "rock_flaking", "count": [ 1, 4 ], "prob": 2 },
       { "item": "flint", "prob": 1 },
+      { "item": "material_limestone", "prob": 1 },
       { "item": "rock_large", "prob": 10 },
       { "item": "field_stone", "prob": 10, "count": [ 1, 4 ] },
       { "item": "pebble", "count": [ 1, 4 ], "prob": 15 }
@@ -195,10 +196,11 @@
     "type": "item_group",
     "subtype": "collection",
     "items": [
-      { "item": "rock", "count": [ 17, 37 ] },
-      { "item": "rock_large", "count": [ 1, 3 ] },
+      { "item": "pebble", "count": [ 50, 100 ] },
+      { "item": "rock", "count": [ 200, 250 ] },
+      { "item": "rock_large", "count": [ 240, 260 ] },
       { "item": "coal_lump", "charges": [ 2500, 5000 ], "prob": 10 },
-      { "item": "material_limestone", "charges": [ 10, 25 ], "prob": 80 },
+      { "item": "material_shrd_limestone", "count": [ 10, 25 ], "prob": 70 },
       { "item": "material_rocksalt", "count": [ 0, 1 ], "prob": 20 },
       { "item": "material_rhodonite", "count": [ 0, 1 ], "prob": 3 },
       { "item": "material_zincite", "count": [ 0, 5 ], "prob": 5 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Mining solid rock now results in a lot more rock and very rarely, you can find a bit of limestone while digging in soil"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

So we have this solid rock tile, which you may mine. I assume it is *at least* 2m³. Yet this gives you currently 37.5l of rock max. This ups the volume of rocks considerably. This can probably be upped even further but I am playing it safe here. Changing the value again is pretty easy.

Also I fell into a geology rabbit hole that was a bit too deep (get it? because its geology) and took me like 2h again. I was researching on finding limestone in topsoil and after reviewing a lot of soil cross sections and reports from 1923[[1]](https://pubs.usgs.gov/bul/0597/report.pdf)[[2]](https://pubs.usgs.gov/bul/0744/report.pdf) I can say this does indeed happen. For logistical reasons I can not link every single cross section I looked at. The above two sources describe glacial deposits and outcrops that are visible on the surface.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Change the total value of 37.5l rocks to 1440-1560l of large rocks, 50-62.5l of ordinary rocks and 1.25-2.5l of pebbles, equaling to max 1625l of rocks.
This changes limestone to limestone shards in that group, which need to be disassembled first and yield more limestone than the other limestone item and makes more sense because indeed, the limestone you get is raw and unrefined. For that reason, I also slightly lowered the chance of limestone appearing.

This also adds a 1% chance per 50l of soil you excavate to contain a small bit of limestone. As explained above, there is a good amount of limestone in Massachusetts and through frost churning, visible outcrops (our boulders also yield limestone) and glacier stuff some of this is bound to be found in topsoil.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Apparently those can also be found near creek/stream beds but considering the situation of the amount of items found next to those I'll pass on that for now.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Applied changes locally. While mining out some solid rock I encountered a pickaxe expired debug message unrelated to my changes. I'll debug that after I filed this one.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

This change rocks. This concludes the geology puns. For now.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
