### PR TITLE
Canonical test ordering - lexicographic

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -185,7 +185,7 @@ jobs:
     - name: Run tests
       if: ${{ github.ref_name != 'master' }}
       run: |
-          .\Cataclysm-test-vcpkg-static-Release-x64.exe --min-duration 20 --rng-seed time --order lex
+          .\Cataclysm-test-vcpkg-static-Release-x64.exe --min-duration 20 --rng-seed time --order lex --wait-for-keypress exit
 
     - name: Dump disk usage logs if job failed
       if: failure()

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -185,7 +185,7 @@ jobs:
     - name: Run tests
       if: ${{ github.ref_name != 'master' }}
       run: |
-          .\Cataclysm-test-vcpkg-static-Release-x64.exe --min-duration 20 --rng-seed time
+          .\Cataclysm-test-vcpkg-static-Release-x64.exe --min-duration 20 --rng-seed time --order lex
 
     - name: Dump disk usage logs if job failed
       if: failure()

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -51,7 +51,7 @@ function run_test
     prefix=$2
     shift 2
 
-    $WINE "$test_bin" --min-duration 0.2 --use-colour yes --rng-seed time $EXTRA_TEST_OPTS "$@" 2>&1 | sed -E 's/^(::(warning|error|debug)[^:]*::)?/\1'"$prefix"'/' || test_exit_code="${PIPESTATUS[0]}" sed_exit_code="${PIPESTATUS[1]}"
+    $WINE "$test_bin" --min-duration 0.2 --use-colour yes --rng-seed time --order lex $EXTRA_TEST_OPTS "$@" 2>&1 | sed -E 's/^(::(warning|error|debug)[^:]*::)?/\1'"$prefix"'/' || test_exit_code="${PIPESTATUS[0]}" sed_exit_code="${PIPESTATUS[1]}"
     if [ "$test_exit_code" -ne "0" ]
     then
         echo "$3test exited with code $test_exit_code"

--- a/build-scripts/gha_test_only.sh
+++ b/build-scripts/gha_test_only.sh
@@ -7,7 +7,7 @@ set -exo pipefail
 
 num_jobs=3
 parallel_opts="--verbose --linebuffer"
-cata_test_opts="--min-duration 20 --use-colour yes --rng-seed time ${EXTRA_TEST_OPTS}"
+cata_test_opts="--min-duration 20 --use-colour yes --rng-seed time --order lex ${EXTRA_TEST_OPTS}"
 [ -z $NUM_TEST_JOBS ] && num_test_jobs=3 || num_test_jobs=$NUM_TEST_JOBS
 
 # We might need binaries installed via pip, so ensure that our personal bin dir is on the PATH

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1967,7 +1967,7 @@ bool Character::is_dead_state() const
         }
     }
     if( !has_vitals ) {
-        debugmsg( _( "WARNING!  Player has no vital part and is invincible." ) );
+        debugmsg( _( "WARNING!  %s has no vital part and is invincible." ), disp_name() );
     }
     return false;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ if (BUILD_TESTING)
         foreach(n args IN ZIP_LISTS _n _args)
             add_test(NAME cata.tiles.gha-${n}
                     COMMAND cata_test-tiles --min-duration 20 --use-colour yes --rng-seed time
-                    --user-dir=test_user_dir_${n} ${args}
+                    --order lex --user-dir=test_user_dir_${n} ${args}
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
             set_tests_properties(cata.tiles.gha-${n} PROPERTIES LABELS "gha")
         endforeach()

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -63,12 +63,12 @@ $(PCH_P): $(PCH_H)
 TEST_BATCHES = "crafting_skill_gain" "[slow]\ ~crafting_skill_gain" "~[slow]\ ~[.]"
 
 $(TEST_BATCHES): $(TEST_TARGET)
-	cd .. && tests/$(TEST_TARGET) --min-duration 0.2 --rng-seed time $@
+	cd .. && tests/$(TEST_TARGET) --min-duration 0.2 --rng-seed time --order lex $@
 
 check: $(TEST_TARGET) $(TEST_BATCHES)
 
 check-single: $(TEST_TARGET)
-	cd .. && tests/$(TEST_TARGET) --min-duration 0.2 --rng-seed time
+	cd .. && tests/$(TEST_TARGET) --min-duration 0.2 --rng-seed time --order lex
 
 clean: clean-pch
 	rm -rf *obj *objwin

--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -11,6 +11,7 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "options_helpers.h"
+#include "overmapbuffer.h"
 #include "player_helpers.h"
 #include "type_id.h"
 
@@ -112,7 +113,10 @@ TEST_CASE( "light_and_fine_detail_vision_mod", "[character][sight][light][vision
 TEST_CASE( "npc_light_and_fine_detail_vision_mod", "[character][npc][sight][light][vision]" )
 {
     Character &u = get_player_character();
-    standard_npc n( "Mr. Testerman" );
+    shared_ptr_fast<npc> guy = make_shared_fast<npc>();
+    overmap_buffer.insert_npc( guy );
+    g->load_npcs();
+    npc &n = *guy;
     n.set_body();
 
     clear_avatar();

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -331,7 +331,10 @@ TEST_CASE( "EOC_transform_line", "[eoc][timed_event]" )
 {
     clear_avatar();
     clear_map();
-    standard_npc npc( "Mr. Testerman" );
+    shared_ptr_fast<npc> guy = make_shared_fast<npc>();
+    overmap_buffer.insert_npc( guy );
+    npc &npc = *guy;
+    clear_character( npc );
     std::optional<tripoint> const dest = random_point( get_map(), []( tripoint const & p ) {
         return p.xy() != get_avatar().pos().xy();
     } );
@@ -1229,7 +1232,6 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     clear_map();
     npc &npc_dst_ranged = spawn_npc( target_pos.xy(), "thug" );
     for( loop = 0; loop < 1000; loop++ ) {
-        get_avatar().set_body();
         arm_shooter( get_avatar(), "shotgun_s" );
         get_avatar().recoil = 0;
         get_avatar().fire_gun( target_pos, 1, *get_avatar().get_wielded_item() );
@@ -1249,7 +1251,6 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     clear_map();
     monster &mon_dst_ranged = spawn_test_monster( "mon_zombie", target_pos );
     for( loop = 0; loop < 1000; loop++ ) {
-        get_avatar().set_body();
         arm_shooter( get_avatar(), "shotgun_s" );
         get_avatar().recoil = 0;
         get_avatar().fire_gun( mon_dst_ranged.pos_bub(), 1, *get_avatar().get_wielded_item() );

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -220,6 +220,8 @@ TEST_CASE( "player_get_dodge", "[player][melee][dodge]" )
 
     avatar &dummy = get_avatar();
     clear_character( dummy );
+    dodge_base_with_dex_and_skill( dummy, 10, 10 );
+    dummy.set_dodges_left( 1 );
 
     const float base_dodge = dummy.get_dodge_base();
 
@@ -241,6 +243,7 @@ TEST_CASE( "player_get_dodge_with_effects", "[player][melee][dodge][effect]" )
 
     avatar &dummy = get_avatar();
     clear_character( dummy );
+    dodge_base_with_dex_and_skill( dummy, 8, 4 );
 
     // Compare all effects against base dodge ability
     const float base_dodge = dummy.get_dodge_base();
@@ -263,6 +266,7 @@ TEST_CASE( "player_get_dodge_with_effects", "[player][melee][dodge][effect]" )
     }
 
     SECTION( "unstable footing: 1/4 dodge" ) {
+        // FIXME: Margin is flat instead of relative %.
         CHECK( dodge_with_effect( dummy, "bouldering" ) == Approx( base_dodge / 4 ).margin( 0.1f ) );
     }
 
@@ -298,6 +302,7 @@ TEST_CASE( "player_get_dodge_stamina_effects", "[player][melee][dodge][stamina]"
 {
     avatar &dummy = get_avatar();
     clear_character( dummy );
+    dodge_base_with_dex_and_skill( dummy, 8, 0 );
 
     SECTION( "8/8/8/8, no skills, unencumbered" ) {
         const int stamina_max = dummy.get_stamina_max();

--- a/tests/mongroup_test.cpp
+++ b/tests/mongroup_test.cpp
@@ -279,6 +279,9 @@ static void test_multi_spawn( const mtype_id &old_mon, int range, int min, int m
 {
     const int upgrade_attempts = 100;
     clear_avatar();
+    // make sure tested scenarios haven't messed with our start time
+    calendar::start_of_cataclysm = calendar::turn_zero;
+    calendar::start_of_game = calendar::turn_zero;
 
     for( int i = 0; i < upgrade_attempts; i++ ) {
         clear_map();

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -55,7 +55,7 @@ static const vproto_id vehicle_prototype_locked_as_hell_car( "locked_as_hell_car
 static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test,
         update_mapgen_id update_mapgen_id_to_apply )
 {
-    wipe_map_terrain();
+    clear_map();
     clear_vehicles();
     clear_avatar();
     Character &player = get_player_character();

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -1228,6 +1228,9 @@ TEST_CASE( "npc_arithmetic", "[npc_talk]" )
     d.add_topic( "TALK_TEST_ARITHMETIC" );
     gen_response_lines( d, 31 );
 
+    // make sure tested scenarios haven't messed with our start time
+    calendar::start_of_cataclysm = calendar::turn_zero;
+    calendar::start_of_game = calendar::turn_zero;
     calendar::turn = calendar::turn_zero;
     REQUIRE( calendar::turn == time_point( 0 ) );
     // "Sets time since cataclysm to 1."

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -338,6 +338,7 @@ TEST_CASE( "all_nutrition_starve_test", "[starve][slow]" )
     const bool print_tests = false;
     avatar &dummy = get_avatar();
     reset_time();
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
     clear_stomach( dummy );
     eat_all_nutrients( dummy );
     if( print_tests ) {

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -274,6 +274,7 @@ TEST_CASE( "Daily_solar_power", "[vehicle][power]" )
 
 TEST_CASE( "maximum_reverse_velocity", "[vehicle][power][reverse]" )
 {
+    clear_map();
     reset_player();
     build_test_map( ter_id( "t_pavement" ) );
     clear_vehicles();

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -16,6 +16,8 @@ static const vproto_id vehicle_prototype_cross_split_test( "cross_split_test" );
 
 TEST_CASE( "vehicle_split_section", "[vehicle]" )
 {
+    wipe_map_terrain();
+    clear_vehicles();
     map &here = get_map();
     Character &player_character = get_player_character();
     for( units::angle dir = 0_degrees; dir < 360_degrees; dir += vehicles::steer_increment ) {


### PR DESCRIPTION
#### Summary
Infrastructure "Tests now run in a guaranteed order (lexicographic) by default (can be overriden with cli argument)"

#### Purpose of change

* https://github.com/CleverRaven/Cataclysm-DDA/pull/78567#issuecomment-2543187162 exposed some good questions. What *is* the ordering in how our tests are run? Apparently it's partly determined by linking order, which makes reproducing some test fails impossible without using the same link order (e.g. being on the same commit and using the same build method).

This is an unnecessary impediment when we're trying to diagnose test failures.

#### Describe the solution
Run the tests in lexicographical order instead.

Note that this works across subsets of tests. As an example I used the tests from #78524 which are DECLARED in the order
NPC rules (avoid doors)
NPC rules (close doors)
NPC rules (avoid locks)

By default that is the order they are run in (declared order). Running the tests with the arguments of `"[npc_rules]" --wait-for-keypress exit --order lex` instead gets us the following order:
NPC rules (avoid doors)
NPC rules (avoid locks)
NPC rules (close doors)

So the desired order(lexicographical) remains consistent even when additional arguments are provided, or subsets of tests are run.

#### Describe alternatives you've considered
We could run in the provided `rand` order instead. I initially thought this would be useful if we needed to specify subsets of tests to run, but lexicographical has us covered there already.

`Since the random order was made subset stable, we promise that given the same random seed, the order of test cases will be the same across different platforms, as long as the tests were compiled against identical version of Catch2. We reserve the right to change the relative order of tests cases between Catch2 versions, but it is unlikely to happen often.`

I thought random order might also be useful if we needed to shuffle the order of test cases *for some reason*, but the more I thought about it I failed to find any 'some reason'.

#### Testing
Works on my machine

Would like to see github CI all green before this is considered mergeable

#### Additional context

**There is a second, mostly-unrelated commit on this branch, intentionally.**

It enables `--wait-for-keypress exit` on MSVC builds, because it is really annoying that the default is to close the tests after being run.

This should only be the case when a human being manually runs the test (and only when using MSVC). It should NOT run when github tests does its auto magic, otherwise they'll get stuck waiting for a keypress that never comes.

If it turns out to be problematic... well that's why it's in a separate commit, we can just get rid of it.