### PR TITLE
[Magiclysm] Fix soul afterburner granting infinite moves

### DIFF
--- a/data/mods/Magiclysm/Spells/attunements/Soulfire.json
+++ b/data/mods/Magiclysm/Spells/attunements/Soulfire.json
@@ -32,6 +32,64 @@
     "energy_source": "MANA"
   },
   {
+    "id": "soul_afterburner",
+    "type": "SPELL",
+    "name": "Soul Afterburner",
+    "description": "You burn a small portion of your soul to gain a large burst of speed.  You will have to wait until your soul has healed before burning a part of it again.",
+    "valid_targets": [ "self" ],
+    "flags": [ "ENHANCEMENT_SPELL", "VERBAL", "SILENT", "MUST_HAVE_CLASS_TO_LEARN" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_SOUL_AFTERBURNER",
+    "shape": "blast",
+    "max_level": 35,
+    "difficulty": 6,
+    "spell_class": "SOULFIRE"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SOUL_AFTERBURNER",
+    "//": "The injury on false effect prevents grinding the spell to max level as soon as it is obtained.",
+    "condition": { "not": { "u_has_effect": "soul_burn" } },
+    "effect": [
+      { "u_message": "You gain a sudden burst of speed!", "type": "good" },
+      { "u_cast_spell": { "id": "soul_afterburner_real" } }
+    ],
+    "false_effect": [
+      { "u_message": "Burning your soul before it healed only resulted in some damage to your body.", "type": "bad" },
+      { "u_cast_spell": { "id": "soul_afterburner_cooldown_backlash" } }
+    ]
+  },
+  {
+    "id": "soul_afterburner_cooldown_backlash",
+    "type": "SPELL",
+    "name": "Soul backlash",
+    "description": { "str": "This is a description for a spell the player will never see.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "flags": [ "NO_EXPLOSION_SFX", "SILENT", "NO_PROJECTILE", "SPLIT_DAMAGE" ],
+    "min_damage": 30,
+    "max_damage": 30,
+    "damage_increment": 1.5,
+    "damage_type": "pure",
+    "shape": "blast",
+    "effect": "attack"
+  },
+  {
+    "id": "soul_afterburner_real",
+    "type": "SPELL",
+    "name": "Soul Afterburner",
+    "description": { "str": "This is a description for a spell the player will never see.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "flags": [ "ENHANCEMENT_SPELL", "VERBAL", "SILENT", "MUST_HAVE_CLASS_TO_LEARN" ],
+    "effect": "mod_moves",
+    "shape": "blast",
+    "min_damage": { "math": [ "max((1500 + (u_spell_level('soul_afterburner') * 200)), 7500)" ] },
+    "max_damage": { "math": [ "max((1500 + (u_spell_level('soul_afterburner') * 200)), 7500)" ] },
+    "max_level": 35,
+    "difficulty": 6,
+    "spell_class": "SOULFIRE",
+    "extra_effects": [ { "id": "soul_afterburner_effect_1", "hit_self": true }, { "id": "eoc_enhancement_setup", "hit_self": true } ]
+  },
+  {
     "id": "soul_afterburner_effect_1",
     "type": "SPELL",
     "name": { "str": "Soul Burn", "//~": "NO_I18N" },
@@ -44,9 +102,8 @@
     "max_damage": 0,
     "valid_targets": [ "self" ],
     "max_level": 35,
-    "min_duration": 1080000,
-    "max_duration": 540000,
-    "duration_increment": -30000
+    "min_duration": { "math": [ "max((1080000 - (u_spell_level('soul_afterburner') * 30000)), 540000)" ] },
+    "max_duration": { "math": [ "max((1080000 - (u_spell_level('soul_afterburner') * 30000)), 540000)" ] }
   },
   {
     "id": "soul_burn",
@@ -58,22 +115,5 @@
     "rating": "bad",
     "show_intensity": false,
     "enchantments": [ { "values": [ { "value": "REGEN_HP", "multiply": -0.7 } ] } ]
-  },
-  {
-    "id": "soul_afterburner",
-    "type": "SPELL",
-    "name": "Soul Afterburner",
-    "description": "You burn a small portion of your soul to gain a large burst of speed.",
-    "valid_targets": [ "self" ],
-    "flags": [ "ENHANCEMENT_SPELL", "VERBAL", "SILENT", "MUST_HAVE_CLASS_TO_LEARN" ],
-    "effect": "mod_moves",
-    "shape": "blast",
-    "min_damage": 1500,
-    "damage_increment": 200,
-    "max_damage": 7500,
-    "max_level": 35,
-    "difficulty": 6,
-    "spell_class": "SOULFIRE",
-    "extra_effects": [ { "id": "soul_afterburner_effect_1", "hit_self": true }, { "id": "eoc_enhancement_setup", "hit_self": true } ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "[Magiclysm] Fix soul afterburner granting infinite moves"

#### Purpose of change

While examinating some Json, I found that nothing stopped the player from casting soul afterburner over and over to get infinite moves.
With this PR, the moves won't be infinite anymore.

#### Describe the solution

Add a EOC that checks if you have the effect the real spell gives. If yes, it doesn't give moves.
Due to the spell not costing anything to cast (not even time), the EOC will also lightly damage the player if they already have said effect so they can't spam the spell and reach max level in it literally one in-game second after gaining the attunement.

#### Describe alternatives you've considered

Making soul afterburner spam grant increasing penalties from overuse. That wouldn't work as the penalties won't apply as long as the player got free moves AKA forever.

#### Testing

Before changes > cast soul afterburner many times to gain as many moves as I want.
After changes > casting it without the effect gives moves and doesn't damage. Casting it with the effect damages and doesn't give moves.

#### Additional context