### PR TITLE
Remove mingw cross build

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -166,25 +166,6 @@ jobs:
             ccache_limit: 4G
             ccache_key: linux-gcc-11-asan
 
-          - compiler: g++
-            os: ubuntu-latest
-            cmake: 0
-            native:
-            pch: 1
-            tiles: 1
-            sound: 1
-            localize: 1
-            libbacktrace: 1
-            title: GCC 12, Ubuntu cross-compile to MinGW-Win64, Tiles, Sound
-            ldflags: -static-libgcc -static-libstdc++
-            mxe_target: x86_64-w64-mingw32.static.gcc12
-            wine: wine
-            # ~285MB in a clean build
-            # ~36MB compressed
-            # observed usage: 3.0GB -> 350MB
-            ccache_limit: 2G
-            ccache_key: mingw-gcc-12
-
           - compiler: g++-9
             os: ubuntu-latest
             cmake: 1


### PR DESCRIPTION
We don't ship cross compiles anymore and there really isn't a place for it since we do have native builds.

#### Summary
Infrastructure "Retired mingw cross compile build"

#### Purpose of change
When looking at test failures, I ran across a weird failure in character validity checking (see https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12266622038/job/34225125913?pr=78437 but the details are not important).
Before digging into it, @akrieger asked if we even needed the cross compile build since we're shipping native binaries for windows.
On reflection, I think we don't need it, it's only useful for issuing builds when you don't have windows build tooling, and we do. On the development side the only reason to make local cross compiles is to troubleshoot the ability to do cross compiles.

#### Describe the solution
Retire the build.

#### Describe alternatives you've considered
Keep it for...???
When looking at the build matrix, I realized it's pretty outdated, we don't have GCC 13 or 14 builds, or clang 13,14,15.  I don't want to dig into that at the same time as removing something like this.

#### Testing
It shouldn't magically keep building after removing this clause?

#### Additional context
I'm open to alternatives that I've missed around usefulness of this build.