### PR TITLE
Use enums instead of bool for ImGui::BeginChild

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2529,7 +2529,7 @@ class spellcasting_callback : public uilist_callback
             ImGui::SameLine( 0.0, -1.0 );
             ImVec2 info_size = ImGui::GetContentRegionAvail();
             info_size.y -= ImGui::GetTextLineHeightWithSpacing();
-            if( ImGui::BeginChild( "spell info", info_size, false,
+            if( ImGui::BeginChild( "spell info", info_size, ImGuiChildFlags_None,
                                    ImGuiWindowFlags_AlwaysVerticalScrollbar ) ) {
                 if( menu->previewing >= 0 && static_cast<size_t>( menu->previewing ) < known_spells.size() ) {
                     display_spell_info( menu->previewing );
@@ -3194,7 +3194,7 @@ void spellbook_callback::refresh( uilist *menu )
 {
     ImGui::TableSetColumnIndex( 2 );
     ImVec2 info_size = ImGui::GetContentRegionAvail();
-    if( ImGui::BeginChild( "spellbook info", info_size, false,
+    if( ImGui::BeginChild( "spellbook info", info_size, ImGuiChildFlags_None,
                            ImGuiWindowFlags_AlwaysAutoResize ) ) {
         if( menu->selected >= 0 && static_cast<size_t>( menu->selected ) < spells.size() ) {
             draw_spellbook_info( spells[menu->selected] );

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -109,7 +109,7 @@ void uilist_impl::draw_controls()
 
         float entry_height = ImGui::GetTextLineHeightWithSpacing();
         ImGuiStyle &style = ImGui::GetStyle();
-        if( ImGui::BeginChild( "scroll", parent.calculated_menu_size, false ) ) {
+        if( ImGui::BeginChild( "scroll", parent.calculated_menu_size ) ) {
             if( ImGui::BeginTable( "menu items", 3, ImGuiTableFlags_SizingFixedFit ) ) {
                 ImGui::TableSetupColumn( "hotkey", ImGuiTableColumnFlags_WidthFixed,
                                          parent.calculated_hotkey_width );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #78476

#### Describe the solution

Use `ImGui::ImGuiChildFlags` enums instead of `bool` for `ImGui::BeginChild` calls