### PR TITLE
Allow color replacements in cataimgui

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -710,30 +710,31 @@ void cataimgui::set_scroll( scroll &s )
     s = scroll::none;
 }
 
-void cataimgui::draw_colored_text( std::string const &text, const nc_color &color,
+void cataimgui::draw_colored_text( const std::string &original_text, const nc_color &color,
                                    float wrap_width, bool *is_selected, bool *is_focused, bool *is_hovered )
 {
     nc_color color_cpy = color;
     ImGui::PushStyleColor( ImGuiCol_Text, color_cpy );
-    draw_colored_text( text, wrap_width, is_selected, is_focused, is_hovered );
+    draw_colored_text( original_text, wrap_width, is_selected, is_focused, is_hovered );
     ImGui::PopStyleColor();
 }
 
-void cataimgui::draw_colored_text( std::string const &text, nc_color &color,
+void cataimgui::draw_colored_text( const std::string &original_text, nc_color &color,
                                    float wrap_width, bool *is_selected, bool *is_focused, bool *is_hovered )
 {
     ImGui::PushStyleColor( ImGuiCol_Text, color );
-    draw_colored_text( text, wrap_width, is_selected, is_focused, is_hovered );
+    draw_colored_text( original_text, wrap_width, is_selected, is_focused, is_hovered );
     ImGui::PopStyleColor();
 }
 
-void cataimgui::draw_colored_text( std::string const &text,
+void cataimgui::draw_colored_text( const std::string &original_text,
                                    float wrap_width, bool *is_selected, bool *is_focused, bool *is_hovered )
 {
-    if( text.empty() ) {
+    if( original_text.empty() ) {
         ImGui::NewLine();
         return;
     }
+    const std::string &text = replace_colors( original_text );
 
     ImGui::PushID( text.c_str() );
     int startColorStackCount = GImGui->ColorStack.Size;

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -99,13 +99,13 @@ ImVec4 imvec4_from_color( nc_color &color );
 
 void set_scroll( scroll &s );
 
-void draw_colored_text( std::string const &text, const nc_color &color,
+void draw_colored_text( const std::string &original_text, const nc_color &color,
                         float wrap_width = 0.0F, bool *is_selected = nullptr,
                         bool *is_focused = nullptr, bool *is_hovered = nullptr );
-void draw_colored_text( std::string const &text, nc_color &color,
+void draw_colored_text( const std::string &original_text, nc_color &color,
                         float wrap_width = 0.0F, bool *is_selected = nullptr,
                         bool *is_focused = nullptr, bool *is_hovered = nullptr );
-void draw_colored_text( std::string const &text,
+void draw_colored_text( const std::string &original_text,
                         float wrap_width = 0.0F, bool *is_selected = nullptr,
                         bool *is_focused = nullptr, bool *is_hovered = nullptr );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Allow color replacement tags (like `bold`, `neutral`, `good`, etc) in cataimgui.