### PR TITLE
[MoM] Psi passives turn off if you can't use psionics

### DIFF
--- a/data/mods/MindOverMatter/mutations/psi_passives.json
+++ b/data/mods/MindOverMatter/mutations/psi_passives.json
@@ -30,6 +30,7 @@
     "purifiable": false,
     "enchantments": [
       {
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "values": [
           { "value": "HUNGER", "multiply": { "math": [ "(-0.03 - (0.00075 * u_spell_level_sum('school': 'BIOKINETIC')))" ] } },
           {
@@ -63,7 +64,12 @@
         "special_vision": [
           {
             "condition": {
-              "or": [ { "npc_has_species": "HORROR" }, { "npc_has_species": "NETHER" }, { "npc_has_species": "nether_player_hate" } ]
+              "and": [
+                { "not": { "u_has_flag": "NO_PSIONICS" } },
+                {
+                  "or": [ { "npc_has_species": "HORROR" }, { "npc_has_species": "NETHER" }, { "npc_has_species": "nether_player_hate" } ]
+                }
+              ]
             },
             "distance": { "math": [ "2 + (0.075 * u_spell_level_sum('school': 'CLAIRSENTIENT'))" ] },
             "descriptions": [ { "id": "nether_creature_sense", "symbol": "?", "color": "c_pink", "text": "You sense an otherworldy danger here." } ]
@@ -83,6 +89,7 @@
     "purifiable": false,
     "enchantments": [
       {
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "values": [
           { "value": "ARMOR_ELEC", "add": { "math": [ "u_spell_level_sum('school': 'ELECTROKINETIC') / -0.2" ] } },
           { "value": "PAIN", "multiply": { "math": [ "u_spell_level_sum('school': 'ELECTROKINETIC') * -0.00035" ] } }
@@ -111,6 +118,7 @@
     "bodytemp_modifiers": [ 250, 750 ],
     "enchantments": [
       {
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "values": [ { "value": "BODYTEMP_SLEEP", "add": { "math": [ "0.05 * u_spell_level_sum('school': 'PYROKINETIC')" ] } } ]
       }
     ],
@@ -141,6 +149,7 @@
     "purifiable": false,
     "enchantments": [
       {
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "values": [
           {
             "value": "OBTAIN_COST_MULTIPLIER",
@@ -161,6 +170,7 @@
     "purifiable": false,
     "enchantments": [
       {
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "values": [
           { "value": "SOCIAL_INTIMIDATE", "add": { "math": [ "(5 + (0.075 * u_spell_level_sum('school': 'TELEPATH')))" ] } },
           { "value": "SOCIAL_LIE", "add": { "math": [ "(5 + (0.075 * u_spell_level_sum('school': 'TELEPATH')))" ] } },
@@ -184,6 +194,7 @@
     "purifiable": false,
     "enchantments": [
       {
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "values": [ { "value": "EVASION", "add": { "math": [ "(0.01 + (0.00025 * u_spell_level_sum('school': 'TELEPORTER')))" ] } } ]
       }
     ]
@@ -201,6 +212,7 @@
     "purifiable": false,
     "enchantments": [
       {
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "values": [
           { "value": "REGEN_HP", "multiply": { "math": [ "(0.1 + (0.0005 * u_spell_level_sum('school': 'VITAKINETIC')))" ] } },
           {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Psi passives turn off if you can't use psionics"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It only makes sense.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add  `"condition": { "not": { "u_has_flag": "NO_PSIONICS" } }` to all the psi passives. This can lead to some problems if you're not careful--for example, your electric armor from electrokinesis turns off if you're near a null now, or if you’re stunned.  

I was not able to do this yet with Photokinesis, since `integrated_armor` doesn't take conditions and since adding mutations through an enchantment is bugged. Once that bug is fixed, I can make the actual fake glasses that provide the effects a secondary mutation that's removed if you have the flag.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Went in as a Clairsentient and spawned some nether monsters. Spawned a null nearby, passive nether vision turned off.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
