### PR TITLE
Add practice for learning to pick locks from scratch

### DIFF
--- a/data/json/recipes/practice/devices.json
+++ b/data/json/recipes/practice/devices.json
@@ -1,5 +1,23 @@
 [
   {
+    "id": "prac_lockpicking_inexperienced",
+    "type": "practice",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_PRACTICE",
+    "subcategory": "CSC_PRACTICE_DEVICES",
+    "name": "lockpicking (inexperienced)",
+    "description": "Figure out how to pick locks by trial and error, though your clumsy attempts will break the pick and jam the lock.",
+    "skill_used": "traps",
+    "practice_data": { "min_difficulty": 0, "max_difficulty": 1, "skill_limit": 2 },
+    "proficiencies": [ { "proficiency": "prof_lockpicking", "time_multiplier": 1, "skill_penalty": 0 } ],
+    "time": "1 h",
+    "//": "Crude picks will eventually lose their shape and the lock will be ruined by clumsy attempts.",
+    "components": [ [ [ "crude_picklock", 1 ] ], [ [ "lock", 1 ] ] ],
+    "autolearn": [ [ "traps", 0 ] ],
+    "//2": "Lock picking is mostly done by touch, but complete darkness makes it slightly harder.",
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
     "id": "prac_lockpicking_crude",
     "type": "practice",
     "activity_level": "NO_EXERCISE",
@@ -14,7 +32,7 @@
     "tools": [ [ "lock" ] ],
     "//": "Crude picks will eventually lose their shape",
     "components": [ [ [ "crude_picklock", 1 ] ] ],
-    "autolearn": [ [ "traps", 3 ] ],
+    "autolearn": [ [ "traps", 2 ] ],
     "book_learn": [ [ "book_lockpick", 1 ] ],
     "//2": "Lock picking is mostly done by touch, but complete darkness makes it slightly harder.",
     "flags": [ "BLIND_EASY" ]
@@ -33,7 +51,7 @@
     "time": "1 h",
     "qualities": [ { "id": "LOCKPICK", "level": 5 } ],
     "tools": [ [ "lock" ] ],
-    "autolearn": [ [ "traps", 3 ] ],
+    "autolearn": [ [ "traps", 2 ] ],
     "book_learn": [ [ "book_lockpick", 1 ] ],
     "flags": [ "BLIND_EASY" ]
   },


### PR DESCRIPTION
#### Summary
Content "Add practice recipe for picking locks while inexperienced"

#### Purpose of change
Currently to learn to pick locks, you need to repeatedly fail to pick locks for an inordinate amount of time, contrive an unrelated means to train Devices to 3 (crafting or reading about traps) then practice, or find the [very rare lockpicking book](https://cdda-guide.nornagon.net/item/book_lockpick).

Practicing lockpicking by using a rudimentary pick on the door at the evac shelter with a default survivor:

| Attempts | Time | Devices | Lockpicking | Consumed   |
| -------- | ---- | ------- | ----------- | ---------- |
| 1        | 50 m | 0 (28%) | 4%          |            |
| 2        | 47 m | 0 (70%) | 7%          |            |
| 3        | 43 m | 1 (0%)  | 10%         |            |
| 4        | 40 m | 1 (10%) | 13%         |            |
| 5        | 39 m | 1 (18%) | 16%         | Pick broke |
| 6        | 38 m | 1 (28%) | 19%         |            |
| 7        | 37 m | 1 (37%) | 22%         |            |
| 8        | 37 m | 1 (40%) | 25%         |            |
| 9        | 36 m | 1 (51%) | 27%         |            |
| 10       | 36 m | 1 (57%) | 30%         | Pick broke |

(Note the devices skill gain is randomized per attempt, so you won't exactly reproduce these results.)

#### Describe the solution

Add a new practice recipe that consumes the lock as well as the pick that can bootstrap you into the current lock picking practice skills.

The new recipe exchanges using more material for reducing the tedium of making dozens of attempts to grind up to Devices 3 before gaining the practice recipe:

| Practice        | Time | Devices | Lockpicking | Consumed    |
| --------------- | ---- | ------- | ----------- | ----------- |
| Inexperienced 1 | 60 m | 2 (0%)  | 7%          | Pick & lock |
| Crude 2         | 60 m | 2 (54%) | 13%         | Pick        |
| Crude 3         | 60 m | 3 (00%) | 19%         | Pick        |
| Crude 4         | 60 m | 3 (00%) | 35%         | Pick        |

(Keep in mind that each pick also requires 30 minutes to craft until you've got Lockpicking.)

#### Describe alternatives you've considered

- Aligning the experience from picking doors with that of practicing.
- Change the current lockpicking recipes to unlock at lower Devices skill.
- Leave the current lockpicking recipes at Devices 3 to make the player use up more locks.
- Resigning myself to crafting improvised picks for Devices 1, then tripwire traps for Devices 2, then reading or building bear / crossbow / shotgun traps for Devices 3, _then_ practice lockpicking.

#### Testing

Recipe appears in game and is craftable:
![image](https://github.com/user-attachments/assets/f5084db1-202f-466e-bd12-523508cadb37)

#### Additional context

Closes #76412

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
