### PR TITLE
eoc: hoist default var value to helper structs

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4849,11 +4849,7 @@
     "rating": "bad",
     "show_intensity": false,
     "enchantments": [
-      {
-        "values": [
-          { "value": "CARRY_WEIGHT", "add": { "global_val": "var", "var_name": "portal_dungeon_carry_strength", "default": -1 } }
-        ]
-      }
+      { "values": [ { "value": "CARRY_WEIGHT", "add": { "global_val": "portal_dungeon_carry_strength", "default": -1 } } ] }
     ]
   },
   {
@@ -4865,11 +4861,7 @@
     "remove_message": "Reality reasserts itself and your time returns to normal.",
     "rating": "bad",
     "show_intensity": false,
-    "enchantments": [
-      {
-        "values": [ { "value": "SPEED", "add": { "global_val": "var", "var_name": "portal_dungeon_slow_strength", "default": -1 } } ]
-      }
-    ]
+    "enchantments": [ { "values": [ { "value": "SPEED", "add": { "global_val": "portal_dungeon_slow_strength", "default": -1 } } ] } ]
   },
   {
     "type": "effect_type",

--- a/data/json/effects_on_condition/nether_eocs/LIXA_EOCs_spells_traps.json
+++ b/data/json/effects_on_condition/nether_eocs/LIXA_EOCs_spells_traps.json
@@ -601,7 +601,7 @@
     "id": "EOC_LIXA_UNFOLD_ENTRY",
     "effect": [
       {
-        "place_override": { "global_val": "place_name", "default_str": "Infinite Corridor" },
+        "place_override": { "global_val": "place_name", "default": "Infinite Corridor" },
         "length": "1 day",
         "key": "LIXA_escape_key"
       },

--- a/data/json/effects_on_condition/nether_eocs/nether_glass_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/nether_glass_effect_on_condition.json
@@ -14,7 +14,7 @@
       "run_eocs": [
         {
           "id": "EOC_nether_glass_no_map",
-          "effect": { "place_override": { "global_val": "place_name", "default_str": "lost level" }, "length": "10 seconds" }
+          "effect": { "place_override": { "global_val": "place_name", "default": "lost level" }, "length": "10 seconds" }
         },
         {
           "id": "EOC_nether_glass_lost_tp",

--- a/data/json/effects_on_condition/nether_eocs/portal_dependent_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_dependent_effect_on_condition.json
@@ -471,7 +471,7 @@
     "id": "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD",
     "//": "Rewards for Portal Dependent characters that survive the dimensional experience of a portal dungeon.",
     "effect": {
-      "switch": { "global_val": "var", "var_name": "portal_dungeon_level" },
+      "switch": { "global_val": "portal_dungeon_level" },
       "cases": [
         {
           "case": 0,
@@ -627,7 +627,7 @@
     "id": "EOC_PORTAL_DEPENDENT_DUNGEON_FINAL_REWARD",
     "//": "Rewards for Portal Dependent characters that survive the last level of a portal dungeon.",
     "effect": {
-      "switch": { "global_val": "var", "var_name": "portal_dungeon_level" },
+      "switch": { "global_val": "portal_dungeon_level" },
       "cases": [
         {
           "case": 5,

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -954,7 +954,7 @@
         "i18n": true
       },
       {
-        "place_override": { "global_val": "place_name", "default_str": "Error" },
+        "place_override": { "global_val": "place_name", "default": "Error" },
         "key": "portal_dungeon",
         "length": "infinite"
       },
@@ -971,7 +971,7 @@
       { "run_eocs": "EOC_PORTAL_STORM_DUNGEON_SHIFT", "time_in_future": [ "5 seconds", "15 seconds" ] },
       { "run_eocs": [ "EOC_PORTAL_STORM_DUNGEON_REFLECTION_SPAWN" ] },
       { "u_message": "You are trapped in <global_val:place_name>!" },
-      { "u_message": { "global_val": "portal_storm_voice_mood", "default_str": "none" }, "snippet": true }
+      { "u_message": { "global_val": "portal_storm_voice_mood", "default": "none" }, "snippet": true }
     ]
   },
   {
@@ -984,7 +984,7 @@
       { "run_eocs": [ "EOC_PORTAL_STORM_DUNGEON_REFLECTION_SPAWN", "capture_generic_nre_anomaly" ] },
       { "mapgen_update": "portal_dungeon", "target_var": { "global_val": "dungeon_loc" } },
       { "u_message": "Weren't you just here?  It feels thicker somehow though." },
-      { "u_message": { "global_val": "portal_storm_voice_mood", "default_str": "none" }, "snippet": true }
+      { "u_message": { "global_val": "portal_storm_voice_mood", "default": "none" }, "snippet": true }
     ]
   },
   {

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -1013,7 +1013,7 @@
       ]
     },
     "effect": {
-      "switch": { "global_val": "var", "var_name": "portal_dungeon_reflect_strength", "default": 0 },
+      "switch": { "global_val": "portal_dungeon_reflect_strength", "default": 0 },
       "cases": [
         {
           "case": 0,
@@ -1095,7 +1095,7 @@
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_DUNGEON_REWARD",
     "effect": {
-      "switch": { "global_val": "var", "var_name": "portal_dungeon_level" },
+      "switch": { "global_val": "portal_dungeon_level" },
       "cases": [
         {
           "case": 2,

--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -54,7 +54,7 @@
     ],
     "effect": [
       {
-        "place_override": { "global_val": "place_name", "default_str": "Quiet Farmhouse" },
+        "place_override": { "global_val": "place_name", "default": "Quiet Farmhouse" },
         "length": "1 day",
         "key": "vitrified_farm_escape_key"
       },

--- a/data/json/monster_special_attacks/void_spider_mechanics.json
+++ b/data/json/monster_special_attacks/void_spider_mechanics.json
@@ -174,7 +174,7 @@
       }
     },
     "effect": [
-      { "place_override": { "global_val": "place_name", "default_str": "strange cavern" }, "length": "10 seconds" },
+      { "place_override": { "global_val": "place_name", "default": "strange cavern" }, "length": "10 seconds" },
       { "run_eocs": "EOC_IN_VOID_SPIDER_LAIR", "time_in_future": "1 seconds" },
       {
         "run_eocs": [

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -24,11 +24,7 @@
         "min_radius": 2,
         "max_radius": 10
       },
-      {
-        "u_add_effect": "warpcloak",
-        "intensity": 1,
-        "duration": { "global_val": "var", "var_name": "invistime", "default": "3 s" }
-      },
+      { "u_add_effect": "warpcloak", "intensity": 1, "duration": { "global_val": "invistime", "default": "3 s" } },
       {
         "u_run_npc_eocs": [
           {
@@ -115,10 +111,7 @@
         "u_message": "You've returned home safely using a designated exit point.  You have earned <global_val:owed_material_tokens> material tokens for your success.",
         "popup": true
       },
-      {
-        "u_spawn_item": "warptoken_material",
-        "count": { "global_val": "var", "var_name": "owed_material_tokens", "default": 50 }
-      }
+      { "u_spawn_item": "warptoken_material", "count": { "global_val": "owed_material_tokens", "default": 50 } }
     ]
   },
   {
@@ -787,7 +780,7 @@
               { "math": [ "owed_material_tokens", "=", "50 * raidswon" ] },
               {
                 "u_spawn_item": "warptoken_material",
-                "count": { "global_val": "var", "var_name": "owed_material_tokens", "default": 50 }
+                "count": { "global_val": "owed_material_tokens", "default": 50 }
               },
               {
                 "u_message": "You have been retroactively awarded <global_val:owed_material_tokens> material tokens for your past successful expeditions.",

--- a/data/mods/Sky_Island/missions_and_mapgen.json
+++ b/data/mods/Sky_Island/missions_and_mapgen.json
@@ -5,11 +5,7 @@
     "//": "Called on landing.  Adds the major earthside affects that are required to register the player as not at home, warpcloak invisibility, starts warpsickness ticking, and creates exits, slaughter missions, and target missions.",
     "condition": { "not": { "u_near_om_location": "sky_island_core", "range": 4 } },
     "effect": [
-      {
-        "u_add_effect": "warpcloak",
-        "intensity": 1,
-        "duration": { "global_val": "var", "var_name": "invistime", "default": "60 s" }
-      },
+      { "u_add_effect": "warpcloak", "intensity": 1, "duration": { "global_val": "invistime", "default": "60 s" } },
       {
         "u_message": "You're still materializing and not fully visible yet.  In about <global_val:invistime> seconds, the world will be able to see you, so if you were warped into danger, now's your chance to get to cover.",
         "popup": false
@@ -61,8 +57,8 @@
       {
         "weighted_list_eocs": [
           [ "EOC_Location1e", 15 ],
-          [ "EOC_Location2e", { "global_val": "var", "var_name": "hardmissions", "default": 0 } ],
-          [ "EOC_Location3e", { "global_val": "var", "var_name": "hardermissions", "default": 0 } ]
+          [ "EOC_Location2e", { "global_val": "hardmissions", "default": 0 } ],
+          [ "EOC_Location3e", { "global_val": "hardermissions", "default": 0 } ]
         ]
       }
     ]
@@ -75,8 +71,8 @@
       {
         "weighted_list_eocs": [
           [ "EOC_Location1m", 15 ],
-          [ "EOC_Location2m", { "global_val": "var", "var_name": "hardmissions", "default": 0 } ],
-          [ "EOC_Location3m", { "global_val": "var", "var_name": "hardermissions", "default": 0 } ]
+          [ "EOC_Location2m", { "global_val": "hardmissions", "default": 0 } ],
+          [ "EOC_Location3m", { "global_val": "hardermissions", "default": 0 } ]
         ]
       }
     ]
@@ -104,9 +100,9 @@
         "weighted_list_eocs": [
           [ "EOC_slaughtermission1", 10 ],
           [ "EOC_slaughtermission2", 20 ],
-          [ "EOC_slaughtermission3", { "global_val": "var", "var_name": "hardermissions", "default": 0 } ],
-          [ "EOC_slaughtermission4", { "global_val": "var", "var_name": "hardermissions", "default": 0 } ],
-          [ "EOC_slaughtermission5", { "global_val": "var", "var_name": "hardmissions", "default": 0 } ],
+          [ "EOC_slaughtermission3", { "global_val": "hardermissions", "default": 0 } ],
+          [ "EOC_slaughtermission4", { "global_val": "hardermissions", "default": 0 } ],
+          [ "EOC_slaughtermission5", { "global_val": "hardmissions", "default": 0 } ],
           [ "EOC_slaughtermission6", 5 ],
           [ "EOC_slaughtermission7", 5 ]
         ]
@@ -131,17 +127,17 @@
           [ "EOC_bonusmission_3", 10 ],
           [ "EOC_bonusmission_4", 15 ],
           [ "EOC_bonusmission_5", 10 ],
-          [ "EOC_bonusmission_6", { "global_val": "var", "var_name": "hardmissions", "default": 0 } ],
-          [ "EOC_bonusmission_7", { "global_val": "var", "var_name": "hardermissions", "default": 0 } ],
-          [ "EOC_bonusmission_8", { "global_val": "var", "var_name": "hardermissions", "default": 0 } ],
-          [ "EOC_bonusmission_9", { "global_val": "var", "var_name": "hardestmissions", "default": 0 } ],
-          [ "EOC_bonusmission_12", { "global_val": "var", "var_name": "hardestmissions", "default": 0 } ],
-          [ "EOC_bonusmission_13", { "global_val": "var", "var_name": "hardestmissions", "default": 0 } ],
-          [ "EOC_bonusmission_10", { "global_val": "var", "var_name": "hardermissions", "default": 0 } ],
-          [ "EOC_bonusmission_11", { "global_val": "var", "var_name": "hardestmissions", "default": 0 } ],
-          [ "EOC_assassinmission1", { "global_val": "var", "var_name": "hardmissions", "default": 0 } ],
-          [ "EOC_assassinmission2", { "global_val": "var", "var_name": "hardermissions", "default": 0 } ],
-          [ "EOC_assassinmission3", { "global_val": "var", "var_name": "hardestmissions", "default": 0 } ]
+          [ "EOC_bonusmission_6", { "global_val": "hardmissions", "default": 0 } ],
+          [ "EOC_bonusmission_7", { "global_val": "hardermissions", "default": 0 } ],
+          [ "EOC_bonusmission_8", { "global_val": "hardermissions", "default": 0 } ],
+          [ "EOC_bonusmission_9", { "global_val": "hardestmissions", "default": 0 } ],
+          [ "EOC_bonusmission_12", { "global_val": "hardestmissions", "default": 0 } ],
+          [ "EOC_bonusmission_13", { "global_val": "hardestmissions", "default": 0 } ],
+          [ "EOC_bonusmission_10", { "global_val": "hardermissions", "default": 0 } ],
+          [ "EOC_bonusmission_11", { "global_val": "hardestmissions", "default": 0 } ],
+          [ "EOC_assassinmission1", { "global_val": "hardmissions", "default": 0 } ],
+          [ "EOC_assassinmission2", { "global_val": "hardermissions", "default": 0 } ],
+          [ "EOC_assassinmission3", { "global_val": "hardestmissions", "default": 0 } ]
         ]
       }
     ]
@@ -273,7 +269,7 @@
           "om_terrain_match_type": "CONTAINS",
           "search_range": 1200,
           "min_distance": 200,
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancelanding", "default": 0 },
+          "reveal_radius": { "global_val": "scoutingdistancelanding", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -292,7 +288,7 @@
           "om_terrain_match_type": "CONTAINS",
           "search_range": 1200,
           "min_distance": 200,
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancelanding", "default": 0 },
+          "reveal_radius": { "global_val": "scoutingdistancelanding", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -311,7 +307,7 @@
           "om_terrain_match_type": "CONTAINS",
           "search_range": 1200,
           "min_distance": 200,
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancelanding", "default": 0 },
+          "reveal_radius": { "global_val": "scoutingdistancelanding", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -328,9 +324,9 @@
         "target_params": {
           "om_terrain": "field",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": { "global_val": "var", "var_name": "exfildistancemax", "default": 30 },
-          "min_distance": { "global_val": "var", "var_name": "exfildistancemin", "default": 5 },
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancetargets", "default": 0 },
+          "search_range": { "global_val": "exfildistancemax", "default": 30 },
+          "min_distance": { "global_val": "exfildistancemin", "default": 5 },
+          "reveal_radius": { "global_val": "scoutingdistancetargets", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -347,9 +343,9 @@
         "target_params": {
           "om_terrain": "forest",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": { "global_val": "var", "var_name": "exfildistancemax", "default": 30 },
-          "min_distance": { "global_val": "var", "var_name": "exfildistancemin", "default": 5 },
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancetargets", "default": 0 },
+          "search_range": { "global_val": "exfildistancemax", "default": 30 },
+          "min_distance": { "global_val": "exfildistancemin", "default": 5 },
+          "reveal_radius": { "global_val": "scoutingdistancetargets", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -366,9 +362,9 @@
         "target_params": {
           "om_terrain": "house",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": { "global_val": "var", "var_name": "exfildistancemax", "default": 30 },
-          "min_distance": { "global_val": "var", "var_name": "exfildistancemin", "default": 5 },
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancetargets", "default": 0 },
+          "search_range": { "global_val": "exfildistancemax", "default": 30 },
+          "min_distance": { "global_val": "exfildistancemin", "default": 5 },
+          "reveal_radius": { "global_val": "scoutingdistancetargets", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -385,9 +381,9 @@
         "target_params": {
           "om_terrain": "field",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": { "global_val": "var", "var_name": "missiondistancemax", "default": 30 },
-          "min_distance": { "global_val": "var", "var_name": "missiondistancemin", "default": 5 },
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancetargets", "default": 0 },
+          "search_range": { "global_val": "missiondistancemax", "default": 30 },
+          "min_distance": { "global_val": "missiondistancemin", "default": 5 },
+          "reveal_radius": { "global_val": "scoutingdistancetargets", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -405,9 +401,9 @@
         "target_params": {
           "om_terrain": "forest",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": { "global_val": "var", "var_name": "missiondistancemax", "default": 30 },
-          "min_distance": { "global_val": "var", "var_name": "missiondistancemin", "default": 5 },
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancetargets", "default": 0 },
+          "search_range": { "global_val": "missiondistancemax", "default": 30 },
+          "min_distance": { "global_val": "missiondistancemin", "default": 5 },
+          "reveal_radius": { "global_val": "scoutingdistancetargets", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -425,9 +421,9 @@
         "target_params": {
           "om_terrain": "house",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": { "global_val": "var", "var_name": "missiondistancemax", "default": 30 },
-          "min_distance": { "global_val": "var", "var_name": "missiondistancemin", "default": 5 },
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancetargets", "default": 0 },
+          "search_range": { "global_val": "missiondistancemax", "default": 30 },
+          "min_distance": { "global_val": "missiondistancemin", "default": 5 },
+          "reveal_radius": { "global_val": "scoutingdistancetargets", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -487,7 +483,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -516,7 +512,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -553,7 +549,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -590,7 +586,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -635,7 +631,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -680,7 +676,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -707,7 +703,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -736,7 +732,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -773,7 +769,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -810,7 +806,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -837,7 +833,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -867,7 +863,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -892,7 +888,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -917,7 +913,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },
@@ -948,7 +944,7 @@
           "type": "mixed"
         },
         { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "var", "var_name": "totalbonus", "default": 1 } }
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
       ]
     }
   },

--- a/data/mods/Sky_Island/obelisk_selector.json
+++ b/data/mods/Sky_Island/obelisk_selector.json
@@ -98,7 +98,7 @@
           "om_terrain_match_type": "CONTAINS",
           "search_range": 1200,
           "min_distance": 200,
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancelanding", "default": 0 },
+          "reveal_radius": { "global_val": "scoutingdistancelanding", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -118,7 +118,7 @@
           "om_terrain_match_type": "CONTAINS",
           "search_range": 1200,
           "min_distance": 200,
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancelanding", "default": 0 },
+          "reveal_radius": { "global_val": "scoutingdistancelanding", "default": 0 },
           "z": 0,
           "random": true
         }
@@ -139,7 +139,7 @@
           "om_terrain_match_type": "CONTAINS",
           "search_range": 1200,
           "min_distance": 200,
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancelanding", "default": 0 },
+          "reveal_radius": { "global_val": "scoutingdistancelanding", "default": 0 },
           "z": -1,
           "random": true
         },
@@ -162,7 +162,7 @@
           "om_terrain_match_type": "CONTAINS",
           "search_range": 1200,
           "min_distance": 200,
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancelanding", "default": 0 },
+          "reveal_radius": { "global_val": "scoutingdistancelanding", "default": 0 },
           "z": 1,
           "random": true
         },
@@ -185,7 +185,7 @@
           "om_terrain_match_type": "CONTAINS",
           "search_range": 1200,
           "min_distance": 200,
-          "reveal_radius": { "global_val": "var", "var_name": "scoutingdistancelanding", "default": 0 },
+          "reveal_radius": { "global_val": "scoutingdistancelanding", "default": 0 },
           "z": -2,
           "random": true
         },

--- a/data/mods/Sky_Island/sickness_checks.json
+++ b/data/mods/Sky_Island/sickness_checks.json
@@ -3,7 +3,7 @@
     "type": "effect_on_condition",
     "id": "EOC_constantticking",
     "//": "This EOC triggers once every x amount of minutes where x is determined by your difficulty.  This happens only while you're away from base, otherwise it's dormant.  All it does is increase your sickness counter by 1 every time it triggers and then calls the more detailed sickness check EOC.",
-    "recurrence": { "global_val": "var", "var_name": "currentpulselength", "default": "15 m" },
+    "recurrence": { "global_val": "currentpulselength", "default": "15 m" },
     "condition": { "u_has_trait": "awayfromhome" },
     "deactivate_condition": { "not": { "u_has_trait": "awayfromhome" } },
     "effect": [

--- a/data/mods/Xedra_Evolved/eocs/abyssal_hunger_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/abyssal_hunger_eocs.json
@@ -8,7 +8,7 @@
       { "u_location_variable": { "global_val": "dungeon_roof_loc" }, "z_adjust": 7, "z_override": true },
       { "revert_location": { "global_val": "dungeon_loc" }, "key": "abyssal_hunger", "time_in_future": "infinite" },
       {
-        "place_override": { "global_val": "place_name", "default_str": "Inside the Abyssal Hunger" },
+        "place_override": { "global_val": "place_name", "default": "Inside the Abyssal Hunger" },
         "key": "abyssal_hunger",
         "length": "infinite"
       },

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -410,12 +410,6 @@ var_info read_var_info( const JsonObject &jo )
     } else if( jo.has_member( "context_val" ) ) {
         type = var_type::context;
         name = get_talk_varname( jo, "context_val" );
-    } else if( jo.has_member( "faction_val" ) ) {
-        type = var_type::faction;
-        name = get_talk_varname( jo, "faction_val" );
-    } else if( jo.has_member( "party_val" ) ) {
-        type = var_type::party;
-        name = get_talk_varname( jo, "party_val" );
     } else {
         jo.throw_error( "Invalid variable type." );
     }
@@ -457,12 +451,6 @@ void write_var_value( var_type type, const std::string &name, dialogue *d,
                 debugmsg( "Tried to use an invalid beta talker.  %s", d->get_callstack() );
             }
             break;
-        case var_type::faction:
-            debugmsg( "Not implemented yet." );
-            break;
-        case var_type::party:
-            debugmsg( "Not implemented yet." );
-            break;
         case var_type::context:
             d->set_value( name, value );
             break;
@@ -483,8 +471,6 @@ void write_var_value( var_type type, const std::string &name, const_dialogue con
         case var_type::var:
         case var_type::u:
         case var_type::npc:
-        case var_type::faction:
-        case var_type::party:
             debugmsg( "Only global variables can be assigned from an eval function.\n%s", d.get_callstack() );
             break;
         default:

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -164,15 +164,9 @@ std::shared_ptr<math_exp> &defer_math( JsonObject const &jo, std::string_view st
 
 }  // namespace
 
-std::string get_talk_varname( const JsonObject &jo, std::string_view member,
-                              bool check_value, dbl_or_var &default_val )
+std::string get_talk_varname( const JsonObject &jo, std::string_view member )
 {
-    if( check_value && !( jo.has_string( "value" ) ||
-                          jo.has_array( "possible_values" ) ) ) {
-        jo.throw_error( "invalid " + std::string( member ) + " condition in " + jo.str() );
-    }
     const std::string &var_basename = jo.get_string( std::string( member ) );
-    default_val = get_dbl_or_var( jo, "default", false );
     return var_basename;
 }
 
@@ -187,8 +181,7 @@ std::string get_talk_var_basename( const JsonObject &jo, std::string_view member
     return var_basename;
 }
 
-dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv, std::string_view member, bool required,
-                                     double default_val )
+dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv )
 {
     dbl_or_var_part ret_val;
     if( jv.test_float() ) {
@@ -199,13 +192,11 @@ dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv, std::string_view membe
             ret_val.math_val.emplace();
             ret_val.math_val->from_json( jo, "math", eoc_math::type_t::ret );
         } else {
-            jo.allow_omitted_members();
             ret_val.var_val = read_var_info( jo );
+            optional( jo, false, "default", ret_val.default_val );
         }
-    } else if( required ) {
-        jv.throw_error( "No valid value for " + std::string( member ) );
     } else {
-        ret_val.dbl_val = default_val;
+        jv.throw_error( "Value must be a float or a variable object" );
     }
     return ret_val;
 }
@@ -216,23 +207,20 @@ dbl_or_var get_dbl_or_var( const JsonObject &jo, std::string_view member, bool r
     dbl_or_var ret_val;
     if( jo.has_array( member ) ) {
         JsonArray ja = jo.get_array( member );
-        ret_val.min = get_dbl_or_var_part( ja.next_value(), member );
-        ret_val.max = get_dbl_or_var_part( ja.next_value(), member );
+        ret_val.min = get_dbl_or_var_part( ja.next_value() );
+        ret_val.max = get_dbl_or_var_part( ja.next_value() );
         ret_val.pair = true;
+    } else if( jo.has_member( member ) ) {
+        ret_val.min = get_dbl_or_var_part( jo.get_member( member ) );
     } else if( required ) {
-        ret_val.min = get_dbl_or_var_part( jo.get_member( member ), member, required, default_val );
+        jo.throw_error( "No valid value for " + std::string( member ) );
     } else {
-        if( jo.has_member( member ) ) {
-            ret_val.min = get_dbl_or_var_part( jo.get_member( member ), member, required, default_val );
-        } else {
-            ret_val.min.dbl_val = default_val;
-        }
+        ret_val.min.dbl_val = default_val;
     }
     return ret_val;
 }
 
-duration_or_var_part get_duration_or_var_part( const JsonValue &jv, const std::string_view &member,
-        bool required, time_duration default_val )
+duration_or_var_part get_duration_or_var_part( const JsonValue &jv )
 {
     duration_or_var_part ret_val;
     if( jv.test_string() ) {
@@ -249,13 +237,21 @@ duration_or_var_part get_duration_or_var_part( const JsonValue &jv, const std::s
             ret_val.math_val.emplace();
             ret_val.math_val->from_json( jo, "math", eoc_math::type_t::ret );
         } else {
-            jo.allow_omitted_members();
             ret_val.var_val = read_var_info( jo );
+            if( jo.has_int( "default" ) ) {
+                ret_val.default_val = time_duration::from_turns( jo.get_int( "default" ) );
+            } else if( jo.has_string( "default" ) ) {
+                std::string const &def_str = jo.get_string( "default" );
+                if( def_str == "infinite" ) {
+                    ret_val.dur_val = time_duration::from_turns( calendar::INDEFINITELY_LONG );
+                } else {
+                    JsonValue const &jv_def = jo.get_member( "default" );
+                    ret_val.dur_val = read_from_json_string<time_duration>( jv_def, time_duration::units );
+                }
+            }
         }
-    } else if( required ) {
-        jv.throw_error( "No valid value for " + std::string( member ) );
     } else {
-        ret_val.dur_val = default_val;
+        jv.throw_error( "Value must be a time string, or an integer, or a variable object" );
     }
     return ret_val;
 }
@@ -267,17 +263,15 @@ duration_or_var get_duration_or_var( const JsonObject &jo, const std::string_vie
     duration_or_var ret_val;
     if( jo.has_array( member ) ) {
         JsonArray ja = jo.get_array( member );
-        ret_val.min = get_duration_or_var_part( ja.next_value(), member );
-        ret_val.max = get_duration_or_var_part( ja.next_value(), member );
+        ret_val.min = get_duration_or_var_part( ja.next_value() );
+        ret_val.max = get_duration_or_var_part( ja.next_value() );
         ret_val.pair = true;
+    } else if( jo.has_member( member ) ) {
+        ret_val.min = get_duration_or_var_part( jo.get_member( member ) );
     } else if( required ) {
-        ret_val.min = get_duration_or_var_part( jo.get_member( member ), member, required, default_val );
+        jo.throw_error( "No valid value for " + std::string( member ) );
     } else {
-        if( jo.has_member( member ) ) {
-            ret_val.min = get_duration_or_var_part( jo.get_member( member ), member, required, default_val );
-        } else {
-            ret_val.min.dur_val = default_val;
-        }
+        ret_val.min.dur_val = default_val;
     }
     return ret_val;
 }
@@ -289,7 +283,7 @@ str_or_var get_str_or_var( const JsonValue &jv, std::string_view member, bool re
     if( jv.test_string() ) {
         ret_val.str_val = jv.get_string();
     } else if( jv.test_object() ) {
-        ret_val = get_str_or_var( jv.get_object(), member, default_val );
+        ret_val = get_str_or_var_part( jv.get_object() );
     } else if( required ) {
         jv.throw_error( "No valid value for " + std::string( member ) );
     } else {
@@ -298,8 +292,7 @@ str_or_var get_str_or_var( const JsonValue &jv, std::string_view member, bool re
     return ret_val;
 }
 
-str_or_var get_str_or_var( const JsonObject &jo, std::string_view,
-                           std::string_view default_val )
+str_or_var get_str_or_var_part( const JsonObject &jo )
 {
     str_or_var ret_val;
     if( jo.has_member( "mutator" ) ) {
@@ -307,7 +300,9 @@ str_or_var get_str_or_var( const JsonObject &jo, std::string_view,
         ret_val.function = conditional_t::get_get_string( jo );
     } else {
         ret_val.var_val = read_var_info( jo );
-        ret_val.default_val = default_val;
+        if( jo.has_string( "default" ) ) {
+            ret_val.default_val = jo.get_string( "default" );
+        }
     }
     return ret_val;
 }
@@ -327,7 +322,7 @@ translation_or_var get_translation_or_var( const JsonValue &jv, std::string_view
 {
     translation_or_var ret_val;
     if( jv.test_object() ) {
-        ret_val = get_translation_or_var( jv.get_object(), member, default_val );
+        ret_val = get_translation_or_var( jv.get_object() );
     } else {
         translation str_val;
         if( jv.read( str_val ) ) {
@@ -341,8 +336,7 @@ translation_or_var get_translation_or_var( const JsonValue &jv, std::string_view
     return ret_val;
 }
 
-translation_or_var get_translation_or_var( const JsonObject &jo, std::string_view,
-        const translation &default_val )
+translation_or_var get_translation_or_var( const JsonObject &jo )
 {
     translation_or_var ret_val;
     translation str_val;
@@ -353,27 +347,28 @@ translation_or_var get_translation_or_var( const JsonObject &jo, std::string_vie
             // if we have a mutator then process that here.
             ret_val.function = conditional_t::get_get_translation( jo );
         } else {
-            ret_val.var_val = read_translation_var_info( jo );
-            ret_val.default_val = default_val;
+            ret_val.var_val = read_var_info( jo );
+            if( jo.has_string( "default" ) ) {
+                ret_val.default_val = to_translation( jo.get_string( "default" ) );
+            }
         }
     }
     return ret_val;
 }
 
 str_translation_or_var get_str_translation_or_var(
-    const JsonValue &jv, std::string_view member, bool required,
-    std::string_view str_default_val, const translation &translation_default_val )
+    const JsonValue &jv, std::string_view member, bool required )
 {
     str_translation_or_var ret_val;
     if( jv.test_object() ) {
         const JsonObject &jo = jv.get_object();
         if( jo.get_bool( "i18n", false ) ) {
-            ret_val.val = get_translation_or_var( jo, member, translation_default_val );
+            ret_val.val = get_translation_or_var( jo );
         } else {
-            ret_val.val = get_str_or_var( jo, member, str_default_val );
+            ret_val.val = get_str_or_var_part( jo );
         }
     } else {
-        ret_val.val = get_str_or_var( jv, member, required, str_default_val );
+        ret_val.val = get_str_or_var( jv, member, required );
     }
     return ret_val;
 }
@@ -395,91 +390,36 @@ tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const_dialog
     return get_map().getglobal( d.const_actor( is_npc )->pos() );
 }
 
-template<class T>
-static T abstract_read_var_info_no_translation( std::string && );
-
-template<>
-std::string abstract_read_var_info_no_translation( std::string &&s )
+var_info read_var_info( const JsonObject &jo )
 {
-    return std::move( s );
-}
-
-template<>
-translation abstract_read_var_info_no_translation( std::string &&s )
-{
-    return no_translation( s );
-}
-
-template<class T>
-static abstract_var_info<T> abstract_read_var_info( const JsonObject &jo )
-{
-    T default_val;
-    dbl_or_var empty;
-    var_type type;
+    var_type type{ var_type::last };
     std::string name;
-    if( jo.has_member( "default_str" ) ) {
-        jo.read( "default_str", default_val );
-    } else if( jo.has_string( "default" ) ) {
-        std::string tmp = std::to_string( to_turns<int>( read_from_json_string<time_duration>
-                                          ( jo.get_member( "default" ), time_duration::units ) ) );
-        default_val = abstract_read_var_info_no_translation<T>( std::move( tmp ) );
-    } else if( jo.has_float( "default" ) ) {
-        std::string tmp = std::to_string( jo.get_float( "default" ) );
-        default_val = abstract_read_var_info_no_translation<T>( std::move( tmp ) );
-    }
 
-    if( jo.has_string( "var_name" ) ) {
-        name = jo.get_string( "var_name" );
-    }
     if( jo.has_member( "u_val" ) ) {
         type = var_type::u;
-        if( name.empty() ) {
-            name = get_talk_varname( jo, "u_val", false, empty );
-        }
+        name = get_talk_varname( jo, "u_val" );
     } else if( jo.has_member( "npc_val" ) ) {
         type = var_type::npc;
-        if( name.empty() ) {
-            name = get_talk_varname( jo, "npc_val", false, empty );
-        }
+        name = get_talk_varname( jo, "npc_val" );
     } else if( jo.has_member( "global_val" ) ) {
         type = var_type::global;
-        if( name.empty() ) {
-            name = get_talk_varname( jo, "global_val", false, empty );
-        }
+        name = get_talk_varname( jo, "global_val" );
     } else if( jo.has_member( "var_val" ) ) {
         type = var_type::var;
-        if( name.empty() ) {
-            name = get_talk_varname( jo, "var_val", false, empty );
-        }
+        name = get_talk_varname( jo, "var_val" );
     } else if( jo.has_member( "context_val" ) ) {
         type = var_type::context;
-        if( name.empty() ) {
-            name = get_talk_varname( jo, "context_val", false, empty );
-        }
+        name = get_talk_varname( jo, "context_val" );
     } else if( jo.has_member( "faction_val" ) ) {
         type = var_type::faction;
-        if( name.empty() ) {
-            name = get_talk_varname( jo, "faction_val", false, empty );
-        }
+        name = get_talk_varname( jo, "faction_val" );
     } else if( jo.has_member( "party_val" ) ) {
         type = var_type::party;
-        if( name.empty() ) {
-            name = get_talk_varname( jo, "party_val", false, empty );
-        }
+        name = get_talk_varname( jo, "party_val" );
     } else {
         jo.throw_error( "Invalid variable type." );
     }
-    return abstract_var_info<T>( type, name, default_val );
-}
-
-var_info read_var_info( const JsonObject &jo )
-{
-    return abstract_read_var_info<std::string>( jo );
-}
-
-translation_var_info read_translation_var_info( const JsonObject &jo )
-{
-    return abstract_read_var_info<translation>( jo );
+    return { type, name };
 }
 
 void write_var_value( var_type type, const std::string &name, dialogue *d,

--- a/src/condition.h
+++ b/src/condition.h
@@ -39,38 +39,29 @@ struct enum_traits<jarg> {
 
 str_or_var get_str_or_var( const JsonValue &jv, std::string_view member, bool required = true,
                            std::string_view default_val = "" );
-str_or_var get_str_or_var( const JsonObject &jo, std::string_view member,
-                           std::string_view default_val = "" );
+str_or_var get_str_or_var_part( const JsonObject &jo );
 translation_or_var get_translation_or_var( const JsonValue &jv, std::string_view member,
         bool required = true, const translation &default_val = {} );
-translation_or_var get_translation_or_var( const JsonObject &jo, std::string_view member,
-        const translation &default_val = {} );
+translation_or_var get_translation_or_var( const JsonObject &jo );
 str_translation_or_var get_str_translation_or_var(
-    const JsonValue &jv, std::string_view member, bool required = true,
-    std::string_view str_default_val = "", const translation &translation_default_val = {} );
+    const JsonValue &jv, std::string_view member, bool required = true );
 dbl_or_var get_dbl_or_var( const JsonObject &jo, std::string_view member, bool required = true,
                            double default_val = 0.0 );
-dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv, std::string_view member,
-                                     bool required = true,
-                                     double default_val = 0.0 );
+dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv );
 duration_or_var get_duration_or_var( const JsonObject &jo, const std::string_view &member,
                                      bool required = true,
                                      time_duration default_val = 0_seconds );
-duration_or_var_part get_duration_or_var_part( const JsonValue &jv, const std::string_view &member,
-        bool required = true,
-        time_duration default_val = 0_seconds );
+duration_or_var_part get_duration_or_var_part( const JsonValue &jv );
 tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const_dialogue const &d,
                                        bool is_npc );
 var_info read_var_info( const JsonObject &jo );
-translation_var_info read_translation_var_info( const JsonObject &jo );
 void write_var_value( var_type type, const std::string &name, dialogue *d,
                       const std::string &value, int call_depth = 0 );
 void write_var_value( var_type type, const std::string &name, dialogue *d,
                       double value );
 void write_var_value( var_type type, const std::string &name, const_dialogue const &d,
                       const std::string &value );
-std::string get_talk_varname( const JsonObject &jo, std::string_view member,
-                              bool check_value, dbl_or_var &default_val );
+std::string get_talk_varname( const JsonObject &jo, std::string_view member );
 std::string get_talk_var_basename( const JsonObject &jo, std::string_view member,
                                    bool check_value );
 // the truly awful declaration for the conditional_t loading helper_function

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -30,8 +30,6 @@ std::optional<std::string> maybe_read_var_value( const var_info &info, const_dia
                                                        call_depth + 1 ) : std::nullopt;
             }
         }
-        case var_type::faction:
-        case var_type::party:
         case var_type::last:
             return std::nullopt;
     }

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -6,9 +6,8 @@
 #include "rng.h"
 #include "talker.h"
 
-template<class T>
-std::optional<std::string> maybe_read_var_value(
-    const abstract_var_info<T> &info, const_dialogue const &d, int call_depth )
+std::optional<std::string> maybe_read_var_value( const var_info &info, const_dialogue const &d,
+        int call_depth )
 {
     global_variables &globvars = get_globals();
     switch( info.type ) {
@@ -39,22 +38,9 @@ std::optional<std::string> maybe_read_var_value(
     return std::nullopt;
 }
 
-template
-std::optional<std::string> maybe_read_var_value( const var_info &, const_dialogue const &,
-        int call_depth );
-template std::optional<std::string> maybe_read_var_value( const translation_var_info &,
-        const_dialogue const &, int call_depth );
-
-template<>
 std::string read_var_value( const var_info &info, const_dialogue const &d )
 {
-    return maybe_read_var_value( info, d ).value_or( info.default_val );
-}
-
-template<>
-std::string read_var_value( const translation_var_info &info, const_dialogue const &d )
-{
-    return maybe_read_var_value( info, d ).value_or( info.default_val.translated() );
+    return maybe_read_var_value( info, d ).value_or( std::string{} );
 }
 
 var_info process_variable( const std::string &type )
@@ -108,14 +94,10 @@ std::string str_or_var::evaluate( const_dialogue const &d ) const
         if( default_val.has_value() ) {
             return default_val.value();
         }
-        std::string var_name = var_val.value().name;
-        debugmsg( "No default value provided for str_or_var_part while encountering unused "
-                  "variable %s.  Add a \"default_str\" member to prevent this.  %s",
-                  var_name, d.get_callstack() );
-        return "";
+        return {};
     }
     debugmsg( "No valid value for str_or_var_part.  %s", d.get_callstack() );
-    return "";
+    return {};
 }
 
 template<>
@@ -135,14 +117,10 @@ std::string translation_or_var::evaluate( const_dialogue const &d ) const
         if( default_val.has_value() ) {
             return default_val.value().translated();
         }
-        std::string var_name = var_val.value().name;
-        debugmsg( "No default value provided for str_or_var_part while encountering unused "
-                  "variable %s.  Add a \"default_str\" member to prevent this.  %s",
-                  var_name, d.get_callstack() );
-        return "";
+        return {};
     }
     debugmsg( "No valid value for str_or_var_part.  %s", d.get_callstack() );
-    return "";
+    return {};
 }
 
 std::string str_translation_or_var::evaluate( const_dialogue const &d ) const
@@ -165,10 +143,6 @@ double dbl_or_var_part::evaluate( const_dialogue const &d ) const
         if( default_val.has_value() ) {
             return default_val.value();
         }
-        std::string var_name = var_val.value().name;
-        debugmsg( "No default value provided for dbl_or_var_part while encountering unused "
-                  "variable %s.  Add a \"default\" member to prevent this.  %s",
-                  var_name, d.get_callstack() );
         return 0;
     }
     if( math_val ) {
@@ -202,10 +176,6 @@ time_duration duration_or_var_part::evaluate( const_dialogue const &d ) const
         if( default_val.has_value() ) {
             return default_val.value();
         }
-        std::string var_name = var_val.value().name;
-        debugmsg( "No default value provided for duration_or_var_part while encountering unused "
-                  "variable %s.  Add a \"default\" member to prevent this.  %s",
-                  var_name, d.get_callstack() );
         return 0_seconds;
     }
     if( math_val ) {

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -32,26 +32,19 @@ struct dbl_or_var;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-template<class T>
-struct abstract_var_info {
-    abstract_var_info( var_type in_type, std::string in_name ): type( in_type ),
+struct var_info {
+    var_info( var_type in_type, std::string in_name ): type( in_type ),
         name( std::move( in_name ) ) {}
-    abstract_var_info( var_type in_type, std::string in_name, T in_default_val ): type( in_type ),
-        name( std::move( in_name ) ), default_val( std::move( in_default_val ) ) {}
-    abstract_var_info() : type( var_type::global ) {}
+    var_info() : type( var_type::last ) {}
     var_type type;
     std::string name;
-    T default_val;
 };
 #pragma GCC diagnostic pop
-
-using var_info = abstract_var_info<std::string>;
-using translation_var_info = abstract_var_info<translation>;
 
 template<class T>
 struct abstract_str_or_var {
     std::optional<T> str_val;
-    std::optional<abstract_var_info<T>> var_val;
+    std::optional<var_info> var_val;
     std::optional<T> default_val;
     std::optional<std::function<T( const_dialogue const & )>> function;
     std::string evaluate( const_dialogue const & ) const;
@@ -91,11 +84,9 @@ struct talk_effect_fun_t {
         }
 };
 
-template<class T>
-std::string read_var_value( const abstract_var_info<T> &info, const_dialogue const &d );
-template<class T>
+std::string read_var_value( const var_info &info, const_dialogue const &d );
 std::optional<std::string> maybe_read_var_value(
-    const abstract_var_info<T> &info, const_dialogue const &d, int call_depth = 0 );
+    const var_info &info, const_dialogue const &d, int call_depth = 0 );
 
 var_info process_variable( const std::string &type );
 

--- a/src/global_vars.h
+++ b/src/global_vars.h
@@ -9,8 +9,6 @@ enum class var_type : int {
     u,
     npc,
     global,
-    faction,
-    party,
     context,
     var,
     last

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1552,12 +1552,10 @@ void mtype::add_special_attack( const JsonArray &inner, const std::string_view )
     }
     mtype_special_attack new_attack = mtype_special_attack( iter->second );
     if( inner.has_array( 1 ) ) {
-        new_attack.actor->cooldown.min = get_dbl_or_var_part( inner.get_array( 1 )[0],
-                                         "special attack cooldown", 0.0 );
-        new_attack.actor->cooldown.max = get_dbl_or_var_part( inner.get_array( 1 )[1],
-                                         "special attack cooldown", 0.0 );
+        new_attack.actor->cooldown.min = get_dbl_or_var_part( inner.get_array( 1 )[0] );
+        new_attack.actor->cooldown.max = get_dbl_or_var_part( inner.get_array( 1 )[1] );
     } else {
-        new_attack.actor->cooldown.min = get_dbl_or_var_part( inner[1], "special attack cooldown", 0.0 );
+        new_attack.actor->cooldown.min = get_dbl_or_var_part( inner[1] );
     }
     special_attacks.emplace( name, new_attack );
     special_attacks_names.push_back( name );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3522,7 +3522,7 @@ talk_effect_fun_t::func f_add_var( const JsonObject &jo, std::string_view member
                                    const std::string_view, bool is_npc )
 {
     dbl_or_var empty;
-    const std::string var_name = get_talk_varname( jo, member, false, empty );
+    const std::string var_name = get_talk_varname( jo, member );
     const std::string var_base_name = get_talk_var_basename( jo, member, false );
     const bool time_check = jo.has_member( "time" ) && jo.get_bool( "time" );
     std::vector<std::string> possible_values = jo.get_string_array( "possible_values" );
@@ -3545,8 +3545,7 @@ talk_effect_fun_t::func f_add_var( const JsonObject &jo, std::string_view member
 talk_effect_fun_t::func f_remove_var( const JsonObject &jo, std::string_view member,
                                       const std::string_view, bool is_npc )
 {
-    dbl_or_var empty;
-    const std::string var_name = get_talk_varname( jo, member, false, empty );
+    const std::string var_name = get_talk_varname( jo, member );
     return [is_npc, var_name]( dialogue const & d ) {
         d.actor( is_npc )->remove_value( var_name );
     };
@@ -6213,7 +6212,7 @@ talk_effect_fun_t::func f_weighted_list_eocs( const JsonObject &jo,
         if( ja.test_int() ) {
             eoc_weight.min = dbl_or_var_part{ ja.next_int() };
         } else {
-            eoc_weight.min = get_dbl_or_var_part( ja.next_value(), member );
+            eoc_weight.min = get_dbl_or_var_part( ja.next_value() );
         }
         eoc_pairs.emplace_back( effect_on_conditions::load_inline_eoc( eoc, src ),
                                 eoc_weight );


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
The code for default EOC-var values is a bit of a mess and stands in the way of other changes I'm planning
- it holds different defaults in `var_info` and the helper structs (`dbl_or_var`, etc)
- it's not clear which default you're getting and the handling is not consistent
- it needs ugly templated code to handle the defaults in `var_info`

#### Describe the solution
Hold JSON-defined default value only in the helper structs `X_or_var`
JSON-defined default is used only when the variable is undefined
Code-defined default is used only when requried = false, like in a bootleg `optional()`

Also change a couple of things that are technically unrelated but in the same code:
- replace obsolete syntax `"var_name"`for variable access `{ "global_val": "var", "var_name": "some_var" },`
- delete unimplemented var types `party` and `faction`. We've carried this cruft around for years

#### Describe alternatives you've considered
N/A

#### Testing
Game loads and existing test units pass

- [ ] write a test unit specifically for defaults if there isn't one

#### Additional context
N/A
