### PR TITLE
Better margin of error for test shot_custom_damage_type

### DIFF
--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -442,8 +442,7 @@ TEST_CASE( "synthetic_range_test", "[.]" )
 static void shoot_monster( const std::string &gun_type, const std::vector<std::string> &mods,
                            const std::string &ammo_type, int range,
                            int expected_damage, const std::string &monster_type,
-                           const std::function<bool ( const standard_npc &, const monster & )> &other_checks = nullptr,
-                           const Approx &expected_other_checks = Approx( 0 ) )
+                           const std::function<bool ( const standard_npc &, const monster & )> &other_checks = nullptr )
 {
     clear_map();
     statistics<int> damage;
@@ -479,7 +478,7 @@ static void shoot_monster( const std::string &gun_type, const std::vector<std::s
     CAPTURE( avg );
     CHECK( avg == Approx( expected_damage ).margin( 20 ) );
     if( other_checks ) {
-        CHECK( other_check_success == expected_other_checks );
+        CHECK( other_check_success == Approx( damage.n() ).margin( 10 ) );
     }
 }
 
@@ -589,14 +588,15 @@ TEST_CASE( "shot_custom_damage_type", "[gun]" "[slow]" )
                tgt.get_value( "general_dmg_type_test_test_fire" ) == "target";
     };
     // Check that ballistics damage processes weird damage types and on-hit EOCs
+    // note: shotguns can miss one-shot critical hit rarely
     shoot_monster( "shotgun_s", {}, "test_shot_00_fire_damage", 1, 80,
-                   "mon_test_zombie", check_eocs, Approx( 200 ).margin( 100 ) );
+                   "mon_test_zombie", check_eocs );
     shoot_monster( "shotgun_s", {}, "test_shot_00_fire_damage", 1, 80,
-                   "mon_test_fire_resist", check_eocs, Approx( 200 ).margin( 100 ) );
+                   "mon_test_fire_resist", check_eocs );
     shoot_monster( "shotgun_s", {}, "test_shot_00_fire_damage", 1, 18,
-                   "mon_test_fire_vresist", check_eocs, Approx( 200 ).margin( 100 ) );
+                   "mon_test_fire_vresist", check_eocs );
     shoot_monster( "shotgun_s", {}, "test_shot_00_fire_damage", 1, 0,
-                   "mon_test_fire_immune", check_eocs, Approx( 200 ).margin( 100 ) );
+                   "mon_test_fire_immune", check_eocs );
 }
 
 // Targeting graph tests


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "better margin of error for test shot_custom_damage_type"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

More test CI fixes

For `ranged_balance_test.cpp`, we'd occasionally see the test `shot_custom_damage_type` fail a check.

In `shot_custom_damage_type`, because the used weapon (shotgun) can miss a one-shot critical hit rarely, the check for whether an EOC was applied on hit would fail. This check was counted per run of `shoot_monster`; the sum of these EOC checks was set to be inside the interval [100, 300]. However, the test can `break;` at 101 runs:
https://github.com/CleverRaven/Cataclysm-DDA/blob/a6dd3f30b321235c924030c6d7c134705a95b76c/tests/ranged_balance_test.cpp#L466-L468

So if two crits missed, 101-2 = 99 is outside [100, 300]. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Set the margin to (total runs) +/- 10 instead of (arbitrary runs) [100,300]. This is more accurate and actually a smaller MoE than it currently is.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

If you see this particular test case fail again, report it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Apparently creatures can bleed while taking 0 damage from `fire_gun`? I'll try to verify this tomorrow.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
