### PR TITLE
Re-allow camps to craft liquid items

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1856,8 +1856,8 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             } else if( !available[line].can_craft ||
                        !available[line].crafter_has_primary_skill ) {
                 popup( _( "Crafter can't craft that!" ) );
-            } else if( !crafter->check_eligible_containers_for_crafting( *current[line],
-                       batch ? line + 1 : 1 ) ) {
+            } else if( available[line].inv_override == nullptr &&
+                       !crafter->check_eligible_containers_for_crafting( *current[line], batch ? line + 1 : 1 ) ) {
                 // popup is already inside check
             } else if( crafter->lighting_craft_speed_multiplier( *current[line] ) <= 0.0f ) {
                 popup( _( "Crafter can't see!" ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
It was not possible to craft liquids at camp since #77715. I thought I had properly accommodated it, but I had not. It was VERY sneakily failing, without any indication. The recipe showed as available (because it was), but pressing enter on the recipe did nothing!

Character::check_eligible_containers_for_crafting silently returns false *without querying at all* because npc::query_yn() always returns false. It doesn't run the popup at all.

#### Describe the solution
Return to the status quo *for camp crafting only*. Since the results are going to be dumped into available LIQUIDCONT furniture/terrains, Character::check_eligible_containers_for_crafting is not doing anything useful. It doesn't matter if our dummy NPC is or isn't holding containers, nothing will be going into them. So just plain skip the check.

#### Describe alternatives you've considered
npc::query_yn() should probably debugmsg, or the crafting window should not allow this kind of silently dropped input.

#### Testing
Crafted some strong alcohol at the camp, it let me

#### Additional context

This situation was never possible before, because only the player could craft through the GUI. Even after NPCs got the ability to craft, they were restricted from crafting liquids which precluded them from trying to activate the recipe (and find this bug). I turned on NPCs being allowed to craft liquids, but only when called from the camp. Thus we have now found this bug.
