### PR TITLE
add spicebush and chokeberries

### DIFF
--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -2442,6 +2442,112 @@
   },
   {
     "type": "terrain",
+    "id": "t_shrub_spicebush",
+    "name": "spicebush",
+    "description": "A bush that features small, red berries.",
+    "symbol": "#",
+    "color": "light_green_green",
+    "move_cost": 8,
+    "coverage": 40,
+    "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE", "BROWSABLE" ],
+    "transforms_into": "t_shrub_spicebush_harvested",
+    "examine_action": "harvest_ter_nectar",
+    "looks_like": "t_shrub_blueberry",
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "shrub_spicebush_harv" } ],
+    "bash": {
+      "str_min": 4,
+      "str_max": 60,
+      "sound": "crunch.",
+      "sound_fail": "brush.",
+      "ter_set": "t_dirt",
+      "items": [
+        { "item": "withered", "prob": 50, "count": [ 1, 2 ] },
+        { "item": "leaves", "count": [ 1, 10 ] },
+        { "item": "twig", "prob": 80, "count": [ 1, 5 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_shrub_spicebush_harvested",
+    "name": "spicebush",
+    "description": "A bush that usually features small, red berries but it was picked clean.",
+    "symbol": "#",
+    "color": "green_green",
+    "move_cost": 8,
+    "coverage": 40,
+    "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "HARVESTED", "SMALL_HIDE" ],
+    "transforms_into": "t_shrub_spicebush",
+    "examine_action": "harvested_plant",
+    "looks_like": "t_shrub_blueberry_harvested",
+    "bash": {
+      "str_min": 4,
+      "str_max": 60,
+      "sound": "crunch.",
+      "sound_fail": "brush.",
+      "ter_set": "t_dirt",
+      "items": [
+        { "item": "withered", "prob": 50, "count": [ 1, 2 ] },
+        { "item": "leaves", "count": [ 1, 10 ] },
+        { "item": "twig", "prob": 80, "count": [ 1, 5 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_shrub_chokeberry",
+    "name": "black chokeberry bush",
+    "description": "Drooping black berries adorn the shrub during autumn.  These have a distinctive star-shaped fold and look quite juicy.",
+    "symbol": "#",
+    "color": "light_green_green",
+    "move_cost": 8,
+    "coverage": 40,
+    "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE", "BROWSABLE" ],
+    "transforms_into": "t_shrub_chokeberry_harvested",
+    "examine_action": "harvest_ter_nectar",
+    "looks_like": "t_shrub_blueberry",
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "shrub_chokeberry_harv" } ],
+    "bash": {
+      "str_min": 4,
+      "str_max": 60,
+      "sound": "crunch.",
+      "sound_fail": "brush.",
+      "ter_set": "t_dirt",
+      "items": [
+        { "item": "withered", "prob": 50, "count": [ 1, 2 ] },
+        { "item": "leaves", "count": [ 1, 10 ] },
+        { "item": "twig", "prob": 80, "count": [ 1, 5 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_shrub_chokeberry_harvested",
+    "name": "black chokeberry bush",
+    "description": "Drooping black berries adorned this shrub, but the shrub was picked clean.",
+    "symbol": "#",
+    "color": "green_green",
+    "move_cost": 8,
+    "coverage": 40,
+    "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "HARVESTED", "SMALL_HIDE" ],
+    "transforms_into": "t_shrub_chokeberry",
+    "examine_action": "harvested_plant",
+    "looks_like": "t_shrub_blueberry_harvested",
+    "bash": {
+      "str_min": 4,
+      "str_max": 60,
+      "sound": "crunch.",
+      "sound_fail": "brush.",
+      "ter_set": "t_dirt",
+      "items": [
+        { "item": "withered", "prob": 50, "count": [ 1, 2 ] },
+        { "item": "leaves", "count": [ 1, 10 ] },
+        { "item": "twig", "prob": 80, "count": [ 1, 5 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_shrub_rose",
     "name": "rose bush",
     "description": "A fat bush of beautiful red roses, if only you could get a date!  Watch out for its thorns!",

--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -168,6 +168,16 @@
     "entries": [ { "drop": "rose_hips", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] } ]
   },
   {
+    "id": "shrub_chokeberry_harv",
+    "type": "harvest",
+    "entries": [ { "drop": "chokeberries", "base_num": [ 6, 12 ], "scale_num": [ 0, 0.5 ] } ]
+  },
+  {
+    "id": "shrub_spicebush_harv",
+    "type": "harvest",
+    "entries": [ { "drop": "spicebush_berries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.5 ] } ]
+  },
+  {
     "id": "shrub_grape_harv",
     "type": "harvest",
     "entries": [

--- a/data/json/items/comestibles/fruit_dishes.json
+++ b/data/json/items/comestibles/fruit_dishes.json
@@ -58,6 +58,7 @@
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "rose_hips_cut", "name": { "str_sp": "%s, rose hip" } },
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "strawberries", "name": { "str_sp": "%s, strawberry" } },
       { "type": "COMPONENT_ID", "condition": "watermelon_wedge", "name": { "str_sp": "%s, watermelon" } },
+      { "type": "COMPONENT_ID", "condition": "chokeberries", "name": { "str_sp": "%s, chokeberries" } },
       { "type": "COMPONENT_ID", "condition": "wintergreen_berry", "name": { "str_sp": "%s, wintergreen berry" } }
     ],
     "weight": "34 g",
@@ -304,6 +305,7 @@
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "blackberries", "name": { "str_sp": "%s, blackberry" } },
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "blueberries", "name": { "str_sp": "%s, blueberry" } },
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "cherries", "name": { "str_sp": "%s, cherry" } },
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "chokeberries", "name": { "str_sp": "%s, chokeberries" } },
       { "type": "COMPONENT_ID", "condition": "cholla_bud", "name": { "str_sp": "%s, cholla bud" } },
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "coconut", "name": { "str_sp": "%s, coconut" } },
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "crabapple", "name": { "str_sp": "%s, crabapple" } },

--- a/data/json/items/comestibles/raw_fruit.json
+++ b/data/json/items/comestibles/raw_fruit.json
@@ -156,12 +156,12 @@
     "symbol": "%",
     "quench": 2,
     "calories": 46,
-    "description": "A handful of sour red berries, probably grown locally in Massachusetts.  Good for urinary tract health.",
+    "description": "A handful of very bitter red berries, probably grown locally in Massachusetts.  Good for urinary tract health.",
     "price": "17 cent",
     "price_postapoc": "33 cent",
     "material": [ "fruit" ],
     "volume": "250 ml",
-    "fun": -5,
+    "fun": -10,
     "flags": [ "SMOKABLE", "EDIBLE_FROZEN" ],
     "smoking_result": "dry_fruit",
     "vitamins": [ [ "vitC", "13300 μg" ], [ "iron", "300 μg" ], [ "calcium", "8 mg" ], [ "fruit_allergen", 1 ] ]
@@ -311,6 +311,18 @@
     "flags": [ "SMOKABLE", "RAW", "EDIBLE_FROZEN" ],
     "smoking_result": "dry_fruit",
     "vitamins": [ [ "vitC", "52200 μg" ], [ "iron", "2300 μg" ], [ "calcium", "55100 μg" ], [ "fruit_allergen", 1 ] ]
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "chokeberries",
+    "name": { "str": "handful of chokeberries", "str_pl": "handfuls of chokeberries" },
+    "description": "A handful of black chokeberries.  They look similar to blackcurrant.  Big and juicy but actually exceedingly bitter.",
+    "copy-from": "cranberries",
+    "calories": "46",
+    "color": "black",
+    "price": "0 cent",
+    "price_postapoc": "10 cent",
+    "vitamins": [ [ "vitC", "21000 μg" ], [ "iron", "600 μg" ], [ "calcium", "30 μg" ], [ "fruit_allergen", 1 ] ]
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/raw_fruit.json
+++ b/data/json/items/comestibles/raw_fruit.json
@@ -316,7 +316,7 @@
     "type": "COMESTIBLE",
     "id": "chokeberries",
     "name": { "str": "handful of chokeberries", "str_pl": "handfuls of chokeberries" },
-    "description": "A handful of black chokeberries.  They look similar to blackcurrant.  Big and juicy but actually exceedingly bitter.",
+    "description": "A handful of black chokeberries.  They look similar to blackcurrant.  Big and juicy but actually exceedingly sour.",
     "copy-from": "cranberries",
     "calories": 46,
     "color": "black",

--- a/data/json/items/comestibles/raw_fruit.json
+++ b/data/json/items/comestibles/raw_fruit.json
@@ -318,7 +318,7 @@
     "name": { "str": "handful of chokeberries", "str_pl": "handfuls of chokeberries" },
     "description": "A handful of black chokeberries.  They look similar to blackcurrant.  Big and juicy but actually exceedingly bitter.",
     "copy-from": "cranberries",
-    "calories": "46",
+    "calories": 46,
     "color": "black",
     "price": "0 cent",
     "price_postapoc": "10 cent",

--- a/data/json/items/comestibles/spice.json
+++ b/data/json/items/comestibles/spice.json
@@ -60,6 +60,25 @@
     "color": "dark_gray"
   },
   {
+    "id": "spicebush_berries",
+    "copy-from": "spice",
+    "type": "COMESTIBLE",
+    "name": { "str_sp": "spicebush berries" },
+    "description": "Small, red berries with a pungent aroma.  It is said they are comparable to allspice, but also boasting their own flavor profile.",
+    "smoking_result": "spicebush_berries_smoked",
+    "spoils_in": "4 days",
+    "extend": { "flags": [ "SMOKABLE" ] },
+    "color": "red"
+  },
+  {
+    "id": "spicebush_berries_smoked",
+    "copy-from": "spice",
+    "type": "COMESTIBLE",
+    "name": { "str_sp": "dry spicebush berries" },
+    "description": "These formerly red berries now have a stronger aroma after being dehydrated.",
+    "color": "brown"
+  },
+  {
     "id": "salt",
     "copy-from": "spice",
     "type": "COMESTIBLE",

--- a/data/json/mapgen_palettes/stream.json
+++ b/data/json/mapgen_palettes/stream.json
@@ -8,6 +8,7 @@
       "1": [
         [ "t_null", 100 ],
         [ "t_sand", 1 ],
+        [ "t_shrub_spicebush", 10 ],
         [ "t_clay", 4 ],
         [ "t_grass_long", 900 ],
         [ "t_region_shrub_forest", 20 ],

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -56,7 +56,15 @@
           "t_shrub_strawberry": 1,
           "t_shrub_grape": 1
         },
-        "t_region_shrub_swamp": { "t_fern": 2, "t_shrub_raspberry": 2, "t_shrub_blueberry": 2, "t_shrub_huckleberry": 1, "t_shrub_rose": 1 },
+        "t_region_shrub_swamp": {
+          "t_fern": 2,
+          "t_shrub_raspberry": 2,
+          "t_shrub_chokeberry": 2,
+          "t_shrub_blueberry": 2,
+          "t_shrub_huckleberry": 1,
+          "t_shrub_spicebush": 1,
+          "t_shrub_rose": 1
+        },
         "t_region_shrub_fruit": {
           "t_shrub_blueberry": 6,
           "t_shrub_strawberry": 6,
@@ -66,7 +74,7 @@
           "t_shrub_huckleberry": 2,
           "t_shrub_peanut": 1
         },
-        "t_region_shrub_decorative": { "t_shrub": 30, "t_fern": 5, "t_shrub_rose": 20, "t_shrub_hydrangea": 20, "t_shrub_lilac": 20, "t_bamboo_long": 5 },
+        "t_region_shrub_decorative": { "t_shrub": 30, "t_fern": 5, "t_shrub_rose": 20, "t_shrub_hydrangea": 20, "t_shrub_lilac": 20, "t_shrub_chokeberry": 15, "t_bamboo_long": 5 },
         "t_region_shrub": { "t_region_shrub_decorative": 60, "t_underbrush": 10, "t_region_shrub_fruit": 30 },
         "t_region_tree_forest_dense": {
           "t_tree": 18,

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -74,7 +74,15 @@
           "t_shrub_huckleberry": 2,
           "t_shrub_peanut": 1
         },
-        "t_region_shrub_decorative": { "t_shrub": 30, "t_fern": 5, "t_shrub_rose": 20, "t_shrub_hydrangea": 20, "t_shrub_lilac": 20, "t_shrub_chokeberry": 15, "t_bamboo_long": 5 },
+        "t_region_shrub_decorative": {
+          "t_shrub": 30,
+          "t_fern": 5,
+          "t_shrub_rose": 20,
+          "t_shrub_hydrangea": 20,
+          "t_shrub_lilac": 20,
+          "t_shrub_chokeberry": 15,
+          "t_bamboo_long": 5
+        },
         "t_region_shrub": { "t_region_shrub_decorative": 60, "t_underbrush": 10, "t_region_shrub_fruit": 30 },
         "t_region_tree_forest_dense": {
           "t_tree": 18,

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -1010,6 +1010,7 @@
       [
         [ "hot_sauce", 1 ],
         [ "pepper", 1 ],
+        [ "spicebush_berries_smoked", 1 ],
         [ "seasoning_salt", 1 ],
         [ "seasoning_italian", 1 ],
         [ "wild_herbs", 1 ],
@@ -1257,6 +1258,8 @@
         [ "seasoning_salt", 4 ],
         [ "soysauce", 1 ],
         [ "pepper", 4 ],
+        [ "spicebush_berries_smoked", 4 ],
+        [ "spicebush_berries", 4 ],
         [ "garlic_clove", 2 ],
         [ "salt", 4 ]
       ]
@@ -1274,6 +1277,8 @@
         [ "seasoning_salt", 4 ],
         [ "soysauce", 1 ],
         [ "pepper", 4 ],
+        [ "spicebush_berries", 4 ],
+        [ "spicebush_berries_smoked", 4 ],
         [ "garlic_clove", 2 ],
         [ "salt", 4 ]
       ]

--- a/data/json/requirements/tailoring.json
+++ b/data/json/requirements/tailoring.json
@@ -142,6 +142,7 @@
         [ "huckleberries", 1 ],
         [ "mulberries", 1 ],
         [ "elderberries", 1 ],
+        [ "chokeberries", 1 ],
         [ "blackberries", 1 ],
         [ "cherries", 1 ],
         [ "grapes", 1 ],

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -1101,6 +1101,8 @@ chk
 Chloe
 Cho
 chode
+chokeberry
+chokeberries
 chokepoints
 Chol
 chonker


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Added chokeberries and spicebush"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

More native flora! This is one small step towards making the forest into a forest as it is currently closer to an orchard.

Chokeberry is an incredibly tempting looking berry but is apparently very, very bitter. Which is why it got that name. Apparently birds and wildlife snack on it without issues, we do have such mutation trees but eliminating morale penalties for such foods is not possible yet as far as I know.

Spicebush is a bush with berries that can be used as spice. Apparently you can also brew tea with the leaves, but this I did not implement as we already have enough sources of tea.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

1. Add chokeberry shrub, item, and smoking result.
   - It is very bitter but it can be smoked. Native americans have used it in pemmican, supporting the statement that it is better smoked. [[1]](https://foragerchef.com/black-chokeberry-aronia-melanocarpa/) This also mentions its use as dye, so I added this there, too.
   - As you can see above, there are other ways of preparing chokeberry, too but I intentionally skipped those as its just fruit juice with more effort and sieving.
   - Nutrition info and the general web results suggest that chokeberries indeed have around 50 calories per 100g. [[2]](https://fddb.info/db/en/food/natural_product_aronia_berries_chokeberries/index.html).
2. Add spicebush shrub, item and smoking result.
   - This can partially replace black pepper and is ideally smoked to preserve it. [[3]](https://backyardforager.com/spicebush-berries-lindera-benzoin/).
   - Spicebush would also grow along rivers, but I am not going to blindly edit the hardcoded C++ river flora again. Not pushing my luck.
   - Yes, it should probably be powdered/crushed but I am skipping this step as it would pretty much only be tedium.
3. When working on chokeberries, I noticed cranberries were described as sour. They are most definitely not sour. They are bitter as fuck. I know because I was foolish enough to try a fresh one in real life. This is also why I adjusted the morale penalty. I'd only eat those raw if I was starving and even then I'd still reconsider.
4. General sources of missing plants: https://www.ecolandscaping.org/06/designing-ecological-landscapes/native-plants/more-edible-and-landscape-worthy-native-plants-of-new-england/ and https://www.ecolandscaping.org/09/developing-healthy-landscapes/ecological-landscaping-101/edible-and-landscape-worthy-native-plants-of-new-england/

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

- ✅ Game loads without any errors.
- ✅ Both shrubs spawn as expected and also get harvested correctly.
- ✅ Both items smoke correctly and can be used in the intended recipes.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Two done. Dozens to go. Includes but is unfortunately (due to work needed) not limited to: at least three more fruit bearing trees: the nannyberry, the tupelo/black gum and black cherry (Prunus serotina). Maybe also chokecherry (not to be confused with choke*berries*). And some more bushes: foxgrape, add groundnut beans (addition to the existing plant), indian cucumber probably, maaaybe staghorn sumac and wild raisin/witherod and hobblebush plus wild strawberry. New England has a lot of virburnum/grape stuff. That and some attention to edible flowers (mostly results in more plant stalks I guess).

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
