### PR TITLE
Unload duct tape, disassemble cardboard roll

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -5132,10 +5132,11 @@
         "max_contains_volume": "1 L",
         "max_contains_weight": "1 kg",
         "item_restriction": [ "duct_tape", "medical_tape", "toilet_paper" ],
-        "volume_multiplier": 0.75
+        "volume_multiplier": 0.75,
+        "moves": 1000
       }
     ],
-    "flags": [ "NO_UNLOAD", "NO_RELOAD" ]
+    "flags": [ "NO_RELOAD" ]
   },
   {
     "id": "tankard_wooden",

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -7137,6 +7137,15 @@
     "flags": [ "BLIND_EASY" ]
   },
   {
+    "result": "cardboard_roll",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "time": "10 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "cardboard", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
     "result": "box_snack",
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Unload duct tape, disassemble cardboard roll"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Duct tape is currently strictly tied to cardboard rolls, because of NO_UNLOAD and NO_RELOAD container flags. After gathering lot of duct tape on your looting trips, you end up with multiple different cardboard rolls, with different ammounts of duct tape, and you cant properly consolidate them into one container.

Lot of people have been annoyed with this and tried to solve the problem with throwing the cardboard rolls into walls, or setting them on fire, to set duct tape free.
My suggestion is to leave cardboard roll with NO_RELOAD flag and remove NO_UNLOAD, and to add the missing disassemble/uncraft recipe for it. I think it would make sense to have the ability to 'unload' any amount of tape from the roll, but not letting the character to 'reload' the cardboard roll again - since the piece/pieces are already detached.
Seems like a healthy compromise - the roleplay aspect will be preserved, and management of duct tape will be possible again.
<!-- With a few sentences, describe your reasons for making this change.

If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Deleted "NO_UNLOAD", left only "NO_RELOAD" flag for the cardboard_roll item in the containers.json file. Added the number of "moves" to remove item from cardboard roll as 1000 (around 10 s)

Added disassemble/uncraft recipe for cardboard_roll, in the recipe_deconstruction.json file - 10 seconds for disassembling, need to have tool with cutting of 1.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
People are mostly dealing with this by smashing cardboard rolls into walls or setting them on fire.
You can also try to wield the cardboard roll with duct tape, then go to AIM, and then you should be able to access duct tape directly and drop it onto different tile - its a cheesy workaround, and you have to do it every time for each specific cardboard roll.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Edited "containers.json" and "recipe_deconstruction.json", and tested it locally on a separate world with debug mode - everything seems to work fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![tape1](https://github.com/user-attachments/assets/7eb3b94d-ad89-4f49-8ea7-34a3b18cb3b3)
![tape2](https://github.com/user-attachments/assets/6c1740fa-ab7c-4fd8-adb2-e261b444b9a8)
![tape3](https://github.com/user-attachments/assets/538db1d0-f6e7-4150-8328-de740dc196ab)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
