### PR TITLE
Jsonify water boiling and other temperature effects on the item

### DIFF
--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -1500,6 +1500,11 @@
     "container": "bottle_plastic",
     "sealed": false,
     "delete": { "flags": [ "DECAYS_IN_AIR" ] },
+    "temperature_effects": [{
+      "temperature_above": "373 K",
+      "transform": "water_clean",
+      "remove_poison": true
+    }],
     "contamination": [ { "disease": "highly_contaminated_food", "probability": 0.1 }, { "disease": "bad_food", "probability": 1 } ]
   },
   {
@@ -1508,7 +1513,8 @@
     "copy-from": "water",
     "name": { "str_sp": "murky water" },
     "description": "Water, the stuff of life.  This water looks like it has quite a bit of life in it in fact, and not the good kind.  You should filter and sterilize it if you want to drink it.",
-    "quench": 30,
+    "temperature_effects": [],
+    "quench": 30,    
     "parasites": 5,
     "contamination": [ { "disease": "highly_contaminated_food", "probability": 100 } ]
   },

--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -1500,11 +1500,7 @@
     "container": "bottle_plastic",
     "sealed": false,
     "delete": { "flags": [ "DECAYS_IN_AIR" ] },
-    "temperature_effects": [{
-      "temperature_above": "373 K",
-      "transform": "water_clean",
-      "remove_poison": true
-    }],
+    "temperature_effects": [ { "temperature_above": "373 K", "transform": "water_clean", "remove_poison": true } ],
     "contamination": [ { "disease": "highly_contaminated_food", "probability": 0.1 }, { "disease": "bad_food", "probability": 1 } ]
   },
   {
@@ -1513,8 +1509,8 @@
     "copy-from": "water",
     "name": { "str_sp": "murky water" },
     "description": "Water, the stuff of life.  This water looks like it has quite a bit of life in it in fact, and not the good kind.  You should filter and sterilize it if you want to drink it.",
-    "temperature_effects": [],
-    "quench": 30,    
+    "temperature_effects": [  ],
+    "quench": 30,
     "parasites": 5,
     "contamination": [ { "disease": "highly_contaminated_food", "probability": 100 } ]
   },

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3502,6 +3502,14 @@ Weakpoints only match if they share the same id, so it's important to define the
   "recipe": "paste_nut_mill_10_1"            // Reference to the recipe that performs the task. The syntax is <product name>_mill_<source amount>_<product amount>. The recipe is then defined as a normal recipe for the source with the product as its result and an id_suffix of "mill_X_Y". 
                                              // See data/json/recipes/food/milling.json for such recipes. Can also use "milling": { "into": "null", "recipe": "" } to override milling from a copied base item.
 },
+"temperature_effects": [{           // Optional. Specifies certain effects happening to the item when it reaches certain internal temperature thresholds.
+                                    // Holds an array of objects
+    "temperature_above": "373 K",   // Temperature needs to be at least this high for the effect to happen.
+    "temperature_below": "0 K",     // Temperature needs to be at least this low for the effect to happen.
+                                    // Exactly one of temperature_above and temperature_below must be set.
+    "transform": "water_clean",     // The item id that we transform into upon reaching the temperature. Boiling water gives clean water, as an example.
+    "remove_poison": true           // Whether we should remove poison from comestible item. Defaults to false.
+}],
 "explode_in_fire": true,                     // Should the item explode if set on fire
 "nanofab_template_group": "nanofab_recipes", // This item is nanofabricator recipe, and point to itemgroup with items, that it could possibly contain; require nanofab_template_group
 "template_requirements": "nanofabricator",   // `requirement`, that needed to craft any of this templates; used as "one full requirememt per 250 ml of item's volume" - item with volume 750 ml would require three times of `requirement`, item of 2L - eight times of `requirement`

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -109,9 +109,6 @@ constexpr units::temperature freezer = units::from_celsius( -5 ); // -5 Celsius
 
 // Temperature in which water freezes.
 constexpr units::temperature freezing = units::from_celsius( 0 ); // 0 Celsius
-
-// Temperature in which water boils.
-constexpr units::temperature boiling = units::from_celsius( 100 ); // 100 Celsius
 } // namespace temperatures
 
 // Slowest speed at which a gun can be aimed.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13225,8 +13225,8 @@ void item::set_temp_flags( units::temperature new_temperature, float freeze_perc
     const islot_temperature_effects *te_data = type->temperature_effects_data.get();
     if( te_data != nullptr ) {
         for( const temperature_effect &eff : te_data->effects ) {
-            if( eff.temperature_above.has_value() && eff.temperature_above.value() <= new_temperature ||
-                eff.temperature_below.has_value() && eff.temperature_below.value() >= new_temperature
+            if( ( eff.temperature_above.has_value() && eff.temperature_above.value() <= new_temperature ) ||
+                ( eff.temperature_below.has_value() && eff.temperature_below.value() >= new_temperature )
               ) {
                 if( eff.transform_into ) {
                     convert( eff.transform_into );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -833,8 +833,9 @@ void Item_factory::finalize_post( itype &obj )
                 debugmsg( "Exactly one of temperature_above and temperature_above must be set in %s temperature_effects",
                           obj.id.str() );
             }
-            if( !eff.transform_into.is_valid() ) {
-                debugmsg( "%s is not a valid item id (in %s temperature_effects)", obj.id.str() );
+            if( eff.transform_into.is_null() || !eff.transform_into.is_valid() ) {
+                debugmsg( "'%s' is not a valid item id (in %s temperature_effects)",
+                          eff.transform_into.c_str(), obj.id.str() );
             }
         }
     }

--- a/src/itype.h
+++ b/src/itype.h
@@ -1204,7 +1204,7 @@ class islot_milling
         void deserialize( const JsonObject &jo );
 };
 
-struct temperature_effect{
+struct temperature_effect {
     std::optional<units::temperature> temperature_above;
     std::optional<units::temperature> temperature_below;
 
@@ -1215,8 +1215,7 @@ struct temperature_effect{
     void load( const JsonObject &jo );
 };
 
-struct islot_temperature_effects
-{
+struct islot_temperature_effects {
     std::vector<temperature_effect> effects;
 };
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -1204,6 +1204,22 @@ class islot_milling
         void deserialize( const JsonObject &jo );
 };
 
+struct temperature_effect{
+    std::optional<units::temperature> temperature_above;
+    std::optional<units::temperature> temperature_below;
+
+    itype_id transform_into;
+    bool remove_poison = false;
+
+    bool was_loaded = false;
+    void load( const JsonObject &jo );
+};
+
+struct islot_temperature_effects
+{
+    std::vector<temperature_effect> effects;
+};
+
 struct memory_card_info {
     float data_chance;
     itype_id on_read_convert_to;
@@ -1260,6 +1276,7 @@ struct itype {
         cata::value_ptr<islot_seed> seed;
         cata::value_ptr<relic> relic_data;
         cata::value_ptr<islot_milling> milling_data;
+        cata::value_ptr<islot_temperature_effects> temperature_effects_data;
         /*@}*/
 
         /** Action to take BEFORE the item is placed on map. If it returns non-zero, item won't be placed. */

--- a/src/itype.h
+++ b/src/itype.h
@@ -1228,6 +1228,14 @@ struct itype {
 
         using FlagsSetType = std::set<flag_id>;
 
+    protected:
+        // private because is should only be accessed through itype::nname!
+        // nname() is used for display purposes
+        translation name = no_translation( "none" );
+
+    public:
+        translation description; // Flavor text
+
         /**
          * Slots for various item type properties. Each slot may contain a valid pointer or null, check
          * this before using it.
@@ -1390,14 +1398,6 @@ struct itype {
         // How should the item explode
         explosion_data explosion;
 
-        translation description; // Flavor text
-
-    protected:
-        // private because is should only be accessed through itype::nname!
-        // nname() is used for display purposes
-        translation name = no_translation( "none" );
-
-    public:
         // Total of item's material portions (materials->second)
         int mat_portion_total = 0;
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -1245,7 +1245,7 @@ struct itype {
         using FlagsSetType = std::set<flag_id>;
 
     protected:
-        // private because is should only be accessed through itype::nname!
+        // private because it should only be accessed through itype::nname!
         // nname() is used for display purposes
         translation name = no_translation( "none" );
 


### PR DESCRIPTION
#### Summary
Infrastructure "Jsonify water boiling and other temperature effects on the item"

#### Purpose of change

I have long known that I can turn `water` into `clean water` by crafting (`&`) it - using some heat and a container suited for boiling. 
But just today I have found out that I don't actually need to spend time watching the kettle boil! I can just put it *into* the fire, go away, come back some time later to nice `clean water` waiting for me. This is great!

However, to my bigger surprise this auto-boiling handling is hardcoded in C++ and only works for `water`->`clean water` specifically.

I thought that hardcode is bad, and JSON is good and set to move the logic into JSON (and perhaps apply it to more different use cases!).

#### Describe the solution

Add a new field to item json (and the deserialization thereof). I'll copy-paste the new docs:
```json5
"temperature_effects": [{           // Optional. Specifies certain effects happening to the item when it reaches certain internal temperature thresholds.
                                    // Holds an array of objects
    "temperature_above": "373 K",   // Temperature needs to be at least this high for the effect to happen.
    "temperature_below": "0 K",     // Temperature needs to be at least this low for the effect to happen.
                                    // Exactly one of temperature_above and temperature_below must be set.
    "transform": "water_clean",     // The item id that we transform into upon reaching the temperature. Boiling water gives clean water, as an example.
    "remove_poison": true           // Whether we should remove poison from comestible item. Defaults to false.
}],
```

Utilize this freshly added field for `water` to `transform` it into `water_clean` at `373 K` and `remove_poison`.

Change the hardcoded water transformation to instead iterate these `temperature_effect`s and execute any of those that get triggered.

Remove the mentions of `"water"`, `"water_clean"` from `item.cpp` and `units::temperature boiling` from codebase.

#### Describe alternatives you've considered

- leave things be and be sad about hardcode
- reject and remove auto-water-boiling altogether, embrace tradition
- do something even more extensive and handle freezing/freezeburn via the same system, somehow.
- do something even more extensive and handle full phase transitions properly (ice<->water<->steam or perhaps butter<->buter(liquid) )

#### Testing

Made a firepit, set it on fire, put in a pot, filled it with water, waited for an hour, checked back, saw `clean water (hot)`
Temporarily changed the water json to transform water into `cooking_oil` instead, repeated the above steps, saw `vegetable cooking oil (hot)`

#### Additional context

Honestly, there's not too much use of the system beyond specifically water->clean water transformation. The only others I could think of were:

- Cooking meat and eggs. Great idea! Does not work in practice because *for some reason* dropping a chunk of meat into a firepit immediately sets its temperature to ~~1.5K~~ 1.5KK, i.e. 1500 kelvin, making it instantly cooked. I have not spent time debugging this further.
- transforming plastic items into "plastic chunks" at high temperatures but that's already handled by the burn code
- bricking electronics at high temps, but idk how i feel about that one
- bricking various mutagens or other medical thingies (flu shot?) at high temps - I kinda like the idea, but I don't have enough experience with those to make a good call.
- Turning eggs (fert.) into eggs (unfert.) when they freeze. Little to no practical value, apart from slightly thinning out bird population (why are they laying eggs in freezing temps i have no idea). Also, looking closer, I don't see a good way to control fertilization status of an individual egg item - it seems to be bound to the overall item type instead.
- Something about lye making? Milk curdling?
- More general phase transition of items (aforementioned ice<->water<->steam, or butter<->melted butter), buuut... 1) i dread having to deal with code handling liquid items in non-waterproof pockets and 2) perhaps that's better defined on the `material` rather than `item` level?
- Perhaps Magiclysm can do some funny alchemy with this...

So this whole PR is just for clean-water un-hardcoding. For now.


(P.s.: driveby change - i've moved `itype::name` field to be the first field in the struct to make debugging in VS less agonizing. No behavior change, no save compat issues or anything of that sort)