### PR TITLE
national weather transcripts grammar fix

### DIFF
--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -795,7 +795,7 @@
     "id": "record_weather",
     "type": "BOOK",
     "name": { "str_sp": "national weather transcripts" },
-    "description": "Old weather records are about as interesting as a rock.",
+    "description": "Old weather records that are about as interesting as a rock.",
     "weight": "454 g",
     "volume": "1750 ml",
     "price": "5 USD",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The record_weather description was slightly wrong so I fixed it.

#### Describe the solution

 I changed the description from "Old weather records are about as interesting as a rock." to "Old weather records that are about as interesting as a rock."
 
#### Describe alternatives you've considered

Nothing really.

#### Testing

I was told there was no need to test a 1 word change.

#### Additional context

I don't think there's anything else to write home to. 
