### PR TITLE
Add new wildlife flags to raw fruit and vegetables

### DIFF
--- a/data/json/items/comestibles/raw_fruit.json
+++ b/data/json/items/comestibles/raw_fruit.json
@@ -37,7 +37,7 @@
     "material": [ "fruit" ],
     "volume": "64 ml",
     "fun": -1,
-    "flags": [ "FREEZERBURN", "SMOKABLE" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "CATTLE", "RABBIT" ],
     "smoking_result": "dry_fruit",
     "vitamins": [ [ "vitC", "4 mg" ], [ "iron", "200 μg" ], [ "calcium", "9 mg" ], [ "fruit_allergen", 1 ] ]
   },
@@ -162,7 +162,7 @@
     "material": [ "fruit" ],
     "volume": "250 ml",
     "fun": -10,
-    "flags": [ "SMOKABLE", "EDIBLE_FROZEN" ],
+    "flags": [ "SMOKABLE", "EDIBLE_FROZEN", "BIRD", "RABBIT", "CATTLE", "RAT", "MOUSE" ],
     "smoking_result": "dry_fruit",
     "vitamins": [ [ "vitC", "13300 μg" ], [ "iron", "300 μg" ], [ "calcium", "8 mg" ], [ "fruit_allergen", 1 ] ]
   },
@@ -341,7 +341,7 @@
     "price_postapoc": "50 cent",
     "material": [ "fruit" ],
     "volume": "250 ml",
-    "fun": 2,
+    "fun": -5,
     "flags": [ "RAW", "EDIBLE_FROZEN", "INEDIBLE", "CATTLE", "RABBIT", "BIRD" ],
     "vitamins": [ [ "vitC", "272640 μg" ], [ "iron", "678 μg" ], [ "calcium", "108160 μg" ], [ "fruit_allergen", 1 ] ]
   },
@@ -382,7 +382,7 @@
     "price_postapoc": "20 cent",
     "material": [ "fruit" ],
     "volume": "100 ml",
-    "flags": [ "SMOKABLE" ],
+    "flags": [ "SMOKABLE", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_fruit",
     "//": "juice pulp is an arbitrary item, but needed some baseline nutrients for byproducts",
     "vitamins": [ [ "vitC", 8 ], [ "fruit_allergen", 1 ] ]

--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -15,6 +15,7 @@
     "volume": "20 ml",
     "price": "0 cent",
     "price_postapoc": "0 cent",
+    "flags": [ "RABBIT", "CATTLE" ],
     "vitamins": [ [ "veggy_allergen", 1 ], [ "vitC", "136 μg" ] ]
   },
   {
@@ -34,7 +35,7 @@
     "healthy": -1,
     "symbol": ",",
     "looks_like": "potato",
-    "flags": [ "RAW" ],
+    "flags": [ "RAW", "RAT", "MOUSE" ],
     "vitamins": [ [ "calcium", 14 ], [ "iron", 1 ], [ "veggy_allergen", 1 ] ],
     "fun": -3
   },
@@ -54,7 +55,7 @@
     "description": "This aromatic rhizome can be eaten as is in an emergency, but it is much better used for making beverages.  Its taste is pleasant but it is also tough and stringy.",
     "comestible_type": "FOOD",
     "symbol": ",",
-    "flags": [ "RAW" ],
+    "flags": [ "RAW", "RAT" ],
     "vitamins": [ [ "calcium", 10 ], [ "iron", 8 ], [ "veggy_allergen", 1 ] ],
     "fun": -3
   },
@@ -74,7 +75,7 @@
     "comestible_type": "FOOD",
     "healthy": -1,
     "symbol": ",",
-    "flags": [ "RAW" ],
+    "flags": [ "RAW", "RAT" ],
     "material": [ "veggy" ],
     "vitamins": [ [ "calcium", 1 ], [ "iron", 8 ], [ "vitC", 2 ], [ "veggy_allergen", 1 ] ],
     "fun": -2
@@ -93,6 +94,7 @@
     "spoils_in": "3 days",
     "description": "Also called ramps, this delicate leafy vegetable is healthy and a tasty ingredient for many dishes.",
     "symbol": ",",
+    "//": "no flags like CATTLE because most wildlife actually hate the onion smell",
     "flags": [ "RAW" ],
     "material": [ "veggy" ],
     "vitamins": [ [ "vitC", 10 ], [ "iron", 2 ], [ "veggy_allergen", 1 ] ],
@@ -113,7 +115,7 @@
     "price_postapoc": "50 cent",
     "material": [ "veggy" ],
     "volume": "180 ml",
-    "flags": [ "EATEN_HOT", "SMOKABLE", "RAW" ],
+    "flags": [ "EATEN_HOT", "SMOKABLE", "RAW", "CATTLE", "RABBIT", "MOUSE", "RAT" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "134700 μg" ], [ "iron", "1100 μg" ], [ "calcium", "71 mg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -134,7 +136,8 @@
     "material": [ "veggy" ],
     "volume": "1632 ml",
     "fun": -2,
-    "flags": [ "SMOKABLE", "RAW", "CATTLE" ],
+    "//": "Actually, not recommended for rats and mice to eat in big quantities because gas but no way to implement that yet, very minor detail though",
+    "flags": [ "SMOKABLE", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "332800 μg" ], [ "iron", "12900 μg" ], [ "calcium", "364 mg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -155,7 +158,7 @@
     "material": [ "veggy" ],
     "volume": "250 ml",
     "fun": -2,
-    "flags": [ "SMOKABLE", "RAW" ],
+    "flags": [ "SMOKABLE", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "25600 μg" ], [ "iron", "300 μg" ], [ "calcium", "28 mg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -174,7 +177,7 @@
     "price": "80 cent",
     "material": [ "veggy" ],
     "volume": "250 ml",
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", 2 ], [ "calcium", 4 ], [ "iron", 2 ], [ "veggy_allergen", 1 ] ]
   },
@@ -195,7 +198,7 @@
     "material": [ "veggy" ],
     "volume": "250 ml",
     "fun": -2,
-    "flags": [ "SMOKABLE", "RAW" ],
+    "flags": [ "SMOKABLE", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "8400 μg" ], [ "iron", "800 μg" ], [ "calcium", "29700 μg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -216,7 +219,8 @@
     "volume": "146 ml",
     "longest_side": "19 cm",
     "fun": 1,
-    "flags": [ "SMOKABLE", "RAW" ],
+    "//": "Carrots are somewhat high in sugar and should only be eaten sparingly by rabbits but there is no way to implement that yet",
+    "flags": [ "SMOKABLE", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "4200 μg" ], [ "iron", "200 μg" ], [ "calcium", "23800 μg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -236,7 +240,7 @@
     "material": [ "veggy" ],
     "volume": "250 ml",
     "fun": -12,
-    "flags": [ "RAW" ],
+    "flags": [ "RAW", "RABBIT" ],
     "vitamins": [ [ "iron", 8 ], [ "veggy_allergen", 1 ] ]
   },
   {
@@ -254,7 +258,7 @@
     "price_postapoc": "10 cent",
     "material": [ "veggy" ],
     "volume": "500 ml",
-    "flags": [ "SMOKABLE", "FREEZERBURN" ],
+    "flags": [ "SMOKABLE", "FREEZERBURN", "RABBIT" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", 94 ], [ "calcium", 9 ], [ "iron", 12 ], [ "veggy_allergen", 1 ] ]
   },
@@ -274,7 +278,7 @@
     "material": [ "veggy" ],
     "volume": "250 ml",
     "fun": -8,
-    "flags": [ "SMOKABLE", "RAW" ],
+    "flags": [ "SMOKABLE", "RAW", "RABBIT", "CATTLE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "calcium", 5 ], [ "iron", 5 ], [ "veggy_allergen", 1 ] ]
   },
@@ -302,7 +306,8 @@
     "material": [ "veggy" ],
     "volume": "146 ml",
     "longest_side": "19 cm",
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW" ],
+    "//": "It appears that celery is energy-negative for rodents",
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "CATTLE", "RABBIT" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "8400 μg" ], [ "iron", "800 μg" ], [ "calcium", "29700 μg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -341,7 +346,8 @@
     "material": [ "veggy" ],
     "volume": "70 ml",
     "smoking_result": "dry_chili",
-    "flags": [ "FREEZERBURN", "RAW", "SMOKABLE" ],
+    "//": "Birds can eat spicy stuff easily due to their inability to taste spiciness",
+    "flags": [ "FREEZERBURN", "RAW", "SMOKABLE", "BIRD" ],
     "vitamins": [ [ "vitC", "64700 μg" ], [ "iron", "500 μg" ], [ "calcium", "6300 μg" ], [ "veggy_allergen", 1 ] ],
     "fun": -2
   },
@@ -373,7 +379,8 @@
     "material": [ "veggy" ],
     "volume": "275 ml",
     "longest_side": "22 cm",
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW" ],
+    "//": "No data on cows finding cucumbers super tasty",
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "8400 μg" ], [ "iron", "800 μg" ], [ "calcium", "48200 μg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -407,7 +414,7 @@
     "material": [ "veggy" ],
     "volume": "60 ml",
     "longest_side": "10 cm",
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "700 μg" ], [ "iron", "300 μg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -438,7 +445,7 @@
     "material": [ "veggy" ],
     "volume": "250 ml",
     "fun": -4,
-    "flags": [ "RAW" ],
+    "flags": [ "RAW", "RAT", "MOUSE" ],
     "//": "Dahlia roots contain an incredible amount of vitamin B6. This isn't a vitamin tracked in Cataclysm, but be careful of vitamin overdose when eating dahlia in real life.",
     "vitamins": [ [ "veggy_allergen", 1 ] ]
   },
@@ -460,7 +467,7 @@
     "volume": "250 ml",
     "fun": -2,
     "smoking_result": "dry_veggy",
-    "flags": [ "RAW", "SMOKABLE" ],
+    "flags": [ "RAW", "SMOKABLE", "RAT", "MOUSE" ],
     "vitamins": [ [ "vitC", "10600 μg" ], [ "iron", "900 μg" ], [ "calcium", "79800 μg" ], [ "veggy_allergen", 1 ] ]
   },
   {
@@ -490,7 +497,7 @@
     "copy-from": "carrot",
     "color": "white",
     "description": "These are often wild carrots, but beware of poisonous lookalikes.  In any case, the root is tough and is not as tasty as a real raw carrot.",
-    "flags": [ "FORAGE_POISON", "RAW", "SMOKABLE" ],
+    "extend": { "flags": [ "FORAGE_POISON" ] },
     "price": "30 cent",
     "price_postapoc": "16 cent",
     "fun": -2,
@@ -612,7 +619,7 @@
     "price_postapoc": "132 cent",
     "material": [ "veggy" ],
     "volume": "1850 ml",
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "CATTLE" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "14 mg" ], [ "iron", "2100 μg" ], [ "calcium", "91 mg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -632,7 +639,7 @@
     "price_postapoc": "20 cent",
     "material": [ "veggy" ],
     "volume": "250 ml",
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "2 mg" ], [ "iron", "300 μg" ], [ "calcium", "13 mg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -650,6 +657,7 @@
     "symbol": ",",
     "material": [ "veggy" ],
     "volume": "250 ml",
+    "flags": [ "CATTLE", "RABBIT" ],
     "price": "0 cent",
     "price_postapoc": "10 cent",
     "vitamins": [ [ "veggy_allergen", 1 ] ]
@@ -715,7 +723,7 @@
     "material": [ "veggy" ],
     "volume": "232 ml",
     "fun": -3,
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "42 mg" ], [ "iron", "1700 μg" ], [ "calcium", "25600 μg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -735,7 +743,7 @@
     "material": [ "veggy" ],
     "volume": "190 ml",
     "fun": -1,
-    "flags": [ "SMOKABLE", "RAW" ],
+    "flags": [ "SMOKABLE", "RAW", "CATTLE", "RAT" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "32900 μg" ], [ "iron", "1100 μg" ], [ "calcium", "5400 μg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -755,7 +763,7 @@
     "material": [ "veggy" ],
     "volume": "2062 ml",
     "fun": -1,
-    "flags": [ "RAW", "INEDIBLE" ],
+    "flags": [ "RAW", "INEDIBLE", "RAT", "MOUSE", "CATTLE" ],
     "vitamins": [ [ "vitC", "102 mg" ], [ "iron", "9200 μg" ], [ "calcium", "237600 μg" ], [ "veggy_allergen", 1 ] ],
     "melee_damage": { "bash": 2 }
   },
@@ -771,8 +779,9 @@
     "quench": 5,
     "volume": "500 ml",
     "weight": "283 g",
+    "//": "Cutting it up makes it viable for rabbits, too.",
     "price_postapoc": "60 cent",
-    "flags": [ "SMOKABLE", "RAW" ],
+    "flags": [ "SMOKABLE", "RAW", "RAT", "MOUSE", "CATTLE", "RABBIT" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "25500 μg" ], [ "iron", "2300 μg" ], [ "calcium", "59400 μg" ] ],
     "melee_damage": { "bash": 0 }
@@ -792,7 +801,8 @@
     "material": [ "veggy" ],
     "volume": "140 ml",
     "fun": -2,
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW" ],
+    "//": "Lots of negative results for cattle, apparently very much not good for them",
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "RABBIT" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", 30 ], [ "calcium", 2 ], [ "iron", 3 ], [ "veggy_allergen", 1 ] ]
   },
@@ -812,7 +822,7 @@
     "material": [ "veggy" ],
     "volume": "107 ml",
     "fun": -12,
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "RABBIT", "CATTLE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", 23 ], [ "calcium", 11 ], [ "iron", 10 ], [ "veggy_allergen", 1 ] ]
   },
@@ -832,7 +842,8 @@
     "material": [ "veggy" ],
     "volume": "117 ml",
     "fun": -12,
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW" ],
+    "//": "Apparently toxic to rabbits",
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "CATTLE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", 1 ], [ "calcium", 23 ], [ "iron", 10 ], [ "veggy_allergen", 1 ] ]
   },
@@ -894,7 +905,7 @@
     "material": [ "veggy" ],
     "volume": "75 ml",
     "fun": -10,
-    "flags": [ "SMOKABLE" ],
+    "flags": [ "SMOKABLE", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "4 mg" ], [ "iron", "1 mg" ], [ "calcium", "13 mg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -971,7 +982,7 @@
     "price_postapoc": "50 cent",
     "material": [ "tomato" ],
     "volume": "150 ml",
-    "flags": [ "SMOKABLE" ],
+    "flags": [ "SMOKABLE", "RABBIT", "CATTLE", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "16900 μg" ], [ "iron", "300 μg" ], [ "calcium", "12300 μg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -1046,7 +1057,7 @@
     "material": [ "veggy" ],
     "volume": "180 ml",
     "longest_side": "22 cm",
-    "flags": [ "EATEN_HOT", "SMOKABLE" ],
+    "flags": [ "EATEN_HOT", "SMOKABLE", "CATTLE", "MOUSE", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "35100 μg" ], [ "iron", "700 μg" ], [ "calcium", "31400 μg" ], [ "veggy_allergen", 1 ] ]
   },
@@ -1099,7 +1110,7 @@
     "volume": "62 ml",
     "fun": -10,
     "use_action": [ "POISON" ],
-    "//": "Fiddleheads that haven't been boiled can make you sick.",
+    "//": "Fiddleheads that haven't been boiled can make you sick.  As they are poisonous here, they will get no CATTLE or RABBIT flag as the poison should not get nullified.",
     "vitamins": [ [ "vitC", 6 ], [ "calcium", 4 ], [ "veggy_allergen", 1 ] ]
   },
   {
@@ -1107,7 +1118,7 @@
     "id": "young_leaves",
     "name": { "str": "handful of young leaves", "str_pl": "handfuls of young leaves" },
     "weight": "20 g",
-    "flags": [ "FREEZERBURN", "RAW" ],
+    "flags": [ "FREEZERBURN", "RAW", "CATTLE", "RABBIT" ],
     "color": "light_green",
     "spoils_in": "1 day",
     "comestible_type": "FOOD",
@@ -1139,7 +1150,7 @@
     "id": "japanese_knotweed_stem",
     "name": { "str_sp": "Japanese knotweed stems" },
     "weight": "60 g",
-    "flags": [ "FREEZERBURN", "RAW" ],
+    "flags": [ "FREEZERBURN", "RAW", "RABBIT", "CATTLE" ],
     "color": "light_green",
     "spoils_in": "2 days",
     "comestible_type": "FOOD",
@@ -1170,7 +1181,7 @@
     "price_postapoc": "20 cent",
     "material": [ "veggy" ],
     "volume": "221 ml",
-    "flags": [ "SMOKABLE", "RAW" ],
+    "flags": [ "SMOKABLE", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "fun": -5,
     "vitamins": [ [ "vitC", "95700 μg" ], [ "iron", "400 μg" ], [ "calcium", "11900 μg" ], [ "veggy_allergen", 1 ] ]
@@ -1222,7 +1233,7 @@
     "fun": -5,
     "description": "A vegetable from the gourd family, bottle gourds were brought to the Americas by the first Native American settlers crossing the Bering strait.  It can be further prepared to produce a hard, watertight shell, usable as a biodegradable liquid container.  Eating it doesn't look worth it.",
     "volume": "4500 ml",
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "CATTLE", "RABBIT", "RAT" ],
     "smoking_result": "dry_bottle_gourd",
     "vitamins": [ [ "iron", "1 mg" ], [ "calcium", "95890 μg" ] ]
   },
@@ -1243,7 +1254,7 @@
     "description": "A normal and healthy purple eggplant.  Needs to be disassembled before being useful for cooking.",
     "healthy": -1,
     "symbol": "e",
-    "flags": [ "RAW" ],
+    "flags": [ "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "vitamins": [ [ "vitC", "12100 μg" ], [ "iron", "1300 μg" ], [ "calcium", "49300 μg" ], [ "veggy_allergen", 1 ] ],
     "fun": -8
   },
@@ -1315,7 +1326,7 @@
     "price_postapoc": 10,
     "material": [ "veggy" ],
     "volume": "250 ml",
-    "flags": [ "FREEZERBURN", "SMOKABLE" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "CATTLE", "RABBIT" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "calcium", 3 ], [ "iron", 3 ], [ "vitC", 1 ], [ "veggy_allergen", 1 ] ]
   },
@@ -1334,7 +1345,7 @@
     "price_postapoc": 10,
     "material": [ "veggy" ],
     "volume": "250 ml",
-    "flags": [ "FREEZERBURN", "SMOKABLE" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "CATTLE", "RABBIT" ],
     "smoking_result": "kombu",
     "vitamins": [ [ "calcium", 3 ], [ "iron", 3 ], [ "vitC", 1 ], [ "veggy_allergen", 1 ] ]
   },
@@ -1353,7 +1364,7 @@
     "price_postapoc": 10,
     "material": [ "veggy" ],
     "volume": "250 ml",
-    "flags": [ "FREEZERBURN", "SMOKABLE" ],
+    "flags": [ "FREEZERBURN", "SMOKABLE", "CATTLE", "RABBIT" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "calcium", 2 ], [ "iron", 4 ], [ "vitC", 1 ], [ "veggy_allergen", 1 ] ]
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Some herbivore threshold mutants can now eat usually unpalatable raw fruit and vegetables"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#78088 introduced more flags, so we are going to use those flags.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Adds flags to items. I have basically gone through the entire file and searched "can (rabbits|cows|rats|mice) eat \<item>" for each of them. Allium things are notoriously unpalatable to wildlife.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

**NONE YET, do not merge until I updated this or you tested it yourself** - I am currently on a train on my way home and the ICE wifi is bad and spotty and does not allow me to download the new version due to its abysmal speed.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
