### PR TITLE
[Magiclysm] Add Mind Crush spell

### DIFF
--- a/data/mods/Magiclysm/Spells/animist.json
+++ b/data/mods/Magiclysm/Spells/animist.json
@@ -1140,5 +1140,32 @@
     "energy_source": "MANA",
     "base_casting_time": 250,
     "base_energy_cost": 250
+  },
+  {
+    "id": "animist_do_psionic_damage_to_head",
+    "type": "SPELL",
+    "name": "Mind Crush",
+    "description": "Directly assault the target's spirit, bypassing any physical protections they have.",
+    "valid_targets": [ "hostile" ],
+    "flags": [ "EVOCATION_SPELL", "CONCENTRATE", "SILENT", "RANDOM_DAMAGE", "RANDOM_DURATION", "NO_LEGS" ],
+    "max_level": 15,
+    "spell_class": "ANIMIST",
+    "effect": "attack",
+    "effect_str": "stunned",
+    "damage_type": "psionic",
+    "affected_body_parts": [ "head" ],
+    "extra_effects": [ { "id": "eoc_evocation_setup", "hit_self": true } ],
+    "shape": "blast",
+    "difficulty": 5,
+    "min_damage": { "math": [ "10 + (u_spell_level('animist_do_psionic_damage_to_head') * 2.5)" ] },
+    "max_damage": { "math": [ "25 + (u_spell_level('animist_do_psionic_damage_to_head') * 6)" ] },
+    "min_duration": { "math": [ "150 + (u_spell_level('animist_do_psionic_damage_to_head') * 10)" ] },
+    "max_duration": { "math": [ "250 + (u_spell_level('animist_do_psionic_damage_to_head') * 25)" ] },
+    "min_range": 3,
+    "max_range": 15,
+    "range_increment": 0.9,
+    "energy_source": "MANA",
+    "base_casting_time": 75,
+    "base_energy_cost": 350
   }
 ]

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1267,7 +1267,8 @@
           { "item": "spell_scroll_summon_undead", "prob": 50 },
           { "item": "spell_scroll_animist_vocalize", "prob": 35 },
           { "item": "spell_scroll_animist_luck_bone", "prob": 30 },
-          { "item": "spell_scroll_animist_add_evasion_spell", "prob": 40 }
+          { "item": "spell_scroll_animist_add_evasion_spell", "prob": 40 },
+          { "item": "spell_scroll_animist_do_psionic_damage_to_head", "prob": 30 }
         ],
         "prob": 35
       },

--- a/data/mods/Magiclysm/itemgroups/spellbooks.json
+++ b/data/mods/Magiclysm/itemgroups/spellbooks.json
@@ -70,6 +70,7 @@
       [ "spell_scroll_animist_summon_watcher", 30 ],
       [ "spell_scroll_animist_vocalize", 30 ],
       [ "spell_scroll_animist_luck_bone", 20 ],
+      [ "spell_scroll_animist_do_psionic_damage_to_head", 25 ],
       [ "spell_scroll_pain_split", 25 ],
       [ "spell_scroll_bio_grotesque", 40 ],
       [ "spell_scroll_bio_fleshpouch", 30 ],

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -2112,5 +2112,14 @@
     "name": { "str": "Scroll of Goodberry", "str_pl": "Scrolls of Goodberry" },
     "description": "Transform a set of berries into a set of even better berries that keep you full and heal your wounds.  Delicious and nutritious.",
     "use_action": { "type": "learn_spell", "spells": [ "druid_goodberry" ] }
+  },
+  {
+    "type": "BOOK",
+    "copy-from": "spell_scroll",
+    "id": "spell_scroll_animist_do_psionic_damage_to_head",
+    "//": "Animist spell",
+    "name": { "str": "Scroll of Mind Crush", "str_pl": "Scrolls of Mind Crush" },
+    "description": "Use your own spirit to attack the target's spirit.",
+    "use_action": { "type": "learn_spell", "spells": [ "animist_do_psionic_damage_to_head" ] }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add Mind Crush spell"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Not a lot going on with the Psionic damage type and animist seems the most appropriate for it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Difficulty 5 Mind Crush spell, which does psionic damage and stuns the target for a short time.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Target's mind = crushed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Feral animists are definitely going to do this to you. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
