### PR TITLE
Fix penentrating strike

### DIFF
--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -134,10 +134,11 @@
     "melee_allowed": true,
     "skill_requirements": [ { "name": "melee", "level": 4 } ],
     "crit_tec": true,
-    "mult_bonuses": [
-      { "stat": "arpen", "type": "bash", "scale": 1.3 },
-      { "stat": "arpen", "type": "cut", "scale": 1.3 },
-      { "stat": "arpen", "type": "stab", "scale": 1.3 }
+    "reach_ok": true,
+    "flat_bonuses": [
+      { "stat": "arpen", "type": "bash", "scaling-stat": "melee", "scale": 2.0 },
+      { "stat": "arpen", "type": "cut", "scaling-stat": "melee", "scale": 2.0 },
+      { "stat": "arpen", "type": "stab", "scaling-stat": "melee", "scale": 2.0 }
     ],
     "messages": [ "You find a weak spot in %s's armor", "<npcname> finds a weak spot in %s's armor!" ],
     "description": "30% armor penetration, crit only, min 4 melee",

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -140,7 +140,7 @@
       { "stat": "arpen", "type": "stab", "scaling-stat": "melee", "scale": 2.0 }
     ],
     "messages": [ "You find a weak spot in %s's armor", "<npcname> finds a weak spot in %s's armor!" ],
-    "description": "Increase armor penetration by 2 times melee skill.",
+    "description": "Increase armor penetration by 2 times melee skill",
     "attack_vectors": [ "vector_null" ]
   },
   {

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -132,7 +132,6 @@
     "id": "PENETRATE",
     "name": "Penetrating Strike",
     "melee_allowed": true,
-    "skill_requirements": [ { "name": "melee", "level": 4 } ],
     "crit_tec": true,
     "reach_ok": true,
     "flat_bonuses": [
@@ -141,7 +140,7 @@
       { "stat": "arpen", "type": "stab", "scaling-stat": "melee", "scale": 2.0 }
     ],
     "messages": [ "You find a weak spot in %s's armor", "<npcname> finds a weak spot in %s's armor!" ],
-    "description": "30% armor penetration, crit only, min 4 melee",
+    "description": "Increase armor penetration by 2 times melee skill.",
     "attack_vectors": [ "vector_null" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix penetrating strike"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Correction of my previous PR #77812.

I misunderstood how "arpen" worked and the technique ended up doing nothing as it just increased the default armor penetration 0 by 33%. I also didn't do enough testing to catch the error.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

There is no good way to increase armor penetration linearly, and how it's applied and how it interacts with weakpoints and crits (pierce crits have 33% armor penetration) is quite complicated, so I derived at a value after testing, which is a flat bonus to armor penetration of 2x melee skill. 

As it scales scales with melee skill and adds a flat armor penetration value, it's especially strong for a character with high melee skill using a low damage weapon. When balancing, I've assumed a character with 0-3 melee skill has a wooden spear, a character with 4-6 melee skill has a knife spear and a character with 7+ melee skill has a qiang.

A 2 melee skill character with a wooden spear (18 pierce) that crit for 2x damage would do 36 base pierce damage + 4 armor penetration.

A 5 melee skill character with a knife spear (26 pierce) that crit for 2x damage would do 52 base pierce damage +10 armor penetration.

A 10 melee skill character with a qiang (43 pierce) that crit for 2x damage would do 86 base pierce damage +20 armor penetration.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Changing it to a stun, like the other weapon categories have.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Made a 8/8/8/8 debug characters with 5 or 10 in all skills, using wooden spears, knifes pears or qiangs and tested it against 55 zombie cops and 55 zombie soldiers.

Here screenshots of the damage log comparing a 8/8/8/8 character with 5 in all skills using a knife spear with penetrating strike and one with a generic crit technique against a zombie cop (6 armor):

![image](https://github.com/user-attachments/assets/9a7ef936-e2d7-4cf8-9ce4-3e01fd324922)

![image](https://github.com/user-attachments/assets/5103d3ad-9c3c-4f82-b501-94c95cd32194)


There was a minimal change in damage against zombie soldiers with 20 stab armor. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
