### PR TITLE
discharged smartphone read fix

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1463,7 +1463,7 @@ class read_inventory_preset: public pickup_inventory_preset
 
             return ( loc->is_book() || loc->type->can_use( "learn_spell" ) ) &&
                    ( p_loc.where() == item_location::type::invalid || !p_loc->is_ebook_storage() ||
-                     p_loc->energy_remaining().value() >= 1000000 );
+                     p_loc->energy_remaining() >= 1_kJ );
         }
 
         std::string get_denial( const item_location &loc ) const override {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1459,7 +1459,11 @@ class read_inventory_preset: public pickup_inventory_preset
         }
 
         bool is_shown( const item_location &loc ) const override {
-            return loc->is_book() || loc->type->can_use( "learn_spell" );
+            const item_location p_loc = loc.parent_item();
+
+            return ( loc->is_book() || loc->type->can_use( "learn_spell" ) ) &&
+                   ( p_loc.where() == item_location::type::invalid || !p_loc->is_ebook_storage() ||
+                     p_loc->energy_remaining().value() >= 1000000 );
         }
 
         std::string get_denial( const item_location &loc ) const override {


### PR DESCRIPTION
#### Summary
Bugfixes "Fixed able to read books stored in smartphone through the read menu without enough charge to read."

#### Purpose of change

Fixes #77919.

#### Describe the solution

In the read menu if the book is stored in a smartphone it is only displayed if it has enough charge to be read.

#### Testing

I spawned a smart phone using the debug menu and checked that the book only shows in the read menu if the smartphone has enough charge for reading it and doesn't show when it is discharged. I also discovered that when reading the book using the read menu it doesn't consume charges from the smartphone which probably should be fixed in a separate pull request. I also tested that regular books still show in the read menu.
