### PR TITLE
Remove path limitation and adjust skip-actions logic in clang-tidy job

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -30,7 +30,6 @@ jobs:
           paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/clang-tidy.sh", "build-scripts/clang-tidy-wrapper.sh", "build-scripts/get_affected_files.py", ".github/workflows/clang-tidy.yml" ]'
   build:
     needs: skip-duplicates
-    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
 
     strategy:
       fail-fast: false
@@ -92,6 +91,7 @@ jobs:
           fs.writeFileSync("files_changed", files.join('\n'));
     - uses: ammaraskar/gcc-problem-matcher@master
     - name: run clang-tidy
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: bash ./build-scripts/clang-tidy.sh
     - name: show most time consuming checks
       if: always()

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -50,6 +50,7 @@ jobs:
         RELEASE: 1
     steps:
     - name: install LLVM 17
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
@@ -62,6 +63,7 @@ jobs:
           sudo apt install python3-pip libncursesw5-dev ninja-build cmake gettext
           pip3 install --user lit
     - name: ensure clang-tidy and FileCheck commands point to LLVM 17
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: |
           mkdir ~/llvm-command-override
           ln -s /usr/bin/clang-tidy-17 ~/llvm-command-override/clang-tidy

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -8,17 +8,6 @@ on:
   pull_request:
     branches:
     - master
-    paths:
-    - '**.c'
-    - '**.cpp'
-    - '**.h'
-    - '**.hpp'
-    - '**/CMakeLists.txt'
-    - '**/Makefile'
-    - 'build-scripts/clang-tidy.sh'
-    - 'build-scripts/clang-tidy-wrapper.sh'
-    - 'build-scripts/get_affected_files.py'
-    - '.github/workflows/clang-tidy.yml'
     types: [opened, reopened, synchronize, ready_for_review]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Tried making the "clang-tidy (src)" job mandatory (again), was reminded that if the job never runs the system counts that as a failure or at least a not-pass.
While looking at docs for skip-duplicate-actions I found that required matrix jobs require special handling https://github.com/marketplace/actions/skip-duplicate-actions#how-to-use-skip-check-with-required-matrix-jobs

#### Describe the solution
Don't use GHA path-based optional triggering for the job, it has to run on every PR now.
Adjust skip-duplicate-actions logic to skip just the (expensive) clang-tidy step instead of the whole job, this allows the matrix job to run but be marked as a success despite being skipped.

#### Describe alternatives you've considered
Do we *really* need clang-tidy to be mandatory? Yes we do, it breaking all the time is a pain.

#### Testing
This just makes things more permissive, so the failure mode is if we have types of changes that erroneously trigger a full clang-tidy check somehow.

#### Additional context
In-flight non-cpp changes will need to be rebased to pick this up before we mark the clang-tidy job as required again, otherwise their lack of a required check will block merging.
I'm not in a HUUUGE hurry to do so, so we can take our time a bit, but we will definitely need to do some amount of rebasing.