### PR TITLE
Prompt before oxytorch activity if you don't have enough gas

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5421,7 +5421,7 @@ void oxytorch_activity_actor::start( player_activity &act, Character &who )
         act.set_to_null();
         return;
     }
-    if ( tool->ammo_sufficient( &who, act.moves_total / 100 ) ) {
+    if( tool->ammo_sufficient( &who, act.moves_total / 100 ) ) {
         add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
         act.moves_left = act.moves_total;
     } else {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5423,9 +5423,9 @@ void oxytorch_activity_actor::start( player_activity &act, Character &who )
     }
     if( tool->ammo_sufficient( &who, act.moves_total / 100 ) ||
         query_yn(
-            _( "Your %1$s doesn't have enough charges to complete the job. Continue anyway?" ), tool->tname()
+            _( "Your %1$s doesn't have enough charges to complete the job.  Continue anyway?" ), tool->tname()
         ) ||
-        test_mode
+        test_mode // In the tests, we want to check that the activity can be resumed.
       ) {
         add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
         act.moves_left = act.moves_total;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5390,7 +5390,7 @@ std::unique_ptr<activity_actor> disassemble_activity_actor::deserialize( JsonVal
     return actor.clone();
 }
 
-void oxytorch_activity_actor::start( player_activity &act, Character &/*who*/ )
+void oxytorch_activity_actor::start( player_activity &act, Character &who )
 {
     const map &here = get_map();
 
@@ -5421,9 +5421,14 @@ void oxytorch_activity_actor::start( player_activity &act, Character &/*who*/ )
         act.set_to_null();
         return;
     }
-
-    add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
-    act.moves_left = act.moves_total;
+    if ( tool->ammo_sufficient( &who, act.moves_total / 100 ) ) {
+        add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
+        act.moves_left = act.moves_total;
+    } else {
+        who.add_msg_if_player( m_bad, _( "Your %1$s doesn't have enough charges." ), tool->tname() );
+        act.set_to_null();
+        return;
+    }
 }
 
 void oxytorch_activity_actor::do_turn( player_activity &/*act*/, Character &who )

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5421,11 +5421,14 @@ void oxytorch_activity_actor::start( player_activity &act, Character &who )
         act.set_to_null();
         return;
     }
-    if( tool->ammo_sufficient( &who, act.moves_total / 100 ) ) {
+    if( tool->ammo_sufficient( &who, act.moves_total / 100 ) ||
+        query_yn(
+            _( "Your %1$s doesn't have enough charges to complete the job. Continue anyway?" ), tool->tname()
+        )
+      ) {
         add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
         act.moves_left = act.moves_total;
     } else {
-        who.add_msg_if_player( m_bad, _( "Your %1$s doesn't have enough charges." ), tool->tname() );
         act.set_to_null();
         return;
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5424,7 +5424,8 @@ void oxytorch_activity_actor::start( player_activity &act, Character &who )
     if( tool->ammo_sufficient( &who, act.moves_total / 100 ) ||
         query_yn(
             _( "Your %1$s doesn't have enough charges to complete the job. Continue anyway?" ), tool->tname()
-        )
+        ) ||
+        test_mode
       ) {
         add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
         act.moves_left = act.moves_total;


### PR DESCRIPTION
#### Summary
Features "Prompt before oxytorch activity if you don't have enough gas"

#### Purpose of change

With the addition of [tiny acetylene tanks](https://github.com/CleverRaven/Cataclysm-DDA/pull/78323), having insufficient gas to torch things is far more prevalent.  Since you need 112 charges to cut through a metal door and the new tanks hold 100, the player can easily waste 96 charges (8 gas per second until it runs out) if they attempt to torch a door with a full tiny tank.

#### Describe the solution

Check if the player has enough acetylene before starting the activity and prompt them if they want to start if it's not possible to finish with the current tank.

#### Describe alternatives you've considered

1. Could make the `oxy_torch` `USES_NEARBY_AMMO` so that multiple tiny tanks can do the job. This would still waste gas when there isn't enough and would also change up welding crafting to be able to squeeze every drop out of each tank.
2. Handwave steel doors to require 6 kg of steel melting requiring 96 gas instead of 7 kg requiring 112 gas, so that you can cut a door with a tiny tank.  This doesn't solve the problem of wasting gas, but at least makes the tiny tanks less punishing.
3. Increase the tiny tank to 1.25 L so that you can cut a door.  As above.
4. Empty the current tank whether or not it'll do the job.  Current behavior.

#### Testing

Prompt appears
![image](https://github.com/user-attachments/assets/0b6a2054-8170-4b7a-9a85-72c0250ac02a)

Can reload and resume
![image](https://github.com/user-attachments/assets/2bc5a8bb-bb01-4406-8163-471fe00d7534)

#### Additional context

[Gas requirements in the `oxy_torch`](https://github.com/AlexMooney/Cataclysm-DDA/blob/786d9eed7d1669ad8c31047890ce921b1c9c0b58/data/json/items/tool/workshop.json#L832-L834)
[Capacity of `tinyweldtank`](https://github.com/Night-Pryanik/Cataclysm-DDA/blob/1716dbd3dca180d75f62487d7bc30755d40f9cc1/data/json/items/magazine/weldgas.json#L3-L18)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->