### PR TITLE
Fix limb drying rate test

### DIFF
--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -147,6 +147,7 @@ void Character::update_body_wetness( const w_point &weather )
     for( const bodypart_id &bp : get_all_body_parts() ) {
 
         const units::temperature temp_conv = get_part_temp_conv( bp );
+        const int drench_cap = get_part_drench_capacity( bp );
         // do sweat related tests assuming not underwater
         if( !is_underwater() ) {
             const int wetness = get_part_wetness( bp );
@@ -177,7 +178,6 @@ void Character::update_body_wetness( const w_point &weather )
             const time_duration drying = average_drying * trait_mult * weather_mult *
                                          temp_mult / clothing_mult;
             const float turns_to_dry = to_turns<float>( drying ) / drying_rate;
-            const int drench_cap = get_part_drench_capacity( bp );
             const float dry_per_turn = static_cast<float>( drench_cap ) / turns_to_dry;
             mod_part_wetness( bp, roll_remainder( dry_per_turn ) * -1 );
 
@@ -193,14 +193,14 @@ void Character::update_body_wetness( const w_point &weather )
         // Safety measure to keep wetness within bounds
         if( get_part_wetness( bp ) <= 0 ) {
             // if we are hot still we should always be a bit wet (still sweating), this is a small hack to make sure we don't miss cooling ticks with good breathability clothing
-            if( temp_conv >= BODYTEMP_HOT && get_part_drench_capacity( bp ) > 0 ) {
+            if( temp_conv >= BODYTEMP_HOT && drench_cap > 0 ) {
                 set_part_wetness( bp, 1 );
             } else {
                 set_part_wetness( bp, 0 );
             }
         }
-        if( get_part_wetness( bp ) > get_part_drench_capacity( bp ) ) {
-            set_part_wetness( bp, get_part_drench_capacity( bp ) );
+        if( get_part_wetness( bp ) > drench_cap ) {
+            set_part_wetness( bp, drench_cap );
         }
 
         // Add effects to track wetness


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "fix limb drying rate and related test data"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

A deeper dive for #78014, fixing the `drying_rate` test case. In retrospect, it is astounding the test even works sometimes.

1. This test case, for _drying a character off_, did not take into account the _current weather_. Whether it's warm or freezing and foggy makes a big difference in the test's outcomes. I captured the weather in the last PR, where it was identified to indeed be the issue:
```
D:\a\Cataclysm-DDA\Cataclysm-DDA\tests\limb_test.cpp(187): FAILED:
  REQUIRE( base_dry == Approx( 450 ).margin( 125 ) )
with expansion:
  587 (0x24b) == Approx( 450.0 )
with messages:
  weather.weather_id.c_str() := "clear"
  units::to_fahrenheit( weather.temperature ) := 19.61243f  <--- 19 degrees F; colder = drying takes longer
  weather.weather_precise->humidity := 58.9053541728
```
I also isolated the same issues by running the following tests, in which `drying rate` nearly always failed:
```
acid_field_expiry_on_map
field_expiry
firebugs
fd_acid_falls_down
fire_spreading
drying_rate
```

2. The approximate "correct" values for the test were mathematically wrong, period. I don't know how the given numbers were calculated, not that it mattered because the weather wasn't standardized for the test.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Respectively,
1.  At beginning of test, set weather (temperature + humidity + CLEAR) to normal as defined by the drying algorithm
2. Readjust test values to be more accurate for normal weather

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran the test a few times after fixing and got results almost identical to the test's expected values, then ran the full suite without any errors. If you see errors again, post them here.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
