### PR TITLE
Add sorting by price to weight ratio

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -667,9 +667,9 @@ struct advanced_inv_sorter {
             }
             case SORTBY_PRICEPERWEIGHT: {
                 const double price_density1 = static_cast<double>( d1.items.front()->price( true ) ) /
-                                              static_cast<double>( std::max( 1l, d1.items.front()->weight().value() ) );
+                                              static_cast<double>( std::max( 1L, d1.items.front()->weight().value() ) );
                 const double price_density2 = static_cast<double>( d2.items.front()->price( true ) ) /
-                                              static_cast<double>( std::max( 1l, d2.items.front()->weight().value() ) );
+                                              static_cast<double>( std::max( 1L, d2.items.front()->weight().value() ) );
                 if( price_density1 != price_density2 ) {
                     return price_density1 > price_density2;
                 }

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -234,6 +234,8 @@ std::string advanced_inventory::get_sortname( advanced_inv_sortby sortby )
             return _( "barter value" );
         case SORTBY_PRICEPERVOLUME:
             return _( "barter value / volume" );
+        case SORTBY_PRICEPERWEIGHT:
+            return _( "barter value / weight" );
         case SORTBY_STACKS:
             return _( "amount" );
     }
@@ -658,6 +660,16 @@ struct advanced_inv_sorter {
                                               static_cast<double>( std::max( 1, d1.volume.value() ) );
                 const double price_density2 = static_cast<double>( d2.items.front()->price( true ) ) /
                                               static_cast<double>( std::max( 1, d2.volume.value() ) );
+                if( price_density1 != price_density2 ) {
+                    return price_density1 > price_density2;
+                }
+                break;
+            }
+            case SORTBY_PRICEPERWEIGHT: {
+                const double price_density1 = static_cast<double>( d1.items.front()->price( true ) ) /
+                                              static_cast<double>( std::max( 1l, d1.items.front()->weight().value() ) );
+                const double price_density2 = static_cast<double>( d2.items.front()->price( true ) ) /
+                                              static_cast<double>( std::max( 1l, d2.items.front()->weight().value() ) );
                 if( price_density1 != price_density2 ) {
                     return price_density1 > price_density2;
                 }
@@ -1243,6 +1255,7 @@ bool advanced_inventory::show_sort_menu( advanced_inventory_pane &pane )
     sm.addentry( SORTBY_SPOILAGE,       true, 's', get_sortname( SORTBY_SPOILAGE ) );
     sm.addentry( SORTBY_PRICE,          true, 'b', get_sortname( SORTBY_PRICE ) );
     sm.addentry( SORTBY_PRICEPERVOLUME, true, 'r', get_sortname( SORTBY_PRICEPERVOLUME ) );
+    sm.addentry( SORTBY_PRICEPERWEIGHT, true, 'g', get_sortname( SORTBY_PRICEPERWEIGHT ) );
     sm.addentry( SORTBY_STACKS,         true, 't', get_sortname( SORTBY_STACKS ) );
     // Pre-select current sort.
     sm.selected = pane.sortby - SORTBY_NONE;

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -4,6 +4,7 @@
 #include <climits>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <initializer_list>
 #include <iterator>
@@ -667,9 +668,9 @@ struct advanced_inv_sorter {
             }
             case SORTBY_PRICEPERWEIGHT: {
                 const double price_density1 = static_cast<double>( d1.items.front()->price( true ) ) /
-                                              static_cast<double>( std::max( 1L, d1.items.front()->weight().value() ) );
+                                              static_cast<double>( std::max<std::int64_t>( 1, d1.items.front()->weight().value() ) );
                 const double price_density2 = static_cast<double>( d2.items.front()->price( true ) ) /
-                                              static_cast<double>( std::max( 1L, d2.items.front()->weight().value() ) );
+                                              static_cast<double>( std::max<std::int64_t>( 1, d2.items.front()->weight().value() ) );
                 if( price_density1 != price_density2 ) {
                     return price_density1 > price_density2;
                 }

--- a/src/advanced_inv_pane.h
+++ b/src/advanced_inv_pane.h
@@ -32,6 +32,7 @@ enum advanced_inv_sortby {
     SORTBY_SPOILAGE,
     SORTBY_PRICE,
     SORTBY_PRICEPERVOLUME,
+    SORTBY_PRICEPERWEIGHT,
     SORTBY_STACKS
 };
 


### PR DESCRIPTION
#### Summary
Interface "Add sorting by price to weight ratio"

#### Purpose of change
Suggested in #77794

#### Describe the solution
Copy price per volume sort and substitute weight for volume.

#### Describe alternatives you've considered

#### Testing
Checked a pile of items. Items were sorted correctly, including stacks.

#### Additional context