### PR TITLE
[Xedra Evolved] Add Exhalation of Ashes spell to salamanders

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
@@ -395,6 +395,42 @@
     "casting_time_increment": -10
   },
   {
+    "id": "salamander_ash_breath_spell",
+    "type": "SPELL",
+    "name": "Exhalation of Ashes",
+    "description": "You can breathe out a cloud of thick smoke, concealing your presence or causing humans to choke.",
+    "valid_targets": [ "hostile", "ally", "ground" ],
+    "skill": "deduction",
+    "teachable": false,
+    "spell_class": "SALAMANDER",
+    "flags": [ "LOUD", "NO_PROJECTILE", "NO_HANDS", "NO_LEGS" ],
+    "effect": "attack",
+    "shape": "cone",
+    "difficulty": 2,
+    "max_level": { "math": [ "str_to_level(1)" ] },
+    "min_damage": 0,
+    "max_damage": 0,
+    "min_range": {
+      "math": [ "min((( (u_spell_level('salamander_ash_breath_spell') * 1.1) + 2) * (scaling_factor(u_val('strength') ) )),20)" ]
+    },
+    "max_range": {
+      "math": [ "min((( (u_spell_level('salamander_ash_breath_spell') * 1.1) + 2) * (scaling_factor(u_val('strength') ) )),20)" ]
+    },
+    "min_aoe": 60,
+    "max_aoe": 60,
+    "field_id": "fd_smoke",
+    "min_field_intensity": 3,
+    "max_field_intensity": 3,
+    "field_chance": 1,
+    "energy_source": "MANA",
+    "base_energy_cost": 150,
+    "final_energy_cost": 75,
+    "energy_increment": -5,
+    "base_casting_time": 50,
+    "final_casting_time": 25,
+    "casting_time_increment": -2
+  },
+  {
     "id": "salamander_fire_breath",
     "type": "SPELL",
     "name": "Breath of the Firedragon",
@@ -411,9 +447,12 @@
     "max_level": { "math": [ "str_to_level(1)" ] },
     "min_damage": { "math": [ "( (u_spell_level('salamander_fire_breath') * 2) + 15) * (scaling_factor(u_val('strength') ) )" ] },
     "max_damage": { "math": [ "( (u_spell_level('salamander_fire_breath') * 3) + 30) * (scaling_factor(u_val('strength') ) )" ] },
-    "min_range": { "math": [ "( (u_spell_level('salamander_fire_breath') * 0.2) + 2) * (scaling_factor(u_val('strength') ) )" ] },
-    "max_range": 8,
-    "range_increment": 0.2,
+    "min_range": {
+      "math": [ "min((( (u_spell_level('salamander_fire_breath') * 0.25) + 2) * (scaling_factor(u_val('strength') ) )),8)" ]
+    },
+    "max_range": {
+      "math": [ "min((( (u_spell_level('salamander_fire_breath') * 0.25) + 2) * (scaling_factor(u_val('strength') ) )),8)" ]
+    },
     "min_aoe": { "math": [ "( (u_spell_level('salamander_fire_breath') * 3) + 27) * (scaling_factor(u_val('strength') ) )" ] },
     "max_aoe": 180,
     "field_id": "fd_fire",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutations.json
@@ -119,13 +119,25 @@
   },
   {
     "type": "mutation",
+    "id": "SALAMANDER_ASH_BREATH",
+    "name": { "str": "Exhalation of Ashes" },
+    "points": 3,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "Upon gaining this ability the Salamander gains the ability to breathe out a cloud of thick smoke.",
+    "prereqs": [ "SALAMANDER_NO_SMOKE_DAMAGE" ],
+    "category": [ "SALAMANDER" ],
+    "spells_learned": [ [ "salamander_ash_breath_spell", 1 ] ]
+  },
+  {
+    "type": "mutation",
     "id": "SALAMANDER_FLAME_BREATH",
     "name": { "str": "Breath of the Firedragon" },
     "points": 3,
     "visibility": 0,
     "ugliness": 0,
     "description": "Upon gaining this ability the Salamander gains the ability to breathe a cone of flames.",
-    "prereqs": [ "SALAMANDER_FLAME_PUNCH" ],
+    "prereqs": [ "SALAMANDER_ASH_BREATH" ],
     "category": [ "SALAMANDER" ],
     "spells_learned": [ [ "salamander_fire_breath", 1 ] ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_spell_learning_eocs.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SALAMANDER_SPELL_EXPERIENCE_INCREASER",
-    "//": "Must be near a source of fire or heat.  The game currently can't detect a nearby fire using EoC--once it can that should be added.",
+    "//": "Must be near a source of fire or heat.",
     "recurrence": [ "6 h", "36 h" ],
     "condition": {
       "and": [
@@ -15,6 +15,7 @@
             "SALAMANDER_SMOKE_TELEPORT",
             "SALAMANDER_FLAME_PUNCH",
             "SALAMANDER_SUMMON_FIRE_SPIRIT",
+            "SALAMANDER_ASH_BREATH",
             "SALAMANDER_FLAME_BREATH",
             "SALAMANDER_SUMMON_FIREBIRD",
             "SALAMANDER_INCREASE_SPEED",
@@ -37,11 +38,7 @@
             { "u_has_item": "oil_lamp_clay_on" },
             { "u_has_item": "cigar_lit" },
             { "u_has_item": "cig_lit" },
-            { "u_is_in_field": "fd_hot_air1" },
-            { "u_is_in_field": "fd_hot_air2" },
-            { "u_is_in_field": "fd_hot_air3" },
-            { "u_is_in_field": "fd_hot_air4" },
-            { "u_is_in_field": "fd_fire" },
+            { "math": [ "u_salamander_near_fire == 1" ] },
             { "math": [ "weather('temperature') >= from_fahrenheit( 80 )" ] }
           ]
         }
@@ -62,6 +59,7 @@
         { "math": [ "u_spell_level('salamander_smoke_teleport_spell') < per_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_flame_punch_spell') < str_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_summon_fire_spirit') < 35" ] },
+        { "math": [ "u_spell_level('salamander_ash_breath_spell') < str_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_fire_breath') < str_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_summon_firebird_spell') < per_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_increase_speed_spell') < str_to_level(1)" ] },
@@ -85,6 +83,7 @@
         [ "EOC_LEVELER_SALAMANDER_SMOKE_TELEPORT", 8 ],
         [ "EOC_LEVELER_SALAMANDER_FLAME_PUNCH", 8 ],
         [ "EOC_LEVELER_SALAMANDER_SUMMON_FIRE_SPIRIT", 8 ],
+        [ "EOC_LEVELER_SALAMANDER_ASH_BREATH", 9 ],
         [ "EOC_LEVELER_SALAMANDER_FLAME_BREATH", 6 ],
         [ "EOC_LEVELER_SALAMANDER_SUMMON_FIREBIRD", 7 ],
         [ "EOC_LEVELER_SALAMANDER_INCREASE_SPEED", 5 ],
@@ -206,6 +205,24 @@
         "type": "good"
       },
       { "math": [ "u_spell_exp('salamander_summon_fire_spirit')", "+=", "paraclesian_passive_spell_exp(1)" ] }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_SALAMANDER_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LEVELER_SALAMANDER_ASH_BREATH",
+    "condition": {
+      "and": [
+        { "math": [ "u_spell_level('salamander_ash_breath_spell') >= 0" ] },
+        { "math": [ "u_spell_level('salamander_ash_breath_spell') < str_to_level(1)" ] }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "Your time spent among the heat and flames has increased your facility with your fae magicks.",
+        "type": "good"
+      },
+      { "math": [ "u_spell_exp('salamander_ash_breath_spell')", "+=", "paraclesian_passive_spell_exp(1)" ] }
     ],
     "false_effect": [ { "run_eocs": "EOC_SALAMANDER_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Add Exhalation of Ashes spell to salamanders"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had the idea for the name, and came up with a spell for it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Exhalation of Ashes trait (prerequisite of Breathing in Cinders, now leads to Breath of the Firedragon), that lets you breathe out a big cloud of thick smoke. Use it to conceal your presence or breathe on ferals/NPCs to puts tons of smoke in their eyes.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Clouds of smoke now possible.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
