### PR TITLE
Added test for morale check for ranged kill of unaware hostile bandit

### DIFF
--- a/tests/morale_test.cpp
+++ b/tests/morale_test.cpp
@@ -2,10 +2,12 @@
 #include <iosfwd>
 #include <utility>
 
+#include "avatar.h"
 #include "bodypart.h"
 #include "cata_catch.h"
 #include "character.h"
 #include "item.h"
+#include "map_helpers.h"
 #include "morale.h"
 #include "npc.h"
 #include "player_helpers.h"
@@ -28,6 +30,7 @@ static const morale_type morale_wet( "morale_wet" );
 
 static const trait_id trait_BADTEMPER( "BADTEMPER" );
 static const trait_id trait_CENOBITE( "CENOBITE" );
+static const trait_id trait_DEBUG_CLAIRVOYANCE( "DEBUG_CLAIRVOYANCE" );
 static const trait_id trait_FLOWERS( "FLOWERS" );
 static const trait_id trait_MASOCHIST( "MASOCHIST" );
 static const trait_id trait_OPTIMISTIC( "OPTIMISTIC" );
@@ -240,6 +243,35 @@ TEST_CASE( "player_morale_kills_hostile_bandit", "[player_morale]" )
         player.mod_moves( 1000 );
         player.melee_attack( badguy, true );
     }
+    REQUIRE( m.get_total_negative_value() == 0 );
+}
+
+TEST_CASE( "player_morale_ranged_kill_of_unaware_hostile_bandit", "[player_morale]" )
+{
+    clear_avatar();
+    avatar &player = get_avatar();
+    // Set the time to midnight to ensure the bandit doesn't notice the player.
+    set_time( calendar::turn_zero + 0_hours );
+    // Give us a clairvoyance to clearly see the target in the night.
+    player.set_mutation( trait_DEBUG_CLAIRVOYANCE );
+    player_morale &m = *player.morale;
+    const tripoint_bub_ms bandit_pos = player.pos_bub() + ( point::east * 2 );
+    npc &badguy = spawn_npc( bandit_pos.xy(), "thug" );
+    badguy.set_all_parts_hp_cur( 1 );
+    CHECK( m.get_total_positive_value() == 0 );
+    CHECK( m.get_total_negative_value() == 0 );
+    CHECK( badguy.guaranteed_hostile() == true );
+    CHECK( badguy.sees( player.pos() ) == false );
+    for( size_t loop = 0; loop < 1000; loop++ ) {
+        player.set_body();
+        arm_shooter( player, "shotgun_s" );
+        player.recoil = 0;
+        player.fire_gun( bandit_pos, 1, *player.get_wielded_item() );
+        if( badguy.is_dead_state() ) {
+            break;
+        }
+    }
+    CHECK( badguy.is_dead_state() == true );
     REQUIRE( m.get_total_negative_value() == 0 );
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
@RenechCDDA in #78371 revealed to me that there's a test for morale for killing hostile bandits, but that test is conducting a melee attack versus already angry hostile bandit. I decided to add a test for stealth-ranged-killing of unaware hostile bandit.

#### Describe the solution
Added a test. Set the time to midnight so bandit won't be able to see us, and give an avatar a debug clairvoyance to clearly see the target to simulate player having some sort of night vision mutation.

#### Describe alternatives you've considered
None.

#### Testing
Locally test is completed without any error. Let's see what online tests say.

#### Additional context
This is my first time I'm writing a test, I hope I've done everything right.