### PR TITLE
Add MELEE_TO_HIT enchantment

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -4905,6 +4905,20 @@
   },
   {
     "type": "GENERIC",
+    "id": "test_MELEE_TO_HIT_ench_item_1",
+    "copy-from": "test_item_ench",
+    "name": "test_MELEE_TO_HIT_ench_item_1",
+    "relic_data": { "passive_effects": [ { "values": [ { "value": "MELEE_TO_HIT", "add": 100 } ] } ] }
+  },
+  {
+    "type": "GENERIC",
+    "id": "test_MELEE_TO_HIT_ench_item_2",
+    "copy-from": "test_item_ench",
+    "name": "test_MELEE_TO_HIT_ench_item_2",
+    "relic_data": { "passive_effects": [ { "values": [ { "value": "MELEE_TO_HIT", "add": -100 } ] } ] }
+  },
+  {
+    "type": "GENERIC",
     "id": "test_BONUS_DODGE_ench_item_1",
     "copy-from": "test_item_ench",
     "name": "test_BONUS_DODGE_ench_item_1",

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -856,6 +856,7 @@ Character status value  | Description
 `MAX_MANA`              | 
 `MAX_STAMINA`           | 
 `MELEE_DAMAGE`          | Adds damage to melee attacks
+`MELEE_TO_HIT`          | Modifies melee attacks' `to_hit`. `add` is recommended since `to_hit` can be below 0 and has a small typical range.
 `MELEE_STAMINA_CONSUMPTION` | Changes amount of stamina used when swing in melee; stamina consumption is a negative value, so `"add": 100` decreases amount of stamina consumed, when `"add": -100` increases it; `"multiply": 1` increases, `"multiply": -0.5` decreases it. Can't be bigger than -50.
 `MENDING_MODIFIER`      | Changes the speed of your limb mend. Since it's a percent, using `multiply` is recommended.
 `METABOLISM`            | Multiplier for `metabolic_rate_base`, which respond for default bmi rate; Formula for basic bmi is `metabolic_rate_base * ( (weight_in_kg / 10 ) + (6.25 * height) - (5 * age) + 5 )`; Since it's a percent, using `multiply` is recommended; Since metabolism is directly connected to weariness, at this moment decreasing it makes you more weary the less metabolism you have; zero metabolism (`multiply: -1`) is handled separately, and makes you never weary.

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4224,10 +4224,13 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         if( jrel.has_object( "melee_damage" ) ) {
             def.melee_relative = load_damage_map( jrel.get_object( "melee_damage" ) );
         }
+        if( jrel.has_int( "to_hit" ) ) {
+            def.m_to_hit += jrel.get_int( "to_hit" );
+        }
     }
     def.using_legacy_to_hit = false; // Reset to false so inherited legacy to_hit s aren't flagged
     if( jo.has_int( "to_hit" ) ) {
-        assign( jo, "to_hit", def.m_to_hit, strict );
+        mandatory( jo, false, "to_hit", def.m_to_hit );
         def.using_legacy_to_hit = true;
     } else if( jo.has_object( "to_hit" ) ) {
         io::acc_data temp;

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -89,6 +89,7 @@ namespace io
             case enchant_vals::mod::PAIN_PENALTY_MOD_PER: return "PAIN_PENALTY_MOD_PER";
             case enchant_vals::mod::PAIN_PENALTY_MOD_SPEED: return "PAIN_PENALTY_MOD_SPEED";
             case enchant_vals::mod::MELEE_DAMAGE: return "MELEE_DAMAGE";
+            case enchant_vals::mod::MELEE_TO_HIT: return "MELEE_TO_HIT";
             case enchant_vals::mod::RANGED_DAMAGE: return "RANGED_DAMAGE";
 			case enchant_vals::mod::RANGED_ARMOR_PENETRATION: return "RANGED_ARMOR_PENETRATION";
             case enchant_vals::mod::DODGE_CHANCE: return "DODGE_CHANCE";

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -68,6 +68,7 @@ enum class mod : int {
     BONUS_DODGE,
     BONUS_BLOCK,
     MELEE_DAMAGE,
+    MELEE_TO_HIT,
     RANGED_DAMAGE,
     RANGED_ARMOR_PENETRATION,
     ATTACK_NOISE,

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -368,7 +368,8 @@ float Character::get_melee_hit_base() const
     hit_weapon = get_hit_weapon( cur_weap );
 
     // Character::get_hit_base includes stat calculations already
-    return Character::get_hit_base() + hit_weapon + mabuff_tohit_bonus();
+    return Character::get_hit_base() + hit_weapon + mabuff_tohit_bonus() +
+           enchantment_cache->modify_value( enchant_vals::mod::MELEE_TO_HIT, 0.0f );
 }
 
 float Character::hit_roll() const

--- a/tests/enchantments_test.cpp
+++ b/tests/enchantments_test.cpp
@@ -333,6 +333,53 @@ TEST_CASE( "Enchantment_MELEE_STAMINA_CONSUMPTION_test", "[magic][enchantments]"
     clear_avatar();
 }
 
+static double test_melee_attack_hit_rate( Character &guy, Creature &mon )
+{
+    int attempted_hits = 0;
+    int successful_hits = 0;
+    int last_hp = mon.get_hp();
+    guy.set_skill_level( skill_melee, 0 );
+    guy.add_effect( effect_debug_no_staggered, 100_seconds );
+    guy.recalculate_enchantment_cache();
+    advance_turn( guy );
+
+    while( attempted_hits != 10 ) {
+        guy.melee_attack_abstract( mon, false, matec_id( "" ) );
+        if( mon.get_hp() != last_hp ) {
+            last_hp = mon.get_hp();
+            successful_hits++;
+        }
+        guy.set_sleepiness( 0 );
+        attempted_hits++;
+    }
+
+    return successful_hits / static_cast<double>( attempted_hits );
+}
+
+TEST_CASE( "Enchantment_MELEE_TO_HIT_test", "[magic][enchantments]" )
+{
+    clear_map();
+    Character &guy = get_player_character();
+    clear_avatar();
+    g->place_critter_at( pseudo_debug_mon, tripoint_south );
+    creature_tracker &creatures = get_creature_tracker();
+    Creature &mon = *creatures.creature_at<Creature>( tripoint_south );
+    double hit_rate = 0;
+
+    INFO( "Character attacks with +100 to hit enchantment" );
+    guy.i_add( item( "test_MELEE_TO_HIT_ench_item_1" ) );
+    hit_rate = test_melee_attack_hit_rate( guy, mon );
+    REQUIRE( hit_rate >= 0.8 );
+    clear_avatar();
+
+
+    INFO( "Character attacks with -100 to hit enchantment" );
+    guy.i_add( item( "test_MELEE_TO_HIT_ench_item_2" ) );
+    hit_rate = test_melee_attack_hit_rate( guy, mon );
+    REQUIRE( hit_rate <= 0.2 );
+    clear_avatar();
+}
+
 TEST_CASE( "Enchantment_BONUS_DODGE_test", "[magic][enchantments]" )
 {
     clear_map();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #77983
Fixes #70528
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a new enchantment to modify to_hit, documentation of it and adds a test to check it continues working
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested using the following in Magiclysm with expected results
```json
  {
    "copy-from": "armguard_larmor",
    "type": "ARMOR",
    "id": "mbracer_melee",
    "name": { "str": "pair of bracers of extreme melee accuracy", "str_pl": "pairs of bracers of extreme melee accuracy" },
    "price_postapoc": "15000 USD",
    "description": "A set of leather bracers worked with images of giant weapons connecting with weakpoints.  Melee weapons you wield will be much more accurate while you wear these.",
    "relic_data": {
      "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "MELEE_TO_HIT", "add": 100 } ] } ]
    }
  },
  {
    "copy-from": "armguard_larmor",
    "type": "ARMOR",
    "id": "mbracer_melee_cursed",
    "name": {
      "str": "cursed pair of bracers of extreme melee accuracy",
      "str_pl": "cursed pairs of bracers of extreme melee accuracy"
    },
    "price_postapoc": "15 USD",
    "description": "A set of leather bracers worked with images of confused wearers missing the broad side of a barn with their swords.  Melee weapons you wield will be much less accurate while you wear these.",
    "relic_data": { "passive_effects": [ { "id": "-100_to_hit" } ] }
  },
  {
    "type": "enchantment",
    "id": "-100_to_hit",
    "has": "WORN",
    "condition": "ALWAYS",
    "values": [ { "value": "MELEE_TO_HIT", "add": -100 } ]
  },
  {
    "type": "GENERIC",
    "id": "warhammer_minus_one_hundred",
    "copy-from": "warhammer",
    "name": { "str": "warhammer -100", "str_pl": "warhammers -100" },
    "to_hit": -100
  }
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
