### PR TITLE
attempt to identify randomly failed vehicle_turret_test cause

### DIFF
--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -25,6 +25,8 @@
 
 static const ammo_effect_str_id ammo_effect_RECYCLED( "RECYCLED" );
 
+static const vproto_id vehicle_prototype_test_turret_rig("test_turret_rig");
+
 static std::vector<const vpart_info *> all_turret_types()
 {
     std::vector<const vpart_info *> res;
@@ -39,8 +41,6 @@ static std::vector<const vpart_info *> all_turret_types()
 }
 
 // Install, reload and fire every possible vehicle turret.
-static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
-
 TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
 {
     clear_map();

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -39,13 +39,14 @@ static std::vector<const vpart_info *> all_turret_types()
 }
 
 // Install, reload and fire every possible vehicle turret.
+static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
+
 TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
 {
     clear_map();
     clear_avatar();
     map &here = get_map();
     Character &player_character = get_player_character();
-    static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
     const tripoint_bub_ms veh_pos( 65, 65, here.get_abs_sub().z() );
     // TODO: Get rid of this set of tests when the cause of this test randomly failing has been elimined.
     REQUIRE( veh_pos.z() == 0 );

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -45,10 +45,18 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
     clear_avatar();
     map &here = get_map();
     Character &player_character = get_player_character();
+    static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
+    const tripoint_bub_ms veh_pos( 65, 65, here.get_abs_sub().z() );
+    // TODO: Get rid of this set of tests when the cause of this test randomly failing has been elimined.
+    REQUIRE( veh_pos.z() == 0 );
+    REQUIRE( vehicle_prototype_test_turret_rig.is_valid() );
+    REQUIRE( here.inbounds( veh_pos ) );
+    // TODO: End
+
     for( const vpart_info *turret_vpi : all_turret_types() ) {
         SECTION( turret_vpi->name() ) {
-            vehicle *veh = here.add_vehicle( STATIC( vproto_id( "test_turret_rig" ) ),
-                                             tripoint_bub_ms( 65, 65, here.get_abs_sub().z() ), 270_degrees, 0, 0, false );
+            vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos, 270_degrees, 0, 0,
+                                             false );
             REQUIRE( veh );
             veh->unlock();
 

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -25,7 +25,7 @@
 
 static const ammo_effect_str_id ammo_effect_RECYCLED( "RECYCLED" );
 
-static const vproto_id vehicle_prototype_test_turret_rig("test_turret_rig");
+static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
 
 static std::vector<const vpart_info *> all_turret_types()
 {

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -48,7 +48,7 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
     map &here = get_map();
     Character &player_character = get_player_character();
     const tripoint_bub_ms veh_pos( 65, 65, here.get_abs_sub().z() );
-    // TODO: Get rid of this set of tests when the cause of this test randomly failing has been elimined.
+    // TODO: Get rid of this set of tests when the cause of this test randomly failing has been eliminated.
     REQUIRE( veh_pos.z() == 0 );
     REQUIRE( vehicle_prototype_test_turret_rig.is_valid() );
     REQUIRE( here.inbounds( veh_pos ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Try to figure out why the vehicle_turret_test suite fails randomly. See #78539.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a few additional REQUIRE entries for thing that could possibly be the cause. My current main suspect is that the z level going into the suite is wrong.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Just force the z level to 0, but I think it's better to see this failure reported and know it's a cause before changing it and just hope that was it and be happy when the errors don't reappear. If this is actually the cause here, it might be warranted to check other places and potentially include it in clear_map().

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
That's what changing the code does, eventually, when PR tests are run.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
@Procyonae's suggested code improvement in the bug report comment triggered the suspicion an incorrect z level may be the cause.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
