### PR TITLE
fill_ter accepts parameters

### DIFF
--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -297,24 +297,35 @@ Examples:
 
 # JSON object definition
 
-The JSON object for a mapgen entry must include either `"fill_ter"`, or `"rows"` and `"terrain"`. All other fields are
-optional.
-
-
 ## Fill terrain using "fill_ter"
 Fill with the given terrain.
 
-Value: `"string"`: Valid terrain id from data/json/terrain.json
+terrain id string or [mapgen value](#mapgen-values)
 
-Example: `"fill_ter": "t_region_groundcover"`
+### Examples
+
+Every tile lacking a terrain character definition will be `t_region_groundcover`
+`"fill_ter": "t_region_groundcover"`
+
+Every tile lacking a terrain character definition will the same one of `t_floor`, `t_pavement` and `t_concrete` across the omt, with `t_floor`being twice as likely to be picked
+```json
+"parameters": {
+  "floor_type": {
+    "type": "ter_str_id",
+    "scope": "omt",
+    "default": { "distribution": [ [ "t_floor", 2 ], [ "t_pavement", 1 ], [ "t_concrete", 1 ] ] }
+  }
+},
+"fill_ter": { "param": "floor_type" },
+```
 
 
 ## ASCII map using "rows" array
 
 Nested array usually of 24 strings, each 24 characters long but can vary for nests (in which case between 1 and 24)
 and defining multiple overmap terrains maps at once (in which case a multiple of 24),
-where each character is defined by "terrain" and optionally "furniture" or other entries below.
-Defaults to all spaces " " if unset.
+where each character can be defined by "terrain" and "furniture" or other entries below.
+`"rows"` can be omitted entirely in which case each row is set to all `" "` (of the appropriate size if used with nests).
 
 Usage:
 
@@ -325,19 +336,9 @@ Usage:
 Other parts can be linked with this map, for example one can place things like a gaspump (with gasoline) or a toilet
 (with water) or items from an item group or fields at the square given by a character.
 
-Any character used here must have some definition elsewhere to indicate its purpose.  Failing to do so is an error which
-will be caught by running the tests.  The tests will run automatically when you make a pull request for adding new maps
-to the game.  If you have defined `fill_ter` or you are writing nested mapgen, then there are a couple of exceptions.
-The space and period characters (` ` and `.`) are permitted to have no definition and be used for 'background' in the
-`rows`.
-
-As keys, you can use any Unicode characters which are not double-width.  This includes for example most European
-alphabets but not Chinese characters.  If you intend to take advantage of this, ensure that your editor is saving the
-file with a UTF-8 encoding.  Accents are acceptable, even when using [combining
-characters](https://en.wikipedia.org/wiki/Combining_character).  No normalization is performed; comparison is done at
-the raw bytes (code unit) level.  Therefore, there are literally an infinite number of mapgen key characters available.
-Please don't abuse this by using distinct characters that are visually indistinguishable, or which are so rare as to be
-unlikely to render correctly for other developers.
+If you specify one of `fill_ter`, `predecessor_mapgen`, `fallback_predecessor_mapgen` or you are writing nested mapgen
+then the space and period characters (` ` and `.`) are permitted to have no definition and be used for 'background' in the `rows`.
+Otherwise any character used must have some definition to indicate its purpose, whether directly in the mapgen or in a specified palette.
 
 Example:
 
@@ -374,7 +375,8 @@ Example:
 ### Row terrains in "terrain"
 **usually required by "rows"**
 
-Defines terrain ids for "rows", each key is a single character with a terrain id string
+Defines terrain ids for `"rows"`, each key is a single character with a terrain id string or [mapgen value](#mapgen-values)
+If you want to remove a terrain definition from a palette in preference of a fallback you can use `t_null`
 
 Value: `{object}: { "a", "t_identifier", ... }`
 
@@ -405,8 +407,8 @@ Example:
 ### Furniture symbols in "furniture" array
 **optional**
 
-Defines furniture ids for "rows" ( each character in rows is a terrain -or- terrain/furniture combo ). "f_null" means no
-furniture but the entry can be left out
+Defines furniture ids for `"rows"`, each key is a single character with a furniture id string or [mapgen value](#mapgen-values)
+If you want to remove a furniture definition from a palette you can use `f_null`
 
 Example:
 
@@ -425,6 +427,15 @@ Example:
   "d": "f_dumpster"
 },
 ```
+
+### Acceptable characters
+
+You should aim to make the rows as clear as possible with your character choice but
+you can use any Unicode characters which are not double-width.  This includes for example most European
+alphabets but not Chinese characters.  If you intend to take advantage of this, ensure that your editor is saving the
+file with a UTF-8 encoding.  Accents are acceptable, even when using [combining
+characters](https://en.wikipedia.org/wiki/Combining_character).  No normalization is performed; comparison is done at
+the raw bytes (code unit) level.  Therefore, there are literally an infinite number of mapgen key characters available.
 
 ## Mapgen flags
 `"flags"` may provide a list of flags to be applied to the mapgen.

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -978,7 +978,6 @@ mapgen_function_json::mapgen_function_json( const JsonObject &jsobj,
         dbl_or_var w, const std::string &context, const point &grid_offset, const point &grid_total )
     : mapgen_function( std::move( w ) )
     , mapgen_function_json_base( jsobj, context )
-    , fill_ter( t_null )
     , rotation( 0 )
     , fallback_predecessor_mapgen_( oter_str_id::NULL_ID() )
 {
@@ -4528,9 +4527,8 @@ bool mapgen_function_json::setup_internal( const JsonObject &jo )
         jo.throw_error( "\"mapgensize\" only allowed for nested mapgen" );
     }
 
-    // something akin to mapgen fill_background.
-    if( jo.has_string( "fill_ter" ) ) {
-        fill_ter = ter_str_id( jo.get_string( "fill_ter" ) ).id();
+    if( jo.has_member( "fill_ter" ) ) {
+        fill_ter = cata::make_value<mapgen_value<ter_id>>( jo.get_member( "fill_ter" ) );
     }
 
     if( jo.has_member( "rotation" ) ) {
@@ -4545,7 +4543,7 @@ bool mapgen_function_json::setup_internal( const JsonObject &jo )
 
     jo.read( "fallback_predecessor_mapgen", fallback_predecessor_mapgen_ );
 
-    return fill_ter != t_null || predecessor_mapgen != oter_str_id::NULL_ID() ||
+    return fill_ter || predecessor_mapgen != oter_str_id::NULL_ID() ||
            fallback_predecessor_mapgen_ != oter_str_id::NULL_ID();
 }
 
@@ -4739,10 +4737,10 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
     }
     fallback_terrain_exists = true;
 
-    // No fill_ter? No format? GTFO.
+    // TODO: Pointless check???
     if( !fallback_terrain_exists ) {
         jo.throw_error(
-            "Need one of 'fill_terrain', 'predecessor_mapgen', 'fallback_predecessor_mapgen', 'terrain' or a palette providing 'terrain'." );
+            "Need one of 'fill_ter', 'predecessor_mapgen', 'fallback_predecessor_mapgen', 'terrain' or a palette providing 'terrain'." );
         // TODO: write TFM.
     }
 
@@ -5347,9 +5345,6 @@ static ret_val<void> apply_mapgen_in_phases(
 void mapgen_function_json::generate( mapgendata &md )
 {
     map *const m = &md.m;
-    if( fill_ter != t_null ) {
-        m->draw_fill_background( fill_ter );
-    }
     const oter_t &ter = *md.terrain_type();
 
     auto do_predecessor_mapgen = [&]( mapgendata & predecessor_md ) {
@@ -5394,6 +5389,15 @@ void mapgen_function_json::generate( mapgendata &md )
     }
 
     mapgendata md_with_params( md, get_args( md, mapgen_parameter_scope::omt ), flags_ );
+
+    if( fill_ter ) {
+        const ter_id chosen_fill_ter = fill_ter->get( md_with_params );
+        if( chosen_fill_ter != t_null ) {
+            m->draw_fill_background( chosen_fill_ter );
+        } else {
+            debugmsg( "fill_ter resolved to t_null" );
+        }
+    }
 
     apply_mapgen_in_phases( md_with_params, setmap_points, objects, tripoint_rel_ms( tripoint_zero ),
                             context_ );
@@ -7987,7 +7991,6 @@ bool update_mapgen_function_json::setup_update( const JsonObject &jo )
 
 bool update_mapgen_function_json::setup_internal( const JsonObject &/*jo*/ )
 {
-    fill_ter = t_null;
     /* update_mapgen doesn't care about fill_ter or rows */
     return true;
 }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4887,6 +4887,16 @@ std::unordered_set<point> nested_mapgen::all_placement_coords() const
     return result;
 }
 
+void nested_mapgen::add( const std::shared_ptr<mapgen_function_json_nested> &p, int weight )
+{
+    funcs_.add( p, weight );
+}
+
+void update_mapgen::add( std::unique_ptr<update_mapgen_function_json> &&p )
+{
+    funcs_.push_back( std::move( p ) );
+}
+
 void jmapgen_objects::finalize()
 {
     std::stable_sort( objects.begin(), objects.end(), compare_phases );

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -571,9 +571,7 @@ class nested_mapgen
         const weighted_int_list<std::shared_ptr<mapgen_function_json_nested>> &funcs() const {
             return funcs_;
         }
-        void add( const std::shared_ptr<mapgen_function_json_nested> &p, int weight ) {
-            funcs_.add( p, weight );
-        }
+        void add( const std::shared_ptr<mapgen_function_json_nested> &p, int weight );
         // Returns a set containing every relative coordinate of a point that
         // might have something placed by this mapgen
         std::unordered_set<point> all_placement_coords() const;
@@ -587,9 +585,7 @@ class update_mapgen
         const std::vector<std::unique_ptr<update_mapgen_function_json>> &funcs() const {
             return funcs_;
         }
-        void add( std::unique_ptr<update_mapgen_function_json> &&p ) {
-            funcs_.push_back( std::move( p ) );
-        }
+        void add( std::unique_ptr<update_mapgen_function_json> &&p );
     private:
         std::vector<std::unique_ptr<update_mapgen_function_json>> funcs_;
 };

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -511,7 +511,7 @@ class mapgen_function_json : public mapgen_function_json_base, public virtual ma
                               const point &grid_offset, const point &grid_total );
         ~mapgen_function_json() override = default;
 
-        ter_id fill_ter;
+        cata::value_ptr<mapgen_value<ter_id>> fill_ter;
         oter_id predecessor_mapgen;
 
     protected:
@@ -544,7 +544,7 @@ class update_mapgen_function_json : public mapgen_function_json_base
 
     protected:
         bool setup_internal( const JsonObject &/*jo*/ ) override;
-        ter_id fill_ter;
+        cata::value_ptr<mapgen_value<ter_id>> fill_ter;
 };
 
 class mapgen_function_json_nested : public mapgen_function_json_base


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "fill_ter accepts parameters"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #66314
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Allows parameters (mapgen values) to be used with `"fill_ter"` the same as you can with `"terrain"` etc
Updates docs
Pretty ugly bc of incomplete type stuff
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with this simple parameter with expected results
```json
      "parameters": {
        "floor_type": {
          "type": "ter_str_id",
          "scope": "omt",
          "default": { "distribution": [ [ "t_floor", 1 ], [ "t_pavement", 1 ], [ "t_concrete", 1 ] ] }
        }
      },
      "fill_ter": { "param": "floor_type" },
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
