### PR TITLE
[MoM] Gateway now auto-ends activity, attunes slightly faster, documention fixed

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -1141,7 +1141,7 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 *Target*: One attuned location<br />
 *Duration*: Instant<br />
 *Stamina Cost*: 10000, minus 200 per level to a minimum of 6000<br />
-*Channeling Time*: 200 moves, minus 5.5 moves per level to a minimum of 75. Attunement takes 8 hours, minus 30 minutes per power level of Gateway to a minimum of 30 minutes<br />
+*Channeling Time*: 200 moves, minus 5.5 moves per level to a minimum of 75. Attunement takes 8 hours, minus 20 minutes per power level of Gateway to a minimum of 30 minutes<br />
 *Effects*: Transport yourself through the Nether to an attuned location. This power works at any distance.  You may have a number of destinations simultaneously equal to 1 + 1 per 3 levels of Gateway (2.5 levels if you have the Good Memory trait, 4 levels if you have the Forgetful trait).<br />
 *Prerequisites*: Farstep 10, Extended Stride 10 <br />
 

--- a/data/mods/MindOverMatter/powers/teleportation_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_eoc.json
@@ -124,7 +124,8 @@
       {
         "u_message": "You have successfully memorized the local area, and may now return to it with your powers.",
         "type": "good"
-      }
+      },
+      "u_cancel_activity"
     ]
   },
   {
@@ -216,7 +217,7 @@
       { "u_assign_activity": "ACT_PSI_TELEPORTER_ATTUNING", "duration": "8 hours" },
       {
         "run_eocs": "EOC_TELEPORT_GATEWAY_ATTUNE_01_SUCCESS",
-        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1080), 0, 27000)" ] }
+        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1200), 0, 27000)" ] }
       }
     ]
   },
@@ -275,7 +276,7 @@
       { "u_assign_activity": "ACT_PSI_TELEPORTER_ATTUNING", "duration": "8 hours" },
       {
         "run_eocs": "EOC_TELEPORT_GATEWAY_ATTUNE_02_SUCCESS",
-        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1080), 0, 27000)" ] }
+        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1200), 0, 27000)" ] }
       }
     ]
   },
@@ -334,7 +335,7 @@
       { "u_assign_activity": "ACT_PSI_TELEPORTER_ATTUNING", "duration": "8 hours" },
       {
         "run_eocs": "EOC_TELEPORT_GATEWAY_ATTUNE_03_SUCCESS",
-        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1080), 0, 27000)" ] }
+        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1200), 0, 27000)" ] }
       }
     ]
   },
@@ -393,7 +394,7 @@
       { "u_assign_activity": "ACT_PSI_TELEPORTER_ATTUNING", "duration": "8 hours" },
       {
         "run_eocs": "EOC_TELEPORT_GATEWAY_ATTUNE_04_SUCCESS",
-        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1080), 0, 27000)" ] }
+        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1200), 0, 27000)" ] }
       }
     ]
   },
@@ -452,7 +453,7 @@
       { "u_assign_activity": "ACT_PSI_TELEPORTER_ATTUNING", "duration": "8 hours" },
       {
         "run_eocs": "EOC_TELEPORT_GATEWAY_ATTUNE_05_SUCCESS",
-        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1080), 0, 27000)" ] }
+        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1200), 0, 27000)" ] }
       }
     ]
   },
@@ -511,7 +512,7 @@
       { "u_assign_activity": "ACT_PSI_TELEPORTER_ATTUNING", "duration": "8 hours" },
       {
         "run_eocs": "EOC_TELEPORT_GATEWAY_ATTUNE_06_SUCCESS",
-        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1080), 0, 27000)" ] }
+        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1200), 0, 27000)" ] }
       }
     ]
   },
@@ -570,7 +571,7 @@
       { "u_assign_activity": "ACT_PSI_TELEPORTER_ATTUNING", "duration": "8 hours" },
       {
         "run_eocs": "EOC_TELEPORT_GATEWAY_ATTUNE_07_SUCCESS",
-        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1080), 0, 27000)" ] }
+        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1200), 0, 27000)" ] }
       }
     ]
   },
@@ -629,7 +630,7 @@
       { "u_assign_activity": "ACT_PSI_TELEPORTER_ATTUNING", "duration": "8 hours" },
       {
         "run_eocs": "EOC_TELEPORT_GATEWAY_ATTUNE_08_SUCCESS",
-        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1080), 0, 27000)" ] }
+        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1200), 0, 27000)" ] }
       }
     ]
   },
@@ -688,7 +689,7 @@
       { "u_assign_activity": "ACT_PSI_TELEPORTER_ATTUNING", "duration": "8 hours" },
       {
         "run_eocs": "EOC_TELEPORT_GATEWAY_ATTUNE_09_SUCCESS",
-        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1080), 0, 27000)" ] }
+        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1200), 0, 27000)" ] }
       }
     ]
   },
@@ -747,7 +748,7 @@
       { "u_assign_activity": "ACT_PSI_TELEPORTER_ATTUNING", "duration": "8 hours" },
       {
         "run_eocs": "EOC_TELEPORT_GATEWAY_ATTUNE_10_SUCCESS",
-        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1080), 0, 27000)" ] }
+        "time_in_future": { "math": [ "28800 - clamp(( u_spell_level('teleport_gateway') * 1200), 0, 27000)" ] }
       }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Gateway now auto-ends activity, attunes slightly faster, documention fixed"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Two reports on Discord. One that the documentation on Gateway was outdated, the other that the attunement activity does not cancel when attunement completes.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `u_cancel_activity` to the end of the attunement EoC, making it automatically stop when completed.

Slightly reduce the time that attuning to an area takes and correct the documentation.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Attunement to a destination now automatically ends
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
