### PR TITLE
Add std::string wrappers for ImGui::InputText* methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -963,7 +963,7 @@ ASTYLE_SOURCES := $(sort \
 # Third party sources should not be astyle'd
 SOURCES += $(THIRD_PARTY_SOURCES)
 
-IMGUI_SOURCES = $(IMGUI_DIR)/imgui.cpp $(IMGUI_DIR)/imgui_demo.cpp $(IMGUI_DIR)/imgui_draw.cpp $(IMGUI_DIR)/imgui_tables.cpp $(IMGUI_DIR)/imgui_widgets.cpp
+IMGUI_SOURCES = $(IMGUI_DIR)/imgui.cpp $(IMGUI_DIR)/imgui_demo.cpp $(IMGUI_DIR)/imgui_draw.cpp $(IMGUI_DIR)/imgui_stdlib.cpp $(IMGUI_DIR)/imgui_tables.cpp $(IMGUI_DIR)/imgui_widgets.cpp
 ifeq ($(SDL), 1)
 	DEFINES += -DIMGUI_DISABLE_OBSOLETE_KEYIO
 	IMGUI_SOURCES += $(IMGUI_DIR)/imgui_freetype.cpp

--- a/msvc-full-features/ImGui-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/ImGui-lib-vcpkg-static.vcxproj
@@ -57,6 +57,7 @@
     <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdlrenderer2.h" />
     <ClInclude Include="..\src\third-party\imgui\imgui_internal.h" />
     <ClInclude Include="..\src\third-party\imgui\imstb_rectpack.h" />
+    <ClInclude Include="..\src\third-party\imgui\imgui_stdlib.h" />
     <ClInclude Include="..\src\third-party\imgui\imstb_textedit.h" />
     <ClInclude Include="..\src\third-party\imgui\imstb_truetype.h" />
     <ClInclude Include="..\src\third-party\imtui\imtui-impl-ncurses.h" />
@@ -70,6 +71,7 @@
     <ClCompile Include="..\src\third-party\imgui\imgui_freetype.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdl2.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdlrenderer2.cpp" />
+    <ClCompile Include="..\src\third-party\imgui\imgui_stdlib.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_tables.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_widgets.cpp" />
     <ClCompile Include="..\src\third-party\imtui\imtui-impl-ncurses.cpp">

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -3,6 +3,7 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui/imgui.h>
 #include <imgui/imgui_internal.h>
+#include <imgui/imgui_stdlib.h>
 #undef IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui/imgui_freetype.h>
 
@@ -815,7 +816,7 @@ class cataimgui::window_impl
 class cataimgui::filter_box_impl
 {
     public:
-        std::array<char, 255> text;
+        std::string text;
         ImGuiID id;
 };
 
@@ -984,7 +985,6 @@ void cataimgui::window::draw_filter( const input_context &ctxt, bool filtering_a
     if( !filter_impl ) {
         filter_impl = std::make_unique<cataimgui::filter_box_impl>();
         filter_impl->id = 0;
-        filter_impl->text[0] = '\0';
     }
 
     if( !filtering_active ) {
@@ -999,8 +999,7 @@ void cataimgui::window::draw_filter( const input_context &ctxt, bool filtering_a
         ImGui::SameLine();
     }
     ImGui::BeginDisabled( !filtering_active );
-    ImGui::InputText( "##FILTERBOX", filter_impl->text.data(),
-                      filter_impl->text.size() );
+    ImGui::InputText( "##FILTERBOX", &filter_impl->text );
     ImGui::EndDisabled();
     if( !filter_impl->id ) {
         filter_impl->id = GImGui->LastItemData.ID;
@@ -1010,7 +1009,7 @@ void cataimgui::window::draw_filter( const input_context &ctxt, bool filtering_a
 std::string cataimgui::window::get_filter()
 {
     if( filter_impl ) {
-        return std::string( filter_impl->text.data() );
+        return filter_impl->text;
     } else {
         return std::string();
     }
@@ -1022,7 +1021,7 @@ void cataimgui::window::clear_filter()
         ImGuiInputTextState *input_state = ImGui::GetInputTextState( filter_impl->id );
         if( input_state ) {
             input_state->ClearText();
-            filter_impl->text[0] = '\0';
+            filter_impl->text.clear();
         }
     }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -108,7 +108,7 @@
 #include "get_version.h"
 #include "harvest.h"
 #include "iexamine.h"
-#include "imgui/imgui.h"
+#include "imgui/imgui_stdlib.h"
 #include "init.h"
 #include "input.h"
 #include "input_context.h"
@@ -2899,7 +2899,7 @@ class end_screen_data
 class end_screen_ui_impl : public cataimgui::window
 {
     public:
-        std::array<char, 255> text;
+        std::string text;
         explicit end_screen_ui_impl() : cataimgui::window( _( "The End" ) ) {
         }
     protected:
@@ -2925,12 +2925,11 @@ void end_screen_data::draw_end_screen_ui()
     avatar &u = get_avatar();
     const bool is_suicide = g->uquit == QUIT_SUICIDE;
     get_event_bus().send<event_type::game_avatar_death>( u.getID(), u.name, u.male, is_suicide,
-            std::string( p_impl.text.data() ) );
+            p_impl.text );
 }
 
 void end_screen_ui_impl::draw_controls()
 {
-    text[0] = '\0';
     avatar &u = get_avatar();
     ascii_art_id art = ascii_art_ascii_tombstone;
     dialogue d( get_talker_for( u ), nullptr );
@@ -2980,7 +2979,7 @@ void end_screen_ui_impl::draw_controls()
         ImGui::AlignTextToFramePadding();
         cataimgui::draw_colored_text( input_label );
         ImGui::SameLine( str_width_to_pixels( input_label.size() + 2 ), 0 );
-        ImGui::InputText( "##LAST_WORD_BOX", text.data(), text.size() );
+        ImGui::InputText( "##LAST_WORD_BOX", &text );
         ImGui::SetKeyboardFocusHere( -1 );
     }
 

--- a/src/third-party/imgui/imgui_stdlib.cpp
+++ b/src/third-party/imgui/imgui_stdlib.cpp
@@ -1,0 +1,85 @@
+// dear imgui: wrappers for C++ standard library (STL) types (std::string, etc.)
+// This is also an example of how you may wrap your own similar types.
+
+// Changelog:
+// - v0.10: Initial version. Added InputText() / InputTextMultiline() calls with std::string
+
+// See more C++ related extension (fmt, RAII, syntaxis sugar) on Wiki:
+//   https://github.com/ocornut/imgui/wiki/Useful-Extensions#cness
+
+#include "imgui.h"
+#include "imgui_stdlib.h"
+
+// Clang warnings with -Weverything
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"    // warning: implicit conversion changes signedness
+#endif
+
+struct InputTextCallback_UserData
+{
+    std::string*            Str;
+    ImGuiInputTextCallback  ChainCallback;
+    void*                   ChainCallbackUserData;
+};
+
+static int InputTextCallback(ImGuiInputTextCallbackData* data)
+{
+    InputTextCallback_UserData* user_data = (InputTextCallback_UserData*)data->UserData;
+    if (data->EventFlag == ImGuiInputTextFlags_CallbackResize)
+    {
+        // Resize string callback
+        // If for some reason we refuse the new length (BufTextLen) and/or capacity (BufSize) we need to set them back to what we want.
+        std::string* str = user_data->Str;
+        IM_ASSERT(data->Buf == str->c_str());
+        str->resize(data->BufTextLen);
+        data->Buf = (char*)str->c_str();
+    }
+    else if (user_data->ChainCallback)
+    {
+        // Forward to user callback, if any
+        data->UserData = user_data->ChainCallbackUserData;
+        return user_data->ChainCallback(data);
+    }
+    return 0;
+}
+
+bool ImGui::InputText(const char* label, std::string* str, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
+{
+    IM_ASSERT((flags & ImGuiInputTextFlags_CallbackResize) == 0);
+    flags |= ImGuiInputTextFlags_CallbackResize;
+
+    InputTextCallback_UserData cb_user_data;
+    cb_user_data.Str = str;
+    cb_user_data.ChainCallback = callback;
+    cb_user_data.ChainCallbackUserData = user_data;
+    return InputText(label, (char*)str->c_str(), str->capacity() + 1, flags, InputTextCallback, &cb_user_data);
+}
+
+bool ImGui::InputTextMultiline(const char* label, std::string* str, const ImVec2& size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
+{
+    IM_ASSERT((flags & ImGuiInputTextFlags_CallbackResize) == 0);
+    flags |= ImGuiInputTextFlags_CallbackResize;
+
+    InputTextCallback_UserData cb_user_data;
+    cb_user_data.Str = str;
+    cb_user_data.ChainCallback = callback;
+    cb_user_data.ChainCallbackUserData = user_data;
+    return InputTextMultiline(label, (char*)str->c_str(), str->capacity() + 1, size, flags, InputTextCallback, &cb_user_data);
+}
+
+bool ImGui::InputTextWithHint(const char* label, const char* hint, std::string* str, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
+{
+    IM_ASSERT((flags & ImGuiInputTextFlags_CallbackResize) == 0);
+    flags |= ImGuiInputTextFlags_CallbackResize;
+
+    InputTextCallback_UserData cb_user_data;
+    cb_user_data.Str = str;
+    cb_user_data.ChainCallback = callback;
+    cb_user_data.ChainCallbackUserData = user_data;
+    return InputTextWithHint(label, hint, (char*)str->c_str(), str->capacity() + 1, flags, InputTextCallback, &cb_user_data);
+}
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/third-party/imgui/imgui_stdlib.cpp
+++ b/src/third-party/imgui/imgui_stdlib.cpp
@@ -33,7 +33,7 @@ static int InputTextCallback(ImGuiInputTextCallbackData* data)
         std::string* str = user_data->Str;
         IM_ASSERT(data->Buf == str->c_str());
         str->resize(data->BufTextLen);
-        data->Buf = (char*)str->c_str();
+        data->Buf = str->data();
     }
     else if (user_data->ChainCallback)
     {
@@ -53,7 +53,7 @@ bool ImGui::InputText(const char* label, std::string* str, ImGuiInputTextFlags f
     cb_user_data.Str = str;
     cb_user_data.ChainCallback = callback;
     cb_user_data.ChainCallbackUserData = user_data;
-    return InputText(label, (char*)str->c_str(), str->capacity() + 1, flags, InputTextCallback, &cb_user_data);
+    return InputText(label, str->data(), str->capacity() + 1, flags, InputTextCallback, &cb_user_data);
 }
 
 bool ImGui::InputTextMultiline(const char* label, std::string* str, const ImVec2& size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
@@ -65,7 +65,7 @@ bool ImGui::InputTextMultiline(const char* label, std::string* str, const ImVec2
     cb_user_data.Str = str;
     cb_user_data.ChainCallback = callback;
     cb_user_data.ChainCallbackUserData = user_data;
-    return InputTextMultiline(label, (char*)str->c_str(), str->capacity() + 1, size, flags, InputTextCallback, &cb_user_data);
+    return InputTextMultiline(label, str->data(), str->capacity() + 1, size, flags, InputTextCallback, &cb_user_data);
 }
 
 bool ImGui::InputTextWithHint(const char* label, const char* hint, std::string* str, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
@@ -77,7 +77,7 @@ bool ImGui::InputTextWithHint(const char* label, const char* hint, std::string* 
     cb_user_data.Str = str;
     cb_user_data.ChainCallback = callback;
     cb_user_data.ChainCallbackUserData = user_data;
-    return InputTextWithHint(label, hint, (char*)str->c_str(), str->capacity() + 1, flags, InputTextCallback, &cb_user_data);
+    return InputTextWithHint(label, hint, str->data(), str->capacity() + 1, flags, InputTextCallback, &cb_user_data);
 }
 
 #if defined(__clang__)

--- a/src/third-party/imgui/imgui_stdlib.h
+++ b/src/third-party/imgui/imgui_stdlib.h
@@ -1,0 +1,21 @@
+// dear imgui: wrappers for C++ standard library (STL) types (std::string, etc.)
+// This is also an example of how you may wrap your own similar types.
+
+// Changelog:
+// - v0.10: Initial version. Added InputText() / InputTextMultiline() calls with std::string
+
+// See more C++ related extension (fmt, RAII, syntaxis sugar) on Wiki:
+//   https://github.com/ocornut/imgui/wiki/Useful-Extensions#cness
+
+#pragma once
+
+#include <string>
+
+namespace ImGui
+{
+    // ImGui::InputText() with std::string
+    // Because text input needs dynamic resizing, we need to setup a callback to grow the capacity
+    IMGUI_API bool  InputText(const char* label, std::string* str, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = nullptr, void* user_data = nullptr);
+    IMGUI_API bool  InputTextMultiline(const char* label, std::string* str, const ImVec2& size = ImVec2(0, 0), ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = nullptr, void* user_data = nullptr);
+    IMGUI_API bool  InputTextWithHint(const char* label, const char* hint, std::string* str, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = nullptr, void* user_data = nullptr);
+}


### PR DESCRIPTION
#### Summary
Infrastructure "Add std::string wrappers for ImGui::InputText* methods"

#### Purpose of change

Came up in #77863, but moved to its own PR to reduce size.

#### Describe the solution

Add the examples from the imgui repo, but replace casting away the const from `std::string::c_str` with using `std::string::data`.
Use the string version in the keybindings ui and the end screen, currently the only uses of input boxes as far as I'm aware.

I've been told nothing is necessary, but I'm still not sure if the first commit needs any kind of attribution, as that's code directly taken from the imgui repository.

#### Describe alternatives you've considered

Maybe organize this differently? As it is, this requires including `imgui/imgui_stdlib.h` when you want to use it, instead of the usual `imgui.h`, which might be unexpected and thus overlooked by developers. And maybe we don't even want to have this in third-party at all?

#### Testing

Filtered some keybinds and let a character die.

#### Additional context

