### PR TITLE
AIM cache filter function once

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -866,9 +866,10 @@ void advanced_inventory::redraw_pane( side p )
     }
 
     std::string fprefix = string_format( _( "[%s] Filter" ), ctxt.get_desc( "FILTER" ) );
+    const std::string &filter = pane.get_filter();
     if( !filter_edit ) {
-        if( !pane.filter.empty() ) {
-            mvwprintw( w, point( 2, getmaxy( w ) - 1 ), "< %s: %s >", fprefix, pane.filter );
+        if( !filter.empty() ) {
+            mvwprintw( w, point( 2, getmaxy( w ) - 1 ), "< %s: %s >", fprefix, filter );
         } else {
             mvwprintw( w, point( 2, getmaxy( w ) - 1 ), "< %s >", fprefix );
         }
@@ -876,10 +877,9 @@ void advanced_inventory::redraw_pane( side p )
     if( active ) {
         wattroff( w, c_white );
     }
-    if( !filter_edit && !pane.filter.empty() ) {
+    if( !filter_edit && !filter.empty() ) {
         std::string fsuffix = string_format( _( "[%s] Reset" ), ctxt.get_desc( "RESET_FILTER" ) );
-        mvwprintz( w, point( 6 + utf8_width( fprefix ), getmaxy( w ) - 1 ), c_white,
-                   pane.filter );
+        mvwprintz( w, point( 6 + utf8_width( fprefix ), getmaxy( w ) - 1 ), c_white, filter );
         mvwprintz( w, point( getmaxx( w ) - utf8_width( fsuffix ) - 2, getmaxy( w ) - 1 ), c_white, "%s",
                    fsuffix );
     }
@@ -1956,7 +1956,7 @@ void advanced_inventory::display()
                 recalc = true;
             }
         } else if( action == "FILTER" ) {
-            std::string filter = spane.filter;
+            const std::string &filter = spane.get_filter();
             filter_edit = true;
             if( ui ) {
                 spopup = std::make_unique<string_input_popup>();

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -81,7 +81,7 @@ void advanced_inventory_pane::load_settings( int saved_area_idx,
     set_area( square, show_vehicle );
     sortby = static_cast<advanced_inv_sortby>( save_state->sort_idx );
     index = save_state->selected_idx;
-    filter = save_state->filter;
+    set_filter( save_state->filter );
     if( area == AIM_CONTAINER ) {
         container = save_state->container;
     }
@@ -101,16 +101,7 @@ bool advanced_inventory_pane::is_filtered( const item &it ) const
     if( filter.empty() ) {
         return false;
     }
-
-    const std::string str = it.tname();
-    if( filtercache.find( str ) == filtercache.end() ) {
-        const auto filter_fn = item_filter_from_string( filter );
-        filtercache[str] = filter_fn;
-
-        return !filter_fn( it );
-    }
-
-    return !filtercache[str]( it );
+    return !filter_function( it );
 }
 
 /** converts a raw list of items to "stacks" - items that are not count_by_charges that otherwise stack go into one stack */
@@ -480,6 +471,6 @@ void advanced_inventory_pane::set_filter( const std::string &new_filter )
         return;
     }
     filter = new_filter;
-    filtercache.clear();
+    filter_function = item_filter_from_string( filter );
     recalc = true;
 }

--- a/src/advanced_inv_pane.h
+++ b/src/advanced_inv_pane.h
@@ -71,10 +71,6 @@ class advanced_inventory_pane
         catacurses::window window;
         std::vector<advanced_inv_listitem> items;
         /**
-         * The current filter string.
-         */
-        std::string filter;
-        /**
          * Whether to recalculate the content of this pane.
          */
         bool recalc = false;
@@ -139,13 +135,19 @@ class advanced_inventory_pane
          */
         units::mass free_weight_capacity() const;
         /**
-         * Set the filter string, disables filtering when the filter string is empty.
+         * Set the filter string and update filter_function.
          */
         void set_filter( const std::string &new_filter );
+        std::string get_filter() const {
+            return filter;
+        };
     private:
+        /**
+         * The current filter string. And function representing that filter.
+         */
+        std::string filter;
+        std::function<bool( const item & )> filter_function;
         /** Only add offset to index, but wrap around! */
         void mod_index( int offset );
-
-        mutable std::map<std::string, std::function<bool( const item & )>> filtercache;
 };
 #endif // CATA_SRC_ADVANCED_INV_PANE_H


### PR DESCRIPTION
#### Summary
Performance "AIM cache filter function once"

#### Purpose of change
Filter functions can be separated into two phases, preparation and run. For example:

preparation
https://github.com/CleverRaven/Cataclysm-DDA/blob/52e00ebe666c7dbd4496b446d315fd785fcf16fb/src/item_search.cpp#L92-L106

run
https://github.com/CleverRaven/Cataclysm-DDA/blob/52e00ebe666c7dbd4496b446d315fd785fcf16fb/src/item_search.cpp#L107-L115

I thought AIM executed the preparation once, but it did not. So I am making it so.

I want to do filter functions with expansive preparation like here #78384 but for AIM. Without this, the game slows down to a crawl.

#### Describe the solution

 - I noticed that the current cache is really bad, maybe even non-sensical, so I deleted it. It stored a filter function for every item name. All the filters are identical.
   - It was originally added here #11235. I don't know if it made sense back then, but it does not make sense now.
 - Store the filter function only once.
 - Prepare filter function on filter change, rather than asking every time if we have cache, just have them.
 - Setters and getters for `filter` and make `filter` private. To find, fix and forbid future access to setting `filter` directly. Now `filter` is set only from `set_filter` and always updates the filter function.

#### Describe alternatives you've considered



#### Testing

 - I did some performance testing. It has nearly no effect on performance (Took < ~1.2 % when moving all items). But it is about 20 times faster for my test.
   - Slow ![old_slow](https://github.com/user-attachments/assets/904f79be-ce8b-4e9b-b3ae-f7ee66be9fa2)
   - Fast ![new_fast](https://github.com/user-attachments/assets/06bf2e71-acdc-48b9-b823-54bc33618d26)
 - It has a huge impact on the upcoming PR. In there, I prepare and catch exceptions.

The test is in this save
[TEST AIM move.zip](https://github.com/user-attachments/files/18087391/TEST.AIM.move.zip)
Move the things through AIM with filters `v:h` on both panes.

To measure the performance, place breakpoint A here
https://github.com/CleverRaven/Cataclysm-DDA/blob/52e00ebe666c7dbd4496b446d315fd785fcf16fb/src/advanced_inv.cpp#L1012
breakpoint B here
https://github.com/CleverRaven/Cataclysm-DDA/blob/52e00ebe666c7dbd4496b446d315fd785fcf16fb/src/advanced_inv.cpp#L1912

1. Load game.
2. Deactivate B. (Otherwise you will hit it by being in AIM).
3. Open AIM.
4. Initialize move all.
5. Observe: The game stops at breakpoint A.
6. Activate breakpoint B.
7. Continue the execution.
8. Observe: breakpoint B is hit.
9. Look at CPU profiling obtained between the breakpoints.



#### Additional context

I went through the View menu (Look around), and it seems to do the preparation part only once.