### PR TITLE
[Innawoods] Delays the shadow lieutenant boss spawn (and warnings) by three seasons (mid winter by default).

### DIFF
--- a/data/mods/innawood/monsters/singularities.json
+++ b/data/mods/innawood/monsters/singularities.json
@@ -9,7 +9,7 @@
     "effect": [ { "math": [ "Lieutenants_active = 1" ] }, { "math": [ "Shadow_Lurking = 1" ] } ],
     "deactivate_condition": { "math": [ "Lieutenants_active >= 1" ] }
   },
-    {
+  {
     "type": "effect_on_condition",
     "id": "EOC_LIEUTENANT_SHADOW_WARN",
     "condition": {

--- a/data/mods/innawood/monsters/singularities.json
+++ b/data/mods/innawood/monsters/singularities.json
@@ -1,5 +1,5 @@
 [
-    {
+  {
     "type": "effect_on_condition",
     "id": "EOC_LIEUTENANT_ACTIVATE_SHADOW",
     "recurrence": "1 second",

--- a/data/mods/innawood/monsters/singularities.json
+++ b/data/mods/innawood/monsters/singularities.json
@@ -1,0 +1,51 @@
+[
+    {
+    "type": "effect_on_condition",
+    "id": "EOC_LIEUTENANT_ACTIVATE_SHADOW",
+    "recurrence": "1 second",
+    "global": true,
+    "run_for_npcs": false,
+    "condition": { "and": [ { "math": [ "time_since('cataclysm', 'unit':'days') >= 270" ] }, { "math": [ "Lieutenants_active < 1" ] } ] },
+    "effect": [ { "math": [ "Lieutenants_active = 1" ] }, { "math": [ "Shadow_Lurking = 1" ] } ],
+    "deactivate_condition": { "math": [ "Lieutenants_active >= 1" ] }
+  },
+    {
+    "type": "effect_on_condition",
+    "id": "EOC_LIEUTENANT_SHADOW_WARN",
+    "condition": {
+      "and": [
+        { "not": "is_day" },
+        { "not": { "u_has_effect": "sleep" } },
+        {
+          "or": [ { "math": [ "Shadow_Lurking > 0" ] }, { "not": { "math": [ "time_since('cataclysm', 'unit':'days') >= 270" ] } } ]
+        },
+        {
+          "or": [ { "math": [ "Shadow_Lurking > 0" ] }, { "math": [ "time_since('cataclysm', 'unit':'days') >= 263" ] } ]
+        },
+        {
+          "or": [ { "math": [ "Shadow_Warnings < 1" ] }, { "math": [ "time_since('cataclysm', 'unit':'days') >= 270" ] } ]
+        },
+        "u_is_outside",
+        {
+          "or": [ { "u_at_om_location": "field" }, { "u_at_om_location": "forest" }, { "u_at_om_location": "forest_thick" } ]
+        }
+      ]
+    },
+    "effect": [
+      { "math": [ "Shadow_Warnings", "+=", "1" ] },
+      {
+        "if": { "math": [ "time_since('cataclysm', 'unit':'days') >= 270" ] },
+        "then": {
+          "if": { "math": [ "Shadow_Warnings < 2" ] },
+          "then": { "u_message": "Shadow_Warnings_Snippets_late", "snippet": true, "popup": true },
+          "else": { "u_message": "Shadow_Warnings_Snippets_late", "snippet": true, "popup": false }
+        },
+        "else": {
+          "if": { "math": [ "Shadow_Warnings < 2" ] },
+          "then": { "u_message": "Shadow_Warnings_Snippets_early", "snippet": true, "popup": true },
+          "else": { "u_message": "Shadow_Warnings_Snippets_early", "snippet": true, "popup": false }
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Innawoods] Delays the shadow lieutenant boss spawn (and its warnings) by three seasons (mid winter by default). Innawoods only."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
An innawoods playthrough is both the most likely to trigger the shadow lieutenant conditions and also the least capable of dealing with the boss and its aftermath. Basically, if it isn't an outright death sentence, then it may as well render the entire area inhospitable with abominations that will revive after a time, possibly costing the PC a base and all of their progress assuming they don't just die outright (which they probably will).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Creates an Innawoods replacement monster json file with the relevant EoCs to delay the checks for the shadow lieutenant spawn by three seasons after the start of the cataclysm. The shadow warnings will begin triggering early warnings one week prior to the shadow lieutenant's possible activation time in the same manner as the base game, with an added line to the EoC to accommodate this change.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Removing the shadow lieutenant fight from Innawoods altogether. This may be justified considering the difficulty of this encounter for an Innawoods playthrough. However, alternatively, it may also pose an interesting nemesis for a suitably late game Innawoods run. 

I also considered changing the timer to be something like two seasons from the start of the cataclysm or even a full year. There wasn't any particular reason to choose three seasons after the cataclysm, and if that's too early/late, I'll re-evaluate this decision based on feedback and commentary.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
First I tested that my new line in the shadow warning EoC didn't screw anything up by just delaying it by just a couple days after the cataclysm and it worked just fine. Then I built the game with the full changes in this PR, debugged the time to winter with a debug character, and waited a couple weeks in-game time in order to ensure the changes were correctly represented. Shadow early warning triggered correctly on day 51 of winter and the shadow spawned roughly one week later on winter day 58. I repeated this a couple times just to be sure, and also tested it once in the base game (which was unaffected by the changes in this PR and represented standard base game behavior, as expected).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
