### PR TITLE
Food price scales with freshness

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7104,6 +7104,11 @@ int item::price_no_contents( bool practical, std::optional<int> price_override )
 
     }
 
+    // Nominal price for perfectly fresh food, decreasing linearly as it gets closer to expiry
+    if( is_food() ) {
+        price *= ( 1.0 - get_relative_rot() );
+    }
+
     if( is_filthy() ) {
         // Filthy items receieve a fixed price malus. This means common clothing ends up
         // with no value (it's *everywhere*), but valuable items retain most of their value.


### PR DESCRIPTION
#### Summary
Balance "Food price scales with freshness"

#### Purpose of change
I can sell my dirty stinky about-to-be-rotten cheeseburger for the same price as a deliciously fresh one, right from the kitchen. That doesn't seem right.

#### Describe the solution
Scale price with rot, linearly

1% of rot time left = It's worth 1% of the normal price

99% of rot time left = It's worth 99% of the normal price

#### Describe alternatives you've considered
NPCs only buy food you cook on demand, right in front of them? This isn't teppanyaki!!

Some sort of scaling other than linear. Linear is easy and fair enough, though.

#### Testing

Sale price for a chunk of raw meat is $0.44. Wait an hour, sale price is now $0.41.

https://github.com/user-attachments/assets/df0c564e-d45e-46ab-98aa-3142f8376957


#### Additional context
Note that pricing is a two-way street. They're worth less buying *and* selling, though for many players I imagine this will only impact their selling habits.

@Karol1223 **I AM RUINING THE ECONOMY** (just thought you'd like to know)
