### PR TITLE
lcmatch instead of wildcard_match for (by)product filter `r:`

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1043,7 +1043,7 @@ static recipe_subset filter_recipes( const recipe_subset &available_recipes,
                 case 'r': {
                     recipe_subset result;
                     for( const itype *e : item_controller->all() ) {
-                        if( wildcard_match( e->nname( 1 ), qry_filter_str.substr( 2 ) ) ) {
+                        if( lcmatch( e->nname( 1 ), qry_filter_str.substr( 2 ) ) ) {
                             result.include( recipe_subset( available_recipes,
                                                            available_recipes.recipes_that_produce( e->get_id() ) ) );
                         }
@@ -1093,7 +1093,7 @@ static const std::vector<SearchPrefix> prefixes = {
     { 'm', to_translation( "yes" ), to_translation( "recipe <color_cyan>memorized</color> (or not)" ) },
     { 'P', to_translation( "Blacksmithing" ), to_translation( "<color_cyan>proficiency</color> used to craft" ) },
     { 'l', to_translation( "5" ), to_translation( "<color_cyan>difficulty</color> of the recipe as a number or range" ) },
-    { 'r', to_translation( "buttermilk" ), to_translation( "recipe's (<color_cyan>by</color>)<color_cyan>products</color>; use * as wildcard" ) },
+    { 'r', to_translation( "buttermilk" ), to_translation( "recipe's (<color_cyan>by</color>)<color_cyan>products</color>" ) },
     { 'L', to_translation( "122 cm" ), to_translation( "result can contain item of <color_cyan>length</color>" ) },
     { 'V', to_translation( "450 ml" ), to_translation( "result can contain item of <color_cyan>volume</color>" ) },
     { 'M', to_translation( "250 kg" ), to_translation( "result can contain item of <color_cyan>mass</color>" ) },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

 - Change the filter for `(by)product` to not use wildcards, it was the only one in that menu. Fitler was originally introduced by me in #64627. I didn't know better at the time.

#### Describe the solution

Use `lcmatch`, like in the others.

#### Describe alternatives you've considered


#### Testing

Filters with partial matches, as expected in that menu.

#### Additional context

 - Split off from #78384