### PR TITLE
[Magiclysm/Innawood] Revamp goblin/orc drops to separate itemgroups, make them fit Innawood

### DIFF
--- a/data/mods/Magiclysm/itemgroups/death_drops.json
+++ b/data/mods/Magiclysm/itemgroups/death_drops.json
@@ -297,7 +297,7 @@
     ]
   },
   {
-    "id": "goblin_bugbear_drops",
+    "id": "goblin_bugbear_death_drops",
     "type": "item_group",
     "subtype": "collection",
     "entries": [
@@ -307,7 +307,7 @@
     ]
   },
   {
-    "id": "goblin_bugbear_stalker_drops",
+    "id": "goblin_bugbear_stalker_death_drops",
     "type": "item_group",
     "subtype": "collection",
     "entries": [

--- a/data/mods/Magiclysm/itemgroups/death_drops.json
+++ b/data/mods/Magiclysm/itemgroups/death_drops.json
@@ -353,17 +353,89 @@
     ]
   },
   {
-    "id": "orc_warrior_drops",
+    "id": "orc_warrior_death_drops",
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "group": "bugbear_armor_drops", "prob": 96 },
-      { "item": "loincloth_fur", "prob": 10 },
-      { "item": "footrags_fur", "prob": 10 },
-      { "item": "gloves_wraps_fur", "prob": 10 },
-      { "item": "bellywrap_fur", "prob": 5 },
-      { "item": "chestwrap_fur", "prob": 5 },
-      { "group": "bugbear_stalker_drops", "prob": 95 }
+      { "group": "orc_armor_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "bugbear_clothing_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "orc_warrior_weapon_drops", "prob": 95, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "orc_archer_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "orc_armor_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "bugbear_clothing_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "orc_archer_melee_weapon_drops", "prob": 50, "damage": [ 1, 4 ] },
+      { "group": "orc_archer_ranged_weapon_drops", "prob": 50, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "orc_blood_warrior_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "orc_armor_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "bugbear_clothing_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "orc_blood_warrior_weapon_drops", "prob": 95, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "orc_blood_mage_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "orc_armor_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "bugbear_clothing_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "magic_plants_common", "prob": 10 },
+      { "group": "magic_plants_uncommon", "prob": 1 }
+    ]
+  },
+  {
+    "id": "orc_warrior_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "survivor_machete", "prob": 96 },
+      { "item": "arming_sword_plus_one", "prob": 2 },
+      { "item": "broadsword_plus_one", "prob": 2 }
+    ]
+  },
+  {
+    "id": "orc_armor_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "helmet_scrap", "prob": 20 },
+      { "item": "armguard_scrap", "prob": 20 },
+      { "item": "boots_scrap", "prob": 20 },
+      { "item": "legguard_scrap", "prob": 20 },
+      { "item": "cuirass_scrap", "prob": 10 }
+    ]
+  },
+  {
+    "id": "orc_archer_melee_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "item": "sheath", "contents-item": "knife_combat", "prob": 100 } ]
+  },
+  {
+    "id": "orc_archer_ranged_weapon_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [ { "item": "longbow", "prob": 85 }, { "item": "quiver_large", "contents-group": "quiver_orc_archer", "prob": 50 } ]
+  },
+  {
+    "id": "orc_blood_warrior_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "mace_pipe_large", "prob": 96 },
+      { "item": "mace_plus_one", "prob": 2 },
+      { "item": "warhammer_plus_one", "prob": 2 }
     ]
   },
   {

--- a/data/mods/Magiclysm/itemgroups/death_drops.json
+++ b/data/mods/Magiclysm/itemgroups/death_drops.json
@@ -349,6 +349,7 @@
       { "item": "xl_gauntlets_larmor", "prob": 20 },
       { "item": "xl_boots_larmor", "prob": 20 },
       { "item": "xl_armguard_larmor", "prob": 20 },
+      { "item": "xl_legguard_larmor", "prob": 20 },
       { "item": "xl_armor_larmor_chest", "prob": 10 }
     ]
   },

--- a/data/mods/Magiclysm/itemgroups/death_drops.json
+++ b/data/mods/Magiclysm/itemgroups/death_drops.json
@@ -245,6 +245,128 @@
     ]
   },
   {
+    "id": "goblin_warrior_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "feral_goblin_death_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "goblin_armor_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "item": "cudgel", "prob": 95, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "goblin_slinger_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "feral_goblin_death_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "goblin_armor_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "item": "sling", "prob": 95, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "goblin_chieftan_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "feral_goblin_death_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "goblin_armor_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "goblin_chieftan_weapon_drops", "prob": 95, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "goblin_armor_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "helmet_scrap_xs", "prob": 40, "damage": [ 1, 4 ] },
+      { "item": "xs_legguard_scrap", "prob": 40, "damage": [ 1, 4 ] },
+      { "item": "xs_boots_scrap", "prob": 40, "damage": [ 1, 4 ] },
+      { "item": "xs_armguard_scrap", "prob": 40, "damage": [ 1, 4 ] },
+      { "item": "xs_cuirass_scrap", "prob": 40, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "goblin_chieftan_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "survivor_stabbing", "prob": 96, "damage": [ 1, 4 ] },
+      { "item": "spear_steel_plus_one", "prob": 3, "damage": [ 1, 4 ] },
+      { "item": "rune_biomancer_weapon", "prob": 1, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "goblin_bugbear_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "bugbear_armor_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "bugbear_clothing_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "bugbear_weapon_drops", "prob": 95, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "goblin_bugbear_stalker_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "bugbear_armor_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "bugbear_clothing_drops", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "bugbear_stalker_weapon_drops", "prob": 95, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
+    "id": "bugbear_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "item": "survivor_machete", "prob": 98 }, { "item": "broadsword_plus_one", "prob": 2 } ]
+  },
+  {
+    "id": "bugbear_stalker_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "group": "survivor_stabbing", "prob": 97 }, { "item": "spear_steel_plus_one", "prob": 3 } ]
+  },
+  {
+    "id": "bugbear_clothing_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "loincloth_fur", "prob": 75 },
+      { "item": "footrags_fur", "prob": 25 },
+      { "item": "gloves_wraps_fur", "prob": 25 },
+      { "item": "bellywrap_fur", "prob": 10 },
+      { "item": "chestwrap_fur", "prob": 25 }
+    ]
+  },
+  {
+    "id": "bugbear_armor_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "xl_helmet_larmor", "prob": 20 },
+      { "item": "xl_gauntlets_larmor", "prob": 20 },
+      { "item": "xl_boots_larmor", "prob": 20 },
+      { "item": "xl_armguard_larmor", "prob": 20 },
+      { "item": "xl_armor_larmor_chest", "prob": 10 }
+    ]
+  },
+  {
+    "id": "orc_warrior_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "bugbear_armor_drops", "prob": 96 },
+      { "item": "loincloth_fur", "prob": 10 },
+      { "item": "footrags_fur", "prob": 10 },
+      { "item": "gloves_wraps_fur", "prob": 10 },
+      { "item": "bellywrap_fur", "prob": 5 },
+      { "item": "chestwrap_fur", "prob": 5 },
+      { "group": "bugbear_stalker_drops", "prob": 95 }
+    ]
+  },
+  {
     "id": "mossling_drops",
     "type": "item_group",
     "subtype": "collection",

--- a/data/mods/Magiclysm/mod_interactions/innawood/orc_goblin_lootgroups.json
+++ b/data/mods/Magiclysm/mod_interactions/innawood/orc_goblin_lootgroups.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "goblin_armor_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "helmet_larmor_xs", "prob": 40 },
+      { "item": "xs_legguard_larmor", "prob": 40 },
+      { "item": "xs_boots_larmor", "prob": 40 },
+      { "item": "xs_armguard_larmor", "prob": 40 },
+      { "item": "xs_gauntlets_larmor", "prob": 40 },
+      { "item": "armor_larmor_chest_xs", "prob": 40 }
+    ]
+  },
+  {
+    "id": "goblin_chieftan_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "group": "survivor_stabbing", "prob": 99 }, { "item": "rune_biomancer_weapon", "prob": 1 } ]
+  },
+  {
+    "id": "bugbear_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "item": "survivor_cutting", "prob": 100 } ]
+  },
+  {
+    "id": "bugbear_stalker_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "group": "survivor_stabbing", "prob": 100 } ]
+  },
+  {
+    "id": "bugbear_armor_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "xl_helmet_larmor", "prob": 20 },
+      { "item": "xl_gauntlets_larmor", "prob": 20 },
+      { "item": "xl_boots_larmor", "prob": 20 },
+      { "item": "xl_armguard_larmor", "prob": 20 },
+      { "item": "xl_legguard_larmor", "prob": 20 },
+      { "item": "xl_armor_larmor_chest", "prob": 10 }
+    ]
+  },
+  {
+    "id": "orc_warrior_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "survivor_machete", "prob": 96 },
+      { "item": "arming_sword_plus_one", "prob": 2 },
+      { "item": "broadsword_plus_one", "prob": 2 }
+    ]
+  },
+  {
+    "id": "orc_armor_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "helmet_larmor", "prob": 40 },
+      { "item": "legguard_larmor", "prob": 40 },
+      { "item": "boots_larmor", "prob": 40 },
+      { "item": "armguard_larmor", "prob": 40 },
+      { "item": "gauntlets_larmor", "prob": 40 },
+      { "item": "armor_larmor_chest", "prob": 40 }
+    ]
+  },
+  {
+    "id": "orc_archer_melee_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "item": "sheath", "contents-item": "primitive_knife", "prob": 100 } ]
+  },
+  {
+    "id": "orc_archer_ranged_weapon_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [ { "item": "longbow", "prob": 85 }, { "item": "quiver_large", "contents-group": "quiver_orc_archer", "prob": 50 } ]
+  },
+  {
+    "id": "orc_blood_warrior_weapon_drops",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "item": "lizardfolk_club", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "quiver_orc_archer",
+    "entries": [ { "item": "arrow_heavy_fire_hardened_fletched", "count": [ 1, 6 ], "charges": [ 1, 10 ] } ]
+  }
+]

--- a/data/mods/Magiclysm/mod_interactions/innawood/orc_goblin_lootgroups.json
+++ b/data/mods/Magiclysm/mod_interactions/innawood/orc_goblin_lootgroups.json
@@ -1,6 +1,23 @@
 [
   {
     "type": "item_group",
+    "id": "bed",
+    "subtype": "distribution",
+    "entries": [ { "item": "grass_blanket", "prob": 2500 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "midden_heap",
+    "//": "a large pile of trash, made for goblin encampments.",
+    "subtype": "collection",
+    "items": [
+      { "group": "trash_forest", "prob": 95 },
+      { "group": "trash_forest", "prob": 70 },
+      { "group": "trash_forest", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
     "subtype": "collection",
     "id": "feral_goblin_death_drops",
     "entries": [
@@ -11,7 +28,7 @@
       { "item": "chestwrap_leather", "prob": 20, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
       { "group": "pants_male", "prob": 75, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
       { "group": "npc_coat", "prob": 2, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
-      { "group": "npc_gloves", "prob": 50, "damage": [ 1, 4 ] },
+      { "group": "npc_gloves", "prob": 50, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
       { "item": "wicker_backpack", "prob": 1, "damage": [ 1, 4 ] }
     ]
   },

--- a/data/mods/Magiclysm/mod_interactions/innawood/orc_goblin_lootgroups.json
+++ b/data/mods/Magiclysm/mod_interactions/innawood/orc_goblin_lootgroups.json
@@ -1,5 +1,21 @@
 [
   {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "feral_goblin_death_drops",
+    "entries": [
+      { "group": "shoes_unisex", "prob": 40, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
+      { "group": "npc_hat", "prob": 10, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
+      { "group": "male_underwear_bottom", "prob": 100, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
+      { "group": "female_underwear_top", "prob": 100, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
+      { "item": "chestwrap_leather", "prob": 20, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
+      { "group": "pants_male", "prob": 75, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
+      { "group": "npc_coat", "prob": 2, "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
+      { "group": "npc_gloves", "prob": 50, "damage": [ 1, 4 ] },
+      { "item": "wicker_backpack", "prob": 1, "damage": [ 1, 4 ] }
+    ]
+  },
+  {
     "id": "goblin_armor_drops",
     "type": "item_group",
     "subtype": "collection",
@@ -22,7 +38,7 @@
     "id": "bugbear_weapon_drops",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "item": "survivor_cutting", "prob": 100 } ]
+    "entries": [ { "group": "survivor_cutting", "prob": 100 } ]
   },
   {
     "id": "bugbear_stalker_weapon_drops",

--- a/data/mods/Magiclysm/monsters/goblin.json
+++ b/data/mods/Magiclysm/monsters/goblin.json
@@ -45,18 +45,7 @@
         "no_dmg_msg_npc": "%1$s hits <npcname>'s %2$s without penetrating their armor."
       }
     ],
-    "death_drops": {
-      "subtype": "collection",
-      "items": [
-        { "group": "feral_goblin_death_drops", "prob": 100 },
-        { "item": "helmet_scrap_xs", "prob": 40 },
-        { "item": "xs_legguard_scrap", "prob": 40 },
-        { "item": "xs_boots_scrap", "prob": 40 },
-        { "item": "xs_armguard_scrap", "prob": 40 },
-        { "item": "xs_cuirass_scrap", "prob": 40 },
-        { "item": "cudgel", "prob": 95 }
-      ]
-    },
+    "death_drops": "goblin_warrior_death_drops",
     "armor": { "bash": 12, "cut": 12, "bullet": 4 },
     "zombify_into": "mon_zombie_goblin",
     "flags": [ "SEES", "HEARS", "HAS_MIND", "WARM", "BASHES", "PATH_AVOID_DANGER", "REVIVES", "GROUP_MORALE", "WIELDED_WEAPON" ]
@@ -68,18 +57,7 @@
     "description": "A goblin, but like something out of history.  Over the dirty, tattered remnants of their street clothes, they're wearing improvised armor and carrying a sling with a pouch for extra stones.  They look at you like a wolf seeing a particularly juicy hunk of lamb.",
     "copy-from": "mon_goblin_warrior",
     "melee_skill": 2,
-    "death_drops": {
-      "subtype": "collection",
-      "items": [
-        { "group": "feral_goblin_death_drops", "prob": 100 },
-        { "item": "helmet_scrap", "prob": 40 },
-        { "item": "legguard_scrap", "prob": 40 },
-        { "item": "boots_scrap", "prob": 40 },
-        { "item": "armguard_scrap", "prob": 40 },
-        { "item": "cuirass_scrap", "prob": 40 },
-        { "item": "sling", "prob": 95 }
-      ]
-    },
+    "death_drops": "goblin_slinger_death_drops",
     "starting_ammo": { "pebble": 30 },
     "extend": {
       "special_attacks": [
@@ -129,25 +107,7 @@
         "no_dmg_msg_npc": "%1$s hits <npcname>'s %2$s without penetrating their armor."
       }
     ],
-    "death_drops": {
-      "subtype": "collection",
-      "items": [
-        { "group": "feral_goblin_death_drops", "prob": 100 },
-        { "item": "helmet_scrap", "prob": 40 },
-        { "item": "legguard_scrap", "prob": 40 },
-        { "item": "boots_scrap", "prob": 40 },
-        { "item": "armguard_scrap", "prob": 40 },
-        { "item": "cuirass_scrap", "prob": 40 },
-        {
-          "distribution": [
-            { "group": "survivor_stabbing", "prob": 96 },
-            { "item": "spear_steel_plus_one", "prob": 3 },
-            { "item": "rune_biomancer_weapon", "prob": 1 }
-          ],
-          "prob": 100
-        }
-      ]
-    }
+    "death_drops": "goblin_chieftan_death_drops"
   },
   {
     "type": "MONSTER",
@@ -324,25 +284,7 @@
       }
     ],
     "path_settings": { "avoid_traps": true, "avoid_sharp": true },
-    "death_drops": {
-      "subtype": "collection",
-      "items": [
-        { "item": "xl_helmet_larmor", "prob": 20 },
-        { "item": "xl_gauntlets_larmor", "prob": 20 },
-        { "item": "xl_boots_larmor", "prob": 20 },
-        { "item": "xl_armguard_larmor", "prob": 20 },
-        { "item": "xl_armor_larmor_chest", "prob": 10 },
-        { "item": "loincloth_fur", "prob": 10 },
-        { "item": "footrags_fur", "prob": 10 },
-        { "item": "gloves_wraps_fur", "prob": 10 },
-        { "item": "bellywrap_fur", "prob": 5 },
-        { "item": "chestwrap_fur", "prob": 5 },
-        {
-          "distribution": [ { "item": "survivor_machete", "prob": 98 }, { "item": "broadsword_plus_one", "prob": 2 } ],
-          "prob": 100
-        }
-      ]
-    },
+    "death_drops": "goblin_bugbear_death_drops",
     "armor": { "bash": 4, "cut": 12, "bullet": 8 },
     "flags": [
       "SEES",
@@ -384,25 +326,7 @@
         "no_dmg_msg_npc": "%1$s hits <npcname>'s %2$s without penetrating their armor."
       }
     ],
-    "death_drops": {
-      "subtype": "collection",
-      "items": [
-        { "item": "xl_helmet_larmor", "prob": 20 },
-        { "item": "xl_gauntlets_larmor", "prob": 20 },
-        { "item": "xl_boots_larmor", "prob": 20 },
-        { "item": "xl_armguard_larmor", "prob": 20 },
-        { "item": "xl_armor_larmor_chest", "prob": 10 },
-        { "item": "loincloth_fur", "prob": 10 },
-        { "item": "footrags_fur", "prob": 10 },
-        { "item": "gloves_wraps_fur", "prob": 10 },
-        { "item": "bellywrap_fur", "prob": 5 },
-        { "item": "chestwrap_fur", "prob": 5 },
-        {
-          "distribution": [ { "group": "survivor_stabbing", "prob": 97 }, { "item": "spear_steel_plus_one", "prob": 3 } ],
-          "prob": 100
-        }
-      ]
-    },
+    "death_drops": "goblin_bugbear_stalker_drops",
     "extend": { "flags": [ "CAMOUFLAGE", "SILENTMOVES" ] }
   }
 ]

--- a/data/mods/Magiclysm/monsters/goblin.json
+++ b/data/mods/Magiclysm/monsters/goblin.json
@@ -326,7 +326,7 @@
         "no_dmg_msg_npc": "%1$s hits <npcname>'s %2$s without penetrating their armor."
       }
     ],
-    "death_drops": "goblin_bugbear_stalker_drops",
+    "death_drops": "goblin_bugbear_stalker_death_drops",
     "extend": { "flags": [ "CAMOUFLAGE", "SILENTMOVES" ] }
   }
 ]

--- a/data/mods/Magiclysm/monsters/orcs.json
+++ b/data/mods/Magiclysm/monsters/orcs.json
@@ -71,29 +71,7 @@
     ],
     "path_settings": { "avoid_traps": true, "avoid_sharp": true },
     "zombify_into": "mon_zorc",
-    "death_drops": {
-      "subtype": "collection",
-      "items": [
-        { "item": "helmet_scrap", "prob": 20 },
-        { "item": "legguard_scrap", "prob": 20 },
-        { "item": "boots_scrap", "prob": 20 },
-        { "item": "armguard_scrap", "prob": 20 },
-        { "item": "cuirass_scrap", "prob": 10 },
-        { "item": "loincloth_fur", "prob": 10 },
-        { "item": "footrags_fur", "prob": 10 },
-        { "item": "gloves_wraps_fur", "prob": 10 },
-        { "item": "bellywrap_fur", "prob": 5 },
-        { "item": "chestwrap_fur", "prob": 5 },
-        {
-          "distribution": [
-            { "item": "survivor_machete", "prob": 96 },
-            { "item": "arming_sword_plus_one", "prob": 2 },
-            { "item": "broadsword_plus_one", "prob": 2 }
-          ],
-          "prob": 100
-        }
-      ]
-    },
+    "death_drops": "orc_warrior_death_drops",
     "flags": [ "SEES", "HEARS", "HAS_MIND", "WARM", "BASHES", "PATH_AVOID_DANGER", "SWARMS", "GROUP_MORALE", "WIELDED_WEAPON" ]
   },
   {
@@ -103,24 +81,7 @@
     "description": "Like a goblin, but stretched and exaggerated until they're as tall as a human but much more heavily muscled, wearing improvised armor and carrying a bow.  They smile silently, baring a set of sharp teeth, as they aim at you.",
     "copy-from": "mon_orc_warrior",
     "melee_skill": 2,
-    "death_drops": {
-      "subtype": "collection",
-      "items": [
-        { "item": "helmet_scrap", "prob": 40 },
-        { "item": "legguard_scrap", "prob": 40 },
-        { "item": "boots_scrap", "prob": 40 },
-        { "item": "armguard_scrap", "prob": 40 },
-        { "item": "cuirass_scrap", "prob": 40 },
-        { "item": "loincloth_fur", "prob": 10 },
-        { "item": "footrags_fur", "prob": 10 },
-        { "item": "gloves_wraps_fur", "prob": 10 },
-        { "item": "bellywrap_fur", "prob": 5 },
-        { "item": "chestwrap_fur", "prob": 5 },
-        { "item": "longbow", "prob": 100 },
-        { "item": "sheath", "contents-item": "knife_combat", "prob": 50 },
-        { "item": "quiver_large", "contents-group": "quiver_orc_archer", "prob": 100 }
-      ]
-    },
+    "death_drops": "orc_archer_death_drops",
     "starting_ammo": { "arrow_wood_heavy": 60 },
     "extend": {
       "special_attacks": [
@@ -175,29 +136,7 @@
         "no_dmg_msg_npc": "%1$s hits <npcname>'s %2$s without penetrating their armor."
       }
     ],
-    "death_drops": {
-      "subtype": "collection",
-      "items": [
-        { "item": "helmet_scrap", "prob": 20 },
-        { "item": "legguard_scrap", "prob": 10 },
-        { "item": "boots_scrap", "prob": 10 },
-        { "item": "armguard_scrap", "prob": 30 },
-        { "item": "cuirass_scrap", "prob": 20 },
-        { "item": "loincloth_fur", "prob": 10 },
-        { "item": "footrags_fur", "prob": 10 },
-        { "item": "gloves_wraps_fur", "prob": 10 },
-        { "item": "bellywrap_fur", "prob": 5 },
-        { "item": "chestwrap_fur", "prob": 5 },
-        {
-          "distribution": [
-            { "item": "mace_pipe_large", "prob": 96 },
-            { "item": "mace_plus_one", "prob": 2 },
-            { "item": "warhammer_plus_one", "prob": 2 }
-          ],
-          "prob": 100
-        }
-      ]
-    }
+    "death_drops": "orc_blood_warrior_death_drops"
   },
   {
     "id": "mon_orc_mage_blood",
@@ -240,21 +179,6 @@
         "monster_message": "%1$s makes a frenzied cry and as they point, %3$s is surrounded by a red glow."
       }
     ],
-    "death_drops": {
-      "subtype": "collection",
-      "items": [
-        { "item": "helmet_scrap", "prob": 20 },
-        { "item": "legguard_scrap", "prob": 10 },
-        { "item": "boots_scrap", "prob": 10 },
-        { "item": "cuirass_scrap", "prob": 20 },
-        { "item": "loincloth_fur", "prob": 10 },
-        { "item": "footrags_fur", "prob": 10 },
-        { "item": "gloves_wraps_fur", "prob": 10 },
-        { "item": "bellywrap_fur", "prob": 5 },
-        { "item": "chestwrap_fur", "prob": 5 },
-        { "group": "magic_plants_common", "prob": 10 },
-        { "group": "magic_plants_uncommon", "prob": 1 }
-      ]
-    }
+    "death_drops": "orc_blood_mage_death_drops"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm/Innawood] Revamp goblin/orc drops to separate itemgroups, make them fit Innawood"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Loaded up a Magiclysm/Innawood game and noticed the goblin villages and realized that goblins might be dropping modern gear, and then realized there were other problems (like goblin armor and clothes dropping undamaged).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove all the in-line death drops from goblins, orcs, and bugbears, make them separate itemgroups.

Make the itemgroups linked to sub-itemgroups like `goblin_chieftan_weapon_drops`

Add damage chance to these groups.

Override the armor Innawood so they have leather armor, not metal armor. Override their weapons so they're stone and bone and wood, not metal. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a goblin camp, killed everyone, checked the loot.

Went to innawood, spawned a goblin camp, killed everyone, made sure there were no talking dolls or floral blankets or anything. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Now with fixed commit history
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
