### PR TITLE
drying_rate test displays weather, clears map

### DIFF
--- a/tests/limb_test.cpp
+++ b/tests/limb_test.cpp
@@ -7,6 +7,7 @@
 #include "item.h"
 #include "itype.h"
 #include "magic_enchantment.h"
+#include "map_helpers.h"
 #include "mutation.h"
 #include "player_helpers.h"
 
@@ -35,6 +36,7 @@ sub_body_part_sub_limb_test_bird_foot_l( "sub_limb_test_bird_foot_l" );
 static const sub_bodypart_str_id
 sub_body_part_sub_limb_test_bird_foot_r( "sub_limb_test_bird_foot_r" );
 
+static const ter_str_id ter_t_grass( "t_grass" );
 static const trait_id trait_DEBUG_BIG_HEAD( "DEBUG_BIG_HEAD" );
 static const trait_id trait_DEBUG_ONLY_HEAD( "DEBUG_ONLY_HEAD" );
 static const trait_id trait_DEBUG_TAIL( "DEBUG_TAIL" );
@@ -160,9 +162,18 @@ TEST_CASE( "Healing/mending_bonuses", "[character][limb]" )
 
 TEST_CASE( "drying_rate", "[character][limb]" )
 {
+    clear_map();
+    map &here = get_map();
     standard_npc dude( "Test NPC" );
     clear_character( dude, true );
     const weather_manager weather = get_weather();
+
+    REQUIRE( here.ter( dude.pos() ).id() == ter_t_grass );
+    REQUIRE( here.furn( dude.pos() ).id() == furn_str_id::NULL_ID() );
+    CAPTURE( weather.weather_id.c_str() );
+    CAPTURE( units::to_fahrenheit( weather.temperature ) );
+    CAPTURE( weather.weather_precise->humidity );
+
     REQUIRE( body_part_arm_l->drying_rate == 1.0f );
     dude.drench( 100, dude.get_drenching_body_parts(), false );
     REQUIRE( dude.get_part_wetness( body_part_arm_l ) == 200 );
@@ -178,6 +189,8 @@ TEST_CASE( "drying_rate", "[character][limb]" )
     // Birdify, clear water
     clear_character( dude, true );
     create_bird_char( dude );
+    REQUIRE( here.ter( dude.pos() ).id() == ter_t_grass );
+    REQUIRE( here.furn( dude.pos() ).id() == furn_str_id::NULL_ID() );
     REQUIRE( body_part_test_bird_wing_l->drying_rate == 2.0f );
     REQUIRE( body_part_test_bird_wing_r->drying_rate == 0.5f );
     REQUIRE( dude.get_part_wetness( body_part_test_bird_wing_l ) == 0 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "drying_rate test displays weather, clears map"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

In `limb_test.cpp`, the `drying_rate` test gave the following on one of my PRs:
```
Mods-(~[slow] ~[.],starting_items)=> ../tests/limb_test.cpp:203: FAILED:
Mods-(~[slow] ~[.],starting_items)=>   CHECK( low_dry == Approx( 900 ).margin( 300 ) )
Mods-(~[slow] ~[.],starting_items)=> with expansion:
Error: Mods-(~[slow] ~[.],starting_items)=>   1213 (0x4bd) == Approx( 900.0 )
```
I know I've seen this one before. I ran `drying_rate` by itself about 30 times, then put a loop in to run it ~1000 times, ran that a couple times, and got no errors. The average is closer to 870 checks versus the expected, which is fine since the MoE is 300. Something is making the drying take unusually long, and it only seems to occur in the full test suite.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I couldn't replicate the test failure, even with the same RNG seed, test call, and build from the PR. Instead, I added a `clear_map()` because we don't want to test the NPC drying off while they're sitting in a shallow river, and added a print for the weather data, just in case.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I haven't seen a fail from the test yet, but if you see it again, report it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
