### PR TITLE
remove avatar_action::move overload; fix Clang-tidy

### DIFF
--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -34,11 +34,6 @@ void eat_or_use( avatar &you, item_location loc );
 // Standard movement; handles attacks, traps, &c. Returns false if auto move
 // should be canceled
 bool move( avatar &you, map &m, const tripoint_rel_ms &d );
-inline bool move( avatar &you, map &m, const point_rel_ms &d )
-{
-    return move( you, m, tripoint_rel_ms( d, 0 ) );
-}
-
 /** Handles swimming by the player. Called by avatar_action::move(). */
 void swim( map &m, avatar &you, const tripoint_bub_ms &p );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1310,7 +1310,7 @@ void game::on_witness_theft( const item &target )
     }
     if( !witnesses.empty() ) {
         if( p.add_faction_warning( target.get_owner() ) ||
-            target.get_owner() == faction_id( "no_faction" ) ) {
+            target.get_owner() == faction_no_faction ) {
             for( npc *elem : witnesses ) {
                 elem->make_angry();
             }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2340,7 +2340,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     }
                     dest_delta = dest_next;
                 }
-                if( !avatar_action::move( player_character, m, dest_delta ) ) {
+                if( !avatar_action::move( player_character, m, tripoint_rel_ms( dest_delta, 0 ) ) ) {
                     // auto-move should be canceled due to a failed move or obstacle
                     player_character.abort_automove();
                 }

--- a/tests/move_cost_test.cpp
+++ b/tests/move_cost_test.cpp
@@ -216,7 +216,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -225,7 +225,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -234,7 +234,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 600 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -600 );
             }
         }
@@ -251,7 +251,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -260,7 +260,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -269,7 +269,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 660 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -660 );
             }
         }
@@ -285,7 +285,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 154 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -154 );
             }
         }
@@ -294,7 +294,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 309 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -309 );
             }
         }
@@ -303,7 +303,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 932 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -932 );
             }
         }
@@ -321,7 +321,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -330,7 +330,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -339,7 +339,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 803 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -803 );
             }
         }
@@ -357,7 +357,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 100 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -100 );
             }
         }
@@ -366,7 +366,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 200 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -200 );
             }
         }
@@ -375,7 +375,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 818 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -818 );
             }
         }
@@ -392,7 +392,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 154 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -154 );
             }
         }
@@ -401,7 +401,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "no crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 309 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -309 );
             }
         }
@@ -410,7 +410,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1246 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -1246 );
             }
         }
@@ -430,7 +430,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1000 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -1000 );
             }
         }
@@ -450,7 +450,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1179 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -1179 );
             }
         }
@@ -469,7 +469,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
             REQUIRE( u.get_moves() == 0 );
             THEN( "apply crawling modifier" ) {
                 CHECK( u.run_cost( 100 ) == 1561 );
-                avatar_action::move( u, get_map(), point_rel_ms::south );
+                avatar_action::move( u, get_map(), tripoint_rel_ms::south );
                 CHECK( u.get_moves() == -1561 );
             }
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Remove unnecessary overload. Split off from #76617.

Fix Clang-tidy. https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12040982706

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

Compiles?

#### Additional context

I will close the other PR.