### PR TITLE
Set transparency cache dirty when placing a vehicle.

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -498,6 +498,7 @@ void map::add_vehicle_to_cache( vehicle *veh )
         ch.set_veh_cached_parts( p.raw(), *veh, static_cast<int>( vpr.part_index() ) );
         if( inbounds( p ) ) {
             ch.set_veh_exists_at( p.raw(), true );
+            set_transparency_cache_dirty( p );
         }
     }
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
There's an intermittent but common test failure that has been cropping up recently that looks like:
```
../tests/vehicle_fake_part_test.cpp:349
../tests/vehicle_fake_part_test.cpp:363: FAILED:
CHECK( !you.sees( you.pos_bub() + point( 10, 10 ) ) )
with expansion:
false
```
Scanning through test runs, it looks like the first place it happened was https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12087387906/job/33711062255 but that doesn't seem to be cause, it looks like #78104 is a likely culprit.
I'm not sure if this is visible in-game, because it's likely that the transparency cache at the vehicle's location gets invalidated before it comes into view anyway, but in tests we need to be able to set the scene in a more ad-hoc way.

#### Describe the solution
Add a transparency cache invalidation for each tile of a vehicle when it's added to the map.

#### Describe alternatives you've considered
I'm a little concerned about there being missing invalidations elsewhere as well, but I'm not up to digging into it right now.

#### Testing
Unfortunately I can't get this to reproduce locally so this is all analysis based, but worst case it should be harmless?