### PR TITLE
Don't Panic and clang-tidy everything if there are no eligible files

### DIFF
--- a/build-scripts/clang-tidy.sh
+++ b/build-scripts/clang-tidy.sh
@@ -97,9 +97,16 @@ else
         includes
 
     tidyable_cpp_files="$( \
-        ( test -f ./files_changed && ( build-scripts/get_affected_files.py ./files_changed | grep -v third-party ) ) || \
+        ( test -f ./files_changed && ( build-scripts/get_affected_files.py ./files_changed ) ) || \
         echo unknown )"
 
+    tidyable_cpp_files="$(echo -n "$tidyable_cpp_files" | grep -v )"
+    if [ -n "$tidyable_cpp_files" ]
+    then
+	echo "No files to tidy, exiting";
+	set -x
+	exit 0
+    fi
     if [ "$tidyable_cpp_files" == "unknown" ]
     then
         echo "Unable to determine affected files, tidying all files"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I was investigating some clang-tidy CI runs that were running over the whole repo and don't look like they should, and I found this logic/"y u do that coretutils" error.
Basically if there are no eligible files to tidy clang-tidy.sh thinks there's an error and then tidies everything instead of nothing.
The specific thing that happens is if you pass an empty string to grep (which means there are no lines to match against), grep thinks it's grep's fault and returns an error status.

#### Describe the solution
We're just calling grep to filter out paths in src/third-party, so it doesn't ned to be involved in that sanity check in the first place.
So capture the previous output to a variable and do the check, then filter out paths with "third-party" afterward.
After that filtering, if we end up with an empty string, exit (successfully) instead of running clang-tidy on everything.

#### Testing
I checked all the scripting logic locally, but I don't have a CI runner set up to test it fully.
Also as this is editing clang-tidy.sh that WILL trigger a tidy of everything, so check back some time tomorrow :/