### PR TITLE
Deduplicate item contents description in the examine display

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5659,19 +5659,19 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
 }
 
 static std::vector<std::pair<const item *, int>> deduplicate_items(
-    const std::list<const item*>& items )
+            const std::list<const item *> &items )
 {
     std::vector<std::pair<item const *, int>> counted_items;
     bool contents_header = false;
-    for( const item* contents_item : items ) {
-        if( contents_item->made_of_from_type( phase_id::LIQUID ) ){
+    for( const item *contents_item : items ) {
+        if( contents_item->made_of_from_type( phase_id::LIQUID ) ) {
             // we won't have duplicate liquids and counting them
             // doesn't really make much sense anyway
             std::pair<const item *, int> new_content( contents_item, 1 );
             counted_items.push_back( new_content );
         } else {
             bool found = false;
-            for( std::pair<const item *, int>& content : counted_items ) {
+            for( std::pair<const item *, int> &content : counted_items ) {
                 if( content.first->stacks_with( *contents_item ) ) {
                     content.second += 1;
                     found = true;
@@ -5712,12 +5712,12 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
         info.emplace_back( "DESCRIPTION", mod_str );
         info.emplace_back( "DESCRIPTION", mod->type->description.translated() );
     }
-    
+
     const std::list<const item *> all_contents = contents.all_items_top();
-    std::vector<std::pair<item const *, int>> counted_contents = deduplicate_items(all_contents);
+    std::vector<std::pair<item const *, int>> counted_contents = deduplicate_items( all_contents );
     bool contents_header = false;
-    for( const auto content_w_count : counted_contents ){
-        const item * contents_item = content_w_count.first;
+    for( const auto content_w_count : counted_contents ) {
+        const item *contents_item = content_w_count.first;
         int count = content_w_count.second;
         if( !contents_header ) {
             insert_separation_line( info );
@@ -5733,11 +5733,11 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
         if( contents_item->made_of_from_type( phase_id::LIQUID ) ) {
             units::volume contents_volume = contents_item->volume() * batch;
             info.emplace_back( "DESCRIPTION",
-                    colorize( contents_item->display_name(), contents_item->color_in_inventory() ) );
+                               colorize( contents_item->display_name(), contents_item->color_in_inventory() ) );
             info.emplace_back( vol_to_info( "CONTAINER", description + space, contents_volume ) );
         } else {
             std::string name;
-            if( count > 1 ){
+            if( count > 1 ) {
                 name += std::to_string( count ) + " ";
             }
             name += colorize( contents_item->display_name( count ), contents_item->color_in_inventory() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5658,6 +5658,35 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
     }
 }
 
+static std::vector<std::pair<const item *, int>> deduplicate_items(
+    const std::list<const item*>& items )
+{
+    std::vector<std::pair<item const *, int>> counted_items;
+    bool contents_header = false;
+    for( const item* contents_item : items ) {
+        if( contents_item->made_of_from_type( phase_id::LIQUID ) ){
+            // we won't have duplicate liquids and counting them
+            // doesn't really make much sense anyway
+            std::pair<const item *, int> new_content( contents_item, 1 );
+            counted_items.push_back( new_content );
+        } else {
+            bool found = false;
+            for( std::pair<const item *, int>& content : counted_items ) {
+                if( content.first->stacks_with( *contents_item ) ) {
+                    content.second += 1;
+                    found = true;
+                }
+            }
+            if( !found ) {
+                std::pair<const item *, int> new_content( contents_item, 1 );
+                counted_items.push_back( new_content );
+            }
+        }
+    }
+    return counted_items;
+}
+
+
 void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                           bool /*debug*/ ) const
 {
@@ -5683,8 +5712,13 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
         info.emplace_back( "DESCRIPTION", mod_str );
         info.emplace_back( "DESCRIPTION", mod->type->description.translated() );
     }
+    
+    const std::list<const item *> all_contents = contents.all_items_top();
+    std::vector<std::pair<item const *, int>> counted_contents = deduplicate_items(all_contents);
     bool contents_header = false;
-    for( const item *contents_item : contents.all_items_top() ) {
+    for( const auto content_w_count : counted_contents ){
+        const item * contents_item = content_w_count.first;
+        int count = content_w_count.second;
         if( !contents_header ) {
             insert_separation_line( info );
             info.emplace_back( "DESCRIPTION", _( "<bold>Contents of this item</bold>:" ) );
@@ -5698,12 +5732,16 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
 
         if( contents_item->made_of_from_type( phase_id::LIQUID ) ) {
             units::volume contents_volume = contents_item->volume() * batch;
-            info.emplace_back( "DESCRIPTION", colorize( contents_item->display_name(),
-                               contents_item->color_in_inventory() ) );
+            info.emplace_back( "DESCRIPTION",
+                    colorize( contents_item->display_name(), contents_item->color_in_inventory() ) );
             info.emplace_back( vol_to_info( "CONTAINER", description + space, contents_volume ) );
         } else {
-            info.emplace_back( "DESCRIPTION", colorize( contents_item->display_name(),
-                               contents_item->color_in_inventory() ) );
+            std::string name;
+            if( count > 1 ){
+                name += std::to_string( count ) + " ";
+            }
+            name += colorize( contents_item->display_name( count ), contents_item->color_in_inventory() );
+            info.emplace_back( "DESCRIPTION", name );
             info.emplace_back( "DESCRIPTION", description.translated() );
         }
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5659,7 +5659,7 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
 }
 
 std::vector<std::pair<const item *, int>> get_item_duplicate_counts(
-            const std::list<const item *> &items )
+        const std::list<const item *> &items )
 {
     std::vector<std::pair<item const *, int>> counted_items;
     for( const item *contents_item : items ) {
@@ -5706,7 +5706,8 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
     }
 
     const std::list<const item *> all_contents = contents.all_items_top();
-    const std::vector<std::pair<item const *, int>> counted_contents = get_item_duplicate_counts( all_contents );
+    const std::vector<std::pair<item const *, int>> counted_contents = get_item_duplicate_counts(
+                all_contents );
     bool contents_header = false;
     for( const auto content_w_count : counted_contents ) {
         const item *contents_item = content_w_count.first;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5709,7 +5709,7 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
     const std::vector<std::pair<item const *, int>> counted_contents = get_item_duplicate_counts(
                 all_contents );
     bool contents_header = false;
-    for( const auto content_w_count : counted_contents ) {
+    for( const std::pair<const item *, int> &content_w_count : counted_contents ) {
         const item *contents_item = content_w_count.first;
         int count = content_w_count.second;
         if( !contents_header ) {

--- a/src/item.h
+++ b/src/item.h
@@ -3352,4 +3352,5 @@ struct disp_mod_by_barrel {
  * was encountered.
  * For display purposes only.
  */
-std::vector<std::pair<const item*, int>> get_item_duplicate_counts( const std::list<const item*>& items );
+std::vector<std::pair<const item *, int>> get_item_duplicate_counts( const std::list<const item *>
+                                       &items );

--- a/src/item.h
+++ b/src/item.h
@@ -3352,5 +3352,5 @@ struct disp_mod_by_barrel {
  * was encountered.
  * For display purposes only.
  */
-std::vector<std::pair<const item *, int>> get_item_duplicate_counts( const std::list<const item *>
-                                       &items );
+std::vector<std::pair<const item *, int>> get_item_duplicate_counts(
+        const std::list<const item *> &items );

--- a/src/item.h
+++ b/src/item.h
@@ -3345,3 +3345,11 @@ struct disp_mod_by_barrel {
         dispersion_modifier( disp ) {}
     void deserialize( const JsonObject &jo );
 };
+
+/**
+ * Given an iterable of `const item* ` (such as obtained from `all_items_top()`),
+ * returns the vector of each unique item in the iterable, and the amount of times it
+ * was encountered.
+ * For display purposes only.
+ */
+std::vector<std::pair<const item*, int>> get_item_duplicate_counts( const std::list<const item*>& items );

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1268,11 +1268,12 @@ void item_pocket::contents_info( std::vector<iteminfo> &info, int pocket_number,
 
     // ablative pockets have their contents displayed earlier in the UI
     if( !is_ablative() ) {
-        std::vector<std::pair<const item *, int>> counted_contents = get_item_duplicate_counts( all_items_top() );
+        std::vector<std::pair<const item *, int>> counted_contents = get_item_duplicate_counts(
+                all_items_top() );
         bool contents_header = false;
 
         for( std::pair<item const *, int> content : counted_contents ) {
-            const item* contents_item = content.first;
+            const item *contents_item = content.first;
             const int count = content.second;
 
             if( !contents_header ) {
@@ -1282,18 +1283,18 @@ void item_pocket::contents_info( std::vector<iteminfo> &info, int pocket_number,
 
             const translation &desc = contents_item->type->description;
 
-            if( contents_item->made_of_from_type(phase_id::LIQUID) ) {
+            if( contents_item->made_of_from_type( phase_id::LIQUID ) ) {
                 info.emplace_back( "DESCRIPTION",
-                    colorize( space + contents_item->display_name(), contents_item->color_in_inventory() ) );
+                                   colorize( space + contents_item->display_name(), contents_item->color_in_inventory() ) );
                 info.emplace_back( vol_to_info( cont_type_str, desc + space, contents_item->volume() ) );
             } else {
-                if( count > 1) {
+                if( count > 1 ) {
                     info.emplace_back( "DESCRIPTION",
-                        space + std::to_string(count) + " " + colorize( contents_item->display_name(
-                            count ), contents_item->color_in_inventory() ) );
+                                       space + std::to_string( count ) + " " + colorize( contents_item->display_name(
+                                                   count ), contents_item->color_in_inventory() ) );
                 } else {
-                    info.emplace_back("DESCRIPTION",
-                        space + colorize(contents_item->display_name(), contents_item->color_in_inventory() ) );
+                    info.emplace_back( "DESCRIPTION",
+                                       space + colorize( contents_item->display_name(), contents_item->color_in_inventory() ) );
                 }
             }
         }


### PR DESCRIPTION
#### Summary
Interface "Deduplicate item contents description in the examine display"

#### Purpose of change

If we have several identical items in our pockets, each individual item is listed separately in the `e`xamine display.
This is unwieldly. See:

![20241206-234910-cataclysm-tiles](https://github.com/user-attachments/assets/1071610e-145f-40de-ab4d-9457147eec35)
![20241206-234914-cataclysm-tiles](https://github.com/user-attachments/assets/757819fe-759d-4599-bd43-ae8d7f2b7101)

#### Describe the solution

Merge the individual items if they are identical into a single one. This is already how it works for *pocket* contents, I'm doing the same thing to the item contents now.

#### Describe alternatives you've considered

N/A

#### Testing

![20241206-234303-cataclysm-tiles](https://github.com/user-attachments/assets/897d0104-f177-4e95-bc4f-7f8f640d48c1)


#### Additional context

This still looks a bit silly with liquid contents (the liquid's description is duplicated), but at least that's not a regression.

![20241208-211902](https://github.com/user-attachments/assets/86b12060-889f-4463-90da-92022931d38b)


