### PR TITLE
Sidebar widget to show faction territory

### DIFF
--- a/data/json/ui/faction.json
+++ b/data/json/ui/faction.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "territory_desc_label",
+    "type": "widget",
+    "label": "Owner",
+    "style": "text",
+    "var": "faction_territory"
+  }
+]

--- a/data/json/ui/layout.json
+++ b/data/json/ui/layout.json
@@ -245,7 +245,15 @@
     "label": "Location",
     "style": "layout",
     "arrange": "rows",
-    "widgets": [ "place_desc", "lighting_desc", "weather_desc", "moon_phase_desc", "date_desc_label", "time_desc_label" ]
+    "widgets": [
+      "territory_desc_label",
+      "place_desc",
+      "lighting_desc",
+      "weather_desc",
+      "moon_phase_desc",
+      "date_desc_label",
+      "time_desc_label"
+    ]
   },
   {
     "id": "place_date_time_layout",
@@ -253,6 +261,6 @@
     "label": "Place/Date/Time",
     "style": "layout",
     "arrange": "rows",
-    "widgets": [ "place_desc", "date_desc_label", "time_desc_label" ]
+    "widgets": [ "territory_desc_label", "place_desc", "date_desc_label", "time_desc_label" ]
   }
 ]

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -813,6 +813,31 @@ std::pair<std::string, nc_color> display::pain_text_color( const Character &u )
     return std::make_pair( pain_string, pain_color );
 }
 
+std::pair<std::string, nc_color> display::faction_text( const Character &u )
+{
+    std::string display_name = _( "None" );
+    nc_color display_color = c_white;
+    std::optional<basecamp *> bcp = overmap_buffer.find_camp( u.global_omt_location().xy() );
+    if( !bcp ) {
+        return std::pair( display_name, display_color );
+    }
+    basecamp *actual_camp = *bcp;
+    const faction_id &owner = actual_camp->get_owner();
+    if( owner->limited_area_claim && u.global_omt_location() != actual_camp->camp_omt_pos() ) {
+        return std::pair( display_name, display_color );
+    }
+    display_name = owner->name;
+    // TODO: Make this magic number into a constant
+    if( owner->likes_u < -10 ) {
+        display_color = c_red;
+    } else if( u.get_faction()->id == owner ) {
+        display_color = c_blue;
+    } else if( owner->likes_u > 10 ) {
+        display_color = c_green;
+    }
+    return std::pair( display_name, display_color );
+}
+
 nc_color display::bodytemp_color( const Character &u, const bodypart_id &bp )
 {
     nc_color color = c_light_gray; // default

--- a/src/display.h
+++ b/src/display.h
@@ -139,6 +139,7 @@ std::pair<std::string, nc_color> health_text_color( const Character &u );
 std::pair<std::string, nc_color> sleepiness_text_color( const Character &u );
 std::pair<std::string, nc_color> pain_text_color( const Creature &c );
 std::pair<std::string, nc_color> pain_text_color( const Character &u );
+std::pair<std::string, nc_color> faction_text( const Character &u );
 // Character morale, as a color-coded ascii emoticon face
 std::pair<std::string, nc_color> morale_face_color( const avatar &u );
 // Helpers for morale_face_color

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -150,6 +150,8 @@ std::string enum_to_string<widget_var>( widget_var data )
             return "carry_weight_value";
         case widget_var::date_text:
             return "date_text";
+        case widget_var::faction_territory:
+            return "faction_territory";
         case widget_var::env_temp_text:
             return "env_temp_text";
         case widget_var::mood_text:
@@ -1053,6 +1055,7 @@ bool widget::uses_text_function() const
         case widget_var::compass_legend_text:
         case widget_var::date_text:
         case widget_var::env_temp_text:
+        case widget_var::faction_territory:
         case widget_var::mood_text:
         case widget_var::move_count_mode_text:
         case widget_var::pain_text:
@@ -1161,6 +1164,9 @@ std::string widget::color_text_function_string( const avatar &ava, unsigned int 
             break;
         case widget_var::env_temp_text:
             desc.first = display::get_temp( ava );
+            break;
+        case widget_var::faction_territory:
+            desc = display::faction_text( ava );
             break;
         case widget_var::mood_text:
             desc = display::morale_face_color( ava );

--- a/src/widget.h
+++ b/src/widget.h
@@ -60,6 +60,7 @@ enum class widget_var : int {
     compass_legend_text, // Names of visible creatures that appear on the compass
     date_text,      // Current date, in terms of day within season
     env_temp_text,  // Environment temperature, if character has thermometer
+    faction_territory,  // Name of faction whose base/territory you are at, if any
     mood_text,      // Mood as a text emote, color string
     move_count_mode_text, // Movement counter and mode letter like "50(R)", color string
     overmap_loc_text,// Local overmap position, pseudo latitude/longitude with Z-level


### PR DESCRIPTION
#### Summary
Interface "Sidebar widget to show faction territory"

#### Purpose of change
It's weird that you can only know the extent of their territory by trying to be naughty, right?

#### Describe the solution
Add a display which gives you a heads-up.

Also adds immersion value, as you can now "feel" you're moving through their territory as opposed to only being reminded when being naughty.

I added this widget to some of the existing sidebar groupings which included place information, as I felt appropriate.

#### Describe alternatives you've considered
Flags! Flags to every base!

I kinda wanted to do background color/highlighting for the "friendly" and "hostile" indicators but I didn't see a way to do that.

#### Testing


https://github.com/user-attachments/assets/9af69cc6-9f6d-4173-a77b-97a50b07bfde



#### Additional context
