### PR TITLE
Appliance interaction menu is no longer cut off at the bottom

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -683,7 +683,7 @@ void uilist::calc_data()
 
     vmax = entries.size();
 
-    ImVec2 title_size = {};
+    ImVec2 title_size = ImVec2();
     bool has_titlebar = !title.empty();
     if( has_titlebar ) {
         title_size = calc_size( title );
@@ -691,19 +691,19 @@ void uilist::calc_data()
         title_size.y += ( s.ItemSpacing.y * expected_num_lines ) + ( s.ItemSpacing.y * 2.0 );
     }
 
-    ImVec2 text_size = {};
+    ImVec2 text_size = ImVec2();
     if( !text.empty() ) {
         text_size = calc_size( text );
         float expected_num_lines = text_size.y / ImGui::GetTextLineHeight();
         text_size.y += ( s.ItemSpacing.y * expected_num_lines ) + ( s.ItemSpacing.y * 2.0 );
     }
 
-    ImVec2 tabs_size = {};
+    ImVec2 tabs_size = ImVec2();
     if( !categories.empty() ) {
         tabs_size.y = ImGui::GetTextLineHeightWithSpacing() + ( 2.0 * s.FramePadding.y );
     }
 
-    ImVec2 desc_size = {};
+    ImVec2 desc_size = ImVec2();
     if( desc_enabled ) {
         desc_size = calc_size( footer_text );
         for( const uilist_entry &ent : entries ) {
@@ -747,9 +747,9 @@ void uilist::calc_data()
             max_avail_height = std::min( max_avail_height, desired_height );
         }
     }
-    calculated_menu_size.y = std::min( max_avail_height - additional_height +
-                                       ( s.FramePadding.y * 2.0 ),
-                                       vmax * ImGui::GetTextLineHeightWithSpacing() + ( s.FramePadding.y * 2.0 ) );
+    calculated_menu_size.y = std::min(
+                                 max_avail_height - additional_height + ( s.FramePadding.y * 2.0 ),
+                                 vmax * ImGui::GetTextLineHeightWithSpacing() + ( s.FramePadding.y * 2.0 ) );
 
     extra_space_left = 0.0;
     extra_space_right = 0.0;

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -195,13 +195,15 @@ void veh_app_interact::init_ui_windows()
     //NOLINTNEXTLINE(cata-use-named-point-constants)
     w_info = catacurses::newwin( height_info, width_info, topleft + point( 1, 1 ) );
 
+    // Try to align the imgui window to be below the header.
+    // to that end, we have some awkward math translating character positions to screen positions here:
     ImVec2 text_metrics = { ImGui::CalcTextSize( "X" ).x, ImGui::GetTextLineHeight() };
     ImVec2 origin = text_metrics * ImVec2{ static_cast<float>( topleft.x ), static_cast<float>( topleft.y + win_height ) };
     ImVec2 size = text_metrics * ImVec2{ static_cast<float>( win_width ), static_cast<float>( height_input ) };
     imenu.desired_bounds = { origin.x,
                              origin.y,
-                             size.x,
-                             size.y + 4.0f * ( ImGui::GetStyle().FramePadding.y + ImGui::GetStyle().WindowBorderSize )
+                             size.x,  // align the width of the input to be the same as the header
+                             -1,      // but let uilist choose the height as it pleases.
                            };
 
     imenu.allow_cancel = true;
@@ -605,7 +607,6 @@ void veh_app_interact::populate_app_actions()
         imenu.addentry( -1, it._enabled, hotkey, it._text );
         app_actions.emplace_back( it._on_submit );
     }
-    imenu.setup();
 }
 
 shared_ptr_fast<ui_adaptor> veh_app_interact::create_or_get_ui_adaptor()


### PR DESCRIPTION
#### Summary
Bugfixes "Appliance interaction menu is no longer cut off at the bottom"

#### Purpose of change

Fixes #78177

#### Describe the solution

Let `uilist` do the sizing instead of trying to re-calculate the needed height in appliance interaction menu code.

#### Describe alternatives you've considered

Unlike the diff  proposed by @ZhilkinSerg, I decided to leave the width of the input as it was - way wider than it needs to be - because ~~I didn't see Serg's comment at the time of my commit~~ I think it looks a bit better that way.

I think ideal solution would be to migrate the "header" of the interaction menu to imgui as well, but that's a bit beyond me for now.

#### Testing

tiles
![20241204-233028-cataclysm-tiles](https://github.com/user-attachments/assets/a5395df4-24a3-45e8-b922-1e0a0f8ee6fb)

smol tiles
![20241204-233041-cataclysm-tiles](https://github.com/user-attachments/assets/9a38aa66-e4a8-4834-927e-c78be16586b1)

curses
![20241204-233502-VsDebugConsole](https://github.com/user-attachments/assets/d96dc31e-729d-4be6-81a3-71181ac511f7)

#### Additional context

two minor drive-by changes (i probably don't need to write this out but hey):

* While i was debugging this thing trying to understand how layout works, i was getting weird values for locals. I'm very rusty with C++, but *I think* `ImVec2 title_size = {};` creates uninitialized (rather than zeroed) value which might be UB and might be bad. So I changed those to `ImVec2 title_size = ImVec2();` (since `ImVec2` conveniently has a nice zero constructor like that). There is no change in behaviour, but the locals in the debugger look a bit less confusing now. 
* removed redundant `imenu.setup();` in `veh_app_interact::populate_app_actions()`. The latter is only ever called in `veh_app_interact::init_ui_windows()`, and is always followed by `imenu.setup();` anyway, so what's the point doing it twice.