### PR TITLE
[DinoMod] smell audit

### DIFF
--- a/data/mods/DinoMod/monsters/dinosaur.json
+++ b/data/mods/DinoMod/monsters/dinosaur.json
@@ -91,7 +91,7 @@
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 2 },
     "grab_strength": 15,
     "special_attacks": [ { "id": "teeth_grab", "cooldown": 10 }, { "id": "teeth_rip", "cooldown": 10 }, [ "EAT_CARRION", 60 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "KEENNOSE", "WARM", "SWIMS" ],
+    "flags": [ "SEES", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "SWIMS" ],
     "harvest": "dino_med_feather_pred",
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE" ],
     "fear_triggers": [ "FRIEND_DIED" ],
@@ -130,7 +130,7 @@
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 2 },
     "grab_strength": 15,
     "special_attacks": [ { "id": "teeth_grab", "cooldown": 10 }, { "id": "teeth_rip", "cooldown": 10 }, [ "EAT_CARRION", 60 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "WARM", "SWIMS" ],
+    "flags": [ "SEES", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "WARM", "SWIMS" ],
     "harvest": "dino_large_pred",
     "dissect": "dissect_dino_large_pred",
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE" ],
@@ -169,7 +169,7 @@
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 1 },
     "grab_strength": 15,
     "special_attacks": [ { "id": "teeth_grab", "cooldown": 10 }, { "id": "teeth_rip", "cooldown": 10 }, [ "LUNGE", 5 ], [ "EAT_CARRION", 60 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "DESTROYS", "WARM", "SWIMS", "PUSH_MON" ],
+    "flags": [ "SEES", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "DESTROYS", "WARM", "SWIMS", "PUSH_MON" ],
     "harvest": "dino_large_pred",
     "dissect": "dissect_dino_large_pred",
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE", "SOUND" ],
@@ -209,7 +209,7 @@
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 1 },
     "grab_strength": 15,
     "special_attacks": [ { "id": "teeth_grab", "cooldown": 10 }, { "id": "teeth_rip", "cooldown": 10 }, [ "LUNGE", 5 ], [ "EAT_CARRION", 60 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "DESTROYS", "WARM", "PUSH_MON" ],
+    "flags": [ "SEES", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "DESTROYS", "WARM", "PUSH_MON" ],
     "harvest": "dino_large_pred",
     "dissect": "dissect_dino_large_pred",
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE", "SOUND" ],
@@ -248,7 +248,7 @@
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 1 },
     "grab_strength": 15,
     "special_attacks": [ { "id": "teeth_grab", "cooldown": 10 }, { "id": "teeth_rip", "cooldown": 10 }, [ "EAT_CARRION", 60 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "WARM" ],
+    "flags": [ "SEES", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "WARM" ],
     "harvest": "allosaurus",
     "dissect": "dissect_dino_large_pred",
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE", "SOUND" ],
@@ -422,7 +422,7 @@
     "reproduction": { "baby_type": { "baby_egg": "egg_albertosaurus" }, "baby_count": 3, "baby_timer": 24 },
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 1 },
-    "flags": [ "SEES", "SMELLS", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "DESTROYS", "WARM", "PUSH_MON" ],
+    "flags": [ "SEES", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "DESTROYS", "WARM", "PUSH_MON" ],
     "grab_strength": 15,
     "special_attacks": [
       { "id": "teeth_puncture", "cooldown": 7 },
@@ -476,7 +476,7 @@
       { "id": "bio_op_takedown", "cooldown": 30 },
       [ "EAT_CARRION", 60 ]
     ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "DESTROYS", "WARM", "PUSH_MON" ],
+    "flags": [ "SEES", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "DESTROYS", "WARM", "PUSH_MON" ],
     "harvest": "dino_large_feather_pred",
     "dissect": "dissect_tyrant_sample_large",
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE", "SOUND" ],
@@ -571,7 +571,6 @@
     ],
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "EATS",
       "ANIMAL",
@@ -621,7 +620,6 @@
     "petfood": { "food": [ "DINOFOOD_B" ] },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "HIT_AND_RUN",
       "ANIMAL",
@@ -676,7 +674,6 @@
     "petfood": { "food": [ "DINOFOOD_A", "DINOFOOD_C" ] },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
@@ -754,7 +751,6 @@
     "petfood": { "food": [ "DINOFOOD_B" ] },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "HIT_AND_RUN",
       "ANIMAL",
@@ -807,7 +803,6 @@
     "petfood": { "food": [ "DINOFOOD_C" ] },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "CORNERED_FIGHTER",
@@ -861,7 +856,6 @@
     "petfood": { "food": [ "DINOFOOD_C" ] },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "CORNERED_FIGHTER",
@@ -914,7 +908,6 @@
     "petfood": { "food": [ "DINOFOOD_C" ] },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "CORNERED_FIGHTER",
@@ -966,7 +959,6 @@
     "special_attacks": [ [ "EAT_CROP", 30 ], [ "BROWSE", 50 ], { "id": "longswipe", "cooldown": 25 } ],
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "CORNERED_FIGHTER",
@@ -1044,19 +1036,7 @@
     "reproduction": { "baby_type": { "baby_egg": "egg_velociraptor" }, "baby_count": 3, "baby_timer": 18 },
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 66 },
-    "flags": [
-      "SEES",
-      "SMELLS",
-      "HEARS",
-      "EATS",
-      "ANIMAL",
-      "PATH_AVOID_DANGER",
-      "KEENNOSE",
-      "WARM",
-      "CLIMBS",
-      "SMALL_HIDER",
-      "CORNERED_FIGHTER"
-    ],
+    "flags": [ "SEES", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CLIMBS", "SMALL_HIDER", "CORNERED_FIGHTER" ],
     "harvest": "dino_pred_feather_leather",
     "dissect": "dissect_raptor_sample_single",
     "anger_triggers": [ "FRIEND_ATTACKED", "PLAYER_WEAK", "HURT" ],
@@ -1109,7 +1089,6 @@
       "EATS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
-      "KEENNOSE",
       "WARM",
       "CLIMBS",
       "CAN_OPEN_DOORS",
@@ -1160,7 +1139,7 @@
     "reproduction": { "baby_type": { "baby_egg": "egg_utahraptor" }, "baby_count": 3, "baby_timer": 18 },
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 2 },
-    "flags": [ "SEES", "SMELLS", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "KEENNOSE", "WARM", "CLIMBS" ],
+    "flags": [ "SEES", "SMELLS", "HEARS", "EATS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CLIMBS" ],
     "harvest": "dino_med_feather_pred",
     "dissect": "dissect_raptor_sample_small",
     "anger_triggers": [ "FRIEND_ATTACKED", "PLAYER_WEAK", "PLAYER_CLOSE", "HURT", "STALK", "SOUND" ],
@@ -1222,12 +1201,10 @@
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 28 },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "EATS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
-      "KEENNOSE",
       "WARM",
       "CLIMBS",
       "CAN_OPEN_DOORS",
@@ -1272,7 +1249,6 @@
     "special_attacks": [ [ "EAT_FOOD", 120 ], [ "EAT_CARRION", 60 ] ],
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "EATS",
       "HIT_AND_RUN",
@@ -1322,7 +1298,6 @@
     "special_attacks": [ [ "EAT_CROP", 40 ], [ "BROWSE", 60 ], [ "GRAZE", 60 ] ],
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
@@ -1376,7 +1351,6 @@
     "special_attacks": [ [ "EAT_CROP", 50 ], [ "BROWSE", 60 ], [ "GRAZE", 60 ] ],
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
@@ -1429,18 +1403,7 @@
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 1 },
     "special_attacks": [ [ "EAT_CROP", 40 ], [ "BROWSE", 60 ], [ "GRAZE", 60 ] ],
-    "flags": [
-      "SEES",
-      "SMELLS",
-      "HEARS",
-      "HIT_AND_RUN",
-      "ANIMAL",
-      "PATH_AVOID_DANGER",
-      "WARM",
-      "CLIMBS",
-      "CORNERED_FIGHTER",
-      "EATS"
-    ],
+    "flags": [ "SEES", "HEARS", "HIT_AND_RUN", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CLIMBS", "CORNERED_FIGHTER", "EATS" ],
     "harvest": "mammal_large_leather",
     "vision_night": 5,
     "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "PLAYER_NEAR_BABY" ],
@@ -1520,19 +1483,7 @@
     "reproduction": { "baby_type": { "baby_egg": "egg_apatosaurus" }, "baby_count": 3, "baby_timer": 24 },
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 1 },
-    "flags": [
-      "SEES",
-      "SMELLS",
-      "HEARS",
-      "ANIMAL",
-      "PATH_AVOID_DANGER",
-      "BASHES",
-      "DESTROYS",
-      "WARM",
-      "PUSH_MON",
-      "CORNERED_FIGHTER",
-      "EATS"
-    ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "DESTROYS", "WARM", "PUSH_MON", "CORNERED_FIGHTER", "EATS" ],
     "harvest": "dino_sauropod",
     "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "PLAYER_NEAR_BABY" ],
     "fear_triggers": [ "FRIEND_DIED" ],
@@ -1670,7 +1621,7 @@
     "special_attacks": [ [ "EAT_CROP", 40 ], [ "BROWSE", 60 ], [ "GRAZE", 60 ] ],
     "description": "Small, four-legged dinosaur with five rows of protective plates running down its back.",
     "reproduction": { "baby_type": { "baby_egg": "egg_scutellosaurus" }, "baby_count": 3, "baby_timer": 24 },
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "CAN_BE_CULLED", "CORNERED_FIGHTER", "EATS" ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "CAN_BE_CULLED", "CORNERED_FIGHTER", "EATS" ],
     "fear_triggers": [ "PLAYER_CLOSE", "FRIEND_DIED" ],
     "harvest": "mammal_small_leather",
     "dissect": "dissect_stego_sample_single",
@@ -1716,7 +1667,7 @@
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 1 },
     "petfood": { "food": [ "DINOFOOD_C" ] },
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "PET_WONT_FOLLOW", "CORNERED_FIGHTER", "EATS" ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "PET_WONT_FOLLOW", "CORNERED_FIGHTER", "EATS" ],
     "harvest": "mammal_large_leather",
     "dissect": "dissect_stego_sample_large",
     "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "PLAYER_NEAR_BABY" ],
@@ -1865,7 +1816,7 @@
     "description": "This heavily armored four legged dinosaur has a beak and a long tail ending in a spiked club of bone.",
     "reproduction": { "baby_type": { "baby_egg": "egg_dyoplosaurus" }, "baby_count": 3, "baby_timer": 24 },
     "petfood": { "food": [ "DINOFOOD_C" ] },
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "PET_WONT_FOLLOW", "CORNERED_FIGHTER", "EATS" ]
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "PET_WONT_FOLLOW", "CORNERED_FIGHTER", "EATS" ]
   },
   {
     "type": "MONSTER",
@@ -1907,7 +1858,7 @@
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 1 },
     "petfood": { "food": [ "DINOFOOD_C" ] },
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "PET_WONT_FOLLOW", "CORNERED_FIGHTER", "EATS" ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "PET_WONT_FOLLOW", "CORNERED_FIGHTER", "EATS" ],
     "harvest": "mammal_large_leather",
     "dissect": "dissect_stego_sample_large",
     "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "PLAYER_NEAR_BABY" ],
@@ -1933,7 +1884,7 @@
     "description": "This heavily armored four legged dinosaur has a horny beak, two bony rings protecting the neck, and a long tail ending in a heavy club of bone.",
     "reproduction": { "baby_type": { "baby_egg": "egg_euoplocephalus" }, "baby_count": 3, "baby_timer": 24 },
     "petfood": { "food": [ "DINOFOOD_C" ] },
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "PET_WONT_FOLLOW", "CORNERED_FIGHTER", "EATS" ]
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "PET_WONT_FOLLOW", "CORNERED_FIGHTER", "EATS" ]
   },
   {
     "type": "MONSTER",
@@ -1954,7 +1905,7 @@
     "description": "This heavily armored four legged dinosaur has several long spikes along the back and a long spiked tail ending in a club of bone.",
     "reproduction": { "baby_type": { "baby_egg": "egg_scolosaurus" }, "baby_count": 3, "baby_timer": 24 },
     "petfood": { "food": [ "DINOFOOD_C" ] },
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "PET_WONT_FOLLOW", "CORNERED_FIGHTER", "EATS" ]
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "PET_WONT_FOLLOW", "CORNERED_FIGHTER", "EATS" ]
   },
   {
     "type": "MONSTER",
@@ -1990,17 +1941,7 @@
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 1 },
     "special_attacks": [ [ "EAT_CROP", 40 ], [ "BROWSE", 60 ], [ "LUNGE", 40 ] ],
     "petfood": { "food": [ "DINOFOOD_C" ] },
-    "flags": [
-      "SEES",
-      "SMELLS",
-      "HEARS",
-      "ANIMAL",
-      "PATH_AVOID_DANGER",
-      "PET_MOUNTABLE",
-      "PET_WONT_FOLLOW",
-      "CAN_BE_CULLED",
-      "EATS"
-    ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "PET_MOUNTABLE", "PET_WONT_FOLLOW", "CAN_BE_CULLED", "EATS" ],
     "harvest": "mammal_large_leather",
     "fear_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_DIED" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "PLAYER_NEAR_BABY" ],
@@ -2043,7 +1984,6 @@
     "petfood": { "food": [ "DINOFOOD_C" ] },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
@@ -2095,7 +2035,6 @@
     "petfood": { "food": [ "DINOFOOD_C" ] },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
@@ -2334,7 +2273,6 @@
     "special_attacks": [ [ "EAT_CROP", 40 ], [ "BROWSE", 60 ] ],
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
@@ -2381,7 +2319,6 @@
     "petfood": { "food": [ "DINOFOOD_C" ] },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
@@ -2422,7 +2359,7 @@
     "description": "A small rhino-like dinosaur with a bony crest studded with small horns and a hooked beak.",
     "reproduction": { "baby_type": { "baby_egg": "egg_aquilops" }, "baby_count": 20, "baby_timer": 40 },
     "special_attacks": [ [ "EAT_CROP", 40 ], [ "BROWSE", 60 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "CAN_BE_CULLED", "SMALL_HIDER", "EATS" ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "CAN_BE_CULLED", "SMALL_HIDER", "EATS" ],
     "harvest": "mammal_tiny",
     "dissect": "dissect_horns_sample_single"
   },
@@ -2443,7 +2380,7 @@
     "description": "A rhino-like dinosaur with a bony crest and sharp beak able to walk on two legs and four.",
     "reproduction": { "baby_type": { "baby_egg": "egg_leptoceratops" }, "baby_count": 20, "baby_timer": 40 },
     "special_attacks": [ [ "LUNGE", 10 ], [ "EAT_CROP", 40 ], [ "BROWSE", 60 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CORNERED_FIGHTER", "EATS" ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CORNERED_FIGHTER", "EATS" ],
     "harvest": "dino_large_leather",
     "dissect": "dissect_horns_sample_small",
     "armor": { "bash": 6, "cut": 6, "bullet": 2 }
@@ -2491,7 +2428,7 @@
       [ "BROWSE", 60 ],
       [ "stretch_horn_DinoMod", 40 ]
     ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "CORNERED_FIGHTER", "EATS" ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "CORNERED_FIGHTER", "EATS" ],
     "harvest": "lokiceratops",
     "dissect": "dissect_horns_sample_huge"
   },
@@ -2508,7 +2445,7 @@
     "description": "A large stocky four-legged dinosaur with a bony crest with several long spikes and one large horn above the beak and a short tail.",
     "reproduction": { "baby_type": { "baby_egg": "egg_styracosaurus" }, "baby_count": 20, "baby_timer": 40 },
     "special_attacks": [ [ "SMASH", 60 ], [ "LUNGE", 10 ], [ "EAT_CROP", 40 ], [ "BROWSE", 60 ], [ "stretch_horn_DinoMod", 40 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "CORNERED_FIGHTER", "EATS" ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "BASHES", "CORNERED_FIGHTER", "EATS" ],
     "harvest": "styracosaurus",
     "dissect": "dissect_horns_sample_huge"
   },
@@ -2692,7 +2629,7 @@
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 99 },
     "petfood": { "food": [ "DINOFOOD_C" ] },
-    "flags": [ "SEES", "SMELLS", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "CAN_BE_CULLED", "SMALL_HIDER", "EATS" ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "CAN_BE_CULLED", "SMALL_HIDER", "EATS" ],
     "harvest": "bird_small",
     "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "PLAYER_NEAR_BABY" ],
     "fear_triggers": [ "PLAYER_CLOSE", "FRIEND_DIED" ],
@@ -2730,18 +2667,7 @@
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 33 },
     "petfood": { "food": [ "DINOFOOD_C" ] },
-    "flags": [
-      "SEES",
-      "SMELLS",
-      "HEARS",
-      "ANIMAL",
-      "PATH_AVOID_DANGER",
-      "CANPLAY",
-      "CAN_DIG",
-      "CAN_BE_CULLED",
-      "CORNERED_FIGHTER",
-      "EATS"
-    ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "CAN_DIG", "CAN_BE_CULLED", "CORNERED_FIGHTER", "EATS" ],
     "harvest": "dino_feather_leather",
     "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "PLAYER_NEAR_BABY" ],
     "fear_triggers": [ "PLAYER_CLOSE", "FRIEND_DIED" ],
@@ -2780,18 +2706,7 @@
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 4 },
     "petfood": { "food": [ "DINOFOOD_C" ] },
     "special_attacks": [ [ "EAT_CROP", 40 ], [ "BROWSE", 60 ], [ "scratch", 20 ] ],
-    "flags": [
-      "SEES",
-      "SMELLS",
-      "HEARS",
-      "ANIMAL",
-      "PATH_AVOID_DANGER",
-      "PET_MOUNTABLE",
-      "HIT_AND_RUN",
-      "SWIMS",
-      "CAN_BE_CULLED",
-      "EATS"
-    ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "PET_MOUNTABLE", "HIT_AND_RUN", "SWIMS", "CAN_BE_CULLED", "EATS" ],
     "harvest": "dino_feather_leather",
     "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "PLAYER_NEAR_BABY" ],
     "fear_triggers": [ "PLAYER_CLOSE", "FRIEND_DIED" ],
@@ -2828,7 +2743,6 @@
     "petfood": { "food": [ "DINOFOOD_B" ] },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "FLIES",
       "HIT_AND_RUN",
@@ -2886,7 +2800,6 @@
     "special_attacks": [ [ "scratch", 10 ], [ "EAT_CARRION", 60 ] ],
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "FLIES",
       "HIT_AND_RUN",

--- a/data/mods/DinoMod/monsters/fungus.json
+++ b/data/mods/DinoMod/monsters/fungus.json
@@ -16,7 +16,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zeratosaurus_fungus",
@@ -35,7 +35,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "SWIMS" ]
+    "flags": [ "SEES", "HEARS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "SWIMS" ]
   },
   {
     "id": "mon_zpinosaurus_fungus",
@@ -54,7 +54,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM", "SWIMS" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM", "SWIMS" ]
   },
   {
     "id": "mon_zorvosaurus_fungus",
@@ -73,7 +73,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zallosaurus_fungus",
@@ -92,7 +92,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zacrocanthosaurus_fungus",
@@ -112,7 +112,7 @@
     "grab_strength": 100,
     "special_attacks": [ { "id": "bite_grab" }, [ "FUNGUS", 200 ], [ "LUNGE", 20 ] ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "GRABS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_ziganotosaurus_fungus",
@@ -132,7 +132,7 @@
     "grab_strength": 100,
     "special_attacks": [ { "id": "bite_grab" }, [ "FUNGUS", 200 ], [ "LUNGE", 20 ] ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "GRABS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_ziats_fungus",
@@ -157,7 +157,7 @@
       { "id": "drag_followup" }
     ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zryptosaurus_fungus",
@@ -177,7 +177,7 @@
     "grab_strength": 75,
     "special_attacks": [ { "id": "bite_grab", "cooldown": 20 }, [ "FUNGUS", 200 ], [ "scratch", 20 ], [ "LUNGE", 20 ] ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zappalachiosaurus_fungus",
@@ -197,7 +197,7 @@
     "grab_strength": 75,
     "special_attacks": [ { "id": "bite_grab", "cooldown": 20 }, [ "FUNGUS", 200 ], [ "scratch", 20 ], [ "LUNGE", 20 ] ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zorgosaurus_fungus",
@@ -217,7 +217,7 @@
     "grab_strength": 100,
     "special_attacks": [ { "id": "bite_grab", "cooldown": 20 }, [ "FUNGUS", 200 ], [ "scratch", 20 ], [ "LUNGE", 20 ] ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zalbertosaurus_fungus",
@@ -237,7 +237,7 @@
     "grab_strength": 75,
     "special_attacks": [ { "id": "bite_grab", "cooldown": 5 }, [ "FUNGUS", 200 ], [ "scratch", 20 ], [ "LUNGE", 5 ] ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zianzhousaurus_fungus",
@@ -256,7 +256,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 }, [ "scratch", 20 ], [ "LUNGE", 5 ] ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zanuqsaurus_fungus",
@@ -275,7 +275,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 }, [ "scratch", 20 ], [ "LUNGE", 10 ] ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zaspletosaurus_fungus",
@@ -294,7 +294,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 }, [ "scratch", 20 ], [ "LUNGE", 5 ] ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zyrannosaurus_fungus",
@@ -313,7 +313,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zallimimus_fungus",
@@ -332,7 +332,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_ztruthiomimus_fungus",
@@ -351,7 +351,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zornithomimus_fungus",
@@ -370,7 +370,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zalcarius_fungus",
@@ -389,7 +389,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "id": "longswipe", "cooldown": 20 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
+    "flags": [ "SEES", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
     "id": "mon_zerizinosaurus_fungus",
@@ -408,7 +408,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "id": "longswipe", "cooldown": 20 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES", "DESTROYS" ]
+    "flags": [ "SEES", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES", "DESTROYS" ]
   },
   {
     "id": "mon_zothronychus_fungus",
@@ -427,7 +427,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "id": "longswipe", "cooldown": 30 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
+    "flags": [ "SEES", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
     "id": "mon_zanzu_fungus",
@@ -446,7 +446,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "id": "longswipe", "cooldown": 30 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
+    "flags": [ "SEES", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
     "id": "mon_zeinonychus_fungus",
@@ -470,7 +470,7 @@
       { "type": "bite", "cooldown": 5 }
     ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zutahraptor_fungus",
@@ -494,7 +494,7 @@
       { "type": "bite", "cooldown": 5 }
     ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
     "id": "mon_zarahsaurus_fungus",
@@ -513,7 +513,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
     "id": "mon_zanchisaurus_fungus",
@@ -532,7 +532,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
     "id": "mon_zissi_fungus",
@@ -551,7 +551,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
     "id": "mon_zaplocanthosaurus_fungus",
@@ -570,7 +570,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
     "id": "mon_zamargasaurus_fungus",
@@ -593,7 +593,7 @@
       [ "SMASH", 30 ]
     ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
     "id": "mon_zapatosaurus_fungus",
@@ -616,7 +616,7 @@
       [ "SMASH", 30 ]
     ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
     "id": "mon_zrontosaurus_fungus",
@@ -698,7 +698,7 @@
       [ "SMASH", 30 ]
     ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
     "id": "mon_zesperosaurus_fungus",
@@ -721,7 +721,7 @@
       [ "SMASH", 30 ]
     ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
     "id": "mon_zastonia_fungus",
@@ -822,7 +822,7 @@
       [ "SMASH", 30 ]
     ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
     "id": "mon_zuoplocephalus_fungus",
@@ -847,7 +847,7 @@
       [ "SMASH", 30 ]
     ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
     "id": "mon_zcolosaurus_fungus",
@@ -872,7 +872,7 @@
       [ "SMASH", 30 ]
     ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
     "id": "mon_zenontosaurus_fungus",
@@ -891,7 +891,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
     "id": "mon_zryosaurus_fungus",
@@ -910,7 +910,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
     "id": "mon_zamptosaurus_fungus",
@@ -929,7 +929,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
     "id": "mon_ziguanodon_fungus",
@@ -1059,7 +1059,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
     "id": "mon_zeptoceratops_fungus",
@@ -1078,7 +1078,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
     "id": "mon_zzuniceratops_fungus",
@@ -1097,7 +1097,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
     "id": "mon_zokiceratops_fungus",
@@ -1116,7 +1116,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
     "id": "mon_ztyracosaurus_fungus",
@@ -1135,7 +1135,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
     "id": "mon_zentrosaurus_fungus",
@@ -1154,7 +1154,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
     "id": "mon_zeiniosaurus_fungus",
@@ -1173,7 +1173,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
     "id": "mon_zachelousaurus_fungus",
@@ -1258,7 +1258,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "id": "impale" } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE", "BASHES" ]
   },
   {
     "id": "mon_zescelosaurus_fungus",
@@ -1277,7 +1277,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ] ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "PET_MOUNTABLE", "BASHES" ]
+    "flags": [ "SEES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "PET_MOUNTABLE", "BASHES" ]
   },
   {
     "id": "mon_zteranodon_fungus",
@@ -1296,7 +1296,7 @@
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES", "FLIES" ]
+    "flags": [ "SEES", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES", "FLIES" ]
   },
   {
     "id": "mon_zuetzalcoatlus_fungus",

--- a/data/mods/DinoMod/monsters/hatchling.json
+++ b/data/mods/DinoMod/monsters/hatchling.json
@@ -171,7 +171,6 @@
     "flags": [
       "SEES",
       "HEARS",
-      "SMELLS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
       "WARM",
@@ -196,7 +195,6 @@
     "flags": [
       "SEES",
       "HEARS",
-      "SMELLS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
       "WARM",
@@ -232,7 +230,6 @@
     "flags": [
       "SEES",
       "HEARS",
-      "SMELLS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
       "WARM",
@@ -747,7 +744,6 @@
     "flags": [
       "SEES",
       "HEARS",
-      "SMELLS",
       "ANIMAL",
       "PATH_AVOID_DANGER",
       "WARM",

--- a/data/mods/DinoMod/monsters/juvenile.json
+++ b/data/mods/DinoMod/monsters/juvenile.json
@@ -290,7 +290,7 @@
     "upgrades": { "age_grow": 70, "into": "mon_gallimimus" },
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 3 },
     "petfood": { "food": [ "DINOFOOD_A", "DINOFOOD_B", "DINOFOOD_C" ] },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY", "CAN_BE_CULLED" ],
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY", "CAN_BE_CULLED" ],
     "harvest": "bird_small"
   },
   {
@@ -444,7 +444,7 @@
     "fear_triggers": [ "FRIEND_DIED" ],
     "upgrades": { "age_grow": 365, "into": "mon_amargasaurus" },
     "petfood": { "food": [ "DINOFOOD_C" ] },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY", "GROUP_MORALE" ]
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY", "GROUP_MORALE" ]
   },
   {
     "id": "mon_apatosaurus_juvenile",
@@ -519,7 +519,7 @@
     "weight": "1000 kg",
     "petfood": { "food": [ "DINOFOOD_C" ] },
     "upgrades": { "age_grow": 365, "into": "mon_stegosaurus" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY", "CAN_BE_CULLED" ]
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_hesperosaurus_juvenile",
@@ -628,7 +628,7 @@
     "color": "yellow",
     "petfood": { "food": [ "DINOFOOD_C" ] },
     "upgrades": { "age_grow": 365, "into": "mon_iguanodon" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY", "CAN_BE_CULLED", "SWIMS" ]
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY", "CAN_BE_CULLED", "SWIMS" ]
   },
   {
     "id": "mon_eolambia_juvenile",
@@ -852,7 +852,6 @@
     "flags": [
       "SEES",
       "HEARS",
-      "SMELLS",
       "FLIES",
       "ANIMAL",
       "PATH_AVOID_DANGER",
@@ -883,7 +882,7 @@
     "hp": 100,
     "upgrades": { "age_grow": 365, "into": "mon_mosasaurus" },
     "petfood": { "food": [ "DINOFOOD_B" ] },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "NO_BREED", "SWIMS", "AQUATIC" ]
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "NO_BREED", "SWIMS", "AQUATIC" ]
   },
   {
     "id": "mon_plesiosaurus_juvenile",
@@ -898,6 +897,6 @@
     "hp": 80,
     "upgrades": { "age_grow": 365, "into": "mon_plesiosaurus" },
     "petfood": { "food": [ "DINOFOOD_B" ] },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "NO_BREED", "SWIMS", "AQUATIC" ]
+    "flags": [ "SEES", "HEARS", "ANIMAL", "PATH_AVOID_DANGER", "CANPLAY", "NO_BREED", "SWIMS", "AQUATIC" ]
   }
 ]

--- a/data/mods/DinoMod/monsters/mutant_dino.json
+++ b/data/mods/DinoMod/monsters/mutant_dino.json
@@ -21,7 +21,6 @@
     "biosignature": { "biosig_item": "feces_dino", "biosig_timer": 1 },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "ANIMAL",
       "PATH_AVOID_DANGER",

--- a/data/mods/DinoMod/monsters/zed-dinosaur.json
+++ b/data/mods/DinoMod/monsters/zed-dinosaur.json
@@ -44,7 +44,7 @@
     "burn_into": "mon_zeratosaurus_scorched",
     "fungalize_into": "mon_zeratosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zeratosaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM", "SWIMS" ],
+    "flags": [ "SEES", "HEARS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM", "SWIMS" ],
     "armor": { "bash": 4, "cut": 5, "bullet": 2 }
   },
   {
@@ -79,7 +79,6 @@
     "upgrades": { "half_life": 30, "into_group": "GROUP_zpinosaurus_UPGRADE" },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "GRABS",
       "POISON",
@@ -129,20 +128,7 @@
     "burn_into": "mon_zorvosaurus_scorched",
     "fungalize_into": "mon_zorvosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zorvosaurus_UPGRADE" },
-    "flags": [
-      "SEES",
-      "SMELLS",
-      "GRABS",
-      "HEARS",
-      "POISON",
-      "STUMBLES",
-      "BASHES",
-      "DESTROYS",
-      "NO_BREATHE",
-      "REVIVES",
-      "FILTHY",
-      "WARM"
-    ],
+    "flags": [ "SEES", "GRABS", "HEARS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
     "vision_night": 3,
     "harvest": "zed_dino_leather",
     "dissect": "dissect_dino_large_pred",
@@ -172,7 +158,7 @@
     "burn_into": "mon_zallosaurus_scorched",
     "fungalize_into": "mon_zallosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zallosaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "GRABS", "STUMBLES", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
+    "flags": [ "SEES", "HEARS", "POISON", "GRABS", "STUMBLES", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
     "armor": { "bash": 4, "cut": 4, "bullet": 2 }
   },
   {
@@ -198,7 +184,7 @@
     "burn_into": "mon_zacrocanthosaurus_scorched",
     "fungalize_into": "mon_zacrocanthosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zacrocanthosaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "GRABS", "HEARS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
+    "flags": [ "SEES", "GRABS", "HEARS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
     "armor": { "bash": 11, "cut": 4, "bullet": 2 }
   },
   {
@@ -222,7 +208,7 @@
     "burn_into": "mon_ziganotosaurus_scorched",
     "fungalize_into": "mon_ziganotosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_ziganotosaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "GRABS", "HEARS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
+    "flags": [ "SEES", "GRABS", "HEARS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
     "armor": { "bash": 4, "cut": 4, "bullet": 2 }
   },
   {
@@ -248,7 +234,7 @@
     "burn_into": "mon_ziats_scorched",
     "fungalize_into": "mon_ziats_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_ziats_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
+    "flags": [ "SEES", "HEARS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
     "armor": { "bash": 4, "cut": 4, "bullet": 2 }
   },
   {
@@ -356,7 +342,7 @@
     "burn_into": "mon_zianzhousaurus_scorched",
     "fungalize_into": "mon_zianzhousaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zianzhousaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "GRABS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
+    "flags": [ "SEES", "HEARS", "GRABS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
     "armor": { "bash": 5, "cut": 5, "bullet": 3 }
   },
   {
@@ -390,7 +376,7 @@
     "burn_into": "mon_zaspletosaurus_scorched",
     "fungalize_into": "mon_zaspletosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zaspletosaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "GRABS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ]
+    "flags": [ "SEES", "HEARS", "GRABS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ]
   },
   {
     "type": "MONSTER",
@@ -425,7 +411,6 @@
     "upgrades": { "half_life": 30, "into_group": "GROUP_zyrannosaurus_UPGRADE" },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "PET_MOUNTABLE",
       "POISON",
@@ -485,7 +470,7 @@
     "burn_into": "mon_zallimimus_scorched",
     "fungalize_into": "mon_zallimimus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zallimimus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "GRABS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
+    "flags": [ "SEES", "HEARS", "GRABS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
     "vision_night": 3,
     "harvest": "zed_dino_feather",
     "categories": [ "DINOSAUR" ],
@@ -732,7 +717,7 @@
       [ "scratch", 10 ],
       { "id": "stomp_DinoMod", "cooldown": 20, "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ] }
     ],
-    "flags": [ "SEES", "SMELLS", "GRABS", "HEARS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
+    "flags": [ "SEES", "GRABS", "HEARS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM" ],
     "armor": { "bash": 8, "cut": 8, "bullet": 6 }
   },
   {
@@ -1112,7 +1097,7 @@
     "burn_into": "mon_zankylosaurus_scorched",
     "fungalize_into": "mon_zankylosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zankylosaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "GRABS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "BASHES" ],
+    "flags": [ "SEES", "HEARS", "GRABS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "BASHES" ],
     "vision_night": 3,
     "harvest": "zed_dino_leather",
     "categories": [ "DINOSAUR" ],
@@ -1178,7 +1163,7 @@
     "burn_into": "mon_zenontosaurus_scorched",
     "fungalize_into": "mon_zenontosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zenontosaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "GRABS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "BASHES" ],
+    "flags": [ "SEES", "HEARS", "GRABS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "BASHES" ],
     "vision_night": 3,
     "harvest": "zed_dino_feather",
     "categories": [ "DINOSAUR" ],
@@ -1214,7 +1199,7 @@
     "burn_into": "mon_zryosaurus_scorched",
     "fungalize_into": "mon_zryosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zryosaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "GRABS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "BASHES" ],
+    "flags": [ "SEES", "HEARS", "GRABS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "BASHES" ],
     "vision_night": 3,
     "harvest": "zed_dino_feather",
     "categories": [ "DINOSAUR" ],
@@ -1250,7 +1235,7 @@
     "burn_into": "mon_zamptosaurus_scorched",
     "fungalize_into": "mon_zamptosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zamptosaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "GRABS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "BASHES" ],
+    "flags": [ "SEES", "HEARS", "GRABS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "BASHES" ],
     "vision_night": 3,
     "harvest": "zed_dino_leather",
     "categories": [ "DINOSAUR" ],
@@ -1509,7 +1494,7 @@
     "burn_into": "mon_zachycephalosaurus_scorched",
     "fungalize_into": "mon_zachycephalosaurus_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zachycephalosaurus_UPGRADE" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY" ],
     "vision_night": 3,
     "harvest": "zed_dino_feather",
     "categories": [ "DINOSAUR" ],
@@ -1693,7 +1678,7 @@
     "fungalize_into": "mon_zosmoceratops_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_zosmoceratops_UPGRADE" },
     "special_attacks": [ { "id": "impale" }, [ "stretch_horn_DinoMod", 7 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY" ],
     "armor": { "bash": 6, "cut": 7, "bullet": 4 }
   },
   {
@@ -1792,20 +1777,7 @@
     "burn_into": "mon_zteranodon_scorched",
     "fungalize_into": "mon_zteranodon_fungus",
     "upgrades": { "half_life": 30, "into": "mon_zteranodon_brute" },
-    "flags": [
-      "SEES",
-      "SMELLS",
-      "HEARS",
-      "POISON",
-      "STUMBLES",
-      "NO_BREATHE",
-      "REVIVES",
-      "FILTHY",
-      "WARM",
-      "BASHES",
-      "FLIES",
-      "HIT_AND_RUN"
-    ],
+    "flags": [ "SEES", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM", "BASHES", "FLIES", "HIT_AND_RUN" ],
     "vision_night": 3,
     "harvest": "zed_dino_feather",
     "categories": [ "DINOSAUR" ],
@@ -1985,7 +1957,7 @@
     "burn_into": "mon_zapatosaurus_scorched",
     "fungalize_into": "mon_zapatosaurus_fungus",
     "upgrades": { "half_life": 30, "into": "mon_zapatosaurus" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM", "BASHES" ],
+    "flags": [ "SEES", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM", "BASHES" ],
     "vision_night": 3,
     "harvest": "zed_dino_leather",
     "categories": [ "DINOSAUR" ],

--- a/data/mods/DinoMod/monsters/zinosaur_upgrade.json
+++ b/data/mods/DinoMod/monsters/zinosaur_upgrade.json
@@ -2245,7 +2245,6 @@
     "fungalize_into": "mon_zallimimus_fungus",
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "GRABS",
       "PET_MOUNTABLE",
@@ -2474,19 +2473,7 @@
     "special_attacks": [ [ "scratch", 10 ], { "id": "bite_grab" }, { "type": "bite", "cooldown": 5 }, [ "tailsmash_DinoMod", 30 ] ],
     "burn_into": "mon_zankylosaurus_scorched",
     "fungalize_into": "mon_zankylosaurus_fungus",
-    "flags": [
-      "SEES",
-      "SMELLS",
-      "HEARS",
-      "GRABS",
-      "POISON",
-      "STUMBLES",
-      "NO_BREATHE",
-      "REVIVES",
-      "FILTHY",
-      "BASHES",
-      "NIGHT_INVISIBILITY"
-    ],
+    "flags": [ "SEES", "HEARS", "GRABS", "POISON", "STUMBLES", "NO_BREATHE", "REVIVES", "FILTHY", "BASHES", "NIGHT_INVISIBILITY" ],
     "harvest": "zed_dino_leather",
     "categories": [ "DINOSAUR" ],
     "armor": { "bash": 16, "cut": 21, "bullet": 7 }

--- a/data/mods/DinoMod/monsters/zinosaur_upgrade.json
+++ b/data/mods/DinoMod/monsters/zinosaur_upgrade.json
@@ -1870,7 +1870,6 @@
     "fungalize_into": "mon_zpinosaurus_fungus",
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "POISON",
       "STUMBLES",
@@ -1921,7 +1920,6 @@
     "fungalize_into": "mon_zorvosaurus_fungus",
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "POISON",
       "STUMBLES",
@@ -1957,19 +1955,7 @@
     "special_attacks": [ [ "scratch", 10 ], { "id": "bite_grab" }, { "id": "teeth_zino_mid", "cooldown": 5 } ],
     "burn_into": "mon_zallosaurus_scorched",
     "fungalize_into": "mon_zallosaurus_fungus",
-    "flags": [
-      "SEES",
-      "SMELLS",
-      "HEARS",
-      "POISON",
-      "STUMBLES",
-      "BASHES",
-      "NO_BREATHE",
-      "REVIVES",
-      "FILTHY",
-      "WARM",
-      "NIGHT_INVISIBILITY"
-    ],
+    "flags": [ "SEES", "HEARS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "WARM", "NIGHT_INVISIBILITY" ],
     "armor": { "bash": 4, "cut": 4, "bullet": 2 }
   },
   {
@@ -2193,7 +2179,6 @@
     "fungalize_into": "mon_zyrannosaurus_fungus",
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "PET_MOUNTABLE",
       "POISON",
@@ -2517,7 +2502,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2539,7 +2524,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2561,7 +2546,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2583,7 +2568,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2605,7 +2590,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2627,7 +2612,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2649,7 +2634,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2671,7 +2656,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2693,7 +2678,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2715,7 +2700,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2737,7 +2722,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2759,7 +2744,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2781,7 +2766,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2803,7 +2788,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2825,7 +2810,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2847,7 +2832,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2867,7 +2852,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2889,7 +2874,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2911,7 +2896,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2933,7 +2918,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2955,7 +2940,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2977,7 +2962,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -2999,7 +2984,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -3065,7 +3050,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -3087,7 +3072,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH", "SMELLS" ] },
     "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
@@ -5665,7 +5650,6 @@
     "death_function": { "message": "The %s's body leaks acid.", "effect": { "id": "death_acid", "hit_self": true } },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "BASHES",
       "GROUP_BASH",
@@ -5718,7 +5702,6 @@
     "death_function": { "message": "The %s's body leaks acid.", "effect": { "id": "death_acid", "hit_self": true } },
     "flags": [
       "SEES",
-      "SMELLS",
       "HEARS",
       "BASHES",
       "GROUP_BASH",


### PR DESCRIPTION
#### Summary
Mods "[DinoMod] smell audit"

#### Purpose of change

Realism, consistency with vanilla content

#### Describe the solution

Audit monsters to make sure only monsters that make sense have the SMELLS flag, inspired by #62681
Remove KEENNOSE flag entirely from living dinos

#### Describe alternatives you've considered

N/A

#### Testing

No changes except removing flags

#### Additional context

There are conflicting reports on how effective the smelling ability of dinosaurs was. It's fair to say that they did not evolve to smell humans, though some did hunt mammals. My current thinking is that plant eaters should not be sensitive to the scent of the player, most daytime predators also should not, but nightstalker evolutions should and so should night adapted predators like deinonychus