### PR TITLE
Build fixies

### DIFF
--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -166,7 +166,7 @@ void scores_ui_impl::init_data()
         const std::string &symbol = m.sym;
         nc_color color = m.color;
         const std::string &name = m.nname();
-        monster_kills_data.emplace_back( std::make_tuple( num_kills, symbol, color, name ) );
+        monster_kills_data.emplace_back( num_kills, symbol, color, name );
     }
     auto sort_by_count_then_name = []( auto & a, auto & b ) {
         return

--- a/src/talker.h
+++ b/src/talker.h
@@ -670,7 +670,6 @@ class talker: virtual public const_talker
         virtual computer *get_computer() {
             return nullptr;
         }
-        virtual void set_pos( tripoint ) {}
         virtual void set_pos( tripoint_bub_ms ) {}
         virtual void update_missions( const std::vector<mission *> & ) {}
         virtual void set_str_max( int ) {}

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -82,11 +82,6 @@ tripoint_abs_omt talker_character_const::global_omt_location() const
     return me_chr_const->global_omt_location();
 }
 
-void talker_character::set_pos( tripoint new_pos )
-{
-    me_chr->setpos( new_pos );
-}
-
 int talker_character_const::get_cur_hp( const bodypart_id &bp ) const
 {
     return me_chr_const->get_hp( bp );
@@ -133,6 +128,11 @@ dealt_damage_instance talker_character_const::deal_damage( Creature *source, bod
         const damage_instance &dam ) const
 {
     return source->deal_damage( source, bp, dam );
+}
+
+void talker_character::set_pos( tripoint_bub_ms new_pos )
+{
+    me_chr->setpos( new_pos );
 }
 
 void talker_character::set_str_max( int value )

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -245,7 +245,7 @@ class talker_character: virtual public talker
             return me_chr;
         }
 
-        void set_pos( tripoint new_pos ) override;
+        void set_pos( tripoint_bub_ms new_pos ) override;
 
         // stats, skills, traits, bionics, and magic
         void set_str_max( int value ) override;

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -307,7 +307,7 @@ bool WORLD::save( const bool is_conversion ) const
     }
 
     if( !is_conversion ) {
-        const auto savefile = folder_path() / PATH_INFO::worldoptions();
+        const cata_path savefile = folder_path() / PATH_INFO::worldoptions();
         const bool saved = write_to_file( savefile, [&]( std::ostream & fout ) {
             JsonOut jout( fout );
 
@@ -423,7 +423,7 @@ void worldfactory::init()
         if( newworld->save( true ) ) {
             const cata_path origin_path = old_world.folder_path();
             // move files from origin_path into new world path
-            for( auto &origin_file : get_files_from_path( ".", origin_path, false ) ) {
+            for( cata_path &origin_file : get_files_from_path( ".", origin_path, false ) ) {
                 std::string filename = origin_file.get_relative_path().filename().generic_u8string();
 
                 if( rename_file( origin_file, ( newworld->folder_path() / filename ) ) ) {
@@ -2153,15 +2153,15 @@ void worldfactory::delete_world( const std::string &worldname, const bool delete
     auto end = std::remove_if( file_paths.begin(), file_paths.end(), isForbidden );
     file_paths.erase( end, file_paths.end() );
 
-    for( auto &file_path : file_paths ) {
+    for( cata_path &file_path : file_paths ) {
         fs::path folder_path = file_path.get_unrelative_path().parent_path();
-        while( folder_path.filename() != worldname ) {
+        while( folder_path.filename() != fs::u8path( worldname ) ) {
             directory_paths.insert( folder_path );
             folder_path = folder_path.parent_path();
         }
     }
 
-    for( auto &file : file_paths ) {
+    for( cata_path &file : file_paths ) {
         remove_file( file );
     }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The merge of #78357 broke the build, not quite sure how, but pretty sure a merge queue would have prevented it.
I'm trying to turn clang-tidy (src) on and warnings keep sneaking in.

#### Describe the solution
Remove a conflicting set_pos(tripoint) method that seems to be dead code anyway and replace with set_pos( tripoint_bub_ms ).
Un-auto some variables, do a UTF8 path translation on a raw string, remove an unneeded tuple constructor from the arguments to an emplace invocation.

#### Describe alternatives you've considered
LEaVe it bRokEn?

#### Testing
It builds, it runs, the infernal racket of the tooling overlords is silenced.