### PR TITLE
Structure Damage: Car Crashes, initial implementation

### DIFF
--- a/data/json/mapgen/house/house01.json
+++ b/data/json/mapgen/house/house01.json
@@ -62,7 +62,8 @@
           "x": [ 4, 13 ],
           "y": 17
         },
-        { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 0 }
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 22, "y": 0 },
+        { "chunks": [ [ "null", 950 ], [ "carcrash_10x10_straight", 16 ], [ "carcrash_10x10_diag_fromleft", 17 ], [ "carcrash_10x10_diag_fromright", 17 ] ], "x": 10, "y": 0 }
       ]
     }
   },

--- a/data/json/mapgen/house/house01.json
+++ b/data/json/mapgen/house/house01.json
@@ -63,7 +63,7 @@
           "y": 17
         },
         { "chunks": [ "rolling_trash_can_1x1" ], "x": 22, "y": 0 },
-        { "chunks": [ [ "null", 950 ], [ "carcrash_10x10_straight", 16 ], [ "carcrash_10x10_diag_fromleft", 17 ], [ "carcrash_10x10_diag_fromright", 17 ] ], "x": 10, "y": 0 }
+        { "chunks": [ [ "null", 95 ], [ "carcrash_10x10_rand", 5 ] ], "x": 10, "y": 0 }
       ]
     }
   },

--- a/data/json/mapgen/house/house10.json
+++ b/data/json/mapgen/house/house10.json
@@ -37,7 +37,10 @@
         { "group": "guns_pistol_common", "x": [ 20, 20 ], "y": [ 8, 8 ], "chance": 4, "ammo": 90, "magazine": 100 },
         { "group": "guns_pistol_common", "x": [ 18, 18 ], "y": [ 20, 20 ], "chance": 3, "ammo": 90, "magazine": 100 }
       ],
-      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ],
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 18, "y": 1 },
+        { "chunks": [ [ "null", 950 ], [ "carcrash_10x10_straight", 16 ], [ "carcrash_10x10_diag_fromleft", 17 ], [ "carcrash_10x10_diag_fromright", 17 ] ], "x": 2, "y": 0 }
+      ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ]
     }
   },

--- a/data/json/mapgen/house/house10.json
+++ b/data/json/mapgen/house/house10.json
@@ -39,7 +39,7 @@
       ],
       "place_nested": [
         { "chunks": [ "rolling_trash_can_1x1" ], "x": 18, "y": 1 },
-        { "chunks": [ [ "null", 950 ], [ "carcrash_10x10_straight", 16 ], [ "carcrash_10x10_diag_fromleft", 17 ], [ "carcrash_10x10_diag_fromright", 17 ] ], "x": 2, "y": 0 }
+        { "chunks": [ [ "null", 95 ], [ "carcrash_10x10_rand", 5 ] ], "x": 2, "y": 0 }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ]
     }

--- a/data/json/mapgen/house/house38.json
+++ b/data/json/mapgen/house/house38.json
@@ -61,7 +61,10 @@
         { "item": "stereo", "x": 14, "y": 18, "chance": 35 }
       ],
       "place_vehicles": [ { "vehicle": "car", "x": 18, "y": 6, "chance": 35, "rotation": 270 } ],
-      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 } ]
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 },
+        { "chunks": [ [ "null", 95 ], [ "carcrash_8x8_straight", 5 ] ], "x": [ 7, 8 ], "y": 0 }
+      ]
     }
   },
   {

--- a/data/json/mapgen/nested/structure_damage_nested.json
+++ b/data/json/mapgen/nested/structure_damage_nested.json
@@ -1,0 +1,175 @@
+[  
+  {
+    "type": "palette",
+    "id": "struc_damage",
+    "parameters": { "crashvariant": { "type": "string", "scope": "omt", "default": { "distribution": [ "fromleft", "fromright" ] } } },
+    "terrain": {
+        "c": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_dirtmoundfloor", "fromright": "t_null" } },
+        "v": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_null", "fromright": "t_dirtmoundfloor" } },
+        "d": "t_dirtmoundfloor",
+        "r": "t_dirtmoundfloor",
+        "w": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_dirtmoundfloor", "fromright": "t_null" } },
+        "j": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_null", "fromright": "t_dirtmoundfloor" } }
+    },
+    "fields": {
+      "m": { "field": "fd_blood", "intensity": 2},
+      "h": { "field": "fd_blood", "intensity": 3},
+      "k": { "field": "fd_blood", "intensity": 3}
+    },
+    "furniture": {
+      "r": "f_rubble",
+      "w": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "f_rubble", "fromright": "f_null" } },
+      "j": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "f_null", "fromright": "f_rubble" } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "carcrash_10x10_straight",
+    "//": "Same as 8x8, but made to distribute with the diagonal variants of the same size.",
+    "object": {
+      "mapgensize": [ 10, 10 ],
+      "place_nested": [ { "chunks": [ "carcrash_8x8_straight" ], "x": [ 0, 2 ], "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "carcrash_8x8_straight",
+    "//": "The walls for the structure being damaged start at y:3.",
+    "object": {
+      "mapgensize": [ 8, 8 ],
+      "rows": [
+        " cccdvvv",
+        " ccdddvv",
+        " ccdddv ",
+        " jddddw ",
+        " jddddw ",
+        "jvddddcw",
+        "jvddddcw",
+        "jjrrrrww"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "struc_damage" ],
+      "place_vehicles": [ { "chance": 100, "fuel": 10, "rotation": 90, "status": 1, "vehicle": "cars_only", "x": 4, "y": 4 } ],
+      "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_8x8_straight_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "carcrash_10x10_diag_fromleft",
+    "//": "The walls for the structure being damaged start at y:3.",
+    "object": {
+      "mapgensize": [ 10, 10 ],
+      "rows": [
+        "dddd      ",
+        "ddddd     ",
+        "dddddddd  ",
+        "rdddddddw ",
+        "rdddddddrw",
+        "jrddddddrw",
+        "jjrrddddr ",
+        "  jjjrrrw ",
+        "          ",
+        "          "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "struc_damage" ],
+      "place_vehicles": [ { "chance": 100, "fuel": 10, "rotation": 35, "status": 1, "vehicle": "cars_only", "x": 5, "y": 3 } ],
+      "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_10x10_diag_fromleft_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "carcrash_10x10_diag_fromright",
+    "//": "The walls for the structure being damaged start at y:3.",
+    "object": {
+      "mapgensize": [ 10, 10 ],
+      "rows": [
+        "      dddd",
+        "     ddddd",
+        "  dddddddd",
+        " wdddddddr",
+        "wrdddddddr",
+        "wrddddddrj",
+        " rddddrrjj",
+        " wrrrjjj  ",
+        "          ",
+        "          "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "struc_damage" ],
+      "place_vehicles": [ { "chance": 100, "fuel": 10, "rotation": 145, "status": 1, "vehicle": "cars_only", "x": 4, "y": 4 } ],
+            "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_10x10_diag_fromright_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "carcrash_8x8_straight_bloodcorpse",
+    "object": {
+      "mapgensize": [ 8, 8 ],
+      "rows": [
+        "    m   ",
+        "    mmmm",
+        "    mhhm",
+        "    mmm ",
+        "     m  ",
+        "     m  ",
+        "    mm  ",
+        "    mm  "
+      ],
+      "place_items": [ { "item": "corpses_verydead", "x": [ 6, 7 ], "y": [ 1, 2 ], "chance": 100 } ],
+      "place_fields": [ { "field": "fd_gibs_flesh", "x": [ 6, 7 ], "y": [ 1, 2 ], "intensity": [ 1, 2 ], "repeat": [ 1, 3 ] } ],
+      "palettes": [ "struc_damage" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "carcrash_10x10_diag_fromleft_bloodcorpse",
+    "object": {
+      "mapgensize": [ 10, 10 ],
+      "rows": [
+        "mm        ",
+        "hhmm      ",
+        "mmmmmmmmm ",
+        "       mm ",
+        "       mm ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          "
+      ],
+      "place_items": [ { "item": "corpses_verydead", "x": [ 0, 1 ], "y": [ 0, 1 ], "chance": 100 } ],
+      "place_fields": [ { "field": "fd_gibs_flesh", "x": [ 0, 1 ], "y": [ 0, 1 ], "intensity": [ 1, 2 ], "repeat": [ 1, 3 ] } ],
+      "palettes": [ "struc_damage" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "carcrash_10x10_diag_fromright_bloodcorpse",
+    "object": {
+      "mapgensize": [ 10, 10 ],
+      "rows": [
+        "        mm",
+        "      mhhm",
+        " mmmmmmmhm",
+        " mm       ",
+        " mm       ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          "
+      ],
+      "place_items": [ { "item": "corpses_verydead", "x": [ 8, 9 ], "y": [ 0, 1 ], "chance": 100 } ],
+      "place_fields": [ { "field": "fd_gibs_flesh", "x": [ 8, 9 ], "y": [ 0, 1 ], "intensity": [ 1, 2 ], "repeat": [ 1, 3 ] } ],
+      "palettes": [ "struc_damage" ]
+    }
+  }
+]

--- a/data/json/mapgen/nested/structure_damage_nested.json
+++ b/data/json/mapgen/nested/structure_damage_nested.json
@@ -30,7 +30,13 @@
     "object": {
       "mapgensize": [ 10, 10 ],
       "palettes": [ "struc_damage" ],
-      "place_nested": [ { "chunks": [ [ "carcrash_10x10_straight", 33 ], [ "carcrash_10x10_diag_fromleft", 33 ], [ "carcrash_10x10_diag_fromright", 33 ] ], "x": 0, "y": 0 } ]
+      "place_nested": [
+        {
+          "chunks": [ [ "carcrash_10x10_straight", 33 ], [ "carcrash_10x10_diag_fromleft", 33 ], [ "carcrash_10x10_diag_fromright", 33 ] ],
+          "x": 0,
+          "y": 0
+        }
+      ]
     }
   },
   {

--- a/data/json/mapgen/nested/structure_damage_nested.json
+++ b/data/json/mapgen/nested/structure_damage_nested.json
@@ -30,17 +30,7 @@
     "object": {
       "mapgensize": [ 10, 10 ],
       "palettes": [ "struc_damage" ],
-      "place_nested": [
-        {
-          "chunks": [
-            [ "carcrash_10x10_straight", 33 ],
-            [ "carcrash_10x10_diag_fromleft", 33 ],
-            [ "carcrash_10x10_diag_fromright", 33 ]
-          ],
-          "x": 0,
-          "y": 0
-        }
-      ]
+      "place_nested": [ { "chunks": [ [ "carcrash_10x10_straight", 33 ], [ "carcrash_10x10_diag_fromleft", 33 ], [ "carcrash_10x10_diag_fromright", 33 ] ], "x": 0, "y": 0 } ]
     }
   },
   {
@@ -48,7 +38,11 @@
     "method": "json",
     "nested_mapgen_id": "carcrash_10x10_straight",
     "//": "Same as 8x8, but made to distribute with the diagonal variants of the same size.",
-    "object": { "mapgensize": [ 10, 10 ], "palettes": [ "struc_damage" ], "place_nested": [ { "chunks": [ "carcrash_8x8_straight" ], "x": [ 0, 2 ], "y": 0 } ] }
+    "object": {
+      "mapgensize": [ 10, 10 ],
+      "palettes": [ "struc_damage" ],
+      "place_nested": [ { "chunks": [ "carcrash_8x8_straight" ], "x": [ 0, 2 ], "y": 0 } ]
+    }
   },
   {
     "type": "mapgen",

--- a/data/json/mapgen/nested/structure_damage_nested.json
+++ b/data/json/mapgen/nested/structure_damage_nested.json
@@ -1,20 +1,20 @@
-[  
+[
   {
     "type": "palette",
     "id": "struc_damage",
     "parameters": { "crashvariant": { "type": "string", "scope": "omt", "default": { "distribution": [ "fromleft", "fromright" ] } } },
     "terrain": {
-        "c": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_dirtmoundfloor", "fromright": "t_null" } },
-        "v": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_null", "fromright": "t_dirtmoundfloor" } },
-        "d": "t_dirtmoundfloor",
-        "r": "t_dirtmoundfloor",
-        "w": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_dirtmoundfloor", "fromright": "t_null" } },
-        "j": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_null", "fromright": "t_dirtmoundfloor" } }
+      "c": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_dirtmoundfloor", "fromright": "t_null" } },
+      "v": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_null", "fromright": "t_dirtmoundfloor" } },
+      "d": "t_dirtmoundfloor",
+      "r": "t_dirtmoundfloor",
+      "w": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_dirtmoundfloor", "fromright": "t_null" } },
+      "j": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_null", "fromright": "t_dirtmoundfloor" } }
     },
     "fields": {
-      "m": { "field": "fd_blood", "intensity": 2},
-      "h": { "field": "fd_blood", "intensity": 3},
-      "k": { "field": "fd_blood", "intensity": 3}
+      "m": { "field": "fd_blood", "intensity": 2 },
+      "h": { "field": "fd_blood", "intensity": 3 },
+      "k": { "field": "fd_blood", "intensity": 3 }
     },
     "furniture": {
       "r": "f_rubble",
@@ -25,12 +25,30 @@
   {
     "type": "mapgen",
     "method": "json",
-    "nested_mapgen_id": "carcrash_10x10_straight",
-    "//": "Same as 8x8, but made to distribute with the diagonal variants of the same size.",
+    "nested_mapgen_id": "carcrash_10x10_rand",
+    "//": "Randomizes between the three car crash variants. The walls for the structure being damaged start at y:3.",
     "object": {
       "mapgensize": [ 10, 10 ],
-      "place_nested": [ { "chunks": [ "carcrash_8x8_straight" ], "x": [ 0, 2 ], "y": 0 } ]
+      "palettes": [ "struc_damage" ],
+      "place_nested": [
+        {
+          "chunks": [
+            [ "carcrash_10x10_straight", 33 ],
+            [ "carcrash_10x10_diag_fromleft", 33 ],
+            [ "carcrash_10x10_diag_fromright", 33 ]
+          ],
+          "x": 0,
+          "y": 0
+        }
+      ]
     }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "carcrash_10x10_straight",
+    "//": "Same as 8x8, but made to distribute with the diagonal variants of the same size.",
+    "object": { "mapgensize": [ 10, 10 ], "palettes": [ "struc_damage" ], "place_nested": [ { "chunks": [ "carcrash_8x8_straight" ], "x": [ 0, 2 ], "y": 0 } ] }
   },
   {
     "type": "mapgen",
@@ -102,7 +120,7 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "struc_damage" ],
       "place_vehicles": [ { "chance": 100, "fuel": 10, "rotation": 145, "status": 1, "vehicle": "cars_only", "x": 4, "y": 4 } ],
-            "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_10x10_diag_fromright_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
+      "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_10x10_diag_fromright_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds car crashes into existing buildings. Initial implementation includes three houses that can spawn with this variant."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The goal of structure damage nests is to reinforce the worldbuilding concept of a brief moment of extreme violence by causing damage to structures consistent with the conditions leading up to the start of the game. This implementation is focused entirely on car crashes into existing structures.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Creates car crash nests that are placed on existing structure omts like houses and stores with a low incidence of spawning. Current implementation is 5% on the three houses that are currently modified in this way (house_01, house_10, house_38). Uses parameters to create some micro variation between each directional variant of car crash, plus a 50/50 chance of spawning a streak of blood and a corpse that the car would have presumably hit and killed. Rolling trashcans were moved around a bit to better facilitate the mapgen for these car crash nests.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Invoking rubble to include structure collapse. I didn't use this because with my testing, ceilings weren't collapsing anyway and overall it looked quite ugly. Instead, I went with upturned dirt and rubble terrains. Ultimately, I'd like to find a way to keep existing floor terrains rather than relying on upturned dirt, but I needed a way to clear terrain and furniture in order to spawn the car. It's something I plan on investigating further with further iterations of this project, and I'd welcome any feedback/guidance to this effect.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
All affected structures were tested in each orientation and variation to ensure they looked good, then rates were adjusted down to around 5% total chance of spawning, split between whatever variants were included in that particular structure.

![cataclysm-tiles_bFeGXPlrdJ](https://github.com/user-attachments/assets/6712d7ac-554a-4597-b183-e89549aa1f8c)
![cataclysm-tiles_Vi7xnr9q9X](https://github.com/user-attachments/assets/c8ab8d4c-199f-4a6f-a605-5e058eeb84c9)
![cataclysm-tiles_63bYlVp46F](https://github.com/user-attachments/assets/89285528-f609-4558-84c8-3a32542045b3)
![cataclysm-tiles_sY6d3jclll](https://github.com/user-attachments/assets/c8600152-ef32-470a-9790-7dbfb82b052c)
![cataclysm-tiles_mQBOBuojwK](https://github.com/user-attachments/assets/903b1c4c-a539-4da2-bab0-f584deadabb6)
![cataclysm-tiles_UfmUphRTl2](https://github.com/user-attachments/assets/a0edc9d4-2be5-4625-9fae-93c8cefc99ca)
![cataclysm-tiles_ZC7YqfMZS6](https://github.com/user-attachments/assets/496748d0-aa43-4a0f-9de6-0a67a69be26a)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

- There is currently no plan to collapse the roofs of affected maps for car crashes. This is technically possible, but I don't think it's necessary due to the relatively small area of damage caused by the collision.
- Some OMTs are not good candidates for car crash nests because they simply won't look good.
- Future work on this concept will include allowance for longer dirt trails so that structures of different shape/distance to sidewalks and roads can also be affected without looking ugly. My primary concern for this is to avoid unnecessary duplication, and it may take some work before I settle on something that I'm happy with, so it's not going in on initial implementation here.
- More houses will be added with later PRs.
- The ultimate goal is for around one percent of city structures to be affected by car crashes. I intend to listen to commentary and feedback to determine if this is too much or too little.
- The other form of structure damage that I have planned is fire damage. This is out of the scope of this particular PR, but I wanted to explain why this is being proposed as "structure damage" and not as "structure car crashes." The fire damage I have planned in question would not be an active fire, but a fire that has already spread and since died out, leaving collapsed walls, piles of ashes, debris, ect. Ceiling collapses would definitely be in the scope for this particular iteration of structure damage.
- I'm receptive to other ideas for how existing structures could be damaged with the use of nested mapgen.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
