### PR TITLE
Fix camp expansion recipes not being available

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -3524,7 +3524,7 @@ class Character : public Creature, public visitable
         // providing the recipe or a nearby allied Character knows it.
         bool has_recipe( const recipe *r ) const;
         bool knows_recipe( const recipe *rec ) const;
-        void learn_recipe( const recipe *rec );
+        void learn_recipe( const recipe *rec, bool override_never_learn = false );
         void forget_recipe( const recipe *rec );
         void forget_all_recipes();
         int exceeds_recipe_requirements( const recipe &rec ) const;

--- a/src/character_crafting.cpp
+++ b/src/character_crafting.cpp
@@ -29,9 +29,9 @@ bool Character::knows_recipe( const recipe *rec ) const
     return get_learned_recipes().contains( rec );
 }
 
-void Character::learn_recipe( const recipe *const rec )
+void Character::learn_recipe( const recipe *const rec, bool override_never_learn )
 {
-    if( rec->never_learn ) {
+    if( rec->never_learn && !override_never_learn ) {
         return;
     }
     learned_recipes->include( rec );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3510,7 +3510,7 @@ void basecamp::start_crafting( const mission_id &miss_id )
     int num_to_make = 1;
     npc dummy;
     for( const recipe_id &some_known_recipe : recipe_deck_all() ) {
-        dummy.learn_recipe( &*some_known_recipe );
+        dummy.learn_recipe( &*some_known_recipe, true );
     }
     for( const npc_ptr &guy : assigned_npcs ) {
         if( guy.get() ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix camp expansion recipes not being available"

#### Purpose of change
Recipes granted by camp expansions were not available through the new:tm: GUI crafting. Why?

![image](https://github.com/user-attachments/assets/85e264f1-f906-47e7-967b-750a29929228)

They were set to never_learn, and to display the recipes we assemble a dummy that *learns them*.

#### Describe the solution
Add an override to force it

#### Describe alternatives you've considered
We could just remove never_learn from the recipes, but then I expect we'd introduce other bugs

#### Testing
![image](https://github.com/user-attachments/assets/dd03ebcc-7697-415d-ad1d-125d08797981)


#### Additional context
