### PR TITLE
Special vision enchantment for Antennae mutation

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4920,7 +4920,18 @@
     "active": true,
     "starts_active": true,
     "restricts_gear": [ "head_crown" ],
-    "allow_soft_gear": true
+    "allow_soft_gear": true,
+    "enchantments": [
+      {
+        "condition": "ACTIVE",
+        "special_vision": [
+          {
+            "distance": 3,
+            "descriptions": [ { "id": "antennae_sense", "symbol": "?", "color": "c_white", "text": "You sense something here." } ]
+          }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -401,7 +401,6 @@ static const species_id species_HUMAN( "HUMAN" );
 static const start_location_id start_location_sloc_shelter_a( "sloc_shelter_a" );
 
 static const trait_id trait_ADRENALINE( "ADRENALINE" );
-static const trait_id trait_ANTENNAE( "ANTENNAE" );
 static const trait_id trait_BADBACK( "BADBACK" );
 static const trait_id trait_BIRD_EYE( "BIRD_EYE" );
 static const trait_id trait_CANNIBAL( "CANNIBAL" );
@@ -11307,9 +11306,6 @@ bool Character::sees( const Creature &critter ) const
     const int dist = rl_dist( pos_bub(), critter.pos_bub() );
     if( std::abs( pos_bub().z() - critter.pos_bub().z() ) > fov_3d_z_range ) {
         return false;
-    }
-    if( dist <= 3 && has_active_mutation( trait_ANTENNAE ) ) {
-        return true;
     }
     if( dist < MAX_CLAIRVOYANCE && dist < clairvoyance() ) {
         return true;


### PR DESCRIPTION
#### Summary
Features "Special vision enchantment for Antennae mutation"

#### Purpose of change
* Closes #39472.

#### Describe the solution
Using recently added infrastructure from #77770 and #78080 by @GuardianDll, I added an `antennae_sense` special vision enchantment to Antennae mutation.
Also I removed check for the mutation from `Character::sees` function so game won't be showing exact name of monster in compass area in sidebar with active mutation anymore.

#### Describe alternatives you've considered
None.

#### Testing
Got the mutation. Debug-spawned debug monster on the other side of the wall from me. While mutation is active, checked that monster is shown as "unknown" glyph in tiles and `?` symbol in curses.

#### Additional context
![изображение](https://github.com/user-attachments/assets/b23daccb-c411-4ddb-9020-5e5d28a0b509)

![изображение](https://github.com/user-attachments/assets/09f8dd99-4d4c-4f8e-a8db-0b2243932aa9)