### PR TITLE
When you back the empty spike it drops shot glassed. Now it doesn't

### DIFF
--- a/data/json/furniture_and_terrain/furniture-alien.json
+++ b/data/json/furniture_and_terrain/furniture-alien.json
@@ -805,7 +805,7 @@
       "str_max": 100,
       "sound": "smash!",
       "sound_fail": "an absence of sound.",
-      "items": [ { "item": "glass", "count": [ 1, 2 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 1, 2 ] } ]
     },
     "examine_action": {
       "type": "effect_on_condition",


### PR DESCRIPTION
It used the item "glass" not "glass_shard". Quick and easy (I think)