### PR TITLE
missing Liam/Luo dialog

### DIFF
--- a/data/json/npcs/your_followers/liam_main_dialogue.json
+++ b/data/json/npcs/your_followers/liam_main_dialogue.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": [ "TALK_FRIEND_Liam", "TALK_FRIEND_Liam_Abilities", "TALK_Liam_Callsigns", "TALK_RADIO" ],
+    "id": [ "TALK_FRIEND_Liam", "TALK_FRIEND_Liam_Abilities", "TALK_Liam_Callsigns" ],
     "type": "talk_topic",
     "dynamic_line": {
       "is_by_radio": " *pshhhttt* This is big turtle, I read you loud and clear, red burrito.",

--- a/data/json/npcs/your_followers/liam_main_dialogue.json
+++ b/data/json/npcs/your_followers/liam_main_dialogue.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": [ "TALK_FRIEND_Liam", "TALK_FRIEND_Liam_Abilities", "TALK_Liam_Callsigns" ],
+    "id": [ "TALK_FRIEND_Liam", "TALK_FRIEND_Liam_Abilities", "TALK_Liam_Callsigns", "TALK_RADIO" ],
     "type": "talk_topic",
     "dynamic_line": {
       "is_by_radio": " *pshhhttt* This is big turtle, I read you loud and clear, red burrito.",
@@ -13,6 +13,7 @@
         "topic": "TALK_FRIEND_Liam_Abilities",
         "effect": "reveal_stats"
       },
+      { "text": "Please go to this location.", "topic": "TALK_GOTO_LOCATION", "effect": "goto_location" },
       { "text": "There's something I want you to do.", "topic": "TALK_Liam_ORDERS" },
       { "text": "I'd like your opinion on a job we're doing.", "topic": "TALK_Liam_Opinions" },
       {
@@ -22,6 +23,11 @@
       },
       { "text": "Can you help me understand something?  (HELP/TUTORIAL)", "topic": "TALK_ALLY_TUTORIAL" },
       { "text": "Big turtle?  Red burrito?  Seriously?", "condition": "is_by_radio", "topic": "TALK_Liam_Callsigns" },
+      {
+        "text": "[DEBUG MIND CONTROL] Now listen closely… (DEBUG FUNCTIONS)",
+        "condition": { "u_has_trait": "DEBUG_MIND_CONTROL" },
+        "topic": "TALK_ALLY_DEBUG"
+      },
       { "text": "I'm going to go my own way for a while.", "topic": "TALK_LEAVE" },
       { "text": "<lets_go>", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/your_followers/luo_follower.json
+++ b/data/json/npcs/your_followers/luo_follower.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": [ "TALK_FRIEND_Luo", "TALK_FRIEND_Luo_Abilities" ],
+    "id": [ "TALK_FRIEND_Luo", "TALK_FRIEND_Luo_Abilities", "TALK_RADIO" ],
     "type": "talk_topic",
     "dynamic_line": {
       "is_by_radio": " *pshhhttt* Hey stinkyface.  It's your favorite mushroom girl.  Over.",
@@ -13,6 +13,7 @@
         "topic": "TALK_FRIEND_Luo_Abilities",
         "effect": "reveal_stats"
       },
+      { "text": "Please go to this location.", "topic": "TALK_GOTO_LOCATION", "effect": "goto_location" },
       { "text": "There's something I want you to do.", "topic": "TALK_LUO_ORDERS" },
       {
         "text": "I just wanted to talk for a bit.",
@@ -21,6 +22,11 @@
       },
       { "text": "Can you help me understand something?  (HELP/TUTORIAL)", "topic": "TALK_ALLY_TUTORIAL" },
       { "text": "I'm going to go my own way for a while.", "topic": "TALK_LEAVE" },
+      {
+        "text": "[DEBUG MIND CONTROL] Now listen closely… (DEBUG FUNCTIONS)",
+        "condition": { "u_has_trait": "DEBUG_MIND_CONTROL" },
+        "topic": "TALK_ALLY_DEBUG"
+      },
       { "text": "<lets_go>", "topic": "TALK_DONE" }
     ]
   },

--- a/data/json/npcs/your_followers/luo_follower.json
+++ b/data/json/npcs/your_followers/luo_follower.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": [ "TALK_FRIEND_Luo", "TALK_FRIEND_Luo_Abilities", "TALK_RADIO" ],
+    "id": [ "TALK_FRIEND_Luo", "TALK_FRIEND_Luo_Abilities" ],
     "type": "talk_topic",
     "dynamic_line": {
       "is_by_radio": " *pshhhttt* Hey stinkyface.  It's your favorite mushroom girl.  Over.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #78244, i.e. inability to order Liam to move to location.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add two pieces of missing dialog to Liam and Luo:
- Order to go to location.
- Debug mind control.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Found Luo as additional potential companion with missing dialog. As far as I can tell the Bone Seer seems to become a standard companion once recruited, resulting in loss of the NPC dialog in the process. Didn't find anyone else who might have special companion dialog.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Limited, unfortunately:
- Loaded save, talked to Liam, saw I could order him to go to a location.
- Also saw there's a direct order to send him to a location that probably could be used as a work around, but didn't bother to see if it actually was present before the dialog modification.
- Debug added debug mind control mutation to PC, talked to Liam, and saw the corresponding dialog option show up.

Haven't bothered to test Luo, relying on the changes being the same to both characters. Testing Luo would require going through the full beggar quest chain, which is far too much work, and I don't have any save left where she was recruited.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Edit:
Tried to add TALK_RADIO to Liam and Luo, but when @Terrorforge told me how to test it I found it's not working properly. I removed it (returning it to the original state), and it's still off. When contacted via radio, Liam gets subjects listed 2-3 times (after removal of TALK_RADIO), but the added entry is there.

It can also be mentioned that Liam wasn't considered to be in radio range when left in the basement, making the feature even less useful (as that's where you're out of the heat/freezing cold.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
