### PR TITLE
Refactor item::made_of_any_food_components

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8661,21 +8661,13 @@ bool item::is_maybe_melee_weapon() const
 
 bool item::made_of_any_food_components( bool deep_search ) const
 {
-    if( components.empty() || !get_comestible() ) {
+    if( components.empty() ) {
         return false;
     }
 
     for( const std::pair<itype_id, std::vector<item>> pair : components ) {
         for( const item &it : pair.second ) {
-            const auto &maybe_food = it.get_comestible();
-            bool must_be_food = maybe_food && ( maybe_food->default_nutrition_read_only().kcal() > 0 ||
-                                                !maybe_food->default_nutrition_read_only().vitamins().empty() );
-            bool has_food_component = false;
-            if( deep_search && !it.components.empty() ) {
-                // make true if any component has food values, even if some don't
-                has_food_component |= it.made_of_any_food_components( deep_search );
-            }
-            if( must_be_food || has_food_component ) {
+            if( it.is_food() || ( deep_search && it.made_of_any_food_components( deep_search ) ) ) {
                 return true;
             }
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/77106#discussion_r1830553963

item::made_of_any_food_components is some crusty code (written by yours truly)

#### Describe the solution
Fix it up

Remove the redundant get_comestible() check at the start. I originally added it to avoid crashing if the component wasn't food, but it doesn't check the component, it checks the parent item! Derp moment on my part. (That crashing was #77500 etc)

Fix up the attempt at an early return. It was going down the entire 'tree' of a single component's err, components before it actually returned, even if it had already found a food item. So again, the early return I wrote was not functioning as it should.

Lastly, replace the checks to default nutrition with item::is_food(). No reason to write new novel code when we should be using the existing checks. Also checking default nutrition is just inappropriate in general.

#### Describe alternatives you've considered
This is not terribly important and it is currently working so no need to change it?

#### Testing
Compiles 👍 

#### Additional context
