### PR TITLE
fix standing tank deconstruction

### DIFF
--- a/data/json/construction/furniture_tools.json
+++ b/data/json/construction/furniture_tools.json
@@ -489,7 +489,7 @@
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_M", "level": 1 } ] ],
     "using": [ [ "welding_standard", 5 ] ],
     "//1": "5cm of weld to join the faucet to the pipe",
-    "components": [ [ [ "metal_tank", 4 ] ], [ [ "water_faucet", 1 ] ] ],
+    "components": [ [ [ "metal_tank", 5 ] ], [ [ "water_faucet", 1 ] ] ],
     "pre_special": "check_empty",
     "post_terrain": "f_standing_tank"
   },

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1267,7 +1267,7 @@
     "coverage": 90,
     "required_str": -1,
     "flags": [ "CONTAINER", "LIQUIDCONT", "NOITEM", "SEALED", "TRANSPARENT" ],
-    "deconstruct": { "items": [ { "item": "metal_tank", "count": 4 }, { "item": "water_faucet", "count": 1 } ] },
+    "deconstruct": { "items": [ { "item": "metal_tank", "count": 5 }, { "item": "water_faucet", "count": 1 } ] },
     "examine_action": "keg",
     "keg_capacity": 1200,
     "bash": {


### PR DESCRIPTION
#### Summary

Bugfixes "Fix standing tank deconstruction"

#### Purpose of change

The standing tank has a capacity of 300L, but when deconstructed, the player is only given four 60L metal tanks totalling 240L capacity.  The other 60L of total capacity vanishes into thin air.  

#### Describe the solution

This change simply gives the player five tanks when deconstructing the standing tank, maintaining a consistent capacity.

#### Describe alternatives you've considered

1. Keep everything as-is, perhaps the loss of capacity is intentional.  After all, is a standing tank REALLY just an outer shell around four or five 60L metal tanks?  Maybe, maybe not..

2. Decrease the total capacity of the standing tank to 240L to maintain consistency this way.

3. Create a new 300L metal tank item and provide that to the player when deconstructing the furniture version of the item, along with the water faucet
 
#### Testing

No testing has been done, this is a simple change to the number of 60L metal tanks provided when deconstructing a standing tank

#### Additional context

Thank you for your consideration.  This is my first PR for this project and appreciate the ability to be able to make suggestions