### PR TITLE
Killing hostile NPCs won't give "Killed innocent" morale debuff anymore

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2474,7 +2474,8 @@ bool npc::is_minion() const
 
 bool npc::guaranteed_hostile() const
 {
-    return is_enemy() || ( my_fac && my_fac->likes_u < -10 );
+    return attitude_to( get_player_character() ) == Attitude::HOSTILE || is_enemy() ||
+           ( my_fac && my_fac->likes_u < -10 );
 }
 
 bool npc::is_walking_with() const


### PR DESCRIPTION
#### Summary
Bugfixes "Killing hostile NPCs won't give "Killed innocent" morale debuff anymore"

#### Purpose of change
* Fixes #30124 (hopefully).

At the moment, to NOT get the morale debuff for killing NPCs, said NPC has to be `guaranteed_hostile`. This condition is true if at least one of the following conditions is true:
1. said NPC `is_enemy`, which means that he must have _NPC_ attitude of killing us (`NPCATT_KILL`) or fleeing from us (`NPCATT_FLEE` or `NPCATT_FLEE_TEMP`).
2. said NPC must have a faction, and this faction must dislike us a lot.

There are situations where hostile NPC isn't aware of us yet and thus is ignoring us and thus his _NPC_ attitude is `NPCATT_NULL`. This means that first condition from the list above will be false.
As @mlangsdorf said in https://github.com/CleverRaven/Cataclysm-DDA/issues/30124#issuecomment-488393482, there _might_ be some bugs or errors in faction assignment or evaluation, and this _might_ be the reason why second condition from the list above also becomes false.
If both conditions are false, killing hostile NPC will give us a morale debuff.

#### Describe the solution
Added a check for hostile _creature_ attitude, i.e. `Creature::Attitude::HOSTILE`. Hostile NPCs which haven't seen us yet (and thus not angry at us and not trying to kill us yet) have this attitude, and thus won't be considered as innocent, even if faction check fail for some reason.

In any case, if these changes won't fix the issue, this additional check for creature attitude won't hurt.

#### Describe alternatives you've considered
None.

#### Testing
I conducted A LOT of testing using several methods from #30124 and #71341, i.e. killing bandits spawned through Old Guard representative's mission, bandits in road block, bandits in `bandits_garage` and some others. I wasn't able to reproduce the original issue. If anyone has a save which can reliably reproduce the issue, please give it to me, I'll try to test it myself.

#### Additional context
None.