### PR TITLE
[Magiclysm] Add sprite override to Spirit-Walking (+1 square of Phase Distance)

### DIFF
--- a/data/mods/Magiclysm/Spells/animist.json
+++ b/data/mods/Magiclysm/Spells/animist.json
@@ -1025,8 +1025,17 @@
       {
         "u_add_effect": "incorporeal",
         "duration": { "math": [ "( 30 + (u_spell_level('animist_spirit_walking') * 3) ) * (enhancement_proficiency_modifier() )" ] }
-      }
+      },
+      { "u_add_trait": "ANIMIST_BODY_OF_SPIRIT_APPEARANCE" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ANIMIST_SPIRIT_WALKING_LOSE_APPEARANCE",
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": { "and": [ { "compare_string": [ "effect_spirit_walking", { "context_val": "effect" } ] } ] },
+    "effect": [ { "u_lose_trait": "ANIMIST_BODY_OF_SPIRIT_APPEARANCE" } ]
   },
   {
     "id": "animist_add_evasion_spell",

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1359,7 +1359,15 @@
     "desc": [ "You have shed your physical form." ],
     "rating": "good",
     "show_in_info": true,
-    "enchantments": [ { "values": [ { "value": "SPEED", "multiply": 3 }, { "value": "MOVE_COST", "multiply": -0.66 } ] } ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "SPEED", "multiply": 3 },
+          { "value": "MOVE_COST", "multiply": -0.66 },
+          { "value": "PHASE_DISTANCE", "add": 1 }
+        ]
+      }
+    ],
     "flags": [
       "ETHEREAL",
       "FEATHER_FALL",

--- a/data/mods/Magiclysm/mutations/temporary.json
+++ b/data/mods/Magiclysm/mutations/temporary.json
@@ -62,5 +62,15 @@
         ]
       }
     ]
+  },
+  {
+    "type": "mutation",
+    "id": "ANIMIST_BODY_OF_SPIRIT_APPEARANCE",
+    "name": { "str": "Body of Spirit", "//~": "NO_I18N" },
+    "description": { "str": "You're a disembodied spirit so you're all glowy and blue.  Spooky!", "//~": "NO_I18N" },
+    "points": 0,
+    "valid": false,
+    "player_display": false,
+    "override_look": { "id": "mon_hologram", "tile_category": "monster" }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add sprite override to Spirit-Walking"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

#78500 looks pretty cool so I thought I should adapt that to the Animist spell that turns you into a spirit too.

Also, I've been meaning to add a PHASE_DISTANCE enchant to Spirit-Walking and now's a good time.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the `mon_hologram` sprite override to Spirit-Walking. Add 1 PHASE_DISTANCE to the effect enchant.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Appearance changes. Now you can walk through walls.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
