### PR TITLE
Update lumbermill with `num_input`

### DIFF
--- a/data/json/npcs/lumbermill_employees/TALK_lumbermill_fabricate.json
+++ b/data/json/npcs/lumbermill_employees/TALK_lumbermill_fabricate.json
@@ -21,15 +21,26 @@
   {
     "id": "EOC_LUMBERMILL_FABRICATE_order",
     "type": "effect_on_condition",
-    "condition": { "expects_vars": [ "name", "batch", "cost" ] },
+    "condition": { "expects_vars": [ "name", "max" ] },
     "effect": [
       {
         "set_string_var": "n_number_fabricate_<context_val:name>",
         "target_var": { "context_val": "item" },
         "parse_tags": true
       },
-      { "math": [ "v_item", "+=", "_batch" ] },
-      { "math": [ "n_number_fabricate_price", "+=", "_cost * _batch" ] }
+      { "math": [ "v_item", "=", "max(0, min(_max, num_input('', v_item)))" ] },
+      { "math": [ "n_number_fabricate_price", "=", "0" ] },
+      { "math": [ "n_number_fabricate_price", "+=", "1   * n_number_fabricate_2x4" ] },
+      { "math": [ "n_number_fabricate_price", "+=", "0.7 * n_number_fabricate_plank_short" ] },
+      { "math": [ "n_number_fabricate_price", "+=", "1.5 * n_number_fabricate_plank_long" ] },
+      { "math": [ "n_number_fabricate_price", "+=", "1   * n_number_fabricate_wooden_post" ] },
+      { "math": [ "n_number_fabricate_price", "+=", "0.7 * n_number_fabricate_wooden_post_short" ] },
+      { "math": [ "n_number_fabricate_price", "+=", "1.5 * n_number_fabricate_wooden_post_long" ] },
+      { "math": [ "n_number_fabricate_price", "+=", "8   * n_number_fabricate_wood_panel" ] },
+      { "math": [ "n_number_fabricate_price", "+=", "16  * n_number_fabricate_wood_sheet" ] },
+      { "math": [ "n_number_fabricate_price", "+=", "25  * n_number_fabricate_wood_beam" ] },
+      { "math": [ "n_number_fabricate_price", "+=", "5   * n_number_fabricate_log" ] },
+      { "math": [ "n_number_fabricate_wait", "=", "max(1, ceil(n_number_fabricate_price/150))" ] }
     ]
   },
   {
@@ -39,177 +50,140 @@
     "dynamic_line": {
       "concatenate": [
         {
-          "math": [ "has_var(n_number_fabricate_price)" ],
-          "yes": "&Your current order.  Total: <npc_val:number_fabricate_price>$",
+          "math": [ "n_number_fabricate_price != 0" ],
+          "yes": "&Your current order.  Total: $<npc_val:number_fabricate_price>.  Waiting time: <npc_val:number_fabricate_wait> days.",
           "no": "We offer various specialty cuts direct to our customers.  Here's a list of available materials.  Order waiting time depends on the amount of lumber ordered.  So, what would you like?"
         },
+        { "math": [ "n_number_fabricate_2x4 != 0" ], "yes": "\n<item_name:2x4>: <npc_val:number_fabricate_2x4> pcs." },
         {
-          "math": [ "has_var(n_number_fabricate_2x4)" ],
-          "yes": "\n<item_name:2x4>: <npc_val:number_fabricate_2x4> pcs."
-        },
-        {
-          "math": [ "has_var(n_number_fabricate_plank_short)" ],
+          "math": [ "n_number_fabricate_plank_short != 0" ],
           "yes": "\n<item_name:plank_short>: <npc_val:number_fabricate_plank_short> pcs."
         },
         {
-          "math": [ "has_var(n_number_fabricate_plank_long)" ],
+          "math": [ "n_number_fabricate_plank_long != 0" ],
           "yes": "\n<item_name:plank_long>: <npc_val:number_fabricate_plank_long> pcs."
         },
         {
-          "math": [ "has_var(n_number_fabricate_wooden_post)" ],
+          "math": [ "n_number_fabricate_wooden_post != 0" ],
           "yes": "\n<item_name:wooden_post>: <npc_val:number_fabricate_wooden_post> pcs."
         },
         {
-          "math": [ "has_var(n_number_fabricate_wooden_post_short)" ],
+          "math": [ "n_number_fabricate_wooden_post_short != 0" ],
           "yes": "\n<item_name:wooden_post_short>: <npc_val:number_fabricate_wooden_post_short> pcs."
         },
         {
-          "math": [ "has_var(n_number_fabricate_wooden_post_long)" ],
+          "math": [ "n_number_fabricate_wooden_post_long != 0" ],
           "yes": "\n<item_name:wooden_post_long>: <npc_val:number_fabricate_wooden_post_long> pcs."
         },
         {
-          "math": [ "has_var(n_number_fabricate_wood_panel)" ],
+          "math": [ "n_number_fabricate_wood_panel != 0" ],
           "yes": "\n<item_name:wood_panel>: <npc_val:number_fabricate_wood_panel> pcs."
         },
         {
-          "math": [ "has_var(n_number_fabricate_wood_sheet)" ],
+          "math": [ "n_number_fabricate_wood_sheet != 0" ],
           "yes": "\n<item_name:wood_sheet>: <npc_val:number_fabricate_wood_sheet> pcs."
         },
         {
-          "math": [ "has_var(n_number_fabricate_wood_beam)" ],
+          "math": [ "n_number_fabricate_wood_beam != 0" ],
           "yes": "\n<item_name:wood_beam>: <npc_val:number_fabricate_wood_beam> pcs."
         },
-        {
-          "math": [ "has_var(n_number_fabricate_log)" ],
-          "yes": "\n<item_name:log>: <npc_val:number_fabricate_log> pcs."
-        }
+        { "math": [ "n_number_fabricate_log != 0" ], "yes": "\n<item_name:log>: <npc_val:number_fabricate_log> pcs." }
       ]
     },
     "responses": [
       {
-        "text": "[x20 <item_name:2x4>, $1 a piece, max 200]",
-        "show_always": true,
-        "condition": { "math": [ "n_number_fabricate_2x4", "<", "200" ] },
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "2x4", "batch": "20", "cost": "1" } },
+        "text": "[<item_name:2x4>, $1 a piece, max 200]",
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "2x4", "max": "200" } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
-        "text": "[x20 <item_name:plank_short>, $0.7 a piece, max 200]",
-        "show_always": true,
-        "condition": { "math": [ "n_number_fabricate_plank_short", "<", "200" ] },
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "plank_short", "batch": "20", "cost": "0.7" } },
+        "text": "[<item_name:plank_short>, $0.7 a piece, max 200]",
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "plank_short", "max": "200" } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
-        "text": "[x20 <item_name:plank_long>, $1.5 a piece, max 200]",
-        "show_always": true,
-        "condition": { "math": [ "n_number_fabricate_plank_long", "<", "200" ] },
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "plank_long", "batch": "20", "cost": "1.5" } },
+        "text": "[<item_name:plank_long>, $1.5 a piece, max 200]",
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "plank_long", "max": "200" } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
-        "text": "[x10 <item_name:wooden_post>, $1 a piece, max 100]",
-        "show_always": true,
-        "condition": { "math": [ "n_number_fabricate_wooden_post", "<", "100" ] },
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wooden_post", "batch": "10", "cost": "1" } },
+        "text": "[<item_name:wooden_post>, $1 a piece, max 100]",
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wooden_post", "max": "100" } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
-        "text": "[x10 <item_name:wooden_post_short>, $0.7 a piece, max 100]",
-        "show_always": true,
-        "condition": { "math": [ "n_number_fabricate_wooden_post_short", "<", "100" ] },
-        "effect": {
-          "run_eocs": "EOC_LUMBERMILL_FABRICATE_order",
-          "variables": { "name": "wooden_post_short", "batch": "10", "cost": "0.7" }
-        },
+        "text": "[<item_name:wooden_post_short>, $0.7 a piece, max 100]",
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wooden_post_short", "max": "100" } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
-        "text": "[x10 <item_name:wooden_post_long>, $1.5 a piece, max 100]",
-        "show_always": true,
-        "condition": { "math": [ "n_number_fabricate_wooden_post_long", "<", "100" ] },
-        "effect": {
-          "run_eocs": "EOC_LUMBERMILL_FABRICATE_order",
-          "variables": { "name": "wooden_post_long", "batch": "10", "cost": "1.5" }
-        },
+        "text": "[<item_name:wooden_post_long>, $1.5 a piece, max 100]",
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wooden_post_long", "max": "100" } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
-        "text": "[x5 <item_name:wood_panel>, $8 a piece, max 100]",
-        "show_always": true,
-        "condition": { "math": [ "n_number_fabricate_wood_panel", "<", "100" ] },
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_panel", "batch": "5", "cost": "8" } },
+        "text": "[<item_name:wood_panel>, $8 a piece, max 100]",
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_panel", "max": "100" } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
-        "text": "[x5 <item_name:wood_sheet>, $16 a piece, max 100]",
-        "show_always": true,
-        "condition": { "math": [ "n_number_fabricate_wood_sheet", "<", "100" ] },
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_sheet", "batch": "5", "cost": "16" } },
+        "text": "[<item_name:wood_sheet>, $16 a piece, max 100]",
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_sheet", "max": "100" } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
-        "text": "[x1 <item_name:wood_beam>, $20 a piece, max 50]",
-        "show_always": true,
-        "condition": { "math": [ "n_number_fabricate_wood_beam", "<", "50" ] },
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_beam", "batch": "1", "cost": "20" } },
+        "text": "[<item_name:wood_beam>, $25 a piece, max 50]",
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_beam", "max": "50" } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
-        "text": "[x5 <item_name:log>, $5 a piece, max 100]",
-        "show_always": true,
-        "condition": { "math": [ "n_number_fabricate_log", "<", "100" ] },
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "log", "batch": "5", "cost": "5" } },
+        "text": "[<item_name:log>, $5 a piece, max 100]",
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "log", "max": "100" } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
         "text": "<color_light_red>[Reset.]</color>",
-        "condition": { "math": [ "has_var(n_number_fabricate_price)" ] },
+        "condition": { "math": [ "n_number_fabricate_price != 0" ] },
         "effect": { "run_eocs": [ "EOC_LUMBERMILL_FABRICATE_cleanup" ] },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
-        "text": "<color_light_green>That's all.  I'm ready to pay.</color>",
-        "condition": { "math": [ "has_var(n_number_fabricate_price)" ] },
-        "//": "Calculate waiting time",
-        "effect": { "math": [ "n_number_fabricate_wait", "=", "max(1, ceil(n_number_fabricate_price/150))" ] },
-        "topic": "TALK_LUMBERMILL_FABRICATE_PAYMENT"
+        "text": "<color_light_green>[$<npc_val:number_fabricate_price>] That's all.  I'm ready to pay.</color>",
+        "condition": { "math": [ "n_number_fabricate_price != 0" ] },
+        "effect": {
+          "u_buy_item": "file",
+          "count": 1,
+          "cost": { "math": [ "n_number_fabricate_price * 100" ] },
+          "true_eocs": [
+            {
+              "id": "EOC_LUMBERMILL_FABRICATE_ordered",
+              "effect": [
+                { "math": [ "n_timer_fabricate_waiting", "=", "time('now')" ] },
+                {
+                  "u_message": "Your order will be ready in <npc_val:number_fabricate_wait> days.\nCome back in that time to pick up your lumber.",
+                  "popup": true
+                }
+              ]
+            }
+          ]
+        },
+        "topic": "TALK_NPC_LUMBERMILL_MERCHANT_INTRO"
       },
       { "text": "Actually, I don't want to place an order.", "topic": "TALK_NPC_LUMBERMILL_MERCHANT_INTRO" }
     ]
   },
   {
     "type": "talk_topic",
-    "id": "TALK_LUMBERMILL_FABRICATE_PAYMENT",
-    "dynamic_line": "Sure.  That'll be $<npc_val:number_fabricate_price>.  I estimate we'll have your order done in <npc_val:number_fabricate_wait> days.",
-    "responses": [
-      {
-        "text": "[$<npc_val:number_fabricate_price>] Deal.",
-        "effect": {
-          "u_buy_item": "file",
-          "count": 1,
-          "cost": { "math": [ "n_number_fabricate_price * 100" ] },
-          "true_eocs": [
-            { "id": "EOC_LUMBERMILL_FABRICATE_ordered", "effect": { "math": [ "n_timer_fabricate_waiting", "=", "time('now')" ] } }
-          ]
-        },
-        "topic": "TALK_NPC_LUMBERMILL_MERCHANT_INTRO"
-      },
-      { "text": "<end_talking_nevermind>", "topic": "TALK_LUMBERMILL_FABRICATE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
     "id": "TALK_LUMBERMILL_FABRICATE_FINISHED",
     "dynamic_line": {
-      "math": [ "time_since(n_timer_fabricate_waiting, 'unit':'days')", ">=", "n_number_fabricate_wait" ],
+      "math": [ "time_since(n_timer_fabricate_waiting, 'unit':'days') >= n_number_fabricate_wait" ],
       "yes": "Let me check…  <u_name>…  Yes, all your lumber are ready, you can pick it up.",
       "no": "Your order?  No, sorry, we're still working on it."
     },
     "responses": [
       {
         "text": "Thanks.  <end_talking_bye>",
-        "condition": { "math": [ "time_since(n_timer_fabricate_waiting, 'unit':'days')", ">=", "n_number_fabricate_wait" ] },
+        "condition": { "math": [ "time_since(n_timer_fabricate_waiting, 'unit':'days') >= n_number_fabricate_wait" ] },
         "switch": true,
         "effect": [
           {
@@ -234,7 +208,7 @@
                 "parse_tags": true
               },
               {
-                "if": { "math": [ "has_var(v_item)" ] },
+                "if": { "math": [ "v_item != 0" ] },
                 "then": { "u_spawn_item": { "context_val": "name" }, "count": { "var_val": "item" } }
               }
             ]

--- a/data/json/npcs/lumbermill_employees/TALK_lumbermill_fabricate.json
+++ b/data/json/npcs/lumbermill_employees/TALK_lumbermill_fabricate.json
@@ -28,7 +28,7 @@
         "target_var": { "context_val": "item" },
         "parse_tags": true
       },
-      { "math": [ "v_item", "=", "max(0, min(_max, num_input('', v_item)))" ] },
+      { "math": [ "v_item", "=", "clamp(num_input('', v_item), 0, _max)" ] },
       { "math": [ "n_number_fabricate_price", "=", "0" ] },
       { "math": [ "n_number_fabricate_price", "+=", "1   * n_number_fabricate_2x4" ] },
       { "math": [ "n_number_fabricate_price", "+=", "0.7 * n_number_fabricate_plank_short" ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
> GuardianDll:
> Also, if you are interested, you can tie math: num_input() so player can specify how much of it player can buy

Apply the suggestion to allow a player to take any number of lumber of the single type in a single action. I couldn't implement this right away because the price calculation didn't take into account that the price might decrease.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
After a bit more inspection, it turned out that I also can't "lose" a variable because the `npc_lose_var` function only accepts a string. `math` doesn't support this either as far as I've looked. Had to rework the conditions a bit.

In the meantime, the topic with the payment was also removed (the message about successful payment was put in a popup).
The price of wooden beams was raised to match the barter price.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Write custom text for the input field?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The ordering process is working.
![lumb3](https://github.com/user-attachments/assets/df5571a0-620b-4aaf-ba45-1364a84023ba)
![lumb2](https://github.com/user-attachments/assets/f42ebcd3-6d41-40d6-9a37-4ef8d47a1e02)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
