### PR TITLE
Add some tests for NPC rules

### DIFF
--- a/data/mods/TEST_DATA/npc_behavior_arenas/arena_maps.json
+++ b/data/mods/TEST_DATA/npc_behavior_arenas/arena_maps.json
@@ -3,7 +3,14 @@
     "type": "palette",
     "id": "npc_behavior_test_palette",
     "furniture": { "a": "f_chair" },
-    "terrain": { ".": "t_thconc_floor", "X": "t_concrete_wall", "C": "t_door_c", "O": "t_door_o", "u": "t_door_frame", "W": "t_door_locked" }
+    "terrain": {
+      ".": "t_thconc_floor",
+      "X": "t_concrete_wall",
+      "C": "t_door_c",
+      "O": "t_door_o",
+      "u": "t_door_frame",
+      "W": "t_door_locked"
+    }
   },
   {
     "type": "mapgen",
@@ -74,5 +81,44 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "npc_behavior_test_palette" ]
     }
+  },
+  {
+    "id": "locked_as_hell_car",
+    "type": "vehicle",
+    "name": "DEBUG locked car DEBUG",
+    "blueprint": [
+      [ "BBDBB" ],
+      [ "B===B" ],
+      [ "B===B" ],
+      [ "B===B" ],
+      [ "BBBBB" ]
+    ],
+    "parts": [
+      { "x": -1, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 1, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -1, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 0, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 1, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 0, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -1, "y": 2, "parts": [ "frame", "board", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "frame", "board", "roof" ] },
+      { "x": 1, "y": 2, "parts": [ "frame", "board", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "frame", "board", "roof" ] },
+      { "x": 0, "y": -2, "parts": [ "frame", "door", "door_lock", "roof" ] },
+      { "x": 1, "y": -2, "parts": [ "frame", "board", "roof" ] },
+      { "x": 2, "y": -1, "parts": [ "frame", "board", "roof" ] },
+      { "x": 2, "y": 0, "parts": [ "frame", "board", "roof" ] },
+      { "x": 2, "y": 1, "parts": [ "frame", "board", "roof" ] },
+      { "x": -2, "y": -1, "parts": [ "frame", "board", "roof" ] },
+      { "x": -2, "y": 0, "parts": [ "frame", "board", "roof" ] },
+      { "x": -2, "y": -2, "parts": [ "frame", "board", "roof" ] },
+      { "x": -1, "y": -2, "parts": [ "frame", "board", "roof" ] },
+      { "x": 2, "y": -2, "parts": [ "frame", "board", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame", "board", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame", "board", "roof" ] }
+    ]
   }
 ]

--- a/data/mods/TEST_DATA/npc_behavior_arenas/arena_maps.json
+++ b/data/mods/TEST_DATA/npc_behavior_arenas/arena_maps.json
@@ -3,7 +3,7 @@
     "type": "palette",
     "id": "npc_behavior_test_palette",
     "furniture": { "a": "f_chair" },
-    "terrain": { ".": "t_thconc_floor", "X": "t_concrete_wall", "C": "t_door_c", "O": "t_door_o", "u": "t_door_frame" }
+    "terrain": { ".": "t_thconc_floor", "X": "t_concrete_wall", "C": "t_door_c", "O": "t_door_o", "u": "t_door_frame", "W": "t_door_locked" }
   },
   {
     "type": "mapgen",
@@ -30,6 +30,41 @@
         "X......................X",
         "X......................X",
         "XXXXXXXXXXXuXXXXXXXXXXXX",
+        "X......................X",
+        "X......................X",
+        "XXXXXXXXXXX.XXXXXXXXXXXX",
+        "........................",
+        "........................"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "npc_behavior_test_palette" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "debug_npc_rules_test_close_doors",
+    "object": {
+      "rows": [
+        "XXXXXXXXXXXXXXXXXXXXXXXX",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "X..........a...........X",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "XXXXXXXXXXXOXXXXXXXXXXXX",
+        "X......................X",
+        "X......................X",
+        "XXXXXXXXXXXCXXXXXXXXXXXX",
+        "X......................X",
+        "X......................X",
+        "XXXXXXXXXXXWXXXXXXXXXXXX",
         "X......................X",
         "X......................X",
         "XXXXXXXXXXX.XXXXXXXXXXXX",

--- a/data/mods/TEST_DATA/npc_behavior_arenas/arena_maps.json
+++ b/data/mods/TEST_DATA/npc_behavior_arenas/arena_maps.json
@@ -1,0 +1,43 @@
+[
+  {
+    "type": "palette",
+    "id": "npc_behavior_test_palette",
+    "furniture": { "a": "f_chair" },
+    "terrain": { ".": "t_thconc_floor", "X": "t_concrete_wall", "C": "t_door_c", "O": "t_door_o", "u": "t_door_frame" }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "debug_npc_rules_test_avoid_doors",
+    "object": {
+      "rows": [
+        "XXXXXXXXXXXXXXXXXXXXXXXX",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "X..........a...........X",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "X......................X",
+        "XC.CCCCCCCCCCCCCCCCCCCCX",
+        "X......................X",
+        "X......................X",
+        "XOOOOOOOOOOOOOOOOOOOO.OX",
+        "X......................X",
+        "X......................X",
+        "XXXXXXXXXXXuXXXXXXXXXXXX",
+        "X......................X",
+        "X......................X",
+        "XXXXXXXXXXX.XXXXXXXXXXXX",
+        "........................",
+        "........................"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "npc_behavior_test_palette" ]
+    }
+  }
+]

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -39,18 +39,18 @@
 
 class Creature;
 
-static const update_mapgen_id
-update_mapgen_debug_npc_rules_test_avoid_doors( "debug_npc_rules_test_avoid_doors" );
-
-static const update_mapgen_id
-update_mapgen_debug_npc_rules_test_close_doors( "debug_npc_rules_test_close_doors" );
-
 static const furn_str_id furn_f_chair( "f_chair" );
+
 static const ter_str_id ter_t_door_c( "t_door_c" );
 static const ter_str_id ter_t_door_locked( "t_door_locked" );
 static const ter_str_id ter_t_door_o( "t_door_o" );
 
-static const vproto_id veh_locked_as_hell_car( "locked_as_hell_car" );
+static const update_mapgen_id
+update_mapgen_debug_npc_rules_test_avoid_doors( "debug_npc_rules_test_avoid_doors" );
+static const update_mapgen_id
+update_mapgen_debug_npc_rules_test_close_doors( "debug_npc_rules_test_close_doors" );
+
+static const vproto_id vehicle_prototype_locked_as_hell_car( "locked_as_hell_car" );
 
 static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test,
         update_mapgen_id update_mapgen_id_to_apply )
@@ -76,7 +76,7 @@ static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test,
     return guy;
 }
 
-TEST_CASE( "NPC rules (avoid doors)", "[npc_rules]" )
+TEST_CASE( "NPC-rules-avoid-doors", "[npc_rules]" )
 {
     /* Avoid doors rule
     * Allows: Door frame, Open doors(??? pre-existing behavior)
@@ -112,7 +112,7 @@ TEST_CASE( "NPC rules (avoid doors)", "[npc_rules]" )
     }
 }
 
-TEST_CASE( "NPC rules (close doors)", "[npc_rules]" )
+TEST_CASE( "NPC-rules-close-doors", "[npc_rules]" )
 {
     /* Close doors rule
     * Target is a chair in a room fully enclosed by concrete walls
@@ -176,7 +176,7 @@ TEST_CASE( "NPC rules (close doors)", "[npc_rules]" )
 
 }
 
-TEST_CASE( "NPC rules (avoid locks)", "[npc_rules]" )
+TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
 {
     /* Avoid locked doors rule
     * Target is a the north side of a locked door (otherwise inaccessible room)
@@ -225,7 +225,7 @@ TEST_CASE( "NPC rules (avoid locks)", "[npc_rules]" )
 
 
     // all sides of the vehicle are locked doors
-    vehicle *test_vehicle = here.add_vehicle( veh_locked_as_hell_car,
+    vehicle *test_vehicle = here.add_vehicle( vehicle_prototype_locked_as_hell_car,
                             car_center_pos, 0_degrees, 0, 0 );
 
     // vehicle is a 5x5 grid, car_door_pos is the only door/exit

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -55,7 +55,7 @@ static const vproto_id vehicle_prototype_locked_as_hell_car( "locked_as_hell_car
 static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test,
         update_mapgen_id update_mapgen_id_to_apply )
 {
-    clear_map();
+    wipe_map_terrain();
     clear_vehicles();
     clear_avatar();
     Character &player = get_player_character();
@@ -238,6 +238,10 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
 
     // NOTE: The door lock is a separate part. We must ensure both the door exists and the door lock exists for this test.
     const int door_index = test_vehicle->index_of_part( door );
+    for( vehicle_part *part_at_door_loc : test_vehicle->get_parts_at( car_door_pos, "",
+            part_status_flag::any ) ) {
+        UNSCOPED_INFO( part_at_door_loc->name() );
+    }
     const int door_lock_index = test_vehicle->next_part_to_lock( door_index );
     REQUIRE( door_lock_index != -1 );
     vehicle_part &door_lock = test_vehicle->part( door_lock_index );

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -41,11 +41,16 @@ class Creature;
 static const update_mapgen_id
 update_mapgen_debug_npc_rules_test_avoid_doors( "debug_npc_rules_test_avoid_doors" );
 
+static const update_mapgen_id
+update_mapgen_debug_npc_rules_test_close_doors( "debug_npc_rules_test_close_doors" );
+
 static const furn_str_id furn_f_chair( "f_chair" );
 static const ter_str_id ter_t_door_c( "t_door_c" );
+static const ter_str_id ter_t_door_locked( "t_door_locked" );
 static const ter_str_id ter_t_door_o( "t_door_o" );
 
-static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test )
+static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test,
+        update_mapgen_id update_mapgen_id_to_apply )
 {
     clear_map();
     clear_avatar();
@@ -60,6 +65,8 @@ static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test )
     tester_rules.clear_overrides(); // just to be sure
     tester_rules.set_flag( rule_to_test );
     REQUIRE( tester_rules.has_flag( rule_to_test ) );
+    const tripoint_abs_omt test_omt_pos = guy->global_omt_location() + point::north;
+    manual_mapgen( test_omt_pos, manual_update_mapgen, update_mapgen_id_to_apply );
     return guy;
 }
 
@@ -74,9 +81,8 @@ TEST_CASE( "NPC rules (avoid doors)", "[npc_rules]" )
     * already opened doors, and concrete floors.
     */
     const ally_rule rule_to_test = ally_rule::avoid_doors;
-    const shared_ptr_fast<npc> &test_subject = setup_generic_rules_test( rule_to_test );
-    const tripoint_abs_omt test_omt_pos = test_subject->global_omt_location() + point::north;
-    manual_mapgen( test_omt_pos, manual_update_mapgen, update_mapgen_debug_npc_rules_test_avoid_doors );
+    const shared_ptr_fast<npc> &test_subject = setup_generic_rules_test( rule_to_test,
+            update_mapgen_debug_npc_rules_test_avoid_doors );
     map &here = get_map();
     tripoint_bub_ms chair_target = test_subject->pos_bub();
     for( const tripoint_bub_ms &furn_loc : here.points_in_radius( test_subject->pos_bub(), 60 ) ) {
@@ -98,4 +104,63 @@ TEST_CASE( "NPC rules (avoid doors)", "[npc_rules]" )
         CAPTURE( debug_log_msg );
         CHECK( here.ter( loc ).id() != ter_t_door_c );
     }
+}
+
+TEST_CASE( "NPC rules (close doors)", "[npc_rules]" )
+{
+    /* Close doors rule
+    * Target is a chair in a room fully enclosed by concrete walls
+    * We have a straight line path to the target, but in the way are several vexing trials!
+    * An open door, a closed door, and a locked door (unlockable from adjacent INDOORS tile).
+    * We must open them all, *and* close them behind us!
+    */
+    const ally_rule rule_to_test = ally_rule::close_doors;
+    const shared_ptr_fast<npc> &test_subject = setup_generic_rules_test( rule_to_test,
+            update_mapgen_debug_npc_rules_test_close_doors );
+    // Some sanity checking to make sure we can even do this test
+    REQUIRE( !test_subject->rules.has_flag( ally_rule::avoid_doors ) );
+    REQUIRE( !test_subject->rules.has_flag( ally_rule::avoid_locks ) );
+    map &here = get_map();
+
+
+    tripoint_bub_ms door_unlock_position;
+    for( const tripoint_bub_ms &ter_loc : here.points_in_radius( test_subject->pos_bub(), 60 ) ) {
+        if( here.ter( ter_loc ) == ter_t_door_locked ) {
+            door_unlock_position = ter_loc + point::south;
+            break;
+        }
+    }
+    here.set_outside_cache_dirty( door_unlock_position.z() );
+    here.build_outside_cache( door_unlock_position.z() );
+    REQUIRE( !here.is_outside( door_unlock_position ) );
+
+    tripoint_bub_ms chair_target = test_subject->pos_bub();
+    for( const tripoint_bub_ms &furn_loc : here.points_in_radius( test_subject->pos_bub(), 60 ) ) {
+        if( here.furn( furn_loc ) == furn_f_chair ) {
+            chair_target = furn_loc;
+            break;
+        }
+    }
+    // if this fails, we somehow didn't find the destination chair (???)
+    REQUIRE( test_subject->pos_bub() != chair_target );
+    test_subject->update_path( chair_target, true, true );
+    // if this fails, we somehow didn't find a path
+    REQUIRE( !test_subject->path.empty() );
+
+    // copy our path before we lose it
+    std::vector<tripoint_bub_ms> path_taken = test_subject->path;
+    int turns_taken = 0;
+    while( turns_taken++ < 100 && test_subject->pos_bub() != chair_target ) {
+        test_subject->set_moves( 100 );
+        test_subject->move();
+    }
+
+    // if this fails we didn't make it to the chair, somehow!
+    CHECK( test_subject->pos_bub() == chair_target );
+
+    for( tripoint_bub_ms &loc : path_taken ) {
+        // any other terrain on the way is valid, as long as it's not an open door.
+        CHECK( here.ter( loc ).id() != ter_t_door_o );
+    }
+
 }

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -231,22 +231,17 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
                             car_center_pos, 0_degrees, 0, 0 );
 
     // vehicle is a 5x5 grid, car_door_pos is the only door/exit
-    std::vector<vehicle_part *> parts_at_target = test_vehicle->get_parts_at(
+    std::vector<vehicle_part *> door_parts_at_target = test_vehicle->get_parts_at(
                 car_door_pos, "LOCKABLE_DOOR", part_status_flag::available );
-    REQUIRE( !parts_at_target.empty() );
-    vehicle_part *door = parts_at_target.front();
+    REQUIRE( !door_parts_at_target.empty() );
 
     // NOTE: The door lock is a separate part. We must ensure both the door exists and the door lock exists for this test.
-    const int door_index = test_vehicle->index_of_part( door );
-    for( vehicle_part *part_at_door_loc : test_vehicle->get_parts_at( car_door_pos, "",
-            part_status_flag::any ) ) {
-        UNSCOPED_INFO( part_at_door_loc->name() );
-    }
-    const int door_lock_index = test_vehicle->next_part_to_lock( door_index );
-    REQUIRE( door_lock_index != -1 );
-    vehicle_part &door_lock = test_vehicle->part( door_lock_index );
-    door_lock.locked = true;
-    REQUIRE( ( door_lock.is_available() && door_lock.locked ) );
+    std::vector<vehicle_part *> door_lock_parts_at_target = test_vehicle->get_parts_at(
+                car_door_pos, "DOOR_LOCKING", part_status_flag::available );
+    REQUIRE( !door_lock_parts_at_target.empty() );
+    vehicle_part *door_lock = door_lock_parts_at_target.front();
+    door_lock->locked = true;
+    REQUIRE( ( door_lock->is_available() && door_lock->locked ) );
 
 
     test_subject->setpos( car_door_unlock_pos );

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -234,6 +234,9 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
     std::vector<vehicle_part *> door_parts_at_target = test_vehicle->get_parts_at(
                 car_door_pos, "LOCKABLE_DOOR", part_status_flag::available );
     REQUIRE( !door_parts_at_target.empty() );
+    vehicle_part *door = door_parts_at_target.front();
+    // The door must be closed for the lock to be effective.
+    door->open = false;
 
     // NOTE: The door lock is a separate part. We must ensure both the door exists and the door lock exists for this test.
     std::vector<vehicle_part *> door_lock_parts_at_target = test_vehicle->get_parts_at(
@@ -241,6 +244,7 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
     REQUIRE( !door_lock_parts_at_target.empty() );
     vehicle_part *door_lock = door_lock_parts_at_target.front();
     door_lock->locked = true;
+    door_lock->open = false;
     REQUIRE( ( door_lock->is_available() && door_lock->locked ) );
 
 

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -237,6 +237,8 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
     vehicle_part *door = door_parts_at_target.front();
     // The door must be closed for the lock to be effective.
     door->open = false;
+    // For some reason, both the door and the door lock must be set to locked.
+    door->locked = true;
 
     // NOTE: The door lock is a separate part. We must ensure both the door exists and the door lock exists for this test.
     std::vector<vehicle_part *> door_lock_parts_at_target = test_vehicle->get_parts_at(

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -254,4 +254,9 @@ TEST_CASE( "NPC rules (avoid locks)", "[npc_rules]" )
     CAPTURE( test_subject->path.size() );
     CHECK( test_subject->path.empty() );
 
+    // and now we check that the opposite is true, that they are allowed to exit the vehicle when the flag is not set
+    test_subject->rules.clear_flag( rule_to_test );
+    test_subject->update_path( outside_car_door_pos, true, true );
+    CHECK( !test_subject->path.empty() );
+
 }

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -56,6 +56,7 @@ static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test,
         update_mapgen_id update_mapgen_id_to_apply )
 {
     clear_map();
+    clear_vehicles();
     clear_avatar();
     Character &player = get_player_character();
     tripoint_bub_ms next_to = player.pos_bub() + point::north;
@@ -224,15 +225,14 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
     const tripoint_bub_ms outside_car_door_pos = car_door_pos + point::north;
 
 
-    // all sides of the vehicle are locked doors
     vehicle *test_vehicle = here.add_vehicle( vehicle_prototype_locked_as_hell_car,
                             car_center_pos, 0_degrees, 0, 0 );
 
     // vehicle is a 5x5 grid, car_door_pos is the only door/exit
     std::vector<vehicle_part *> parts_at_target = test_vehicle->get_parts_at(
                 car_door_pos, "LOCKABLE_DOOR", part_status_flag::available );
-    vehicle_part *door = parts_at_target.front();
     REQUIRE( !parts_at_target.empty() );
+    vehicle_part *door = parts_at_target.front();
 
     // NOTE: The door lock is a separate part. We must ensure both the door exists and the door lock exists for this test.
     const int door_index = test_vehicle->index_of_part( door );

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -1,0 +1,101 @@
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "calendar.h"
+#include "cata_catch.h"
+#include "character.h"
+#include "common_types.h"
+#include "creature_tracker.h"
+#include "faction.h"
+#include "field.h"
+#include "field_type.h"
+#include "game.h"
+#include "line.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "mapgen_helpers.h"
+#include "memory_fast.h"
+#include "npc.h"
+#include "npctalk.h"
+#include "overmapbuffer.h"
+#include "pathfinding.h"
+#include "pimpl.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "test_data.h"
+#include "text_snippets.h"
+#include "type_id.h"
+#include "units.h"
+#include "veh_type.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+
+class Creature;
+
+static const update_mapgen_id
+update_mapgen_debug_npc_rules_test_avoid_doors( "debug_npc_rules_test_avoid_doors" );
+
+static const furn_str_id furn_f_chair( "f_chair" );
+static const ter_str_id ter_t_door_c( "t_door_c" );
+static const ter_str_id ter_t_door_o( "t_door_o" );
+
+static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test )
+{
+    clear_map();
+    clear_avatar();
+    Character &player = get_player_character();
+    tripoint_bub_ms next_to = player.pos_bub() + point::north;
+    REQUIRE( next_to != player.pos_bub() );
+    shared_ptr_fast<npc> guy = make_shared_fast<npc>();
+    clear_character( *guy );
+    guy->setpos( next_to );
+    npc_follower_rules &tester_rules = guy->rules;
+    tester_rules = npc_follower_rules(); // just to be sure
+    tester_rules.clear_overrides(); // just to be sure
+    tester_rules.set_flag( rule_to_test );
+    REQUIRE( tester_rules.has_flag( rule_to_test ) );
+    return guy;
+}
+
+TEST_CASE( "NPC rules (avoid doors)", "[npc_rules]" )
+{
+    /* Avoid doors rule
+    * Allows: Door frame, Open doors(??? pre-existing behavior)
+    * DOES NOT ALLOW: closed door (unlocked)
+    * Target is a chair in a room fully enclosed by concrete walls
+    * The straight-line path would take them through a door frame, closed door, and open door. This would fail.
+    * The legal path winds back and forth through the corridors (snake pattern) but only crosses a door frame,
+    * already opened doors, and concrete floors.
+    */
+    const ally_rule rule_to_test = ally_rule::avoid_doors;
+    const shared_ptr_fast<npc> &test_subject = setup_generic_rules_test( rule_to_test );
+    const tripoint_abs_omt test_omt_pos = test_subject->global_omt_location() + point::north;
+    manual_mapgen( test_omt_pos, manual_update_mapgen, update_mapgen_debug_npc_rules_test_avoid_doors );
+    map &here = get_map();
+    tripoint_bub_ms chair_target = test_subject->pos_bub();
+    for( const tripoint_bub_ms &furn_loc : here.points_in_radius( test_subject->pos_bub(), 60 ) ) {
+        if( here.furn( furn_loc ) == furn_f_chair ) {
+            chair_target = furn_loc;
+            break;
+        }
+    }
+    // if this fails, we somehow didn't find the destination chair (???)
+    REQUIRE( test_subject->pos_bub() != chair_target );
+    test_subject->update_path( chair_target, true, true );
+    // if this fails, we somehow didn't find a path
+    REQUIRE( !test_subject->path.empty() );
+    int path_position = 0;
+    for( tripoint_bub_ms &loc : test_subject->path ) {
+        std::string debug_log_msg = string_format( "Terrain at path position %d was %s",
+                                    path_position, here.ter( loc ).id().c_str() );
+        path_position++;
+        CAPTURE( debug_log_msg );
+        CHECK( here.ter( loc ).id() != ter_t_door_c );
+    }
+}

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -62,6 +62,8 @@ static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test,
     tripoint_bub_ms next_to = player.pos_bub() + point::north;
     REQUIRE( next_to != player.pos_bub() );
     shared_ptr_fast<npc> guy = make_shared_fast<npc>();
+    overmap_buffer.insert_npc( guy );
+    g->load_npcs();
     clear_character( *guy );
     guy->setpos( next_to );
     talk_function::follow( *guy );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
NPC test coverage is lacking...

#### Describe the solution
Expand it.

#### Describe alternatives you've considered


#### Testing
This *is* the test.

#### Additional context
The lock doors rule test only tests vehicle doors because the rule does not consider terrain doors. This is pre-existing behavior.

Although it spends some time setting up actual terrain to check this, I've commented out the check that verifies the behavior is correct, as it will currently fail.