### PR TITLE
[MoM] Add `mon_hologram` appearance to Astral Projection

### DIFF
--- a/data/mods/MindOverMatter/mutations/temporary.json
+++ b/data/mods/MindOverMatter/mutations/temporary.json
@@ -229,6 +229,16 @@
   },
   {
     "type": "mutation",
+    "id": "CLAIR_ASTRAL_PROJECTION_APPEARANCE",
+    "name": { "str": "Astral Form", "//~": "NO_I18N" },
+    "description": { "str": "You're a disembodied mind so you're all glowy and blue.  Spooky!", "//~": "NO_I18N" },
+    "points": 0,
+    "valid": false,
+    "player_display": false,
+    "override_look": { "id": "mon_hologram", "tile_category": "monster" }
+  },
+  {
+    "type": "mutation",
     "id": "TELEKINETIC_LIFTER_1",
     "name": { "str": "Lifting Hand" },
     "points": 0,

--- a/data/mods/MindOverMatter/powers/clairsentience_eoc.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_eoc.json
@@ -190,6 +190,7 @@
       { "u_add_effect": "effect_clair_astral_projection", "duration": "PERMANENT" },
       { "u_add_effect": "incorporeal", "duration": "PERMANENT" },
       { "u_message": "As you meditate, you feel your spirit slipping free from your body.", "type": "good" },
+      { "u_add_trait": "CLAIR_ASTRAL_PROJECTION_APPEARANCE" },
       { "u_spawn_item": "body_astral_projection", "suppress_message": true },
       { "u_spawn_item": "item_clair_astral_projection_cord", "suppress_message": true, "force_equip": true },
       { "math": [ "u_spell_level('clair_astral_projection_return') = 0" ] }
@@ -202,6 +203,7 @@
       { "u_remove_item_with": "item_clair_astral_projection_cord" },
       { "u_lose_effect": "effect_clair_astral_projection" },
       { "u_lose_effect": "incorporeal" },
+      { "u_lose_trait": "CLAIR_ASTRAL_PROJECTION_APPEARANCE" },
       { "math": [ "u_spell_level('clair_astral_projection_passwall') = -1" ] },
       { "math": [ "u_spell_level('clair_astral_projection_return') = -1" ] },
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add `mon_hologram` appearance to Astral Projection"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Looking for a way to make astrally projecting look neater and saw the sprite for the `hologram` on HHG
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a hidden trait with an `override_look` for `mon_hologram` that's applied to Astral Projection and removed when you stop. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spooky 

![Untitled2](https://github.com/user-attachments/assets/c946c8cc-f3ba-4f2b-a230-9a6dd8b390a8)

Ultica Version:

![Untitled2](https://github.com/user-attachments/assets/5e15850e-7af1-47c9-a763-db65dc639fb9)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
