### PR TITLE
Check transforming items for consistency wrt cables

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -433,7 +433,7 @@ std::string iuse_transform::get_name() const
     return iuse_actor::get_name();
 }
 
-void iuse_transform::finalize( const itype_id &source )
+void iuse_transform::finalize( const itype_id &my_item_type )
 {
     if( !item::type_is_defined( target ) && target_group.is_empty() ) {
         debugmsg( "Invalid transform target: %s", target.c_str() );
@@ -448,7 +448,7 @@ void iuse_transform::finalize( const itype_id &source )
         // transform uses migration pocket if not
     }
 
-    if( source.obj().can_use( "link_up" ) ) {
+    if( my_item_type.obj().can_use( "link_up" ) ) {
         // The linkage logic currently assumes that the links persist
         // through transformation, and fails pretty badly (segfaults)
         // if that happens to not be the case.
@@ -457,7 +457,7 @@ void iuse_transform::finalize( const itype_id &source )
         // but we don't have any of those implemented right now, so the check stays.
         if( !target.obj().can_use( "link_up" ) ) {
             debugmsg( "Item %s has link_up action, yet transforms into %s which doesn't.",
-                      source.c_str(), target.c_str() );
+                      my_item_type.c_str(), target.c_str() );
         }
     }
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -433,7 +433,7 @@ std::string iuse_transform::get_name() const
     return iuse_actor::get_name();
 }
 
-void iuse_transform::finalize( const itype_id & )
+void iuse_transform::finalize( const itype_id &source )
 {
     if( !item::type_is_defined( target ) && target_group.is_empty() ) {
         debugmsg( "Invalid transform target: %s", target.c_str() );
@@ -446,6 +446,19 @@ void iuse_transform::finalize( const itype_id & )
 
         // todo: check contents fit container?
         // transform uses migration pocket if not
+    }
+
+    if( source.obj().can_use( "link_up" ) ) {
+        // The linkage logic currently assumes that the links persist
+        // through transformation, and fails pretty badly (segfaults)
+        // if that happens to not be the case.
+        // It is not unreasonable to want items that violate this assumption (one example is
+        // the infamous Apple mouse which cannot be operated while charging),
+        // but we don't have any of those implemented right now, so the check stays.
+        if( !target.obj().can_use( "link_up" ) ) {
+            debugmsg( "Item %s has link_up action, yet transforms into %s which doesn't.",
+                      source.c_str(), target.c_str() );
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Check that transformed-into items have plug_in action when the transformed-from item does, and complain if that's not the case.

Prevents #78535-like issues from reoccuring

#### Describe the solution

Add the aforementioned check to `iuse_transform::finalize`

#### Describe alternatives you've considered

Make transform logic smarter and do (*handwave*) something meaningful when a plugged-in item transforms into unpluggable one. But i don't have a use case to support, and that's more work so maybe some other day.

#### Testing

Compiled, loaded game, no errors.
Reverted #78537 loaded game, got error, as explected.
Changed the transform target of a cell phone into `"asdfsdfsfda"`, loaded the game, got a bunch of errors as expected, and no segfaults

#### Additional context
N/A