### PR TITLE
Reign in carbide craft quantity

### DIFF
--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -2615,14 +2615,14 @@
     "batch_time_factors": [ 25, 2 ],
     "//2": "some loss/waste, e.g. imperfect smelting; powder escaping",
     "//2a": "Lower limit is based on a guesstimate about how much charge you need in the furnace for it to operate",
-    "charges": 95000,
+    "charges": 950,
     "book_learn": [ [ "textbook_chemistry", 4 ], [ "textbook_gaswarfare", 4 ], [ "atomic_survival", 3 ] ],
     "//3": "At least some knowledge on chemicals handling is required.",
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],
     "qualities": [ { "id": "FINE_GRIND", "level": 1 } ],
     "//4": "460kJ per mole @ 70% energy efficiency",
-    "tools": [ [ [ "fake_arc_furnace", 650000 ] ] ],
-    "components": [ [ [ "cac2powder", 100000 ] ] ]
+    "tools": [ [ [ "fake_arc_furnace", 6500 ] ] ],
+    "components": [ [ [ "cac2powder", 1000 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
@EvanBalster  pointed out to me that the batch size for this recipe set by #76788 was way too large.
On review I either neglected to account for charges in the inputs or double counted or something, because it's off by about 100x.

#### Describe the solution
Drop the inputs, outputs, and charges required by 100x.

#### Testing
Re-tested in game and found that the amount needed for the reaction is about half a liter of carbide mix instead of 50, and that it yields about a "metric cup" of carbide.