### PR TITLE
Tests: clear_map() clears basecamps

### DIFF
--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -205,6 +205,9 @@ class basecamp
         //change name of camp
         void set_name( const std::string &new_name );
         void query_new_name( bool force = false );
+        // remove the camp without safety checks; use abandon_camp() for in-game
+        void remove_camp( const tripoint_abs_omt &omt_pos ) const;
+        // remove the camp from an in-game context
         void abandon_camp();
         void scan_pseudo_items();
         void add_expansion( const std::string &terrain, const tripoint_abs_omt &new_pos );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2165,6 +2165,21 @@ void basecamp::start_upgrade( const mission_id &miss_id )
     }
 }
 
+void basecamp::remove_camp( const tripoint_abs_omt &omt_pos ) const
+{
+    std::set<tripoint_abs_omt> &known_camps = get_player_character().camps;
+    known_camps.erase( omt_pos );
+
+    overmap_buffer.remove_camp( *this );
+
+    map &here = get_map();
+    const tripoint_abs_sm sm_pos = coords::project_to<coords::sm>( omt_pos );
+    const tripoint_abs_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
+    // We cannot use bb_pos here, because bb_pos may be {0,0,0} if you haven't examined the bulletin board on camp ever.
+    // here.remove_submap_camp( here.getlocal( bb_pos ) );
+    here.remove_submap_camp( here.bub_from_abs( ms_pos ) );
+}
+
 void basecamp::abandon_camp()
 {
     validate_assignees();
@@ -2181,15 +2196,7 @@ void basecamp::abandon_camp()
     }
     // We must send this message early, before the name is erased.
     add_msg( m_info, _( "You abandon %s." ), name );
-    std::set<tripoint_abs_omt> &known_camps = get_player_character().camps;
-    known_camps.erase( omt_pos );
-    overmap_buffer.remove_camp( *this );
-    map &here = get_map();
-    const tripoint_abs_sm sm_pos = coords::project_to<coords::sm>( omt_pos );
-    const tripoint_abs_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
-    // We cannot use bb_pos here, because bb_pos may be {0,0,0} if you haven't examined the bulletin board on camp ever.
-    // here.remove_submap_camp( here.getlocal( bb_pos ) );
-    here.remove_submap_camp( here.bub_from_abs( ms_pos ) );
+    remove_camp( omt_pos );
 }
 
 void basecamp::scan_pseudo_items()

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -22,6 +22,7 @@
 #include "map_iterator.h"
 #include "mapdata.h"
 #include "npc.h"
+#include "overmapbuffer.h"
 #include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
@@ -123,6 +124,18 @@ void clear_zones()
     zm.clear();
 }
 
+void clear_basecamps()
+{
+    std::optional<basecamp *> camp;
+    do {
+        const tripoint_abs_omt &avatar_pos = get_avatar().global_omt_location();
+        camp = overmap_buffer.find_camp( avatar_pos.xy() );
+        if( camp && *camp != nullptr ) {
+            ( **camp ).remove_camp( avatar_pos );
+        }
+    } while( camp );
+}
+
 void clear_map( int zmin, int zmax )
 {
     map &here = get_map();
@@ -140,6 +153,7 @@ void clear_map( int zmin, int zmax )
         clear_items( z );
     }
     here.process_items();
+    clear_basecamps();
 }
 
 void clear_map_and_put_player_underground()

--- a/tests/map_helpers.h
+++ b/tests/map_helpers.h
@@ -18,6 +18,7 @@ void clear_npcs();
 void clear_fields( int zlevel );
 void clear_items( int zlevel );
 void clear_zones();
+void clear_basecamps();
 void clear_map( int zmin = -2, int zmax = 0 );
 void clear_radiation();
 void clear_map_and_put_player_underground();

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -336,6 +336,7 @@ TEST_CASE( "npc_talk_location", "[npc_talk]" )
     dialogue d;
     prep_test( d );
 
+    REQUIRE( !overmap_buffer.find_camp( get_avatar().global_omt_location().xy() ) );
     change_om_type( "pond_field_north" );
     d.add_topic( "TALK_TEST_LOCATION" );
     d.gen_responses( d.topic_stack.back() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "clear basecamps for tests in clear_map()"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When the test `npc_talk_location` was run after any set of tests that makes a basecamp (e.g. `camp_calorie_counting`), it would fail. This was because camps could still exist on the overmap tile from those previous tests, which would count as a dialogue response for this:
```JSON
{
  "text": "This is a faction camp any test response.",
  "topic": "TALK_DONE",
  "condition": { "u_at_om_location": "FACTION_CAMP_ANY" }
},
```
and the dialogue counts would be larger than expected.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

EDIT: clear_map() removes all basecamps, added it to the test. Added a `REQUIRE` that makes sure there aren't any camps found.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran `npc_talk_location` by itself and with `camp_calorie_counting` before it, no errors.

EDIT: Ran all tests locally, no issues, check for test errors in CI

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The faction camp OM used (`faction_base_camp_11`) is legacy, should probably be removed 

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
