### PR TITLE
typified iuse & iuse_actor

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1983,7 +1983,7 @@ void activity_handlers::start_fire_do_turn( player_activity *act, Character *you
 
     you->mod_moves( -you->get_moves() );
     const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
-    const float light = actor->light_mod( you->pos() );
+    const float light = actor->light_mod( you->pos_bub() );
     act->moves_left -= light * 100;
     if( light < 0.1 ) {
         add_msg( m_bad, _( "There is not enough sunlight to start a fire now.  You stop trying." ) );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -434,7 +434,7 @@ bool avatar::read( item_location &book, item_location ereader )
     // spells are handled in a different place
     // src/iuse_actor.cpp -> learn_spell_actor::use
     if( book->get_use( "learn_spell" ) ) {
-        book->get_use( "learn_spell" )->call( this, *book, pos() );
+        book->get_use( "learn_spell" )->call( this, *book, pos_bub() );
         return true;
     }
 
@@ -1488,7 +1488,7 @@ bool avatar::invoke_item( item *used, const tripoint_bub_ms &pt, int pre_obtain_
     umenu.hilight_disabled = true;
 
     for( const auto &e : use_methods ) {
-        const auto res = e.second.can_call( *this, *used, pt.raw() );
+        const auto res = e.second.can_call( *this, *used, pt );
         umenu.addentry_desc( MENU_AUTOASSIGN, res.success(), MENU_AUTOASSIGN, e.second.get_name(),
                              res.str() );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9692,7 +9692,7 @@ item Character::find_firestarter_with_charges( const int quantity ) const
             const use_function *usef = it.type->get_use( "firestarter" );
             if( usef != nullptr && usef->get_actor_ptr() != nullptr ) {
                 const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
-                if( actor->can_use( *this->as_character(), it, tripoint::zero ).success() ) {
+                if( actor->can_use( *this->as_character(), it, tripoint_bub_ms::zero ).success() ) {
                     ret = it;
                     return true;
                 }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1664,9 +1664,8 @@ void construct::done_grave( const tripoint_bub_ms &p, Character &player_characte
         }
     }
     if( player_character.has_quality( qual_CUT ) ) {
-        // TODO: fix point types
         iuse::handle_ground_graffiti( player_character, nullptr, _( "Inscribe something on the grave?" ),
-                                      p.raw() );
+                                      p );
     } else {
         add_msg( m_neutral,
                  _( "Unfortunately you don't have anything sharp to place an inscription on the grave." ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3083,7 +3083,7 @@ void game::move_save_to_graveyard()
         debugmsg( "could not find save files in '%s'", save_dir );
     }
 
-    for( const auto &src_path : save_files ) {
+    for( const cata_path &src_path : save_files ) {
         const cata_path dst_path = graveyard_dir / src_path.get_relative_path().filename();
 
         if( rename_file( src_path, dst_path ) ) {
@@ -8183,7 +8183,7 @@ bool game::take_screenshot() const
                                       timestamp_now() );
 
     std::string file_name = ensure_valid_file_name( tmp_file_name );
-    auto current_file_path = map_directory / file_name;
+    cata_path current_file_path = map_directory / file_name;
 
     // Take a screenshot of the viewport.
     if( take_screenshot( current_file_path.generic_u8string() ) ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1136,7 +1136,7 @@ class activatable_inventory_preset : public pickup_inventory_preset
             }
 
             if( uses.size() == 1 ) {
-                const auto ret = uses.begin()->second.can_call( you, it, you.pos() );
+                const auto ret = uses.begin()->second.can_call( you, it, you.pos_bub() );
                 if( !ret.success() ) {
                     return trim_trailing_punctuations( ret.str() );
                 }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1715,7 +1715,7 @@ static void read()
         item the_book = *loc.get_item();
         if( avatar_action::check_stealing( get_player_character(), the_book ) ) {
             if( loc->type->can_use( "learn_spell" ) ) {
-                the_book.get_use( "learn_spell" )->call( &player_character, the_book, player_character.pos() );
+                the_book.get_use( "learn_spell" )->call( &player_character, the_book, player_character.pos_bub() );
             } else {
                 loc = loc.obtain( player_character );
                 player_character.read( loc );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1918,7 +1918,7 @@ void iexamine::locked_object( Character &you, const tripoint_bub_ms &examp )
         //~ %1$s: terrain/furniture name, %2$s: prying tool name
         you.add_msg_if_player( _( "You attempt to pry open the %1$s using your %2$s…" ),
                                target_name, best_prying.tname() );
-        iuse::crowbar( &you, &best_prying, examp.raw() );
+        iuse::crowbar( &you, &best_prying, examp );
     } else if( action == act::pick ) {
         locked_object_pickable( you, examp );
     }
@@ -1990,7 +1990,7 @@ void iexamine::locked_object_pickable( Character &you, const tripoint_bub_ms &ex
         const use_function *iuse_fn = it->type->get_use( "PICK_LOCK" );
         you.add_msg_if_player( _( "You attempt to pick the lock of %1$s using your %2$s…" ),
                                target_name, it->tname() );
-        const ret_val<void> can_use = iuse_fn->can_call( you, *it, examp.raw() );
+        const ret_val<void> can_use = iuse_fn->can_call( you, *it, examp );
         if( can_use.success() ) {
             iuse_fn->call( &you, *it, examp );
             return;
@@ -3438,7 +3438,7 @@ static void add_firestarter( item *it, std::multimap<int, item *> &firestarters,
     const use_function *usef = it->type->get_use( "firestarter" );
     if( usef != nullptr && usef->get_actor_ptr() != nullptr ) {
         const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
-        if( actor->can_use( you, *it, examp.raw() ).success() ) {
+        if( actor->can_use( you, *it, examp ).success() ) {
             firestarters.insert( std::pair<int, item *>( actor->moves_cost_fast, it ) );
         }
     }
@@ -3517,9 +3517,9 @@ void iexamine::fireplace( Character &you, const tripoint_bub_ms &examp )
                 const use_function *usef = it->type->get_use( "firestarter" );
                 const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
                 you.add_msg_if_player( _( "You attempt to start a fire with your %s…" ), it->tname() );
-                const ret_val<void> can_use = actor->can_use( you, *it, examp.raw() );
+                const ret_val<void> can_use = actor->can_use( you, *it, examp );
                 if( can_use.success() ) {
-                    const int charges = actor->use( &you, *it, examp.raw() ).value_or( 0 );
+                    const int charges = actor->use( &you, *it, examp ).value_or( 0 );
                     you.use_charges( it->typeId(), charges );
                     return;
                 } else {

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -147,7 +147,7 @@ item_action_map item_action_generator::map_actions_to_items( Character &you,
 
             const use_function *func = actual_item->get_use( use );
             if( !( func && func->get_actor_ptr() &&
-                   func->get_actor_ptr()->can_use( you, *actual_item, you.pos() ).success() ) ) {
+                   func->get_actor_ptr()->can_use( you, *actual_item, you.pos_bub() ).success() ) ) {
                 continue;
             }
 
@@ -382,7 +382,7 @@ std::string use_function::get_type() const
     }
 }
 
-ret_val<void> iuse_actor::can_use( const Character &, const item &, const tripoint & ) const
+ret_val<void> iuse_actor::can_use( const Character &, const item &, const tripoint_bub_ms & ) const
 {
     return ret_val<void>::make_success();
 }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1664,7 +1664,7 @@ class iuse_function_wrapper : public iuse_actor
             : iuse_actor( type ), cpp_function( f ) { }
 
         ~iuse_function_wrapper() override = default;
-        std::optional<int> use( Character *p, item &it, const tripoint &pos ) const override {
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override {
             return cpp_function( p, &it, pos );
         }
         std::unique_ptr<iuse_actor> clone() const override {

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -184,9 +184,10 @@ const use_function *itype::get_use( const std::string &iuse_name ) const
 
 int itype::tick( Character *p, item &it, const tripoint &pos ) const
 {
+    const tripoint_bub_ms position{pos}; // TODO: Get rid of this when operation typified
     int charges_to_use = 0;
     for( const auto &method : tick_action ) {
-        charges_to_use += method.second.call( p, it, pos ).value_or( 0 );
+        charges_to_use += method.second.call( p, it, position ).value_or( 0 );
     }
 
     return charges_to_use;
@@ -207,6 +208,7 @@ std::optional<int> itype::invoke( Character *p, item &it, const tripoint &pos ) 
 std::optional<int> itype::invoke( Character *p, item &it, const tripoint &pos,
                                   const std::string &iuse_name ) const
 {
+    const tripoint_bub_ms position{ pos }; // TODO: Get rid of this when operation typified.
     const use_function *use = get_use( iuse_name );
     if( use == nullptr ) {
         debugmsg( "Tried to invoke %s on a %s, which doesn't have this use_function",
@@ -214,7 +216,7 @@ std::optional<int> itype::invoke( Character *p, item &it, const tripoint &pos,
         return 0;
     }
     if( p ) {
-        const auto ret = use->can_call( *p, it, pos );
+        const auto ret = use->can_call( *p, it, position );
 
         if( !ret.success() ) {
             p->add_msg_if_player( m_info, ret.str() );
@@ -222,7 +224,7 @@ std::optional<int> itype::invoke( Character *p, item &it, const tripoint &pos,
         }
     }
 
-    return use->call( p, it, pos );
+    return use->call( p, it, position );
 }
 
 std::string gun_type_type::name() const

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -414,28 +414,29 @@ static std::string format_object_pair( const std::pair<std::string, int> &pair,
 static std::string format_object_pair_article( const std::pair<std::string, int> &pair );
 static std::string format_object_pair_no_article( const std::pair<std::string, int> &pair );
 
-static std::string colorized_field_description_at( const tripoint &point );
-static std::string colorized_trap_name_at( const tripoint &point );
-static std::string colorized_ter_name_flags_at( const tripoint &point,
+static std::string colorized_field_description_at( const tripoint_bub_ms &point );
+static std::string colorized_trap_name_at( const tripoint_bub_ms &point );
+static std::string colorized_ter_name_flags_at( const tripoint_bub_ms &point,
         const std::vector<std::string> &flags = {}, const std::vector<ter_str_id> &ter_whitelist = {} );
-static std::string colorized_feature_description_at( const tripoint &center_point, bool &item_found,
+static std::string colorized_feature_description_at( const tripoint_bub_ms &center_point,
+        bool &item_found,
         const units::volume &min_visible_volume );
 
 static std::string colorized_item_name( const item &item );
 static std::string colorized_item_description( const item &item );
-static item get_top_item_at_point( const tripoint &point,
+static item get_top_item_at_point( const tripoint_bub_ms &point,
                                    const units::volume &min_visible_volume );
 
 static std::string effects_description_for_creature( Creature *creature, std::string &pose,
         const std::string &pronoun_gender );
 
-static object_names_collection enumerate_objects_around_point( const tripoint &point,
-        int radius, const tripoint &bounds_center_point, int bounds_radius,
-        const tripoint &camera_pos, const units::volume &min_visible_volume, bool create_figure_desc,
-        std::unordered_set<tripoint> &ignored_points,
+static object_names_collection enumerate_objects_around_point( const tripoint_bub_ms &point,
+        int radius, const tripoint_bub_ms &bounds_center_point, int bounds_radius,
+        const tripoint_bub_ms &camera_pos, const units::volume &min_visible_volume, bool create_figure_desc,
+        std::unordered_set<tripoint_bub_ms> &ignored_points,
         std::unordered_set<const vehicle *> &vehicles_recorded );
-static item::extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
-        const tripoint &camera_pos,
+static item::extended_photo_def photo_def_for_camera_point( const tripoint_bub_ms &aim_point,
+        const tripoint_bub_ms &camera_pos,
         std::vector<monster *> &monster_vec, std::vector<Character *> &character_vec );
 
 static const std::vector<std::string> camera_ter_whitelist_flags = {
@@ -482,7 +483,7 @@ std::optional<std::string> iuse::can_smoke( const Character &you )
     return std::nullopt;
 }
 
-std::optional<int> iuse::sewage( Character *p, item *, const tripoint & )
+std::optional<int> iuse::sewage( Character *p, item *, const tripoint_bub_ms & )
 {
     if( !p->query_yn( _( "Are you sure you want to drink… this?" ) ) ) {
         return std::nullopt;
@@ -493,13 +494,13 @@ std::optional<int> iuse::sewage( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::honeycomb( Character *p, item *, const tripoint & )
+std::optional<int> iuse::honeycomb( Character *p, item *, const tripoint_bub_ms & )
 {
     get_map().spawn_item( p->pos_bub(), itype_wax, 2 );
     return 1;
 }
 
-std::optional<int> iuse::xanax( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::xanax( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->add_msg_if_player( _( "You take some %s." ), it->tname() );
     p->add_effect( effect_took_xanax, 90_minutes );
@@ -536,17 +537,17 @@ static int alcohol( Character &p, const item &it, const int strength )
     return 1;
 }
 
-std::optional<int> iuse::alcohol_weak( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::alcohol_weak( Character *p, item *it, const tripoint_bub_ms & )
 {
     return alcohol( *p, *it, 0 );
 }
 
-std::optional<int> iuse::alcohol_medium( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::alcohol_medium( Character *p, item *it, const tripoint_bub_ms & )
 {
     return alcohol( *p, *it, 1 );
 }
 
-std::optional<int> iuse::alcohol_strong( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::alcohol_strong( Character *p, item *it, const tripoint_bub_ms & )
 {
     return alcohol( *p, *it, 2 );
 }
@@ -559,7 +560,7 @@ std::optional<int> iuse::alcohol_strong( Character *p, item *it, const tripoint 
  * @param it the item to be smoked.
  * @return Charges used in item smoked
  */
-std::optional<int> iuse::smoking( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::smoking( Character *p, item *it, const tripoint_bub_ms & )
 {
     std::optional<std::string> litcig = can_smoke( *p );
     if( litcig.has_value() ) {
@@ -613,7 +614,7 @@ std::optional<int> iuse::smoking( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::ecig( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::ecig( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( it->typeId() == itype_ecig ) {
         p->add_msg_if_player( m_neutral, _( "You take a puff from your electronic cigarette." ) );
@@ -640,7 +641,7 @@ std::optional<int> iuse::ecig( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::antibiotic( Character *p, item *, const tripoint & )
+std::optional<int> iuse::antibiotic( Character *p, item *, const tripoint_bub_ms & )
 {
     p->add_msg_player_or_npc( m_neutral,
                               _( "You take some antibiotics." ),
@@ -662,7 +663,7 @@ std::optional<int> iuse::antibiotic( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::eyedrops( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::eyedrops( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_underwater() ) {
         return std::nullopt;
@@ -687,7 +688,7 @@ std::optional<int> iuse::eyedrops( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::fungicide( Character *p, item *, const tripoint & )
+std::optional<int> iuse::fungicide( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->cant_do_underwater() ) {
         return std::nullopt;
@@ -744,7 +745,7 @@ std::optional<int> iuse::fungicide( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::antifungal( Character *p, item *, const tripoint & )
+std::optional<int> iuse::antifungal( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->cant_do_underwater() ) {
         return std::nullopt;
@@ -762,7 +763,7 @@ std::optional<int> iuse::antifungal( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::antiparasitic( Character *p, item *, const tripoint & )
+std::optional<int> iuse::antiparasitic( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->cant_do_underwater() ) {
         return std::nullopt;
@@ -811,7 +812,7 @@ std::optional<int> iuse::antiparasitic( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::anticonvulsant( Character *p, item *, const tripoint & )
+std::optional<int> iuse::anticonvulsant( Character *p, item *, const tripoint_bub_ms & )
 {
     p->add_msg_if_player( _( "You take some anticonvulsant medication." ) );
     /** @EFFECT_STR reduces duration of anticonvulsant medication */
@@ -832,7 +833,7 @@ std::optional<int> iuse::anticonvulsant( Character *p, item *, const tripoint & 
     return 1;
 }
 
-std::optional<int> iuse::weed_cake( Character *p, item *, const tripoint & )
+std::optional<int> iuse::weed_cake( Character *p, item *, const tripoint_bub_ms & )
 {
     p->add_msg_if_player(
         _( "You start scarfing down the delicious cake.  It tastes a little funny, though…" ) );
@@ -856,7 +857,7 @@ std::optional<int> iuse::weed_cake( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::coke( Character *p, item *, const tripoint & )
+std::optional<int> iuse::coke( Character *p, item *, const tripoint_bub_ms & )
 {
     p->add_msg_if_player( _( "You snort a bump of coke." ) );
     /** @EFFECT_STR reduces duration of coke */
@@ -872,7 +873,7 @@ std::optional<int> iuse::coke( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::meth( Character *p, item *, const tripoint & )
+std::optional<int> iuse::meth( Character *p, item *, const tripoint_bub_ms & )
 {
     /** @EFFECT_STR reduces duration of meth */
     time_duration duration = 1_minutes * ( 60 - p->str_cur );
@@ -910,7 +911,7 @@ std::optional<int> iuse::meth( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::flu_vaccine( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::flu_vaccine( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->add_msg_if_player( _( "You inject the vaccine." ) );
     time_point expiration_date = it->birthday() + 24_weeks;
@@ -929,7 +930,7 @@ std::optional<int> iuse::flu_vaccine( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::poison( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::poison( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->has_trait( trait_EATDEAD ) ) {
         return 1;
@@ -951,7 +952,7 @@ std::optional<int> iuse::poison( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::meditate( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::meditate( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action meditate that requires character but no character is present",
@@ -970,7 +971,7 @@ std::optional<int> iuse::meditate( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::thorazine( Character *p, item *, const tripoint & )
+std::optional<int> iuse::thorazine( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->has_effect( effect_took_thorazine ) ) {
         p->remove_effect( effect_took_thorazine );
@@ -995,7 +996,7 @@ std::optional<int> iuse::thorazine( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::prozac( Character *p, item *, const tripoint & )
+std::optional<int> iuse::prozac( Character *p, item *, const tripoint_bub_ms & )
 {
     if( !p->has_effect( effect_took_prozac ) ) {
         p->add_effect( effect_took_prozac, 12_hours );
@@ -1010,7 +1011,7 @@ std::optional<int> iuse::prozac( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::datura( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::datura( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_npc() ) {
         return std::nullopt;
@@ -1024,14 +1025,14 @@ std::optional<int> iuse::datura( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::flumed( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::flumed( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->add_effect( effect_took_flumed, 10_hours );
     p->add_msg_if_player( _( "You take some %s." ), it->tname() );
     return 1;
 }
 
-std::optional<int> iuse::flusleep( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::flusleep( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->add_effect( effect_took_flumed, 12_hours );
     p->mod_sleepiness( 30 );
@@ -1040,7 +1041,7 @@ std::optional<int> iuse::flusleep( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::inhaler( Character *p, item *, const tripoint & )
+std::optional<int> iuse::inhaler( Character *p, item *, const tripoint_bub_ms & )
 {
     p->add_msg_player_or_npc( m_neutral, _( "You take a puff from your inhaler." ),
                               _( "<npcname> takes a puff from their inhaler." ) );
@@ -1055,7 +1056,7 @@ std::optional<int> iuse::inhaler( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::oxygen_bottle( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::oxygen_bottle( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->mod_moves( -to_moves<int>( 10_seconds ) );
     p->add_msg_player_or_npc( m_neutral, string_format( _( "You breathe deeply from the %s." ),
@@ -1076,7 +1077,7 @@ std::optional<int> iuse::oxygen_bottle( Character *p, item *it, const tripoint &
     return 1;
 }
 
-std::optional<int> iuse::blech( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::blech( Character *p, item *it, const tripoint_bub_ms & )
 {
     // TODO: Add more effects?
     if( it->made_of( phase_id::LIQUID ) ) {
@@ -1114,7 +1115,7 @@ std::optional<int> iuse::blech( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::blech_because_unclean( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::blech_because_unclean( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p->is_npc() ) {
         if( test_mode ) {
@@ -1135,7 +1136,7 @@ std::optional<int> iuse::blech_because_unclean( Character *p, item *it, const tr
     return 1;
 }
 
-std::optional<int> iuse::plantblech( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::plantblech( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( p->has_trait( trait_THRESH_PLANT ) ) {
         double multiplier = -1;
@@ -1158,7 +1159,7 @@ std::optional<int> iuse::plantblech( Character *p, item *it, const tripoint &pos
     }
 }
 
-std::optional<int> iuse::chew( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::chew( Character *p, item *it, const tripoint_bub_ms & )
 {
     // TODO: Add more effects?
     p->add_msg_if_player( _( "You chew your %s." ), it->tname() );
@@ -1191,7 +1192,7 @@ static void do_purify( Character &p )
     }
 }
 
-std::optional<int> iuse::purify_smart( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::purify_smart( Character *p, item *it, const tripoint_bub_ms & )
 {
     std::vector<trait_id> valid; // Which flags the player has
     std::vector<std::string> valid_names; // Which flags the player has
@@ -1410,7 +1411,7 @@ static bool marloss_prevented( const Character &p )
     return false;
 }
 
-std::optional<int> iuse::marloss( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::marloss( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( marloss_prevented( *p ) ) {
         return std::nullopt;
@@ -1422,7 +1423,7 @@ std::optional<int> iuse::marloss( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::marloss_seed( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::marloss_seed( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !query_yn( _( "Are you sure you want to eat the %s?  You could plant it in a mound of dirt." ),
                    colorize( it->tname(), it->color_in_inventory() ) ) ) {
@@ -1439,7 +1440,7 @@ std::optional<int> iuse::marloss_seed( Character *p, item *it, const tripoint & 
     return 1;
 }
 
-std::optional<int> iuse::marloss_gel( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::marloss_gel( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( marloss_prevented( *p ) ) {
         return std::nullopt;
@@ -1451,7 +1452,7 @@ std::optional<int> iuse::marloss_gel( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::mycus( Character *p, item *, const tripoint & )
+std::optional<int> iuse::mycus( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->is_npc() ) {
         return 1;
@@ -1552,16 +1553,16 @@ std::optional<int> iuse::mycus( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::petfood( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::petfood( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->is_comestible() ) {
         p->add_msg_if_player( _( "You doubt someone would want to eat %1$s." ), it->tname() );
         return std::nullopt;
     }
 
-    const std::optional<tripoint> pnt = choose_adjacent( string_format(
-                                            _( "Tame which animal with %s?" ),
-                                            it->tname() ) );
+    const std::optional<tripoint_bub_ms> pnt = choose_adjacent_bub( string_format(
+                _( "Tame which animal with %s?" ),
+                it->tname() ) );
     if( !pnt ) {
         return std::nullopt;
     }
@@ -1642,7 +1643,7 @@ std::optional<int> iuse::petfood( Character *p, item *it, const tripoint & )
     return std::nullopt;
 }
 
-std::optional<int> iuse::radio_mod( Character *p, item *, const tripoint & )
+std::optional<int> iuse::radio_mod( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->is_npc() ) {
         // Now THAT would be kinda cruel
@@ -1703,7 +1704,7 @@ std::optional<int> iuse::radio_mod( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::remove_all_mods( Character *p, item *, const tripoint & )
+std::optional<int> iuse::remove_all_mods( Character *p, item *, const tripoint_bub_ms & )
 {
     if( !p ) {
         return std::nullopt;
@@ -1739,13 +1740,12 @@ std::optional<int> iuse::remove_all_mods( Character *p, item *, const tripoint &
     return 0;
 }
 
-static bool good_fishing_spot( const tripoint &pos, Character *p )
+static bool good_fishing_spot( const tripoint_bub_ms &pos, Character *p )
 {
-    std::unordered_set<tripoint> fishable_locations = g->get_fishable_locations( 60, pos );
+    std::unordered_set<tripoint> fishable_locations = g->get_fishable_locations( 60, pos.raw() );
     std::vector<monster *> fishables = g->get_fishable_monsters( fishable_locations );
     map &here = get_map();
     // isolated little body of water with no definite fish population
-    // TODO: fix point types
     const oter_id &cur_omt =
         overmap_buffer.ter( coords::project_to<coords::omt>( here.getglobal( pos ) ) );
     std::string om_id = cur_omt.id().c_str();
@@ -1761,7 +1761,7 @@ static bool good_fishing_spot( const tripoint &pos, Character *p )
     return true;
 }
 
-std::optional<int> iuse::fishing_rod( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::fishing_rod( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_npc() ) {
         // Long actions - NPCs don't like those yet.
@@ -1773,7 +1773,7 @@ std::optional<int> iuse::fishing_rod( Character *p, item *it, const tripoint & )
     map &here = get_map();
     std::optional<tripoint_bub_ms> found;
     for( const tripoint_bub_ms &pnt : here.points_in_radius( p->pos_bub(), 1 ) ) {
-        if( here.has_flag( ter_furn_flag::TFLAG_FISHABLE, pnt ) && good_fishing_spot( pnt.raw(), p ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_FISHABLE, pnt ) && good_fishing_spot( pnt, p ) ) {
             found = pnt;
             break;
         }
@@ -1789,7 +1789,7 @@ std::optional<int> iuse::fishing_rod( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::fish_trap( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::fish_trap( Character *p, item *it, const tripoint_bub_ms & )
 {
     map &here = get_map();
     // Handle deploying fish trap.
@@ -1810,17 +1810,17 @@ std::optional<int> iuse::fish_trap( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
 
-    const std::optional<tripoint> pnt_ = choose_adjacent( _( "Put fish trap where?" ) );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Put fish trap where?" ) );
     if( !pnt_ ) {
         return std::nullopt;
     }
-    const tripoint_bub_ms pnt = tripoint_bub_ms( *pnt_ );
+    const tripoint_bub_ms pnt = *pnt_;
 
     if( !here.has_flag( ter_furn_flag::TFLAG_FISHABLE, pnt ) ) {
         p->add_msg_if_player( m_info, _( "You can't fish there!" ) );
         return std::nullopt;
     }
-    if( !good_fishing_spot( pnt.raw(), p ) ) {
+    if( !good_fishing_spot( pnt, p ) ) {
         return std::nullopt;
     }
     it->active = true;
@@ -1834,9 +1834,8 @@ std::optional<int> iuse::fish_trap( Character *p, item *it, const tripoint & )
 
 }
 
-std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_bub_ms &pos )
 {
-    const tripoint_bub_ms position{ pos }; // TODO: Get rid of this when operation typified.
     map &here = get_map();
     // Handle processing fish trap over time.
     if( it->ammo_remaining() == 0 ) {
@@ -1846,7 +1845,7 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint 
     if( it->age() > 3_hours ) {
         it->active = false;
 
-        if( !here.has_flag( ter_furn_flag::TFLAG_FISHABLE, position ) ) {
+        if( !here.has_flag( ter_furn_flag::TFLAG_FISHABLE, pos ) ) {
             return 0;
         }
 
@@ -1878,14 +1877,14 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint 
         }
 
         if( fishes == 0 ) {
-            it->ammo_consume( it->ammo_remaining(), position, nullptr );
+            it->ammo_consume( it->ammo_remaining(), pos, nullptr );
             player.practice( skill_survival, rng( 5, 15 ) );
 
             return 0;
         }
 
         //get the fishables around the trap's spot
-        std::unordered_set<tripoint> fishable_locations = g->get_fishable_locations( 60, position.raw() );
+        std::unordered_set<tripoint> fishable_locations = g->get_fishable_locations( 60, pos.raw() );
         std::vector<monster *> fishables = g->get_fishable_monsters( fishable_locations );
         for( int i = 0; i < fishes; i++ ) {
             player.practice( skill_survival, rng( 3, 10 ) );
@@ -1894,9 +1893,9 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint 
                 // reduce the abstract fish_population marker of that fish
                 chosen_fish->fish_population -= 1;
                 if( chosen_fish->fish_population <= 0 ) {
-                    g->catch_a_monster( chosen_fish, position.raw(), p, 300_hours ); //catch the fish!
+                    g->catch_a_monster( chosen_fish, pos.raw(), p, 300_hours ); //catch the fish!
                 } else {
-                    here.add_item_or_charges( position, item::make_corpse( chosen_fish->type->id,
+                    here.add_item_or_charges( pos, item::make_corpse( chosen_fish->type->id,
                                               calendar::turn + rng( 0_turns,
                                                       3_hours ) ) );
                 }
@@ -1913,29 +1912,29 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint 
                     //but it's not as comfortable as if you just put fishes in the same tile with the trap.
                     //Also: corpses and comestibles do not rot in containers like this, but on the ground they will rot.
                     //we don't know when it was caught so use a random turn
-                    here.add_item_or_charges( position, item::make_corpse( fish_mon, it->birthday() + rng( 0_turns,
+                    here.add_item_or_charges( pos, item::make_corpse( fish_mon, it->birthday() + rng( 0_turns,
                                               3_hours ) ) );
                     break; //this can happen only once
                 }
             }
         }
-        it->ammo_consume( bait_consumed, position, nullptr );
+        it->ammo_consume( bait_consumed, pos, nullptr );
     }
     return 0;
 }
 
-std::optional<int> iuse::extinguisher( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::extinguisher( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
     // If anyone other than the player wants to use one of these,
     // they're going to need to figure out how to aim it.
-    const std::optional<tripoint> dest_ = choose_adjacent( _( "Spray where?" ) );
+    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent_bub( _( "Spray where?" ) );
     if( !dest_ ) {
         return std::nullopt;
     }
-    tripoint_bub_ms dest = tripoint_bub_ms( *dest_ );
+    tripoint_bub_ms dest = *dest_;
 
     p->mod_moves( -to_moves<int>( 2_seconds ) );
 
@@ -2301,18 +2300,18 @@ class exosuit_interact
         }
 };
 
-std::optional<int> iuse::mace( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::mace( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
     // If anyone other than the player wants to use one of these,
     // they're going to need to figure out how to aim it.
-    const std::optional<tripoint> dest_ = choose_adjacent( _( "Spray where?" ) );
+    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent_bub( _( "Spray where?" ) );
     if( !dest_ ) {
         return std::nullopt;
     }
-    tripoint_bub_ms dest = tripoint_bub_ms( *dest_ );
+    tripoint_bub_ms dest = *dest_;
 
     p->mod_moves( -to_moves<int>( 2_seconds ) );
 
@@ -2345,7 +2344,7 @@ std::optional<int> iuse::mace( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::manage_exosuit( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::manage_exosuit( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p->is_avatar() ) {
         return std::nullopt;
@@ -2358,7 +2357,7 @@ std::optional<int> iuse::manage_exosuit( Character *p, item *it, const tripoint 
     return 0;
 }
 
-std::optional<int> iuse::unpack_item( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::unpack_item( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_underwater() ) {
         return std::nullopt;
@@ -2372,7 +2371,7 @@ std::optional<int> iuse::unpack_item( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::pack_cbm( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::pack_cbm( Character *p, item *it, const tripoint_bub_ms & )
 {
     item_location bionic = g->inv_map_splice( []( const item & e ) {
         return e.is_bionic() && e.has_flag( flag_NO_PACKED );
@@ -2403,7 +2402,7 @@ std::optional<int> iuse::pack_cbm( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::pack_item( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::pack_item( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action pack_item that requires character but no character is present",
@@ -2433,7 +2432,7 @@ std::optional<int> iuse::pack_item( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::water_purifier( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::water_purifier( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -2523,7 +2522,7 @@ std::optional<int> iuse::purify_water( Character *p, item *purifier, item_locati
     return std::nullopt;
 }
 
-std::optional<int> iuse::water_tablets( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::water_tablets( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -2544,7 +2543,7 @@ std::optional<int> iuse::water_tablets( Character *p, item *it, const tripoint &
     return purify_water( p, it, obj );
 }
 
-std::optional<int> iuse::radio_off( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::radio_off( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->ammo_sufficient( p ) ) {
         p->add_msg_if_player( _( "It's dead." ) );
@@ -2555,7 +2554,7 @@ std::optional<int> iuse::radio_off( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::directional_antenna( Character *p, item *, const tripoint & )
+std::optional<int> iuse::directional_antenna( Character *p, item *, const tripoint_bub_ms & )
 {
     // Find out if we have an active radio
     auto radios = p->cache_get_items_with( itype_radio_on );
@@ -2610,7 +2609,7 @@ static int radio_static_chance( const radio_tower_reference &tref )
                  ( max_strength - RADIO_MIN_STRENGTH ) );
 }
 
-std::optional<int> iuse::radio_tick( Character *, item *it, const tripoint &pos )
+std::optional<int> iuse::radio_tick( Character *, item *it, const tripoint_bub_ms &pos )
 {
     std::string message = _( "Radio: Kssssssssssssh." );
     const radio_tower_reference tref = overmap_buffer.find_radio_station( it->frequency );
@@ -2664,7 +2663,7 @@ std::optional<int> iuse::radio_tick( Character *, item *it, const tripoint &pos 
     return 1;
 }
 
-std::optional<int> iuse::radio_on( Character *, item *it, const tripoint & )
+std::optional<int> iuse::radio_on( Character *, item *it, const tripoint_bub_ms & )
 {
 
     const auto tower_desc = []( const int noise ) {
@@ -2713,14 +2712,14 @@ std::optional<int> iuse::radio_on( Character *, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::noise_emitter_on( Character *, item *, const tripoint &pos )
+std::optional<int> iuse::noise_emitter_on( Character *, item *, const tripoint_bub_ms &pos )
 {
     sounds::sound( pos, 30, sounds::sound_t::alarm, _( "KXSHHHHRRCRKLKKK!" ), true, "tool",
                    "noise_emitter" );
     return 1;
 }
 
-std::optional<int> iuse::emf_passive_on( Character *, item *, const tripoint &pos )
+std::optional<int> iuse::emf_passive_on( Character *, item *, const tripoint_bub_ms &pos )
 {
     // need to calculate distance to closest electrical thing
 
@@ -2738,7 +2737,7 @@ std::optional<int> iuse::emf_passive_on( Character *, item *, const tripoint &po
         return 1;
     }
 
-    for( const tripoint &loc : closest_points_first( pos, max ) ) {
+    for( const tripoint_bub_ms &loc : closest_points_first( pos, max ) ) {
         const Creature *critter = creatures.creature_at( loc );
 
         // if the creature exists and is either a robot or electric
@@ -2774,7 +2773,7 @@ std::optional<int> iuse::emf_passive_on( Character *, item *, const tripoint &po
     return 1;
 }
 
-std::optional<int> iuse::ma_manual( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::ma_manual( Character *p, item *it, const tripoint_bub_ms & )
 {
     // [CR] - should NPCs just be allowed to learn this stuff? Just like that?
 
@@ -2791,12 +2790,12 @@ std::optional<int> iuse::ma_manual( Character *p, item *it, const tripoint & )
 }
 
 // TODO: Why does this exist?
-std::optional<int> iuse::crowbar_weak( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::crowbar_weak( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     return iuse::crowbar( p, it, pos );
 }
 
-std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -2815,8 +2814,8 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint &pos )
         return false;
     };
 
-    const std::optional<tripoint_bub_ms> pnt_ = ( pos != p->pos_bub().raw() ) ? tripoint_bub_ms(
-                pos ) : choose_adjacent_highlight(
+    const std::optional<tripoint_bub_ms> pnt_ = ( pos != p->pos_bub() ) ?
+            pos : choose_adjacent_highlight(
                 _( "Pry where?" ), _( "There is nothing to pry nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
@@ -2872,7 +2871,7 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint &pos )
     return std::nullopt;
 }
 
-std::optional<int> iuse::makemound( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::makemound( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action makemound that requires character but no character is present",
@@ -2882,13 +2881,13 @@ std::optional<int> iuse::makemound( Character *p, item *it, const tripoint & )
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    const std::optional<tripoint> pnt_ = choose_adjacent( _( "Till soil where?" ) );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Till soil where?" ) );
     if( !pnt_ ) {
         return std::nullopt;
     }
-    const tripoint pnt = *pnt_;
+    const tripoint_bub_ms pnt = *pnt_;
 
-    if( pnt == p->pos() ) {
+    if( pnt == p->pos_bub() ) {
         p->add_msg_if_player( m_info,
                               _( "You think about jumping on a shovel, but then change your mind." ) );
         return std::nullopt;
@@ -2907,7 +2906,7 @@ std::optional<int> iuse::makemound( Character *p, item *it, const tripoint & )
     }
 }
 
-std::optional<int> iuse::dig( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::dig( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action dig that requires character but no character is present",
@@ -2931,7 +2930,7 @@ std::optional<int> iuse::dig( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::dig_channel( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::dig_channel( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action dig_channel that requires character but no character is present",
@@ -2951,7 +2950,7 @@ std::optional<int> iuse::dig_channel( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::fill_pit( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::fill_pit( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action fill_pit that requires character but no character is present",
@@ -2971,7 +2970,7 @@ std::optional<int> iuse::fill_pit( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::clear_rubble( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::clear_rubble( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action clear_rubble that requires character but no character is present",
@@ -2991,13 +2990,13 @@ std::optional<int> iuse::clear_rubble( Character *p, item *it, const tripoint & 
     return 0;
 }
 
-std::optional<int> iuse::siphon( Character *p, item *, const tripoint & )
+std::optional<int> iuse::siphon( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     map &here = get_map();
-    const std::function<bool( const tripoint & )> f = [&here]( const tripoint & pnt ) {
+    const std::function<bool( const tripoint_bub_ms & )> f = [&here]( const tripoint_bub_ms & pnt ) {
         const optional_vpart_position vp = here.veh_at( pnt );
         return !!vp;
     };
@@ -3022,8 +3021,8 @@ std::optional<int> iuse::siphon( Character *p, item *, const tripoint & )
         }
     }
     if( found_more_than_one ) {
-        std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-                                           _( "Siphon from where?" ), _( "There is nothing to siphon from nearby." ), f, false );
+        std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Siphon from where?" ), _( "There is nothing to siphon from nearby." ), f, false );
         if( !pnt_ ) {
             return std::nullopt;
         }
@@ -3041,7 +3040,7 @@ std::optional<int> iuse::siphon( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::change_eyes( Character *p, item *, const tripoint & )
+std::optional<int> iuse::change_eyes( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->is_avatar() ) {
         p->customize_appearance( customize_appearance_choice::EYES );
@@ -3049,7 +3048,7 @@ std::optional<int> iuse::change_eyes( Character *p, item *, const tripoint & )
     return std::nullopt;
 }
 
-std::optional<int> iuse::change_skin( Character *p, item *, const tripoint & )
+std::optional<int> iuse::change_skin( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->is_avatar() ) {
         p->customize_appearance( customize_appearance_choice::SKIN );
@@ -3057,7 +3056,7 @@ std::optional<int> iuse::change_skin( Character *p, item *, const tripoint & )
     return std::nullopt;
 }
 
-static std::optional<int> dig_tool( Character *p, item *it, const tripoint &pos,
+static std::optional<int> dig_tool( Character *p, item *it, const tripoint_bub_ms &pos,
                                     const activity_id activity,
                                     const std::string &prompt, const std::string &fail, const std::string &success,
                                     int extra_moves = 0 )
@@ -3075,12 +3074,12 @@ static std::optional<int> dig_tool( Character *p, item *it, const tripoint &pos,
     }
 
     tripoint_bub_ms pnt( pos );
-    if( pos == p->pos_bub().raw() ) {
-        const std::optional<tripoint> pnt_ = choose_adjacent( prompt );
+    if( pos == p->pos_bub() ) {
+        const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( prompt );
         if( !pnt_ ) {
             return std::nullopt;
         }
-        pnt = tripoint_bub_ms( *pnt_ );
+        pnt = *pnt_;
     }
 
     map &here = get_map();
@@ -3129,7 +3128,7 @@ static std::optional<int> dig_tool( Character *p, item *it, const tripoint &pos,
     return 0; // handled when the activity finishes
 }
 
-std::optional<int> iuse::jackhammer( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::jackhammer( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     // use has_enough_charges to check for UPS availability
     // p is assumed to exist for iuse cases
@@ -3143,7 +3142,7 @@ std::optional<int> iuse::jackhammer( Character *p, item *it, const tripoint &pos
 
 }
 
-std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( p->is_npc() ) {
         return std::nullopt;
@@ -3152,10 +3151,10 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint &pos 
 
     std::optional<tripoint_bub_ms> target;
     // Prompt for a target lock to pick, or use the given tripoint
-    if( pos == you.pos() ) {
+    if( pos == you.pos_bub() ) {
         target = lockpick_activity_actor::select_location( you );
     } else {
-        target = tripoint_bub_ms( pos );
+        target = pos;
     }
     if( !target.has_value() ) {
         return std::nullopt;
@@ -3190,7 +3189,7 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint &pos 
     return 1;
 }
 
-std::optional<int> iuse::pickaxe( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::pickaxe( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( p->is_npc() ) {
         // Long action
@@ -3205,7 +3204,7 @@ std::optional<int> iuse::pickaxe( Character *p, item *it, const tripoint &pos )
 
 }
 
-std::optional<int> iuse::geiger( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::geiger( Character *p, item *it, const tripoint_bub_ms & )
 {
     int ch = uilist( _( "Geiger counter:" ), {
         _( "Scan yourself or other person" ), _( "Scan the ground" ), _( "Turn continuous scan on" )
@@ -3213,17 +3212,17 @@ std::optional<int> iuse::geiger( Character *p, item *it, const tripoint & )
     creature_tracker &creatures = get_creature_tracker();
     switch( ch ) {
         case 0: {
-            const std::function<bool( const tripoint & )> f = [&]( const tripoint & pnt ) {
+            const std::function<bool( const tripoint_bub_ms & )> f = [&]( const tripoint_bub_ms & pnt ) {
                 return creatures.creature_at<Character>( pnt ) != nullptr;
             };
 
-            const std::optional<tripoint> pnt_ = choose_adjacent_highlight( _( "Scan whom?" ),
-                                                 _( "There is no one to scan nearby." ), f, false );
+            const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight( _( "Scan whom?" ),
+                    _( "There is no one to scan nearby." ), f, false );
             if( !pnt_ ) {
                 return std::nullopt;
             }
-            const tripoint &pnt = *pnt_;
-            if( pnt == p->pos() ) {
+            const tripoint_bub_ms &pnt = *pnt_;
+            if( pnt == p->pos_bub() ) {
                 p->add_msg_if_player( m_info, _( "Your radiation level: %d mSv (%d mSv from items)" ), p->get_rad(),
                                       static_cast<int>( p->get_leak_level() ) );
                 break;
@@ -3252,7 +3251,7 @@ std::optional<int> iuse::geiger( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::geiger_active( Character *, item *, const tripoint &pos )
+std::optional<int> iuse::geiger_active( Character *, item *, const tripoint_bub_ms &pos )
 {
     const int rads = get_map().get_radiation( pos );
     if( rads == 0 ) {
@@ -3264,7 +3263,7 @@ std::optional<int> iuse::geiger_active( Character *, item *, const tripoint &pos
                             rads > 25 ? _( "geiger_medium" ) : _( "geiger_low" );
 
     sounds::sound( pos, 6, sounds::sound_t::alarm, description, true, "tool", sound_var );
-    if( !get_avatar().can_hear( pos, 6 ) ) {
+    if( !get_avatar().can_hear( pos.raw(), 6 ) ) {
         // can not hear it, but may have alarmed other creatures
         return 1;
     }
@@ -3286,7 +3285,7 @@ std::optional<int> iuse::geiger_active( Character *, item *, const tripoint &pos
     return 1;
 }
 
-std::optional<int> iuse::teleport( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::teleport( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_npc() ) {
         // That would be evil
@@ -3303,7 +3302,7 @@ std::optional<int> iuse::teleport( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::can_goo( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::can_goo( Character *p, item *it, const tripoint_bub_ms & )
 {
     it->convert( itype_canister_empty );
     int tries = 0;
@@ -3353,9 +3352,9 @@ std::optional<int> iuse::can_goo( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::granade_act( Character *, item *it, const tripoint &pos )
+std::optional<int> iuse::granade_act( Character *, item *it, const tripoint_bub_ms &pos )
 {
-    if( pos.x == -999 || pos.y == -999 ) {
+    if( pos.x() == -999 || pos.y() == -999 ) {
         return std::nullopt;
     }
     map &here = get_map();
@@ -3373,7 +3372,7 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint &pos
             sounds::sound( pos, 100, sounds::sound_t::electronic_speech, _( "BUGFIXES!" ),
                            true, "speech", it->typeId().str() );
             explosion_handler::draw_explosion( pos, explosion_radius, c_light_cyan );
-            for( const tripoint &dest : here.points_in_radius( pos, explosion_radius ) ) {
+            for( const tripoint_bub_ms &dest : here.points_in_radius( pos, explosion_radius ) ) {
                 monster *const mon = creatures.creature_at<monster>( dest, true );
                 if( mon && ( mon->type->in_species( species_INSECT ) || mon->is_hallucination() ) ) {
                     mon->die_in_explosion( nullptr );
@@ -3385,7 +3384,7 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint &pos
             sounds::sound( pos, 100, sounds::sound_t::electronic_speech, _( "BUFFS!" ),
                            true, "speech", it->typeId().str() );
             explosion_handler::draw_explosion( pos, explosion_radius, c_green );
-            for( const tripoint &dest : here.points_in_radius( pos, explosion_radius ) ) {
+            for( const tripoint_bub_ms &dest : here.points_in_radius( pos, explosion_radius ) ) {
                 if( monster *const mon_ptr = creatures.creature_at<monster>( dest ) ) {
                     monster &critter = *mon_ptr;
                     critter.set_speed_base(
@@ -3400,7 +3399,7 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint &pos
                     buff_stat( person->int_max, rng( 0, person->int_max / 2 ) );
                     /** @EFFECT_PER_MAX increases possible granade per buff for NPCs */
                     buff_stat( person->per_max, rng( 0, person->per_max / 2 ) );
-                } else if( player_character.pos() == dest ) {
+                } else if( player_character.pos_bub() == dest ) {
                     /** @EFFECT_STR_MAX increases possible granade str buff */
                     buff_stat( player_character.str_max, rng( 0, player_character.str_max / 2 ) );
                     /** @EFFECT_DEX_MAX increases possible granade dex buff */
@@ -3427,7 +3426,7 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint &pos
             sounds::sound( pos, 100, sounds::sound_t::electronic_speech, _( "NERFS!" ),
                            true, "speech", it->typeId().str() );
             explosion_handler::draw_explosion( pos, explosion_radius, c_red );
-            for( const tripoint &dest : here.points_in_radius( pos, explosion_radius ) ) {
+            for( const tripoint_bub_ms &dest : here.points_in_radius( pos, explosion_radius ) ) {
                 if( monster *const mon_ptr = creatures.creature_at<monster>( dest ) ) {
                     monster &critter = *mon_ptr;
                     critter.set_speed_base(
@@ -3442,7 +3441,7 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint &pos
                     person->int_max -= rng( 0, person->int_max / 2 );
                     /** @EFFECT_PER_MAX increases possible granade per debuff for NPCs (NEGATIVE) */
                     person->per_max -= rng( 0, person->per_max / 2 );
-                } else if( player_character.pos() == dest ) {
+                } else if( player_character.pos_bub() == dest ) {
                     /** @EFFECT_STR_MAX increases possible granade str debuff (NEGATIVE) */
                     player_character.str_max -= rng( 0, player_character.str_max / 2 );
                     /** @EFFECT_DEX_MAX increases possible granade dex debuff (NEGATIVE) */
@@ -3467,7 +3466,7 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint &pos
             sounds::sound( pos, 100, sounds::sound_t::electronic_speech, _( "REVERTS!" ),
                            true, "speech", it->typeId().str() );
             explosion_handler::draw_explosion( pos, explosion_radius, c_pink );
-            for( const tripoint &dest : here.points_in_radius( pos, explosion_radius ) ) {
+            for( const tripoint_bub_ms &dest : here.points_in_radius( pos, explosion_radius ) ) {
                 if( monster *const mon_ptr = creatures.creature_at<monster>( dest ) ) {
                     monster &critter = *mon_ptr;
                     critter.set_speed_base( critter.type->speed );
@@ -3475,7 +3474,7 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint &pos
                     critter.clear_effects();
                 } else if( npc *const person = creatures.creature_at<npc>( dest ) ) {
                     person->environmental_revert_effect();
-                } else if( player_character.pos() == dest ) {
+                } else if( player_character.pos_bub() == dest ) {
                     player_character.environmental_revert_effect();
                     do_purify( player_character );
                 }
@@ -3485,7 +3484,7 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint &pos
     return 1;
 }
 
-std::optional<int> iuse::c4( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::c4( Character *p, item *it, const tripoint_bub_ms & )
 {
     int time = 0;
     bool got_value = false;
@@ -3509,12 +3508,12 @@ std::optional<int> iuse::c4( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::acidbomb_act( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::acidbomb_act( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( !p ) {
         it->charges = -1;
         map &here = get_map();
-        for( const tripoint_bub_ms &tmp : here.points_in_radius( tripoint_bub_ms( pos ), 1 ) ) {
+        for( const tripoint_bub_ms &tmp : here.points_in_radius( pos, 1 ) ) {
             here.add_field( tmp, fd_acid, 3 );
         }
         return 1;
@@ -3522,23 +3521,23 @@ std::optional<int> iuse::acidbomb_act( Character *p, item *it, const tripoint &p
     return std::nullopt;
 }
 
-std::optional<int> iuse::grenade_inc_act( Character *p, item *, const tripoint &pos )
+std::optional<int> iuse::grenade_inc_act( Character *p, item *, const tripoint_bub_ms &pos )
 {
-    if( pos.x == -999 || pos.y == -999 ) {
+    if( pos.x() == -999 || pos.y() == -999 ) {
         return std::nullopt;
     }
 
     map &here = get_map();
     int num_flames = rng( 3, 5 );
     for( int current_flame = 0; current_flame < num_flames; current_flame++ ) {
-        tripoint_bub_ms dest( tripoint_bub_ms( pos ) + point( rng( -5, 5 ), rng( -5, 5 ) ) );
-        std::vector<tripoint_bub_ms> flames = line_to( tripoint_bub_ms( pos ), dest, 0, 0 );
+        tripoint_bub_ms dest( pos + point( rng( -5, 5 ), rng( -5, 5 ) ) );
+        std::vector<tripoint_bub_ms> flames = line_to( pos, dest, 0, 0 );
         for( tripoint_bub_ms &flame : flames ) {
             here.add_field( flame, fd_fire, rng( 0, 2 ) );
         }
     }
-    explosion_handler::explosion( p, pos, 8, 0.8, true );
-    for( const tripoint_bub_ms &dest : here.points_in_radius( tripoint_bub_ms( pos ), 2 ) ) {
+    explosion_handler::explosion( p, pos.raw(), 8, 0.8, true );
+    for( const tripoint_bub_ms &dest : here.points_in_radius( pos, 2 ) ) {
         here.add_field( dest, fd_incendiary, 3 );
     }
 
@@ -3551,13 +3550,13 @@ std::optional<int> iuse::grenade_inc_act( Character *p, item *, const tripoint &
     return 0;
 }
 
-std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub_ms &pos )
 {
 
     if( !p ) {
         // It was thrown or dropped, so burst into flames
         map &here = get_map();
-        for( const tripoint_bub_ms &pt : here.points_in_radius( tripoint_bub_ms( pos ), 1, 0 ) ) {
+        for( const tripoint_bub_ms &pt : here.points_in_radius( pos, 1, 0 ) ) {
             const int intensity = 1 + one_in( 3 ) + one_in( 5 );
             here.add_field( pt, fd_fire, intensity );
         }
@@ -3578,7 +3577,7 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint &po
     return 0;
 }
 
-std::optional<int> iuse::firecracker_pack( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::firecracker_pack( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_underwater() ) {
         return std::nullopt;
@@ -3595,7 +3594,7 @@ std::optional<int> iuse::firecracker_pack( Character *p, item *it, const tripoin
     return 0; // don't use any charges at all. it has became a new item
 }
 
-std::optional<int> iuse::firecracker_pack_act( Character *, item *it, const tripoint &pos )
+std::optional<int> iuse::firecracker_pack_act( Character *, item *it, const tripoint_bub_ms &pos )
 {
     // Two seconds of lit fuse burning
     // Followed by random number of explosions (4-6) per turn until 25 epxlosions have happened
@@ -3615,7 +3614,7 @@ std::optional<int> iuse::firecracker_pack_act( Character *, item *it, const trip
     return 0;
 }
 
-std::optional<int> iuse::firecracker( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::firecracker( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_underwater() ) {
         return std::nullopt;
@@ -3631,7 +3630,7 @@ std::optional<int> iuse::firecracker( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::mininuke( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::mininuke( Character *p, item *it, const tripoint_bub_ms & )
 {
     int time;
     bool got_value = query_int( time, _( "Set the timer to ___ turns (0 to cancel)?" ) );
@@ -3648,7 +3647,7 @@ std::optional<int> iuse::mininuke( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::portal( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::portal( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
@@ -3661,22 +3660,22 @@ std::optional<int> iuse::portal( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::tazer( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::tazer( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
 
-    tripoint pnt = pos;
-    if( pos == p->pos() ) {
-        const std::optional<tripoint> pnt_ = choose_adjacent( _( "Shock where?" ) );
+    tripoint_bub_ms pnt = pos;
+    if( pos == p->pos_bub() ) {
+        const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Shock where?" ) );
         if( !pnt_ ) {
             return std::nullopt;
         }
         pnt = *pnt_;
     }
 
-    if( pnt == p->pos() ) {
+    if( pnt == p->pos_bub() ) {
         p->add_msg_if_player( m_info, _( "Umm.  No." ) );
         return std::nullopt;
     }
@@ -3734,7 +3733,7 @@ std::optional<int> iuse::tazer( Character *p, item *it, const tripoint &pos )
     return 1;
 }
 
-std::optional<int> iuse::tazer2( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::tazer2( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( it->ammo_remaining( p, true ) >= 2 ) {
         // Instead of having a ctrl+c+v of the function above, spawn a fake tazer and use it
@@ -3749,7 +3748,7 @@ std::optional<int> iuse::tazer2( Character *p, item *it, const tripoint &pos )
     return std::nullopt;
 }
 
-std::optional<int> iuse::shocktonfa_off( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::shocktonfa_off( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( !p ) {
         debugmsg( "%s called action shocktonfa_off that requires character but no character is present",
@@ -3777,7 +3776,7 @@ std::optional<int> iuse::shocktonfa_off( Character *p, item *it, const tripoint 
     return 0;
 }
 
-std::optional<int> iuse::shocktonfa_on( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::shocktonfa_on( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( !p ) { // Effects while simply on
         debugmsg( "%s called action shocktonfa_on that requires character but no character is present",
@@ -3805,7 +3804,7 @@ std::optional<int> iuse::shocktonfa_on( Character *p, item *it, const tripoint &
     return 0;
 }
 
-std::optional<int> iuse::mp3( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::mp3( Character *p, item *it, const tripoint_bub_ms & )
 {
     // TODO: avoid item id hardcoding to make this function usable for pure json-defined devices.
     if( !it->ammo_sufficient( p ) ) {
@@ -3860,13 +3859,13 @@ static std::string get_music_description()
     return _( "a sweet guitar solo!" );
 }
 
-void iuse::play_music( Character *p, const tripoint &source, const int volume,
+void iuse::play_music( Character *p, const tripoint_bub_ms &source, const int volume,
                        const int max_morale, bool play_sounds )
 {
     std::string sound = "music";
 
     auto lambda_should_do_effects = [&source, &volume]( Character * p ) {
-        return p && p->can_hear( source, volume ) && !p->in_sleep_state();
+        return p && p->can_hear( source.raw(), volume ) && !p->in_sleep_state();
     };
 
     auto lambda_add_music_effects = [&max_morale, &volume]( Character & guy ) {
@@ -3898,7 +3897,7 @@ void iuse::play_music( Character *p, const tripoint &source, const int volume,
         if( !music.empty() ) {
             sound = music;
             // descriptions aren't printed for sounds at our position
-            if( lambda_should_do_effects( p ) && p->pos() == source ) {
+            if( lambda_should_do_effects( p ) && p->pos_bub() == source ) {
                 p->add_msg_if_player( _( "You listen to %s" ), music );
             }
         }
@@ -3909,7 +3908,7 @@ void iuse::play_music( Character *p, const tripoint &source, const int volume,
     }
 }
 
-std::optional<int> iuse::mp3_on( Character *p, item *, const tripoint &pos )
+std::optional<int> iuse::mp3_on( Character *p, item *, const tripoint_bub_ms &pos )
 {
     // mp3 player in inventory, we can listen
     play_music( p, pos, 0, 20 );
@@ -3917,7 +3916,7 @@ std::optional<int> iuse::mp3_on( Character *p, item *, const tripoint &pos )
     return 1;
 }
 
-std::optional<int> iuse::mp3_deactivate( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::mp3_deactivate( Character *p, item *it, const tripoint_bub_ms & )
 {
 
     if( it->typeId() == itype_mp3_on ) {
@@ -3940,7 +3939,7 @@ std::optional<int> iuse::mp3_deactivate( Character *p, item *it, const tripoint 
 
 }
 
-std::optional<int> iuse::rpgdie( Character *you, item *die, const tripoint & )
+std::optional<int> iuse::rpgdie( Character *you, item *die, const tripoint_bub_ms & )
 {
     if( you->cant_do_mounted() ) {
         return std::nullopt;
@@ -3962,7 +3961,7 @@ std::optional<int> iuse::rpgdie( Character *you, item *die, const tripoint & )
     return roll;
 }
 
-std::optional<int> iuse::dive_tank( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::dive_tank( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p && p->is_worn( *it ) ) {
         if( p->is_underwater() && p->oxygen < 10 ) {
@@ -3984,7 +3983,7 @@ std::optional<int> iuse::dive_tank( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::dive_tank_activate( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::dive_tank_activate( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( it->ammo_remaining() == 0 ) {
         p->add_msg_if_player( _( "Your %s is empty." ), it->tname() );
@@ -4004,7 +4003,7 @@ std::optional<int> iuse::dive_tank_activate( Character *p, item *it, const tripo
     return 1;
 }
 
-std::optional<int> iuse::solarpack( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::solarpack( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action solarpack that requires character but no character is present",
@@ -4038,7 +4037,7 @@ std::optional<int> iuse::solarpack( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action solarpack_off that requires character but no character is present",
@@ -4060,7 +4059,7 @@ std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint &
     return 0;
 }
 
-std::optional<int> iuse::gasmask_activate( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::gasmask_activate( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( it->ammo_remaining() == 0 ) {
         p->add_msg_if_player( _( "Your %s doesn't have a filter." ), it->tname() );
@@ -4073,12 +4072,11 @@ std::optional<int> iuse::gasmask_activate( Character *p, item *it, const tripoin
     return 0;
 }
 
-std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint_bub_ms &pos )
 {
-    const tripoint_bub_ms position{pos}; // TODO: Get rid of this when operation typified.
     if( p && p->is_worn( *it ) ) {
         // calculate amount of absorbed gas per filter charge
-        const field &gasfield = get_map().field_at( position );
+        const field &gasfield = get_map().field_at( pos );
         for( const auto &dfield : gasfield ) {
             const field_entry &entry = dfield.second;
             int gas_abs_factor = to_turns<int>( entry.get_field_type()->gas_absorption_factor );
@@ -4099,7 +4097,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
             }
         }
         if( it->get_var( "gas_absorbed", 0 ) >= 60 ) {
-            it->ammo_consume( 1, position, p );
+            it->ammo_consume( 1, pos, p );
             it->set_var( "gas_absorbed", 0 );
             if( it->ammo_remaining() < 10 ) {
                 p->add_msg_player_or_npc(
@@ -4125,7 +4123,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
     return 0;
 }
 
-std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_npc() ) {
         // Long action
@@ -4266,7 +4264,7 @@ std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint &
     return 0;
 }
 
-std::optional<int> iuse::fitness_check( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::fitness_check( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->has_trait( trait_ILLITERATE ) ) {
         p->add_msg_if_player( m_info, _( "You don't know what you're looking at." ) );
@@ -4317,7 +4315,7 @@ std::optional<int> iuse::fitness_check( Character *p, item *it, const tripoint &
     return 1;
 }
 
-std::optional<int> iuse::hand_crank( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::hand_crank( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_npc() ) {
         // Long action
@@ -4351,7 +4349,7 @@ std::optional<int> iuse::hand_crank( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::vibe( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::vibe( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_npc() ) {
         // Long action
@@ -4391,9 +4389,9 @@ std::optional<int> iuse::vibe( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::vortex( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::vortex( Character *p, item *it, const tripoint_bub_ms & )
 {
-    std::vector<point> spawn;
+    std::vector<point_bub_ms> spawn;
     spawn.reserve( 28 );
     for( int i = -3; i <= 3; i++ ) {
         spawn.emplace_back( -3, i );
@@ -4403,7 +4401,7 @@ std::optional<int> iuse::vortex( Character *p, item *it, const tripoint & )
     }
 
     while( !spawn.empty() ) {
-        const tripoint offset( random_entry_removed( spawn ), 0 );
+        const tripoint_bub_ms offset( random_entry_removed( spawn ), 0 );
         monster *const mon = g->place_critter_at( mon_vortex, offset + p->pos() );
         if( !mon ) {
             continue;
@@ -4420,7 +4418,7 @@ std::optional<int> iuse::vortex( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::dog_whistle( Character *p, item *, const tripoint & )
+std::optional<int> iuse::dog_whistle( Character *p, item *, const tripoint_bub_ms & )
 {
     if( !p->is_avatar() ) {
         return std::nullopt;
@@ -4480,7 +4478,7 @@ std::optional<int> iuse::dog_whistle( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::call_of_tindalos( Character *p, item *, const tripoint & )
+std::optional<int> iuse::call_of_tindalos( Character *p, item *, const tripoint_bub_ms & )
 {
     map &here = get_map();
     for( const tripoint_bub_ms &dest : here.points_in_radius( p->pos_bub(), 12 ) ) {
@@ -4492,7 +4490,7 @@ std::optional<int> iuse::call_of_tindalos( Character *p, item *, const tripoint 
     return 1;
 }
 
-std::optional<int> iuse::blood_draw( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::blood_draw( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_npc() ) {
         return std::nullopt;    // No NPCs for now!
@@ -4595,7 +4593,7 @@ void iuse::cut_log_into_planks( Character &p )
     p.activity.placement = get_map().getglobal( p.pos_bub() );
 }
 
-std::optional<int> iuse::lumber( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::lumber( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action lumber that requires character but no character is present",
@@ -4648,7 +4646,7 @@ static int chop_moves( Character *p, item *it )
     return moves;
 }
 
-std::optional<int> iuse::chop_tree( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::chop_tree( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action chop_tree that requires character but no character is present",
@@ -4659,21 +4657,21 @@ std::optional<int> iuse::chop_tree( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
     map &here = get_map();
-    const std::function<bool( const tripoint & )> f = [&here, p]( const tripoint & pnt ) {
-        if( pnt == p->pos() ) {
+    const std::function<bool( const tripoint_bub_ms & )> f = [&here, p]( const tripoint_bub_ms & pnt ) {
+        if( pnt == p->pos_bub() ) {
             return false;
         }
         return here.has_flag( ter_furn_flag::TFLAG_TREE, pnt );
     };
 
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-            _( "Chop down which tree?" ), _( "There is no tree to chop down nearby." ), f, false );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Chop down which tree?" ), _( "There is no tree to chop down nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
-    const tripoint &pnt = *pnt_;
+    const tripoint_bub_ms &pnt = *pnt_;
     if( !f( pnt ) ) {
-        if( pnt == p->pos() ) {
+        if( pnt == p->pos_bub() ) {
             p->add_msg_if_player( m_info, _( "You're not stern enough to shave yourself with THIS." ) );
         } else {
             p->add_msg_if_player( m_info, _( "You can't chop down that." ) );
@@ -4694,7 +4692,7 @@ std::optional<int> iuse::chop_tree( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action chop_logs that requires character but no character is present",
@@ -4710,18 +4708,19 @@ std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint & )
         ter_t_stump
     };
     map &here = get_map();
-    const std::function<bool( const tripoint & )> f = [&allowed_ter_id, &here]( const tripoint & pnt ) {
+    const std::function<bool( const tripoint_bub_ms & )> f = [&allowed_ter_id,
+    &here]( const tripoint_bub_ms & pnt ) {
         const ter_id &type = here.ter( pnt );
         const bool is_allowed_terrain = allowed_ter_id.find( type.id() ) != allowed_ter_id.end();
         return is_allowed_terrain;
     };
 
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-            _( "Chop which tree trunk?" ), _( "There is no tree trunk to chop nearby." ), f, false );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Chop which tree trunk?" ), _( "There is no tree trunk to chop nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
-    const tripoint &pnt = *pnt_;
+    const tripoint_bub_ms &pnt = *pnt_;
     if( !f( pnt ) ) {
         p->add_msg_if_player( m_info, _( "You can't chop that." ) );
         return std::nullopt;
@@ -4738,7 +4737,7 @@ std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_npc() ) {
         // Long action
@@ -4785,7 +4784,7 @@ std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint & )
     return std::nullopt;
 }
 
-std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint &it_pnt )
+std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms &it_pnt )
 {
     if( !p ) {
         debugmsg( "%s called action hacksaw that requires character but no character is present",
@@ -4824,16 +4823,16 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint &it_pnt
         }
         return std::nullopt;
     }
-    if( p->pos() == it_pnt ) {
+    if( p->pos_bub() == it_pnt ) {
         p->assign_activity( hacksaw_activity_actor( pnt, item_location{ *p, it } ) );
     } else {
-        p->assign_activity( hacksaw_activity_actor( pnt, it->typeId(), tripoint_bub_ms( it_pnt ) ) );
+        p->assign_activity( hacksaw_activity_actor( pnt, it->typeId(), it_pnt ) );
     }
 
     return std::nullopt;
 }
 
-std::optional<int> iuse::boltcutters( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::boltcutters( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -4872,26 +4871,23 @@ std::optional<int> iuse::boltcutters( Character *p, item *it, const tripoint & )
     return std::nullopt;
 }
 
-std::optional<int> iuse::mop( Character *p, item *, const tripoint & )
+std::optional<int> iuse::mop( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     map &here = get_map();
-    const std::function<bool( const tripoint & )> f = [&here]( const tripoint & pnt ) {
-        // TODO: fix point types
-        return here.terrain_moppable( tripoint_bub_ms( pnt ) );
+    const std::function<bool( const tripoint_bub_ms & )> f = [&here]( const tripoint_bub_ms & pnt ) {
+        return here.terrain_moppable( pnt );
     };
 
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-            _( "Mop where?" ), _( "There is nothing to mop nearby." ), f, false );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Mop where?" ), _( "There is nothing to mop nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
-    // TODO: fix point types
     const tripoint_bub_ms pnt( *pnt_ );
-    // TODO: fix point types
-    if( !f( pnt.raw() ) ) {
+    if( !f( pnt ) ) {
         if( pnt == p->pos_bub() ) {
             p->add_msg_if_player( m_info, _( "You mop yourself up." ) );
             p->add_msg_if_player( m_info, _( "The universe implodes and reforms around you." ) );
@@ -4915,9 +4911,9 @@ std::optional<int> iuse::mop( Character *p, item *, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint_bub_ms & )
 {
-    const std::optional<tripoint> dest_ = choose_adjacent( _( "Spray where?" ) );
+    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent_bub( _( "Spray where?" ) );
     if( !dest_ ) {
         return std::nullopt;
     }
@@ -4925,7 +4921,7 @@ std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint & )
 }
 
 std::optional<int> iuse::handle_ground_graffiti( Character &p, item *it, const std::string &prefix,
-        const tripoint &where )
+        const tripoint_bub_ms &where )
 {
     map &here = get_map();
     string_input_popup popup;
@@ -5000,7 +4996,7 @@ static bool heat_item( Character &p )
     return true;
 }
 
-std::optional<int> iuse::heatpack( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::heatpack( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( heat_item( *p ) ) {
         it->convert( itype_heatpack_used, p );
@@ -5008,7 +5004,7 @@ std::optional<int> iuse::heatpack( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::heat_food( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::heat_food( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( get_map().has_nearby_fire( p->pos_bub() ) ) {
         heat_item( *p );
@@ -5027,7 +5023,7 @@ std::optional<int> iuse::heat_food( Character *p, item *it, const tripoint & )
     return std::nullopt;
 }
 
-std::optional<int> iuse::hotplate( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::hotplate( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -5043,7 +5039,7 @@ std::optional<int> iuse::hotplate( Character *p, item *it, const tripoint & )
     return std::nullopt;
 }
 
-std::optional<int> iuse::hotplate_atomic( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::hotplate_atomic( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -5055,7 +5051,7 @@ std::optional<int> iuse::hotplate_atomic( Character *p, item *it, const tripoint
     return std::nullopt;
 }
 
-std::optional<int> iuse::towel( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::towel( Character *p, item *it, const tripoint_bub_ms & )
 {
     return towel_common( p, it, false );
 }
@@ -5130,14 +5126,14 @@ int iuse::towel_common( Character *p, item *it, bool )
     return it ? 1 : 0;
 }
 
-std::optional<int> iuse::unfold_generic( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::unfold_generic( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->assign_activity( vehicle_unfolding_activity_actor( *it ) );
     p->i_rem( it );
     return 0;
 }
 
-std::optional<int> iuse::adrenaline_injector( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::adrenaline_injector( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_npc() && p->get_effect_dur( effect_adrenaline ) >= 30_minutes ) {
         return std::nullopt;
@@ -5160,7 +5156,7 @@ std::optional<int> iuse::adrenaline_injector( Character *p, item *it, const trip
     return 1;
 }
 
-std::optional<int> iuse::jet_injector( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::jet_injector( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->ammo_sufficient( p ) ) {
         p->add_msg_if_player( m_info, _( "The jet injector is empty." ) );
@@ -5182,7 +5178,7 @@ std::optional<int> iuse::jet_injector( Character *p, item *it, const tripoint & 
     return 1;
 }
 
-std::optional<int> iuse::stimpack( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::stimpack( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->get_item_position( it ) >= -1 ) {
         p->add_msg_if_player( m_info,
@@ -5205,7 +5201,7 @@ std::optional<int> iuse::stimpack( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::radglove( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::radglove( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->get_item_position( it ) >= -1 ) {
         p->add_msg_if_player( m_info,
@@ -5233,7 +5229,7 @@ std::optional<int> iuse::radglove( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::talking_doll( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::talking_doll( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->ammo_sufficient( p ) ) {
         p->add_msg_if_player( m_info, _( "The %s's batteries are dead." ), it->tname() );
@@ -5248,7 +5244,7 @@ std::optional<int> iuse::talking_doll( Character *p, item *it, const tripoint & 
     return 1;
 }
 
-std::optional<int> iuse::gun_repair( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::gun_repair( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
@@ -5303,7 +5299,7 @@ std::optional<int> gun_repair( Character *p, item *, item_location &loc )
     return 1;
 }
 
-std::optional<int> iuse::gunmod_attach( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::gunmod_attach( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it || !it->is_gunmod() ) {
         debugmsg( "tried to attach non-gunmod" );
@@ -5340,7 +5336,7 @@ std::optional<int> iuse::gunmod_attach( Character *p, item *it, const tripoint &
     } while( true );
 }
 
-std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it || !it->is_toolmod() ) {
         debugmsg( "tried to attach non-toolmod" );
@@ -5395,7 +5391,7 @@ std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint 
     return 0;
 }
 
-std::optional<int> iuse::bell( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::bell( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( it->typeId() == itype_cow_bell ) {
         sounds::sound( p->pos(), 12, sounds::sound_t::music, _( "Clank!  Clank!" ), true, "misc",
@@ -5415,7 +5411,7 @@ std::optional<int> iuse::bell( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::seed( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::seed( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_npc() ||
         query_yn( _( "Are you sure you want to eat the %s?  You could plant it in a mound of dirt." ),
@@ -5433,7 +5429,7 @@ bool iuse::robotcontrol_can_target( Character *p, const monster &m )
            && rl_dist( p->pos(), m.pos() ) <= 10;
 }
 
-std::optional<int> iuse::robotcontrol( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::robotcontrol( Character *p, item *it, const tripoint_bub_ms & )
 {
 
     bool isComputer = !it->has_flag( flag_MAGICAL );
@@ -5490,9 +5486,9 @@ std::optional<int> iuse::robotcontrol( Character *p, item *it, const tripoint & 
                     tripoint seen_loc;
                     // Show locations of seen robots, center on player if robot is not seen
                     if( p->sees( candidate ) ) {
-                        seen_loc = candidate.pos();
+                        seen_loc = candidate.pos_bub().raw();
                     } else {
-                        seen_loc = p->pos();
+                        seen_loc = p->pos_bub().raw();
                     }
                     locations.push_back( seen_loc );
                 }
@@ -5599,7 +5595,7 @@ void item::extended_photo_def::serialize( JsonOut &jsout ) const
     jsout.end_object();
 }
 
-std::optional<int> iuse::epic_music( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::epic_music( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( !it->get_var( "EIPC_MUSIC_ON" ).empty() &&
         it->ammo_sufficient( p ) ) {
@@ -5611,7 +5607,7 @@ std::optional<int> iuse::epic_music( Character *p, item *it, const tripoint &pos
     return std::nullopt;
 }
 
-std::optional<int> iuse::einktabletpc( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::einktabletpc( Character *p, item *it, const tripoint_bub_ms & )
 {
 
     if( p->cant_do_mounted() ) {
@@ -5713,7 +5709,7 @@ std::optional<int> iuse::einktabletpc( Character *p, item *it, const tripoint & 
                 if( it->is_transformable() ) {
                     const use_function *readinglight = it->type->get_use( "transform" );
                     if( readinglight ) {
-                        readinglight->call( p, *it, p->pos() );
+                        readinglight->call( p, *it, p->pos_bub() );
                     }
                 }
                 it->activate();
@@ -5830,7 +5826,7 @@ std::optional<int> iuse::einktabletpc( Character *p, item *it, const tripoint & 
     return std::nullopt;
 }
 
-static std::string colorized_trap_name_at( const tripoint &point )
+static std::string colorized_trap_name_at( const tripoint_bub_ms &point )
 {
     const trap &trap = get_map().tr_at( point );
     std::string name;
@@ -5848,7 +5844,7 @@ static const std::unordered_map<description_affix, std::string> description_affi
     { description_affix::DESCRIPTION_AFFIX_ILLUMINATED_BY, translate_marker( " in %s" ) },
 };
 
-static std::string colorized_field_description_at( const tripoint &point )
+static std::string colorized_field_description_at( const tripoint_bub_ms &point )
 {
     std::string field_text;
     const field &field = get_map().field_at( point );
@@ -5879,7 +5875,7 @@ static std::string colorized_item_description( const item &item )
     return item.info( dummy, &query, 1 );
 }
 
-static item get_top_item_at_point( const tripoint &point,
+static item get_top_item_at_point( const tripoint_bub_ms &point,
                                    const units::volume &min_visible_volume )
 {
     map_stack items = get_map().i_at( point );
@@ -5893,7 +5889,7 @@ static item get_top_item_at_point( const tripoint &point,
     return item();
 }
 
-static std::string colorized_ter_name_flags_at( const tripoint &point,
+static std::string colorized_ter_name_flags_at( const tripoint_bub_ms &point,
         const std::vector<std::string> &flags, const std::vector<ter_str_id> &ter_whitelist )
 {
     map &here = get_map();
@@ -5928,7 +5924,8 @@ static std::string colorized_ter_name_flags_at( const tripoint &point,
     return std::string();
 }
 
-static std::string colorized_feature_description_at( const tripoint &center_point, bool &item_found,
+static std::string colorized_feature_description_at( const tripoint_bub_ms &center_point,
+        bool &item_found,
         const units::volume &min_visible_volume )
 {
     item_found = false;
@@ -6073,16 +6070,16 @@ struct object_names_collection {
     std::string obj_nearby_text;
 };
 
-static object_names_collection enumerate_objects_around_point( const tripoint &point,
-        const int radius, const tripoint &bounds_center_point, const int bounds_radius,
-        const tripoint &camera_pos, const units::volume &min_visible_volume, bool create_figure_desc,
-        std::unordered_set<tripoint> &ignored_points,
+static object_names_collection enumerate_objects_around_point( const tripoint_bub_ms &point,
+        const int radius, const tripoint_bub_ms &bounds_center_point, const int bounds_radius,
+        const tripoint_bub_ms &camera_pos, const units::volume &min_visible_volume, bool create_figure_desc,
+        std::unordered_set<tripoint_bub_ms> &ignored_points,
         std::unordered_set<const vehicle *> &vehicles_recorded )
 {
     map &here = get_map();
-    const tripoint_range<tripoint> bounds =
+    const tripoint_range<tripoint_bub_ms> bounds =
         here.points_in_radius( bounds_center_point, bounds_radius );
-    const tripoint_range<tripoint> points_in_radius = here.points_in_radius( point, radius );
+    const tripoint_range<tripoint_bub_ms> points_in_radius = here.points_in_radius( point, radius );
     int dist = rl_dist( camera_pos, point );
 
     bool item_found = false;
@@ -6094,7 +6091,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
     std::string description_terrain_on_figure;
 
     // store objects in radius
-    for( const tripoint &point_around_figure : points_in_radius ) {
+    for( const tripoint_bub_ms &point_around_figure : points_in_radius ) {
         if( !bounds.is_point_inside( point_around_figure ) ||
             !here.sees( camera_pos, point_around_figure, dist + radius ) ||
             ( ignored_points.find( point_around_figure ) != ignored_points.end() &&
@@ -6222,14 +6219,14 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
     return ret_obj;
 }
 
-static item::extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
-        const tripoint &camera_pos,
+static item::extended_photo_def photo_def_for_camera_point( const tripoint_bub_ms &aim_point,
+        const tripoint_bub_ms &camera_pos,
         std::vector<monster *> &monster_vec, std::vector<Character *> &character_vec )
 {
     // look for big items on top of stacks in the background for the selfie description
     const units::volume min_visible_volume = 490_ml;
 
-    std::unordered_set<tripoint> ignored_points;
+    std::unordered_set<tripoint_bub_ms> ignored_points;
     std::unordered_set<const vehicle *> vehicles_recorded;
 
     std::unordered_map<std::string, std::string> description_figures_appearance;
@@ -6238,7 +6235,7 @@ static item::extended_photo_def photo_def_for_camera_point( const tripoint &aim_
     std::string timestamp = to_string( time_point( calendar::turn ) );
     int dist = rl_dist( camera_pos, aim_point );
     map &here = get_map();
-    const tripoint_range<tripoint> bounds = here.points_in_radius( aim_point, 2 );
+    const tripoint_range<tripoint_bub_ms> bounds = here.points_in_radius( aim_point, 2 );
     item::extended_photo_def photo;
     bool need_store_weather = false;
     int outside_tiles_num = 0;
@@ -6256,7 +6253,7 @@ static item::extended_photo_def photo_def_for_camera_point( const tripoint &aim_
 
     creature_tracker &creatures = get_creature_tracker();
     // first scan for critters and mark nearby furniture, vehicles and items
-    for( const tripoint &current : bounds ) {
+    for( const tripoint_bub_ms &current : bounds ) {
         if( !here.sees( camera_pos, current, dist + 3 ) ) {
             continue; // disallow photos with non-visible objects
         }
@@ -6447,7 +6444,6 @@ static item::extended_photo_def photo_def_for_camera_point( const tripoint &aim_
                                               obj_list );
     }
 
-    // TODO: fix point types
     tripoint_abs_omt omp( coords::project_to<coords::omt>( here.getglobal( aim_point ) ) );
     const oter_id &cur_ter = overmap_buffer.ter( omp );
     om_vision_level vision = overmap_buffer.seen( omp );
@@ -6631,7 +6627,7 @@ static bool show_photo_selection( Character &p, item &it, const std::string &var
     return true;
 }
 
-std::optional<int> iuse::camera( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::camera( Character *p, item *it, const tripoint_bub_ms & )
 {
     enum {c_shot, c_photos, c_monsters, c_upload};
 
@@ -6678,24 +6674,24 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint & )
             p->add_msg_if_player( _( "Never mind." ) );
             return std::nullopt;
         }
-        tripoint aim_point = *aim_point_;
+        tripoint_bub_ms aim_point{ *aim_point_ };
         bool incorrect_focus = false;
-        tripoint_range<tripoint> aim_bounds = here.points_in_radius( aim_point, 2 );
+        tripoint_range<tripoint_bub_ms> aim_bounds = here.points_in_radius( aim_point, 2 );
 
-        std::vector<tripoint> trajectory = line_to( p->pos(), aim_point, 0, 0 );
+        std::vector<tripoint_bub_ms> trajectory = line_to( p->pos_bub(), aim_point, 0, 0 );
         trajectory.push_back( aim_point );
 
         p->mod_moves( -to_moves<int>( 1_seconds ) * 0.5 );
         sounds::sound( p->pos(), 8, sounds::sound_t::activity, _( "Click." ), true, "tool",
                        "camera_shutter" );
 
-        for( std::vector<tripoint>::iterator point_it = trajectory.begin();
+        for( std::vector<tripoint_bub_ms>::iterator point_it = trajectory.begin();
              point_it != trajectory.end();
              ++point_it ) {
-            const tripoint trajectory_point = *point_it;
+            const tripoint_bub_ms trajectory_point = *point_it;
             if( point_it != trajectory.end() ) {
-                const tripoint next_point = *( point_it + 1 ); // Trajectory ends on last visible tile
-                if( !here.sees( p->pos(), next_point, rl_dist( p->pos(), next_point ) + 3 ) ) {
+                const tripoint_bub_ms next_point = *( point_it + 1 ); // Trajectory ends on last visible tile
+                if( !here.sees( p->pos_bub(), next_point, rl_dist( p->pos_bub(), next_point ) + 3 ) ) {
                     p->add_msg_if_player( _( "You have the wrong camera focus." ) );
                     incorrect_focus = true;
                     // recalculate target point
@@ -6707,7 +6703,7 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint & )
             monster *const mon = creatures.creature_at<monster>( trajectory_point, true );
             Character *const guy = creatures.creature_at<Character>( trajectory_point );
             if( mon || guy || trajectory_point == aim_point ) {
-                int dist = rl_dist( p->pos(), trajectory_point );
+                int dist = rl_dist( p->pos_bub(), trajectory_point );
 
                 int camera_bonus = it->has_flag( flag_CAMERA_PRO ) ? 10 : 0;
                 int photo_quality = 20 - rng( dist, dist * 2 ) * 2 + rng( camera_bonus / 2, camera_bonus );
@@ -6760,7 +6756,7 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint & )
                 std::vector<item::extended_photo_def> extended_photos;
                 std::vector<monster *> monster_vec;
                 std::vector<Character *> character_vec;
-                item::extended_photo_def photo = photo_def_for_camera_point( trajectory_point, p->pos(),
+                item::extended_photo_def photo = photo_def_for_camera_point( trajectory_point, p->pos_bub(),
                                                  monster_vec, character_vec );
                 photo.quality = photo_quality;
 
@@ -6916,7 +6912,7 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint_bub_ms &pos )
 {
 
     if( get_map().has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos.xy() ) ) {
@@ -6965,10 +6961,10 @@ std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint
                        "environment", "police_siren" );
     }
 
-    const point p2( it->get_var( "HANDCUFFS_X", 0 ), it->get_var( "HANDCUFFS_Y", 0 ) );
+    const point_bub_ms p2( it->get_var( "HANDCUFFS_X", 0 ), it->get_var( "HANDCUFFS_Y", 0 ) );
 
-    if( ( it->ammo_remaining() > it->type->maximum_charges() - 1000 ) && ( p2.x != pos.x ||
-            p2.y != pos.y ) ) {
+    if( ( it->ammo_remaining() > it->type->maximum_charges() - 1000 ) && ( p2.x() != pos.x() ||
+            p2.y() != pos.y() ) ) {
 
         if( p->is_elec_immune() ) {
             if( one_in( 10 ) ) {
@@ -6988,8 +6984,8 @@ std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint
             it->charges = 1;
         }
 
-        it->set_var( "HANDCUFFS_X", pos.x );
-        it->set_var( "HANDCUFFS_Y", pos.y );
+        it->set_var( "HANDCUFFS_X", pos.x() );
+        it->set_var( "HANDCUFFS_Y", pos.y() );
 
         return 1;
 
@@ -6998,7 +6994,7 @@ std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint
     return 1;
 }
 
-std::optional<int> iuse::ehandcuffs( Character *, item *it, const tripoint & )
+std::optional<int> iuse::ehandcuffs( Character *, item *it, const tripoint_bub_ms & )
 {
     if( it->active ) {
         add_msg( _( "The %s are clamped tightly on your wrists.  You can't take them off." ),
@@ -7010,18 +7006,18 @@ std::optional<int> iuse::ehandcuffs( Character *, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::afs_translocator( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::afs_translocator( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
 
-    const std::optional<tripoint> dest_ = choose_adjacent( _( "Create buoy where?" ) );
+    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent_bub( _( "Create buoy where?" ) );
     if( !dest_ ) {
         return std::nullopt;
     }
 
-    tripoint dest = *dest_;
+    tripoint_bub_ms dest = *dest_;
 
     p->mod_moves( -to_moves<int>( 2_seconds ) );
 
@@ -7038,7 +7034,7 @@ std::optional<int> iuse::afs_translocator( Character *p, item *it, const tripoin
     }
 }
 
-std::optional<int> iuse::foodperson_voice( Character *, item *, const tripoint &pos )
+std::optional<int> iuse::foodperson_voice( Character *, item *, const tripoint_bub_ms &pos )
 {
     if( calendar::once_every( 1_minutes ) ) {
         const SpeechBubble &speech = get_speech( "foodperson_mask" );
@@ -7048,7 +7044,7 @@ std::optional<int> iuse::foodperson_voice( Character *, item *, const tripoint &
     return 0;
 }
 
-std::optional<int> iuse::foodperson( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::foodperson( Character *p, item *it, const tripoint_bub_ms & )
 {
     // Prevent crash if battery was somehow removed.
     if( !it->magazine_current() ) {
@@ -7063,7 +7059,7 @@ std::optional<int> iuse::foodperson( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::radiocar( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::radiocar( Character *p, item *it, const tripoint_bub_ms & )
 {
     int choice = -1;
     item *bomb_it = it->get_item_with( []( const item & c ) {
@@ -7140,7 +7136,7 @@ std::optional<int> iuse::radiocar( Character *p, item *it, const tripoint & )
     return 1;
 }
 
-std::optional<int> iuse::radiocaron( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::radiocaron( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->ammo_sufficient( p ) ) {
         // Deactivate since other mode has an iuse too.
@@ -7181,7 +7177,7 @@ static void sendRadioSignal( Character &p, const flag_id &signal )
                     std::map<std::string, use_function> use_methods = it.type->use_methods;
                     if( use_methods.find( "transform" ) != use_methods.end() ) {
                         it.type->get_use( "transform" )->call( &p, it, loc );
-                        item_location itm_loc = item_location( map_cursor( tripoint_bub_ms( loc ) ), &it );
+                        item_location itm_loc = item_location( map_cursor( loc ), &it );
                         here.update_lum( itm_loc, true );
                     } else {
                         it.type->get_use( it.type->use_methods.begin()->first )->call( &p, it, loc );
@@ -7197,7 +7193,7 @@ static void sendRadioSignal( Character &p, const flag_id &signal )
                     // Invoke to transform a radio-modded explosive into its active form
                     if( itm->has_flag( flag_RADIO_INVOKE_PROC ) ) {
                         itm->type->invoke( &p, *itm, loc.raw() );
-                        item_location itm_loc = item_location( map_cursor( tripoint_bub_ms( loc ) ), itm );
+                        item_location itm_loc = item_location( map_cursor( loc ), itm );
                         here.update_lum( itm_loc, true );
                     }
                 }
@@ -7206,7 +7202,7 @@ static void sendRadioSignal( Character &p, const flag_id &signal )
     }
 }
 
-std::optional<int> iuse::radiocontrol_tick( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::radiocontrol_tick( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         // Player has dropped the controller
@@ -7225,7 +7221,7 @@ std::optional<int> iuse::radiocontrol_tick( Character *p, item *it, const tripoi
     return 1;
 }
 
-std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint_bub_ms & )
 {
     const char *car_action = nullptr;
 
@@ -7366,7 +7362,7 @@ static bool hackveh( Character &p, item &it, vehicle &veh )
     return success;
 }
 
-static vehicle *pickveh( const tripoint &center, bool advanced )
+static vehicle *pickveh( const tripoint_bub_ms &center, bool advanced )
 {
     static const std::string ctrl = "CTRL_ELECTRONIC";
     static const std::string advctrl = "REMOTE_CONTROLS";
@@ -7376,7 +7372,7 @@ static vehicle *pickveh( const tripoint &center, bool advanced )
 
     for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
         vehicle *&v = veh.v;
-        if( rl_dist( center, v->pos_bub().raw() ) < 40 &&
+        if( rl_dist( center, v->pos_bub() ) < 40 &&
             v->fuel_left( itype_battery ) > 0 &&
             ( !empty( v->get_avail_parts( advctrl ) ) ||
               ( !advanced && !empty( v->get_avail_parts( ctrl ) ) ) ) ) {
@@ -7409,7 +7405,7 @@ static vehicle *pickveh( const tripoint &center, bool advanced )
     }
 }
 
-std::optional<int> iuse::remoteveh_tick( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::remoteveh_tick( Character *p, item *it, const tripoint_bub_ms & )
 {
     vehicle *remote = g->remoteveh();
     bool stop = false;
@@ -7431,7 +7427,7 @@ std::optional<int> iuse::remoteveh_tick( Character *p, item *it, const tripoint 
     return 1;
 }
 
-std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     vehicle *remote = g->remoteveh();
 
@@ -7543,9 +7539,8 @@ static bool multicooker_hallu( Character &p )
 
 }
 
-std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint_bub_ms &pos )
 {
-    const tripoint_bub_ms position{pos}; // TODO: Get rid of this when operation typified.
     static const int charges_to_start = 50;
     const int charge_buffer = 2;
 
@@ -7754,7 +7749,7 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint &po
                                   _( "The screen flashes blue symbols and scales as the multi-cooker begins to shake." ) );
 
             it->convert( itype_multi_cooker_filled, p ).active = true;
-            it->ammo_consume( charges_to_start - charge_buffer, position, p );
+            it->ammo_consume( charges_to_start - charge_buffer, pos, p );
 
             p->practice( skill_cooking, meal->difficulty * 3 ); //little bonus
 
@@ -7832,9 +7827,8 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint &po
     return 0;
 }
 
-std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoint_bub_ms &pos )
 {
-    const tripoint_bub_ms position{pos}; // TODO: Get rid of this when operation typified.
     const int charge_buffer = 2;
 
     //stop action before power runs out and iuse deletes the cooker
@@ -7843,7 +7837,7 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
         it->erase_var( "RECIPE" );
         it->convert( itype_multi_cooker, p );
         //drain the buffer amount given at activation
-        it->ammo_consume( charge_buffer, position, p );
+        it->ammo_consume( charge_buffer, pos, p );
         p->add_msg_if_player( m_info,
                               _( "Batteries low, entering standby mode.  With a low buzzing sound the multi-cooker shuts down." ) );
         return 0;
@@ -7870,7 +7864,7 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
             meal.heat_up();
         } else {
             meal.set_item_temperature( std::max( temperatures::cold,
-                                                 get_weather().get_temperature( position.raw() ) ) );
+                                                 get_weather().get_temperature( pos.raw() ) ) );
         }
 
         it->active = false;
@@ -7885,7 +7879,7 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
         }
 
         //~ sound of a multi-cooker finishing its cycle!
-        sounds::sound( position, 8, sounds::sound_t::alarm, _( "ding!" ), true, "misc", "ding" );
+        sounds::sound( pos, 8, sounds::sound_t::alarm, _( "ding!" ), true, "misc", "ding" );
 
         return 0;
     } else {
@@ -7896,7 +7890,7 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
     return 0;
 }
 
-std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bub_ms & )
 {
     weather_manager &weather = get_weather();
     const w_point weatherPoint = *weather.weather_precise;
@@ -7966,7 +7960,7 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint & 
     return 1; //TODO check
 }
 
-std::optional<int> iuse::sextant( Character *p, item *, const tripoint &pos )
+std::optional<int> iuse::sextant( Character *p, item *, const tripoint_bub_ms &pos )
 {
     const std::pair<units::angle, units::angle> sun_position = sun_azimuth_altitude( calendar::turn );
     const float altitude = to_degrees( sun_position.second );
@@ -7985,20 +7979,20 @@ std::optional<int> iuse::sextant( Character *p, item *, const tripoint &pos )
     return 0;
 }
 
-std::optional<int> iuse::lux_meter( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::lux_meter( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     p->add_msg_if_player( m_neutral, _( "The illumination is %.1f." ),
-                          g->natural_light_level( pos.z ) );
+                          g->natural_light_level( pos.z() ) );
 
     return it->type->charges_to_use();
 }
 
-std::optional<int> iuse::dbg_lux_meter( Character *p, item *, const tripoint &pos )
+std::optional<int> iuse::dbg_lux_meter( Character *p, item *, const tripoint_bub_ms &pos )
 {
     map &here = get_map();
     const float incident_light = incident_sunlight( current_weather( here.getglobal( pos ) ),
                                  calendar::turn );
-    const float nat_light = g->natural_light_level( pos.z );
+    const float nat_light = g->natural_light_level( pos.z() );
     const float sunlight = sun_light_at( calendar::turn );
     const float sun_irrad = sun_irradiance( calendar::turn );
     const float incident_irrad = incident_sun_irradiance( current_weather( here.getglobal( pos ) ),
@@ -8010,7 +8004,7 @@ std::optional<int> iuse::dbg_lux_meter( Character *p, item *, const tripoint &po
     return 0;
 }
 
-std::optional<int> iuse::calories_intake_tracker( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::calories_intake_tracker( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->has_trait( trait_ILLITERATE ) ) {
         p->add_msg_if_player( m_info, _( "You don't know what you're looking at." ) );
@@ -8031,18 +8025,19 @@ std::optional<int> iuse::calories_intake_tracker( Character *p, item *it, const 
     return 1;
 }
 
-std::optional<int> iuse::directional_hologram( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::directional_hologram( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( it->is_armor() &&  !p->is_worn( *it ) ) {
         p->add_msg_if_player( m_neutral, _( "You need to wear the %1$s before activating it." ),
                               it->tname() );
         return std::nullopt;
     }
-    const std::optional<tripoint> posp = choose_adjacent( _( "Choose hologram direction." ) );
+    const std::optional<tripoint_bub_ms> posp = choose_adjacent_bub(
+                _( "Choose hologram direction." ) );
     if( !posp ) {
         return std::nullopt;
     }
-    const tripoint delta = *posp - get_player_character().pos();
+    const tripoint_rel_ms delta = *posp - get_player_character().pos_bub();
 
     monster *const hologram = g->place_critter_at( mon_hologram, *posp );
     if( !hologram ) {
@@ -8059,7 +8054,7 @@ std::optional<int> iuse::directional_hologram( Character *p, item *it, const tri
     return 1;
 }
 
-std::optional<int> iuse::capture_monster_veh( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::capture_monster_veh( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -8112,9 +8107,8 @@ int item::contain_monster( const tripoint_bub_ms &target )
     return 0;
 }
 
-std::optional<int> iuse::capture_monster_act( Character *p, item *it, const tripoint &pos )
+std::optional<int> iuse::capture_monster_act( Character *p, item *it, const tripoint_bub_ms &pos )
 {
-    const tripoint_bub_ms position{ pos }; // TODO: Get rid of this when typing operation.
     if( p->is_mounted() ) {
         p->add_msg_if_player( m_info, _( "You can't capture a creature mounted." ) );
         return std::nullopt;
@@ -8123,7 +8117,7 @@ std::optional<int> iuse::capture_monster_act( Character *p, item *it, const trip
         // Remember contained_name for messages after release_monster erases it
         const std::string contained_name = it->get_var( "contained_name", "" );
 
-        if( it->release_monster( position ) ) {
+        if( it->release_monster( pos ) ) {
             p->invalidate_weight_carried_cache();
             // It's been activated somewhere where there isn't a player or monster, good.
             return 0;
@@ -8463,7 +8457,7 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
     return true;
 }
 
-std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8483,7 +8477,7 @@ std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoin
     return std::nullopt;
 }
 
-std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8503,7 +8497,7 @@ std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoi
     return std::nullopt;
 }
 
-std::optional<int> iuse::heat_all_items( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::heat_all_items( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8531,7 +8525,7 @@ washing_requirements washing_requirements_for_volume( const units::volume &vol )
     return { water, cleanser, time };
 }
 
-std::optional<int> iuse::wash_soft_items( Character *p, item *, const tripoint & )
+std::optional<int> iuse::wash_soft_items( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8551,7 +8545,7 @@ std::optional<int> iuse::wash_soft_items( Character *p, item *, const tripoint &
     return 0;
 }
 
-std::optional<int> iuse::wash_hard_items( Character *p, item *, const tripoint & )
+std::optional<int> iuse::wash_hard_items( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8571,7 +8565,7 @@ std::optional<int> iuse::wash_hard_items( Character *p, item *, const tripoint &
     return 0;
 }
 
-std::optional<int> iuse::wash_all_items( Character *p, item *, const tripoint & )
+std::optional<int> iuse::wash_all_items( Character *p, item *, const tripoint_bub_ms & )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8690,7 +8684,7 @@ std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_it
     return 0;
 }
 
-std::optional<int> iuse::break_stick( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::break_stick( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->mod_moves( -to_moves<int>( 2_seconds ) );
     p->mod_stamina( static_cast<int>( 0.05f * p->get_stamina_max() ) );
@@ -8725,7 +8719,7 @@ std::optional<int> iuse::break_stick( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::weak_antibiotic( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::weak_antibiotic( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->add_msg_if_player( _( "You take some %s." ), it->tname() );
     if( p->has_effect( effect_infected ) && !p->has_effect( effect_weak_antibiotic ) ) {
@@ -8736,7 +8730,7 @@ std::optional<int> iuse::weak_antibiotic( Character *p, item *it, const tripoint
     return 1;
 }
 
-std::optional<int> iuse::strong_antibiotic( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::strong_antibiotic( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->add_msg_if_player( _( "You take some %s." ), it->tname() );
     if( p->has_effect( effect_infected ) && !p->has_effect( effect_strong_antibiotic ) ) {
@@ -8766,7 +8760,7 @@ static item *wield_before_use( Character *const p, item *const it, const std::st
     return it;
 }
 
-std::optional<int> iuse::craft( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -8803,7 +8797,7 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::disassemble( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::disassemble( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -8821,7 +8815,7 @@ std::optional<int> iuse::disassemble( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::post_up( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::post_up( Character *p, item *it, const tripoint_bub_ms & )
 {
     map &here = get_map();
 
@@ -8846,7 +8840,7 @@ std::optional<int> iuse::post_up( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::melatonin_tablet( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::melatonin_tablet( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->add_msg_if_player( _( "You pop a %s." ), it->tname() );
     if( p->has_effect( effect_melatonin ) ) {
@@ -8857,14 +8851,14 @@ std::optional<int> iuse::melatonin_tablet( Character *p, item *it, const tripoin
     return 1;
 }
 
-std::optional<int> iuse::coin_flip( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::coin_flip( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->add_msg_if_player( m_info, _( "You flip a %s." ), it->tname() );
     p->add_msg_if_player( m_info, one_in( 2 ) ? _( "Heads!" ) : _( "Tails!" ) );
     return 0;
 }
 
-std::optional<int> iuse::play_game( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::play_game( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->is_avatar() ) {
         std::vector<npc *> followers = g->get_npcs_if( [p]( const npc & n ) {
@@ -8912,7 +8906,7 @@ std::optional<int> iuse::play_game( Character *p, item *it, const tripoint & )
     return 0;
 }
 
-std::optional<int> iuse::magic_8_ball( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::magic_8_ball( Character *p, item *it, const tripoint_bub_ms & )
 {
     p->add_msg_if_player( m_info, _( "You ask the %s, then flip it." ), it->tname() );
     int rn = rng( 0, 3 );
@@ -8933,7 +8927,7 @@ std::optional<int> iuse::magic_8_ball( Character *p, item *it, const tripoint & 
     return 0;
 }
 
-std::optional<int> iuse::measure_resonance( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::measure_resonance( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !it->ammo_sufficient( p ) ) {
         popup( _( "The device doesn't have enough power to function!" ) );
@@ -8999,7 +8993,7 @@ std::optional<int> iuse::measure_resonance( Character *p, item *it, const tripoi
     return 0;
 }
 
-std::optional<int> iuse::change_outfit( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::change_outfit( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p->is_avatar() ) {
         debugmsg( "NPC %s tried to swap outfit", p->get_name() );
@@ -9012,7 +9006,7 @@ std::optional<int> iuse::change_outfit( Character *p, item *it, const tripoint &
     return std::nullopt;
 }
 
-std::optional<int> iuse::electricstorage( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::electricstorage( Character *p, item *it, const tripoint_bub_ms & )
 {
     // From item processing
     if( !p ) {
@@ -9140,7 +9134,7 @@ std::optional<int> iuse::electricstorage( Character *p, item *it, const tripoint
     return std::nullopt;
 }
 
-std::optional<int> iuse::ebooksave( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::ebooksave( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action ebooksave that requires character but no character is present",
@@ -9187,7 +9181,7 @@ std::optional<int> iuse::ebooksave( Character *p, item *it, const tripoint & )
     return std::nullopt;
 }
 
-std::optional<int> iuse::ebookread( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::ebookread( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p ) {
         debugmsg( "%s called action ebookread that requires character but no character is present",
@@ -9220,7 +9214,7 @@ std::optional<int> iuse::ebookread( Character *p, item *it, const tripoint & )
     if( p->fine_detail_vision_mod() > 4 && !it->active && it->is_transformable() ) {
         const use_function *readinglight = it->type->get_use( "transform" );
         if( readinglight ) {
-            readinglight->call( p, *it, p->pos() );
+            readinglight->call( p, *it, p->pos_bub() );
         }
     }
 
@@ -9236,7 +9230,7 @@ std::optional<int> iuse::ebookread( Character *p, item *it, const tripoint & )
     return std::nullopt;
 }
 
-std::optional<int> iuse::binder_add_recipe( Character *p, item *binder, const tripoint & )
+std::optional<int> iuse::binder_add_recipe( Character *p, item *binder, const tripoint_bub_ms & )
 {
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -9313,9 +9307,8 @@ std::optional<int> iuse::binder_add_recipe( Character *p, item *binder, const tr
 }
 
 std::optional<int> iuse::binder_manage_recipe( Character *p, item *binder,
-        const tripoint &ipos )
+        const tripoint_bub_ms &ipos )
 {
-    const tripoint_bub_ms pos{ ipos }; // TODO: Get rid of this when operation typified.
     if( p->is_underwater() ) {
         p->add_msg_if_player( m_info, _( "Doing that would ruin the %1$s." ), binder->tname() );
         return std::nullopt;
@@ -9355,14 +9348,14 @@ std::optional<int> iuse::binder_manage_recipe( Character *p, item *binder,
     binder->set_saved_recipes( binder_recipes );
 
     const int pages = bookbinder_copy_activity_actor::pages_for_recipe( *rec );
-    binder->ammo_consume( pages, pos, p );
+    binder->ammo_consume( pages, ipos, p );
 
     return std::nullopt;
 }
 
-std::optional<int> iuse::voltmeter( Character *p, item *, const tripoint & )
+std::optional<int> iuse::voltmeter( Character *p, item *, const tripoint_bub_ms & )
 {
-    const std::optional<tripoint> pnt_ = choose_adjacent( _( "Check voltage where?" ) );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Check voltage where?" ) );
     if( !pnt_ ) {
         return std::nullopt;
     }
@@ -9390,7 +9383,7 @@ void use_function::dump_info( const item &it, std::vector<iteminfo> &dump ) cons
 }
 
 ret_val<void> use_function::can_call( const Character &p, const item &it,
-                                      const tripoint &pos ) const
+                                      const tripoint_bub_ms &pos ) const
 {
     if( actor == nullptr ) {
         return ret_val<void>::make_failure( _( "You can't do anything interesting with your %s." ),
@@ -9404,13 +9397,7 @@ ret_val<void> use_function::can_call( const Character &p, const item &it,
 }
 
 std::optional<int> use_function::call( Character *p, item &it,
-                                       const tripoint &pos ) const
-{
-    return actor->use( p, it, pos );
-}
-
-std::optional<int> use_function::call( Character *p, item &it,
                                        const tripoint_bub_ms &pos ) const
 {
-    return use_function::call( p, it, pos.raw() );
+    return actor->use( p, it, pos );
 }

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "clone_ptr.h"
+#include "coords_fwd.h"
 #include "item_location.h"
 #include "type_id.h"
 #include "units_fwd.h"
@@ -18,7 +19,6 @@ class JsonObject;
 class item;
 class monster;
 struct iteminfo;
-struct tripoint;
 template<typename T> class ret_val;
 
 // iuse methods return the number of charges expended, which is usually "1", or no value.
@@ -30,203 +30,203 @@ namespace iuse
 {
 
 // FOOD AND DRUGS (ADMINISTRATION)
-std::optional<int> alcohol_medium( Character *, item *, const tripoint & );
-std::optional<int> alcohol_strong( Character *, item *, const tripoint & );
-std::optional<int> alcohol_weak( Character *, item *, const tripoint & );
-std::optional<int> antibiotic( Character *, item *, const tripoint & );
-std::optional<int> anticonvulsant( Character *, item *, const tripoint & );
-std::optional<int> antifungal( Character *, item *, const tripoint & );
-std::optional<int> antiparasitic( Character *, item *, const tripoint & );
-std::optional<int> blech( Character *, item *, const tripoint & );
-std::optional<int> blech_because_unclean( Character *, item *, const tripoint & );
-std::optional<int> chew( Character *, item *, const tripoint & );
-std::optional<int> coke( Character *, item *, const tripoint & );
-std::optional<int> datura( Character *, item *, const tripoint & );
-std::optional<int> ecig( Character *, item *, const tripoint & );
-std::optional<int> eyedrops( Character *, item *, const tripoint & );
-std::optional<int> flu_vaccine( Character *, item *, const tripoint & );
-std::optional<int> flumed( Character *, item *, const tripoint & );
-std::optional<int> flusleep( Character *, item *, const tripoint & );
-std::optional<int> fungicide( Character *, item *, const tripoint & );
-std::optional<int> honeycomb( Character *, item *, const tripoint & );
-std::optional<int> inhaler( Character *, item *, const tripoint & );
-std::optional<int> marloss( Character *, item *, const tripoint & );
-std::optional<int> marloss_gel( Character *, item *, const tripoint & );
-std::optional<int> marloss_seed( Character *, item *, const tripoint & );
-std::optional<int> meditate( Character *, item *, const tripoint & );
-std::optional<int> meth( Character *, item *, const tripoint & );
-std::optional<int> mycus( Character *, item *, const tripoint & );
-std::optional<int> petfood( Character *p, item *it, const tripoint & );
-std::optional<int> plantblech( Character *, item *, const tripoint & );
-std::optional<int> poison( Character *, item *, const tripoint & );
-std::optional<int> prozac( Character *, item *, const tripoint & );
-std::optional<int> purify_smart( Character *, item *, const tripoint & );
-std::optional<int> sewage( Character *, item *, const tripoint & );
-std::optional<int> smoking( Character *, item *, const tripoint & );
-std::optional<int> thorazine( Character *, item *, const tripoint & );
-std::optional<int> weed_cake( Character *, item *, const tripoint & );
-std::optional<int> xanax( Character *, item *, const tripoint & );
+std::optional<int> alcohol_medium( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> alcohol_strong( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> alcohol_weak( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> antibiotic( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> anticonvulsant( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> antifungal( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> antiparasitic( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> blech( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> blech_because_unclean( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> chew( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> coke( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> datura( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> ecig( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> eyedrops( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> flu_vaccine( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> flumed( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> flusleep( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> fungicide( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> honeycomb( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> inhaler( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> marloss( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> marloss_gel( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> marloss_seed( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> meditate( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> meth( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> mycus( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> petfood( Character *p, item *it, const tripoint_bub_ms & );
+std::optional<int> plantblech( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> poison( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> prozac( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> purify_smart( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> sewage( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> smoking( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> thorazine( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> weed_cake( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> xanax( Character *, item *, const tripoint_bub_ms & );
 
 // TOOLS
-std::optional<int> acidbomb_act( Character *, item *, const tripoint & );
-std::optional<int> adrenaline_injector( Character *, item *, const tripoint & );
-std::optional<int> afs_translocator( Character *, item *, const tripoint & );
-std::optional<int> bell( Character *, item *, const tripoint & );
-std::optional<int> blood_draw( Character *, item *, const tripoint & );
-std::optional<int> boltcutters( Character *, item *, const tripoint & );
-std::optional<int> break_stick( Character *, item *, const tripoint & );
-std::optional<int> c4( Character *, item *, const tripoint & );
-std::optional<int> call_of_tindalos( Character *, item *, const tripoint & );
-std::optional<int> camera( Character *, item *, const tripoint & );
-std::optional<int> can_goo( Character *, item *, const tripoint & );
-std::optional<int> capture_monster_act( Character *, item *, const tripoint & );
-std::optional<int> heat_solid_items( Character *p, item *it, const tripoint & );
-std::optional<int> heat_liquid_items( Character *p, item *it, const tripoint & );
-std::optional<int> heat_all_items( Character *p, item *it, const tripoint & );
-std::optional<int> capture_monster_veh( Character *, item *, const tripoint & );
-std::optional<int> change_eyes( Character *, item *, const tripoint & );
-std::optional<int> change_skin( Character *, item *, const tripoint & );
-std::optional<int> chop_logs( Character *, item *, const tripoint & );
-std::optional<int> chop_tree( Character *, item *, const tripoint & );
-std::optional<int> clear_rubble( Character *, item *, const tripoint & );
-std::optional<int> coin_flip( Character *, item *, const tripoint & );
-std::optional<int> contacts( Character *, item *, const tripoint & );
-std::optional<int> crowbar( Character *, item *, const tripoint & );
-std::optional<int> crowbar_weak( Character *, item *, const tripoint & );
-std::optional<int> dig( Character *, item *, const tripoint & );
-std::optional<int> dig_channel( Character *, item *, const tripoint & );
-std::optional<int> directional_antenna( Character *, item *, const tripoint & );
-std::optional<int> directional_hologram( Character *, item *, const tripoint & );
-std::optional<int> dive_tank_activate( Character *, item *, const tripoint & );
-std::optional<int> dive_tank( Character *, item *, const tripoint & );
-std::optional<int> dog_whistle( Character *, item *, const tripoint & );
-std::optional<int> ehandcuffs( Character *, item *, const tripoint & );
-std::optional<int> ehandcuffs_tick( Character *, item *, const tripoint & );
-std::optional<int> epic_music( Character *, item *, const tripoint & );
-std::optional<int> einktabletpc( Character *, item *, const tripoint & );
-std::optional<int> emf_passive_on( Character *, item *, const tripoint & );
-std::optional<int> extinguisher( Character *, item *, const tripoint & );
-std::optional<int> fill_pit( Character *, item *, const tripoint & );
-std::optional<int> firecracker( Character *, item *, const tripoint & );
-std::optional<int> firecracker_pack( Character *, item *, const tripoint & );
-std::optional<int> firecracker_pack_act( Character *, item *, const tripoint & );
-std::optional<int> fish_trap( Character *, item *, const tripoint & );
-std::optional<int> fish_trap_tick( Character *, item *, const tripoint & );
-std::optional<int> fishing_rod( Character *, item *, const tripoint & );
-std::optional<int> fitness_check( Character *p, item *it, const tripoint & );
-std::optional<int> foodperson( Character *, item *, const tripoint & );
-std::optional<int> foodperson_voice( Character *, item *, const tripoint & );
-std::optional<int> gasmask( Character *, item *, const tripoint & );
-std::optional<int> gasmask_activate( Character *, item *, const tripoint & );
-std::optional<int> geiger( Character *, item *, const tripoint & );
-std::optional<int> geiger_active( Character *, item *, const tripoint & );
-std::optional<int> granade_act( Character *, item *, const tripoint & );
-std::optional<int> grenade_inc_act( Character *, item *, const tripoint & );
-std::optional<int> gun_repair( Character *, item *, const tripoint & );
-std::optional<int> gunmod_attach( Character *, item *, const tripoint & );
-std::optional<int> hacksaw( Character *, item *, const tripoint &it_pnt );
-std::optional<int> hairkit( Character *, item *, const tripoint & );
-std::optional<int> hand_crank( Character *, item *, const tripoint & );
-std::optional<int> heat_food( Character *, item *, const tripoint & );
-std::optional<int> heatpack( Character *, item *, const tripoint & );
-std::optional<int> hotplate( Character *, item *, const tripoint & );
-std::optional<int> hotplate_atomic( Character *, item *, const tripoint & );
-std::optional<int> jackhammer( Character *, item *, const tripoint & );
-std::optional<int> jet_injector( Character *, item *, const tripoint & );
-std::optional<int> lumber( Character *, item *, const tripoint & );
-std::optional<int> ma_manual( Character *, item *, const tripoint & );
-std::optional<int> magic_8_ball( Character *, item *, const tripoint & );
-std::optional<int> measure_resonance( Character *, item *, const tripoint & );
-std::optional<int> change_outfit( Character *, item *, const tripoint & );
-std::optional<int> electricstorage( Character *, item *, const tripoint & );
-std::optional<int> ebooksave( Character *, item *, const tripoint & );
-std::optional<int> ebookread( Character *, item *, const tripoint & );
-std::optional<int> makemound( Character *, item *, const tripoint & );
-std::optional<int> mace( Character *, item *, const tripoint & );
-std::optional<int> manage_exosuit( Character *, item *, const tripoint & );
-std::optional<int> melatonin_tablet( Character *, item *, const tripoint & );
-std::optional<int> mininuke( Character *, item *, const tripoint & );
-std::optional<int> molotov_lit( Character *, item *, const tripoint & );
-std::optional<int> mop( Character *, item *, const tripoint & );
-std::optional<int> mp3( Character *, item *, const tripoint & );
-std::optional<int> mp3_on( Character *, item *, const tripoint & );
-std::optional<int> mp3_deactivate( Character *, item *, const tripoint & );
-std::optional<int> noise_emitter_on( Character *, item *, const tripoint & );
-std::optional<int> oxygen_bottle( Character *, item *, const tripoint & );
-std::optional<int> oxytorch( Character *, item *, const tripoint & );
-std::optional<int> binder_add_recipe( Character *, item *, const tripoint & );
-std::optional<int> binder_manage_recipe( Character *, item *, const tripoint & );
-std::optional<int> pack_cbm( Character *p, item *it, const tripoint & );
-std::optional<int> pack_item( Character *, item *, const tripoint & );
-std::optional<int> pick_lock( Character *p, item *it, const tripoint &pos );
-std::optional<int> pickaxe( Character *, item *, const tripoint & );
-std::optional<int> play_game( Character *, item *, const tripoint & );
-std::optional<int> portable_game( Character *, item *, const tripoint & );
-std::optional<int> portal( Character *, item *, const tripoint & );
-std::optional<int> radglove( Character *, item *, const tripoint & );
-std::optional<int> radio_mod( Character *, item *, const tripoint & );
-std::optional<int> radio_off( Character *, item *, const tripoint & );
-std::optional<int> radio_on( Character *, item *, const tripoint & );
-std::optional<int> radio_tick( Character *, item *, const tripoint & );
-std::optional<int> remove_all_mods( Character *, item *, const tripoint & );
-std::optional<int> robotcontrol( Character *, item *, const tripoint & );
-std::optional<int> rpgdie( Character *, item *, const tripoint & );
-std::optional<int> seed( Character *, item *, const tripoint & );
-std::optional<int> shavekit( Character *, item *, const tripoint & );
-std::optional<int> shocktonfa_off( Character *, item *, const tripoint & );
-std::optional<int> shocktonfa_on( Character *, item *, const tripoint & );
-std::optional<int> siphon( Character *, item *, const tripoint & );
-std::optional<int> solarpack( Character *, item *, const tripoint & );
-std::optional<int> solarpack_off( Character *, item *, const tripoint & );
-std::optional<int> spray_can( Character *, item *, const tripoint & );
-std::optional<int> stimpack( Character *, item *, const tripoint & );
-std::optional<int> strong_antibiotic( Character *, item *, const tripoint & );
-std::optional<int> talking_doll( Character *, item *, const tripoint & );
-std::optional<int> tazer( Character *, item *, const tripoint & );
-std::optional<int> tazer2( Character *, item *, const tripoint & );
-std::optional<int> teleport( Character *, item *, const tripoint & );
-std::optional<int> toolmod_attach( Character *, item *, const tripoint & );
-std::optional<int> towel( Character *, item *, const tripoint & );
-std::optional<int> unfold_generic( Character *, item *, const tripoint & );
-std::optional<int> unpack_item( Character *, item *, const tripoint & );
-std::optional<int> vibe( Character *, item *, const tripoint & );
-std::optional<int> voltmeter( Character *p, item *it, const tripoint & );
-std::optional<int> vortex( Character *, item *, const tripoint & );
-std::optional<int> wash_all_items( Character *, item *, const tripoint & );
-std::optional<int> wash_hard_items( Character *, item *, const tripoint & );
+std::optional<int> acidbomb_act( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> adrenaline_injector( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> afs_translocator( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> bell( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> blood_draw( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> boltcutters( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> break_stick( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> c4( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> call_of_tindalos( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> camera( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> can_goo( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> capture_monster_act( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> heat_solid_items( Character *p, item *it, const tripoint_bub_ms & );
+std::optional<int> heat_liquid_items( Character *p, item *it, const tripoint_bub_ms & );
+std::optional<int> heat_all_items( Character *p, item *it, const tripoint_bub_ms & );
+std::optional<int> capture_monster_veh( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> change_eyes( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> change_skin( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> chop_logs( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> chop_tree( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> clear_rubble( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> coin_flip( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> contacts( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> crowbar( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> crowbar_weak( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> dig( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> dig_channel( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> directional_antenna( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> directional_hologram( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> dive_tank_activate( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> dive_tank( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> dog_whistle( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> ehandcuffs( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> ehandcuffs_tick( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> epic_music( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> einktabletpc( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> emf_passive_on( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> extinguisher( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> fill_pit( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> firecracker( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> firecracker_pack( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> firecracker_pack_act( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> fish_trap( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> fish_trap_tick( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> fishing_rod( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> fitness_check( Character *p, item *it, const tripoint_bub_ms & );
+std::optional<int> foodperson( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> foodperson_voice( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> gasmask( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> gasmask_activate( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> geiger( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> geiger_active( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> granade_act( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> grenade_inc_act( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> gun_repair( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> gunmod_attach( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> hacksaw( Character *, item *, const tripoint_bub_ms &it_pnt );
+std::optional<int> hairkit( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> hand_crank( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> heat_food( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> heatpack( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> hotplate( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> hotplate_atomic( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> jackhammer( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> jet_injector( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> lumber( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> ma_manual( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> magic_8_ball( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> measure_resonance( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> change_outfit( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> electricstorage( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> ebooksave( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> ebookread( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> makemound( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> mace( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> manage_exosuit( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> melatonin_tablet( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> mininuke( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> molotov_lit( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> mop( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> mp3( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> mp3_on( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> mp3_deactivate( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> noise_emitter_on( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> oxygen_bottle( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> oxytorch( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> binder_add_recipe( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> binder_manage_recipe( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> pack_cbm( Character *p, item *it, const tripoint_bub_ms & );
+std::optional<int> pack_item( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> pick_lock( Character *p, item *it, const tripoint_bub_ms &pos );
+std::optional<int> pickaxe( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> play_game( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> portable_game( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> portal( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> radglove( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> radio_mod( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> radio_off( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> radio_on( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> radio_tick( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> remove_all_mods( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> robotcontrol( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> rpgdie( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> seed( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> shavekit( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> shocktonfa_off( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> shocktonfa_on( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> siphon( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> solarpack( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> solarpack_off( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> spray_can( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> stimpack( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> strong_antibiotic( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> talking_doll( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> tazer( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> tazer2( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> teleport( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> toolmod_attach( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> towel( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> unfold_generic( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> unpack_item( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> vibe( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> voltmeter( Character *p, item *it, const tripoint_bub_ms & );
+std::optional<int> vortex( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> wash_all_items( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> wash_hard_items( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> wash_items( Character *p, bool soft_items, bool hard_items );
-std::optional<int> wash_soft_items( Character *, item *, const tripoint & );
-std::optional<int> water_purifier( Character *, item *, const tripoint & );
-std::optional<int> water_tablets( Character *, item *, const tripoint & );
-std::optional<int> weak_antibiotic( Character *, item *, const tripoint & );
-std::optional<int> weather_tool( Character *, item *, const tripoint & );
-std::optional<int> sextant( Character *, item *, const tripoint & );
-std::optional<int> lux_meter( Character *, item *, const tripoint & );
-std::optional<int> dbg_lux_meter( Character *, item *, const tripoint & );
-std::optional<int> calories_intake_tracker( Character *p, item *, const tripoint & );
+std::optional<int> wash_soft_items( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> water_purifier( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> water_tablets( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> weak_antibiotic( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> weather_tool( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> sextant( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> lux_meter( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> dbg_lux_meter( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> calories_intake_tracker( Character *p, item *, const tripoint_bub_ms & );
 
 // MACGUFFINS
 
-std::optional<int> radiocar( Character *, item *, const tripoint & );
-std::optional<int> radiocaron( Character *, item *, const tripoint & );
-std::optional<int> radiocontrol( Character *, item *, const tripoint & );
-std::optional<int> radiocontrol_tick( Character *, item *, const tripoint & );
+std::optional<int> radiocar( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> radiocaron( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> radiocontrol( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> radiocontrol_tick( Character *, item *, const tripoint_bub_ms & );
 
-std::optional<int> multicooker( Character *, item *, const tripoint & );
-std::optional<int> multicooker_tick( Character *, item *, const tripoint & );
+std::optional<int> multicooker( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> multicooker_tick( Character *, item *, const tripoint_bub_ms & );
 
-std::optional<int> remoteveh( Character *, item *, const tripoint & );
-std::optional<int> remoteveh_tick( Character *, item *, const tripoint & );
+std::optional<int> remoteveh( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> remoteveh_tick( Character *, item *, const tripoint_bub_ms & );
 
-std::optional<int> craft( Character *, item *, const tripoint & );
+std::optional<int> craft( Character *, item *, const tripoint_bub_ms & );
 
-std::optional<int> disassemble( Character *, item *, const tripoint & );
+std::optional<int> disassemble( Character *, item *, const tripoint_bub_ms & );
 
-std::optional<int> post_up( Character *, item *, const tripoint & );
+std::optional<int> post_up( Character *, item *, const tripoint_bub_ms & );
 
 // Helper functions for other iuse functions
 void cut_log_into_planks( Character & );
-void play_music( Character *p, const tripoint &source, int volume, int max_morale,
+void play_music( Character *p, const tripoint_bub_ms &source, int volume, int max_morale,
                  bool play_sounds = true );
 std::optional<int> purify_water( Character *p, item *purifier, item_location &water );
 int towel_common( Character *, item *, bool );
@@ -236,7 +236,7 @@ bool robotcontrol_can_target( Character *, const monster & );
 
 // Helper for handling pesky wannabe-artists
 std::optional<int> handle_ground_graffiti( Character &p, item *it, const std::string &prefix,
-        const tripoint &where );
+        const tripoint_bub_ms &where );
 
 //helper for lit cigs
 std::optional<std::string> can_smoke( const Character &you );
@@ -272,7 +272,7 @@ heating_requirements heating_requirements_for_weight( const units::mass &,
         const units::mass &, const units::volume & );
 
 using use_function_pointer = std::optional<int> ( * )( Character *, item *,
-                             const tripoint & );
+                             const tripoint_bub_ms & );
 
 class iuse_actor
 {
@@ -291,8 +291,8 @@ class iuse_actor
 
         virtual ~iuse_actor() = default;
         virtual void load( const JsonObject &jo, const std::string &src ) = 0;
-        virtual std::optional<int> use( Character *, item &, const tripoint & ) const = 0;
-        virtual ret_val<void> can_use( const Character &, const item &, const tripoint & ) const;
+        virtual std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const = 0;
+        virtual ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const;
         virtual void info( const item &, std::vector<iteminfo> & ) const {}
         /**
          * Returns a deep copy of this object. Example implementation:
@@ -333,10 +333,8 @@ struct use_function {
         use_function( const std::string &type, use_function_pointer f );
         explicit use_function( std::unique_ptr<iuse_actor> f ) : actor( std::move( f ) ) {}
 
-        // TODO: get rid of untyped overload
-        std::optional<int> call( Character *, item &, const tripoint & ) const;
         std::optional<int> call( Character *, item &, const tripoint_bub_ms & ) const;
-        ret_val<void> can_call( const Character &, const item &, const tripoint &pos ) const;
+        ret_val<void> can_call( const Character &, const item &, const tripoint_bub_ms &pos ) const;
 
         iuse_actor *get_actor_ptr() {
             return actor.get();

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -232,7 +232,7 @@ void iuse_transform::load( const JsonObject &obj, const std::string & )
     obj.read( "menu_text", menu_text );
 }
 
-std::optional<int> iuse_transform::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> iuse_transform::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     int scale = 1;
     auto iter = it.type->ammo_scale.find( type );
@@ -367,7 +367,7 @@ void iuse_transform::do_transform( Character *p, item &it, const std::string &va
 }
 
 ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
-                                       const tripoint & ) const
+                                       const tripoint_bub_ms & ) const
 {
     if( need_worn && !p.is_worn( it ) ) {
         return ret_val<void>::make_failure( _( "You need to wear the %1$s before activating it." ),
@@ -510,7 +510,7 @@ void unpack_actor::load( const JsonObject &obj, const std::string & )
     assign( obj, "filthy_volume_threshold", filthy_vol_threshold );
 }
 
-std::optional<int> unpack_actor::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> unpack_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     std::vector<item> items = item_group::items_from( unpack_group, calendar::turn );
     item last_armor;
@@ -563,7 +563,7 @@ void message_iuse::load( const JsonObject &obj, const std::string & )
 }
 
 std::optional<int> message_iuse::use( Character *p, item &it,
-                                      const tripoint &pos ) const
+                                      const tripoint_bub_ms &pos ) const
 {
     if( !p ) {
         return std::nullopt;
@@ -599,7 +599,7 @@ void sound_iuse::load( const JsonObject &obj, const std::string & )
 }
 
 std::optional<int> sound_iuse::use( Character *, item &,
-                                    const tripoint &pos ) const
+                                    const tripoint_bub_ms &pos ) const
 {
     sounds::sound( pos, sound_volume, sounds::sound_t::alarm, sound_message.translated(), true,
                    sound_id, sound_variant );
@@ -625,11 +625,12 @@ std::unique_ptr<iuse_actor> explosion_iuse::clone() const
 // Those points must have a clear line of sight and a clear path to
 // the center of the explosion.
 // They must also be passable.
-static std::vector<tripoint> points_for_gas_cloud( const tripoint &center, int radius )
+static std::vector<tripoint_bub_ms> points_for_gas_cloud( const tripoint_bub_ms &center,
+        int radius )
 {
     map &here = get_map();
-    std::vector<tripoint> result;
-    for( const tripoint &p : closest_points_first( center, radius ) ) {
+    std::vector<tripoint_bub_ms> result;
+    for( const tripoint_bub_ms &p : closest_points_first( center, radius ) ) {
         if( here.impassable( p ) ) {
             continue;
         }
@@ -670,7 +671,7 @@ void explosion_iuse::load( const JsonObject &obj, const std::string & )
     obj.read( "scrambler_blast_radius", scrambler_blast_radius );
 }
 
-std::optional<int> explosion_iuse::use( Character *p, item &it, const tripoint &pos ) const
+std::optional<int> explosion_iuse::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
     if( explosion.power >= 0.0f ) {
         Character *source = p;
@@ -682,31 +683,31 @@ std::optional<int> explosion_iuse::use( Character *p, item &it, const tripoint &
                 source = g->find_npc( thrower );
             }
         }
-        explosion_handler::explosion( source, pos, explosion );
+        explosion_handler::explosion( source, pos.raw(), explosion );
     }
 
     if( draw_explosion_radius >= 0 ) {
         explosion_handler::draw_explosion( pos, draw_explosion_radius, draw_explosion_color );
     }
     if( do_flashbang ) {
-        explosion_handler::flashbang( pos, flashbang_player_immune );
+        explosion_handler::flashbang( pos.raw(), flashbang_player_immune );
     }
     map &here = get_map();
     if( fields_radius >= 0 && fields_type.id() ) {
-        std::vector<tripoint> gas_sources = points_for_gas_cloud( pos, fields_radius );
-        for( tripoint &gas_source : gas_sources ) {
+        std::vector<tripoint_bub_ms> gas_sources = points_for_gas_cloud( pos, fields_radius );
+        for( tripoint_bub_ms &gas_source : gas_sources ) {
             const int field_intensity = rng( fields_min_intensity, fields_max_intensity );
             here.add_field( gas_source, fields_type, field_intensity, 1_turns );
         }
     }
     if( scrambler_blast_radius >= 0 ) {
-        for( const tripoint &dest : here.points_in_radius( pos, scrambler_blast_radius ) ) {
-            explosion_handler::scrambler_blast( dest );
+        for( const tripoint_bub_ms &dest : here.points_in_radius( pos, scrambler_blast_radius ) ) {
+            explosion_handler::scrambler_blast( dest.raw() );
         }
     }
     if( emp_blast_radius >= 0 ) {
-        for( const tripoint &dest : here.points_in_radius( pos, emp_blast_radius ) ) {
-            explosion_handler::emp_blast( dest );
+        for( const tripoint_bub_ms &dest : here.points_in_radius( pos, emp_blast_radius ) ) {
+            explosion_handler::emp_blast( dest.raw() );
         }
     }
     return 1;
@@ -798,7 +799,7 @@ void consume_drug_iuse::info( const item &, std::vector<iteminfo> &dump ) const
     }
 }
 
-std::optional<int> consume_drug_iuse::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> consume_drug_iuse::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     auto need_these = tools_needed;
 
@@ -844,7 +845,7 @@ std::optional<int> consume_drug_iuse::use( Character *p, item &it, const tripoin
     for( const auto &field : fields_produced ) {
         const field_type_id fid = field_type_id( field.first );
         for( int i = 0; i < 3; i++ ) {
-            point offset( rng( -2, 2 ), rng( -2, 2 ) );
+            point_rel_ms offset( rng( -2, 2 ), rng( -2, 2 ) );
             here.add_field( p->pos_bub() + offset, fid, field.second );
         }
     }
@@ -897,7 +898,7 @@ int delayed_transform_iuse::time_to_do( const item &it ) const
 }
 
 std::optional<int> delayed_transform_iuse::use( Character *p, item &it,
-        const tripoint &pos ) const
+        const tripoint_bub_ms &pos ) const
 {
     if( time_to_do( it ) > 0 ) {
         p->add_msg_if_player( m_info, "%s", not_ready_msg );
@@ -931,7 +932,7 @@ void place_monster_iuse::load( const JsonObject &obj, const std::string & )
     }
 }
 
-std::optional<int> place_monster_iuse::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> place_monster_iuse::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     if( it.ammo_remaining() < need_charges ) {
         p->add_msg_if_player( m_info, _( "This requires %d charges to activate." ), need_charges );
@@ -1025,15 +1026,15 @@ void place_npc_iuse::load( const JsonObject &obj, const std::string & )
     obj.read( "place_randomly", place_randomly );
 }
 
-std::optional<int> place_npc_iuse::use( Character *p, item &, const tripoint & ) const
+std::optional<int> place_npc_iuse::use( Character *p, item &, const tripoint_bub_ms & ) const
 {
     map &here = get_map();
-    const tripoint_range<tripoint> target_range = place_randomly ?
-            points_in_radius( p->pos(), radius ) :
-            points_in_radius( choose_adjacent( _( "Place NPC where?" ) ).value_or( p->pos() ), 0 );
+    const tripoint_range<tripoint_bub_ms> target_range = place_randomly ?
+            points_in_radius( p->pos_bub(), radius ) :
+            points_in_radius( choose_adjacent_bub( _( "Place NPC where?" ) ).value_or( p->pos_bub() ), 0 );
 
-    const std::optional<tripoint> target_pos =
-    random_point( target_range, [&here]( const tripoint & t ) {
+    const std::optional<tripoint_bub_ms> target_pos =
+    random_point( target_range, [&here]( const tripoint_bub_ms & t ) {
         return here.passable( t ) && here.has_floor_or_support( t ) &&
                !get_creature_tracker().creature_at( t );
     } );
@@ -1192,9 +1193,9 @@ static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
 }
 
 std::optional<int> deploy_furn_actor::use( Character *p, item &it,
-        const tripoint &pos ) const
+        const tripoint_bub_ms &pos ) const
 {
-    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, tripoint_bub_ms( pos ) );
+    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, pos );
     if( !suitable.success() ) {
         p->add_msg_if_player( m_info, suitable.str() );
         return std::nullopt;
@@ -1224,9 +1225,10 @@ void deploy_appliance_actor::load( const JsonObject &obj, const std::string & )
     mandatory( obj, false, "base", appliance_base );
 }
 
-std::optional<int> deploy_appliance_actor::use( Character *p, item &it, const tripoint &pos ) const
+std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
+        const tripoint_bub_ms &pos ) const
 {
-    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, tripoint_bub_ms( pos ) );
+    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, pos );
     if( !suitable.success() ) {
         p->add_msg_if_player( m_info, suitable.str() );
         return std::nullopt;
@@ -1282,7 +1284,7 @@ void reveal_map_actor::reveal_targets( const tripoint_abs_omt &center,
     }
 }
 
-std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     if( it.already_used_by_player( *p ) ) {
         p->add_msg_if_player( _( "There isn't anything new on the %s." ), it.tname() );
@@ -1326,9 +1328,8 @@ bool firestarter_actor::prep_firestarter_use( const Character &p, tripoint_bub_m
 {
     // checks for fuel are handled by use and the activity, not here
     if( pos == p.pos_bub() ) {
-        if( const std::optional<tripoint> pnt_ = choose_adjacent( _( "Light where?" ) ) ) {
-            // TODO: fix point types
-            pos = tripoint_bub_ms( *pnt_ );
+        if( const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Light where?" ) ) ) {
+            pos = *pnt_;
         } else {
             return false;
         }
@@ -1363,7 +1364,6 @@ bool firestarter_actor::prep_firestarter_use( const Character &p, tripoint_bub_m
     // Check for an adjacent fire container
     for( const tripoint_bub_ms &query : here.points_in_radius( pos, 1 ) ) {
         // Don't ask if we're setting a fire on top of a fireplace
-        // TODO: fix point types
         if( here.has_flag_furn( "FIRE_CONTAINER", pos ) ) {
             break;
         }
@@ -1371,7 +1371,6 @@ bool firestarter_actor::prep_firestarter_use( const Character &p, tripoint_bub_m
         if( query == pos ) {
             continue;
         }
-        // TODO: fix point types
         if( here.has_flag_furn( "FIRE_CONTAINER", query ) ) {
             if( !query_yn( _( "Are you sure you want to start fire here?  There's a fireplace adjacent." ) ) ) {
                 return false;
@@ -1412,7 +1411,7 @@ void firestarter_actor::resolve_firestarter_use( Character *p, const tripoint_bu
 }
 
 ret_val<void> firestarter_actor::can_use( const Character &p, const item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     if( p.is_underwater() ) {
         return ret_val<void>::make_failure( _( "You can't do that while underwater." ) );
@@ -1422,14 +1421,14 @@ ret_val<void> firestarter_actor::can_use( const Character &p, const item &it,
         return ret_val<void>::make_failure( _( "This tool doesn't have enough charges." ) );
     }
 
-    if( need_sunlight && light_mod( p.pos() ) <= 0.0f ) {
+    if( need_sunlight && light_mod( p.pos_bub() ) <= 0.0f ) {
         return ret_val<void>::make_failure( _( "You need direct sunlight to light a fire with this." ) );
     }
 
     return ret_val<void>::make_success();
 }
 
-float firestarter_actor::light_mod( const tripoint &pos ) const
+float firestarter_actor::light_mod( const tripoint_bub_ms &pos ) const
 {
     if( !need_sunlight ) {
         return 1.0f;
@@ -1439,7 +1438,7 @@ float firestarter_actor::light_mod( const tripoint &pos ) const
     }
 
     if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::moderate ) {
-        return std::pow( g->natural_light_level( pos.z ) / 80.0f, 8 );
+        return std::pow( g->natural_light_level( pos.z() ) / 80.0f, 8 );
     }
 
     return 0.0f;
@@ -1460,7 +1459,7 @@ int firestarter_actor::moves_cost_by_fuel( const tripoint_bub_ms &pos ) const
 }
 
 std::optional<int> firestarter_actor::use( Character *p, item &it,
-        const tripoint &spos ) const
+        const tripoint_bub_ms &spos ) const
 {
     if( !p ) {
         debugmsg( "%s called action firestarter that requires character but no character is present",
@@ -1468,9 +1467,8 @@ std::optional<int> firestarter_actor::use( Character *p, item &it,
         return std::nullopt;
     }
 
-    // TODO: fix point types
     tripoint_bub_ms pos( spos );
-    float light = light_mod( p->pos() );
+    float light = light_mod( p->pos_bub() );
     if( !prep_firestarter_use( *p, pos ) ) {
         return std::nullopt;
     }
@@ -1521,7 +1519,7 @@ std::unique_ptr<iuse_actor> salvage_actor::clone() const
     return std::make_unique<salvage_actor>( *this );
 }
 
-std::optional<int> salvage_actor::use( Character *p, item &cutter, const tripoint & ) const
+std::optional<int> salvage_actor::use( Character *p, item &cutter, const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action salvage that requires character but no character is present",
@@ -1945,7 +1943,7 @@ bool inscribe_actor::item_inscription( item &tool, item &cut ) const
     return true;
 }
 
-std::optional<int> inscribe_actor::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> inscribe_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action inscribe that requires character but no character is present",
@@ -1972,7 +1970,7 @@ std::optional<int> inscribe_actor::use( Character *p, item &it, const tripoint &
     }
 
     if( choice == 0 ) {
-        const std::optional<tripoint> dest_ = choose_adjacent( _( "Write where?" ) );
+        const std::optional<tripoint_bub_ms> dest_ = choose_adjacent_bub( _( "Write where?" ) );
         if( !dest_ ) {
             return std::nullopt;
         }
@@ -2015,7 +2013,7 @@ std::unique_ptr<iuse_actor> fireweapon_off_actor::clone() const
 }
 
 std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action fireweapon_off that requires character but no character is present",
@@ -2042,7 +2040,7 @@ std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
 }
 
 ret_val<void> fireweapon_off_actor::can_use( const Character &p, const item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     if( !it.ammo_sufficient( &p ) ) {
         return ret_val<void>::make_failure( _( "This tool doesn't have enough charges." ) );
@@ -2069,7 +2067,7 @@ std::unique_ptr<iuse_actor> fireweapon_on_actor::clone() const
 }
 
 std::optional<int> fireweapon_on_actor::use( Character *p, item &it,
-        const tripoint &pos ) const
+        const tripoint_bub_ms &pos ) const
 {
     bool extinguish = true;
     translation deactivation_msg;
@@ -2118,7 +2116,7 @@ std::unique_ptr<iuse_actor> manualnoise_actor::clone() const
     return std::make_unique<manualnoise_actor>( *this );
 }
 
-std::optional<int> manualnoise_actor::use( Character *p, item &, const tripoint & ) const
+std::optional<int> manualnoise_actor::use( Character *p, item &, const tripoint_bub_ms & ) const
 {
     // Uses the moves specified by iuse_actor's definition
     p->mod_moves( -moves );
@@ -2131,7 +2129,7 @@ std::optional<int> manualnoise_actor::use( Character *p, item &, const tripoint 
 }
 
 ret_val<void> manualnoise_actor::can_use( const Character &p, const item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     if( !it.ammo_sufficient( &p ) ) {
         return ret_val<void>::make_failure( _( "This tool doesn't have enough charges." ) );
@@ -2149,7 +2147,8 @@ std::unique_ptr<iuse_actor> play_instrument_iuse::clone() const
     return std::make_unique<play_instrument_iuse>( *this );
 }
 
-std::optional<int> play_instrument_iuse::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> play_instrument_iuse::use( Character *p, item &it,
+        const tripoint_bub_ms & ) const
 {
     if( it.active ) {
         it.active = false;
@@ -2169,7 +2168,7 @@ std::optional<int> play_instrument_iuse::use( Character *p, item &it, const trip
 }
 
 ret_val<void> play_instrument_iuse::can_use( const Character &p, const item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     // TODO (maybe): Mouth encumbrance? Smoke? Lack of arms? Hand encumbrance?
     if( p.is_underwater() ) {
@@ -2212,7 +2211,7 @@ void musical_instrument_actor::load( const JsonObject &obj, const std::string & 
 }
 
 std::optional<int> musical_instrument_actor::use( Character *p, item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     if( !p ) {
         it.active = false;
@@ -2321,13 +2320,13 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
     }
 
     // We already played the sounds, just handle applying effects now
-    iuse::play_music( p, p->pos(), volume, morale_effect, /*play_sounds=*/false );
+    iuse::play_music( p, p->pos_bub(), volume, morale_effect, /*play_sounds=*/false );
 
     return 0;
 }
 
 ret_val<void> musical_instrument_actor::can_use( const Character &p, const item &,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     // TODO: (maybe): Mouth encumbrance? Smoke? Lack of arms? Hand encumbrance?
     if( p.is_underwater() ) {
@@ -2389,7 +2388,7 @@ void learn_spell_actor::info( const item &, std::vector<iteminfo> &dump ) const
     }
 }
 
-std::optional<int> learn_spell_actor::use( Character *p, item &, const tripoint & ) const
+std::optional<int> learn_spell_actor::use( Character *p, item &, const tripoint_bub_ms & ) const
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "It's too dark to read." ) );
@@ -2518,7 +2517,7 @@ std::string cast_spell_actor::get_name() const
     return mundane ? _( "Activate" ) : _( "Cast spell" );
 }
 
-std::optional<int> cast_spell_actor::use( Character *p, item &it, const tripoint &pos ) const
+std::optional<int> cast_spell_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
     if( need_worn && !p->is_worn( it ) ) {
         p->add_msg_if_player( m_info, _( "You need to wear the %1$s before activating it." ), it.tname() );
@@ -2613,13 +2612,12 @@ static item_location form_loc_recursive( T &loc, item &it )
     return item_location( loc, &it );
 }
 
-static item_location form_loc( Character &you, const tripoint &p, item &it )
+static item_location form_loc( Character &you, const tripoint_bub_ms &p, item &it )
 {
     if( you.has_item( it ) ) {
         return form_loc_recursive( you, it );
     }
-    const tripoint_bub_ms bub = tripoint_bub_ms( p );
-    map_cursor mc( bub );
+    map_cursor mc( p );
     if( mc.has_item( it ) ) {
         return form_loc_recursive( mc, it );
     }
@@ -2637,7 +2635,7 @@ static item_location form_loc( Character &you, const tripoint &p, item &it )
     return item_location( you, &it );
 }
 
-std::optional<int> holster_actor::use( Character *you, item &it, const tripoint &p ) const
+std::optional<int> holster_actor::use( Character *you, item &it, const tripoint_bub_ms &p ) const
 {
     if( you->is_wielding( it ) ) {
         you->add_msg_if_player( _( "You need to unwield your %s before using it." ), it.tname() );
@@ -2732,7 +2730,7 @@ void ammobelt_actor::info( const item &, std::vector<iteminfo> &dump ) const
                        item::nname( belt ) ) );
 }
 
-std::optional<int> ammobelt_actor::use( Character *p, item &, const tripoint & ) const
+std::optional<int> ammobelt_actor::use( Character *p, item &, const tripoint_bub_ms & ) const
 {
     item mag( belt );
     mag.ammo_unset();
@@ -2806,7 +2804,7 @@ bool repair_item_actor::can_use_tool( const Character &p, const item &tool, bool
     return true;
 }
 
-static item_location get_item_location( Character &p, item &it, const tripoint &pos )
+static item_location get_item_location( Character &p, item &it, const tripoint_bub_ms &pos )
 {
     // Item on a character
     if( p.has_item( it ) ) {
@@ -2830,11 +2828,11 @@ static item_location get_item_location( Character &p, item &it, const tripoint &
     }
 
     // Item on the map
-    return item_location( map_cursor( tripoint_bub_ms( pos ) ), &it );
+    return item_location( map_cursor( pos ), &it );
 }
 
 std::optional<int> repair_item_actor::use( Character *p, item &it,
-        const tripoint &position ) const
+        const tripoint_bub_ms &position ) const
 {
     if( !can_use_tool( *p, it, true ) ) {
         return std::nullopt;
@@ -3394,23 +3392,24 @@ void heal_actor::load( const JsonObject &obj, const std::string & )
     }
 }
 
-static Character &get_patient( Character &healer, const tripoint &pos )
+static Character &get_patient( Character &healer, const tripoint_bub_ms &pos )
 {
-    if( healer.pos() == pos ) {
+    if( healer.pos_bub() == pos ) {
         return healer;
     }
 
     Character *const person = get_creature_tracker().creature_at<Character>( pos );
     if( !person ) {
         // Default to heal self on failure not to break old functionality
-        add_msg_debug( debugmode::DF_IUSE, "No heal target at position %d,%d,%d", pos.x, pos.y, pos.z );
+        add_msg_debug( debugmode::DF_IUSE, "No heal target at position %d,%d,%d", pos.x(), pos.y(),
+                       pos.z() );
         return healer;
     }
 
     return *person;
 }
 
-std::optional<int> heal_actor::use( Character *p, item &it, const tripoint &pos ) const
+std::optional<int> heal_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
     if( p->cant_do_underwater() ) {
         return std::nullopt;
@@ -3884,18 +3883,18 @@ std::unique_ptr<iuse_actor> place_trap_actor::clone() const
     return std::make_unique<place_trap_actor>( *this );
 }
 
-static bool is_solid_neighbor( const tripoint &pos, const point &offset )
+static bool is_solid_neighbor( const tripoint_bub_ms &pos, const point_rel_ms &offset )
 {
     map &here = get_map();
-    const tripoint_bub_ms a = tripoint_bub_ms( pos ) + tripoint( offset, 0 );
-    const tripoint_bub_ms b = tripoint_bub_ms( pos ) - tripoint( offset, 0 );
+    const tripoint_bub_ms a = pos + offset;
+    const tripoint_bub_ms b = pos - offset;
     return here.move_cost( a ) != 2 && here.move_cost( b ) != 2;
 }
 
-static bool has_neighbor( const tripoint &pos, const ter_id &terrain_id )
+static bool has_neighbor( const tripoint_bub_ms &pos, const ter_id &terrain_id )
 {
     map &here = get_map();
-    for( const tripoint &t : here.points_in_radius( pos, 1, 0 ) ) {
+    for( const tripoint_bub_ms &t : here.points_in_radius( pos, 1, 0 ) ) {
         if( here.ter( t ) == terrain_id ) {
             return true;
         }
@@ -3903,10 +3902,10 @@ static bool has_neighbor( const tripoint &pos, const ter_id &terrain_id )
     return false;
 }
 
-bool place_trap_actor::is_allowed( Character &p, const tripoint &pos,
+bool place_trap_actor::is_allowed( Character &p, const tripoint_bub_ms &pos,
                                    const std::string &name ) const
 {
-    if( !allow_under_player && pos == p.pos() ) {
+    if( !allow_under_player && pos == p.pos_bub() ) {
         p.add_msg_if_player( m_info, _( "Yeah.  Place the %s at your feet.  Real damn smart move." ),
                              name );
         return false;
@@ -3917,8 +3916,10 @@ bool place_trap_actor::is_allowed( Character &p, const tripoint &pos,
         return false;
     }
     if( needs_solid_neighbor ) {
-        if( !is_solid_neighbor( pos, point::east ) && !is_solid_neighbor( pos, point::south ) &&
-            !is_solid_neighbor( pos, point::south_east ) && !is_solid_neighbor( pos, point::north_east ) ) {
+        if( !is_solid_neighbor( pos, point_rel_ms::east ) &&
+            !is_solid_neighbor( pos, point_rel_ms::south ) &&
+            !is_solid_neighbor( pos, point_rel_ms::south_east ) &&
+            !is_solid_neighbor( pos, point_rel_ms::north_east ) ) {
             p.add_msg_if_player( m_info, _( "You must place the %s between two solid tiles." ), name );
             return false;
         }
@@ -3938,24 +3939,25 @@ bool place_trap_actor::is_allowed( Character &p, const tripoint &pos,
                                  name );
         } else {
             p.add_msg_if_player( m_bad, _( "You trigger a %s!" ), existing_trap.name() );
-            existing_trap.trigger( pos, p );
+            existing_trap.trigger( pos.raw(), p );
         }
         return false;
     }
     return true;
 }
 
-static void place_and_add_as_known( Character &p, const tripoint &pos, const trap_str_id &id )
+static void place_and_add_as_known( Character &p, const tripoint_bub_ms &pos,
+                                    const trap_str_id &id )
 {
     map &here = get_map();
     here.trap_set( pos, id );
     const trap &tr = here.tr_at( pos );
     if( !tr.can_see( pos, p ) ) {
-        p.add_known_trap( pos, tr );
+        p.add_known_trap( pos.raw(), tr );
     }
 }
 
-std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     const bool could_bury = !bury_question.empty();
     if( !allow_underwater && p->cant_do_underwater() ) {
@@ -3964,12 +3966,13 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    const std::optional<tripoint> pos_ = choose_adjacent( string_format( _( "Place %s where?" ),
-                                         it.tname() ) );
+    const std::optional<tripoint_bub_ms> pos_ = choose_adjacent_bub( string_format(
+                _( "Place %s where?" ),
+                it.tname() ) );
     if( !pos_ ) {
         return std::nullopt;
     }
-    tripoint pos = *pos_;
+    tripoint_bub_ms pos = *pos_;
 
     if( !is_allowed( *p, pos, it.tname() ) ) {
         return std::nullopt;
@@ -3980,9 +3983,10 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
                                   outer_layer_trap.obj().get_trap_radius() + 1;
     if( unburied_data.trap.obj().get_trap_radius() > 0 ) {
         // Math correction for multi-tile traps
-        pos.x = ( pos.x - p->posx() ) * distance_to_trap_center + p->posx();
-        pos.y = ( pos.y - p->posy() ) * distance_to_trap_center + p->posy();
-        for( const tripoint &t : here.points_in_radius( pos, outer_layer_trap.obj().get_trap_radius(),
+        pos.x() = ( pos.x() - p->posx() ) * distance_to_trap_center + p->posx();
+        pos.y() = ( pos.y() - p->posy() ) * distance_to_trap_center + p->posy();
+        for( const tripoint_bub_ms &t : here.points_in_radius( pos,
+                outer_layer_trap.obj().get_trap_radius(),
                 0 ) ) {
             if( !is_allowed( *p, t, it.tname() ) ) {
                 p->add_msg_if_player( m_info,
@@ -4027,7 +4031,8 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
     if( !placed_trap.is_null() ) {
         const_cast<trap &>( placed_trap ).set_trap_data( it.typeId() );
     }
-    for( const tripoint &t : here.points_in_radius( pos, data.trap.obj().get_trap_radius(), 0 ) ) {
+    for( const tripoint_bub_ms &t : here.points_in_radius( pos, data.trap.obj().get_trap_radius(),
+            0 ) ) {
         if( t != pos ) {
             place_and_add_as_known( *p, t, outer_layer_trap );
         }
@@ -4041,7 +4046,7 @@ void emit_actor::load( const JsonObject &obj, const std::string & )
     assign( obj, "scale_qty", scale_qty );
 }
 
-std::optional<int> emit_actor::use( Character *, item &it, const tripoint &pos ) const
+std::optional<int> emit_actor::use( Character *, item &it, const tripoint_bub_ms &pos ) const
 {
     map &here = get_map();
     const float scaling = scale_qty ? it.charges : 1.0f;
@@ -4081,7 +4086,7 @@ void saw_barrel_actor::load( const JsonObject &jo, const std::string & )
 }
 
 //Todo: Make this consume charges if performed with a tool that uses charges.
-std::optional<int> saw_barrel_actor::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> saw_barrel_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action saw_barrel that requires character but no character is present",
@@ -4142,7 +4147,7 @@ void saw_stock_actor::load( const JsonObject &jo, const std::string & )
 }
 
 //Todo: Make this consume charges if performed with a tool that uses charges.
-std::optional<int> saw_stock_actor::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> saw_stock_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action saw_stock that requires character but no character is present",
@@ -4218,7 +4223,7 @@ void molle_attach_actor::load( const JsonObject &jo, const std::string & )
 }
 
 std::optional<int> molle_attach_actor::use( Character *p, item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action molle_attach that requires character but no character is present",
@@ -4250,7 +4255,7 @@ std::unique_ptr<iuse_actor> molle_attach_actor::clone() const
 }
 
 std::optional<int> molle_detach_actor::use( Character *p, item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
 
     std::vector<const item *> items_attached = it.get_contents().get_added_pockets();
@@ -4284,7 +4289,7 @@ void molle_detach_actor::load( const JsonObject &jo, const std::string & )
 }
 
 std::optional<int> install_bionic_actor::use( Character *p, item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     if( p->can_install_bionics( *it.type, *p, false ) ) {
         if( !p->has_trait( trait_DEBUG_BIONICS ) && !p->has_flag( json_flag_MANUAL_CBM_INSTALLATION ) ) {
@@ -4299,7 +4304,7 @@ std::optional<int> install_bionic_actor::use( Character *p, item &it,
 }
 
 ret_val<void> install_bionic_actor::can_use( const Character &p, const item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     if( !it.is_bionic() ) {
         return ret_val<void>::make_failure();
@@ -4356,7 +4361,7 @@ void install_bionic_actor::finalize( const itype_id &my_item_type )
 }
 
 std::optional<int> detach_gunmods_actor::use( Character *p, item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     auto filter_irremovable = []( std::vector<item *> &gunmods ) {
         gunmods.erase(
@@ -4409,7 +4414,7 @@ std::optional<int> detach_gunmods_actor::use( Character *p, item &it,
 }
 
 ret_val<void> detach_gunmods_actor::can_use( const Character &p, const item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     const std::vector<const item *> mods = it.gunmods();
 
@@ -4448,7 +4453,7 @@ void detach_gunmods_actor::finalize( const itype_id &my_item_type )
 }
 
 std::optional<int> modify_gunmods_actor::use( Character *p, item &it,
-        const tripoint &pnt ) const
+        const tripoint_bub_ms &pnt ) const
 {
 
     std::vector<item *> mods;
@@ -4481,7 +4486,7 @@ std::optional<int> modify_gunmods_actor::use( Character *p, item &it,
 }
 
 ret_val<void> modify_gunmods_actor::can_use( const Character &p, const item &it,
-        const tripoint & ) const
+        const tripoint_bub_ms & ) const
 {
     if( !p.is_wielding( it ) ) {
         return ret_val<void>::make_failure( _( "Need to be wielding." ) );
@@ -4606,7 +4611,7 @@ void link_up_actor::info( const item &it, std::vector<iteminfo> &dump ) const
     }
 }
 
-std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &pnt ) const
+std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint_bub_ms &pnt ) const
 {
     if( !p ) {
         debugmsg( "%s called action link_up that requires character but no character is present",
@@ -4929,17 +4934,18 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
     map &here = get_map();
     // Selection: Attach electrical cable to vehicle ports / appliances, OR vehicle batteries.
 
-    const auto can_link = [&here, &to_ports]( const tripoint & point ) {
+    const auto can_link = [&here, &to_ports]( const tripoint_bub_ms & point ) {
         const optional_vpart_position ovp = here.veh_at( point );
         return ovp && ovp->vehicle().avail_linkable_part( ovp->mount_pos(), to_ports ) != -1;
     };
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight( _( "Attach the cable where?" ),
-                                         "", can_link, false, false );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Attach the cable where?" ),
+                "", can_link, false, false );
     if( !pnt_ ) {
         p->add_msg_if_player( _( "Never mind." ) );
         return std::nullopt;
     }
-    const tripoint &selection = *pnt_;
+    const tripoint_bub_ms &selection = *pnt_;
     const optional_vpart_position sel_vp = here.veh_at( selection );
     if( !sel_vp ) {
         p->add_msg_if_player( _( "There's no vehicle there." ) );
@@ -4995,9 +5001,10 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
         const bool using_power_cord = it.typeId() == itype_power_cord;
         if( using_power_cord && it.link().t_veh->is_powergrid() && sel_vp->vehicle().is_powergrid() ) {
             // If both vehicles are adjacent power grids, try to merge them together first.
-            const point prev_pos = here.bub_from_abs( it.link().t_veh->coord_translate( it.link().t_mount ) +
-                                   it.link().t_abs_pos ).xy().raw();
-            if( selection.xy().distance( prev_pos ) <= 1.5f &&
+            const point_bub_ms prev_pos = here.bub_from_abs( it.link().t_veh->coord_translate(
+                                              it.link().t_mount ) +
+                                          it.link().t_abs_pos ).xy();
+            if( selection.xy().raw().distance( prev_pos.raw() ) <= 1.5f &&
                 it.link().t_veh->merge_appliance_into_grid( sel_vp->vehicle() ) ) {
                 it.link().t_veh->part_removal_cleanup();
                 p->add_msg_if_player( _( "You merge the two power grids." ) );
@@ -5029,19 +5036,19 @@ std::optional<int> link_up_actor::link_tow_cable( Character *p, item &it,
 {
     map &here = get_map();
 
-    const auto can_link = [&here]( const tripoint & point ) {
+    const auto can_link = [&here]( const tripoint_bub_ms & point ) {
         const optional_vpart_position ovp = here.veh_at( point );
         return ovp && ovp->vehicle().is_external_part( point );
     };
 
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-            to_towing ? _( "Attach cable to the vehicle that will do the towing." ) :
-            _( "Attach cable to the vehicle that will be towed." ), "", can_link, false, false );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                to_towing ? _( "Attach cable to the vehicle that will do the towing." ) :
+                _( "Attach cable to the vehicle that will be towed." ), "", can_link, false, false );
     if( !pnt_ ) {
         p->add_msg_if_player( _( "Never mind." ) );
         return std::nullopt;
     }
-    const tripoint &selection = *pnt_;
+    const tripoint_bub_ms &selection = *pnt_;
     const optional_vpart_position sel_vp = here.veh_at( selection );
     if( !sel_vp ) {
         p->add_msg_if_player( _( "There's no vehicle there." ) );
@@ -5089,7 +5096,7 @@ std::optional<int> link_up_actor::link_tow_cable( Character *p, item &it,
 }
 
 std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
-        const tripoint &pnt ) const
+        const tripoint_bub_ms &pnt ) const
 {
     avatar *you = p->as_avatar();
     if( !you ) {
@@ -5257,7 +5264,7 @@ void deploy_tent_actor::load( const JsonObject &obj, const std::string & )
     assign( obj, "broken_type", broken_type );
 }
 
-std::optional<int> deploy_tent_actor::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> deploy_tent_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     int diam = 2 * radius + 1;
     if( p->cant_do_mounted() ) {
@@ -5335,7 +5342,7 @@ void weigh_self_actor::info( const item &, std::vector<iteminfo> &dump ) const
                        _( "Use this item to weigh yourself.  Includes everything you are wearing." ) );
 }
 
-std::optional<int> weigh_self_actor::use( Character *p, item &, const tripoint & ) const
+std::optional<int> weigh_self_actor::use( Character *p, item &, const tripoint_bub_ms & ) const
 {
     if( p->is_mounted() ) {
         p->add_msg_if_player( m_info, _( "You cannot weigh yourself while mounted." ) );
@@ -5379,7 +5386,7 @@ void sew_advanced_actor::load( const JsonObject &obj, const std::string & )
     }
 }
 
-std::optional<int> sew_advanced_actor::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> sew_advanced_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     if( p->is_npc() ) {
         return std::nullopt;
@@ -5620,7 +5627,7 @@ void change_scent_iuse::load( const JsonObject &obj, const std::string & )
     assign( obj, "waterproof", waterproof );
 }
 
-std::optional<int> change_scent_iuse::use( Character *p, item &it, const tripoint & ) const
+std::optional<int> change_scent_iuse::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
     p->set_value( "prev_scent", p->get_type_of_scent().c_str() );
     if( waterproof ) {
@@ -5673,7 +5680,7 @@ void effect_on_conditons_actor::info( const item &, std::vector<iteminfo> &dump 
 }
 
 std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
-        const tripoint &point ) const
+        const tripoint_bub_ms &point ) const
 {
     if( need_worn && !p->is_worn( it ) ) {
         p->add_msg_if_player( m_info, _( "You need to wear the %1$s before activating it." ), it.tname() );
@@ -5693,7 +5700,7 @@ std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
         }
         loc = item_location( *p->as_character(), &it );
     } else {
-        loc = item_location( map_cursor( tripoint_bub_ms( point ) ), &it );
+        loc = item_location( map_cursor( point ), &it );
     }
 
     dialogue d( ( char_ptr == nullptr ? nullptr : get_talker_for( char_ptr ) ), get_talker_for( loc ) );

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -113,8 +113,8 @@ class iuse_transform : public iuse_actor
 
         ~iuse_transform() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
         void finalize( const itype_id &my_item_type ) override;
@@ -142,7 +142,7 @@ class unpack_actor : public iuse_actor
 
         ~unpack_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> &dump ) const override;
 };
@@ -160,7 +160,7 @@ class message_iuse : public iuse_actor
 
         ~message_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
 };
@@ -182,7 +182,7 @@ class sound_iuse : public iuse_actor
 
         ~sound_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
 };
@@ -220,7 +220,7 @@ class explosion_iuse : public iuse_actor
 
         ~explosion_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -268,7 +268,7 @@ class consume_drug_iuse : public iuse_actor
 
         ~consume_drug_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 
@@ -303,7 +303,7 @@ class delayed_transform_iuse : public iuse_transform
 
         ~delayed_transform_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -336,7 +336,7 @@ class place_monster_iuse : public iuse_actor
         place_monster_iuse() : iuse_actor( "place_monster" ) { }
         ~place_monster_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -364,7 +364,7 @@ class change_scent_iuse : public iuse_actor
         change_scent_iuse() : iuse_actor( "change_scent" ) { }
         ~change_scent_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -383,7 +383,7 @@ class place_npc_iuse : public iuse_actor
         place_npc_iuse() : iuse_actor( "place_npc" ) { }
         ~place_npc_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -402,7 +402,7 @@ class deploy_furn_actor : public iuse_actor
 
         ~deploy_furn_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -419,7 +419,7 @@ class deploy_appliance_actor : public iuse_actor
         ~deploy_appliance_actor() override = default;
 
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -455,7 +455,7 @@ class reveal_map_actor : public iuse_actor
 
         ~reveal_map_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -484,7 +484,7 @@ class firestarter_actor : public iuse_actor
         /** Player here isn't const because pyromaniacs gain a mood boost from it */
         static void resolve_firestarter_use( Character *p, const tripoint_bub_ms &pos );
         /** Modifier on speed - higher is better, 0 means it won't work. */
-        float light_mod( const tripoint &pos ) const;
+        float light_mod( const tripoint_bub_ms &pos ) const;
         /** Checks quality of fuel on the tile and interpolates move cost based on that. */
         int moves_cost_by_fuel( const tripoint_bub_ms &pos ) const;
 
@@ -492,8 +492,8 @@ class firestarter_actor : public iuse_actor
 
         ~firestarter_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -514,7 +514,7 @@ class salvage_actor : public iuse_actor
 
         ~salvage_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
     private:
         void cut_up( Character &p, item_location &cut ) const;
@@ -557,7 +557,7 @@ class inscribe_actor : public iuse_actor
 
         ~inscribe_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -580,8 +580,8 @@ class fireweapon_off_actor : public iuse_actor
 
         ~fireweapon_off_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -601,7 +601,7 @@ class fireweapon_on_actor : public iuse_actor
 
         ~fireweapon_on_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -622,8 +622,8 @@ class manualnoise_actor : public iuse_actor
 
         ~manualnoise_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -634,8 +634,8 @@ class play_instrument_iuse : public iuse_actor
 
         ~play_instrument_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -679,8 +679,8 @@ class musical_instrument_actor : public iuse_actor
 
         ~musical_instrument_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -697,7 +697,7 @@ class learn_spell_actor : public iuse_actor
 
         ~learn_spell_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *p, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *p, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -724,7 +724,7 @@ class cast_spell_actor : public iuse_actor
 
         ~cast_spell_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
         std::string get_name() const override;
@@ -751,7 +751,7 @@ class holster_actor : public iuse_actor
 
         ~holster_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -765,7 +765,7 @@ class ammobelt_actor : public iuse_actor
 
         ~ammobelt_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -856,7 +856,7 @@ class repair_item_actor : public iuse_actor
 
         ~repair_item_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
         std::string get_name() const override;
@@ -923,7 +923,7 @@ class heal_actor : public iuse_actor
 
         ~heal_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -965,12 +965,12 @@ class place_trap_actor : public iuse_actor
          * The trap that makes up the outer layer of a multi-tile trap. This is not supported for buried traps!
          */
         trap_str_id outer_layer_trap;
-        bool is_allowed( Character &p, const tripoint &pos, const std::string &name ) const;
+        bool is_allowed( Character &p, const tripoint_bub_ms &pos, const std::string &name ) const;
 
         explicit place_trap_actor( const std::string &type = "place_trap" );
         ~place_trap_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -984,7 +984,7 @@ class emit_actor : public iuse_actor
         explicit emit_actor( const std::string &type = "emit_actor" ) : iuse_actor( type ) {}
         ~emit_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void finalize( const itype_id &my_item_type ) override;
 };
@@ -995,7 +995,7 @@ class saw_barrel_actor : public iuse_actor
         explicit saw_barrel_actor( const std::string &type = "saw_barrel" ) : iuse_actor( type ) {}
 
         void load( const JsonObject &jo, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
         ret_val<void> can_use_on( const Character &you, const item &it, const item &target ) const;
@@ -1007,7 +1007,7 @@ class saw_stock_actor : public iuse_actor
         explicit saw_stock_actor( const std::string &type = "saw_stock" ) : iuse_actor( type ) {}
 
         void load( const JsonObject &jo, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
         ret_val<void> can_use_on( const Character &you, const item &it, const item &target ) const;
@@ -1023,7 +1023,7 @@ class molle_attach_actor : public iuse_actor
         int moves;
 
         void load( const JsonObject &jo, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -1036,7 +1036,7 @@ class molle_detach_actor : public iuse_actor
         int moves;
 
         void load( const JsonObject &jo, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -1046,8 +1046,8 @@ class install_bionic_actor : public iuse_actor
         explicit install_bionic_actor( const std::string &type = "install_bionic" ) : iuse_actor( type ) {}
 
         void load( const JsonObject &, const std::string & ) override {}
-        std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
-        ret_val<void> can_use( const Character &, const item &it, const tripoint & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
+        ret_val<void> can_use( const Character &, const item &it, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void finalize( const itype_id &my_item_type ) override;
 };
@@ -1058,8 +1058,8 @@ class detach_gunmods_actor : public iuse_actor
         explicit detach_gunmods_actor( const std::string &type = "detach_gunmods" ) : iuse_actor( type ) {}
 
         void load( const JsonObject &, const std::string & ) override {}
-        std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
-        ret_val<void> can_use( const Character &, const item &it, const tripoint & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
+        ret_val<void> can_use( const Character &, const item &it, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void finalize( const itype_id &my_item_type ) override;
 };
@@ -1070,8 +1070,8 @@ class modify_gunmods_actor : public iuse_actor
         explicit modify_gunmods_actor( const std::string &type = "modify_gunmods" ) : iuse_actor( type ) {}
 
         void load( const JsonObject &, const std::string & ) override {}
-        std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
-        ret_val<void> can_use( const Character &, const item &it, const tripoint & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
+        ret_val<void> can_use( const Character &, const item &it, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void finalize( const itype_id &my_item_type ) override;
 };
@@ -1095,7 +1095,7 @@ class link_up_actor : public iuse_actor
 
         std::optional<int> link_to_veh_app( Character *p, item &it, bool to_ports ) const;
         std::optional<int> link_tow_cable( Character *p, item &it, bool to_towing ) const;
-        std::optional<int> link_extend_cable( Character *p, item &it, const tripoint &pnt ) const;
+        std::optional<int> link_extend_cable( Character *p, item &it, const tripoint_bub_ms &pnt ) const;
         std::optional<int> remove_extensions( Character *p, item &it ) const;
 
         link_up_actor() : iuse_actor( "link_up" ) {}
@@ -1105,7 +1105,7 @@ class link_up_actor : public iuse_actor
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
-        std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
 };
 
 class deploy_tent_actor : public iuse_actor
@@ -1123,7 +1123,7 @@ class deploy_tent_actor : public iuse_actor
 
         ~deploy_tent_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
         bool check_intact( const tripoint_bub_ms &center ) const;
@@ -1142,7 +1142,7 @@ class weigh_self_actor : public iuse_actor
 
         ~weigh_self_actor() override = default;
         void load( const JsonObject &jo, const std::string & ) override;
-        std::optional<int> use( Character *p, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *p, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -1164,7 +1164,7 @@ class sew_advanced_actor : public iuse_actor
 
         ~sew_advanced_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -1186,7 +1186,7 @@ class effect_on_conditons_actor : public iuse_actor
 
         ~effect_on_conditons_actor() override = default;
         void load( const JsonObject &obj, const std::string &src ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint &point ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &point ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2331,8 +2331,8 @@ void outfit::activate_combat_items( npc &guy )
             if( transform->target->has_flag( flag_USE_UPS ) && guy.available_ups() == 0_kJ ) {
                 continue;
             }
-            if( transform->can_use( guy, candidate, tripoint::zero ).success() ) {
-                transform->use( &guy, candidate, tripoint::zero );
+            if( transform->can_use( guy, candidate, tripoint_bub_ms::zero ).success() ) {
+                transform->use( &guy, candidate, tripoint_bub_ms::zero );
                 guy.add_msg_if_npc( _( "<npcname> activates their %s." ), candidate.display_name() );
             }
         }
@@ -2351,8 +2351,8 @@ void outfit::deactivate_combat_items( npc &guy )
             candidate.active ) {
             const iuse_transform *transform = dynamic_cast<const iuse_transform *>
                                               ( candidate.type->get_use( "transform" )->get_actor_ptr() );
-            if( transform->can_use( guy, candidate, tripoint::zero ).success() ) {
-                transform->use( &guy, candidate, tripoint::zero );
+            if( transform->can_use( guy, candidate, tripoint_bub_ms::zero ).success() ) {
+                transform->use( &guy, candidate, tripoint_bub_ms::zero );
                 guy.add_msg_if_npc( _( "<npcname> deactivates their %s." ), candidate.display_name() );
             }
         }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -372,7 +372,7 @@ void vehicle::build_electronics_menu( veh_menu &menu )
             menu.add( _( "Play arcade machine" ) )
             .hotkey( "ARCADE" )
             .enable( !!arc_itm )
-            .on_submit( [arc_itm] { iuse::portable_game( &get_avatar(), arc_itm, tripoint::zero ); } );
+            .on_submit( [arc_itm] { iuse::portable_game( &get_avatar(), arc_itm, tripoint_bub_ms::zero ); } );
             break;
         }
     }
@@ -938,7 +938,7 @@ void vehicle::play_music() const
 {
     Character &player_character = get_player_character();
     for( const vpart_reference &vp : get_enabled_parts( "STEREO" ) ) {
-        iuse::play_music( &player_character, vp.pos_bub().raw(), 15, 30 );
+        iuse::play_music( &player_character, vp.pos_bub(), 15, 30 );
     }
 }
 

--- a/tests/battery_mod_test.cpp
+++ b/tests/battery_mod_test.cpp
@@ -174,7 +174,7 @@ TEST_CASE( "battery_tool_mod_test", "[battery][mod]" )
 
                     Character *dummy = &get_avatar();
                     clear_avatar();
-                    actor->use( dummy, flashlight, dummy->pos() );
+                    actor->use( dummy, flashlight, dummy->pos_bub() );
 
                     // Regression tests for #42764 / #42854
                     THEN( "mod remains installed" ) {

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -108,7 +108,7 @@ TEST_CASE( "tool_transform_when_activated", "[iuse][tool][transform]" )
             const use_function *use = flashlight.type->get_use( "transform" );
             REQUIRE( use != nullptr );
             const iuse_transform *actor = dynamic_cast<const iuse_transform *>( use->get_actor_ptr() );
-            actor->use( dummy, flashlight, dummy->pos() );
+            actor->use( dummy, flashlight, dummy->pos_bub() );
 
             THEN( "it becomes active" ) {
                 CHECK( flashlight.active );

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -384,7 +384,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             const use_function *use = elec_shears.type->get_use( "transform" );
             REQUIRE( use != nullptr );
             const iuse_transform *actor = dynamic_cast<const iuse_transform *>( use->get_actor_ptr() );
-            actor->use( &dummy, elec_shears, dummy.pos() );
+            actor->use( &dummy, elec_shears, dummy.pos_bub() );
 
             dummy.i_add( elec_shears );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 3 );
@@ -430,7 +430,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             const use_function *use = elec_shears.type->get_use( "transform" );
             REQUIRE( use != nullptr );
             const iuse_transform *actor = dynamic_cast<const iuse_transform *>( use->get_actor_ptr() );
-            actor->use( &dummy, elec_shears, dummy.pos() );
+            actor->use( &dummy, elec_shears, dummy.pos_bub() );
 
             dummy.i_add( elec_shears );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 3 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Replace usage of untyped coordinates with typed ones. This time in iuse and iuse_actor.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Search for "point " in the files (iuse.h, iuse.cpp, iuse_actor.h, and iuse_actor.cpp).
- Replace untyped operations with typed ones, and adapt the usages.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load a save, walk up a ramp, jump into a car, drive through some hay bales, run over a zombie corpse with inventory, run over a turkey, smash into a stationary vehicle. Saw nothing strange.
The changes should have no functional effect, so there is no particular thing to look out for.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This one was a bit scary since all derived classes had to be changed in a single sweep, so if I suffered from the dreaded template crisis where it fails to link because something, somewhere, didn't match up with some template somewhere I'd be screwed (normally you can change one operation and its usages and link, so have some idea about where something can have gone wrong). Fortunately, I didn't suffer from any template issues this time, not even the typical one with pages and pages of usages of the operation disliking a parameter somewhere in the output (which can be tracked down, as the error location is buried somewhere in that mess).

I think this PR was a bit smaller than usual, but this was a good point to stop.

P.S. Screwed up the typing of the branch name, but so what: it doesn't really matter, and I didn't notice until I tried to push it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
