### PR TITLE
Forbid learning spells from spellbooks with low morale

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2386,7 +2386,7 @@ void learn_spell_actor::info( const item &, std::vector<iteminfo> &dump ) const
     }
 }
 
-std::optional<int> learn_spell_actor::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> learn_spell_actor::use( Character *p, item &, const tripoint & ) const
 {
     //TODO: combine/replace the checks below with "checks for conditions" from Character::check_read_condition
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2388,6 +2388,8 @@ void learn_spell_actor::info( const item &, std::vector<iteminfo> &dump ) const
 
 std::optional<int> learn_spell_actor::use( Character *p, item &it, const tripoint & ) const
 {
+    //TODO: combine/replace the checks below with "checks for conditions" from Character::check_read_condition
+
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( m_bad, _( "It's too dark to read." ) );
         return std::nullopt;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2386,14 +2386,18 @@ void learn_spell_actor::info( const item &, std::vector<iteminfo> &dump ) const
     }
 }
 
-std::optional<int> learn_spell_actor::use( Character *p, item &, const tripoint & ) const
+std::optional<int> learn_spell_actor::use( Character *p, item &it, const tripoint & ) const
 {
     if( p->fine_detail_vision_mod() > 4 ) {
-        p->add_msg_if_player( _( "It's too dark to read." ) );
+        p->add_msg_if_player( m_bad, _( "It's too dark to read." ) );
         return std::nullopt;
     }
     if( p->has_trait( trait_ILLITERATE ) ) {
-        p->add_msg_if_player( _( "You can't read." ) );
+        p->add_msg_if_player( m_bad, _( "You can't read." ) );
+        return std::nullopt;
+    }
+    if( !p->has_morale_to_read() ) {
+        p->add_msg_if_player( m_bad, _( "What's the point of studying?  (Your morale is too low!)" ) );
         return std::nullopt;
     }
     std::vector<uilist_entry> uilist_initializer;

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -697,7 +697,7 @@ class learn_spell_actor : public iuse_actor
 
         ~learn_spell_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *p, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -697,7 +697,7 @@ class learn_spell_actor : public iuse_actor
 
         ~learn_spell_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint & ) const override;
+        std::optional<int> use( Character *p, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };


### PR DESCRIPTION
#### Summary
Bugfixes "Forbid learning spells from spellbooks with low morale"

#### Purpose of change
* Closes #39195.

#### Describe the solution
Added a check for morale `learn_spell_actor::use`.

#### Describe alternatives you've considered
None.

#### Testing
In a world with Magiclysm debug-spawned `A Beginner's Guide to Magic`. Killed several zombie children to get a very low morale. Tried to read the book, got a `What's the point of studying?  (Your morale is too low!)` message.

#### Additional context
Reading spellbooks is too permissive compared to reading usual books. For example, you can read spellbooks while driving, or without reading glasses or vision-fixing bionic (while being hyperopic). Initially I wanted to simply put checks for these conditions into `learn_spell_actor::use` but decided not to because of code duplication. Added a TODO instead.