### PR TITLE
Skip enscripten build on no-code-changes PRs

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -356,7 +356,7 @@ jobs:
         if-no-files-found: ignore
         retention-days: 9
   emscripten:
-    needs: [ varied_builds ]
+    needs: [ skip-duplicates-code, varied_builds ]
     uses: ./.github/workflows/emscripten.yml
-    if: ${{ success() && github.event.pull_request.draft == false }}
+    if: ${{ needs.skip-duplicates.outputs.should_skip_code != 'true' && success() && github.event.pull_request.draft == false }}
     secrets: inherit


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I noticed the enscripten build was running on a change where all of the other matrix build steps were skipped.

#### Describe the solution
Add a dependency on the skip-duplicate-actions job and a conditional for invoking the enscripten build.