### PR TITLE
Fix archery_damage_test CI occasional failure

### DIFF
--- a/tests/archery_damage_test.cpp
+++ b/tests/archery_damage_test.cpp
@@ -59,6 +59,8 @@ static void test_projectile_attack( const std::string &target_type, bool killabl
 {
     for( int i = 0; i < 10; ++i ) {
         monster target{ mtype_id( target_type ), tripoint_zero };
+        //the missed_by field is modified by deal_projectile_attack() and must be reset
+        attack.missed_by = accuracy_critical * 0.75;
         target.deal_projectile_attack( nullptr, attack, false );
         CAPTURE( target_type );
         CAPTURE( target.get_hp() );
@@ -73,7 +75,6 @@ static void test_archery_balance( const std::string &weapon_type, const std::str
                                   const std::string &killable, const std::string &unkillable )
 {
     item weapon( weapon_type );
-    // The standard modern hunting arrow, make this a parameter if we extend to crossbows.
     weapon.ammo_set( itype_id( ammo_type ), 1 );
 
     projectile test_projectile;
@@ -83,7 +84,7 @@ static void test_archery_balance( const std::string &weapon_type, const std::str
     test_projectile.critical_multiplier = weapon.ammo_data()->ammo->critical_multiplier;
 
     dealt_projectile_attack attack {
-        test_projectile, nullptr, dealt_damage_instance(), tripoint_bub_ms_zero, accuracy_critical - 0.05
+        test_projectile, nullptr, dealt_damage_instance(), tripoint_bub_ms_zero, accuracy_critical * 0.75
     };
     if( !killable.empty() ) {
         test_projectile_attack( killable, true, attack, weapon_type );
@@ -100,6 +101,8 @@ static void test_archery_balance( const std::string &weapon_type, const std::str
 
 TEST_CASE( "archery_damage_thresholds", "[balance],[archery]" )
 {
+    // undodgable bolt fired with a guaranteed crit 10 times
+
     // Selfbow can't kill a turkey
     test_archery_balance( "selfbow", "arrow_metal", "", "mon_turkey" );
     test_archery_balance( "rep_crossbow", "bolt_steel", "", "mon_turkey" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "fix archery_damage_test CI occasional failure"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fed up with CI failures, this is one of them

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Turns out that `attack.missed_by` was being slightly incremented in `deal_projectile_attack()` and not being reset:
https://github.com/CleverRaven/Cataclysm-DDA/blob/fc8e17709b4d756698a011d9cee34703d652b0b3/tests/archery_damage_test.cpp#L60-L62
So if the `missed_by` rolls (10 d 1000, in this case) were too low, the sum of the 10 iterations' additions to `attack.missed_by` would set it above the crit threshold and the bolts shot for the test wouldn't do enough damage. It took about 30 runs of `archery_damage_test` to isolate this.

I made `attack.missed_by` reset in the loop, so it should be fine now.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I made sure `attack.missed_by` wasn't incrementing anymore, and I ran the test successfully a couple times, but keep an eye out for future failures.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Thankfully, this was just an issue with the test as far as I can tell.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
