### PR TITLE
Fix `bio_blindfold` not working correctly after a save & load cycle

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -627,6 +627,8 @@ Character::Character() :
     // Only call these if game is initialized
     if( !!g && json_flag::is_ready() ) {
         recalc_sight_limits();
+        trait_flag_cache.clear();
+        bio_flag_cache.clear();
         calc_encumbrance();
         worn.recalc_ablative_blocking(this);
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix `bio_blindfold` not working correctly after a save & load cycle"
#### Purpose of change
Fix #77522 
#### Describe the solution
https://github.com/CleverRaven/Cataclysm-DDA/blob/3a0d074afb601a3d261a4823bf3611d2c5bd584c/src/character.cpp#L627-L633
Add `trait_flag_cache.clear()` and `bio_flag_cache.clear()` here.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
#### Describe alternatives you've considered
Save `trait_flag_cache` and `bio_flag_cache` in savedata?
#### Testing
Compiled and tested locally.
#### Additional context
I'm not confident with this patch, sight calculation is really a mess.