### PR TITLE
Optimized scent_map::shift

### DIFF
--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -82,14 +82,21 @@ void scent_map::draw( const catacurses::window &win, const int div, const tripoi
 
 void scent_map::shift( const point &sm_shift )
 {
-    scent_array<int> new_scent;
-    for( size_t x = 0; x < MAPSIZE_X; ++x ) {
-        for( size_t y = 0; y < MAPSIZE_Y; ++y ) {
+    // Set up iteration such that we ensure data has been moved before
+    // it's overwritten.
+    const int x_start = sm_shift.x >= 0 ? 0 : MAPSIZE_X - 1;
+    const int x_stop = sm_shift.x >= 0 ? MAPSIZE_X : -1;
+    const int x_step = sm_shift.x >= 0 ? 1 : -1;
+    const int y_start = sm_shift.y >= 0 ? 0 : MAPSIZE_Y - 1;
+    const int y_stop = sm_shift.y >= 0 ? MAPSIZE_Y : -1;
+    const int y_step = sm_shift.y >= 0 ? 1 : -1;
+
+    for( int x = x_start; x != x_stop; x += x_step ) {
+        for( int y = y_start; y != y_stop; y += y_step ) {
             const point p = point( x, y ) + sm_shift;
-            new_scent[x][y] = inbounds( p ) ? grscent[ p.x ][ p.y ] : 0;
+            grscent[x][y] = inbounds( p ) ? grscent[p.x][p.y] : 0;
         }
     }
-    grscent = new_scent;
 }
 
 int scent_map::get( const tripoint &p ) const


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Optimize scent_map operation scent_map::shift to make it faster and not warn about stack usage.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Copy the logic from map::shift which has already solved the problem of determining in which direction to iterate in two dimensions in order to ensure entries are overwritten only after they have been copied. The change gets rid of a local map that then is copied onto the "real" map, and instead makes all the changes in the "real" map directly.

Also had to change iterator type from `size_t` to `int`, as the former is unsigned, and thus doesn't contain -1 (the value fulfilling the break condition when iterating from the top).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Ignore it. It's probably not particularly important.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Not sure if the test is actually testing the correct thing...
- Load a save.
- Walk to some reasonably open area.
- Debug enable scent map display.
- Walk in one direction for a fair distance (132+ tiles).
- Walk back.
- Shift directions to all 8 alternatives.

The observation is that the scent map remain as a trail when walking in one direction, but then breaks and gets removed in front of you when walking back, erasing old data at a distance (while generating new data in the immediate vicinity). The erasure seems to be about the reality bubble range away, so it seems to work correctly, but I'm not entirely sure, as I've never looked at this before.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
