### PR TITLE
Stash mission ids and remove after loop for 0.H

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -252,6 +252,7 @@ bool mission::on_creature_fusion( Creature &fuser, Creature &fused )
         return false;
     }
     bool mission_transfered = false;
+    std::vector<int> mission_ids_to_remove;
     for( const int mission_id : mon_fused->mission_ids ) {
         const mission *const found_mission = mission::find( mission_id );
         if( !found_mission ) {
@@ -262,9 +263,12 @@ bool mission::on_creature_fusion( Creature &fuser, Creature &fused )
         if( type->goal == MGOAL_KILL_MONSTER || type->goal == MGOAL_KILL_MONSTERS ) {
             // the fuser has to be killed now!
             mon_fuser->mission_ids.emplace( mission_id );
-            mon_fused->mission_ids.erase( mission_id );
+            mission_ids_to_remove.push_back( mission_id );
             mission_transfered = true;
         }
+    }
+    for( const int mission_id : mission_ids_to_remove ) {
+        mon_fused->mission_ids.erase( mission_id );
     }
     return mission_transfered;
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #77844 
Fixes #77751 
Looks like if a Devourer eats the target of a mission it crashes, but only on some platforms.

#### Describe the solution
Stash the mission ids to remove and do so after exiting the loop that iterates over the st::map

#### Describe alternatives you've considered
Lots of options but this is pretty standard.

#### Testing
I pulled the save and verified no crash after the DD eats the mission target.
Received the message indicating a mission target was in the DD.
Killed the DD, mission goal switched to the NPC that gave the quest.

Reproduced crash with same procedure without my fix.