### PR TITLE
[Innawoods] Remove man-made trash from stream palette loot

### DIFF
--- a/data/mods/innawood/mapgen_palettes/stream.json
+++ b/data/mods/innawood/mapgen_palettes/stream.json
@@ -1,0 +1,41 @@
+[
+  {
+    "type": "palette",
+    "id": "stream_palette",
+    "terrain": {
+      " ": "t_null",
+      "~": "t_water_moving_sh",
+      "1": [
+        [ "t_null", 100 ],
+        [ "t_sand", 1 ],
+        [ "t_shrub_spicebush", 10 ],
+        [ "t_clay", 4 ],
+        [ "t_grass_long", 900 ],
+        [ "t_region_shrub_forest", 20 ],
+        [ "t_region_tree_forest", 20 ]
+      ],
+      "2": [ [ "t_null", 150 ], [ "t_grass_long", 10 ], [ "t_region_shrub_forest", 1 ], [ "t_region_tree_forest", 1 ] ]
+    },
+    "furniture": {
+      " ": "f_null",
+      "1": [
+        [ "f_null", 800 ],
+        [ "f_region_weed", 10 ],
+        [ "f_boulder_small", 3 ],
+        [ "f_boulder_medium", 2 ],
+        [ "f_boulder_large", 1 ]
+      ],
+      "2": [
+        [ "f_null", 1400 ],
+        [ "f_region_weed", 10 ],
+        [ "f_boulder_small", 3 ],
+        [ "f_boulder_medium", 2 ],
+        [ "f_boulder_large", 1 ]
+      ]
+    },
+    "items": {
+      "1": { "item": "creek_bed", "chance": 15, "repeat": [ 0, 2 ] },
+      "2": { "item": "creek_bed", "chance": 10, "repeat": [ 0, 3 ] }
+    }
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Innawoods] Removes man-made trash from stream loot spawns."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Streams were spawning a bunch of man-made trash like talking dolls, steel chains, gallon jugs, heroin, ect. As indicated by the Innawoods readme.md, this is not consistent with the Innawoods mod design goals.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Makes a replacement stream mapgen palette where the only changes are to remove the item groups containing man-made trash. It now only has the creek_bed item group, which is exclusively natural items like wood and stones.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Modifying the item groups instead. I didn't do this because that might have had further-reaching implications than this one change would make.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Before (Innawoods world):
![ymLUJHO](https://github.com/user-attachments/assets/422ab1f3-e75a-453e-a104-ad01f07026f2)
Steel chains, gallon jugs, wheels, meth, all sorts of man-made stuff all over the place.

After (Innawoods world):
![SWWEeEJ](https://github.com/user-attachments/assets/b9d6d209-79a6-4544-b9ec-a8b513362840)
Just sticks, logs, rocks, ect.

After (base game, no Innawoods):
![3WheQl0](https://github.com/user-attachments/assets/161a0fb3-0166-412a-8639-b2d360229a1f)
Man-made junk remains in the base game, just not in innawoods.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
