### PR TITLE
Crafting GUI filter: by bodypart coverage; Add filter by layer (for crafting GUI, AIM, inventory etc.)

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -990,6 +990,11 @@ static recipe_subset filter_recipes( const recipe_subset &available_recipes,
                                        recipe_subset::search_type::covers, progress_callback );
                     break;
 
+                case 'e':
+                    filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
+                                       recipe_subset::search_type::layer, progress_callback );
+                    break;
+
                 case 'd':
                     filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
                                        recipe_subset::search_type::description_result, progress_callback );
@@ -1075,6 +1080,7 @@ static const std::vector<SearchPrefix> prefixes = {
     { 'l', to_translation( "5" ), to_translation( "<color_cyan>difficulty</color> of the recipe as a number or range" ) },
     { 'r', to_translation( "buttermilk" ), to_translation( "recipe's (<color_cyan>by</color>)<color_cyan>products</color>; use * as wildcard" ) },
     { 'v', to_translation( "head" ), to_translation( "<color_cyan>body part</color> the result covers" ) },
+    { 'e', to_translation( "close to skin" ), to_translation( "<color_cyan>layer</color> the result covers" ) },
     { 'a', to_translation( "brisk" ), to_translation( "recipe's <color_cyan>activity level</color>" ) }
 };
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -985,6 +985,11 @@ static recipe_subset filter_recipes( const recipe_subset &available_recipes,
                                        recipe_subset::search_type::quality_result, progress_callback );
                     break;
 
+                case 'v':
+                    filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
+                                       recipe_subset::search_type::covers, progress_callback );
+                    break;
+
                 case 'd':
                     filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
                                        recipe_subset::search_type::description_result, progress_callback );
@@ -1069,6 +1074,7 @@ static const std::vector<SearchPrefix> prefixes = {
     { 'P', to_translation( "Blacksmithing" ), to_translation( "<color_cyan>proficiency</color> used to craft" ) },
     { 'l', to_translation( "5" ), to_translation( "<color_cyan>difficulty</color> of the recipe as a number or range" ) },
     { 'r', to_translation( "buttermilk" ), to_translation( "recipe's (<color_cyan>by</color>)<color_cyan>products</color>; use * as wildcard" ) },
+    { 'v', to_translation( "head" ), to_translation( "<color_cyan>body part</color> the result covers" ) },
     { 'a', to_translation( "brisk" ), to_translation( "recipe's <color_cyan>activity level</color>" ) }
 };
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3831,6 +3831,28 @@ static void armor_protect_dmg_info( int dmg, std::vector<iteminfo> &info )
     }
 }
 
+std::string item::layer_to_string( layer_level data )
+{
+    switch( data ) {
+        case layer_level::PERSONAL:
+            return _( "Personal aura" );
+        case layer_level::SKINTIGHT:
+            return _( "Close to skin" );
+        case layer_level::NORMAL:
+            return _( "Normal" );
+        case layer_level::WAIST:
+            return _( "Waist" );
+        case layer_level::OUTER:
+            return _( "Outer" );
+        case layer_level::BELTED:
+            return _( "Strapped" );
+        case layer_level::AURA:
+            return _( "Outer aura" );
+        default:
+            return _( "Should never see this" );
+    }
+}
+
 void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                                   int /*batch*/, bool /*debug*/, const sub_bodypart_id &sbp ) const
 {
@@ -3846,31 +3868,7 @@ void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_qu
 
         // get the layers this bit of the armor covers if its unique compared to the rest of the armor
         for( const layer_level &ll : get_layer( sbp ) ) {
-            switch( ll ) {
-                case layer_level::PERSONAL:
-                    layering += _( " <stat>Personal aura</stat>." );
-                    break;
-                case layer_level::SKINTIGHT:
-                    layering += _( " <stat>Close to skin</stat>." );
-                    break;
-                case layer_level::NORMAL:
-                    layering += _( " <stat>Normal</stat>." );
-                    break;
-                case layer_level::WAIST:
-                    layering += _( " <stat>Waist</stat>." );
-                    break;
-                case layer_level::OUTER:
-                    layering += _( " <stat>Outer</stat>." );
-                    break;
-                case layer_level::BELTED:
-                    layering += _( " <stat>Strapped</stat>." );
-                    break;
-                case layer_level::AURA:
-                    layering += _( " <stat>Outer aura</stat>." );
-                    break;
-                default:
-                    layering += _( " Should never see this." );
-            }
+            layering += string_format( " <stat>%s</stat>.", item::layer_to_string( ll ) );
         }
         //~ Limb-specific coverage (%s = name of limb)
         info.emplace_back( "DESCRIPTION", string_format( _( "<bold>Coverage</bold>:%s" ), layering ) );

--- a/src/item.h
+++ b/src/item.h
@@ -547,6 +547,11 @@ class item : public visitable
                          bool debug ) const;
 
         /**
+         * @return human readable, translated string.
+         */
+        static std::string layer_to_string( layer_level data );
+
+        /**
          * Calculate all burning calculations, but don't actually apply them to item.
          * DO apply them to @ref fire_data argument, though.
          * @return Amount of "burn" that would be applied to the item.

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -104,7 +104,7 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
                     }
                 }
             }
-            return [filter, filtered_bodyparts, filtered_sub_bodyparts]( const item & i ) {
+            return [filtered_bodyparts, filtered_sub_bodyparts]( const item & i ) {
                 return std::any_of( filtered_bodyparts.begin(), filtered_bodyparts.end(),
                 [&i]( const bodypart_id & bp ) {
                     return i.covers( bp );

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -115,6 +115,21 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
                 } );
             };
         }
+        // covers layer
+        case 'e': {
+            std::unordered_set<layer_level> filtered_layers;
+            for( layer_level layer = layer_level( 0 ); layer != layer_level::NUM_LAYER_LEVELS; ++layer ) {
+                if( lcmatch( item::layer_to_string( layer ), filter ) ) {
+                    filtered_layers.insert( layer );
+                }
+            }
+            return [filtered_layers]( const item & i ) {
+                const std::vector<layer_level> layers = i.get_layer();
+                return std::any_of( layers.begin(), layers.end(), [&filtered_layers]( layer_level l ) {
+                    return filtered_layers.count( l );
+                } );
+            };
+        }
         // by name
         default:
             return [filter]( const item & a ) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1082,6 +1082,7 @@ static const std::vector<ItemFilterPrefix> item_filter_prefixes = {
     { 's', to_translation( "devices" ), to_translation( "<color_cyan>skill</color> taught by books" ) },
     { 'd', to_translation( "pipe" ), to_translation( "<color_cyan>disassembled</color> components" ) },
     { 'v', to_translation( "hand" ), to_translation( "covers <color_cyan>body part</color>" ) },
+    { 'e', to_translation( "close to skin" ), to_translation( "covers <color_cyan>layer</color>" ) },
     { 'b', to_translation( "mre;sealed" ), to_translation( "items satisfying <color_cyan>both</color> conditions" ) }
 };
 

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -188,6 +188,7 @@ static std::string cached_item_info( const itype_id &item_type )
 // keep data for one search cycle
 static std::unordered_set<bodypart_id> filtered_bodyparts;
 static std::unordered_set<sub_bodypart_id> filtered_sub_bodyparts;
+static std::unordered_set<layer_level> filtered_layers;
 
 std::vector<const recipe *> recipe_subset::search(
     const std::string_view txt, const search_type key,
@@ -239,6 +240,13 @@ std::vector<const recipe *> recipe_subset::search(
                 || std::any_of( filtered_sub_bodyparts.begin(), filtered_sub_bodyparts.end(),
                 [&result_item]( const sub_bodypart_id & sbp ) {
                     return result_item.covers( sbp );
+                } );
+            }
+
+            case search_type::layer: {
+                const std::vector<layer_level> layers = item( r->result() ).get_layer();
+                return std::any_of( layers.begin(), layers.end(), []( layer_level l ) {
+                    return filtered_layers.count( l );
                 } );
             }
 
@@ -334,6 +342,15 @@ std::vector<const recipe *> recipe_subset::search(
                         || lcmatch( sbp->name_multiple.translated(), txt ) ) {
                         filtered_sub_bodyparts.insert( sbp->id );
                     }
+                }
+            }
+            break;
+        }
+        case search_type::layer: {
+            filtered_layers.clear();
+            for( layer_level layer = layer_level( 0 ); layer != layer_level::NUM_LAYER_LEVELS; ++layer ) {
+                if( lcmatch( item::layer_to_string( layer ), txt ) ) {
+                    filtered_layers.insert( layer );
                 }
             }
             break;

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -149,6 +149,7 @@ class recipe_subset
             tool,
             quality,
             quality_result,
+            covers,
             description_result,
             proficiency,
             difficulty,

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -150,6 +150,7 @@ class recipe_subset
             quality,
             quality_result,
             covers,
+            layer,
             description_result,
             proficiency,
             difficulty,


### PR DESCRIPTION
#### Summary
Interface "Crafting GUI filter: by bodypart coverage; Add filter by layer (for crafting GUI, AIM, inventory etc.);;; make them two lines in the changelog, please"

#### Purpose of change

![image](https://github.com/user-attachments/assets/c63b4ccf-3209-4a25-9fee-7244baa34d54)
_Crafting GUI filter._

 - Fixes #63091 (This is the last part! I am proud of myself 😏.)

#### Describe the solution

`coverage` in Crafting GUI

 - Copy and paste (mostly) `covers` from `item_search.cpp` (used by e.g. AIM) to crafting GUI.
https://github.com/CleverRaven/Cataclysm-DDA/blob/c2fdece67993d2cea49d09efbb1684829230cdc7/src/item_search.cpp#L90-L91
 - Use the prefix `v:` just as in AIM.
 - Started a pattern of allowing each search key to define "one time job" to prepare the search. In this case, prepare bodypart ids from the user's filter string. Then, in the main loop, use that prepared data.

`layer`
 - Make a filter similar to `coverage` filter.
 - Use prefix `e:` in both, crafting GUI and AIM.

#### Describe alternatives you've considered

Move code from `item_search.cpp` into a common function and use it at both places.

#### Testing

Note: `d:` is the slow full-text search (see #63091) and `v:` is the new filter filtering by bodypart coverage.

refactor

 - Tested the refactor by searching `v:head` in AIM

coverage

 - Search `v:head`, `v:fingers`, `v:heel` etc. in the crafting GUI.
 - Searching for head armour that is close to skin with `v:head, d:close to` now takes 3 to 4 seconds. Took over 50 seconds before with `d:head, d:close to`.
 - Results are more accurate (and so much faster) if you search for a torso covering armour with `v:torso` than with `d:torso`.
   - Example found by `d:torso` and correctly not found by `v:torso` is `tempered steel chainmail sheet`. It can be used to craft `exoskeleton torso armor` which is in the full description.
 - `v:head, v:torso` returns turtleneck and such.

layer

 - Search `e: close to`, `e: normal`, `e: outer`, `e: strapp` in crafting GUI, AIM, inventory. 
 - Searching for head armour that is close to skin with `v:head, e:close to` is instant and returns the same as `v:head, d:close to` which takes 3 to 4 seconds.

#### Additional context
