### PR TITLE
Fix selected item name not being visible in some menus

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -171,8 +171,8 @@ void uilist_impl::draw_controls()
                         std::string &str2 = entry.ctxt;
                         nc_color color = entry.enabled || entry.force_color ? entry.text_color : parent.disabled_color;
                         if( is_selected || is_hovered ) {
-                            str1 = entry._txt_nocolor;
-                            str2 = entry._ctxt_nocolor;
+                            str1 = entry._txt_nocolor();
+                            str2 = entry._ctxt_nocolor();
                             color = parent.hilight_color;
                         }
 
@@ -248,81 +248,73 @@ static std::optional<input_event> hotkey_from_char( const int ch )
 
 uilist_entry::uilist_entry( const std::string &txt )
     : retval( -1 ), enabled( true ), hotkey( std::nullopt ), txt( txt ),
-      text_color( c_red_red )
+      text_color( c_red_red ), _txt_nocolor_cached( "" ), _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
 }
 
 uilist_entry::uilist_entry( const std::string &txt, const std::string &desc )
     : retval( -1 ), enabled( true ), hotkey( std::nullopt ), txt( txt ),
-      desc( desc ), text_color( c_red_red )
+      desc( desc ), text_color( c_red_red ), _txt_nocolor_cached( "" ), _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
 }
 
 uilist_entry::uilist_entry( const std::string &txt, const int key )
     : retval( -1 ), enabled( true ), hotkey( hotkey_from_char( key ) ), txt( txt ),
-      text_color( c_red_red )
+      text_color( c_red_red ), _txt_nocolor_cached( "" ), _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
 }
 
 uilist_entry::uilist_entry( const std::string &txt, const std::optional<input_event> &key )
     : retval( -1 ), enabled( true ), hotkey( key ), txt( txt ),
-      text_color( c_red_red )
+      text_color( c_red_red ), _txt_nocolor_cached( "" ), _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
 }
 
 uilist_entry::uilist_entry( const int retval, const bool enabled, const int key,
                             const std::string &txt )
     : retval( retval ), enabled( enabled ), hotkey( hotkey_from_char( key ) ), txt( txt ),
-      text_color( c_red_red )
+      text_color( c_red_red ), _txt_nocolor_cached( "" ), _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
 }
 
 uilist_entry::uilist_entry( const int retval, const bool enabled,
                             const std::optional<input_event> &key,
                             const std::string &txt )
     : retval( retval ), enabled( enabled ), hotkey( key ), txt( txt ),
-      text_color( c_red_red )
+      text_color( c_red_red ), _txt_nocolor_cached( "" ), _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
 }
 
 uilist_entry::uilist_entry( const int retval, const bool enabled, const int key,
                             const std::string &txt, const std::string &desc )
     : retval( retval ), enabled( enabled ), hotkey( hotkey_from_char( key ) ), txt( txt ),
-      desc( desc ), text_color( c_red_red )
+      desc( desc ), text_color( c_red_red ), _txt_nocolor_cached( "" ), _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
 }
 
 uilist_entry::uilist_entry( const int retval, const bool enabled,
                             const std::optional<input_event> &key, const std::string &txt, const std::string &desc )
     : retval( retval ), enabled( enabled ), hotkey( key ), txt( txt ),
-      desc( desc ), text_color( c_red_red )
+      desc( desc ), text_color( c_red_red ), _txt_nocolor_cached( "" ), _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
 }
 
 uilist_entry::uilist_entry( const int retval, const bool enabled, const int key,
                             const std::string &txt, const std::string &desc,
                             const std::string &column )
     : retval( retval ), enabled( enabled ), hotkey( hotkey_from_char( key ) ), txt( txt ),
-      desc( desc ), ctxt( column ), text_color( c_red_red )
+      desc( desc ), ctxt( column ), text_color( c_red_red ), _txt_nocolor_cached( "" ),
+      _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
 }
 
 uilist_entry::uilist_entry( const int retval, const bool enabled,
@@ -330,20 +322,36 @@ uilist_entry::uilist_entry( const int retval, const bool enabled,
                             const std::string &txt, const std::string &desc,
                             const std::string &column )
     : retval( retval ), enabled( enabled ), hotkey( key ), txt( txt ),
-      desc( desc ), ctxt( column ), text_color( c_red_red )
+      desc( desc ), ctxt( column ), text_color( c_red_red ), _txt_nocolor_cached( "" ),
+      _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
 }
 
 uilist_entry::uilist_entry( const int retval, const bool enabled, const int key,
                             const std::string &txt,
                             const nc_color &keycolor, const nc_color &txtcolor )
     : retval( retval ), enabled( enabled ), hotkey( hotkey_from_char( key ) ), txt( txt ),
-      hotkey_color( keycolor ), text_color( txtcolor )
+      hotkey_color( keycolor ), text_color( txtcolor ), _txt_nocolor_cached( "" ),
+      _ctxt_nocolor_cached( "" )
 {
-    _txt_nocolor = remove_color_tags( txt );
-    _ctxt_nocolor = remove_color_tags( ctxt );
+
+}
+
+const std::string uilist_entry::_txt_nocolor()
+{
+    if( _txt_nocolor_cached.empty() && !txt.empty() ) {
+        _txt_nocolor_cached = remove_color_tags( txt );
+    }
+    return _txt_nocolor_cached;
+}
+
+const std::string uilist_entry::_ctxt_nocolor()
+{
+    if( _ctxt_nocolor_cached.empty() && !ctxt.empty() ) {
+        _ctxt_nocolor_cached = remove_color_tags( ctxt );
+    }
+    return _ctxt_nocolor_cached;
 }
 
 uilist::size_scalar &uilist::size_scalar::operator=( auto_assign )

--- a/src/ui.h
+++ b/src/ui.h
@@ -61,7 +61,6 @@ struct mvwzstr {
  * uilist_entry: entry line for uilist
  */
 struct uilist_entry {
-    public:
         int retval;                 // return this int
         bool enabled;               // darken, and forbid scrolling if hilight_disabled is false
         bool force_color = false;   // Never darken this option

--- a/src/ui.h
+++ b/src/ui.h
@@ -61,118 +61,123 @@ struct mvwzstr {
  * uilist_entry: entry line for uilist
  */
 struct uilist_entry {
-    int retval;                 // return this int
-    bool enabled;               // darken, and forbid scrolling if hilight_disabled is false
-    bool force_color = false;   // Never darken this option
-    // std::nullopt: automatically assign an unassigned hotkey
-    // input_event(): disable hotkey
-    std::optional<input_event> hotkey;
-    std::string txt;            // what it says on the tin
-    std::string desc;           // optional, possibly longer, description
-    std::string ctxt;           // second column text
-    nc_color hotkey_color;
-    nc_color text_color;
-    mvwzstr extratxt;
+    public:
+        int retval;                 // return this int
+        bool enabled;               // darken, and forbid scrolling if hilight_disabled is false
+        bool force_color = false;   // Never darken this option
+        // std::nullopt: automatically assign an unassigned hotkey
+        // input_event(): disable hotkey
+        std::optional<input_event> hotkey;
+        std::string txt;            // what it says on the tin
+        std::string desc;           // optional, possibly longer, description
+        std::string ctxt;           // second column text
+        nc_color hotkey_color;
+        nc_color text_color;
+        mvwzstr extratxt;
 
-    // In the following constructors, int key only support letters (a-z, A-Z) and
-    // digits (0-9), MENU_AUTOASSIGN, and 0 or ' ' (disable hotkey). Other
-    // values may not work under keycode mode.
+        // In the following constructors, int key only support letters (a-z, A-Z) and
+        // digits (0-9), MENU_AUTOASSIGN, and 0 or ' ' (disable hotkey). Other
+        // values may not work under keycode mode.
 
-    /**
-    * @param txt string that will be displayed on the entry first column
-    */
-    explicit uilist_entry( const std::string &txt );
-    /**
-    * @param txt string that will be displayed on the entry first column
-    * @param desc entry description if menu desc_enabled is true
-    * @see uilist::desc_enabled
-    */
-    uilist_entry( const std::string &txt, const std::string &desc );
-    /**
-    * @param txt string that will be displayed on the entry first column
-    * @param key hotkey character that when pressed will return this entry return value
-    */
-    uilist_entry( const std::string &txt, int key );
-    /**
-    * @param txt string that will be displayed on the entry first column
-    * @param key hotkey character that when pressed will return this entry return value
-    */
-    uilist_entry( const std::string &txt, const std::optional<input_event> &key );
-    /**
-    * @param retval return value of this option when selected during menu query
-    * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
-    * @param key hotkey character that when pressed will return this entry return value
-    * @param txt string that will be displayed on the entry first column
-    */
-    uilist_entry( int retval, bool enabled, int key, const std::string &txt );
-    /**
-    * @param retval return value of this option when selected during menu query
-    * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
-    * @param key hotkey character that when pressed will return this entry return value
-    * @param txt string that will be displayed on the entry first column
-    */
-    uilist_entry( int retval, bool enabled, const std::optional<input_event> &key,
-                  const std::string &txt );
-    /**
-    * @param retval return value of this option when selected during menu query
-    * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
-    * @param key hotkey character that when pressed will return this entry return value
-    * @param txt string that will be displayed on the entry first column
-    * @param desc entry description if menu desc_enabled is true
-    * @see uilist::desc_enabled
-    */
-    uilist_entry( int retval, bool enabled, int key, const std::string &txt, const std::string &desc );
-    /**
-    * @param retval return value of this option when selected during menu query
-    * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
-    * @param key hotkey character that when pressed will return this entry return value
-    * @param txt string that will be displayed on the entry first column
-    * @param desc entry description if menu desc_enabled is true
-    * @see uilist::desc_enabled
-    */
-    uilist_entry( int retval, bool enabled, const std::optional<input_event> &key,
-                  const std::string &txt, const std::string &desc );
-    /**
-    * @param retval return value of this option when selected during menu query
-    * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
-    * @param key hotkey character that when pressed will return this entry return value
-    * @param txt string that will be displayed on the entry first column
-    * @param desc entry description if menu desc_enabled is true
-    * @param column string that will be displayed on the entry second column
-    * @see uilist::desc_enabled
-    */
-    uilist_entry( int retval, bool enabled, int key, const std::string &txt, const std::string &desc,
-                  const std::string &column );
-    /**
-    * @param retval return value of this option when selected during menu query
-    * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
-    * @param key hotkey character that when pressed will return this entry return value
-    * @param txt string that will be displayed on the entry first column
-    * @param desc entry description if menu desc_enabled is true
-    * @param column string that will be displayed on the entry second column
-    * @see uilist::desc_enabled
-    */
-    uilist_entry( int retval, bool enabled, const std::optional<input_event> &key,
-                  const std::string &txt, const std::string &desc,
-                  const std::string &column );
-    /**
-    * @param retval return value of this option when selected during menu query
-    * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
-    * @param key hotkey character that when pressed will return this entry return value
-    * @param txt string that will be displayed on the entry first column
-    * @param keycolor color of the hotkey character
-    * @param txtcolor entry text string color
-    */
-    uilist_entry( int retval, bool enabled, int key, const std::string &txt,
-                  const nc_color &keycolor, const nc_color &txtcolor );
-    template<typename Enum, typename... Args,
-             typename = std::enable_if_t<std::is_enum_v<Enum>>>
-                                         explicit uilist_entry( Enum e, Args && ... args ) :
-                                             uilist_entry( static_cast<int>( e ), std::forward<Args>( args )... )
-    {}
+        /**
+        * @param txt string that will be displayed on the entry first column
+        */
+        explicit uilist_entry( const std::string &txt );
+        /**
+        * @param txt string that will be displayed on the entry first column
+        * @param desc entry description if menu desc_enabled is true
+        * @see uilist::desc_enabled
+        */
+        uilist_entry( const std::string &txt, const std::string &desc );
+        /**
+        * @param txt string that will be displayed on the entry first column
+        * @param key hotkey character that when pressed will return this entry return value
+        */
+        uilist_entry( const std::string &txt, int key );
+        /**
+        * @param txt string that will be displayed on the entry first column
+        * @param key hotkey character that when pressed will return this entry return value
+        */
+        uilist_entry( const std::string &txt, const std::optional<input_event> &key );
+        /**
+        * @param retval return value of this option when selected during menu query
+        * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
+        * @param key hotkey character that when pressed will return this entry return value
+        * @param txt string that will be displayed on the entry first column
+        */
+        uilist_entry( int retval, bool enabled, int key, const std::string &txt );
+        /**
+        * @param retval return value of this option when selected during menu query
+        * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
+        * @param key hotkey character that when pressed will return this entry return value
+        * @param txt string that will be displayed on the entry first column
+        */
+        uilist_entry( int retval, bool enabled, const std::optional<input_event> &key,
+                      const std::string &txt );
+        /**
+        * @param retval return value of this option when selected during menu query
+        * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
+        * @param key hotkey character that when pressed will return this entry return value
+        * @param txt string that will be displayed on the entry first column
+        * @param desc entry description if menu desc_enabled is true
+        * @see uilist::desc_enabled
+        */
+        uilist_entry( int retval, bool enabled, int key, const std::string &txt, const std::string &desc );
+        /**
+        * @param retval return value of this option when selected during menu query
+        * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
+        * @param key hotkey character that when pressed will return this entry return value
+        * @param txt string that will be displayed on the entry first column
+        * @param desc entry description if menu desc_enabled is true
+        * @see uilist::desc_enabled
+        */
+        uilist_entry( int retval, bool enabled, const std::optional<input_event> &key,
+                      const std::string &txt, const std::string &desc );
+        /**
+        * @param retval return value of this option when selected during menu query
+        * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
+        * @param key hotkey character that when pressed will return this entry return value
+        * @param txt string that will be displayed on the entry first column
+        * @param desc entry description if menu desc_enabled is true
+        * @param column string that will be displayed on the entry second column
+        * @see uilist::desc_enabled
+        */
+        uilist_entry( int retval, bool enabled, int key, const std::string &txt, const std::string &desc,
+                      const std::string &column );
+        /**
+        * @param retval return value of this option when selected during menu query
+        * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
+        * @param key hotkey character that when pressed will return this entry return value
+        * @param txt string that will be displayed on the entry first column
+        * @param desc entry description if menu desc_enabled is true
+        * @param column string that will be displayed on the entry second column
+        * @see uilist::desc_enabled
+        */
+        uilist_entry( int retval, bool enabled, const std::optional<input_event> &key,
+                      const std::string &txt, const std::string &desc,
+                      const std::string &column );
+        /**
+        * @param retval return value of this option when selected during menu query
+        * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
+        * @param key hotkey character that when pressed will return this entry return value
+        * @param txt string that will be displayed on the entry first column
+        * @param keycolor color of the hotkey character
+        * @param txtcolor entry text string color
+        */
+        uilist_entry( int retval, bool enabled, int key, const std::string &txt,
+                      const nc_color &keycolor, const nc_color &txtcolor );
+        template<typename Enum, typename... Args,
+                 typename = std::enable_if_t<std::is_enum_v<Enum>>>
+                                             explicit uilist_entry( Enum e, Args && ... args ) :
+                                                 uilist_entry( static_cast<int>( e ), std::forward<Args>( args )... )
+        {}
 
-    std::string _txt_nocolor;   // what it says on the tin
-    std::string _ctxt_nocolor;  // second column text
+    public:
+        const std::string _txt_nocolor();  // what it says on the tin
+        const std::string _ctxt_nocolor(); // second column text
+    private:
+        std::string _txt_nocolor_cached;   // cached return values of the above
+        std::string _ctxt_nocolor_cached;
 };
 
 /**


### PR DESCRIPTION
#### Summary
Bugfixes "Fix currently selected item not being visible in some menus"

#### Purpose of change

Fix this: 
![20241206-211630-cataclysm-tiles](https://github.com/user-attachments/assets/3ce0d67f-8eba-43c9-9ece-e35227615453)

Fixes #77368
Fixes #77503

#### Describe the solution

Cache entries' context less agressively - only when it is first read (i.e. when the menu is being rendered), and not immedaitely on construction (when it is still being prepared).
See https://github.com/CleverRaven/Cataclysm-DDA/blob/cfe9f6c26abd931c2151ee0994dfc0a6419a7e52/src/item_action.cpp#L354-L355 for an example of breaking code

#### Describe alternatives you've considered

Use getter/setter for setting `.txt` / `.ctxt` which would invalidate the cache at even more appropriate times. But that would mean working with getters/setters...

#### Testing
![20241206-212036-cataclysm-tiles](https://github.com/user-attachments/assets/511f4c43-407f-4f98-b855-9e4ebf842b40)

![20241206-220734-cataclysm-tiles](https://github.com/user-attachments/assets/a86f2c5e-f194-4166-8e31-b8c3f03306c0)

![20241206-221143-cataclysm-tiles](https://github.com/user-attachments/assets/d1bec802-9084-4fff-b35e-d0f98d53757e)



#### Additional context

Originally broken by #76346 . Current PR does not reintroduce the problems #76346 was solving.

Astyle adds an extra indentation level to the whole of `struct uilist_entry {` now that I've marked the cached fields as private. I don't know if I should let them be public (to negate the diff) or if the indent is fine. Lemme know if i should change this.