### PR TITLE
fix: reset keybinding to `Unbound locally!` now works

### DIFF
--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -884,6 +884,11 @@ bool input_context::action_reset( const std::string &action_id )
         if( iter_action == iter_def->second.end() ) {
             continue;
         }
+        if( iter_action->second.input_events.empty() ) {
+            // special case: reset to an empty local keybinding "Unbound locally!"
+            inp_mngr.get_or_create_event_list( action_id, context );
+            continue;
+        }
         for( const input_event &event : iter_action->second.input_events ) {
             inp_mngr.add_input_for_action( action_id, context, event );
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

 - Fix #73644.

#### Describe the solution

Add the empty list of `input_events`. It's not as messy as I assumed it would be!

#### Describe alternatives you've considered

#### Testing

 - Tested by adding new keybinding to HELP_KEYBINDINGS so that I don't have to load a save to test it.
 - Tested reproduction steps in #73644

#### Additional context

