### PR TITLE
reorder the cardinal direction indicators in the AIM drop window

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -56,13 +56,7 @@ class uilist_impl : cataimgui::window
             return parent.desired_bounds.value_or( parent.calculated_bounds );
         }
         void draw_controls() override;
-        void on_resized() override;
 };
-
-void uilist_impl::on_resized()
-{
-    parent.setup();
-}
 
 void uilist_impl::draw_controls()
 {
@@ -897,7 +891,6 @@ shared_ptr_fast<uilist_impl> uilist::create_or_get_ui()
         } else {
             ui = current_ui = make_shared_fast<uilist_impl>( *this, title );
         }
-        current_ui->on_resized();
     }
     return current_ui;
 }


### PR DESCRIPTION
#### Summary
Interface "some little improvements to the AIM drop menu"

#### Purpose of change

I put the rows in the wrong order, so they no longer corresponded to the numpad. While I’m here, make some other little improvements that I think people will like.

Fixes #77967

#### Testing

Open the advanced inventory manager, then drop something. When it asks which square to drop it in to, examine the menu to ensure its correctness.