### PR TITLE
[Magiclysm] Give elves their own sight trait instead of using fey vision, slightly reduce their hearing.

### DIFF
--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -564,6 +564,7 @@
     "points": 2,
     "visibility": 2,
     "ugliness": 1,
+    "types": [ "EYES" ],
     "description": "While your reddish eyes have been known to give other people a start, they help you see in the dark.  You have much better night vision than a human, even being able to craft in the dark.",
     "category": [ "SPECIES_GOBLIN" ],
     "enchantments": [ "ench_goblin_eyes" ],

--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -332,6 +332,17 @@
   },
   {
     "type": "mutation",
+    "id": "ELVEN_SIGHT",
+    "name": { "str": "Elvensight" },
+    "points": 2,
+    "description": "Like a cat, elven eyes are well-attuned to low levels of light, able to pick up even the slightest glimmer.  You have greatly-enhanced night vision.",
+    "types": [ "EYES" ],
+    "category": [ "SPECIES_ELF" ],
+    "threshreq": [ "THRESH_SPECIES_ELF" ],
+    "enchantments": [ { "values": [ { "value": "NIGHT_VIS", "add": 5 } ] } ]
+  },
+  {
+    "type": "mutation",
     "id": "ELVEN_HEARING",
     "name": { "str": "Elven Hearing" },
     "purifiable": false,
@@ -341,7 +352,7 @@
     "category": [ "SPECIES_ELF" ],
     "threshreq": [ "THRESH_SPECIES_ELF" ],
     "flags": [ "SAFECRACK_NO_TOOL" ],
-    "enchantments": [ { "values": [ { "value": "HEARING_MULT", "multiply": 5.1 } ] } ]
+    "enchantments": [ { "values": [ { "value": "HEARING_MULT", "multiply": 2 } ] } ]
   },
   {
     "type": "mutation",
@@ -413,12 +424,6 @@
     "id": "DEFT",
     "copy-from": "DEFT",
     "extend": { "category": [ "SPECIES_ELF" ] }
-  },
-  {
-    "type": "mutation",
-    "id": "ELFA_NV",
-    "copy-from": "ELFA_NV",
-    "extend": { "category": [ "SPECIES_ELF" ], "threshreq": [ "THRESH_SPECIES_ELF" ] }
   },
   {
     "type": "mutation",

--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -1305,7 +1305,7 @@
       "THRESH_SPECIES_ELF",
       "ANIMALEMPATH2",
       "ELVEN_BUILD",
-      "ELFA_NV",
+      "ELVEN_SIGHT",
       "ELVEN_BEAUTY",
       "ELVEN_SLEEP",
       "ELFA_EARS",

--- a/data/mods/Magiclysm/traits/fantasy_species.json
+++ b/data/mods/Magiclysm/traits/fantasy_species.json
@@ -11,7 +11,7 @@
       "THRESH_SPECIES_ELF",
       "ANIMALEMPATH2",
       "ELVEN_BUILD",
-      "ELFA_NV",
+      "ELVEN_SIGHT",
       "ELVEN_BEAUTY",
       "ELVEN_SLEEP",
       "ELFA_EARS",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Give elves their own sight trait instead of using fey vision"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When I first added the Magiclysm fantasy species, there was no way to give someone night vision except the hardcoded traits. But now we can use enchantments.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Give elves the `Elvensight` trait, which provides 5 squares of night vision. Someday hopefully there will be a distinction between "No Light" and "Low Light' and I can greatly increase this but make it not work at all in total darkness, but until then, 5 squares will work.

I cut their hearing from 5.1 multiplier to 2 multiplier, since the way hearing works means you'll be constantly woken up by the tiniest sounds with such a high hearing level. 

Also add the EYES type to this and the goblin Nocturnal Vision trait.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Elvensight shows up in character creation.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
