### PR TITLE
typified end of 'a'

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1643,32 +1643,32 @@ void glide_activity_actor::do_turn( player_activity &act, Character &you )
 {
     tripoint_rel_ms heading;
     if( jump_direction == 0 ) {
-        heading = tripoint_rel_ms( tripoint_south );
+        heading = tripoint_rel_ms_south;
     }
     if( jump_direction == 1 ) {
-        heading = tripoint_rel_ms( tripoint_south_west );
+        heading = tripoint_rel_ms_south_west;
     }
     if( jump_direction == 2 ) {
-        heading = tripoint_rel_ms( tripoint_west );
+        heading = tripoint_rel_ms_west;
     }
     if( jump_direction == 3 ) {
-        heading = tripoint_rel_ms( tripoint_north_west );
+        heading = tripoint_rel_ms_north_west;
     }
     if( jump_direction == 4 ) {
-        heading = tripoint_rel_ms( tripoint_north );
+        heading = tripoint_rel_ms_north;
     }
     if( jump_direction == 5 ) {
-        heading = tripoint_rel_ms( tripoint_north_east );
+        heading = tripoint_rel_ms_north_east;
     }
     if( jump_direction == 6 ) {
-        heading = tripoint_rel_ms( tripoint_east );
+        heading = tripoint_rel_ms_east;
     }
     if( jump_direction == 7 ) {
-        heading = tripoint_rel_ms( tripoint_south_east );
+        heading = tripoint_rel_ms_south_east;
     }
     const tripoint_abs_ms newpos = you.get_location() + heading;
     const tripoint_bub_ms checknewpos = you.pos_bub() + heading;
-    if( get_map().tr_at( you.pos_bub() ) != tr_ledge || heading == tripoint_rel_ms( tripoint_zero ) ) {
+    if( get_map().tr_at( you.pos_bub() ) != tr_ledge || heading == tripoint_rel_ms_zero ) {
         you.add_msg_player_or_npc( m_good,
                                    _( "You come to a gentle landing." ),
                                    _( "<npcname> comes to a gentle landing." ) );
@@ -1737,28 +1737,28 @@ glide_activity_actor::glide_activity_actor( Character *you, int jump_direction, 
     // What's the purpose of assigning a variable that isn't used? Is some code AWOL?
     tripoint_rel_ms heading;
     if( jump_direction == 0 ) {
-        heading = tripoint_rel_ms( tripoint_south );
+        heading = tripoint_rel_ms_south;
     }
     if( jump_direction == 1 ) {
-        heading = tripoint_rel_ms( tripoint_south_west );
+        heading = tripoint_rel_ms_south_west;
     }
     if( jump_direction == 2 ) {
-        heading = tripoint_rel_ms( tripoint_west );
+        heading = tripoint_rel_ms_west;
     }
     if( jump_direction == 3 ) {
-        heading = tripoint_rel_ms( tripoint_north_west );
+        heading = tripoint_rel_ms_north_west;
     }
     if( jump_direction == 4 ) {
-        heading = tripoint_rel_ms( tripoint_north );
+        heading = tripoint_rel_ms_north;
     }
     if( jump_direction == 5 ) {
-        heading = tripoint_rel_ms( tripoint_north_east );
+        heading = tripoint_rel_ms_north_east;
     }
     if( jump_direction == 6 ) {
-        heading = tripoint_rel_ms( tripoint_east );
+        heading = tripoint_rel_ms_east;
     }
     if( jump_direction == 7 ) {
-        heading = tripoint_rel_ms( tripoint_south_west );
+        heading = tripoint_rel_ms_south_west;
     }
 }
 
@@ -3221,7 +3221,7 @@ void open_gate_activity_actor::serialize( JsonOut &jsout ) const
 
 std::unique_ptr<activity_actor> open_gate_activity_actor::deserialize( JsonValue &jsin )
 {
-    open_gate_activity_actor actor( 0, tripoint_bub_ms( tripoint_zero ) );
+    open_gate_activity_actor actor( 0, tripoint_bub_ms_zero );
 
     JsonObject data = jsin.get_object();
 
@@ -4630,7 +4630,7 @@ void move_furniture_activity_actor::serialize( JsonOut &jsout ) const
 
 std::unique_ptr<activity_actor> move_furniture_activity_actor::deserialize( JsonValue &jsin )
 {
-    move_furniture_activity_actor actor = move_furniture_activity_actor( tripoint_zero, false );
+    move_furniture_activity_actor actor = move_furniture_activity_actor( tripoint_rel_ms_zero, false );
 
     JsonObject data = jsin.get_object();
 
@@ -5551,9 +5551,8 @@ void tent_placement_activity_actor::start( player_activity &act, Character & )
 void tent_placement_activity_actor::finish( player_activity &act, Character &p )
 {
     map &here = get_map();
-    const tripoint_bub_ms center = p.pos_bub() + tripoint( ( radius + 1 ) * target.x,
-                                   ( radius + 1 ) * target.y,
-                                   0 );
+    const tripoint_bub_ms center = p.pos_bub() + point( ( radius + 1 ) * target.x(),
+                                   ( radius + 1 ) * target.y() );
 
     // Make a square of floor surrounded by wall.
     for( const tripoint_bub_ms &dest : here.points_in_radius( center, radius ) ) {
@@ -6606,7 +6605,7 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
         }
     }
 
-    here.cut_down_tree( tripoint_bub_ms( pos ), direction.xy().raw() );
+    here.cut_down_tree( pos, direction.xy().raw() );
 
     who.add_msg_if_player( m_good, _( "You finish chopping down a tree." ) );
     // sound of falling tree

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -614,7 +614,7 @@ class pickup_activity_actor : public activity_actor
 class boltcutting_activity_actor : public activity_actor
 {
     public:
-        explicit boltcutting_activity_actor( const tripoint &target,
+        explicit boltcutting_activity_actor( const tripoint_bub_ms &target,
                                              const item_location &tool ) : target( target ), tool( tool ) {};
 
         activity_id get_type() const override {
@@ -636,7 +636,7 @@ class boltcutting_activity_actor : public activity_actor
         bool testing = false; // NOLINT(cata-serialize)
 
     private:
-        tripoint target;
+        tripoint_bub_ms target;
         item_location tool;
 
         bool can_resume_with_internal( const activity_actor &other,
@@ -1217,7 +1217,7 @@ class milk_activity_actor : public activity_actor
 {
     public:
         milk_activity_actor() = default;
-        milk_activity_actor( int moves, std::vector<tripoint> coords,
+        milk_activity_actor( int moves, std::vector<tripoint_abs_ms> coords,
                              std::vector<std::string> str_values ) : total_moves( moves ), monster_coords( std::move( coords ) ),
             string_values( std::move( str_values ) ) {}
 
@@ -1239,19 +1239,19 @@ class milk_activity_actor : public activity_actor
 
     private:
         int total_moves {};
-        std::vector<tripoint> monster_coords {};
+        std::vector<tripoint_abs_ms> monster_coords {};
         std::vector<std::string> string_values {};
 };
 
 class shearing_activity_actor : public activity_actor
 {
     private:
-        tripoint mon_coords;    // monster is tied for the duration
+        tripoint_bub_ms mon_coords;    // monster is tied for the duration
         bool shearing_tie;      // was the monster tied due to shearing
 
     public:
         explicit shearing_activity_actor(
-            const tripoint &mon_coords, bool shearing_tie = true )
+            const tripoint_bub_ms &mon_coords, bool shearing_tie = true )
             : mon_coords( mon_coords ), shearing_tie( shearing_tie ) {};
 
         activity_id get_type() const override {
@@ -1314,11 +1314,11 @@ class disassemble_activity_actor : public activity_actor
 class move_furniture_activity_actor : public activity_actor
 {
     private:
-        tripoint dp;
+        tripoint_rel_ms dp;
         bool via_ramp;
 
     public:
-        move_furniture_activity_actor( const tripoint &dp, bool via_ramp ) :
+        move_furniture_activity_actor( const tripoint_rel_ms &dp, bool via_ramp ) :
             dp( dp ), via_ramp( via_ramp ) {}
         activity_id get_type() const override {
             return activity_id( "ACT_FURNITURE_MOVE" );
@@ -1374,7 +1374,7 @@ class tent_placement_activity_actor : public activity_actor
 {
     private:
         int moves_total;
-        tripoint target;
+        tripoint_rel_ms target;
         int radius = 1;
         item it;
         string_id<furn_t> wall;
@@ -1383,7 +1383,7 @@ class tent_placement_activity_actor : public activity_actor
         string_id<furn_t> door_closed;
 
     public:
-        tent_placement_activity_actor( int moves_total, tripoint target, int radius, const item &it,
+        tent_placement_activity_actor( int moves_total, tripoint_rel_ms target, int radius, const item &it,
                                        string_id<furn_t> wall, string_id<furn_t> floor, std::optional<string_id<furn_t>> floor_center,
                                        string_id<furn_t> door_closed ) : moves_total( moves_total ), target( target ), radius( radius ),
             it( it ), wall( wall ), floor( floor ), floor_center( floor_center ),
@@ -1409,7 +1409,7 @@ class tent_placement_activity_actor : public activity_actor
 class oxytorch_activity_actor : public activity_actor
 {
     public:
-        explicit oxytorch_activity_actor( const tripoint &target,
+        explicit oxytorch_activity_actor( const tripoint_bub_ms &target,
                                           const item_location &tool ) : target( target ), tool( tool ) {};
 
         activity_id get_type() const override {
@@ -1430,7 +1430,7 @@ class oxytorch_activity_actor : public activity_actor
         // debugmsg causes a backtrace when fired during cata_test
         bool testing = false;  // NOLINT(cata-serialize)
     private:
-        tripoint target;
+        tripoint_bub_ms target;
         item_location tool;
 
         bool can_resume_with_internal( const activity_actor &other,
@@ -1517,7 +1517,7 @@ class play_with_pet_activity_actor : public activity_actor
 class prying_activity_actor : public activity_actor
 {
     public:
-        explicit prying_activity_actor( const tripoint &target,
+        explicit prying_activity_actor( const tripoint_bub_ms &target,
                                         const item_location &tool ) : target( target ), tool( tool ) {};
 
         activity_id get_type() const override {
@@ -1541,7 +1541,7 @@ class prying_activity_actor : public activity_actor
         // debugmsg causes a backtrace when fired during cata_test
         bool testing = false;  // NOLINT(cata-serialize)
     private:
-        tripoint target;
+        tripoint_bub_ms target;
         item_location tool;
         bool prying_nails = false;
 
@@ -1998,7 +1998,7 @@ class disable_activity_actor : public activity_actor
 {
     public:
         disable_activity_actor() = default;
-        disable_activity_actor( const tripoint &target, int moves_total,
+        disable_activity_actor( const tripoint_bub_ms &target, int moves_total,
                                 bool reprogram ) : target( target ), moves_total( moves_total ), reprogram( reprogram ) {}
 
         activity_id get_type() const override {
@@ -2022,7 +2022,7 @@ class disable_activity_actor : public activity_actor
         static int get_disable_turns();
 
     private:
-        tripoint target;
+        tripoint_bub_ms target;
         int moves_total;
         bool reprogram;
 };

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -408,7 +408,7 @@ static bool check_butcher_dissect( const int roll )
     return !failed;
 }
 
-static bool butcher_dissect_item( item &what, const tripoint &pos,
+static bool butcher_dissect_item( item &what, const tripoint_bub_ms &pos,
                                   const time_point &age, const int roll )
 {
     if( roll < 0 ) {
@@ -1027,7 +1027,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
             roll = roll < 0 ? 0 : roll;
             add_msg_debug( debugmode::DF_ACT_BUTCHER, "Roll penalty for corpse damage = %s",
                            0 - corpse_item->damage_level() );
-            butcher_dissect_item( *item, you.pos(), calendar::turn, roll );
+            butcher_dissect_item( *item, you.pos_bub(), calendar::turn, roll );
         }
         if( dissectable_num > 0 ) {
             practice += dissectable_practice / dissectable_num;
@@ -1780,7 +1780,7 @@ void activity_handlers::generic_game_turn_handler( player_activity *act, Charact
         if( !act->targets.empty() ) {
             item &game_item = *act->targets.front();
             int req = game_item.ammo_required();
-            bool fail = req > 0 && game_item.ammo_consume( req, tripoint_zero, you ) == 0;
+            bool fail = req > 0 && game_item.ammo_consume( req, tripoint_bub_ms_zero, you ) == 0;
             if( fail ) {
                 act->moves_left = 0;
                 if( you->is_avatar() ) {
@@ -3485,7 +3485,7 @@ void activity_handlers::jackhammer_finish( player_activity *act, Character *you 
     act->set_to_null();
     if( !act->targets.empty() ) {
         item &it = *act->targets.front();
-        it.ammo_consume( it.ammo_required(), tripoint_zero, you );
+        it.ammo_consume( it.ammo_required(), tripoint_bub_ms_zero, you );
     } else {
         debugmsg( "jackhammer activity targets empty" );
     }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1041,7 +1041,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                 ( you.is_npc() && player_character.pos_bub() == src_loc ) ) {
                 return activity_reason_info::fail( do_activity_reason::ALREADY_WORKING );
             }
-            if( guy_work_spot != tripoint_bub_ms{} ) {
+            if( guy_work_spot != tripoint_bub_ms_zero ) {
                 vehicle *other_veh = veh_pointer_or_null( here.veh_at( guy_work_spot ) );
                 // working on same vehicle - store the index to check later.
                 if( other_veh && other_veh == veh && guy.activity_vehicle_part_index != -1 ) {
@@ -1272,8 +1272,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
     if( act == ACT_MULTIPLE_CONSTRUCTION ) {
         zones = mgr.get_zones( zone_type_CONSTRUCTION_BLUEPRINT,
                                here.getglobal( src_loc ), _fac_id( you ) );
-        // TODO: fix point types
-        const partial_con *part_con = here.partial_con_at( tripoint_bub_ms( src_loc ) );
+        const partial_con *part_con = here.partial_con_at( src_loc );
         std::optional<construction_id> part_con_idx;
         if( part_con ) {
             part_con_idx = part_con->id;
@@ -1295,8 +1294,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             const blueprint_options &options = dynamic_cast<const blueprint_options &>
                                                ( zones.front().get_options() );
             const construction_id index = options.get_index();
-            // TODO: fix point types
-            return find_base_construction( you, pre_inv, tripoint_bub_ms( src_loc ), part_con_idx,
+            return find_base_construction( you, pre_inv, src_loc, part_con_idx,
                                            index );
         }
     } else if( act == ACT_MULTIPLE_FARM ) {
@@ -1337,8 +1335,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                 // If its a farm zone with no specified seed, and we've checked for tilling and harvesting.
                 // then it means no further work can be done here
             } else if( !seed.is_empty() &&
-                       // TODO: fix point types
-                       warm_enough_to_plant( src_loc.raw() ) &&
+                       warm_enough_to_plant( src_loc ) &&
                        here.has_flag_ter_or_furn( seed->seed->required_terrain_flag, src_loc ) ) {
                 if( here.has_items( src_loc ) ) {
                     return activity_reason_info::fail( do_activity_reason::BLOCKING_TILE );
@@ -1962,7 +1959,6 @@ static bool butcher_corpse_activity( Character &you, const tripoint_bub_ms &src_
             }
             elem.set_var( "activity_var", you.name );
             you.assign_activity( ACT_BUTCHER_FULL, 0, true );
-            // TODO: fix point types
             you.activity.targets.emplace_back( map_cursor( src_loc ), &elem );
             you.activity.placement = here.getglobal( src_loc );
             return true;
@@ -2035,7 +2031,6 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
     if( stage == THINK ) {
         //initialize num_processed
         num_processed = 0;
-        // TODO: fix point types
         std::vector<tripoint_abs_ms> src_set;
         src_set.reserve( act.coord_set.size() );
         for( const tripoint &p : act.coord_set ) {
@@ -2153,7 +2148,6 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
         }
     }
     if( stage == DO ) {
-        // TODO: fix point types
         const tripoint_abs_ms src( act.placement );
         const tripoint_bub_ms src_loc = here.bub_from_abs( src );
 
@@ -2613,7 +2607,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
         // TODO: add zone type like zone_type_CRAFT?
         src_set.insert( here.getglobal( localpos ) );
     } else if( act_id != ACT_FETCH_REQUIRED ) {
-        zone_type_id zone_type = get_zone_for_act( tripoint_bub_ms{}, mgr, act_id, _fac_id( you ) );
+        zone_type_id zone_type = get_zone_for_act( tripoint_bub_ms_zero, mgr, act_id, _fac_id( you ) );
         src_set = mgr.get_near( zone_type, abspos, ACTIVITY_SEARCH_DISTANCE, nullptr, _fac_id( you ) );
         // multiple construction will form a list of targets based on blueprint zones and unfinished constructions
         if( act_id == ACT_MULTIPLE_CONSTRUCTION ) {
@@ -2682,7 +2676,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
                     if( &guy == &you ) {
                         continue;
                     }
-                    if( guy.has_player_activity() && tripoint_abs_ms( guy.activity.placement ) == *it2 ) {
+                    if( guy.has_player_activity() && guy.activity.placement == *it2 ) {
                         it2 = src_set.erase( it2 );
                         skip = true;
                         break;
@@ -2731,8 +2725,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
                                      act_id == ACT_MULTIPLE_MINE ||
                                      act_id == ACT_MULTIPLE_DIS ||
                                      ( act_id == ACT_MULTIPLE_CONSTRUCTION &&
-                                       // TODO: fix point types
-                                       !here.partial_con_at( tripoint_bub_ms( src_loc ) ) );
+                                       !here.partial_con_at( src_loc ) );
     // some activities require the target tile to be part of a zone.
     // tidy up activity doesn't - it wants things that may not be in a zone already - things that may have been left lying around.
     if( needs_to_be_in_zone && !zone ) {
@@ -3005,7 +2998,6 @@ static bool generic_multi_activity_do(
     if( ( ( reason == do_activity_reason::NEEDS_HARVESTING ) ||
           ( reason == do_activity_reason::NEEDS_CUT_HARVESTING ) ) &&
         here.has_flag_furn( ter_furn_flag::TFLAG_GROWTH_HARVEST, src_loc ) ) {
-        // TODO: fix point types
         iexamine::harvest_plant( you, src_loc, true );
     } else if( ( reason == do_activity_reason::NEEDS_CLEARING ) &&
                here.has_flag_furn( ter_furn_flag::TFLAG_GROWTH_OVERGROWN, src_loc ) ) {
@@ -3032,7 +3024,6 @@ static bool generic_multi_activity_do(
             if( !here.has_flag_ter_or_furn( seed->seed->required_terrain_flag, src_loc ) ) {
                 continue;
             }
-            // TODO: fix point types
             iexamine::plant_seed( you, src_loc, itype_id( seed ) );
             you.backlog.emplace_front( act_id );
             return false;
@@ -3152,7 +3143,6 @@ static bool generic_multi_activity_do(
                                               elem.charges );
                     player_activity act = player_activity( disassemble_activity_actor( r.time_to_craft_moves( you,
                                                            recipe_time_flag::ignore_proficiencies ) * qty ) );
-                    // TODO: fix point types
                     act.targets.emplace_back( map_cursor( src_loc ), &elem );
                     act.placement = here.getglobal( src_loc );
                     act.position = qty;
@@ -3555,7 +3545,7 @@ int get_auto_consume_moves( Character &you, const bool food )
         return 0;
     }
 
-    const tripoint pos = you.pos();
+    const tripoint_bub_ms pos = you.pos_bub();
     zone_manager &mgr = zone_manager::get_manager();
     zone_type_id consume_type_zone( "" );
     if( food ) {
@@ -3572,7 +3562,7 @@ int get_auto_consume_moves( Character &you, const bool food )
     }
     item_location best_comestible;
     for( const tripoint_abs_ms &loc : dest_set ) {
-        if( loc.z() != you.pos().z ) {
+        if( loc.z() != pos.z() ) {
             continue;
         }
 

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -104,7 +104,7 @@ static rule_state get_autopickup_rule( const item *pickup_item )
  * @param from container to drop items from.
  * @param where location on the map to drop items to.
  */
-static void empty_autopickup_target( item *what, tripoint where )
+static void empty_autopickup_target( item *what, tripoint_bub_ms where )
 {
     bool is_rigid = what->all_pockets_rigid();
     for( item *entry : what->all_items_top() ) {
@@ -177,7 +177,7 @@ static std::vector<item_location> get_autopickup_items( item_location &from )
             if( !force_pick_container ) {
                 if( item_entry->is_container() ) {
                     // whitelisted containers should exclude contained blacklisted items
-                    empty_autopickup_target( item_entry, from.position() );
+                    empty_autopickup_target( item_entry, from.pos_bub() );
                 } else if( item_entry->made_of_from_type( phase_id::LIQUID ) ) {
                     // liquid items should never be picked up without container
                     force_pick_container = true;
@@ -246,10 +246,10 @@ static std::vector<item_location> get_autopickup_items( item_location &from )
  * @return sequence of selected items on the map.
  */
 drop_locations auto_pickup::select_items(
-    const std::vector<item_stack::iterator> &from, const tripoint &location )
+    const std::vector<item_stack::iterator> &from, const tripoint_bub_ms &location )
 {
     drop_locations result;
-    const map_cursor map_location = map_cursor( tripoint_bub_ms( location ) );
+    const map_cursor map_location = map_cursor( location );
 
     // iterate over all item stacks found in location
     for( const item_stack::iterator &stack : from ) {

--- a/src/auto_pickup.h
+++ b/src/auto_pickup.h
@@ -23,7 +23,7 @@ struct tripoint;
 namespace auto_pickup
 {
 std::list<std::pair<item_location, int>> select_items(
-        const std::vector<item_stack::iterator> &from, const tripoint &location );
+        const std::vector<item_stack::iterator> &from, const tripoint_bub_ms &location );
 /**
  * The currently-active set of auto-pickup rules, in a form that allows quick
  * lookup. When this is filled (by @ref auto_pickup::create_rule()), every

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1276,7 +1276,7 @@ void avatar::rebuild_aim_cache()
             }
 
             // some basic angle inclusion math, but also everything with 15 is still seen
-            if( rl_dist( tripoint( point( smx, smy ), pos().z ), pos() ) < 15 ) {
+            if( rl_dist( tripoint_bub_ms( smx, smy, pos_bub().z() ), pos_bub() ) < 15 ) {
                 aim_cache[smx][smy] = false;
             } else if( lower_bound > upper_bound ) {
                 aim_cache[smx][smy] = !( current_angle >= lower_bound ||
@@ -1466,7 +1466,7 @@ item::reload_option avatar::select_ammo( const item_location &base, bool prompt,
     return game_menus::inv::select_ammo( *this, base, prompt, empty );
 }
 
-bool avatar::invoke_item( item *used, const tripoint &pt, int pre_obtain_moves )
+bool avatar::invoke_item( item *used, const tripoint_bub_ms &pt, int pre_obtain_moves )
 {
     const std::map<std::string, use_function> &use_methods = used->type->use_methods;
     const int num_methods = use_methods.size();
@@ -1477,7 +1477,7 @@ bool avatar::invoke_item( item *used, const tripoint &pt, int pre_obtain_moves )
     } else if( num_methods == 1 && !has_relic ) {
         return invoke_item( used, use_methods.begin()->first, pt, pre_obtain_moves );
     } else if( num_methods == 0 && has_relic ) {
-        return used->use_relic( *this, pt );
+        return used->use_relic( *this, pt.raw() );
     }
 
     uilist umenu;
@@ -1486,7 +1486,7 @@ bool avatar::invoke_item( item *used, const tripoint &pt, int pre_obtain_moves )
     umenu.hilight_disabled = true;
 
     for( const auto &e : use_methods ) {
-        const auto res = e.second.can_call( *this, *used, pt );
+        const auto res = e.second.can_call( *this, *used, pt.raw() );
         umenu.addentry_desc( MENU_AUTOASSIGN, res.success(), MENU_AUTOASSIGN, e.second.get_name(),
                              res.str() );
     }
@@ -1505,7 +1505,7 @@ bool avatar::invoke_item( item *used, const tripoint &pt, int pre_obtain_moves )
     int choice = umenu.ret;
     // Use the relic
     if( choice == num_methods ) {
-        return used->use_relic( *this, pt );
+        return used->use_relic( *this, pt.raw() );
     }
     if( choice < 0 || choice >= num_methods ) {
         return false;
@@ -1516,17 +1516,12 @@ bool avatar::invoke_item( item *used, const tripoint &pt, int pre_obtain_moves )
     return invoke_item( used, method, pt, pre_obtain_moves );
 }
 
-bool avatar::invoke_item( item *used, const tripoint_bub_ms &pt, int pre_obtain_moves )
-{
-    return avatar::invoke_item( used, pt.raw(), pre_obtain_moves );
-}
-
 bool avatar::invoke_item( item *used )
 {
     return Character::invoke_item( used );
 }
 
-bool avatar::invoke_item( item *used, const std::string &method, const tripoint &pt,
+bool avatar::invoke_item( item *used, const std::string &method, const tripoint_bub_ms &pt,
                           int pre_obtain_moves )
 {
     if( pre_obtain_moves == -1 ) {

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -323,11 +323,9 @@ class avatar : public Character
                 advanced_inv_area &square );
 
         using Character::invoke_item;
-        // TODO: Get rid of untyped overload
-        bool invoke_item( item *, const tripoint &pt, int pre_obtain_moves ) override;
         bool invoke_item( item *, const tripoint_bub_ms &pt, int pre_obtain_moves ) override;
         bool invoke_item( item * ) override;
-        bool invoke_item( item *, const std::string &, const tripoint &pt,
+        bool invoke_item( item *, const std::string &, const tripoint_bub_ms &pt,
                           int pre_obtain_moves = -1 ) override;
         bool invoke_item( item *, const std::string & ) override;
 

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -176,7 +176,7 @@ static bool check_water_affect_items( avatar &you )
     return true;
 }
 
-bool avatar_action::move( avatar &you, map &m, const tripoint &d )
+bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
 {
     bool in_shell = you.has_active_mutation( trait_SHELL2 ) ||
                     you.has_active_mutation( trait_SHELL3 );
@@ -197,14 +197,14 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
 
     const bool is_riding = you.is_mounted();
     tripoint_bub_ms dest_loc;
-    if( d.z == 0 && ( you.has_effect( effect_stunned ) || you.has_effect( effect_psi_stunned ) ) ) {
+    if( d.z() == 0 && ( you.has_effect( effect_stunned ) || you.has_effect( effect_psi_stunned ) ) ) {
         dest_loc.x() = rng( you.posx() - 1, you.posx() + 1 );
         dest_loc.y() = rng( you.posy() - 1, you.posy() + 1 );
         dest_loc.z() = you.posz();
     } else {
-        dest_loc.x() = you.posx() + d.x;
-        dest_loc.y() = you.posy() + d.y;
-        dest_loc.z() = you.posz() + d.z;
+        dest_loc.x() = you.posx() + d.x();
+        dest_loc.y() = you.posy() + d.y();
+        dest_loc.z() = you.posz() + d.z();
     }
 
     if( dest_loc == you.pos_bub() ) {
@@ -228,12 +228,12 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         if( weapon && weapon->has_flag( flag_DIG_TOOL ) ) {
             if( weapon->type->can_use( "JACKHAMMER" ) &&
                 weapon->ammo_sufficient( &you ) ) {
-                you.invoke_item( &*weapon, "JACKHAMMER", dest_loc.raw() );
+                you.invoke_item( &*weapon, "JACKHAMMER", dest_loc );
                 // don't move into the tile until done mining
                 you.defer_move( dest_loc.raw() );
                 return true;
             } else if( weapon->type->can_use( "PICKAXE" ) ) {
-                you.invoke_item( &*weapon, "PICKAXE", dest_loc.raw() );
+                you.invoke_item( &*weapon, "PICKAXE", dest_loc );
                 // don't move into the tile until done mining
                 you.defer_move( dest_loc.raw() );
                 return true;
@@ -483,7 +483,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                 add_msg( m_info, _( "%s to dive underwater." ),
                          press_x( ACTION_MOVE_DOWN ) );
             }
-            avatar_action::swim( get_map(), get_avatar(), dest_loc.raw() );
+            avatar_action::swim( get_map(), get_avatar(), dest_loc );
         }
 
         g->on_move_effects();
@@ -571,7 +571,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     return false;
 }
 
-void avatar_action::swim( map &m, avatar &you, const tripoint &p )
+void avatar_action::swim( map &m, avatar &you, const tripoint_bub_ms &p )
 {
     if( !m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, p ) ) {
         dbg( D_ERROR ) << "game:plswim: Tried to swim in "
@@ -618,7 +618,7 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
             popup( _( "You need to breathe but you can't swim!  Get to dry land, quick!" ) );
         }
     }
-    bool diagonal = p.x != you.posx() && p.y != you.posy();
+    bool diagonal = p.x() != you.posx() && p.y() != you.posy();
     if( you.in_vehicle ) {
         m.unboard_vehicle( you.pos_bub() );
     }
@@ -701,9 +701,9 @@ void avatar_action::autoattack( avatar &you, map &m )
         return rate_critter( *l ) > rate_critter( *r );
     } );
 
-    const tripoint diff = best.pos() - you.pos();
-    if( std::abs( diff.x ) <= 1 && std::abs( diff.y ) <= 1 && diff.z == 0 ) {
-        move( you, m, tripoint( diff.xy(), 0 ) );
+    const tripoint_rel_ms diff = best.pos_bub() - you.pos_bub();
+    if( std::abs( diff.x() ) <= 1 && std::abs( diff.y() ) <= 1 && diff.z() == 0 ) {
+        move( you, m, tripoint_rel_ms( diff.xy(), 0 ) );
         return;
     }
 
@@ -1030,7 +1030,7 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     // Shift our position to our "peeking" position, so that the UI
     // for picking a throw point lets us target the location we couldn't
     // otherwise see.
-    const tripoint original_player_position = you.pos();
+    const tripoint_bub_ms original_player_position = you.pos_bub();
     if( blind_throw_from_pos ) {
         you.setpos( *blind_throw_from_pos );
     }

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -33,14 +33,14 @@ void eat_or_use( avatar &you, item_location loc );
 
 // Standard movement; handles attacks, traps, &c. Returns false if auto move
 // should be canceled
-bool move( avatar &you, map &m, const tripoint &d );
-inline bool move( avatar &you, map &m, const point &d )
+bool move( avatar &you, map &m, const tripoint_rel_ms &d );
+inline bool move( avatar &you, map &m, const point_rel_ms &d )
 {
-    return move( you, m, tripoint( d, 0 ) );
+    return move( you, m, tripoint_rel_ms( d, 0 ) );
 }
 
 /** Handles swimming by the player. Called by avatar_action::move(). */
-void swim( map &m, avatar &you, const tripoint &p );
+void swim( map &m, avatar &you, const tripoint_bub_ms &p );
 
 void autoattack( avatar &you, map &m );
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4473,12 +4473,12 @@ void cata_tiles::init_draw_sct()
     do_draw_sct = true;
 }
 void cata_tiles::init_draw_zones( const tripoint_bub_ms &_start, const tripoint_bub_ms &_end,
-                                  const tripoint &_offset )
+                                  const tripoint_rel_ms &_offset )
 {
     do_draw_zones = true;
     zone_start = _start;
     zone_end = _end;
-    zone_offset = _offset;
+    zone_offset = _offset.raw();
 }
 void cata_tiles::init_draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id )
 {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -631,7 +631,7 @@ class cata_tiles
         void void_sct();
 
         void init_draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
-                              const tripoint &offset );
+                              const tripoint_rel_ms &offset );
         void draw_zones_frame();
         void void_zones();
 

--- a/src/character.h
+++ b/src/character.h
@@ -1947,11 +1947,9 @@ class Character : public Creature, public visitable
          * Returns true if it destroys the item. Consumes charges from the item.
          * Multi-use items are ONLY supported when all use_methods are iuse_actor!
          */
-        // TODO: Get rid of untyped overload
-        virtual bool invoke_item( item *, const tripoint &pt, int pre_obtain_moves = -1 );
         virtual bool invoke_item( item *, const tripoint_bub_ms &pt, int pre_obtain_moves = -1 );
         /** As above, but with a pre-selected method. Debugmsg if this item doesn't have this method. */
-        virtual bool invoke_item( item *, const std::string &, const tripoint &pt,
+        virtual bool invoke_item( item *, const std::string &, const tripoint_bub_ms &pt,
                                   int pre_obtain_moves = -1 );
         /** As above two, but with position equal to current position */
         virtual bool invoke_item( item * );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1561,9 +1561,9 @@ bool Creature::attack_air( const tripoint &p )
 
     // Attack animation
     if( get_option<bool>( "ANIMATIONS" ) ) {
-        std::map<tripoint, nc_color> area_color;
-        area_color[p] = c_black;
-        explosion_handler::draw_custom_explosion( p, area_color, "animation_hit" );
+        std::map<tripoint_bub_ms, nc_color> area_color;
+        area_color[tripoint_bub_ms( p )] = c_black;
+        explosion_handler::draw_custom_explosion( area_color, "animation_hit" );
     }
 
     // Chance to remove last known location

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -280,7 +280,7 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
     // Draw the explosion, but only if the explosion center is within the reality bubble
     map &bubble_map = get_map();
     if( bubble_map.inbounds( m->getglobal( p ) ) ) {
-        std::map<tripoint, nc_color> explosion_colors;
+        std::map<tripoint_bub_ms, nc_color> explosion_colors;
         for( const tripoint_bub_ms &pt : closed ) {
             const tripoint_bub_ms bubble_pos( bubble_map.bub_from_abs( m->getglobal( pt ) ) );
 
@@ -299,10 +299,10 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
                 col = c_yellow;
             }
 
-            explosion_colors[bubble_pos.raw()] = col;
+            explosion_colors[bubble_pos] = col;
         }
 
-        draw_custom_explosion( get_player_character().pos(), explosion_colors );
+        draw_custom_explosion( explosion_colors );
     }
 
     creature_tracker &creatures = get_creature_tracker();

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -104,9 +104,6 @@ void shockwave( const tripoint &p, int radius, int force, int stun, int dam_mult
 // TODO: Get rid of untyped overload
 void draw_explosion( const tripoint &p, int radius, const nc_color &col );
 void draw_explosion( const tripoint_bub_ms &p, int radius, const nc_color &col );
-// TODO: Get rid of untyped overload
-void draw_custom_explosion( const tripoint &p, const std::map<tripoint, nc_color> &area,
-                            const std::optional<std::string> &tile_id = std::nullopt );
 void draw_custom_explosion( const std::map<tripoint_bub_ms, nc_color> &area,
                             const std::optional<std::string> &tile_id = std::nullopt );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3946,13 +3946,13 @@ static shared_ptr_fast<game::draw_callback_t> create_zone_callback(
                                  point( player_character.posx() - getmaxx( g->w_terrain ) / 2,
                                         player_character.posy() - getmaxy( g->w_terrain ) / 2 ) );
 
-            tripoint offset;
+            tripoint_rel_ms offset;
 #if defined(TILES)
             if( use_tiles ) {
-                offset = tripoint_zero; //TILES
+                offset = tripoint_rel_ms_zero; //TILES
             } else {
 #endif
-                offset = tripoint( offset2, 0 ); //CURSES
+                offset = tripoint_rel_ms( offset2.x, offset2.y, 0 ); //CURSES
 #if defined(TILES)
             }
 #endif
@@ -4953,7 +4953,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
                 break;
             }
             if( m.has_flag( ter_furn_flag::TFLAG_LIQUID, u.pos_bub() ) && force_remaining == 0 ) {
-                avatar_action::swim( m, u, u.pos() );
+                avatar_action::swim( m, u, u.pos_bub() );
             } else {
                 u.setpos( traj[i] );
             }
@@ -5869,7 +5869,7 @@ bool game::npc_menu( npc &who )
                 u.i_rem( &used );
             }
         } else {
-            bool did_use = u.invoke_item( &used, heal_string, who.pos() );
+            bool did_use = u.invoke_item( &used, heal_string, who.pos_bub() );
             if( did_use ) {
                 // Note: exiting a body part selection menu counts as use here
                 u.mod_moves( -300 );
@@ -10371,7 +10371,7 @@ bool game::disable_robot( const tripoint_bub_ms &p )
     const itype_id mon_item_id = critter.type->revert_to_itype;
     if( !mon_item_id.is_empty() &&
         query_yn( _( "Deactivate the %s?" ), critter.name() ) ) {
-        const disable_activity_actor actor( p.raw(), disable_activity_actor::get_disable_turns(), false );
+        const disable_activity_actor actor( p, disable_activity_actor::get_disable_turns(), false );
         u.assign_activity( actor );
         return true;
     }
@@ -10385,7 +10385,7 @@ bool game::disable_robot( const tripoint_bub_ms &p )
         }
 
         if( choice == 0 ) {
-            u.assign_activity( disable_activity_actor( p.raw(), disable_activity_actor::get_disable_turns(),
+            u.assign_activity( disable_activity_actor( p, disable_activity_actor::get_disable_turns(),
                                true ) );
         }
     }
@@ -10422,6 +10422,12 @@ bool game::prompt_dangerous_tile( const tripoint &dest_loc,
 }
 
 std::vector<std::string> game::get_dangerous_tile( const tripoint &dest_loc,
+        const size_t max ) const
+{
+    return game::get_dangerous_tile( tripoint_bub_ms( dest_loc ), max );
+}
+
+std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_loc,
         const size_t max ) const
 {
     if( u.is_blind() ) {
@@ -10535,6 +10541,13 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint &dest_loc,
 
 bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool furniture_move )
 {
+    return game::walk_move( tripoint_bub_ms( dest_loc ), via_ramp, furniture_move );
+}
+
+bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
+                      const bool furniture_move )
+{
+
     const tripoint_abs_ms dest_loc_abs = m.getglobal( dest_loc );
 
     if( m.has_flag_ter( ter_furn_flag::TFLAG_SMALL_PASSAGE, dest_loc ) ) {
@@ -10551,7 +10564,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
         }
     }
 
-    const int ramp_adjust = via_ramp ? u.posz() : dest_loc.z;
+    const int ramp_adjust = via_ramp ? u.posz() : dest_loc.z();
     const float dest_light_level = get_map().ambient_light_at( tripoint_bub_ms( point_bub_ms(
                                        dest_loc.xy() ), ramp_adjust ) );
 
@@ -10590,14 +10603,13 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     bool shifting_furniture = false; // moving furniture and staying still; skip check for move_cost > 0
 
     const tripoint_bub_ms furn_pos = u.pos_bub() + u.grab_point;
-    const tripoint_bub_ms furn_dest = tripoint_bub_ms( dest_loc ) + tripoint_rel_ms( u.grab_point.xy(),
-                                      0 );
+    const tripoint_bub_ms furn_dest = dest_loc + u.grab_point.xy();
 
     bool grabbed = u.get_grab_type() != object_type::NONE;
     if( grabbed ) {
-        const tripoint dp = dest_loc - u.pos();
-        pushing = dp.xy() ==  u.grab_point.xy().raw();
-        pulling = dp.xy() == -u.grab_point.xy().raw();
+        const tripoint_rel_ms dp = dest_loc - u.pos_bub();
+        pushing = dp.xy() == u.grab_point.xy();
+        pulling = dp.xy() == -u.grab_point.xy();
     }
 
     // Now make sure we're actually holding something
@@ -10633,16 +10645,16 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     if( m.impassable( dest_loc ) && !pushing && !shifting_furniture ) {
         if( vp_there && u.mounted_creature && u.mounted_creature->has_flag( mon_flag_RIDEABLE_MECH ) &&
             vp_there->vehicle().handle_potential_theft( u ) ) {
-            tripoint diff = dest_loc - u.pos();
-            if( diff.x < 0 ) {
-                diff.x -= 2;
-            } else if( diff.x > 0 ) {
-                diff.x += 2;
+            tripoint_rel_ms diff = dest_loc - u.pos_bub();
+            if( diff.x() < 0 ) {
+                diff.x() -= 2;
+            } else if( diff.x() > 0 ) {
+                diff.x() += 2;
             }
-            if( diff.y < 0 ) {
-                diff.y -= 2;
-            } else if( diff.y > 0 ) {
-                diff.y += 2;
+            if( diff.y() < 0 ) {
+                diff.y() -= 2;
+            } else if( diff.y() > 0 ) {
+                diff.y() += 2;
             }
             u.mounted_creature->shove_vehicle( dest_loc + diff.xy(),
                                                dest_loc );
@@ -10664,16 +10676,16 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
             iexamine::ledge( u, tripoint_bub_ms( dest_loc ) );
             return true;
         } else if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "ALWAYS" &&
-                   !prompt_dangerous_tile( dest_loc, &harmful_stuff ) ) {
+                   !prompt_dangerous_tile( dest_loc.raw(), &harmful_stuff ) ) {
             return true;
         } else if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "RUNNING" &&
-                   ( !u.is_running() || !prompt_dangerous_tile( dest_loc, &harmful_stuff ) ) ) {
+                   ( !u.is_running() || !prompt_dangerous_tile( dest_loc.raw(), &harmful_stuff ) ) ) {
             add_msg( m_warning,
                      _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );
             return true;
         } else if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "CROUCHING" &&
-                   ( !u.is_crouching() || !prompt_dangerous_tile( dest_loc, &harmful_stuff ) ) ) {
+                   ( !u.is_crouching() || !prompt_dangerous_tile( dest_loc.raw(), &harmful_stuff ) ) ) {
             add_msg( m_warning,
                      _( "Stepping into that %1$s looks risky.  Crouch and move into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );
@@ -10691,7 +10703,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
 
     int modifier = 0;
     if( grabbed && u.get_grab_type() == object_type::FURNITURE &&
-        ( u.pos_bub() + u.grab_point ).raw() == dest_loc ) {
+        ( u.pos_bub() + u.grab_point ) == dest_loc ) {
         modifier = -m.furn( dest_loc ).obj().movecost;
     }
 
@@ -10699,12 +10711,12 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
                                            modifier,
                                            via_ramp );
 
-    if( !furniture_move && grabbed_move( dest_loc - u.pos(), via_ramp ) ) {
+    if( !furniture_move && grabbed_move( dest_loc - u.pos_bub(), via_ramp ) ) {
         return true;
     } else if( mcost == 0 ) {
         return false;
     }
-    bool diag = trigdist && u.posx() != dest_loc.x && u.posy() != dest_loc.y;
+    bool diag = trigdist && u.posx() != dest_loc.x() && u.posy() != dest_loc.y();
     const int previous_moves = u.get_moves();
     if( u.is_mounted() ) {
         auto *crit = u.mounted_creature.get();
@@ -10800,7 +10812,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
 
     //only clatter items every so often based on activity level
     if( to_turns<int>( calendar::turn - u.last_pocket_noise ) > std::max( static_cast<int>
-            ( 10 - u.activity_level() ), 1 ) )  {
+            ( 10 - u.activity_level() ), 1 ) ) {
         u.make_clatter_sound();
         u.last_pocket_noise = calendar::turn;
     }
@@ -10812,9 +10824,9 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     tripoint_bub_ms oldpos = u.pos_bub();
     tripoint_abs_ms old_abs_pos = m.getglobal( oldpos );
 
-    bool moving = dest_loc != oldpos.raw();
+    bool moving = dest_loc != oldpos;
 
-    point submap_shift = place_player( dest_loc );
+    point submap_shift = place_player( dest_loc.raw() );
     point_rel_ms ms_shift = coords::project_to<coords::ms>( point_rel_sm( submap_shift ) );
     oldpos = oldpos - ms_shift.raw();
 
@@ -10876,7 +10888,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     if( u.will_be_cramped_in_vehicle_tile( dest_loc_abs ) ) {
         if( u.get_size() == creature_size::huge ) {
             add_msg( m_warning, _( "You barely fit in this tiny human vehicle." ) );
-        } else if( u.get_total_volume() > u.get_base_volume() )  {
+        } else if( u.get_total_volume() > u.get_base_volume() ) {
             add_msg( m_warning,
                      _( "All the stuff you're carrying isn't making it any easier to move in here." ) );
         }
@@ -10886,12 +10898,6 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     on_move_effects();
 
     return true;
-}
-
-bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
-                      const bool furniture_move )
-{
-    return game::walk_move( dest_loc.raw(), via_ramp, furniture_move );
 }
 
 point game::place_player( const tripoint &dest_loc, bool quick )
@@ -11448,9 +11454,9 @@ bool game::phasing_move_enchant( const tripoint &dest_loc, const int phase_dista
     return false;
 }
 
-bool game::can_move_furniture( tripoint fdest, const tripoint &dp )
+bool game::can_move_furniture( tripoint_bub_ms fdest, const tripoint_rel_ms &dp )
 {
-    const bool pulling_furniture = dp.xy() == -u.grab_point.xy().raw();
+    const bool pulling_furniture = dp.xy() == -u.grab_point.xy();
     const bool has_floor = m.has_floor_or_water( fdest );
     creature_tracker &creatures = get_creature_tracker();
     bool is_ramp_or_road = m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fdest ) ||
@@ -11459,7 +11465,7 @@ bool game::can_move_furniture( tripoint fdest, const tripoint &dp )
     return  m.passable( fdest ) &&
             creatures.creature_at<npc>( fdest ) == nullptr &&
             creatures.creature_at<monster>( fdest ) == nullptr &&
-            ( !pulling_furniture || is_empty( u.pos() + dp ) ) &&
+            ( !pulling_furniture || is_empty( u.pos_bub() + dp ) ) &&
             ( !has_floor || m.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ||
               is_ramp_or_road ) &&
             !m.has_furn( fdest ) &&
@@ -11467,7 +11473,7 @@ bool game::can_move_furniture( tripoint fdest, const tripoint &dp )
             ( !has_floor || m.tr_at( fdest ).is_null() );
 }
 
-int game::grabbed_furn_move_time( const tripoint &dp )
+int game::grabbed_furn_move_time( const tripoint_rel_ms &dp )
 {
     // Furniture: pull, push, or standing still and nudging object around.
     // Can push furniture out of reach.
@@ -11477,9 +11483,9 @@ int game::grabbed_furn_move_time( const tripoint &dp )
         return 0;
     }
 
-    tripoint_bub_ms fdest = fpos + tripoint( dp.xy(), 0 ); // intended destination of furniture.
+    tripoint_bub_ms fdest = fpos + tripoint_rel_ms( dp.xy(), 0 ); // intended destination of furniture.
 
-    const bool canmove = can_move_furniture( fdest.raw(), dp );
+    const bool canmove = can_move_furniture( fdest, dp );
     const furn_t &furntype = m.furn( fpos ).obj();
     const map_stack &ms = m.i_at( fdest );
     const int dst_items = ms.size();
@@ -11535,7 +11541,7 @@ int game::grabbed_furn_move_time( const tripoint &dp )
     return moves_total;
 }
 
-bool game::grabbed_furn_move( const tripoint &dp )
+bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
 {
     // Furniture: pull, push, or standing still and nudging object around.
     // Can push furniture out of reach.
@@ -11550,22 +11556,22 @@ bool game::grabbed_furn_move( const tripoint &dp )
 
     int ramp_z_offset = 0;
     // Furniture could be on a ramp at different time than player so adjust for that.
-    if( m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, fpos + tripoint( dp.xy(), 0 ) ) ) {
+    if( m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, fpos + dp.xy() ) ) {
         ramp_z_offset = 1;
-    } else if( m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fpos + tripoint( dp.xy(), 0 ) ) ) {
+    } else if( m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fpos + dp.xy() ) ) {
         ramp_z_offset = -1;
     }
 
-    const bool pushing_furniture = dp.xy() ==  u.grab_point.xy().raw();
-    const bool pulling_furniture = dp.xy() == -u.grab_point.xy().raw();
+    const bool pushing_furniture = dp.xy() ==  u.grab_point.xy();
+    const bool pulling_furniture = dp.xy() == -u.grab_point.xy();
     const bool shifting_furniture = !pushing_furniture && !pulling_furniture;
 
     // Intended destination of furniture.
-    const tripoint_bub_ms fdest = fpos + tripoint( dp.xy(), ramp_z_offset );
+    const tripoint_bub_ms fdest = fpos + tripoint_rel_ms( dp.xy(), ramp_z_offset );
 
     // Unfortunately, game::is_empty fails for tiles we're standing on,
     // which will forbid pulling, so:
-    const bool canmove = can_move_furniture( fdest.raw(), dp );
+    const bool canmove = can_move_furniture( fdest, dp );
     // @TODO: it should be possible to move over invisible traps. This should probably
     // trigger the trap.
     // The current check (no move if trap) allows a player to detect invisible traps by
@@ -11697,7 +11703,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
     }
 
     if( !m.has_floor_or_water( fdest ) && !m.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ) {
-        std::string danger_tile = enumerate_as_string( get_dangerous_tile( fdest.raw() ) );
+        std::string danger_tile = enumerate_as_string( get_dangerous_tile( fdest ) );
         add_msg( _( "You let go of the %1$s as it falls down the %2$s." ), furntype.name(), danger_tile );
         u.grab( object_type::NONE );
         m.drop_furniture( fdest );
@@ -11708,9 +11714,9 @@ bool game::grabbed_furn_move( const tripoint &dp )
 
     if( shifting_furniture ) {
         // We didn't move
-        tripoint d_sum = u.grab_point.raw() + dp;
-        if( std::abs( d_sum.x ) < 2 && std::abs( d_sum.y ) < 2 ) {
-            u.grab_point.raw() = d_sum; // furniture moved relative to us
+        tripoint_rel_ms d_sum = u.grab_point + dp;
+        if( std::abs( d_sum.x() ) < 2 && std::abs( d_sum.y() ) < 2 ) {
+            u.grab_point = d_sum; // furniture moved relative to us
         } else { // we pushed furniture out of reach
             add_msg( _( "You let go of the %s." ), furntype.name() );
             u.grab( object_type::NONE );
@@ -11729,7 +11735,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
     return false;
 }
 
-bool game::grabbed_move( const tripoint &dp, const bool via_ramp )
+bool game::grabbed_move( const tripoint_rel_ms &dp, const bool via_ramp )
 {
     if( u.get_grab_type() == object_type::NONE ) {
         return false;
@@ -11737,7 +11743,7 @@ bool game::grabbed_move( const tripoint &dp, const bool via_ramp )
 
     // vehicle: pulling, pushing, or moving around the grabbed object.
     if( u.get_grab_type() == object_type::VEHICLE ) {
-        return grabbed_veh_move( tripoint_rel_ms( dp ) );
+        return grabbed_veh_move( dp );
     }
 
     if( u.get_grab_type() == object_type::FURNITURE ) {

--- a/src/game.h
+++ b/src/game.h
@@ -789,7 +789,7 @@ class game
         void draw_weather( const weather_printable &wPrint ) const;
         void draw_sct() const;
         void draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
-                         const tripoint &offset ) const;
+                         const tripoint_rel_ms &offset ) const;
         // Draw critter (if visible!) on its current position into w_terrain.
         // @param center the center of view, same as when calling map::draw
         void draw_critter( const Creature &critter, const tripoint &center );
@@ -865,7 +865,7 @@ class game
         bool phasing_move( const tripoint &dest, bool via_ramp = false );
         // Handle shifting through terrain and walls, with distance defined by enchantment.
         bool phasing_move_enchant( const tripoint &dest, int phase_distance = 0 );
-        bool can_move_furniture( tripoint fdest, const tripoint &dp );
+        bool can_move_furniture( tripoint_bub_ms fdest, const tripoint_rel_ms &dp );
         // Regular movement. Returns false if it failed for any reason
         // TODO: Get rid of untyped overload
         bool walk_move( const tripoint &dest, bool via_ramp = false, bool furniture_move = false );
@@ -915,7 +915,7 @@ class game
         /** Check for dangerous stuff at dest_loc, return false if the player decides
         not to step there */
         // Handle pushing during move, returns true if it handled the move
-        bool grabbed_move( const tripoint &dp, bool via_ramp );
+        bool grabbed_move( const tripoint_rel_ms &dp, bool via_ramp );
         bool grabbed_veh_move( const tripoint_rel_ms &dp );
 
         void control_vehicle(); // Use vehicle controls  '^'
@@ -945,8 +945,8 @@ class game
         */
         bool warn_player_maybe_anger_local_faction( bool really_bad_offense = false,
                 bool asking_for_public_goods = false );
-        int grabbed_furn_move_time( const tripoint &dp );
-        bool grabbed_furn_move( const tripoint &dp );
+        int grabbed_furn_move_time( const tripoint_rel_ms &dp );
+        bool grabbed_furn_move( const tripoint_rel_ms &dp );
 
         void reload_item(); // Reload an item
         void reload_wielded( bool prompt = false );
@@ -968,7 +968,10 @@ class game
         void mon_info_update( );    //Update seen monsters information
         void cleanup_dead();     // Delete any dead NPCs/monsters
         bool is_dangerous_tile( const tripoint &dest_loc ) const;
+        // TODO: Get rid of untyped overload.
         std::vector<std::string> get_dangerous_tile( const tripoint &dest_loc, size_t max = 0 ) const;
+        std::vector<std::string> get_dangerous_tile( const tripoint_bub_ms &dest_loc,
+                size_t max = 0 ) const;
         bool prompt_dangerous_tile( const tripoint &dest_loc,
                                     std::vector<std::string> *harmful_stuff = nullptr ) const;
         // Pick up items from the given point

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2317,7 +2317,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 // so no rotation needed
                 pldrive( get_delta_from_movement_action( act, iso_rotate::no ) );
             } else {
-                point dest_delta = get_delta_from_movement_action( act, iso_rotate::yes );
+                point_rel_ms dest_delta = get_delta_from_movement_action_rel_ms( act, iso_rotate::yes );
                 if( auto_travel_mode && !player_character.is_auto_moving() ) {
                     for( int i = 0; i < SEEX; i++ ) {
                         tripoint_bub_ms auto_travel_destination =
@@ -2334,8 +2334,8 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                         }
                     }
                     act = player_character.get_next_auto_move_direction();
-                    const point dest_next = get_delta_from_movement_action( act, iso_rotate::yes );
-                    if( dest_next == point_zero ) {
+                    const point_rel_ms dest_next = get_delta_from_movement_action_rel_ms( act, iso_rotate::yes );
+                    if( dest_next == point_rel_ms_zero ) {
                         player_character.abort_automove();
                     }
                     dest_delta = dest_next;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2600,7 +2600,7 @@ void iexamine::plant_seed( Character &you, const tripoint_bub_ms &examp, const i
 void iexamine::dirtmound( Character &you, const tripoint_bub_ms &examp )
 {
 
-    if( !warm_enough_to_plant( get_player_character().pos() ) ) {
+    if( !warm_enough_to_plant( get_player_character().pos_bub() ) ) {
         add_msg( m_info, _( "It is too cold to plant anything now." ) );
         return;
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2802,9 +2802,9 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint &pos )
     }
 
     map &here = get_map();
-    const std::function<bool( const tripoint & )> f =
-    [&here, p]( const tripoint & pnt ) {
-        if( pnt == p->pos() ) {
+    const std::function<bool( const tripoint_bub_ms & )> f =
+    [&here, p]( const tripoint_bub_ms & pnt ) {
+        if( pnt == p->pos_bub() ) {
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->prying->valid();
@@ -2814,13 +2814,14 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint &pos )
         return false;
     };
 
-    const std::optional<tripoint> pnt_ = ( pos != p->pos() ) ? pos : choose_adjacent_highlight(
-            _( "Pry where?" ), _( "There is nothing to pry nearby." ), f, false );
+    const std::optional<tripoint_bub_ms> pnt_ = ( pos != p->pos_bub().raw() ) ? tripoint_bub_ms(
+                pos ) : choose_adjacent_highlight(
+                _( "Pry where?" ), _( "There is nothing to pry nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
 
-    const tripoint &pnt = *pnt_;
+    const tripoint_bub_ms &pnt = *pnt_;
 
     const pry_data *prying;
     if( here.has_furn( pnt ) ) {
@@ -2830,7 +2831,7 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint &pos )
     }
 
     if( !f( pnt ) ) {
-        if( pnt == p->pos() ) {
+        if( pnt == p->pos_bub() ) {
             if( it->typeId() == STATIC( itype_id( "hammer" ) ) ) {
                 p->add_msg_if_player( m_info, _( "You try to hit yourself with the hammer." ) );
                 p->add_msg_if_player( m_info, _( "But you can't touch this." ) );
@@ -4749,9 +4750,9 @@ std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint & )
     }
 
     map &here = get_map();
-    const std::function<bool( const tripoint & )> f =
-    [&here, p]( const tripoint & pnt ) {
-        if( pnt == p->pos() ) {
+    const std::function<bool( const tripoint_bub_ms & )> f =
+    [&here, p]( const tripoint_bub_ms & pnt ) {
+        if( pnt == p->pos_bub() ) {
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->oxytorch->valid();
@@ -4761,14 +4762,14 @@ std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint & )
         return false;
     };
 
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-            _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
-    const tripoint &pnt = *pnt_;
+    const tripoint_bub_ms &pnt = *pnt_;
     if( !f( pnt ) ) {
-        if( pnt == p->pos() ) {
+        if( pnt == p->pos_bub() ) {
             p->add_msg_if_player( m_info, _( "Yuck.  Acetylene gas smells weird." ) );
         } else {
             p->add_msg_if_player( m_info, _( "You can't cut that." ) );
@@ -4836,9 +4837,9 @@ std::optional<int> iuse::boltcutters( Character *p, item *it, const tripoint & )
     }
 
     map &here = get_map();
-    const std::function<bool( const tripoint & )> f =
-    [&here, p]( const tripoint & pnt ) {
-        if( pnt == p->pos() ) {
+    const std::function<bool( const tripoint_bub_ms & )> f =
+    [&here, p]( const tripoint_bub_ms & pnt ) {
+        if( pnt == p->pos_bub() ) {
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->boltcut->valid();
@@ -4848,14 +4849,14 @@ std::optional<int> iuse::boltcutters( Character *p, item *it, const tripoint & )
         return false;
     };
 
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-            _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
-    const tripoint &pnt = *pnt_;
+    const tripoint_bub_ms &pnt = *pnt_;
     if( !f( pnt ) ) {
-        if( pnt == p->pos() ) {
+        if( pnt == p->pos_bub() ) {
             p->add_msg_if_player( m_info,
                                   _( "You neatly sever all of the veins and arteries in your body.  Oh, wait; never mind." ) );
         } else {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4436,7 +4436,7 @@ std::optional<int> modify_gunmods_actor::use( Character *p, item &it,
     if( prompt.ret >= 0 ) {
         // set gun to default in case this changes anything
         it.gun_set_mode( gun_mode_DEFAULT );
-        p->invoke_item( mods[prompt.ret], "transform", pnt );
+        p->invoke_item( mods[prompt.ret], "transform", tripoint_bub_ms( pnt ) );
         it.on_contents_changed();
         return 0;
     }
@@ -5228,19 +5228,19 @@ std::optional<int> deploy_tent_actor::use( Character *p, item &it, const tripoin
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    const std::optional<tripoint> dir = choose_direction( string_format(
-                                            _( "Put up the %s where (%dx%d clear area)?" ), it.tname(), diam, diam ) );
+    const std::optional<tripoint_rel_ms> dir = choose_direction_rel_ms( string_format(
+                _( "Put up the %s where (%dx%d clear area)?" ), it.tname(), diam, diam ) );
     if( !dir ) {
         return std::nullopt;
     }
-    const tripoint direction = *dir;
+    const tripoint_rel_ms direction = *dir;
 
     map &here = get_map();
     // We place the center of the structure (radius + 1)
     // spaces away from the player.
     // First check there's enough room.
-    const tripoint_bub_ms center = p->pos_bub() + tripoint( ( radius + 1 ) * direction.x,
-                                   ( radius + 1 ) * direction.y, 0 );
+    const tripoint_bub_ms center = p->pos_bub() + point_rel_ms( ( radius + 1 ) * direction.x(),
+                                   ( radius + 1 ) * direction.y() );
     creature_tracker &creatures = get_creature_tracker();
     for( const tripoint_bub_ms &dest : here.points_in_radius( center, radius ) ) {
         if( const optional_vpart_position vp = here.veh_at( dest ) ) {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -472,14 +472,14 @@ static std::set<tripoint_bub_ms> spell_effect_area( const spell &sp, const tripo
     std::set<tripoint_bub_ms> targets = calculate_spell_effect_area( sp, target, caster );
     if( !sp.has_flag( spell_flag::NO_EXPLOSION_SFX ) ) {
         // Draw the explosion
-        std::map<tripoint, nc_color> explosion_colors;
+        std::map<tripoint_bub_ms, nc_color> explosion_colors;
         for( const tripoint_bub_ms &pt : targets ) {
-            explosion_colors[pt.raw()] = sp.damage_type_color();
+            explosion_colors[pt] = sp.damage_type_color();
         }
 
         std::string exp_name = "explosion_" + sp.id().str();
 
-        explosion_handler::draw_custom_explosion( get_player_character().pos(), explosion_colors,
+        explosion_handler::draw_custom_explosion( explosion_colors,
                 exp_name );
     }
     return targets;

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1539,7 +1539,7 @@ npc_ptr talk_function::temp_npc( const string_id<npc_template> &type )
 void talk_function::field_plant( npc &p, const std::string &place )
 {
     Character &player_character = get_player_character();
-    if( !warm_enough_to_plant( player_character.pos() ) ) {
+    if( !warm_enough_to_plant( player_character.pos_bub() ) ) {
         popup( _( "It is too cold to plant anything now." ) );
         return;
     }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -512,10 +512,10 @@ void milk_source( monster &source_mon )
 
     else if( milkable_ammo->second > 0 ) {
         const int moves = to_moves<int>( time_duration::from_minutes( milkable_ammo->second / 2 ) );
-        std::vector<tripoint> coords{};
+        std::vector<tripoint_abs_ms> coords{};
         std::vector<std::string> str_values{};
         Character &player_character = get_player_character();
-        coords.push_back( get_map().getglobal( source_mon.pos_bub() ).raw() );
+        coords.push_back( get_map().getglobal( source_mon.pos_bub() ) );
         // pin the cow in place if it isn't already
         bool temp_tie = !source_mon.has_effect( effect_tied );
         if( temp_tie ) {
@@ -548,7 +548,7 @@ void shear_animal( monster &z )
         z.add_effect( effect_tied, 1_turns, true );
     }
 
-    guy.assign_activity( shearing_activity_actor( z.pos(), !monster_tied ) );
+    guy.assign_activity( shearing_activity_actor( z.pos_bub(), !monster_tied ) );
 }
 
 void remove_battery( monster &z )

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1195,7 +1195,7 @@ void monster::move()
             }
 
             // Try to shove vehicle out of the way
-            shove_vehicle( destination.raw(), candidate );
+            shove_vehicle( destination, tripoint_bub_ms( candidate ) );
             // Bail out if we can't move there and we can't bash.
             if( !pathed && !can_move_to( candidate ) ) {
                 if( !can_bash ) {
@@ -2366,8 +2366,8 @@ int monster::turns_to_reach( const point &p )
     return static_cast<int>( turns + .9 ); // Halve (to get turns) and round up
 }
 
-void monster::shove_vehicle( const tripoint &remote_destination,
-                             const tripoint &nearby_destination )
+void monster::shove_vehicle( const tripoint_bub_ms &remote_destination,
+                             const tripoint_bub_ms &nearby_destination )
 {
     map &here = get_map();
     if( this->has_flag( mon_flag_PUSH_VEH ) && !is_hallucination() ) {
@@ -2422,7 +2422,7 @@ void monster::shove_vehicle( const tripoint &remote_destination,
                 int shove_moves = shove_veh_mass_moves_factor * veh_mass / 10_kilogram;
                 shove_moves = std::max( shove_moves, shove_moves_minimal );
                 this->mod_moves( -shove_moves );
-                const tripoint_rel_ms destination_delta( -nearby_destination + remote_destination );
+                const tripoint_rel_ms destination_delta( remote_destination - nearby_destination );
                 const tripoint_rel_ms shove_destination( clamp( destination_delta.x(), -1, 1 ),
                         clamp( destination_delta.y(), -1, 1 ),
                         clamp( destination_delta.z(), -1, 1 ) );

--- a/src/monster.h
+++ b/src/monster.h
@@ -256,8 +256,8 @@ class monster : public Creature
         void anger_cub_threatened( monster_plan &mon_plan );
         void move(); // Actual movement
         void footsteps( const tripoint &p ); // noise made by movement
-        void shove_vehicle( const tripoint &remote_destination,
-                            const tripoint &nearby_destination ); // shove vehicles out of the way
+        void shove_vehicle( const tripoint_bub_ms &remote_destination,
+                            const tripoint_bub_ms &nearby_destination ); // shove vehicles out of the way
 
         // check if the given square could drown a drownable monster
         bool is_aquatic_danger( const tripoint &at_pos ) const;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3372,7 +3372,7 @@ void npc::process_turn()
     // TODO: Make NPCs leave the player if there's a path out of map and player is sleeping/unseen/etc.
 }
 
-bool npc::invoke_item( item *used, const tripoint &pt, int )
+bool npc::invoke_item( item *used, const tripoint_bub_ms &pt, int )
 {
     const auto &use_methods = used->type->use_methods;
 
@@ -3382,11 +3382,6 @@ bool npc::invoke_item( item *used, const tripoint &pt, int )
         return Character::invoke_item( used, use_methods.begin()->first, pt );
     }
     return false;
-}
-
-bool npc::invoke_item( item *used, const tripoint_bub_ms &pt, int pre_obtain_moves )
-{
-    return npc::invoke_item( used, pt.raw(), pre_obtain_moves );
 }
 
 bool npc::invoke_item( item *used, const std::string &method )

--- a/src/npc.h
+++ b/src/npc.h
@@ -1096,8 +1096,6 @@ class npc : public Character
         void process_turn() override;
 
         using Character::invoke_item;
-        // TODO: Get rid of untyped overload
-        bool invoke_item( item *, const tripoint &pt, int pre_obtain_moves ) override;
         bool invoke_item( item *, const tripoint_bub_ms &pt, int pre_obtain_moves ) override;
         bool invoke_item( item *used, const std::string &method ) override;
         bool invoke_item( item * ) override;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5463,7 +5463,7 @@ talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view membe
                 if( target_var.has_value() ) {
                     tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
                     if( get_map().inbounds( target_pos ) ) {
-                        guy->invoke_item( it->get_item(), method_str, get_map().bub_from_abs( target_pos ).raw() );
+                        guy->invoke_item( it->get_item(), method_str, get_map().bub_from_abs( target_pos ) );
                         return;
                     }
                 }

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -426,7 +426,7 @@ void Pickup::autopickup( const tripoint &p )
         local.has_flag( ter_furn_flag::TFLAG_SEALED, p ) ) {
         return;
     }
-    drop_locations selected_items = auto_pickup::select_items( here, p );
+    drop_locations selected_items = auto_pickup::select_items( here, tripoint_bub_ms( p ) );
     if( selected_items.empty() ) {
         return;
     }

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -256,7 +256,7 @@ void timed_event::actualize()
                     get_memorial().add(
                         pgettext( "memorial_male", "Water level reached the ceiling." ),
                         pgettext( "memorial_female", "Water level reached the ceiling." ) );
-                    avatar_action::swim( here, player_character, player_character.pos() );
+                    avatar_action::swim( here, player_character, player_character.pos_bub() );
                 }
             }
             // flood_buf is filled with correct tiles; now copy them back to here

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5905,7 +5905,7 @@ void vehicle::idle( bool on_map )
         engine_on = false;
     }
 
-    if( !warm_enough_to_plant( player_character.pos() ) ) {
+    if( !warm_enough_to_plant( player_character.pos_bub() ) ) {
         for( int i : planters ) {
             vehicle_part &vp = parts[ i ];
             if( vp.enabled ) {

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -673,7 +673,7 @@ bool vehicle::can_enable( const vehicle_part &pt, bool alert ) const
         return false;
     }
 
-    if( pt.info().has_flag( "PLANTER" ) && !warm_enough_to_plant( get_player_character().pos() ) ) {
+    if( pt.info().has_flag( "PLANTER" ) && !warm_enough_to_plant( get_player_character().pos_bub() ) ) {
         if( alert ) {
             add_msg( m_bad, _( "It is too cold to plant anything now." ) );
         }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -868,10 +868,10 @@ rl_vec2d convert_wind_to_coord( const int angle )
     return rl_vec2d( 0, 0 );
 }
 
-bool warm_enough_to_plant( const tripoint &pos )
+bool warm_enough_to_plant( const tripoint_bub_ms &pos )
 {
     // semi-appropriate temperature for most plants
-    return get_weather().get_temperature( pos ) >= units::from_fahrenheit( 50 );
+    return get_weather().get_temperature( pos.raw() ) >= units::from_fahrenheit( 50 );
 }
 
 bool warm_enough_to_plant( const tripoint_abs_omt &pos )

--- a/src/weather.h
+++ b/src/weather.h
@@ -173,7 +173,7 @@ nc_color get_wind_color( double );
  * The first overload is in map-square coords, the second for larger scale
  * queries.
  */
-bool warm_enough_to_plant( const tripoint &pos );
+bool warm_enough_to_plant( const tripoint_bub_ms &pos );
 bool warm_enough_to_plant( const tripoint_abs_omt &pos );
 
 bool is_wind_blocker( const tripoint_bub_ms &location );

--- a/tests/gates_test.cpp
+++ b/tests/gates_test.cpp
@@ -165,7 +165,7 @@ TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows
         REQUIRE( here.ter_set( pos, ter_t_door_c ) );
         REQUIRE( here.ter( pos ).obj().id == ter_t_door_c->id );
 
-        REQUIRE( avatar_action::move( they, here, tripoint_east ) );
+        REQUIRE( avatar_action::move( they, here, tripoint_rel_ms_east ) );
 
         THEN( "avatar should spend move points" ) {
             CHECK( they.get_moves() == -open_move_cost );
@@ -175,7 +175,7 @@ TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows
         REQUIRE( here.ter_set( pos, ter_t_door_locked ) );
         REQUIRE( here.ter( pos ).obj().id == ter_t_door_locked->id );
 
-        REQUIRE_FALSE( avatar_action::move( they, here, tripoint_east ) );
+        REQUIRE_FALSE( avatar_action::move( they, here, tripoint_rel_ms_east ) );
 
         THEN( "avatar should not spend move points" ) {
             CHECK( they.get_moves() == 0 );
@@ -188,7 +188,7 @@ TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows
             REQUIRE( here.ter_set( pos, ter_t_window_no_curtains ) );
             REQUIRE( here.ter( pos ).obj().id == ter_t_window_no_curtains->id );
 
-            REQUIRE_FALSE( avatar_action::move( they, here, tripoint_east ) );
+            REQUIRE_FALSE( avatar_action::move( they, here, tripoint_rel_ms_east ) );
 
             THEN( "avatar should spend move points" ) {
                 CHECK( they.get_moves() == 0 );
@@ -227,7 +227,7 @@ TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows
             REQUIRE( here.ter_set( pos, ter_t_window_no_curtains ) );
             REQUIRE( here.ter( pos ).obj().id == ter_t_window_no_curtains->id );
 
-            REQUIRE( avatar_action::move( they, here, tripoint_east ) );
+            REQUIRE( avatar_action::move( they, here, tripoint_rel_ms_east ) );
 
             THEN( "avatar should spend move points" ) {
                 CHECK( they.get_moves() == -open_move_cost );

--- a/tests/move_cost_test.cpp
+++ b/tests/move_cost_test.cpp
@@ -216,7 +216,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -225,7 +225,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -234,7 +234,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 600 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -600 );
             }
         }
@@ -251,7 +251,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -260,7 +260,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -269,7 +269,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 660 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -660 );
             }
         }
@@ -285,7 +285,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 154 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -154 );
             }
         }
@@ -294,7 +294,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 309 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -309 );
             }
         }
@@ -303,7 +303,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 932 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -932 );
             }
         }
@@ -321,7 +321,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -330,7 +330,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -339,7 +339,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 803 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -803 );
             }
         }
@@ -357,7 +357,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -366,7 +366,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -375,7 +375,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 818 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -818 );
             }
         }
@@ -392,7 +392,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 154 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -154 );
             }
         }
@@ -401,7 +401,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 309 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -309 );
             }
         }
@@ -410,7 +410,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1246 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -1246 );
             }
         }
@@ -430,7 +430,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1000 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -1000 );
             }
         }
@@ -450,7 +450,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1179 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -1179 );
             }
         }
@@ -469,7 +469,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1561 );
-                avatar_action::move( u, get_map(), point_south );
+                avatar_action::move( u, get_map(), point_rel_ms_south );
                 CHECK( u.get_moves() == -1561 );
             }
         }

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -346,7 +346,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             monster &mon = test_monster( true );
 
             REQUIRE( dummy.max_quality( qual_SHEAR ) <= 0 );
-            dummy.activity = player_activity( shearing_activity_actor( mon.pos(), false ) );
+            dummy.activity = player_activity( shearing_activity_actor( mon.pos_bub(), false ) );
             dummy.activity.start_or_resume( dummy, false );
 
             THEN( "shearing can't start" ) {
@@ -362,7 +362,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             dummy.i_add( item( itype_test_shears ) );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 1 );
 
-            dummy.activity = player_activity( shearing_activity_actor( mon.pos(), false ) );
+            dummy.activity = player_activity( shearing_activity_actor( mon.pos_bub(), false ) );
             dummy.activity.start_or_resume( dummy, false );
             REQUIRE( dummy.activity.id() == ACT_SHEARING );
 
@@ -390,7 +390,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             dummy.i_add( elec_shears );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 3 );
 
-            dummy.activity = player_activity( shearing_activity_actor( mon.pos(), false ) );
+            dummy.activity = player_activity( shearing_activity_actor( mon.pos_bub(), false ) );
             dummy.activity.start_or_resume( dummy, false );
             REQUIRE( dummy.activity.id() == ACT_SHEARING );
 
@@ -407,7 +407,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             dummy.i_add( item( itype_test_shears ) );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 1 );
 
-            dummy.activity = player_activity( shearing_activity_actor( mon.pos(), false ) );
+            dummy.activity = player_activity( shearing_activity_actor( mon.pos_bub(), false ) );
             dummy.activity.start_or_resume( dummy, false );
 
             THEN( "shearing can't start" ) {
@@ -436,7 +436,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             dummy.i_add( elec_shears );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 3 );
 
-            dummy.activity = player_activity( shearing_activity_actor( mon.pos(), false ) );
+            dummy.activity = player_activity( shearing_activity_actor( mon.pos_bub(), false ) );
             dummy.activity.start_or_resume( dummy, false );
             REQUIRE( dummy.activity.id() == ACT_SHEARING );
 
@@ -476,7 +476,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             dummy.i_add( item( itype_test_shears ) );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 1 );
 
-            dummy.activity = player_activity( shearing_activity_actor( mon.pos(), false ) );
+            dummy.activity = player_activity( shearing_activity_actor( mon.pos_bub(), false ) );
             dummy.activity.start_or_resume( dummy, false );
             REQUIRE( dummy.activity.id() == ACT_SHEARING );
 
@@ -528,7 +528,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             dummy.i_add( item( itype_test_shears ) );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 1 );
 
-            dummy.activity = player_activity( shearing_activity_actor( mon.pos(), false ) );
+            dummy.activity = player_activity( shearing_activity_actor( mon.pos_bub(), false ) );
             dummy.activity.start_or_resume( dummy, false );
             REQUIRE( dummy.activity.id() == ACT_SHEARING );
 
@@ -549,7 +549,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             dummy.i_add( item( itype_test_shears ) );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 1 );
 
-            dummy.activity = player_activity( shearing_activity_actor( mon.pos(), true ) );
+            dummy.activity = player_activity( shearing_activity_actor( mon.pos_bub(), true ) );
             dummy.activity.start_or_resume( dummy, false );
             REQUIRE( dummy.activity.id() == ACT_SHEARING );
 
@@ -579,7 +579,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
     };
 
     auto setup_activity = [&dummy]( const item_location & torch ) -> void {
-        boltcutting_activity_actor act{tripoint_zero, torch};
+        boltcutting_activity_actor act{tripoint_bub_ms_zero, torch};
         act.testing = true;
         dummy.assign_activity( act );
     };
@@ -1109,7 +1109,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
     };
 
     auto setup_activity = [&dummy]( const item_location & torch ) -> void {
-        oxytorch_activity_actor act{tripoint_zero, torch};
+        oxytorch_activity_actor act{tripoint_bub_ms_zero, torch};
         act.testing = true;
         dummy.assign_activity( act );
     };
@@ -1373,7 +1373,7 @@ TEST_CASE( "prying", "[activity][prying]" )
 
     auto setup_activity = [&dummy]( const item_location & tool,
     const tripoint_bub_ms &target = tripoint_bub_ms_zero ) -> void {
-        prying_activity_actor act{target.raw(), tool};
+        prying_activity_actor act{target, tool};
         act.testing = true;
         dummy.assign_activity( act );
     };
@@ -1708,7 +1708,7 @@ static const std::vector<std::function<player_activity()>> test_activities {
     //player_activity( longsalvage_activity_actor() ),
     [] { return player_activity( meditate_activity_actor() ); },
     [] { return player_activity( migration_cancel_activity_actor() ); },
-    [] { return player_activity( milk_activity_actor( 1, {get_avatar().pos()}, {std::string()} ) ); },
+    [] { return player_activity( milk_activity_actor( 1, {get_avatar().get_location()}, {std::string()} ) ); },
     [] { return player_activity( mop_activity_actor( 1 ) ); },
     //player_activity( move_furniture_activity_actor( p, false ) ),
     [] { return player_activity( move_items_activity_actor( {}, {}, false, tripoint_rel_ms_north ) ); },

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -261,8 +261,8 @@ struct swim_scenario {
 static int swimming_steps( avatar &swimmer )
 {
     map &here = get_map();
-    const tripoint left = swimmer.pos();
-    const tripoint right = left + tripoint_east;
+    const tripoint_bub_ms left = swimmer.pos_bub();
+    const tripoint_bub_ms right = left + tripoint_east;
     int steps = 0;
     constexpr int STOP_STEPS = 9000;
     int last_moves = swimmer.get_speed();
@@ -271,11 +271,11 @@ static int swimming_steps( avatar &swimmer )
     swimmer.set_stamina( last_stamina );
     while( swimmer.get_stamina() > 0 && !swimmer.has_effect( effect_winded ) && steps < STOP_STEPS ) {
         if( steps % 2 == 0 ) {
-            REQUIRE( swimmer.pos() == left );
-            REQUIRE( avatar_action::move( swimmer, here, tripoint_east ) );
+            REQUIRE( swimmer.pos_bub() == left );
+            REQUIRE( avatar_action::move( swimmer, here, tripoint_rel_ms_east ) );
         } else {
-            REQUIRE( swimmer.pos() == right );
-            REQUIRE( avatar_action::move( swimmer, here, tripoint_west ) );
+            REQUIRE( swimmer.pos_bub() == right );
+            REQUIRE( avatar_action::move( swimmer, here, tripoint_rel_ms_west ) );
         }
         ++steps;
         REQUIRE( swimmer.get_moves() < last_moves );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Change usage of untyped coordinates to typed ones. This time reaching the end of the letter 'a' in the file list.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Find usages of untyped coordinates and replace them with typed ones, propagating easy conversion to users and removing untyped operations rendered obsolete by the migration of their usages.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
This should not have any functional effect*, so a simple test was used.
- Loaded save, walked up ramp, jumped into car, ran through hay bales, run over a zombie corpse with inventory, running over a turkey, smashed into a stationary vehicle. Nothing odd noticed.

* A test in player_activity_test.cpp was feeding an untyped reality bubble coordinate into an operation that was fed untyped absolute coordinates by its uses in the real code. The test was changed to feed in the corresponding absolute coordinate. We'll see if the test fails when it's run.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Changes to avatar had to be done in lockstep with Character and npc due to inheritance, so that's why those files were affected as well.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
