### PR TITLE
Fix typo in 'f_empty_spike' bash drops

### DIFF
--- a/data/json/furniture_and_terrain/furniture-alien.json
+++ b/data/json/furniture_and_terrain/furniture-alien.json
@@ -805,7 +805,7 @@
       "str_max": 100,
       "sound": "smash!",
       "sound_fail": "an absence of sound.",
-      "items": [ { "item": "glass", "count": [ 1, 2 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 1, 2 ] } ]
     },
     "examine_action": {
       "type": "effect_on_condition",


### PR DESCRIPTION
#### Summary
Bugfixes "Typo fixed for 'f_empty_spike' involving bash drops"

#### Purpose of Change
The typo in the `f_empty_spike` definition caused incorrect bash drop behavior. This fix ensures the correct item, `glass_shard`, is dropped when the object is bashed.

#### Describe the Solution
- Updated the `f_empty_spike` JSON entry to replace `"glass"` with `"glass_shard"` under the `bash` action's `items` field.

#### Testing
- Validated the updated JSON by running the game and confirming the correct item drops.
- Confirmed no syntax errors in the JSON structure.

#### Additional Context
This fixes a minor issue with the object behavior, ensuring intended functionality.