### PR TITLE
Fix reference after removal error in grab break code

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1845,7 +1845,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
                     monster *m = t.as_monster();
                     if( m->is_grabbing( eff.get_bp().id() ) ) {
                         m->remove_grab( eff.get_bp().id() );
-                        const std::string released_body_part_name = eff.get_bp()->name.translation();
+                        const std::string released_body_part_name = eff.get_bp()->name.translated();
                         remove_effect( eff.get_id(), eff.get_bp() );
                         add_msg_debug( debugmode::DF_MELEE, "Grabber %s knocked back, grab on %s removed", t.get_name(),
                                        released_body_part_name );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1845,9 +1845,10 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
                     monster *m = t.as_monster();
                     if( m->is_grabbing( eff.get_bp().id() ) ) {
                         m->remove_grab( eff.get_bp().id() );
+                        const std::string released_body_part_name = eff.get_bp()->name.translation();
                         remove_effect( eff.get_id(), eff.get_bp() );
                         add_msg_debug( debugmode::DF_MELEE, "Grabber %s knocked back, grab on %s removed", t.get_name(),
-                                       eff.get_bp()->name );
+                                       released_body_part_name );
                     }
                 }
             }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Forward port of #78067 to 0.I.
When the code handling grab break due to a push technique is executed, it attempts to record a debug message about the grab break, in doing so it dereferences an effect object that has been removed.

#### Describe the solution
Stash the string in question before removing the effect.