### PR TITLE
filter: use the O(log(n)) instead of O(n) method

### DIFF
--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -34,10 +34,8 @@ static std::function< bool( const item & )> can_contain_filter( std::string_view
     }
     // copy the debug item template (itype), put it on heap so the itype pointer doesn't move
     // TODO unique_ptr
-    std::shared_ptr<itype> filtered_fake_itype = std::make_shared<itype>( *( item_controller->find( [](
-    const itype & i ) {
-        return i.get_id() == STATIC( itype_id( "debug_item_search" ) );
-    } )[0] ) );
+    std::shared_ptr<itype> filtered_fake_itype = std::make_shared<itype>
+            ( *item_controller->find_template( STATIC( itype_id( "debug_item_search" ) ) ) );
     item filtered_fake_item = set_function( filtered_fake_itype.get(), uni );
     // pass to keep filtered_fake_itype valid until lambda capture is destroyed (while item is needed)
     return [filtered_fake_itype, filtered_fake_item]( const item & i ) {

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -209,9 +209,8 @@ static Unit can_contain_filter( std::string_view hint, std::string_view txt, Uni
         popup( err.what() );
     }
     // copy the debug item template (itype)
-    filtered_fake_itype = itype( *( item_controller->find( []( const itype & i ) {
-        return i.get_id() == STATIC( itype_id( "debug_item_search" ) );
-    } )[0] ) );
+    filtered_fake_itype = itype( *item_controller->find_template( STATIC(
+                                     itype_id( "debug_item_search" ) ) ) );
     return uni;
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

I used O(n) and complicated the way of getting `itype` from `itype_id` in:
 - #78519
 - #78384 / #78518

#### Describe the solution

Use the correct and faster method.

#### Describe alternatives you've considered

#### Testing

1. Launch the game.
2. Try filters `L:122 cm` in AIM and crafting GUI.
3. Observe: They throw no errors and work.

#### Additional context

 - I mentioned it should be faster in the additional context of #78519 but I didn't know I just missed the correct method.
