### PR TITLE
Add trait property to supress traits being granted at random in chargen

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1001,6 +1001,7 @@
     "enchantments": [ { "values": [ { "value": "CONSUME_TIME_MOD", "multiply": 0.5 } ] } ],
     "description": "You've been taught proper table manners from your early childhood on; now, you can't even think about eating without being seated at a table and taking your time.  Eating without a table and chair frustrates you, but eating like a civilized person gives you a bigger morale bonus.",
     "starting_trait": true,
+    "random_at_chargen": false,
     "valid": false
   },
   {
@@ -1242,6 +1243,7 @@
     "points": 2,
     "description": "Practicality is far less important than style.  Your morale is improved by wearing fashionable and attractive clothing.",
     "starting_trait": true,
+    "random_at_chargen": false,
     "valid": false
   },
   {
@@ -1310,6 +1312,7 @@
     "points": 2,
     "description": "For your whole life you've been forbidden from indulging in your peculiar tastes.  Now the world's ended, and you'll be damned if anyone is going to tell you that you can't eat people.",
     "starting_trait": true,
+    "random_at_chargen": false,
     "valid": false,
     "cancels": [ "VEGETARIAN", "VEGAN", "HERBIVORE", "RUMINANT", "GRAZER" ],
     "flags": [ "CANNIBAL" ]
@@ -1321,6 +1324,7 @@
     "points": 1,
     "description": "You're convinced that these things that look vaguely human from elsewhere are definitely not people.  Therefore it's okay to eat them, right?",
     "starting_trait": true,
+    "random_at_chargen": false,
     "valid": false,
     "cancels": [ "VEGETARIAN", "VEGAN", "HERBIVORE", "RUMINANT", "GRAZER", "CANNIBAL" ],
     "flags": [ "STRICT_HUMANITARIAN" ]
@@ -1332,6 +1336,7 @@
     "points": 2,
     "description": "You don't feel any remorse or guilt for harming your fellow man.",
     "starting_trait": true,
+    "random_at_chargen": false,
     "valid": false,
     "social_modifiers": { "intimidate": 5 },
     "types": [ "HUMAN_EMPATHY" ],
@@ -1344,6 +1349,7 @@
     "points": 2,
     "description": "You derive enjoyment from killing things.  Putting end to life seem to spark some dark satisfaction and thrill, and you crave it every moment.",
     "starting_trait": true,
+    "random_at_chargen": false,
     "valid": false,
     "social_modifiers": { "intimidate": 10 },
     "types": [ "HUMAN_EMPATHY" ],
@@ -1916,6 +1922,7 @@
     "vitamin_cost": 160,
     "description": "You suffer from a minor chemical imbalance, whether mental or physical.  Minor changes to your internal chemistry will manifest themselves on occasion, such as hunger, sleepiness, narcotic effects, etc.",
     "starting_trait": true,
+    "random_at_chargen": false,
     "category": [ "SLIME", "MEDICAL", "CHIMERA", "ELFA" ]
   },
   {
@@ -1962,6 +1969,7 @@
     "vitamin_cost": 160,
     "description": "Ever since the sky first broke, you have felt unwell, your head split by alien thoughts.  You will periodically suffer from delusions, ranging from minor effects to full visual hallucinations.  Some of these effects may be controlled through the use of antipsychotics.",
     "starting_trait": true,
+    "random_at_chargen": false,
     "category": [ "MEDICAL" ]
   },
   {
@@ -1972,6 +1980,7 @@
     "vitamin_cost": 160,
     "description": "You randomly fall asleep without any reason.",
     "starting_trait": true,
+    "random_at_chargen": false,
     "category": [ "MEDICAL" ]
   },
   {
@@ -9045,7 +9054,8 @@
     "points": -2,
     "vitamin_cost": 160,
     "description": "You have an unhealthy obsession with fire, and you get anxious if you don't light them every now and then or stand near them often.  However, you gain a mood bonus from doing so.",
-    "starting_trait": true
+    "starting_trait": true,
+    "random_at_chargen": false
   },
   {
     "type": "mutation",

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -198,6 +198,8 @@ struct mutation_branch {
         // Whether it has positive as well as negative effects.
         bool mixed_effect  = false;
         bool startingtrait = false;
+        // By default startingtrait = true traits can be randomly assigned, this allows that to be reversed.
+        bool random_at_chargen = true;
         bool activated     = false;
         translation activation_msg;
         // Should it activate as soon as it is gained?

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -311,6 +311,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string_view src )
     optional( jo, was_loaded, "visibility", visibility, 0 );
     optional( jo, was_loaded, "ugliness", ugliness, 0 );
     optional( jo, was_loaded, "starting_trait", startingtrait, false );
+    optional( jo, was_loaded, "random_at_chargen", random_at_chargen, true );
     optional( jo, was_loaded, "mixed_effect", mixed_effect, false );
     optional( jo, was_loaded, "active", activated, false );
     optional( jo, was_loaded, "starts_active", starts_active, false );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4872,14 +4872,14 @@ void Character::add_traits()
 trait_id Character::random_good_trait()
 {
     return get_random_trait( []( const mutation_branch & mb ) {
-        return mb.points > 0;
+        return mb.points > 0 && mb.random_at_chargen;
     } );
 }
 
 trait_id Character::random_bad_trait()
 {
     return get_random_trait( []( const mutation_branch & mb ) {
-        return mb.points < 0;
+        return mb.points < 0 && mb.random_at_chargen;
     } );
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Got a report of NPCs spawning with unexpected traits after #76935, which I believe expanded the traits that NPCs can have assigned to them.

#### Describe the solution
Add a property to mutations indicating they shouldn't be acquired at random at chargen time.
Adjusted random selection at chargen time to filter on this property.
Assigned new property to traits that shouldn't be randomly assigned, either to players or NPCs.

#### Testing
Need to run a quick test to generate a bunch of random NPCs and enumerate the traits they spawn with.