### PR TITLE
Fix EOC loop performance issue

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -25,6 +25,7 @@
     "id": "EOC_vitrified_farm_entry_event",
     "eoc_type": "EVENT",
     "required_event": "avatar_enters_omt",
+    "condition": { "or": [ { "u_at_om_location": "unvitrified_farm_0" }, { "u_at_om_location": "unvitrified_orchard" } ] },
     "effect": [ { "run_eocs": "EOC_vitrified_farm_init" } ]
   },
   {
@@ -32,7 +33,6 @@
     "id": "EOC_vitrified_farm_init",
     "condition": {
       "and": [
-        { "or": [ { "u_at_om_location": "unvitrified_farm_0" }, { "u_at_om_location": "unvitrified_orchard" } ] },
         {
           "and": [
             { "not": { "u_has_effect": "VITRIFYING" } },
@@ -48,7 +48,12 @@
     },
     "false_effect": [
       {
-        "if": { "not": { "u_has_trait": "NOT_GLASS" } },
+        "if": {
+          "and": [
+            { "not": { "u_has_trait": "NOT_GLASS" } },
+            { "or": [ { "u_at_om_location": "unvitrified_farm_0" }, { "u_at_om_location": "unvitrified_orchard" } ] }
+          ]
+        },
         "then": { "run_eocs": [ "EOC_vitrified_farm_init" ], "time_in_future": "1 seconds" }
       }
     ],

--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -33,17 +33,13 @@
     "id": "EOC_vitrified_farm_init",
     "condition": {
       "and": [
-        {
-          "and": [
-            { "not": { "u_has_effect": "VITRIFYING" } },
-            { "not": { "u_has_trait": "NOT_GLASS" } },
-            { "not": { "u_is_on_terrain": "t_quietfarm_border_ground" } },
-            { "not": { "u_is_on_terrain": "t_quietfarm_border_fence" } },
-            { "not": { "u_is_on_terrain": "t_quietfarm_border_fence_closed" } },
-            { "not": { "u_is_on_terrain": "t_quietfarm_border_fence_open" } },
-            { "math": [ "u_vitri_glass_entered < 2" ] }
-          ]
-        }
+        { "not": { "u_has_effect": "VITRIFYING" } },
+        { "not": { "u_has_trait": "NOT_GLASS" } },
+        { "not": { "u_is_on_terrain": "t_quietfarm_border_ground" } },
+        { "not": { "u_is_on_terrain": "t_quietfarm_border_fence" } },
+        { "not": { "u_is_on_terrain": "t_quietfarm_border_fence_closed" } },
+        { "not": { "u_is_on_terrain": "t_quietfarm_border_fence_open" } },
+        { "math": [ "u_vitri_glass_entered < 2" ] }
       ]
     },
     "false_effect": [

--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -33,13 +33,18 @@
     "id": "EOC_vitrified_farm_init",
     "condition": {
       "and": [
-        { "not": { "u_has_effect": "VITRIFYING" } },
-        { "not": { "u_has_trait": "NOT_GLASS" } },
-        { "not": { "u_is_on_terrain": "t_quietfarm_border_ground" } },
-        { "not": { "u_is_on_terrain": "t_quietfarm_border_fence" } },
-        { "not": { "u_is_on_terrain": "t_quietfarm_border_fence_closed" } },
-        { "not": { "u_is_on_terrain": "t_quietfarm_border_fence_open" } },
-        { "math": [ "u_vitri_glass_entered < 2" ] }
+        { "or": [ { "u_at_om_location": "unvitrified_farm_0" }, { "u_at_om_location": "unvitrified_orchard" } ] },
+        {
+          "and": [
+            { "not": { "u_has_effect": "VITRIFYING" } },
+            { "not": { "u_has_trait": "NOT_GLASS" } },
+            { "not": { "u_is_on_terrain": "t_quietfarm_border_ground" } },
+            { "not": { "u_is_on_terrain": "t_quietfarm_border_fence" } },
+            { "not": { "u_is_on_terrain": "t_quietfarm_border_fence_closed" } },
+            { "not": { "u_is_on_terrain": "t_quietfarm_border_fence_open" } },
+            { "math": [ "u_vitri_glass_entered < 2" ] }
+          ]
+        }
       ]
     },
     "false_effect": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix an EOC that was looping infinitely and starting more loops as you travel"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Partially addresses #78208
The save in the issue has 1479 versions of EOC_vitrified_farm_init that run every second but Guardian is also getting a hot path that is almost entirely eat_carrion() which I can't repro locally
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Only check for stepping onto appropriate OMTs. Once we're in only loop if we're still on said OMTs (waiting on fence/in open gate/on terrain below destroyed gate)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested that opening that save for and passing 1s and then saving removes all instances of the EOC from the save
Tested that entering a naturally spawned quiet farm works as intended inc leaving after entering border (EOC loop deactivates) and then reentering, entering the border and waiting (loop continues until you commit to entering or leaving) and entering proper
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
