### PR TITLE
fix incorrect variable migration

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -876,7 +876,7 @@ void game::legacy_migrate_npctalk_var_prefix( std::unordered_map<std::string, st
     // migrate existing variables with npctalk_var prefix to no prefix (npctalk_var_foo to just foo)
     // remove after 0.J
 
-    if( savegame_loading_version >= 35 ) {
+    if( savegame_loading_version >= 36 ) {
         return;
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -871,7 +871,7 @@ void game::load_map( const tripoint_abs_sm &pos_sm,
 }
 
 void game::legacy_migrate_npctalk_var_prefix( std::unordered_map<std::string, std::string>
-        map_of_vars )
+        &map_of_vars )
 {
     // migrate existing variables with npctalk_var prefix to no prefix (npctalk_var_foo to just foo)
     // remove after 0.J

--- a/src/game.h
+++ b/src/game.h
@@ -737,7 +737,7 @@ class game
         void load_map( const tripoint_abs_sm &pos_sm, bool pump_events = false );
         // Removes legacy npctalk_var_ prefix from older versions of the game. Should be removed after 0.J
         static void legacy_migrate_npctalk_var_prefix( std::unordered_map<std::string, std::string>
-                map_of_vars );
+                &map_of_vars );
         /**
          * The overmap which contains the center submap of the reality bubble.
          */

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -69,7 +69,7 @@ extern std::map<std::string, std::list<input_event>> quick_shortcuts_map;
  * Changes that break backwards compatibility should bump this number, so the game can
  * load a legacy format loader.
  */
-const int savegame_version = 35;
+const int savegame_version = 36;
 
 /*
  * This is a global set by detected version header in .sav, maps.txt, or overmap.

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2817,7 +2817,7 @@ void item::io( Archive &archive )
     // game::legacy_migrate_npctalk_var_prefix( item_vars );
     // doesn't work here, because item_vars is cata::heap<std::map<>>, not std::unordered_map<>
     // remove after 0.J
-    if( savegame_loading_version < 35 ) {
+    if( savegame_loading_version < 36 ) {
         const std::string prefix = "npctalk_var_";
         for( auto i = item_vars.begin(); i != item_vars.end(); ) {
             if( i->first.rfind( prefix, 0 ) == 0 ) {

--- a/tests/submap_load_test.cpp
+++ b/tests/submap_load_test.cpp
@@ -851,7 +851,7 @@ static JsonValue submap_fd_pre_migration = json_loader::from_string( submap_fd_p
 static void load_from_jsin( submap &sm, const JsonValue &jsin )
 {
     // Ensure that the JSON is up to date for our savegame version
-    REQUIRE( savegame_version == 35 );
+    REQUIRE( savegame_version == 36 );
     int version = 0;
     JsonObject sm_json = jsin.get_object();
     if( sm_json.has_member( "version" ) ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #77980
#### Describe the solution
Apply fix by Andrei
#### Additional context
I still not sure what it does fully
~~I do not bump the game version again because it won't help with variables that were already migrated incorrectly~~ version is bumped once again