### PR TITLE
Categorically fix type issues with restore_on_out_of_scope

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -560,8 +560,7 @@ construction_id construction_menu( const bool blueprint )
     tilecontext->set_disable_occlusion( true );
     g->invalidate_main_ui_adaptor();
 #endif
-    std::unique_ptr<restore_on_out_of_scope<tripoint_rel_ms>> restore_view
-            = std::make_unique<restore_on_out_of_scope<tripoint_rel_ms>>( player_character.view_offset );
+    restore_on_out_of_scope restore_view( player_character.view_offset );
 
     const auto recalc_buffer = [&]() {
         //leave room for top and bottom UI text
@@ -1062,7 +1061,7 @@ construction_id construction_menu( const bool blueprint )
                         add_msg( m_info, _( "It is too dark to construct right now." ) );
                     } else {
                         draw_preview.reset();
-                        restore_view.reset();
+                        restore_view.cancel();
                         restore_ui.reset();
                         ui.reset();
                         place_construction( { constructs[select] } );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -347,7 +347,7 @@ shared_ptr_fast<ui_adaptor> editmap::create_or_get_ui_adaptor()
 std::optional<tripoint_bub_ms> editmap::edit()
 {
     avatar &player_character = get_avatar();
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( player_character.view_offset );
+    restore_on_out_of_scope view_offset_prev( player_character.view_offset );
     target = player_character.pos_bub() + player_character.view_offset;
     input_context ctxt( "EDITMAP" );
     ctxt.set_iso( true );
@@ -381,8 +381,8 @@ std::optional<tripoint_bub_ms> editmap::edit()
     on_out_of_scope invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope info_title_prev( info_title_curr );
 
     creature_tracker &creatures = get_creature_tracker();
     do {
@@ -1129,8 +1129,8 @@ void editmap::edit_feature()
     on_out_of_scope invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope info_title_prev( info_title_curr );
 
     blink = true;
     bool quit = false;
@@ -1250,8 +1250,8 @@ void editmap::edit_fld()
     on_out_of_scope invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope info_title_prev( info_title_curr );
     map &here = get_map();
 
     blink = true;
@@ -1415,8 +1415,8 @@ void editmap::edit_itm()
     on_out_of_scope invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope info_title_prev( info_title_curr );
 
     shared_ptr_fast<uilist_impl> ilmenu_ui = ilmenu.create_or_get_ui();
 
@@ -1700,8 +1700,8 @@ int editmap::select_shape( shapetype shape, int mode )
     on_out_of_scope invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope info_title_prev( info_title_curr );
 
     do {
         if( moveall ) {
@@ -1745,8 +1745,8 @@ int editmap::select_shape( shapetype shape, int mode )
                 on_out_of_scope invalidate_current_ui_2( [this]() {
                     do_ui_invalidation();
                 } );
-                restore_on_out_of_scope<std::string> info_txt_prev_2( info_txt_curr );
-                restore_on_out_of_scope<std::string> info_title_prev_2( info_title_curr );
+                restore_on_out_of_scope info_txt_prev_2( info_txt_curr );
+                restore_on_out_of_scope info_title_prev_2( info_title_curr );
 
                 do {
                     info_txt_curr.clear();
@@ -1855,9 +1855,9 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
     on_out_of_scope invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<tinymap *> tinymap_ptr_prev( tmpmap_ptr );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope tinymap_ptr_prev( tmpmap_ptr );
+    restore_on_out_of_scope info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope info_title_prev( info_title_curr );
     map &here = get_map();
 
     int lastsel = gmenu.selected;
@@ -2063,8 +2063,8 @@ void editmap::mapgen_retarget()
     on_out_of_scope invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope info_title_prev( info_title_curr );
 
     blink = true;
     do {
@@ -2130,8 +2130,8 @@ void editmap::edit_mapgen()
     on_out_of_scope invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope info_title_prev( info_title_curr );
     map &here = get_map();
 
     do {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3359,7 +3359,7 @@ void game::load_packs( const std::string &msg, const std::vector<mod_id> &packs 
     for( const auto &e : available ) {
         loading_ui::show( msg, e->name() );
         const MOD_INFORMATION &mod = *e;
-        restore_on_out_of_scope<check_plural_t> restore_check_plural( check_plural );
+        restore_on_out_of_scope restore_check_plural( check_plural );
         if( mod.ident.str() == "test_data" ) {
             check_plural = check_plural_t::none;
         }
@@ -7030,9 +7030,9 @@ void game::zones_manager()
         {
             ui.mark_resize();
         } );
-        restore_on_out_of_scope<bool> show_prev( show );
-        restore_on_out_of_scope<std::optional<tripoint>> zone_start_prev( zone_start );
-        restore_on_out_of_scope<std::optional<tripoint>> zone_end_prev( zone_end );
+        restore_on_out_of_scope show_prev( show );
+        restore_on_out_of_scope zone_start_prev( zone_start );
+        restore_on_out_of_scope zone_end_prev( zone_end );
         show = false;
         zone_start = std::nullopt;
         zone_end = std::nullopt;
@@ -7377,9 +7377,9 @@ void game::zones_manager()
                         on_out_of_scope invalidate_current_ui( [&]() {
                             ui.mark_resize();
                         } );
-                        restore_on_out_of_scope<bool> show_prev( show );
-                        restore_on_out_of_scope<std::optional<tripoint>> zone_start_prev( zone_start );
-                        restore_on_out_of_scope<std::optional<tripoint>> zone_end_prev( zone_end );
+                        restore_on_out_of_scope show_prev( show );
+                        restore_on_out_of_scope zone_start_prev( zone_start );
+                        restore_on_out_of_scope zone_end_prev( zone_end );
                         show = false;
                         zone_start = std::nullopt;
                         zone_end = std::nullopt;

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -245,7 +245,7 @@ class generic_factory
                     jo.throw_error( string_format( "cannot specify both '%s' and '%s'",
                                                    abstract_member_name, id_member_name ) );
                 }
-                restore_on_out_of_scope<check_plural_t> restore_check_plural( check_plural );
+                restore_on_out_of_scope restore_check_plural( check_plural );
                 check_plural = check_plural_t::none;
                 const std::string abstract_id =  jo.get_string( abstract_member_name );
                 def.id = string_id<T>( abstract_id );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4193,7 +4193,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
 {
     bool strict = src == "dda";
 
-    restore_on_out_of_scope<check_plural_t> restore_check_plural( check_plural );
+    restore_on_out_of_scope restore_check_plural( check_plural );
     if( jo.has_string( "abstract" ) ) {
         check_plural = check_plural_t::none;
     }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -456,7 +456,7 @@ target_handler::trajectory target_handler::mode_select_only( avatar &you, int ra
     ui.mode = target_ui::TargetMode::SelectOnly;
     ui.range = range;
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -483,7 +483,7 @@ target_handler::trajectory target_handler::mode_throw( avatar &you, item &releva
     ui.relevant = &relevant;
     ui.range = you.throw_range( relevant );
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -495,7 +495,7 @@ target_handler::trajectory target_handler::mode_reach( avatar &you, item_locatio
     ui.relevant = weapon.get_item();
     ui.range = weapon ? weapon->current_reach_range( you ) : 1;
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -509,7 +509,7 @@ target_handler::trajectory target_handler::mode_turret_manual( avatar &you, turr
     ui.range = turret.range();
     ui.ammo = turret.ammo_data();
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -539,7 +539,7 @@ target_handler::trajectory target_handler::mode_turrets( avatar &you, vehicle &v
     ui.vturrets = &turrets;
     ui.range = range_total;
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -554,7 +554,7 @@ target_handler::trajectory target_handler::mode_spell( avatar &you, spell &casti
     ui.no_fail = no_fail;
     ui.no_mana = no_mana;
 
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope view_offset_prev( you.view_offset );
     return ui.run();
 }
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3517,14 +3517,14 @@ static void CheckMessages()
     }
     bool resized = false;
     if( resize_dims.has_value() ) {
-        restore_on_out_of_scope<input_event> prev_last_input( last_input );
+        restore_on_out_of_scope prev_last_input( last_input );
         needupdate = resized = handle_resize( resize_dims.value().x, resize_dims.value().y );
     }
     // resizing already reinitializes the render target
     if( !resized && render_target_reset ) {
         throwErrorIf( !SetupRenderTarget(), "SetupRenderTarget failed" );
         needupdate = true;
-        restore_on_out_of_scope<input_event> prev_last_input( last_input );
+        restore_on_out_of_scope prev_last_input( last_input );
         // FIXME: SDL_RENDER_TARGETS_RESET only seems to be fired after the first redraw
         // when restoring the window after system sleep, rather than immediately
         // on focus gain. This seems to mess up the first redraw and

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -364,8 +364,8 @@ void ui_adaptor::redraw_invalidated( )
     }
     imgui_frame_started = true;
 
-    restore_on_out_of_scope<bool> prev_redraw_in_progress( redraw_in_progress );
-    restore_on_out_of_scope<bool> prev_restart_redrawing( restart_redrawing );
+    restore_on_out_of_scope prev_redraw_in_progress( redraw_in_progress );
+    restore_on_out_of_scope prev_restart_redrawing( restart_redrawing );
     redraw_in_progress = true;
 
     do {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -972,10 +972,10 @@ void veh_interact::do_install()
         return;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope prev_title( title );
     title = _( "Choose new part to install here:" );
 
-    restore_on_out_of_scope<std::unique_ptr<install_info_t>> prev_install_info( std::move(
+    restore_on_out_of_scope prev_install_info( std::move(
                 install_info ) );
     install_info = std::make_unique<install_info_t>();
 
@@ -1152,14 +1152,14 @@ void veh_interact::do_repair()
         return;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope prev_title( title );
     title = _( "Choose a part here to repair:" );
 
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
 
     int pos = 0;
 
-    restore_on_out_of_scope<int> prev_hilight_part( highlight_part );
+    restore_on_out_of_scope prev_hilight_part( highlight_part );
 
     avatar &player_character = get_avatar();
     while( true ) {
@@ -1275,7 +1275,7 @@ void veh_interact::do_mend()
             break;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope prev_title( title );
     title = _( "Choose a part here to mend:" );
 
     avatar &player_character = get_avatar();
@@ -1311,7 +1311,7 @@ void veh_interact::do_refill()
             break;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope prev_title( title );
     title = _( "Select part to refill:" );
 
     auto act = [&]( const vehicle_part & pt ) {
@@ -1628,12 +1628,12 @@ void veh_interact::display_overview()
 void veh_interact::overview( const overview_enable_t &enable,
                              const overview_action_t &action )
 {
-    restore_on_out_of_scope<overview_enable_t> prev_overview_enable( overview_enable );
-    restore_on_out_of_scope<overview_action_t> prev_overview_action( overview_action );
+    restore_on_out_of_scope prev_overview_enable( overview_enable );
+    restore_on_out_of_scope prev_overview_action( overview_action );
     overview_enable = enable;
     overview_action = action;
 
-    restore_on_out_of_scope<int> prev_overview_pos( overview_pos );
+    restore_on_out_of_scope prev_overview_pos( overview_pos );
 
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
 
@@ -1811,10 +1811,10 @@ void veh_interact::do_remove()
         return;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope prev_title( title );
     title = _( "Choose a part here to remove:" );
 
-    restore_on_out_of_scope<std::unique_ptr<remove_info_t>> prev_remove_info( std::move(
+    restore_on_out_of_scope prev_remove_info( std::move(
                 remove_info ) );
     remove_info = std::make_unique<remove_info_t>();
 
@@ -1830,9 +1830,9 @@ void veh_interact::do_remove()
 
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
 
-    restore_on_out_of_scope<overview_enable_t> prev_overview_enable( overview_enable );
+    restore_on_out_of_scope prev_overview_enable( overview_enable );
 
-    restore_on_out_of_scope<int> prev_hilight_part( highlight_part );
+    restore_on_out_of_scope prev_hilight_part( highlight_part );
 
     while( true ) {
         int part = parts_here[ pos ];
@@ -1911,7 +1911,7 @@ void veh_interact::do_siphon()
             break;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope prev_title( title );
     title = _( "Select part to siphon:" );
 
     auto sel = [&]( const vehicle_part & pt ) {
@@ -2000,7 +2000,7 @@ void veh_interact::do_assign_crew()
         return;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope prev_title( title );
     title = _( "Assign crew positions:" );
 
     auto sel = []( const vehicle_part & pt ) {

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -19,7 +19,7 @@ player_activity veh_shape::start( const tripoint_bub_ms &pos )
     on_out_of_scope cleanup( []() {
         get_map().invalidate_map_cache( get_avatar().view_offset.z() );
     } );
-    restore_on_out_of_scope<tripoint_rel_ms> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope view_offset_prev( you.view_offset );
 
     cursor_allowed.clear();
     for( const vpart_reference &part : veh.get_all_parts() ) {

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -559,7 +559,7 @@ static void CheckMessages()
         DispatchMessage( &msg );
     }
     if( needs_resize ) {
-        restore_on_out_of_scope<int> prev_lastchar( lastchar );
+        restore_on_out_of_scope prev_lastchar( lastchar );
         handle_resize( 0, 0 );
         refresh_display();
     }

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -2806,8 +2806,8 @@ TEST_CASE( "auto_whitelist", "[item][pocket][item_spawn]" )
         itype_id const id = spawned_w_modifier->get_contents().first_item().typeId();
         get_map().i_clear( spawned_w_custom_container.pos_bub() );
         get_map().i_clear( spawned_in_def_container.pos_bub() );
-        restore_on_out_of_scope<std::optional<units::temperature>> restore_temp(
-                    get_weather().forced_temperature );
+        restore_on_out_of_scope restore_temp(
+            get_weather().forced_temperature );
         get_weather().forced_temperature = units::from_celsius( 21 );
         spawned_w_modifier->only_item().set_relative_rot( 10 );
         REQUIRE( spawned_w_modifier->only_item().has_rotten_away() );

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -216,9 +216,9 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
 {
     // this test case is mainly for checking the format of debug messages.
     // the text style check itself is tested in the lit test of clang-tidy.
-    restore_on_out_of_scope<error_log_format_t> restore_error_log_format( error_log_format );
-    restore_on_out_of_scope<check_plural_t> restore_check_plural( check_plural );
-    restore_on_out_of_scope<json_error_output_colors_t> error_colors( json_error_output_colors );
+    restore_on_out_of_scope restore_error_log_format( error_log_format );
+    restore_on_out_of_scope restore_check_plural( check_plural );
+    restore_on_out_of_scope error_colors( json_error_output_colors );
     error_log_format = error_log_format_t::human_readable;
     check_plural = check_plural_t::certain;
     json_error_output_colors = json_error_output_colors_t::no_colors;
@@ -395,7 +395,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         R"~({"str": "bar", "str_pl": "bar", "//NOLINT(cata-text-style)": "blah"})~" );
 
     {
-        restore_on_out_of_scope<check_plural_t> restore_check_plural_2( check_plural );
+        restore_on_out_of_scope restore_check_plural_2( check_plural );
         check_plural = check_plural_t::none;
         test_pl_translation_text_style_check(
             Catch::Equals( "" ),
@@ -468,8 +468,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
 
 TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation]" )
 {
-    restore_on_out_of_scope<error_log_format_t> restore_error_log_format( error_log_format );
-    restore_on_out_of_scope<json_error_output_colors_t> error_colors( json_error_output_colors );
+    restore_on_out_of_scope restore_error_log_format( error_log_format );
+    restore_on_out_of_scope error_colors( json_error_output_colors );
     error_log_format = error_log_format_t::human_readable;
     json_error_output_colors = json_error_output_colors_t::no_colors;
 
@@ -535,8 +535,8 @@ TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation]" 
 
 TEST_CASE( "report_unvisited_members", "[json]" )
 {
-    restore_on_out_of_scope<error_log_format_t> restore_error_log_format( error_log_format );
-    restore_on_out_of_scope<json_error_output_colors_t> error_colors( json_error_output_colors );
+    restore_on_out_of_scope restore_error_log_format( error_log_format );
+    restore_on_out_of_scope error_colors( json_error_output_colors );
     error_log_format = error_log_format_t::human_readable;
     json_error_output_colors = json_error_output_colors_t::no_colors;
 
@@ -596,8 +596,8 @@ TEST_CASE( "report_unvisited_members", "[json]" )
 
 TEST_CASE( "correct_cursor_position_for_unicode_json_error", "[json]" )
 {
-    restore_on_out_of_scope<error_log_format_t> restore_error_log_format( error_log_format );
-    restore_on_out_of_scope<json_error_output_colors_t> error_colors( json_error_output_colors );
+    restore_on_out_of_scope restore_error_log_format( error_log_format );
+    restore_on_out_of_scope error_colors( json_error_output_colors );
     error_log_format = error_log_format_t::human_readable;
     json_error_output_colors = json_error_output_colors_t::no_colors;
 
@@ -655,8 +655,8 @@ static void test_string_error_throws_matches( Matcher &&matcher, const std::stri
 
 TEST_CASE( "jsonin_get_string", "[json]" )
 {
-    restore_on_out_of_scope<error_log_format_t> restore_error_log_format( error_log_format );
-    restore_on_out_of_scope<json_error_output_colors_t> error_colors( json_error_output_colors );
+    restore_on_out_of_scope restore_error_log_format( error_log_format );
+    restore_on_out_of_scope error_colors( json_error_output_colors );
     error_log_format = error_log_format_t::human_readable;
     json_error_output_colors = json_error_output_colors_t::no_colors;
 

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -217,8 +217,8 @@ TEST_CASE( "milk_rotting", "[active_item][map]" )
     tripoint_bub_ms const test_loc;
     tripoint_abs_sm const test_loc_sm = project_to<coords::sm>( here.getglobal( test_loc ) );
 
-    restore_on_out_of_scope<std::optional<units::temperature>> restore_temp(
-                get_weather().forced_temperature );
+    restore_on_out_of_scope restore_temp(
+        get_weather().forced_temperature );
     get_weather().forced_temperature = units::from_celsius( 21 );
     REQUIRE( units::to_celsius( get_weather().get_temperature( test_loc.raw() ) ) == 21 );
 
@@ -268,8 +268,8 @@ TEST_CASE( "active_monster_drops", "[active_item][map]" )
     get_avatar().setpos( tripoint::zero );
     tripoint_bub_ms start_loc = get_avatar().pos_bub() + tripoint::east;
     map &here = get_map();
-    restore_on_out_of_scope<std::optional<units::temperature>> restore_temp(
-                get_weather().forced_temperature );
+    restore_on_out_of_scope restore_temp(
+        get_weather().forced_temperature );
     get_weather().forced_temperature = units::from_celsius( 21 );
 
     bool const cookie_rotten_before_death = GENERATE( true, false );

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -144,7 +144,7 @@ static void monster_attack_zlevel( const std::string &title, const tripoint &off
 TEST_CASE( "monster_attack", "[vision][reachability]" )
 {
     clear_map();
-    restore_on_out_of_scope<time_point> restore_calendar_turn( calendar::turn );
+    restore_on_out_of_scope restore_calendar_turn( calendar::turn );
     calendar::turn = daylight_time( calendar::turn ) + 2_hours;
     scoped_weather_override weather_clear( WEATHER_CLEAR );
     SECTION( "attacking on open ground" ) {
@@ -192,7 +192,7 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
     std::array<float, 6> expected_average_damage_at_range = { 0, 0, 8.5, 6.5, 5, 3.25 };
     clear_map();
     map &here = get_map();
-    restore_on_out_of_scope<time_point> restore_calendar_turn( calendar::turn );
+    restore_on_out_of_scope restore_calendar_turn( calendar::turn );
     calendar::turn = sunrise( calendar::turn );
     scoped_weather_override weather_clear( WEATHER_CLEAR );
     const tripoint_bub_ms target_location = { 65, 65, 0 };
@@ -337,7 +337,7 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
     // Set up further from the target
     const tripoint_bub_ms target_location = attacker_location + tripoint{ 4, 0, 0 };
     clear_map();
-    restore_on_out_of_scope<time_point> restore_calendar_turn( calendar::turn );
+    restore_on_out_of_scope restore_calendar_turn( calendar::turn );
     calendar::turn = daylight_time( calendar::turn ) + 2_hours;
     scoped_weather_override weather_clear( WEATHER_CLEAR );
     clear_creatures();

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -321,7 +321,7 @@ TEST_CASE( "check_mon_id" )
 TEST_CASE( "write_slope_to_speed_map_trig", "[.]" )
 {
     clear_map_and_put_player_underground();
-    restore_on_out_of_scope<bool> restore_trigdist( trigdist );
+    restore_on_out_of_scope restore_trigdist( trigdist );
     override_option opt( "CIRCLEDIST", "true" );
     trigdist = true;
     test_moves_to_squares( "mon_zombie_dog", true );
@@ -331,7 +331,7 @@ TEST_CASE( "write_slope_to_speed_map_trig", "[.]" )
 TEST_CASE( "write_slope_to_speed_map_square", "[.]" )
 {
     clear_map_and_put_player_underground();
-    restore_on_out_of_scope<bool> restore_trigdist( trigdist );
+    restore_on_out_of_scope restore_trigdist( trigdist );
     override_option opt( "CIRCLEDIST", "false" );
     trigdist = false;
     test_moves_to_squares( "mon_zombie_dog", true );
@@ -343,7 +343,7 @@ TEST_CASE( "write_slope_to_speed_map_square", "[.]" )
 TEST_CASE( "monster_speed_square", "[speed]" )
 {
     clear_map_and_put_player_underground();
-    restore_on_out_of_scope<bool> restore_trigdist( trigdist );
+    restore_on_out_of_scope restore_trigdist( trigdist );
     override_option opt( "CIRCLEDIST", "false" );
     trigdist = false;
     monster_check();
@@ -352,7 +352,7 @@ TEST_CASE( "monster_speed_square", "[speed]" )
 TEST_CASE( "monster_speed_trig", "[speed]" )
 {
     clear_map_and_put_player_underground();
-    restore_on_out_of_scope<bool> restore_trigdist( trigdist );
+    restore_on_out_of_scope restore_trigdist( trigdist );
     override_option opt( "CIRCLEDIST", "true" );
     trigdist = true;
     monster_check();

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -469,7 +469,7 @@ void test_scenario::run()
     }
 
     std::string player_action_str;
-    restore_on_out_of_scope<test_mode_spilling_action_t> restore_test_mode_spilling(
+    restore_on_out_of_scope restore_test_mode_spilling(
         test_mode_spilling_action );
     switch( cur_player_action ) {
         case player_action::spill_all: {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Followup to #78452. Eliminate confusion and standardize on an untyped pattern for `restore_on_out_of_scope`. This categorically avoids issues with explicit typing that doesn't match the type of the variable, which then avoid incorrect behavior caused by compiler generated temporaries for conversions.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Automatically remove the explicit typing from all `restore_on_out_of_scope` in the repo with sed. Delete the constructor that accepts a non-T so future erroneous usage gets a compile error.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
CI.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
