### PR TITLE
Make the set of files that causes clang-tidy to rerun everything much more specific

### DIFF
--- a/build-scripts/clang-tidy.sh
+++ b/build-scripts/clang-tidy.sh
@@ -75,7 +75,7 @@ set +x
 
 # Check for changes to any files that would require us to run clang-tidy across everything
 changed_global_files="$( ( cat ./files_changed || echo 'unknown' ) | \
-    egrep -i "clang-tidy|build-scripts|cmake|unknown" || true )"
+    egrep -i "clang-tidy.sh|clang-tidy-wrapper.sh|clang-tidy.yml|.clang-tidy|files_changed|get_affected_files.py|CMakeLists.txt|CMakePresets.json|unknown" || true )"
 if [ -n "$changed_global_files" ]
 then
     first_changed_file="$(echo "$changed_global_files" | head -n 1)"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Clang-tidy is both something we very much want to keep working right and something it can be very expensive to run.
The previous filter that caused a full clang-tidy run on a PR was very overbroad.

#### Describe the solution
Limited the files that trigger a full run across everything to be much more specific.

#### Describe alternatives you've considered
It's possible this isn't even something we want to happen automatically, instead running clang-tidy manually when we monkey with these core files.

#### Testing
It's all about how it runs in CI.
(this PR will of course trigger a full rerun)