### PR TITLE
Wall wiring tweaks

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -59,7 +59,8 @@
     "name": { "str": "abstract concrete wall", "//~": "NO_I18N" },
     "description": "Encompasses most concrete-like walls.  If you see this in-game, it's a bug.",
     "roof": "t_concrete_roof",
-    "color": "light_gray"
+    "color": "light_gray",
+    "extend": { "flags": [ "WIRED_WALL" ] }
   },
   {
     "type": "terrain",
@@ -68,7 +69,8 @@
     "name": { "str": "abstract brick wall", "//~": "NO_I18N" },
     "description": "Encompasses most brick-like walls.  If you see this in-game, it's a bug.",
     "roof": "t_brick_roof",
-    "color": "brown"
+    "color": "brown",
+    "extend": { "flags": [ "WIRED_WALL" ] }
   },
   {
     "type": "terrain",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1801,13 +1801,6 @@
   },
   {
     "type": "keybinding",
-    "id": "HIDE",
-    "category": "APP_INTERACT",
-    "name": "Hide/Unhide wiring",
-    "bindings": [ { "input_method": "keyboard_any", "key": "h" } ]
-  },
-  {
-    "type": "keybinding",
     "id": "DISCONNECT_GRID",
     "category": "APP_INTERACT",
     "name": "Separate from power grid",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1801,6 +1801,13 @@
   },
   {
     "type": "keybinding",
+    "id": "HIDE",
+    "category": "APP_INTERACT",
+    "name": "Hide/Unhide wiring",
+    "bindings": [ { "input_method": "keyboard_any", "key": "h" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "DISCONNECT_GRID",
     "category": "APP_INTERACT",
     "name": "Separate from power grid",

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3234,6 +3234,7 @@ void vehicle_part::deserialize( const JsonObject &data )
     data.read( "locked", locked );
     data.read( "last_disconnected", last_disconnected );
     data.read( "last_charged", last_charged );
+    data.read( "hidden", hidden );
 
     if( migration != nullptr ) {
         for( const itype_id &it : migration->add_veh_tools ) {
@@ -3289,6 +3290,7 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "locked", locked );
     json.member( "last_disconnected", last_disconnected );
     json.member( "last_charged", last_charged );
+    json.member( "hidden", hidden );
     json.end_object();
 }
 

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -1,3 +1,4 @@
+#include "cached_options.h"
 #include "game.h"
 #include "handle_liquid.h"
 #include "imgui/imgui.h"
@@ -594,11 +595,12 @@ void veh_app_interact::populate_app_actions()
                                    veh->is_powergrid() ? _( " / merge power grid" ) : "" ) );
 #if defined(TILES)
     // Hide
-    app_actions.emplace_back( [this]() {
-        hide();
-    } );
-    imenu.addentry( -1, use_tiles && vp->info().has_flag( flag_WIRING ),
-                    ctxt.keys_bound_to( "HIDE" ).front(), ctxt.get_action_name( "HIDE" ) );
+    if( use_tiles && vp->info().has_flag( flag_WIRING ) ) {
+        app_actions.emplace_back( [this]() {
+            hide();
+        } );
+        imenu.addentry( -1, true, ctxt.keys_bound_to( "HIDE" ).front(), ctxt.get_action_name( "HIDE" ) );
+    }
 #endif
 
     if( veh->is_powergrid() && veh->part_count() > 1 && !vp->info().has_flag( VPFLAG_WALL_MOUNTED ) ) {

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -536,6 +536,13 @@ void veh_app_interact::plug()
     }
 }
 
+void veh_app_interact::hide()
+{
+    const int part_idx = veh->part_at( veh->coord_translate( a_point ) );
+    vehicle_part &vp = veh->part( part_idx );
+    vp.hidden = !vp.hidden;
+}
+
 void veh_app_interact::populate_app_actions()
 {
     map &here = get_map();
@@ -585,6 +592,14 @@ void veh_app_interact::populate_app_actions()
                     string_format( "%s%s", ctxt.get_action_name( "PLUG" ),
                                    //~ An addendum to Plug In's description, as in: Plug in appliance / merge power grid".
                                    veh->is_powergrid() ? _( " / merge power grid" ) : "" ) );
+#if defined(TILES)
+    // Hide
+    app_actions.emplace_back( [this]() {
+        hide();
+    } );
+    imenu.addentry( -1, use_tiles && vp->info().has_flag( flag_WIRING ),
+                    ctxt.keys_bound_to( "HIDE" ).front(), ctxt.get_action_name( "HIDE" ) );
+#endif
 
     if( veh->is_powergrid() && veh->part_count() > 1 && !vp->info().has_flag( VPFLAG_WALL_MOUNTED ) ) {
         // Disconnect from power grid

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -599,7 +599,7 @@ void veh_app_interact::populate_app_actions()
         app_actions.emplace_back( [this]() {
             hide();
         } );
-        imenu.addentry( -1, true, ctxt.keys_bound_to( "HIDE" ).front(), ctxt.get_action_name( "HIDE" ) );
+        imenu.addentry( -1, true, 0, "Hide/Unhide wiring" );
     }
 #endif
 

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -140,6 +140,11 @@ class veh_app_interact
         */
         void plug();
         /**
+        * Function associated with the "HIDE" action.
+        * Hides the selected tiles sprite.
+        */
+        void hide();
+        /**
          * The main loop of the appliance UI. Redraws windows, checks for input, and
          * performs selected actions. The loop exits once an activity is assigned
          * (either directly to the player or to 'act'), or when QUIT input is received.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -519,6 +519,9 @@ struct vehicle_part {
         /** door is locked */
         bool locked = false;
 
+        // If the part's sprite/symbol shouldn't be shown
+        bool hidden = false;
+
         /** direction the part is facing */
         units::angle direction = 0_degrees;
 

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -66,6 +66,9 @@ vpart_display vehicle::get_display_of_tile( const point_rel_ms &dp, bool rotate,
     }
 
     const vehicle_part &vp = part( part_idx );
+    if( vp.hidden ) {
+        return {};
+    }
     const vpart_info &vpi = vp.info();
 
     auto variant_it = vpi.variants.find( vp.variant );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Ability to hide/unhide revealed wall wiring by examining it"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Wall wiring having a sprite is convenient for setting it up but is mainly annoying after that
Exterior walls of most pre existing buildings should have WIRED_WALL for verisimilitude
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds an option to the appliance menu (that only shows up when appropriate) to disable/reenable the sprite showing for that tile
Allows revealing wall wiring in concrete/brick walls that are part of the newish widely used parametrized_walls_palette
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I can't get hiding the symbol to work for non tiles display, it doesn't seem setup to be able to understand not drawing a null layer that it was expecting so I've just disabled the option if you're not using tiles
Making toggling the option apply to the whole connected network could be cool but seemed substantially more awkward to implement
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked the option only showed up when appropriate and it removed the sprite leaving the underlying sprite instead (wall)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
