### PR TITLE
[Defense Mode] Add DinoMod

### DIFF
--- a/data/mods/DinoMod/mod_interactions/Defense_Mode/monstergroups.json
+++ b/data/mods/DinoMod/mod_interactions/Defense_Mode/monstergroups.json
@@ -1,0 +1,25 @@
+[
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DINOMOD_DM",
+    "default": "mon_dilophosaurus_dm",
+    "monsters": [
+      { "monster": "mon_dilophosaurus_dm", "weight": 10 },
+      { "monster": "mon_ceratosaurus_dm", "weight": 10 },
+      { "monster": "mon_spinosaurus_dm", "weight": 10 },
+      { "monster": "mon_torvosaurus_dm", "weight": 10 },
+      { "monster": "mon_allosaurus_dm", "weight": 10 },
+      { "monster": "mon_acrocanthosaurus_dm", "weight": 10 },
+      { "monster": "mon_giganotosaurus_dm", "weight": 10 },
+      { "monster": "mon_siats_dm", "weight": 10 },
+      { "monster": "mon_dryptosaurus_dm", "weight": 10 },
+      { "monster": "mon_appalachiosaurus_dm", "weight": 10 },
+      { "monster": "mon_gorgosaurus_dm", "weight": 10 },
+      { "monster": "mon_albertosaurus_dm", "weight": 10 },
+      { "monster": "mon_qianzhousaurus_dm", "weight": 10 },
+      { "monster": "mon_nanuqsaurus_dm", "weight": 10 },
+      { "monster": "mon_daspletosaurus_dm", "weight": 10 },
+      { "monster": "mon_tyrannosaurus_dm", "weight": 10 }
+    ]
+  }
+]

--- a/data/mods/DinoMod/mod_interactions/Defense_Mode/monsters.json
+++ b/data/mods/DinoMod/mod_interactions/Defense_Mode/monsters.json
@@ -1,0 +1,189 @@
+[
+  {
+    "type": "SPECIES",
+    "id": "DINOMOD_DM",
+    "flags": [ "ALL_SEEING", "NEMESIS" ],
+    "bleeds": "fd_blood"
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "DINOMOD_dm",
+    "base_faction": "animal"
+  },
+  {
+    "id": "mon_dilophosaurus_dm",
+    "copy-from": "mon_dilophosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_ceratosaurus_dm",
+    "copy-from": "mon_ceratosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_spinosaurus_dm",
+    "copy-from": "mon_spinosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_torvosaurus_dm",
+    "copy-from": "mon_torvosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_allosaurus_dm",
+    "copy-from": "mon_allosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_acrocanthosaurus_dm",
+    "copy-from": "mon_acrocanthosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_giganotosaurus_dm",
+    "copy-from": "mon_giganotosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_siats_dm",
+    "copy-from": "mon_siats",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_dryptosaurus_dm",
+    "copy-from": "mon_dryptosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_appalachiosaurus_dm",
+    "copy-from": "mon_appalachiosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_gorgosaurus_dm",
+    "copy-from": "mon_gorgosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_albertosaurus_dm",
+    "copy-from": "mon_albertosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_qianzhousaurus_dm",
+    "copy-from": "mon_qianzhousaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_nanuqsaurus_dm",
+    "copy-from": "mon_nanuqsaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_daspletosaurus_dm",
+    "copy-from": "mon_daspletosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_tyrannosaurus_dm",
+    "copy-from": "mon_tyrannosaurus",
+    "type": "MONSTER",
+    "default_faction": "DINOMOD_dm",
+    "species": [ "DINOMOD_DM" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  }
+]


### PR DESCRIPTION
#### Summary
Mods "[Defense Mode] Add DinoMod"

#### Purpose of change

Already done! Sorry, forgot.
#### Describe the solution

Adds some new EOCs, species types, monster factions, and copy-from entries to produce functional cross-compatibility between the two mods, allowing its big predators to spawn in a wave. Design copied from #67670

#### Describe alternatives you've considered

Add interesting and well known plant eating dinos like triceratops and smaller dinos like tawas.

#### Testing

WIP

#### Additional context

Thanks to @MNG-cataclysm for figuring this out