### PR TITLE
move ax(wood axe) from "real_axes" to "real_great_axes" in melee.json

### DIFF
--- a/data/json/requirements/melee.json
+++ b/data/json/requirements/melee.json
@@ -432,7 +432,6 @@
     "//": "Any real, cutting weapons that can be used like an axe; large, heavy head with two sharp sides on a pole.",
     "tools": [
       [
-        [ "ax", -1 ],
         [ "hatchet", -1 ],
         [ "copper_ax", -1 ],
         [ "iceaxe", -1 ],
@@ -454,7 +453,8 @@
         [ "mc_battleaxe", -1 ],
         [ "hc_battleaxe", -1 ],
         [ "ch_battleaxe", -1 ],
-        [ "qt_battleaxe", -1 ]
+        [ "qt_battleaxe", -1 ],
+        [ "ax", -1 ]
       ]
     ]
   },


### PR DESCRIPTION
Move the wood axe from "real_axes" to "real_great_axes". The wood axe trains the great axe proficiency in combat, but is used by the hand axe proficiency practice recipes. The wood axe seems to be a poor fit for "real_axes".

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Make wood axe usable for great axe proficiency practice instead of hand axe proficiency practice"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Using a wood axe in combat increases 'Great Axe Familiarity', but it's used for the 'hand axes' proficiency practice recipes rather than the 'great axes' line. I believe the two should change the same proficiency. The "hand axes" beginner recipe description says "Practice your chopping motions against an imaginary assailant", and most of the other weapons eligible for the recipe (excepting the bolted/welded battle axe and bill) are one-handed and relatively light (excepting, again, the bolted/welded battle axe and bill). The 'Great Axe Familiarity' recipe says "Drill the proper form while swinging a heavy axe". Most of the weapons eligible for this recipe are two-handed and relatively heavy. Additionally, the "Great Axe Familiarity" proficiency itself says "You're not quite a professional lumberjack, but you can handle an axe." Based on the ~5lb weight of the wood axe and its description as a "large, two-handed wood axe", I believe it makes more sense to change the wood axe's practice eligibility than what proficiency it uses, based on the current state of those proficiencies. 
See #77962, though this doesn't touch the fire ax, since that already seems to be fixed. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
See #77962, though it won't fix the fire axe issue for 0.H (which seems to be fixed in experimental)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered changing the proficiency the wood axe used, but changing the practice recipe is more consistent with the other items in the relevant proficiencies. It might be worth revisiting the great axes/hand axes proficiencies or renaming them, but one hand/two hand (which appears to be mostly the rule currently) seems an intuitive and natural split. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I examined the practice recipe in game, changed the json, restarted my game, and checked the practice recipe again. The wood axe is now used for the "great axes (beginner)" recipe.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The real_axes and real_great_axes lists are both described as "Any real, cutting weapons that can be used like an axe; large, heavy head with two sharp sides on a pole." This does not seem to be an accurate description of either list.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
