### PR TITLE
Fix issue with bashing satalight dish and negative noise

### DIFF
--- a/data/json/furniture_and_terrain/furniture-roof.json
+++ b/data/json/furniture_and_terrain/furniture-roof.json
@@ -45,6 +45,10 @@
     "required_str": 10,
     "flags": [ "TRANSPARENT", "NOITEM" ],
     "bash": {
+      "str_min": 6,
+      "str_max": 10,
+      "sound": "whack!",
+      "sound_fail": "womp!",
       "items": [
         { "item": "scrap", "count": [ 4, 6 ] },
         { "item": "plastic_chunk", "count": [ 4, 12 ] },


### PR DESCRIPTION
# Pull Request: Fix Negative Sound When Smashing Satellite Dish

#### Summary
Bugfixes "Fix negative sound when smashing satellite dish"

---

#### Purpose of Change
This change resolves **issue #77823**, where smashing a satellite dish produced an error for a negative sound volume. The expected behavior is for a positive sound value to be generated when the dish is smashed, providing appropriate feedback to the player.

---

#### Describe the Solution
The fix involves adding `bash` properties to the satellite dish item, including:

- **Strength-based bashing effects**:
  - `str_min`: 6
  - `str_max`: 10
- **Sound effects**:
  - `sound`: "whack!" for successful bashing
  - `sound_fail`: "womp!" for failed bashing
- **Material drops**:
  - Items dropped include `scrap` (4–6 units) and `plastic_chunk` (4–12 units).

These changes resolves the negative sound bug.

---

#### Testing
The following steps were taken to test the fix:

1. Verified the JSON structure for correctness.
2. Loaded the game with the modified satellite dish properties and tested:
   - Bashing the dish produces the correct sounds: `"whack!"` or `"womp!"` depending on success or failure.
   - No errors related to negative sound values are encountered.
   - Materials (`scrap` and `plastic_chunk`) drop as intended.
   - Strength thresholds (`str_min` and `str_max`) are respected during bashing.

---

#### Additional Context
This change improves gameplay interactions with the satellite dish and resolves the error encountered when smashing it. Below is an example of the new `bash` properties in JSON format:

```json
"bash": {
  "str_min": 6,
  "str_max": 10,
  "sound": "whack!",
  "sound_fail": "womp!",
  "items": [
    { "item": "scrap", "count": [ 4, 6 ] },
    { "item": "plastic_chunk", "count": [ 4, 12 ] }
  ]
}
```
#### Related Issues
Fixes #77823.