### PR TITLE
Martial Mastery: Insight is cleared when using other martial arts

### DIFF
--- a/data/mods/Perk_melee/EOC/Insight_eocs.json
+++ b/data/mods/Perk_melee/EOC/Insight_eocs.json
@@ -4,7 +4,11 @@
     "type": "effect_on_condition",
     "recurrence": "1 seconds",
     "condition": {
-      "and": [ { "u_has_flag": "MELEE_PERK_INSIGHT" }, { "x_in_y_chance": { "x": { "math": [ "u_val('perception')" ] }, "y": 20 } } ]
+      "and": [
+        { "u_has_flag": "MELEE_PERK_INSIGHT" },
+        { "u_using_martial_art": "style_none" },
+        { "x_in_y_chance": { "x": { "math": [ "u_val('perception')" ] }, "y": 20 } }
+      ]
     },
     "effect": [
       {
@@ -19,7 +23,8 @@
         ],
         "else": [ { "u_cast_spell": { "id": "perk_insight_spell" }, "targeted": true } ]
       }
-    ]
+    ],
+    "false_effect": [ { "if": { "not": { "u_using_martial_art": "style_none" } }, "then": [ { "u_lose_effect": "perk_insight" } ] } ]
   },
   {
     "id": "EOC_PERK_SPEND_INSIGHT",


### PR DESCRIPTION
#### Summary
Mods "Martial Mastery: Insight is cleared when using other martial arts"

#### Purpose of change
Fix for #77441

#### Describe the solution
More eoc conditions.