### PR TITLE
Don't run item::on_pickup when the item is wielded

### DIFF
--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -214,9 +214,11 @@ item_location Character::try_add( item it, const item *avoid, const item *origin
     }
     std::pair<item_location, item_pocket *> pocket = best_pocket( it, avoid, ignore_pkt_settings );
     item_location ret = item_location::nowhere;
+    bool wielded = false;
     if( pocket.second == nullptr ) {
         if( !has_weapon() && allow_wield && wield( it ) ) {
             ret = item_location( *this, &weapon );
+            wielded = true;
         } else {
             return ret;
         }
@@ -235,7 +237,9 @@ item_location Character::try_add( item it, const item *avoid, const item *origin
     if( keep_invlet ) {
         ret->invlet = it.invlet;
     }
-    ret->on_pickup( *this );
+    if( !wielded ) {
+        ret->on_pickup( *this );
+    }
     cached_info.erase( "reloadables" );
     return ret;
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Don't run item::on_pickup when the item is wielded"

#### Purpose of change

Fixes  #77861

#### Describe the solution

`item::on_pickup` spills all open pockets. This is clearly not intended behavior when the item is wielded instead of put into inventory. `item::on_wield` is already run when wielding.

#### Describe alternatives you've considered



#### Testing

Used reproduction steps from issue.

#### Additional context

