### PR TITLE
Make barter / volume sorting account for stack size

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -655,9 +655,9 @@ struct advanced_inv_sorter {
                 break;
             case SORTBY_PRICEPERVOLUME: {
                 const double price_density1 = static_cast<double>( d1.items.front()->price( true ) ) /
-                                              static_cast<double>( std::max( 1, d1.volume.value() ) );
+                                              static_cast<double>( std::max( 1, d1.items.front()->volume().value() ) );
                 const double price_density2 = static_cast<double>( d2.items.front()->price( true ) ) /
-                                              static_cast<double>( std::max( 1, d2.volume.value() ) );
+                                              static_cast<double>( std::max( 1, d2.items.front()->volume().value() ) );
                 if( price_density1 != price_density2 ) {
                     return price_density1 > price_density2;
                 }


### PR DESCRIPTION
#### Summary
Bugfixes "Make barter / volume sorting account for stack size"

#### Purpose of change
Fixes #77794

#### Describe the solution
Check the volume of the first item instead of the whole stack.

#### Describe alternatives you've considered

#### Testing
Before:
![Screenshot_20241210_191310](https://github.com/user-attachments/assets/4f03d288-26cb-4639-9ac6-13c4f4efe2ef)
After:
![Screenshot_20241210_191604](https://github.com/user-attachments/assets/58d6b39e-69aa-4224-981f-67c2d304021c)

#### Additional context
Maybe one day I'll be able to make simple changes without including obvious bugs.