### PR TITLE
Fix mac OS market share script

### DIFF
--- a/tools/macos-market-share.py
+++ b/tools/macos-market-share.py
@@ -39,6 +39,8 @@ replacement = {
     'OS X Mountain Lion': (10, 8),
     'mac OS X Leopard': (10, 6),
     'mac OS X Tiger': (10, 4),
+    'mac OS X Jaguar': (10, 2),
+    'mac OS X Panther': (10, 3),
     'Other': (0,)
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
As by `COMPILER_SUPPORT.md` downloaded todays CVS data and running this script lead to errors.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adding the two version missing in the dictionary.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
This is the output:
```
2023-10 :: 10.11:  2.8  10.12:  3.9  10.13:  5.5  10.14:  7.0  10.15: 99.4
2023-11 :: 10.11:  1.8  10.12:  3.0  10.13:  4.3  10.14:  5.4  10.15: 99.6
2023-12 :: 10.11:  1.8  10.12:  3.0  10.13:  4.4  10.14:  5.4  10.15: 99.6
2024-01 :: 10.11:  1.5  10.12:  2.5  10.13:  3.8  10.14:  4.6  10.15: 99.7
2024-02 :: 10.11:  1.5  10.12:  2.4  10.13:  3.8  10.14:  4.6  10.15: 99.5
2024-03 :: 10.11:  1.9  10.12:  2.8  10.13:  4.2  10.14:  5.2  10.15: 99.5
2024-04 :: 10.11:  1.4  10.12:  2.3  10.13:  3.6  10.14:  4.4  10.15: 99.6
2024-05 :: 10.11:  1.3  10.12:  2.3  10.13:  3.6  10.14:  4.4  10.15: 99.6
2024-06 :: 10.11:  1.3  10.12:  2.4  10.13:  3.7  10.14:  4.5  10.15: 99.5
2024-07 :: 10.11:  1.3  10.12:  2.5  10.13:  3.9  10.14:  4.7  10.15: 99.5
2024-08 :: 10.11:  1.3  10.12:  2.3  10.13:  3.4  10.14:  4.2  10.15: 99.5
2024-09 :: 10.11:  1.2  10.12:  2.0  10.13:  3.1  10.14:  3.8  10.15: 99.6
2024-10 :: 10.11:  1.0  10.12:  1.8  10.13:  2.7  10.14:  3.4  10.15: 99.7
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
According to https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide
> Apple are incorrectly reporting all macOS releases since Catalina 10.15 as Catalina 10.15. You can read more about it [here](https://bugs.webkit.org/show_bug.cgi?id=216593).
> We can't correctly show usage for Catalina 10.15, Big Sur 11, Monterey 12, Ventura 13 or Sonoma 14 until Apple fixes this.

The bug on WebKit has been open in Sep 2020.

Interesting [note](https://bugs.webkit.org/show_bug.cgi?id=216593#c15), emphasis **mine**:
> Having frozen the user agent string macOS version, there is now essentially no public information on macOS usage by version. Apple do not appear to publish any such stats themselves, leaving web stats the only source of information that software developers can make decisions on (like StatCounter global stats) - **but this information is no longer reliable as UA strings are frozen**. It is difficult to know which versions to target and the wrong decision could leave lots of macOS users unsupported.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->