### PR TITLE
[Xedra Evolved] Reasonable Werewolf nerfs

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -104,7 +104,6 @@
           { "value": "SOCIAL_INTIMIDATE", "add": 40 },
           { "value": "METABOLISM", "multiply": 4 },
           { "value": "LEARNING_FOCUS", "add": -10 },
-          { "value": "READING_SPEED_MULTIPLIER", "multiply": 4 },
           { "value": "OBTAIN_COST_MULTIPLIER", "multiply": 2 }
         ],
         "mutations": [ "MUZZLE", "TAIL_FLUFFY", "PAWS", "LUPINE_FUR", "LUPINE_EARS", "PERSISTENCE_HUNTER2", "PRED3" ]
@@ -129,7 +128,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_WAR_FORM_BANNED_ACTIVITY",
+    "id": "EOC_WAR_FORM_BANNED_ACTIVITY_PHYSICAL",
     "eoc_type": "EVENT",
     "required_event": "character_starts_activity",
     "condition": {
@@ -148,11 +147,47 @@
             { "compare_string": [ "ACT_BOLTCUTTING", { "context_val": "activity" } ] },
             { "compare_string": [ "ACT_HAIRCUT", { "context_val": "activity" } ] },
             { "compare_string": [ "ACT_SHAVE", { "context_val": "activity" } ] },
-            { "compare_string": [ "ACT_CRACKING", { "context_val": "activity" } ] }
+            { "compare_string": [ "ACT_CRACKING", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_MULTIPLE_FARM", { "context_val": "activity" } ] }
           ]
         }
       ]
     },
     "effect": [ "u_cancel_activity", { "u_message": "Your war form lacks the necessary precision for that.", "type": "bad" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_WAR_FORM_BANNED_ACTIVITY_MENTAL",
+    "eoc_type": "EVENT",
+    "required_event": "character_starts_activity",
+    "condition": {
+      "and": [
+        { "u_has_trait": "WEREWOLF_HYBRID_FORM_TRAITS" },
+        {
+          "or": [
+            { "compare_string": [ "ACT_READ", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_EBOOKSAVE", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_TIDY_UP", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_MOP", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_VEHICLE_DECONSTRUCTION", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_MULTIPLE_DIS", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_MULTIPLE_FISH", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_FISH", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_GENERIC_GAME", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_GAME", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_DISASSEMBLE", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_SOCIALIZE", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_VIBE", { "context_val": "activity" } ] }
+          ]
+        }
+      ]
+    },
+    "effect": [
+      "u_cancel_activity",
+      {
+        "u_message": "Your mind is filled with the urge to sink your fangs into your enemies throats, leaving no room for other activities.",
+        "type": "bad"
+      }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -147,13 +147,12 @@
             { "compare_string": [ "ACT_BOLTCUTTING", { "context_val": "activity" } ] },
             { "compare_string": [ "ACT_HAIRCUT", { "context_val": "activity" } ] },
             { "compare_string": [ "ACT_SHAVE", { "context_val": "activity" } ] },
-            { "compare_string": [ "ACT_CRACKING", { "context_val": "activity" } ] },
-            { "compare_string": [ "ACT_MULTIPLE_FARM", { "context_val": "activity" } ] }
+            { "compare_string": [ "ACT_CRACKING", { "context_val": "activity" } ] }
           ]
         }
       ]
     },
-    "effect": [ "u_cancel_activity", { "u_message": "Your war form lacks the necessary precision for that.", "type": "bad" } ]
+    "effect": [ "u_cancel_activity", { "u_message": "Your war form lacks the fine dexterity for that.", "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",
@@ -177,7 +176,8 @@
             { "compare_string": [ "ACT_GAME", { "context_val": "activity" } ] },
             { "compare_string": [ "ACT_DISASSEMBLE", { "context_val": "activity" } ] },
             { "compare_string": [ "ACT_SOCIALIZE", { "context_val": "activity" } ] },
-            { "compare_string": [ "ACT_VIBE", { "context_val": "activity" } ] }
+            { "compare_string": [ "ACT_VIBE", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_MULTIPLE_FARM", { "context_val": "activity" } ] }
           ]
         }
       ]

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -101,7 +101,11 @@
           { "value": "STAMINA_REGEN_MOD", "add": 0.2 },
           { "value": "MELEE_STAMINA_CONSUMPTION", "multiply": -0.33 },
           { "value": "SOCIAL_PERSUADE", "add": -50 },
-          { "value": "SOCIAL_INTIMIDATE", "add": 40 }
+          { "value": "SOCIAL_INTIMIDATE", "add": 40 },
+          { "value": "METABOLISM", "multiply": 4 },
+          { "value": "LEARNING_FOCUS", "add": -10 },
+          { "value": "READING_SPEED_MULTIPLIER", "multiply": 4 },
+          { "value": "OBTAIN_COST_MULTIPLIER", "multiply": 2 }
         ],
         "mutations": [ "MUZZLE", "TAIL_FLUFFY", "PAWS", "LUPINE_FUR", "LUPINE_EARS", "PERSISTENCE_HUNTER2", "PRED3" ]
       },

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -189,5 +189,13 @@
         "type": "bad"
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_WAR_FORM_SHIFT_BACK_ON_SLEEP",
+    "eoc_type": "EVENT",
+    "required_event": "character_falls_asleep",
+    "condition": { "u_has_trait": "WEREWOLF_HYBRID_FORM_TRAITS" },
+    "effect": [ { "u_deactivate_trait": "WEREWOLF_HYBRID_FORM" } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -126,5 +126,33 @@
     "flags": [ "NO_SPELLCASTING", "PRED3", "TOUGH_FEET", "TEMPORARY_SHAPESHIFT", "SHAPESHIFT_SIZE_HUGE" ],
     "override_look": { "id": "mon_loup_garou", "tile_category": "monster" },
     "integrated_armor": [ "integrated_claws_werewolf", "integrated_werewolf_teeth", "integrated_lupine_fur" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_WAR_FORM_BANNED_ACTIVITY",
+    "eoc_type": "EVENT",
+    "required_event": "character_starts_activity",
+    "condition": {
+      "and": [
+        { "u_has_trait": "WEREWOLF_HYBRID_FORM_TRAITS" },
+        {
+          "or": [
+            { "compare_string": [ "ACT_LOCKPICK", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_REPAIR_ITEM", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_MEND_ITEM", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_VEHICLE_REPAIR", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_RELOAD", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_FIRSTAID", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_MILK", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_HACKSAW", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_BOLTCUTTING", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_HAIRCUT", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_SHAVE", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_CRACKING", { "context_val": "activity" } ] }
+          ]
+        }
+      ]
+    },
+    "effect": [ "u_cancel_activity", { "u_message": "Your war form lacks the necessary precision for that.", "type": "bad" } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -185,7 +185,7 @@
     "effect": [
       "u_cancel_activity",
       {
-        "u_message": "Your mind is filled with the urge to sink your fangs into your enemies throats, leaving no room for other activities.",
+        "u_message": "Your mind is filled with the urge to sink your fangs into your enemies' throats, leaving no room for these passive activities.",
         "type": "bad"
       }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Reasonable Werewolf nerfs"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Talking with people on Discord about ways to disincentivize you from spending all your time in war form.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a few more enchantments for war form:

1. Your metabolism runs 5x normal speed in war form. You are a 3-meter-tall wall of fangs and muscle who regenerates from being blown almost to bits in minutes. You run hotter than most people.
2. -10 penalty to Learning focus. The rage of war form makes it hard to concentrate (war form already has `COMBAT_CATCHUP` to offset this for combat skills.
4. You transfer items from containers at one third of normal speed because you have giant hands with massive claws that make it very difficulty to manipulate anything. It should probably be even slower but this is a good start. 

Werewolves already craft 80% slower in war form, so this is a good addition.

Also implemented two EoCs that auto-cancel certain activities when you try to do them, like lockpicking or hacksawing or applying first aid (you don't have the necessary fine dexterity) or reading or socializing or playing video games (your mind is too filled with the urge to hunt to concentrate on that). 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Game loads, it is still possible to gain combat skill xp in war form. Trying to pick locks auto-cancels with the appropriate message.
![Untitled2](https://github.com/user-attachments/assets/3902f196-0d95-47c1-91b6-1efdc34b0dfa)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Using this same method I can stop shapeshifted owls, wolves, bats, deer, etc. from doing most things that they shouldn't be able to do
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
