### PR TITLE
Fix vehicle_turret test

### DIFF
--- a/data/mods/TEST_DATA/behaviour_test.json
+++ b/data/mods/TEST_DATA/behaviour_test.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "test_seedling",
+    "method": "json",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "sealed_item": { " ": { "items": { "item": "farming_seeds", "chance": 100 }, "furniture": "f_plant_seedling" } }
+    }
+  }
+]

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -29,6 +29,8 @@ static const itype_id itype_sandwich_cheese_grilled( "sandwich_cheese_grilled" )
 static const itype_id itype_sweater( "sweater" );
 static const itype_id itype_water( "water" );
 
+static const nested_mapgen_id nested_mapgen_test_seedling( "test_seedling" );
+
 static const string_id<behavior::node_t> behavior_node_t_npc_needs( "npc_needs" );
 
 namespace behavior
@@ -228,7 +230,18 @@ TEST_CASE( "check_monster_behavior_tree_locust", "[monster][behavior]" )
     SECTION( "Special Attack EAT_CROP" ) {
         test_monster.set_special( "EAT_CROP", 0 );
         CHECK( monster_goals.tick( &oracle ) == "idle" );
-        here.furn_set( monster_location, furn_id( "f_plant_seedling" ) );
+
+        // Gross but I couldn't figure out how to place a sealed item without manual mapgen and the mapgen helper version doesn't let you specify rel_ms and adding that as a defaulted arg breaks the templated manual_mapgen()...
+        const tripoint_abs_ms abs_pos = here.getglobal( monster_location );
+        tripoint_abs_omt pos;
+        point_omt_ms pos_rel;
+        std::tie( pos, pos_rel ) = project_remain<coords::omt>( abs_pos );
+        tinymap tm;
+        tm.load( pos, true );
+        mapgendata md( pos, *tm.cast_to_map(), 0.0f, calendar::turn, nullptr );
+        const auto &ptr = nested_mapgens[nested_mapgen_test_seedling].funcs().pick();
+        ( *ptr )->nest( md, tripoint_rel_ms( rebase_rel( pos_rel ), 0 ), "test" );
+
         CHECK( monster_goals.tick( &oracle ) == "EAT_CROP" );
         test_monster.set_special( "EAT_CROP", 1 );
         CHECK( monster_goals.tick( &oracle ) == "idle" );

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -139,8 +139,10 @@ void clear_basecamps()
 void clear_map( int zmin, int zmax )
 {
     map &here = get_map();
-    // Reset z level to 0
-    here.load( tripoint_abs_sm( here.get_abs_sub().xy(), 0 ), false );
+    if( const tripoint_abs_sm &abs_sub = here.get_abs_sub(); abs_sub.z() != 0 ) {
+        // Reset z level to 0
+        here.load( tripoint_abs_sm( abs_sub.xy(), 0 ), false );
+    }
     // Clearing all z-levels is rather slow, so just clear the ones I know the
     // tests use for now.
     for( int z = zmin; z <= zmax; ++z ) {

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -139,6 +139,8 @@ void clear_basecamps()
 void clear_map( int zmin, int zmax )
 {
     map &here = get_map();
+    // Reset z level to 0
+    here.load( tripoint_abs_sm( here.get_abs_sub().xy(), 0 ), false );
     // Clearing all z-levels is rather slow, so just clear the ones I know the
     // tests use for now.
     for( int z = zmin; z <= zmax; ++z ) {

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -85,14 +85,10 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
 TEST_CASE( "conjoined_vehicles", "[vehicle]" )
 {
     map &here = get_map();
-    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 40, 40, here.get_abs_sub().z() ),
-                      0_degrees );
-    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 42, 42, here.get_abs_sub().z() ),
-                      0_degrees );
-    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 44, 44, here.get_abs_sub().z() ),
-                      45_degrees );
-    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 48, 44, here.get_abs_sub().z() ),
-                      45_degrees );
+    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 40, 40, 0 ), 0_degrees );
+    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 42, 42, 0 ), 0_degrees );
+    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 44, 44, 0 ), 45_degrees );
+    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 48, 44, 0 ), 45_degrees );
 }
 
 TEST_CASE( "crater_crash", "[vehicle]" )
@@ -100,7 +96,7 @@ TEST_CASE( "crater_crash", "[vehicle]" )
     tinymap here;
     tripoint_abs_omt map_location( 30, 30, 0 );
     here.load( map_location, true );
-    here.add_vehicle( vehicle_prototype_car, { 14, 11, here.get_abs_sub().z() }, 45_degrees );
+    here.add_vehicle( vehicle_prototype_car, { 14, 11, 0 }, 45_degrees );
     const tripoint_omt_ms end{ 20, 20, 0 };
     for( tripoint_omt_ms cursor = { 14, 4, 0 }; cursor.y() < end.y(); cursor.y()++ ) {
         for( cursor.x() = 4; cursor.x() < end.x(); cursor.x()++ ) {
@@ -118,7 +114,8 @@ TEST_CASE( "split_vehicle_during_mapgen", "[vehicle]" )
 
     tinymap tm;
     // Wherever the main map is, create this tinymap outside its bounds.
-    tm.load( project_to<coords::omt>( here.get_abs_sub() ) + tripoint_rel_omt( 10, 10, 0 ), false );
+    tm.load( tripoint_abs_omt( project_to<coords::omt>( here.get_abs_sub().xy() ), 0 )
+             + tripoint_rel_omt( 10, 10, 0 ), false );
     wipe_map_terrain( tm.cast_to_map() );
     REQUIRE( tm.get_vehicles().empty() );
     tripoint_omt_ms vehicle_origin{ 14, 14, 0 };

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -47,19 +47,13 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
     clear_avatar();
     map &here = get_map();
     Character &player_character = get_player_character();
-    const tripoint_bub_ms veh_pos( 65, 65, here.get_abs_sub().z() );
-    // TODO: Get rid of this set of tests when the cause of this test randomly failing has been eliminated.
-    REQUIRE( veh_pos.z() == 0 );
-    REQUIRE( vehicle_prototype_test_turret_rig.is_valid() );
-    REQUIRE( here.inbounds( veh_pos ) );
-    // TODO: End
+    const tripoint_bub_ms veh_pos( 65, 65, 0 );
 
     for( const vpart_info *turret_vpi : all_turret_types() ) {
         SECTION( turret_vpi->name() ) {
-            vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos, 270_degrees, 0, 0,
-                                             false );
+            vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos, 270_degrees, 0, 2,
+                                             false, true );
             REQUIRE( veh );
-            veh->unlock();
 
             const int turr_idx = veh->install_part( point_rel_ms::zero, turret_vpi->id );
             REQUIRE( turr_idx >= 0 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
(Hopefully) Fixes #78539
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Courtesy of #78540 it appears the issue is just it using the wrong z level
Attempts to prevent this issue from occurring in future by setting the z level of the map to 0 in clear_map(). I'm not aware what the performance cost of that is and it may want removing if the tests start taking noticeably longer on average
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran the test suite locally with the same arguments as the CI run without anything obvious sticking out
`All tests passed (28669103 assertions in 1102 test cases)`
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
