### PR TITLE
Add dormant zombies to cities and hordes

### DIFF
--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -230,17 +230,26 @@
     "name": "GROUP_VANILLA_DORMANT",
     "default": "mon_pseudo_dormant_zombie",
     "//": "only dormant zombies",
-    "monsters": [ { "monster": "mon_pseudo_dormant_zombie", "weight": 50, "cost_multiplier": 0 } ]
+    "//2": "These are generated in MonsterGenerator::generate_fake_pseudo_dormant_monster",
+    "monsters": [
+      { "monster": "mon_pseudo_dormant_zombie", "weight": 264, "cost_multiplier": 0 },
+      { "monster": "pseudo_dormant_mon_zombie_fat", "weight": 266, "cost_multiplier": 0 },
+      { "monster": "pseudo_dormant_mon_zombie_child", "weight": 100, "cost_multiplier": 0 },
+      { "monster": "pseudo_dormant_mon_zombie_tough", "weight": 50, "cost_multiplier": 0 },
+      { "monster": "pseudo_dormant_mon_zombie_rot", "weight": 60, "cost_multiplier": 0 },
+      { "monster": "pseudo_dormant_mon_zombie_crawler", "weight": 30, "cost_multiplier": 0 },
+      { "monster": "pseudo_dormant_mon_zombie_brainless", "weight": 30, "cost_multiplier": 0 }
+    ]
   },
   {
     "type": "monstergroup",
     "name": "GROUP_VANILLA",
     "default": "mon_zombie",
-    "//": "Normalized to 1000",
+    "//": "Normalized to 1300",
     "monsters": [
-      { "group": "GROUP_VANILLA_NO_FERAL", "weight": 777, "cost_multiplier": 0 },
-      { "group": "GROUP_CIVILIANS_STANDARD", "weight": 477, "cost_multiplier": 0 },
-      { "group": "GROUP_FERAL", "weight": 66, "cost_multiplier": 0 },
+      { "group": "GROUP_VANILLA_NO_FERAL", "weight": 701, "cost_multiplier": 0 },
+      { "group": "GROUP_CIVILIANS_STANDARD", "weight": 500, "cost_multiplier": 0 },
+      { "group": "GROUP_FERAL", "weight": 99, "cost_multiplier": 0 },
       { "group": "GROUP_VANILLA_DORMANT", "weight": 100, "cost_multiplier": 0 }
     ]
   },

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -96,6 +96,7 @@
     "name": "GROUP_ZOMBIE",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 500, "cost_multiplier": 0 },
+      { "group": "GROUP_VANILLA_DORMANT", "weight": 250, "cost_multiplier": 0 },
       { "monster": "mon_zombie", "weight": 10, "cost_multiplier": 7, "pack_size": [ 5, 20 ] },
       { "monster": "mon_zombie", "weight": 10, "cost_multiplier": 13, "pack_size": [ 15, 40 ] },
       { "monster": "mon_zombie", "weight": 10, "cost_multiplier": 20, "pack_size": [ 25, 60 ] },
@@ -226,13 +227,21 @@
   },
   {
     "type": "monstergroup",
+    "name": "GROUP_VANILLA_DORMANT",
+    "default": "mon_pseudo_dormant_zombie",
+    "//": "only dormant zombies",
+    "monsters": [ { "monster": "mon_pseudo_dormant_zombie", "weight": 50, "cost_multiplier": 0 } ]
+  },
+  {
+    "type": "monstergroup",
     "name": "GROUP_VANILLA",
     "default": "mon_zombie",
     "//": "Normalized to 1000",
     "monsters": [
-      { "group": "GROUP_VANILLA_NO_FERAL", "weight": 801, "cost_multiplier": 0 },
-      { "group": "GROUP_CIVILIANS_STANDARD", "weight": 500, "cost_multiplier": 0 },
-      { "group": "GROUP_FERAL", "weight": 99, "cost_multiplier": 0 }
+      { "group": "GROUP_VANILLA_NO_FERAL", "weight": 777, "cost_multiplier": 0 },
+      { "group": "GROUP_CIVILIANS_STANDARD", "weight": 477, "cost_multiplier": 0 },
+      { "group": "GROUP_FERAL", "weight": 66, "cost_multiplier": 0 },
+      { "group": "GROUP_VANILLA_DORMANT", "weight": 100, "cost_multiplier": 0 }
     ]
   },
   {
@@ -282,6 +291,7 @@
     "//": "+15% child",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 200, "cost_multiplier": 0 },
+      { "group": "GROUP_VANILLA_DORMANT", "weight": 130, "cost_multiplier": 0 },
       { "monster": "mon_zombie", "weight": 483 },
       { "monster": "mon_zombie_fat", "weight": 130, "cost_multiplier": 2 },
       { "monster": "mon_zombie_tough", "weight": 50, "cost_multiplier": 3 },

--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -111,7 +111,7 @@
     ],
     "fungalize_into": "mon_zombie_crawler_fungal",
     "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_CRAWLER_UPGRADE" },
-    "extend": { "flags": [ "ATTACK_LOWER" ] },
+    "extend": { "flags": [ "ATTACK_LOWER", "GEN_DORMANT" ] },
     "delete": { "flags": [ "PUSH_MON" ] }
   },
   {
@@ -129,7 +129,7 @@
     "fungalize_into": "mon_zombie_fat_fungus",
     "upgrades": { "half_life": 32, "into_group": "GROUP_ZOMBIE_FAT" },
     "armor": { "bash": 5, "cut": 3, "bullet": 2, "electric": 2 },
-    "extend": { "weakpoint_sets": [ "wps_humanoid_head_small" ] }
+    "extend": { "weakpoint_sets": [ "wps_humanoid_head_small" ], "flags": [ "GEN_DORMANT" ] }
   },
   {
     "id": "mon_zombie_fireman",
@@ -187,7 +187,8 @@
     "melee_dice_sides": 2,
     "grab_strength": 15,
     "fungalize_into": "mon_zombie_rot_fungal",
-    "upgrades": { "half_life": 43, "into": "mon_devourer" }
+    "upgrades": { "half_life": 43, "into": "mon_devourer" },
+    "extend": { "flags": [ "GEN_DORMANT" ] }
   },
   {
     "id": "mon_zombie_swat",

--- a/data/json/monsters/zed_children.json
+++ b/data/json/monsters/zed_children.json
@@ -53,7 +53,7 @@
     "copy-from": "mon_zombie_child_base",
     "categories": [ "CLASSIC" ],
     "death_function": { "effect": { "id": "death_guilt", "min_level": 6 } },
-    "extend": { "flags": [ "GUILT_CHILD" ] }
+    "extend": { "flags": [ "GUILT_CHILD", "GEN_DORMANT" ] }
   },
   {
     "id": "mon_zombie_creepy",

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -57,7 +57,7 @@
     "harvest": "zombie_humanoid_headless",
     "decay": "zombie_decay_bone",
     "upgrades": { "half_life": 24, "into_group": "GROUP_ZOMBIE_BRAINLESS_UPGRADE" },
-    "extend": { "flags": [ "NOHEAD" ] },
+    "extend": { "flags": [ "NOHEAD", "GEN_DORMANT" ] },
     "delete": { "flags": [ "SEES" ], "special_attacks": [ "bite_humanoid" ] },
     "//3": "Removed Bite attack to reflect damage to mouth.",
     "//4": "Has NOHEAD flag to reflect the head is already catastrophically damaged.  Only detects through hearing."


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add dormant zombies to more locations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
With the introduction of #70600, dormant zombies have been in the game for some time but were only added to mass graves. This pr aims to fix that by adding a `GROUP_VANILLA_DORMANT` monstergroup which has all zombies from `GROUP_VANILLA_ONLY_HUMANS` as dormant corpses. This is achieved by using the flag implemented in #70632.
While I would like to have this pr merged, I have had some observations during testing which do need to be considered:
 - I have **not** noticed the pseudo_dormant monsters alive before they die and turn into traps, except when teleporting in.
 - I have noticed that triggering one trap seems to remove others around it (see additional context).
 - I have seen corpses get up without the trap being triggered and the trap being left behind as a result.
 - Corpses that have their trap removed in any way will make a new trap after a few turns.
 - The traps can be observed and will tell the player that there is a dormant zombie on the tile.
 - The names for the traps generated by #70632 prepend `pseudo_dormant_` which ends up with slightly silly names such as `pseudo_dormant_mon_zombie_fat`
 - Because the traps have a tendency to sometimes disappear and traps don't instantly respawn, it is possible to loot a dormant corpse before it gets up.

This pr does nothing to resolve or change the above observations, I just want to provide any reviewers with enough information to see if this passes muster.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a new monstergroup `GROUP_VANILLA_DORMANT` which has the monsters from `GROUP_VANILLA_ONLY_HUMANS` in it as dormant corpses using the flag added #70632. Added the new mongroup to other mongroups so the dormant zombies spawn in, the mongroups I've added it to are mostly used in spawning monsters in cities and hordes.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game loads, dormant zombies spawn, traps trigger and spawn zombies from corpses.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
According @Procyonae removing 
https://github.com/CleverRaven/Cataclysm-DDA/blob/5bf092649d6439d01f69ffa2304507ed6e807cb5/src/trapfunc.cpp#L1681-L1691 
Resolves some of the issues with traps erasing other traps, I've compiled this locally and it does seem to help with some of the problems, but traps still disappear with seemingly no reason. As I have little C++ knowledge I'll leave this to others who know more.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
