### PR TITLE
Several tweaks for using musical instruments

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2138,6 +2138,7 @@ std::optional<int> play_instrument_iuse::use( Character *p, item &it, const trip
 {
     if( it.active ) {
         it.active = false;
+        p->remove_effect( effect_playing_instrument );
         p->add_msg_player_or_npc( _( "You stop playing your %s." ),
                                   _( "<npcname> stops playing their %s." ),
                                   it.display_name() );
@@ -2147,13 +2148,32 @@ std::optional<int> play_instrument_iuse::use( Character *p, item &it, const trip
                                   _( "<npcname> starts playing their %s." ),
                                   it.display_name() );
         it.active = true;
+        p->add_effect( effect_playing_instrument, 1_turns, false, 1 );
     }
     return std::nullopt;
 }
 
-ret_val<void> play_instrument_iuse::can_use( const Character &, const item &,
+ret_val<void> play_instrument_iuse::can_use( const Character &p, const item &it,
         const tripoint & ) const
 {
+    // TODO (maybe): Mouth encumbrance? Smoke? Lack of arms? Hand encumbrance?
+    if( p.is_underwater() ) {
+        return ret_val<void>::make_failure( _( "You can't do that while underwater." ) );
+    }
+    if( p.is_mounted() ) {
+        return ret_val<void>::make_failure( _( "You can't do that while mounted." ) );
+    }
+    if( !p.is_worn( it ) && !p.is_wielding( it ) ) {
+        return ret_val<void>::make_failure( _( "You need to hold or wear %s to play it." ),
+                                            it.type_name() );
+    }
+    // No one-man band for now
+    // Remove/rework this check after we will be able to distinguish between wind, string, and percussion instruments
+    // TODO: allow playing several string/percussion instruments if you have additional arms
+    if( !it.active && p.has_effect( effect_playing_instrument ) ) {
+        return ret_val<void>::make_failure( _( "You can't play multiple musical instruments at once." ) );
+    }
+
     return ret_val<void>::make_success();
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Several tweaks for using musical instruments"

#### Purpose of change
- You could start playing musical instruments underwater or while mounted;
- You could play multiple musical instruments at once;
- After you started playing, the effect of this (`effect_playing_instrument`) was applied only on the next turn;
- After you stopped playing, the effect was removed only on the next turn.

* Closes #44714.

#### Describe the solution
- Added checks for being underwater or while mounted;
- Added `effect_playing_instrument` effect for 1 turn and intensity of 1 right after activation of instrument, and removed the effect right after deactivation;
- Forbade playing multiple instruments at once. No one-man band for now;
- Forbade playing instruments not being worn or wielded.

#### Describe alternatives you've considered
None.

#### Testing
Tried to play acoustic guitar while it was in my backpack - fail.
Tried to play the guitar while I was wearing it - success.
Tried to play the guitar underwater - fail.
Tried to play simultaneously worn acoustic guitar and worn electric guitar - fail.
Checked that effect is applied after right after activation and removed right after after deactivation of the instrument.

#### Additional context
None.