### PR TITLE
[MoM] Add the Gamma Sterilization photokinetic power

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -575,6 +575,15 @@ Powers causing photokinetic damage have a 40% chance to blind the target for 3 s
 *Effects*: Unleash a burst of electromagnetic waves, overloading any electronic sensors within the target area.  Any robots caught in the blast will be unable to perceive their environment for the power's duration.<br />
 *Prerequisites*: Star Flash 5 *or* Photon Beam 4, Radio Transception 6<br />
 
+## Gamma Sterilization (C)
+*Difficulty*: 5<br />
+*Target*: Self<br />
+*Duration*: 10 seconds per item of food sterilized<br />
+*Stamina Cost*: 7500, minus 200 per level to a minimum of 4000<br />
+*Channeling Time*: 15 seconds<br />
+*Effects*: Irradiate food, killing bacteria and helping to preserve it for far longer. The psion may irradiate as much food as they can carry, but it takes longer the greater amount of food they wish to irradiate. Every 7 to 9 seconds spent irradiating costs the psion 1 to 3 calories.<br />
+*Prerequisites*: Lucent Barrier 7, Chameleoflage 4, Illuminate 9 *or* Photon Beam 5 *or* Star Flash 3<br />
+
 ## Veil of Light (C)
 *Difficulty*: 6<br />
 *Target*: Self<br />

--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -581,7 +581,7 @@ Powers causing photokinetic damage have a 40% chance to blind the target for 3 s
 *Duration*: 10 seconds per item of food sterilized<br />
 *Stamina Cost*: 7500, minus 200 per level to a minimum of 4000<br />
 *Channeling Time*: 15 seconds<br />
-*Effects*: Irradiate food, killing bacteria and helping to preserve it for far longer. The psion may irradiate as much food as they can carry, but it takes longer the greater amount of food they wish to irradiate. Every 7 to 9 seconds spent irradiating costs the psion 1 to 3 calories.<br />
+*Effects*: Irradiate food, killing bacteria and helping to preserve it for far longer. The psion may irradiate as much food as they can carry, but it takes longer the greater amount of food they wish to irradiate (40g per second time). Every 10 to 15 seconds spent irradiating costs the psion 1 to 3 calories.<br />
 *Prerequisites*: Lucent Barrier 7, Chameleoflage 4, Illuminate 9 *or* Photon Beam 5 *or* Star Flash 3<br />
 
 ## Veil of Light (C)

--- a/data/mods/MindOverMatter/activity_types.json
+++ b/data/mods/MindOverMatter/activity_types.json
@@ -21,6 +21,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "verb": "sterilizing",
     "based_on": "time",
+    "can_resume": false,
     "completion_eoc": "EOC_PHOTOKIN_RADIATION_STERILIZATION_FINALIZE"
   },
   {

--- a/data/mods/MindOverMatter/activity_types.json
+++ b/data/mods/MindOverMatter/activity_types.json
@@ -16,6 +16,14 @@
     "based_on": "time"
   },
   {
+    "id": "ACT_PSI_PHOTOKIN_RADIATION_STERILIZATION",
+    "type": "activity_type",
+    "activity_level": "LIGHT_EXERCISE",
+    "verb": "sterilizing",
+    "based_on": "time",
+    "completion_eoc": "EOC_PHOTOKIN_RADIATION_STERILIZATION_FINALIZE"
+  },
+  {
     "id": "ACT_PSI_STUDYING_POWER",
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
@@ -439,6 +439,7 @@
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_HIDE_UGLY",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_LIGHT_IMAGE",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_RADIO",
+          "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_STERILIZE_FOOD",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_STUN_ROBOTS",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_INVISIBILITY",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_LIGHT_FLASH",
@@ -517,6 +518,14 @@
     "id": "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_RADIO",
     "condition": { "and": [ { "u_has_trait": "PHOTOKINETIC" }, { "math": [ "u_spell_level('photokinetic_radio')", ">=", "0" ] } ] },
     "effect": [ { "u_learn_recipe": "practice_photokinetic_radio" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_STERILIZE_FOOD",
+    "condition": {
+      "and": [ { "u_has_trait": "PHOTOKINETIC" }, { "math": [ "u_spell_level('photokinetic_sterilize_food')", ">=", "0" ] } ]
+    },
+    "effect": [ { "u_learn_recipe": "practice_photokinetic_sterilize_food" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1275,6 +1275,13 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_photokin_sterilization",
+    "//": "Hidden effect, used as a tracker",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_photokin_invisibility",
     "name": [ "Invisibility" ],
     "desc": [ "Nothing can see you." ],

--- a/data/mods/MindOverMatter/json_flags.json
+++ b/data/mods/MindOverMatter/json_flags.json
@@ -107,5 +107,10 @@
     "id": "TELEPORT_IMMUNE",
     "type": "monster_flag",
     "//": "Immune to forcible teleportation"
+  },
+  {
+    "id": "PHOTOKIN_IRRADIATION_READY",
+    "type": "json_flag",
+    "//": "Used to tag foods to be radiation sterilized"
   }
 ]

--- a/data/mods/MindOverMatter/powers/learning_eocs/photokinesis.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/photokinesis.json
@@ -391,7 +391,56 @@
       { "math": [ "u_vitamin('vitamin_psi_learning_counter')", "=", "0" ] },
       { "u_learn_recipe": "practice_photokinetic_radio" },
       {
-        "u_message": "Use of your powers has led to an insight.  You read and broadcast radio waves, communicating with anyone else who is left out there, if you can figure out the technique.",
+        "u_message": "Use of your powers has led to an insight.  You could read and broadcast radio waves, communicating with anyone else who is left out there, if you can figure out the technique.",
+        "popup": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PHOTOKIN_LEARNING_STERILIZE_FOOD",
+    "recurrence": [
+      { "math": [ "jmath_photokinesis_learning_eocs_modifiers(global_tier_two_power_learning_time_low)" ] },
+      { "math": [ "jmath_photokinesis_learning_eocs_modifiers(global_tier_two_power_learning_time_high)" ] }
+    ],
+    "condition": {
+      "and": [
+        { "u_has_trait": "PHOTOKINETIC" },
+        { "math": [ "u_vitamin('vitamin_psi_learning_counter')", "==", "1" ] },
+        {
+          "or": [
+            { "test_eoc": "EOC_CONDITION_ODDS_OF_RANDOM_TIER_TWO_POWER_INSIGHT" },
+            {
+              "and": [
+                { "math": [ "u_spell_level('photokinetic_rad_immunity')", ">=", "7" ] },
+                { "math": [ "u_spell_level('photokinetic_camouflage')", ">=", "4" ] },
+                {
+                  "or": [
+                    { "math": [ "u_spell_level('photokinetic_light_flash')", ">=", "3" ] },
+                    { "math": [ "u_spell_level('photokinetic_light_up_enemy')", ">=", "9" ] },
+                    { "math": [ "u_spell_level('photokinetic_light_beam')", ">=", "5" ] }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        { "test_eoc": "EOC_PSI_LEARNING_BANNED_EFFECTS" },
+        { "math": [ "u_spell_level('photokinetic_sterilize_food')", "<=", "0" ] },
+        { "not": { "u_know_recipe": "practice_photokinetic_sterilize_food" } }
+      ]
+    },
+    "deactivate_condition": {
+      "or": [
+        { "not": { "u_has_trait": "PHOTOKINETIC" } },
+        { "math": [ "u_spell_level('photokinetic_sterilize_food')", ">=", "1" ] }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_vitamin('vitamin_psi_learning_counter')", "=", "0" ] },
+      { "u_learn_recipe": "practice_photokinetic_sterilize_food" },
+      {
+        "u_message": "Use of your powers has led to an insight.  With a focused burst of radiation, you could sterilize food, making it last much longer without going rotten, if you can figure out the technique.",
         "popup": true
       }
     ]

--- a/data/mods/MindOverMatter/powers/photokinesis.json
+++ b/data/mods/MindOverMatter/powers/photokinesis.json
@@ -545,6 +545,28 @@
     }
   },
   {
+    "id": "photokinetic_sterilize_food",
+    "type": "SPELL",
+    "name": "[Ψ]Gamma Sterilization",
+    "description": "Use a focused emission of high-power radiation to eliminating microorganisms in food and allowing it to last much longer before rotting.  This power is <color_red>extremely taxing</color>.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "spell_class": "PHOTOKINETIC",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "NO_HANDS", "NO_LEGS", "SILENT", "RANDOM_DAMAGE" ],
+    "difficulty": 5,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_PHOTOKINETIC_STERILIZE_FOODS",
+    "shape": "blast",
+    "energy_source": "STAMINA",
+    "base_energy_cost": 7500,
+    "final_energy_cost": 4000,
+    "energy_increment": -150,
+    "base_casting_time": 1500
+  },
+  {
     "id": "photokinetic_stun_robots",
     "type": "SPELL",
     "name": "[Ψ]Sensor Jamming",

--- a/data/mods/MindOverMatter/powers/photokinesis.json
+++ b/data/mods/MindOverMatter/powers/photokinesis.json
@@ -563,7 +563,7 @@
     "energy_source": "STAMINA",
     "base_energy_cost": 7500,
     "final_energy_cost": 4000,
-    "energy_increment": -150,
+    "energy_increment": -200,
     "base_casting_time": 1500
   },
   {

--- a/data/mods/MindOverMatter/powers/photokinesis_eocs.json
+++ b/data/mods/MindOverMatter/powers/photokinesis_eocs.json
@@ -101,6 +101,75 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_PHOTOKINETIC_STERILIZE_FOODS",
+    "effect": [
+      { "math": [ "u_photokinetic_sterilize_item_count", "=", "0" ] },
+      {
+        "u_run_inv_eocs": "manual_mult",
+        "title": "What food or drink do you want to sterilize?",
+        "search_data": [
+          { "category": "food", "excluded_flags": [ "IRRADIATED" ] },
+          { "category": "drink", "excluded_flags": [ "IRRADIATED" ] }
+        ],
+        "true_eocs": [
+          {
+            "id": "EOC_PHOTOKINETIC_STERILIZE_FOODS_PREP",
+            "effect": [ { "math": [ "u_photokinetic_sterilize_item_count", "++" ] }, { "npc_set_flag": "PHOTOKIN_IRRADIATION_READY" } ]
+          }
+        ]
+      },
+      {
+        "u_add_effect": "effect_photokin_sterilization",
+        "duration": { "math": [ "(u_photokinetic_sterilize_item_count * 10) + 1" ] }
+      },
+      {
+        "u_assign_activity": "ACT_PSI_PHOTOKIN_RADIATION_STERILIZATION",
+        "duration": { "math": [ "u_photokinetic_sterilize_item_count * 10" ] }
+      },
+      { "run_eocs": "EOC_PHOTOKIN_RADIATION_STERILIZATION_COST", "time_in_future": [ 7, 9 ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PHOTOKIN_RADIATION_STERILIZATION_CANCELS_STERILIZING",
+    "eoc_type": "EVENT",
+    "required_event": "character_finished_activity",
+    "condition": {
+      "and": [
+        { "compare_string": [ "ACT_PSI_PHOTOKIN_RADIATION_STERILIZATION", { "context_val": "activity" } ] },
+        { "u_has_effect": "effect_photokin_sterilization" }
+      ]
+    },
+    "effect": [ { "u_lose_effect": "effect_photokin_sterilization" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PHOTOKIN_RADIATION_STERILIZATION_COST",
+    "condition": { "u_has_effect": "effect_photokin_sterilization" },
+    "effect": [
+      { "math": [ "u_calories()", "-=", "rand(2) + 1" ] },
+      { "run_eocs": "EOC_PHOTOKIN_RADIATION_STERILIZATION_COST", "time_in_future": [ 7, 9 ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PHOTOKIN_RADIATION_STERILIZATION_FINALIZE",
+    "condition": { "u_has_effect": "effect_photokin_sterilization" },
+    "effect": [
+      {
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "flags": [ "PHOTOKIN_IRRADIATION_READY" ] } ],
+        "true_eocs": [
+          {
+            "id": "EOC_PHOTOKIN_RADIATION_STERILIZATION_FINALIZE_END",
+            "effect": [ { "npc_unset_flag": "PHOTOKIN_IRRADIATION_READY" }, { "npc_set_flag": "IRRADIATED" } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PHOTOKIN_REMOVE_INVISIBILITY_MELEE_CHARACTER",
     "//": "This will not prevent invisibility from being removed if you use your psi on someone in melee range, but that is intended--the rippling light distortion from quick movement is what gives you away, and psi doesn't require body movements",
     "eoc_type": "EVENT",

--- a/data/mods/MindOverMatter/powers/photokinesis_eocs.json
+++ b/data/mods/MindOverMatter/powers/photokinesis_eocs.json
@@ -103,7 +103,7 @@
     "type": "effect_on_condition",
     "id": "EOC_PHOTOKINETIC_STERILIZE_FOODS",
     "effect": [
-      { "math": [ "u_photokinetic_sterilize_item_count", "=", "0" ] },
+      { "math": [ "u_photokinetic_sterilize_item_weight_in_grams", "=", "0" ] },
       {
         "u_run_inv_eocs": "manual_mult",
         "title": "What food or drink do you want to sterilize?",
@@ -114,19 +114,23 @@
         "true_eocs": [
           {
             "id": "EOC_PHOTOKINETIC_STERILIZE_FOODS_PREP",
-            "effect": [ { "math": [ "u_photokinetic_sterilize_item_count", "++" ] }, { "npc_set_flag": "PHOTOKIN_IRRADIATION_READY" } ]
+            "effect": [
+              { "math": [ "u_photokinetic_sterilize_item_weight_in_grams", "+=", "n_weight() / 1000" ] },
+              { "npc_set_flag": "PHOTOKIN_IRRADIATION_READY" }
+            ]
           }
         ]
       },
+      { "math": [ "u_photokinetic_sterilize_item_weight_in_grams", "/=", "40" ] },
       {
         "u_add_effect": "effect_photokin_sterilization",
-        "duration": { "math": [ "(u_photokinetic_sterilize_item_count * 10) + 1" ] }
+        "duration": { "math": [ "max( ( u_photokinetic_sterilize_item_weight_in_grams + 1), 1)" ] }
       },
       {
         "u_assign_activity": "ACT_PSI_PHOTOKIN_RADIATION_STERILIZATION",
-        "duration": { "math": [ "u_photokinetic_sterilize_item_count * 10" ] }
+        "duration": { "math": [ "max( ( u_photokinetic_sterilize_item_weight_in_grams + 1), 1)" ] }
       },
-      { "run_eocs": "EOC_PHOTOKIN_RADIATION_STERILIZATION_COST", "time_in_future": [ 7, 9 ] }
+      { "run_eocs": "EOC_PHOTOKIN_RADIATION_STERILIZATION_COST" }
     ]
   },
   {
@@ -148,7 +152,7 @@
     "condition": { "u_has_effect": "effect_photokin_sterilization" },
     "effect": [
       { "math": [ "u_calories()", "-=", "rand(2) + 1" ] },
-      { "run_eocs": "EOC_PHOTOKIN_RADIATION_STERILIZATION_COST", "time_in_future": [ 7, 9 ] }
+      { "run_eocs": "EOC_PHOTOKIN_RADIATION_STERILIZATION_COST", "time_in_future": [ 10, 15 ] }
     ]
   },
   {

--- a/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
@@ -907,6 +907,7 @@
     "tools": [
       [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_photokinesis", -1 ] ]
     ],
+    "components": [ [ [ "matrix_crystal_photokin_dust", 1 ] ] ],
     "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
     "result_eocs": [
       {
@@ -995,6 +996,7 @@
     "tools": [
       [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_photokinesis", -1 ] ]
     ],
+    "components": [ [ [ "matrix_crystal_photokin_dust", 1 ] ] ],
     "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
     "result_eocs": [
       {
@@ -1083,6 +1085,7 @@
     "tools": [
       [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_photokinesis", -1 ] ]
     ],
+    "components": [ [ [ "matrix_crystal_photokin_dust", 1 ] ] ],
     "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
     "result_eocs": [
       {

--- a/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
@@ -21,6 +21,7 @@
       "practice_photokinetic_hide_ugly",
       "practice_photokinetic_light_image",
       "practice_photokinetic_radio",
+      "practice_photokinetic_sterilize_food",
       "practice_photokinetic_stun_robots",
       "practice_photokinetic_invisibility",
       "practice_photokinetic_light_flash",
@@ -965,6 +966,94 @@
                 "popup": true
               },
               { "math": [ "u_spell_level('photokinetic_radio')", "=", "1" ] },
+              { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 25,50)" ] },
+              { "u_lose_effect": "effect_psi_learning_new_power" }
+            ],
+            "false_effect": [
+              { "u_message": "You just couldn't manage to grasp the technique.  You'll have to try again.", "popup": true },
+              { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 25,50 )" ] },
+              { "u_lose_effect": "effect_psi_learning_new_power" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: gamma sterilization",
+    "id": "practice_photokinetic_sterilize_food",
+    "description": "Contemplate your powers and improve your ability use focused radiation to make food last longer.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 4,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
+    "tools": [
+      [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_photokinesis", -1 ] ]
+    ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_PHOTOKIN_STERILIZE_FOOD",
+        "condition": { "math": [ "u_spell_level('photokinetic_sterilize_food')", ">=", "1" ] },
+        "effect": [
+          { "set_string_var": "photokinetic_sterilize_food", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
+        ],
+        "false_effect": [
+          { "set_string_var": "photokinetic_sterilize_food", "target_var": { "u_val": "latest_studied_power_name" } },
+          { "u_message": "You attempt to unlock new capabilities within your mind." },
+          { "u_assign_activity": "ACT_PSI_LEARNING_NEW_POWER", "duration": "16 hours" },
+          { "u_add_effect": "effect_psi_learning_new_power", "duration": "16 hours" },
+          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" },
+          {
+            "run_eocs": "EOC_PRACTICE_PHOTOKIN_STERILIZE_FOOD_LEARNING",
+            "time_in_future": [ { "math": [ "learn_new_power_lower_time_bound(5)" ] }, { "math": [ "learn_new_power_upper_time_bound(5)" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PRACTICE_PHOTOKIN_STERILIZE_FOOD_LEARNING",
+    "condition": {
+      "and": [
+        { "compare_string": [ "photokinetic_sterilize_food", { "u_val": "latest_studied_power_name" } ] },
+        { "u_has_effect": "effect_psi_learning_new_power" },
+        {
+          "not": { "u_has_any_effect": [ "sleep", "effect_vitakin_wakeful_resting", "lack_sleep", "sleep_deprived", "under_operation" ] }
+        }
+      ]
+    },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PRACTICE_PHOTOKIN_STERILIZE_FOOD_LEARNING_2",
+            "condition": {
+              "and": [
+                {
+                  "roll_contested": { "math": [ "u_skill('metaphysics') + u_has_proficiency('prof_contemplation_photokinesis')" ] },
+                  "difficulty": 9
+                }
+              ]
+            },
+            "effect": [
+              {
+                "u_message": "As you meditate, all the pieces suddenly come together.  You've unlocked: <spell_name:<u_val:latest_studied_power_name>>.",
+                "popup": true
+              },
+              { "math": [ "u_spell_level('photokinetic_sterilize_food')", "=", "1" ] },
               { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 25,50)" ] },
               { "u_lose_effect": "effect_psi_learning_new_power" }
             ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add the Gamma Sterilization photokinetic power"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When Photokinetics were first added, they had the ability to irradiate food to make it last longer. Then they lost it. 

Time to bring it back.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Difficulty 5 Gamma Sterilization power, which lets you irradiate food and drink. When you use the power, you get a menu that lets you pick food and then counts up the mass of items you want to irradiate, sets a flag to keep track of them, then starts an activity. This activity is high-energy but short time (40g of food irradiated per second), following the results of #69460. When the activity is completed, the items you picked are irradiated. The calorie cost and time it takes scales with the amount of items selected.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![Untitled2](https://github.com/user-attachments/assets/321c6512-99ac-40d5-a246-cf73364be8e4)

The power can show up through insight, contemplation teaches the power, the power is usage and lasts an appropriate amount of time (mostly a short time). 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
