### PR TITLE
math: use sstream for number conversion

### DIFF
--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "cata_assert.h"
-#include "cata_scope_helpers.h"
 #include "cata_utility.h"
 #include "condition.h"
 #include "debug.h"
@@ -55,8 +54,13 @@ constexpr std::optional<double> get_constant( std::string_view token )
 
 std::optional<double> get_number( std::string_view token )
 {
-    if( std::optional<double> ret = svtod( token ); ret ) {
-        return *ret;
+    // FIXME: port to std::from_chars once double conversion is supported
+    std::istringstream conv( std::string{ token } );
+    conv.imbue( std::locale::classic() );
+    double val{};
+    conv >> val;
+    if( conv && conv.eof() ) {
+        return val;
     }
 
     return get_constant( token );
@@ -299,10 +303,6 @@ class math_exp::math_exp_impl
             if( str.empty() ) {
                 return false;
             }
-            std::locale const &oldloc = std::locale::global( std::locale::classic() );
-            on_out_of_scope reset_loc( [&oldloc]() {
-                std::locale::global( oldloc );
-            } );
             try {
                 _parse( str );
             } catch( math::syntax_error const &ex ) {

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -961,6 +961,6 @@ TEST_CASE( "tname_i18n_order", "[item][tname][translations]" )
     CHECK( backpack.tname() ==
            "<color_c_green>++</color> backpack (burnt) (filthy)" );
 
-    set_language_from_options();
+    set_language( "en" );
 }
 #endif


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
The math parser  uses a number-conversion function that doesn't work too well because:
- it doesn't respect token boundaries because the tokens aren't null-terminated
- it uses the C locale instead of the C++ one

- Fixes: #78334

AFAICT, the issue occurs only in test units and only on windows, since #77885, due to [this bit of code](https://github.com/CleverRaven/Cataclysm-DDA/blob/9d3c4c68d99987c4aec0d66e13d8407badcb048b/src/translations.cpp#L83-L88). In normal game operation, the C-locale is immediately overwritten in `update_global_locale()`.

#### Describe the solution
Use stringstream for number conversions. This respects token boundaries and definitely uses the locale we want.

#### Describe alternatives you've considered
Wait for `std::from_chars()`
Delete [dead code](https://github.com/CleverRaven/Cataclysm-DDA/blob/9d3c4c68d99987c4aec0d66e13d8407badcb048b/src/translations.cpp#L83-L88)

#### Testing
Updated test unit
@mqrause please test


#### Additional context
N/A


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
