### PR TITLE
Migrate popups in pocket settings menu to ImGui

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -17,6 +17,7 @@
 #include "flat_set.h"
 #include "imgui/imgui.h"
 #include "input.h"
+#include "input_popup.h"
 #include "input_context.h"
 #include "inventory.h"
 #include "item.h"
@@ -32,7 +33,6 @@
 #include "output.h"
 #include "point.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "ui.h"
 #include "units.h"
@@ -306,11 +306,9 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         whitelist = false;
         return true;
     } else if( action == "FAV_PRIORITY" ) {
-        string_input_popup popup;
-        popup.title( string_format( _( "Enter Priority (current priority %d)" ),
-                                    selected_pocket->settings.priority() ) );
-        const int ret = popup.query_int();
-        if( popup.confirmed() ) {
+        number_input_popup<int> popup( 34, selected_pocket->settings.priority(), _( "Enter Priority" ) );
+        const int ret = popup.query();
+        if( !popup.cancelled() ) {
             selected_pocket->settings.set_priority( ret );
             selected_pocket->settings.set_was_edited();
         }
@@ -434,16 +432,10 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         }
         return true;
     } else if( action == "FAV_SAVE_PRESET" ) {
-        string_input_popup custom_preset_popup;
-        custom_preset_popup
-        .title( _( "Enter a preset name:" ) )
-        .width( 25 );
-        if( selected_pocket->settings.get_preset_name().has_value() ) {
-            custom_preset_popup.text( selected_pocket->settings.get_preset_name().value() );
-        }
-        custom_preset_popup.query_string();
-        if( !custom_preset_popup.canceled() ) {
-            const std::string &rval = custom_preset_popup.text();
+        string_input_popup_imgui popup( 34, selected_pocket->settings.get_preset_name().value_or( "" ),
+                                        _( "Enter a preset name:" ) );
+        const std::string &rval = popup.query();
+        if( !popup.cancelled() ) {
             // Check if already exists
             item_pocket::load_presets();
             if( item_pocket::has_preset( rval ) ) {


### PR DESCRIPTION
#### Summary
Interface "Migrate popups in pocket settings menu to ImGui"

#### Purpose of change

 - Resolve #75661 (This only addresses the last problem or two standing).
 - Fixes #77290

#### Describe the solution

 Migrate to Imgui.

#### Describe alternatives you've considered


#### Testing

Priority before (behind the window):
![image](https://github.com/user-attachments/assets/729cc10c-2a8c-4848-8df5-2cb83e653a66)

Priority after:
![image](https://github.com/user-attachments/assets/574c737e-0855-4bbb-8e4c-f32412d283c4)

 - Check values `12` and `-5` work


Save preset before:
![image](https://github.com/user-attachments/assets/c08b9989-cc6e-4f1a-8629-1628d70d4ac4)

Save preset after:
![image](https://github.com/user-attachments/assets/a14f6851-d8d9-4f69-b241-d12727e24b39)


This shadow is not there either anymore:
![image](https://github.com/user-attachments/assets/ebdcaeca-7f43-4a65-a8e5-7b43bc50e832)


#### Additional context
