### PR TITLE
Draw item name in separate column of item action menu

### DIFF
--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -339,27 +339,20 @@ void game::item_action_menu( item_location loc )
     auto iter = menu_items.begin();
     std::advance( iter, iactions.size() );
     sort_menu( iter, menu_items.end() );
-    // Determine max lengths, to print the menu nicely.
-    std::pair<int, int> max_len;
-    for( const auto &elem : menu_items ) {
-        max_len.first = std::max( max_len.first, utf8_width( std::get<1>( elem ), true ) );
-        max_len.second = std::max( max_len.second, utf8_width( std::get<2>( elem ), true ) );
-    }
     // Fill the menu.
     for( const auto &elem : menu_items ) {
         std::string ss;
         ss += std::get<1>( elem );
-        ss += std::string( max_len.first - utf8_width( std::get<1>( elem ), true ), ' ' );
-        ss += std::string( 4, ' ' );
 
-        ss += std::get<2>( elem );
-        ss += std::string( max_len.second - utf8_width( std::get<2>( elem ), true ), ' ' );
+        std::string ss_ctxt;
+        ss_ctxt += std::get<2>( elem );
 
         const std::optional<input_event> bind = key_bound_to( ctxt, std::get<0>( elem ) );
         const bool enabled = assigned_action( std::get<0>( elem ) );
         const std::string desc =  std::get<3>( elem ) ;
 
         kmenu.addentry_desc( num, enabled, bind, ss, desc );
+        kmenu.entries[num].ctxt = ss_ctxt;
         num++;
     }
 


### PR DESCRIPTION
#### Summary
Summary: None

#### Purpose of change

Draw item action menu nicely even with non-square font.

#### Describe the solution

Draw item in a separate column of item action menu instead of formatting string with whitespaces in a single column with item action name.

#### Additional context

**Before:**
_non-square font_
![image](https://github.com/user-attachments/assets/e6b443c9-0f66-46e5-8cf5-7a9d1e9b966f)

_square font_
![image](https://github.com/user-attachments/assets/df4512db-04ba-42b1-87ea-0827fe944114)

**After:**

_non-square font_
![image](https://github.com/user-attachments/assets/eefcf160-2ac3-4d72-a64f-0f7ab1deab94)

_square font_
![image](https://github.com/user-attachments/assets/e445ac57-b420-423f-b4f5-e777309ffb56)


