### PR TITLE
Added ownership to several places of Tacoma Commune ranch camp

### DIFF
--- a/data/json/mapgen/ranch_camp.json
+++ b/data/json/mapgen/ranch_camp.json
@@ -544,6 +544,11 @@
   {
     "method": "json",
     "object": {
+      "faction_owner": [
+        { "id": "tacoma_commune", "x": [ 48, 71 ], "y": [ 0, 23 ] },
+        { "id": "tacoma_commune", "x": [ 24, 47 ], "y": [ 24, 47 ] },
+        { "id": "tacoma_commune", "x": [ 48, 71 ], "y": [ 24, 47 ] }
+      ],
       "fill_ter": "t_dirt",
       "rows": [
         "..%.....................................................................",
@@ -635,6 +640,10 @@
   {
     "method": "json",
     "object": {
+      "faction_owner": [
+        { "id": "tacoma_commune", "x": [ 0, 23 ], "y": [ 24, 47 ] },
+        { "id": "tacoma_commune", "x": [ 24, 47 ], "y": [ 24, 47 ] }
+      ],
       "fill_ter": "t_floor",
       "rows": [
         "................................................x.............x.........",
@@ -1051,6 +1060,7 @@
     "method": "json",
     "om_terrain": "ranch_camp_68_basement",
     "object": {
+      "faction_owner": [ { "id": "tacoma_commune", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
       "fill_ter": "t_dirtfloor",
       "rows": [
         "                        ",


### PR DESCRIPTION
#### Summary
Bugfixes "Added ownership to several places of Tacoma Commune ranch camp"

#### Purpose of change
* Closes #38812.

#### Describe the solution
Added ownership to several places of Tacoma Commune ranch camp.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned Tacoma Commune ranch camp, teleported to `ranch_camp_67` OMT (the garage of the commune), tried to pickup items, got theft warning.

#### Additional context
None.