### PR TITLE
[Xedra Evolved] Add Commanding the Grasses as an intro trait for Arvore, make Hungry Thirsty Roots require leveling other spells

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -771,7 +771,7 @@
     "id": "arvore_summon_grass_field_spell",
     "type": "SPELL",
     "name": { "str": "Commanding the Grasses" },
-    "description": "Your command over plants allows you to cause grass to grow in profusion from the soil, making the terrain very difficult for enemies to traversse.",
+    "description": "Your command over plants allows you to cause grass to grow in profusion from the soil, making the terrain very difficult for enemies to traverse.",
     "valid_targets": [ "hostile", "ground" ],
     "flags": [ "VERRBAL", "SOMATIC", "NO_PROJECTILE", "NO_HANDS", "NO_LEGS" ],
     "max_level": { "math": [ "int_to_level(1)" ] },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -331,7 +331,8 @@
     "energy_increment": -10,
     "base_casting_time": 150,
     "final_casting_time": 100,
-    "casting_time_increment": -4
+    "casting_time_increment": -4,
+    "learn_spells": { "arvore_roots_spell": 7 }
   },
   {
     "id": "arvore_summon_wood_spirit",
@@ -434,7 +435,7 @@
     "base_energy_cost": 550,
     "final_energy_cost": 250,
     "energy_increment": -15,
-    "learn_spells": { "arvore_tree_singing_spell": 12 }
+    "learn_spells": { "arvore_roots_spell": 8, "arvore_tree_singing_spell": 12 }
   },
   {
     "id": "arvore_summon_briars_arc",
@@ -739,7 +740,7 @@
     "base_casting_time": 150,
     "final_casting_time": 75,
     "casting_time_increment": -5,
-    "learn_spells": { "arvore_create_living_tent_spell": 10 }
+    "learn_spells": { "arvore_roots_spell": 8, "arvore_create_living_tent_spell": 10 }
   },
   {
     "type": "SPELL",
@@ -767,12 +768,49 @@
     "casting_time_increment": -150
   },
   {
+    "id": "arvore_summon_grass_field_spell",
+    "type": "SPELL",
+    "name": { "str": "Commanding the Grasses" },
+    "description": "Your command over plants allows you to cause grass to grow in profusion from the soil, making the terrain very difficult for enemies to traversse.",
+    "valid_targets": [ "hostile", "ground" ],
+    "flags": [ "VERRBAL", "SOMATIC", "NO_PROJECTILE", "NO_HANDS", "NO_LEGS" ],
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "skill": "deduction",
+    "teachable": false,
+    "difficulty": 1,
+    "spell_class": "ARVORE",
+    "effect": "ter_transform",
+    "effect_str": "ter_arvore_command_grasses",
+    "shape": "blast",
+    "damage_type": "bash",
+    "min_range": {
+      "math": [ "( ( (u_spell_level('arvore_summon_grass_field_spell') * 0.8) + 3) * (scaling_factor(u_val('intelligence') ) ) )" ]
+    },
+    "max_range": {
+      "math": [ "( ( (u_spell_level('arvore_summon_grass_field_spell') * 0.8) + 3) * (scaling_factor(u_val('intelligence') ) ) )" ]
+    },
+    "min_aoe": {
+      "math": [ "( ( (u_spell_level('arvore_summon_grass_field_spell') * 0.5) + 2) * (scaling_factor(u_val('intelligence') ) ) )" ]
+    },
+    "max_aoe": {
+      "math": [ "( ( (u_spell_level('arvore_summon_grass_field_spell') * 0.5) + 5) * (scaling_factor(u_val('intelligence') ) ) )" ]
+    },
+    "energy_source": "MANA",
+    "base_casting_time": 100,
+    "final_casting_time": 35,
+    "casting_time_increment": -4,
+    "base_energy_cost": 150,
+    "final_energy_cost": 75,
+    "energy_increment": -5,
+    "learn_spells": { "arvore_roots_spell": 6 }
+  },
+  {
     "id": "arvore_roots_spell",
     "type": "SPELL",
     "name": { "//~": "The name is a reference to the poem \"Goblin Market\" by Christina Rossetti.", "str": "Hungry Thirsty Roots" },
     "description": "Your command over plants allows you to call forth roots from the earth to clutch and grasp at your enemies.",
     "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "NO_PROJECTILE", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
+    "flags": [ "VERRBAL", "NO_PROJECTILE", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
     "max_level": { "math": [ "per_to_level(1)" ] },
     "skill": "deduction",
     "teachable": false,
@@ -782,15 +820,12 @@
     "effect_str": "effect_hungry_roots",
     "shape": "blast",
     "damage_type": "bash",
-    "min_aoe": 0,
-    "max_aoe": 3,
-    "aoe_increment": 0.25,
-    "min_range": 2,
-    "max_range": 70,
-    "range_increment": 0.65,
-    "min_dot": 0,
-    "max_dot": 5,
-    "dot_increment": 0.1,
+    "min_range": { "math": [ "( ( (u_spell_level('arvore_roots_spell') * 0.65) + 2) * (scaling_factor(u_val('perception') ) ) )" ] },
+    "max_range": { "math": [ "( ( (u_spell_level('arvore_roots_spell') * 0.65) + 2) * (scaling_factor(u_val('perception') ) ) )" ] },
+    "min_aoe": { "math": [ "( ( (u_spell_level('arvore_roots_spell') * 0.25) + 0) * (scaling_factor(u_val('perception') ) ) )" ] },
+    "max_aoe": { "math": [ "( ( (u_spell_level('arvore_roots_spell') * 0.25) + 0) * (scaling_factor(u_val('perception') ) ) )" ] },
+    "min_dot": { "math": [ "( ( (u_spell_level('arvore_roots_spell') * 0.1) + 0) * (scaling_factor(u_val('perception') ) ) )" ] },
+    "max_dot": { "math": [ "( ( (u_spell_level('arvore_roots_spell') * 0.1) + 0) * (scaling_factor(u_val('perception') ) ) )" ] },
     "min_duration": { "math": [ "( ( (u_spell_level('arvore_roots_spell') * 50) + 300) * (scaling_factor(u_val('perception') ) ) )" ] },
     "max_duration": { "math": [ "( ( (u_spell_level('arvore_roots_spell') * 100) + 1000) * (scaling_factor(u_val('perception') ) ) )" ] },
     "energy_source": "MANA",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
@@ -262,7 +262,7 @@
     "points": 3,
     "visibility": 0,
     "ugliness": 0,
-    "prereqs": [ "ARVORE_ROOTS_SPELL" ],
+    "prereqs": [ "ARVORE_SUMMON_GRASS_FIELD" ],
     "leads_to": [ "ARVORE_ANTI_PLANT_SPELL" ],
     "description": "Upon gaining this ability, the Arvore gains the ability to summon semitangible roots that will shatter walls and furniture.",
     "category": [ "ARVORE" ],
@@ -335,15 +335,15 @@
   },
   {
     "type": "mutation",
-    "id": "ARVORE_ROOTS_SPELL",
-    "name": { "str": "Command the Roots" },
+    "id": "ARVORE_SUMMON_GRASS_FIELD",
+    "name": { "str": "Commanding the Grasses" },
     "points": 3,
     "visibility": 0,
     "ugliness": 0,
     "leads_to": [ "ARVORE_TERRAIN_BASH_SPELL" ],
-    "description": "Upon gaining this ability the Arvore gains the ability to call up grasping roots from the ground.",
+    "description": "Upon gaining this ability the Arvore gains the ability to cause grass to rapidly grow on fertile terrain, slowing their enemies.",
     "category": [ "ARVORE" ],
-    "spells_learned": [ [ "arvore_roots_spell", 1 ] ]
+    "spells_learned": [ [ "arvore_summon_grass_field_spell", 1 ] ]
   },
   {
     "type": "mutation",
@@ -352,7 +352,8 @@
     "points": 3,
     "visibility": 0,
     "ugliness": 0,
-    "leads_to": [ "ARVORE_NURTURING_THE_GREEN" ],
+    "prereqs": [ "ARVORE_NURTURING_THE_GREEN" ],
+    "prereqs2": [ "ARVORE_SUMMON_GRASS_FIELD" ],
     "description": "Upon gaining this ability the Arvore gains the ability to summon a thick climbing vine from diggable ground.",
     "category": [ "ARVORE" ],
     "spells_learned": [ [ "arvore_climbing_vine_spell", 1 ] ]
@@ -557,7 +558,7 @@
     "name": { "str": "Entangling Vines" },
     "points": 6,
     "description": "At will, you can extend a cluster of grasping vines to grab one target and drag them in.  They have a range equal to 1/2 your Dexterity.",
-    "prereqs": [ "ARVORE_ROOTS_SPELL" ],
+    "prereqs": [ "ARVORE_CLIMBING_VINE_SPELL" ],
     "category": [ "ARVORE" ],
     "activated_is_setup": false,
     "active": true,

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_spell_learning_eocs.json
@@ -20,7 +20,7 @@
             "ARVORE_FOREST_TRANSLOCATION",
             "ARVORE_TURN_INTO_TREE",
             "ARVORE_VERDANT_INFUSION",
-            "ARVORE_ROOTS_SPELL",
+            "ARVORE_SUMMON_GRASS_FIELD",
             "ARVORE_CLIMBING_VINE_SPELL",
             "ARVORE_ANTI_PLANT_SPELL",
             "ARVORE_CULTIVATE_GOBLIN_FRUIT",
@@ -76,6 +76,7 @@
         { "math": [ "u_spell_level('arvore_forest_translocate') < per_to_level(1)" ] },
         { "math": [ "u_spell_level('arvore_overgrowth_spell') < int_to_level(1)" ] },
         { "math": [ "u_spell_level('arvore_verdant_infusion') < per_to_level(1)" ] },
+        { "math": [ "u_spell_level('arvore_summon_grass_field_spell') < per_to_level(1)" ] },
         { "math": [ "u_spell_level('arvore_roots_spell') < per_to_level(1)" ] },
         { "math": [ "u_spell_level('arvore_climbing_vine_spell') < int_to_level(1)" ] },
         { "math": [ "u_spell_level('arvore_anti_plant_spell') < per_to_level(1)" ] },
@@ -102,6 +103,7 @@
         [ "EOC_LEVELER_ARVORE_FOREST_TRANSLOCATION", 2 ],
         [ "EOC_LEVELER_ARVORE_TURN_INTO_TREE", 3 ],
         [ "EOC_LEVELER_ARVORE_VERDANT_INFUSION", 6 ],
+        [ "EOC_LEVELER_ARVORE_SUMMON_GRASS_FIELD_SPELL", 10 ],
         [ "EOC_LEVELER_ARVORE_ROOTS_SPELL", 8 ],
         [ "EOC_LEVELER_ARVORE_CLIMBING_VINE_SPELL", 8 ],
         [ "EOC_LEVELER_ARVORE_LIVING_TENT_SPELL", 6 ],
@@ -346,6 +348,24 @@
         "type": "good"
       },
       { "math": [ "u_spell_exp('arvore_verdant_infusion')", "+=", "paraclesian_passive_spell_exp(1)" ] }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_ARVORE_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LEVELER_ARVORE_SUMMON_GRASS_FIELD_SPELL",
+    "condition": {
+      "and": [
+        { "math": [ "u_spell_level('arvore_summon_grass_field_spell') >= 0" ] },
+        { "math": [ "u_spell_level('arvore_summon_grass_field_spell') < int_to_level(1)" ] }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "Your time spent under the shadows of the trees has increased your facility with your fae magicks.",
+        "type": "good"
+      },
+      { "math": [ "u_spell_exp('arvore_summon_grass_field_spell')", "+=", "paraclesian_passive_spell_exp(1)" ] }
     ],
     "false_effect": [ { "run_eocs": "EOC_ARVORE_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
   },

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/mutations.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/mutations.json
@@ -88,5 +88,11 @@
     "id": "UNDINE_WATER_FORM_CAMOUFLAGE_ON",
     "trait": "UNDINE_WATER_FORM_CAMOUFLAGE",
     "//": "remove after 0.I"
+  },
+  {
+    "type": "TRAIT_MIGRATION",
+    "id": "ARVORE_ROOTS_SPELL",
+    "trait": "ARVORE_SUMMON_GRASS_FIELD",
+    "//": "remove after 0.I"
   }
 ]

--- a/data/mods/Xedra_Evolved/ter_transforms/arvore_ter_transforms.json
+++ b/data/mods/Xedra_Evolved/ter_transforms/arvore_ter_transforms.json
@@ -65,6 +65,27 @@
   },
   {
     "type": "ter_furn_transform",
+    "id": "ter_arvore_command_grasses",
+    "terrain": [
+      {
+        "result": "t_grass_tall",
+        "valid_terrain": [ "t_grass_long" ],
+        "message": "The grass grows tall, reaching toward the sky."
+      },
+      {
+        "result": [ [ "t_grass_long", 100 ], [ "t_grass_tall", 25 ] ],
+        "valid_terrain": [ "t_grass" ],
+        "message": "The grass grows tall, reaching toward the sky."
+      },
+      {
+        "result": [ [ "t_grass", 50 ], [ "t_grass_long", 100 ], [ "t_grass_tall", 10 ] ],
+        "valid_flags": [ "DIGGABLE" ],
+        "message": "The ground churns as blades of grass push out of the soil."
+      }
+    ]
+  },
+  {
+    "type": "ter_furn_transform",
     "id": "ter_arvore_wood_wall",
     "terrain": [
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods  "[Xedra Evolved] Add Commanding the Grasses as an intro trait for Arvore, make Hungry Thirsty Roots require leveling other spells"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Add an idea for a new Arvore spell but it works best as an introductory spell, so rather than increasing the number of traits, I thought I could reorganize them.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a new first-tier trait, Commanding the Grasses, which teaches a spell that turns diggable terrain into grass, favoring taller grasses.

Migrate the existing Commanding the Roots trait to Commanding the Grasses. Rework trait prerequisites to account for this.

The spell Hungry Thirsty Roots is now learned by leveling other spells. I also made it scale using math instead of the hard-coded spell modifiers.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Took that poor zombie almost a minute to get to me:
![Untitled2](https://github.com/user-attachments/assets/c2337774-947c-4e25-91fe-89a866d8c5b4)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
