### PR TITLE
fix checks for charges in EoC, excluding items with flags that do not have own charges

### DIFF
--- a/data/mods/Aftershock/spells/psionics/electrokinesis_concentration_eocs.json
+++ b/data/mods/Aftershock/spells/psionics/electrokinesis_concentration_eocs.json
@@ -230,7 +230,7 @@
       { "math": [ "u_afs_electrokin_personal_battery_count = 0" ] },
       {
         "u_run_inv_eocs": "all",
-        "search_data": [ { "uses_energy": true, "excluded_flags": [ "INTEGRATED", "PSEUDO", "USES_BIONIC_POWER" ] } ],
+        "search_data": [ { "uses_energy": true, "excluded_flags": [ "USES_BIONIC_POWER" ] } ],
         "true_eocs": [
           {
             "id": "EOC_AFS_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_COUNTER",

--- a/data/mods/Aftershock/spells/psionics/electrokinesis_concentration_eocs.json
+++ b/data/mods/Aftershock/spells/psionics/electrokinesis_concentration_eocs.json
@@ -230,7 +230,7 @@
       { "math": [ "u_afs_electrokin_personal_battery_count = 0" ] },
       {
         "u_run_inv_eocs": "all",
-        "search_data": [ { "uses_energy": true, "excluded_flags": ["INTEGRATED", "PSEUDO", "USES_BIONIC_POWER"] } ],
+        "search_data": [ { "uses_energy": true, "excluded_flags": [ "INTEGRATED", "PSEUDO", "USES_BIONIC_POWER" ] } ],
         "true_eocs": [
           {
             "id": "EOC_AFS_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_COUNTER",

--- a/data/mods/Aftershock/spells/psionics/electrokinesis_concentration_eocs.json
+++ b/data/mods/Aftershock/spells/psionics/electrokinesis_concentration_eocs.json
@@ -230,7 +230,7 @@
       { "math": [ "u_afs_electrokin_personal_battery_count = 0" ] },
       {
         "u_run_inv_eocs": "all",
-        "search_data": [ { "uses_energy": true } ],
+        "search_data": [ { "uses_energy": true, "excluded_flags": ["INTEGRATED", "PSEUDO", "USES_BIONIC_POWER"] } ],
         "true_eocs": [
           {
             "id": "EOC_AFS_ELECTROKIN_PERSONAL_BATTERY_INV_SCANNER_COUNTER",

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -298,7 +298,7 @@
                     "condition": { "not": { "u_has_effect": "effect_electrokin_personal_battery" } },
                     "effect": {
                       "u_run_inv_eocs": "random",
-                      "search_data": [ { "uses_energy": true, "excluded_flags": [ "INTEGRATED", "PSEUDO", "USES_BIONIC_POWER" ] } ],
+                      "search_data": [ { "uses_energy": true, "excluded_flags": [ "USES_BIONIC_POWER" ] } ],
                       "true_eocs": [
                         {
                           "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_INV_RESULT",

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -298,7 +298,7 @@
                     "condition": { "not": { "u_has_effect": "effect_electrokin_personal_battery" } },
                     "effect": {
                       "u_run_inv_eocs": "random",
-                      "search_data": [ { "uses_energy": true, "excluded_flags": ["INTEGRATED", "PSEUDO", "USES_BIONIC_POWER"] } ],
+                      "search_data": [ { "uses_energy": true, "excluded_flags": [ "INTEGRATED", "PSEUDO", "USES_BIONIC_POWER" ] } ],
                       "true_eocs": [
                         {
                           "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_INV_RESULT",

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -298,7 +298,7 @@
                     "condition": { "not": { "u_has_effect": "effect_electrokin_personal_battery" } },
                     "effect": {
                       "u_run_inv_eocs": "random",
-                      "search_data": [ { "uses_energy": true } ],
+                      "search_data": [ { "uses_energy": true, "excluded_flags": ["INTEGRATED", "PSEUDO", "USES_BIONIC_POWER"] } ],
                       "true_eocs": [
                         {
                           "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_INV_RESULT",

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -368,7 +368,7 @@
     "effect": [
       {
         "u_run_inv_eocs": "all",
-        "search_data": [ { "uses_energy": true, "excluded_flags": [ "INTEGRATED", "PSEUDO", "USES_BIONIC_POWER" ] } ],
+        "search_data": [ { "uses_energy": true, "excluded_flags": [ "USES_BIONIC_POWER" ] } ],
         "true_eocs": [
           {
             "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS_DISTRIBUTION",

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -368,7 +368,7 @@
     "effect": [
       {
         "u_run_inv_eocs": "all",
-        "search_data": [ { "uses_energy": true } ],
+        "search_data": [ { "uses_energy": true, "excluded_flags": ["INTEGRATED", "PSEUDO", "USES_BIONIC_POWER"] } ],
         "true_eocs": [
           {
             "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS_DISTRIBUTION",

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -368,7 +368,7 @@
     "effect": [
       {
         "u_run_inv_eocs": "all",
-        "search_data": [ { "uses_energy": true, "excluded_flags": ["INTEGRATED", "PSEUDO", "USES_BIONIC_POWER"] } ],
+        "search_data": [ { "uses_energy": true, "excluded_flags": [ "INTEGRATED", "PSEUDO", "USES_BIONIC_POWER" ] } ],
         "true_eocs": [
           {
             "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_POWER_ITEMS_DISTRIBUTION",


### PR DESCRIPTION
#### Summary
Bugfixes "fix checks for charges in EoC, excluding items with flags that do not have own charges"

#### Purpose of change

Fixes #78426

#### Describe the solution

Added exclusion flags check for `"INTEGRATED"`, `"PSEUDO"` and `"USES_BIONIC_POWER"`. I've scanned repo for other EoCs using same `uses_energy()` checks, ensured they are dealing with power additions/removal too, fixed them.

#### Describe alternatives you've considered

Rewriting `item::uses_energy()` to prevent EoC check on devices without energy pool will require too many changes in the code everywhere it is called to ensure it does not introduce incorrect behavior.

#### Testing

Loaded save that caused error, waited a few hundred turns, no error, checked inventory if electronic devices actually charge - they do. Works fine.

#### Additional context

Possibly I've missed a few flags or some obscure legacy ways of draining power.