### PR TITLE
[Magiclysm] Add feral technomancers

### DIFF
--- a/data/mods/Magiclysm/Spells/feral_wizards.json
+++ b/data/mods/Magiclysm/Spells/feral_wizards.json
@@ -262,5 +262,52 @@
     "effect_str": "effect_feral_stormshaper_stormhammer_cooldown",
     "min_duration": 12000,
     "max_duration": 36000
+  },
+  {
+    "id": "feral_technomancer_summon_mage_blade_spell",
+    "type": "SPELL",
+    "name": { "str": "Call Mage Blade Monster", "//~": "NO_I18N" },
+    "description": { "str": "Summon a mage blade by effect.  You should never see this.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "max_level": 20,
+    "flags": [ "SOMATIC", "NO_LEGS" ],
+    "shape": "blast",
+    "effect": "attack",
+    "effect_str": "effect_feral_technomancer_mage_blade",
+    "extra_effects": [ { "id": "feral_technomancer_mage_blade_internal_cooldown", "hit_self": true } ],
+    "min_duration": 36000,
+    "max_duration": 1080000,
+    "duration_increment": 36000
+  },
+  {
+    "id": "feral_technomancer_mage_blade_internal_cooldown",
+    "type": "SPELL",
+    "name": { "str": "Call Mage Blade Monster Cooldown", "//~": "NO_I18N" },
+    "description": {
+      "str": "Designed to make any future mage blades have a much longer cooldown than the first one so that dispelling them is tactically advantageous.  You shouldn't see this.",
+      "//~": "NO_I18N"
+    },
+    "valid_targets": [ "self" ],
+    "flags": [ "SOMATIC", "NO_LEGS", "RANDOM_DURATION" ],
+    "shape": "blast",
+    "effect": "attack",
+    "effect_str": "effect_feral_technomancer_mage_blade_cooldown",
+    "min_duration": 12000,
+    "max_duration": 36000
+  },
+  {
+    "id": "feral_technomancer_bless_spell",
+    "type": "SPELL",
+    "name": { "str": "Bless Self", "//~": "NO_I18N" },
+    "description": { "str": "Cast bless on yourself if you're a feral.  You should never see this.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "max_level": 20,
+    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS" ],
+    "shape": "blast",
+    "effect": "attack",
+    "effect_str": "effect_feral_technomancer_bless",
+    "min_duration": 6000,
+    "max_duration": 30000,
+    "duration_increment": 1200
   }
 ]

--- a/data/mods/Magiclysm/Spells/feral_wizards.json
+++ b/data/mods/Magiclysm/Spells/feral_wizards.json
@@ -388,7 +388,6 @@
     "max_level": 25,
     "min_damage": 1,
     "max_damage": 2,
-    "damage_increment": 0.15,
     "min_range": 1,
     "max_range": 5,
     "range_increment": 0.25,

--- a/data/mods/Magiclysm/Spells/feral_wizards.json
+++ b/data/mods/Magiclysm/Spells/feral_wizards.json
@@ -296,6 +296,38 @@
     "max_duration": 36000
   },
   {
+    "id": "feral_technomancer_summon_mage_armor_spell",
+    "type": "SPELL",
+    "name": { "str": "Call Mage Armor Monster", "//~": "NO_I18N" },
+    "description": { "str": "Summon a mage armor by effect.  You should never see this.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "max_level": 20,
+    "flags": [ "SOMATIC", "NO_LEGS" ],
+    "shape": "blast",
+    "effect": "attack",
+    "effect_str": "effect_feral_technomancer_mage_armor",
+    "extra_effects": [ { "id": "feral_technomancer_mage_armor_internal_cooldown", "hit_self": true } ],
+    "min_duration": 36000,
+    "max_duration": 1080000,
+    "duration_increment": 36000
+  },
+  {
+    "id": "feral_technomancer_mage_armor_internal_cooldown",
+    "type": "SPELL",
+    "name": { "str": "Call Mage Armor Monster Cooldown", "//~": "NO_I18N" },
+    "description": {
+      "str": "Designed to make any future mage armor have a much longer cooldown than the first one so that dispelling them is tactically advantageous.  You shouldn't see this.",
+      "//~": "NO_I18N"
+    },
+    "valid_targets": [ "self" ],
+    "flags": [ "SOMATIC", "NO_LEGS", "RANDOM_DURATION" ],
+    "shape": "blast",
+    "effect": "attack",
+    "effect_str": "effect_feral_technomancer_mage_armor_cooldown",
+    "min_duration": 12000,
+    "max_duration": 36000
+  },
+  {
     "id": "feral_technomancer_bless_spell",
     "type": "SPELL",
     "name": { "str": "Bless Self", "//~": "NO_I18N" },

--- a/data/mods/Magiclysm/Spells/feral_wizards.json
+++ b/data/mods/Magiclysm/Spells/feral_wizards.json
@@ -312,6 +312,22 @@
     "duration_increment": 36000
   },
   {
+    "id": "feral_high_technomancer_summon_mage_armor_spell",
+    "type": "SPELL",
+    "name": { "str": "Call Mage Armor Monster", "//~": "NO_I18N" },
+    "description": { "str": "Summon a mage armor by effect.  You should never see this.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "max_level": 20,
+    "flags": [ "SOMATIC", "NO_LEGS" ],
+    "shape": "blast",
+    "effect": "attack",
+    "effect_str": "effect_feral_high_technomancer_mage_armor",
+    "extra_effects": [ { "id": "feral_technomancer_mage_armor_internal_cooldown", "hit_self": true } ],
+    "min_duration": 36000,
+    "max_duration": 1080000,
+    "duration_increment": 36000
+  },
+  {
     "id": "feral_technomancer_mage_armor_internal_cooldown",
     "type": "SPELL",
     "name": { "str": "Call Mage Armor Monster Cooldown", "//~": "NO_I18N" },
@@ -341,5 +357,61 @@
     "min_duration": 6000,
     "max_duration": 30000,
     "duration_increment": 1200
+  },
+  {
+    "id": "feral_invisibility",
+    "type": "SPELL",
+    "name": { "str": "Feral invisibilty", "//~": "NO_I18N" },
+    "description": { "str": "Cast invisibility on yourself if you're a feral.  You should never see this.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "effect": "attack",
+    "effect_str": "invisibility",
+    "shape": "blast",
+    "flags": [ "ENHANCEMENT_SPELL", "SILENT", "SOMATIC", "RANDOM_DURATION" ],
+    "min_duration": 1250,
+    "max_duration": 6000,
+    "duration_increment": 250
+  },
+  {
+    "id": "feral_animated_blade",
+    "type": "SPELL",
+    "name": { "str": "Feral Animated Blade", "//~": "NO_I18N" },
+    "description": {
+      "str": "This spell conjures flying animated blades that will cut you down to size.  Into small pieces that is.",
+      "//~": "NO_I18N"
+    },
+    "valid_targets": [ "hostile", "ground" ],
+    "flags": [ "SOMATIC", "VERBAL", "CONCENTRATE", "RANDOM_DAMAGE", "RANDOM_DURATION", "HOSTILE_SUMMON" ],
+    "effect": "summon",
+    "effect_str": "mon_animated_blade_feral",
+    "shape": "blast",
+    "max_level": 25,
+    "min_damage": 1,
+    "max_damage": 2,
+    "damage_increment": 0.15,
+    "min_range": 1,
+    "max_range": 5,
+    "range_increment": 0.25,
+    "min_aoe": 3,
+    "max_aoe": 3,
+    "min_duration": 2000,
+    "max_duration": 5000
+  },
+  {
+    "id": "feral_synaptic_stimulation",
+    "type": "SPELL",
+    "name": { "str": "Feral Synaptic Stimulation", "//~": "NO_I18N" },
+    "description": { "str": "This spell stimulates the synapses in your brain if you're a feral.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "flags": [ "ENHANCEMENT_SPELL", "NO_LEGS", "VERBAL", "NO_PROJECTILE" ],
+    "effect": "attack",
+    "effect_str": "synaptic_stim",
+    "shape": "blast",
+    "spell_class": "TECHNOMANCER",
+    "energy_source": "MANA",
+    "max_level": 20,
+    "min_duration": 6000,
+    "max_duration": 180000,
+    "duration_increment": 8700
   }
 ]

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1528,6 +1528,67 @@
     "desc": [ "" ]
   },
   {
+    "type": "effect_type",
+    "id": "effect_feral_technomancer_mage_blade",
+    "name": [ { "str": "Wielding Mage Blade", "//~": "NO_I18N" } ],
+    "desc": [ { "str": "You are a monster wielding a mage blade, as this effect indicates.", "//~": "NO_I18N" } ],
+    "show_in_info": true
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_feral_technomancer_mage_blade_cooldown",
+    "//": "Longer internal cooldown for feral mage blade",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_feral_technomancer_mage_armor",
+    "name": [ "Mage Armor" ],
+    "desc": [ { "str": "You are a monster wearing conjured armor, as this effect indicates.", "//~": "NO_I18N" } ],
+    "enchantments": [
+      {
+        "incoming_damage_mod": [
+          { "type": "cut", "add": -15 },
+          { "type": "bash", "add": -15 },
+          { "type": "stab", "add": -15 },
+          { "type": "bullet", "add": -15 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_feral_technomancer_mage_armor_cooldown",
+    "//": "Longer internal cooldown for feral mage armor",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_feral_technomancer_bless",
+    "name": [ "Bless" ],
+    "desc": [ { "str": "You get bonuses to hit and dodge because monsters don't have stats.", "//~": "NO_I18N" } ],
+    "base_mods": { "hit_mod": [ 2 ], "dodge_mod": [ 2 ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_feral_high_technomancer_mage_armor",
+    "name": [ "Mage Armor" ],
+    "desc": [ { "str": "You are a monster wearing conjured armor, as this effect indicates.", "//~": "NO_I18N" } ],
+    "enchantments": [
+      {
+        "values": [ { "value": "LUMINATION", "add": 15 } ],
+        "incoming_damage_mod": [
+          { "type": "cut", "add": -30 },
+          { "type": "bash", "add": -30 },
+          { "type": "stab", "add": -30 },
+          { "type": "bullet", "add": -30 }
+        ]
+      }
+    ]
+  },
+  {
     "id": "effect_dispel_magic",
     "type": "effect_type",
     "name": [ "Dispel Magic" ],
@@ -1599,6 +1660,8 @@
       "effect_technomancer_gain_electronics_computer",
       "effect_technomancer_pain_ignore",
       "effect_feral_stormshaper_stormhammer",
+      "effect_feral_technomancer_mage_blade",
+      "effect_feral_technomancer_mage_armor",
       "enchant_windrun_monster"
     ]
   },
@@ -1749,6 +1812,8 @@
       "effect_burning_trail",
       "effect_ring_of_flight",
       "effect_feral_stormshaper_stormhammer",
+      "effect_feral_technomancer_mage_blade",
+      "effect_feral_technomancer_mage_armor",
       "enchant_windrun_monster"
     ]
   },

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1546,6 +1546,7 @@
     "id": "effect_feral_technomancer_mage_armor",
     "name": [ "Mage Armor" ],
     "desc": [ { "str": "You are a monster wearing conjured armor, as this effect indicates.", "//~": "NO_I18N" } ],
+    "show_in_info": true,
     "enchantments": [
       {
         "incoming_damage_mod": [
@@ -1569,6 +1570,7 @@
     "id": "effect_feral_technomancer_bless",
     "name": [ "Bless" ],
     "desc": [ { "str": "You get bonuses to hit and dodge because monsters don't have stats.", "//~": "NO_I18N" } ],
+    "show_in_info": true,
     "base_mods": { "hit_mod": [ 2 ], "dodge_mod": [ 2 ] }
   },
   {
@@ -1576,6 +1578,7 @@
     "id": "effect_feral_high_technomancer_mage_armor",
     "name": [ "Mage Armor" ],
     "desc": [ { "str": "You are a monster wearing conjured armor, as this effect indicates.", "//~": "NO_I18N" } ],
+    "show_in_info": true,
     "enchantments": [
       {
         "values": [ { "value": "LUMINATION", "add": 15 } ],
@@ -1662,6 +1665,7 @@
       "effect_feral_stormshaper_stormhammer",
       "effect_feral_technomancer_mage_blade",
       "effect_feral_technomancer_mage_armor",
+      "effect_feral_technomancer_bless",
       "enchant_windrun_monster"
     ]
   },
@@ -1814,6 +1818,7 @@
       "effect_feral_stormshaper_stormhammer",
       "effect_feral_technomancer_mage_blade",
       "effect_feral_technomancer_mage_armor",
+      "effect_feral_technomancer_bless",
       "enchant_windrun_monster"
     ]
   },

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -315,6 +315,7 @@
     "apply_message": "Your mind accelerates.",
     "remove_message": "Your mind returns to normal speed.",
     "rating": "good",
+    "show_in_info": true,
     "base_mods": { "dex_mod": [ 4 ], "int_mod": [ 4 ], "speed_mod": [ 30 ] }
   },
   {

--- a/data/mods/Magiclysm/harvest_dissect.json
+++ b/data/mods/Magiclysm/harvest_dissect.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "dissect_mon_feral_technomancer",
+    "type": "harvest",
+    "message": "You search for any salvageable hardware in what's left of the technomancer.  They have not given much care to their bionics, but some of the electronics look surprisingly intact.",
+    "entries": [
+      {
+        "drop": "feral_technomancer_CBM_harvest",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED", "FILTHY" ],
+        "faults": [ "fault_bionic_salvaged" ],
+        "base_num": [ 0, 1 ],
+        "scale_num": [ 0.1, 0.4 ],
+        "max": 2
+      },
+      {
+        "drop": "feral_technomancer_CBM_harvest_power",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED", "FILTHY" ],
+        "faults": [ "fault_bionic_salvaged" ],
+        "base_num": [ 0, 2 ],
+        "scale_num": [ 0.1, 0.6 ],
+        "max": 5
+      }
+    ]
+  },
+  {
+    "id": "dissect_mon_feral_high_technomancer",
+    "type": "harvest",
+    "message": "You search for any salvageable hardware in what's left of the technomancer.  They have not given much care to their bionics, but some of the electronics look surprisingly intact.",
+    "entries": [
+      {
+        "drop": "feral_high_technomancer_CBM_harvest",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED", "FILTHY" ],
+        "faults": [ "fault_bionic_salvaged" ],
+        "base_num": [ 0, 2 ],
+        "scale_num": [ 0.1, 0.6 ],
+        "max": 4
+      },
+      {
+        "drop": "feral_high_technomancer_CBM_harvest_power",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED", "FILTHY" ],
+        "faults": [ "fault_bionic_salvaged" ],
+        "base_num": [ 0, 2 ],
+        "scale_num": [ 0.1, 0.6 ],
+        "max": 5
+      }
+    ]
+  }
+]

--- a/data/mods/Magiclysm/itemgroups/death_drops.json
+++ b/data/mods/Magiclysm/itemgroups/death_drops.json
@@ -125,6 +125,22 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "mon_feral_technomancer_death_drops",
+    "entries": [
+      {
+        "distribution": [ { "group": "enchanted_rings_common", "prob": 80 }, { "group": "enchanted_rings_uncommon", "prob": 20 } ],
+        "prob": 4
+      },
+      { "distribution": [ { "item": "robe_wizard", "prob": 50 }, { "item": "robe", "prob": 50 } ], "prob": 20 },
+      { "item": "crystallized_mana", "prob": 20, "charges": [ 1, 5 ] },
+      { "group": "default_zombie_clothes", "prob": 100 },
+      { "group": "enchanted_combat_items", "prob": 25 },
+      { "group": "technomancer_items", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "feral_goblin_death_drops",
     "entries": [
       { "group": "default_zombie_clothes", "prob": 100, "custom-flags": [ "UNDERSIZE" ], "damage": [ 1, 4 ] },

--- a/data/mods/Magiclysm/itemgroups/harvest_cbm.json
+++ b/data/mods/Magiclysm/itemgroups/harvest_cbm.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "feral_technomancer_CBM_harvest_power",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "feral_technomancer_CBM_harvest_charging_tools", "prob": 25 },
+      {
+        "distribution": [ { "item": "bio_power_storage", "prob": 90 }, { "item": "bio_power_storage_mkII", "prob": 10 } ],
+        "prob": 50
+      },
+      { "item": "bio_power_storage", "prob": 20 },
+      { "item": "burnt_out_bionic", "prob": 50 }
+    ]
+  },
+  {
+    "id": "feral_technomancer_CBM_harvest_charging_tools",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "bio_ethanol", "prob": 50 },
+      { "item": "bio_fuel_cell_gasoline", "prob": 50 },
+      { "item": "bio_fuel_cell_blood", "prob": 5 },
+      { "item": "bio_torsionratchet", "prob": 200 }
+    ]
+  },
+  {
+    "id": "feral_technomancer_CBM_harvest",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "Nothing combat-oriented, this was a civilian",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "bio_alarm", "prob": 20 },
+          { "item": "bio_flashlight", "prob": 30 },
+          { "item": "bio_geiger", "prob": 10 },
+          { "item": "bio_jointservo", "prob": 15 },
+          { "item": "bio_lockpick", "prob": 30 },
+          { "item": "bio_tattoo_led", "prob": 40 },
+          { "item": "burnt_out_bionic", "prob": 60 }
+        ],
+        "prob": 90
+      },
+      {
+        "distribution": [
+          { "item": "bio_tools", "prob": 15 },
+          { "item": "bio_electrokit", "prob": 15 },
+          { "item": "bio_magnet", "prob": 15 },
+          { "item": "bio_soporific", "prob": 20 },
+          { "item": "bio_sunglasses", "prob": 25 },
+          { "item": "bio_syringe", "prob": 10 },
+          { "item": "bio_tattoo_led", "prob": 40 },
+          { "item": "burnt_out_bionic", "prob": 50 }
+        ],
+        "prob": 30
+      },
+      {
+        "distribution": [
+          { "group": "Zomborg_CBM_harvest_stat_enhancements", "prob": 100 },
+          { "group": "Zomborg_CBM_harvest_sensors", "prob": 60 },
+          { "group": "Zomborg_CBM_harvest_expensive_utilities", "prob": 1 }
+        ],
+        "prob": 30
+      },
+      {
+        "distribution": [
+          { "group": "Zomborg_CBM_harvest_stat_enhancements", "prob": 30 },
+          { "group": "Zomborg_CBM_harvest_sensors", "prob": 60 },
+          { "group": "Zomborg_CBM_harvest_expensive_utilities", "prob": 1 }
+        ],
+        "prob": 20
+      }
+    ]
+  },
+  {
+    "id": "feral_high_technomancer_CBM_harvest_power",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "feral_technomancer_CBM_harvest_charging_tools", "prob": 25 },
+      {
+        "distribution": [ { "item": "bio_power_storage", "prob": 75 }, { "item": "bio_power_storage_mkII", "prob": 25 } ],
+        "prob": 50
+      },
+      { "item": "bio_power_storage", "prob": 20 },
+      { "item": "burnt_out_bionic", "prob": 30 }
+    ]
+  },
+  {
+    "id": "feral_high_technomancer_CBM_harvest",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "Nothing combat-oriented, this was a civilian",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "bio_alarm", "prob": 20 },
+          { "item": "bio_flashlight", "prob": 30 },
+          { "item": "bio_geiger", "prob": 10 },
+          { "item": "bio_jointservo", "prob": 15 },
+          { "item": "bio_lockpick", "prob": 30 },
+          { "item": "bio_tattoo_led", "prob": 40 },
+          { "item": "burnt_out_bionic", "prob": 30 }
+        ],
+        "prob": 90
+      },
+      {
+        "distribution": [
+          { "item": "bio_tools", "prob": 15 },
+          { "item": "bio_electrokit", "prob": 15 },
+          { "item": "bio_magnet", "prob": 15 },
+          { "item": "bio_soporific", "prob": 20 },
+          { "item": "bio_sunglasses", "prob": 25 },
+          { "item": "bio_syringe", "prob": 10 },
+          { "item": "bio_tattoo_led", "prob": 40 },
+          { "item": "burnt_out_bionic", "prob": 30 }
+        ],
+        "prob": 30
+      },
+      {
+        "distribution": [
+          { "group": "Zomborg_CBM_harvest_stat_enhancements", "prob": 50 },
+          { "group": "Zomborg_CBM_harvest_sensors", "prob": 20 },
+          { "group": "Zomborg_CBM_harvest_expensive_utilities", "prob": 1 }
+        ],
+        "prob": 30
+      },
+      {
+        "distribution": [
+          { "group": "Zomborg_CBM_harvest_stat_enhancements", "prob": 30 },
+          { "group": "Zomborg_CBM_harvest_sensors", "prob": 60 }
+        ],
+        "prob": 20
+      }
+    ]
+  }
+]

--- a/data/mods/Magiclysm/monstergroups.json
+++ b/data/mods/Magiclysm/monstergroups.json
@@ -202,26 +202,38 @@
   {
     "type": "monstergroup",
     "name": "GROUP_LAB",
-    "monsters": [ { "monster": "mon_feral_lab_magician", "weight": 25, "cost_multiplier": 5 } ]
+    "monsters": [
+      { "monster": "mon_feral_lab_magician", "weight": 25, "cost_multiplier": 5 },
+      { "monster": "mon_feral_technomancer", "weight": 8, "cost_multiplier": 5 },
+      { "monster": "mon_feral_technomancer_enhanced", "weight": 2, "cost_multiplier": 10 }
+    ]
   },
   {
     "type": "monstergroup",
     "name": "GROUP_LAB_SURFACE",
     "monsters": [
       { "monster": "mon_feral_lab_magician", "weight": 25, "cost_multiplier": 5 },
+      { "monster": "mon_feral_technomancer", "weight": 8, "cost_multiplier": 5 },
+      { "monster": "mon_feral_technomancer_enhanced", "weight": 2, "cost_multiplier": 10 },
       { "monster": "mon_feral_radiation_mage", "weight": 2, "cost_multiplier": 10 }
     ]
   },
   {
     "type": "monstergroup",
     "name": "GROUP_MICROLAB",
-    "monsters": [ { "monster": "mon_feral_lab_magician", "weight": 2, "cost_multiplier": 5 } ]
+    "monsters": [
+      { "monster": "mon_feral_lab_magician", "weight": 2, "cost_multiplier": 5 },
+      { "monster": "mon_feral_technomancer", "weight": 2, "cost_multiplier": 5 },
+      { "monster": "mon_feral_technomancer_enhanced", "weight": 1, "cost_multiplier": 50 }
+    ]
   },
   {
     "type": "monstergroup",
     "name": "GROUP_LAB_RESEARCHERS",
     "monsters": [
       { "monster": "mon_feral_lab_magician", "weight": 20, "cost_multiplier": 5 },
+      { "monster": "mon_feral_technomancer", "weight": 10, "cost_multiplier": 5 },
+      { "monster": "mon_feral_technomancer_enhanced", "weight": 2, "cost_multiplier": 10 },
       { "monster": "mon_feral_radiation_mage", "weight": 1, "cost_multiplier": 10 }
     ]
   },

--- a/data/mods/Magiclysm/monstergroups.json
+++ b/data/mods/Magiclysm/monstergroups.json
@@ -80,7 +80,9 @@
       { "monster": "mon_feral_magus", "weight": 50, "cost_multiplier": 2 },
       { "monster": "mon_feral_magus_enhanced", "weight": 5, "cost_multiplier": 4 },
       { "monster": "mon_feral_stormshaper", "weight": 50, "cost_multiplier": 2 },
-      { "monster": "mon_feral_stormshaper_enhanced", "weight": 5, "cost_multiplier": 4 }
+      { "monster": "mon_feral_stormshaper_enhanced", "weight": 5, "cost_multiplier": 4 },
+      { "monster": "mon_feral_technomancer", "weight": 50, "cost_multiplier": 2 },
+      { "monster": "mon_feral_technomancer_enhanced", "weight": 5, "cost_multiplier": 4 }
     ]
   },
   {

--- a/data/mods/Magiclysm/monsters/feral_wizards.json
+++ b/data/mods/Magiclysm/monsters/feral_wizards.json
@@ -1098,5 +1098,125 @@
         }
       ]
     }
+  },
+  {
+    "id": "mon_feral_technomancer_enhanced",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_wizard_default",
+    "name": { "str": "feral high technomancer" },
+    "description": "At first seeming like just another feral, a closer look shows the implanted metal amid the flesh, a tell-tale sign of a technomancer.  Their movements are more controlled than most of the other ferals, but they still have bloodshot eyes.",
+    "symbol": "@",
+    "color": "dark_gray",
+    "dissect": "dissect_mon_feral_high_technomancer",
+    "death_drops": {
+      "subtype": "collection",
+      "items": [ { "group": "enchanted_combat_items", "prob": 30 }, { "group": "mon_feral_technomancer_death_drops", "prob": 100 } ]
+    },
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_high_technomancer_summon_mage_blade",
+          "type": "spell",
+          "spell_data": { "id": "feral_technomancer_summon_mage_blade_spell", "min_level": 5, "hit_self": true },
+          "cooldown": 40,
+          "condition": {
+            "and": [
+              { "not": { "u_has_effect": "effect_feral_technomancer_mage_blade_cooldown" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "not": { "u_has_flag": "MUTE" } }
+            ]
+          },
+          "monster_message": "%1$s raises an arm and a blade of glowing light materializes."
+        },
+        {
+          "id": "feral_high_technomancer_summon_mage_armor",
+          "type": "spell",
+          "spell_data": { "id": "feral_high_technomancer_summon_mage_armor_spell", "min_level": 5, "hit_self": true },
+          "cooldown": 40,
+          "condition": {
+            "and": [
+              { "not": { "u_has_effect": "effect_feral_technomancer_mage_armor_cooldown" } },
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } }
+            ]
+          },
+          "monster_message": "%1$s raises an arm and a suit of glowing armor appears on their body."
+        },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "feral_high_technomancer_mageblade_attack",
+          "cooldown": 2,
+          "move_cost": 100,
+          "accuracy": 5,
+          "damage_max_instance": [ { "damage_type": "cut", "amount": 11 }, { "damage_type": "light", "amount": 32 } ],
+          "condition": { "u_has_effect": "effect_feral_technomancer_mage_blade" },
+          "hit_dmg_u": "%1$s hits your %2$s with a blade of light!",
+          "hit_dmg_npc": "%1$s hits <npcname>'s %2$s with a blade of light!",
+          "miss_msg_u": "%1$s swings a blade of light at you, but you dodge!",
+          "miss_msg_npc": "%1$s swings a blade of light at <npcname>, but they dodge!",
+          "no_dmg_msg_u": "%1$s swings a blade of light at your %2$s, but it does no damage.",
+          "no_dmg_msg_npc": "%1$s swings a blade of light at <npcname>'s %2$s, but it does no damage."
+        },
+        {
+          "id": "feral_technomancer_lase",
+          "type": "spell",
+          "spell_data": { "id": "laze", "min_level": 4 },
+          "cooldown": 20,
+          "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+          "monster_message": "%1$s points and fires a beam of light!"
+        },
+        {
+          "id": "feral_technomancer_bless",
+          "type": "spell",
+          "spell_data": { "id": "feral_technomancer_bless_spell", "min_level": 2, "hit_self": true },
+          "cooldown": 20,
+          "condition": {
+            "and": [
+              { "not": { "u_has_effect": "effect_feral_technomancer_bless" } },
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } }
+            ]
+          },
+          "monster_message": "%1$s mutters some words and their body is limned in light."
+        },
+        {
+          "id": "feral_high_technomancer_invisibility",
+          "type": "spell",
+          "spell_data": { "id": "feral_invisibility", "min_level": 2, "hit_self": true },
+          "cooldown": 20,
+          "condition": {
+            "and": [
+              { "not": { "u_has_effect": "effect_feral_technomancer_bless" } },
+              { "math": [ "u_val('morale') <= -20" ] },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } }
+            ]
+          },
+          "monster_message": "%1$s makes a gesture and disappears."
+        },
+        {
+          "id": "feral_high_technomancer_summon_blade",
+          "type": "spell",
+          "spell_data": { "id": "feral_animated_blade", "min_level": 10 },
+          "cooldown": 65,
+          "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
+          "monster_message": "%1$s gestures and swords appear out of thin air!"
+        },
+        {
+          "id": "feral_high_technomancer_synaptic_stim",
+          "type": "spell",
+          "spell_data": { "id": "feral_synaptic_stimulation", "min_level": 4, "hit_self": true },
+          "cooldown": 40,
+          "condition": {
+            "and": [
+              { "not": { "u_has_effect": "synaptic_stim" } },
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } }
+            ]
+          },
+          "monster_message": "%1$s mutters some words and begins moving much faster."
+        }
+      ]
+    }
   }
 ]

--- a/data/mods/Magiclysm/monsters/feral_wizards.json
+++ b/data/mods/Magiclysm/monsters/feral_wizards.json
@@ -1104,7 +1104,7 @@
     "type": "MONSTER",
     "copy-from": "mon_feral_wizard_default",
     "name": { "str": "feral high technomancer" },
-    "description": "At first seeming like just another feral, a closer look shows the implanted metal amid the flesh, a tell-tale sign of a technomancer.  Their movements are more controlled than most of the other ferals, but they still have bloodshot eyes.",
+    "description": "This feral human has obvious bionic enhancements in what would have been the sign of a powerful technomancer before the Cataclysm.  They move with much more speed and grace than most feral humans you've seen.",
     "symbol": "@",
     "color": "dark_gray",
     "dissect": "dissect_mon_feral_high_technomancer",

--- a/data/mods/Magiclysm/monsters/feral_wizards.json
+++ b/data/mods/Magiclysm/monsters/feral_wizards.json
@@ -996,5 +996,117 @@
     "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER", "EATS" ],
     "armor": { "electric": 40 },
     "special_when_hit": [ "ZAPBACK", 100 ]
+  },
+  {
+    "id": "mon_feral_technomancer",
+    "type": "MONSTER",
+    "name": { "str": "feral technomancer" },
+    "description": "At first seeming like just another feral, a closer look shows the implanted metal amid the flesh, a tell-tale sign of a technomancer.  Their movements are more controlled than most of the other ferals, but they still have bloodshot eyes.",
+    "default_faction": "zombie",
+    "looks_like": "chud",
+    "bodytype": "human",
+    "species": [ "FERAL" ],
+    "volume": "62500 ml",
+    "weight": "81500 g",
+    "hp": 84,
+    "speed": 100,
+    "material": [ "flesh" ],
+    "symbol": "@",
+    "color": "yellow",
+    "aggression": 30,
+    "morale": 100,
+    "melee_skill": 3,
+    "melee_dice": 1,
+    "melee_dice_sides": 6,
+    "weakpoint_sets": [ "wps_humanoid_body" ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
+    "dodge": 1,
+    "harvest": "human",
+    "dissect": "dissect_mon_feral_technomancer",
+    "vision_day": 45,
+    "vision_night": 3,
+    "stomach_size": 700,
+    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
+    "special_attacks": [
+      {
+        "type": "monster_attack",
+        "attack_type": "melee",
+        "id": "feral_stormshaper_spell_lightning_blast",
+        "cooldown": 8,
+        "move_cost": 100,
+        "range": 9,
+        "accuracy": 4,
+        "damage_max_instance": [ { "damage_type": "electric", "amount": 20 } ],
+        "dodgeable": true,
+        "blockable": false,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+        "hit_dmg_u": "%1$s gestures and sparks impact your %2$s!",
+        "hit_dmg_npc": "%1$s gestures and sparks impact <npcname>'s %2$s!",
+        "miss_msg_u": "%1$s gestures and you narrowly avoid a shower of sparks!",
+        "miss_msg_npc": "%1$s gestures and <npcname> narrowly avoids a shower of sparks!",
+        "no_dmg_msg_u": "%1$s gestures and your %2$s is impacted by a shower of sparks bolt, but they do no damage.",
+        "no_dmg_msg_npc": "%1$s gestures and <npcname>'s %2$s is impacted by a shower of sparks bolt, but they do no damage."
+      },
+      {
+        "id": "feral_stormshaper_wall_of_fog",
+        "type": "spell",
+        "spell_data": { "id": "stormshaper_wall_of_fog", "min_level": 5 },
+        "cooldown": 20,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+        "monster_message": "%1$s gestures and fog rapidly condenses out of the air!"
+      },
+      {
+        "id": "feral_stormshaper_shocking dash",
+        "type": "spell",
+        "spell_data": { "id": "shocking_dash", "min_level": 5 },
+        "cooldown": 25,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+        "monster_message": "%1$s surges forward in a burst of sparks."
+      },
+      {
+        "id": "feral_stormshaper_blinding_flash",
+        "type": "spell",
+        "spell_data": { "id": "blinding_flash", "min_level": 3 },
+        "cooldown": 45,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+        "monster_message": "%1$s makes a quick gesture and the air erupts into eye-searing light!"
+      },
+      {
+        "id": "feral_stormshaper_summon_stormhammer",
+        "type": "spell",
+        "spell_data": { "id": "feral_stormshaper_summon_stormhammer_spell", "min_level": 5, "hit_self": true },
+        "cooldown": 50,
+        "condition": {
+          "and": [
+            { "not": { "u_has_effect": "effect_feral_stormshaper_stormhammer_cooldown" } },
+            { "not": { "u_has_flag": "NO_SPELLCASTING" } }
+          ]
+        },
+        "monster_message": "%1$s snaps an arm out and a hammer made of lightning crackles into existence."
+      },
+      {
+        "type": "monster_attack",
+        "attack_type": "melee",
+        "id": "feral_stormshaper_stormhammer_attack",
+        "cooldown": 2,
+        "move_cost": 100,
+        "accuracy": 4,
+        "damage_max_instance": [ { "damage_type": "bash", "amount": 30 }, { "damage_type": "electric", "amount": 15 } ],
+        "condition": { "u_has_effect": "effect_feral_stormshaper_stormhammer" },
+        "hit_dmg_u": "%1$s stormhammers your %2$s!",
+        "hit_dmg_npc": "%1$s stormhammers <npcname>'s %2$s!",
+        "miss_msg_u": "%1$s tries to stormhammers you, but you dodge!",
+        "miss_msg_npc": "%1$s tries to stormhammer <npcname>, but they dodge!",
+        "no_dmg_msg_u": "%1$s stormhammers your %2$s, but they do no damage.",
+        "no_dmg_msg_npc": "%1$s stormhammers <npcname>'s %2$s, but they do no damage."
+      },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
+    "death_drops": "mon_feral_stormshaper_death_drops",
+    "zombify_into": "mon_zombie",
+    "fungalize_into": "mon_feral_human_pipe_fungal_infected",
+    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER", "EATS" ]
   }
 ]

--- a/data/mods/Magiclysm/monsters/feral_wizards.json
+++ b/data/mods/Magiclysm/monsters/feral_wizards.json
@@ -1,5 +1,26 @@
 [
   {
+    "id": "mon_feral_wizard_default",
+    "type": "MONSTER",
+    "copy-from": "mon_feral_human_pipe",
+    "//": "interstitial copy-from to edit flags and special attacks appropriately",
+    "special_attacks": [ [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "WARM",
+      "BASHES",
+      "GROUP_BASH",
+      "HUMAN",
+      "CAN_OPEN_DOORS",
+      "PATH_AVOID_DANGER",
+      "PATH_AVOID_FIRE",
+      "PRIORITIZE_TARGETS",
+      "EATS"
+    ]
+  },
+  {
     "id": "mon_feral_human_magician",
     "type": "MONSTER",
     "name": { "str": "feral wizard" },
@@ -1000,113 +1021,82 @@
   {
     "id": "mon_feral_technomancer",
     "type": "MONSTER",
+    "copy-from": "mon_feral_wizard_default",
     "name": { "str": "feral technomancer" },
     "description": "At first seeming like just another feral, a closer look shows the implanted metal amid the flesh, a tell-tale sign of a technomancer.  Their movements are more controlled than most of the other ferals, but they still have bloodshot eyes.",
-    "default_faction": "zombie",
-    "looks_like": "chud",
-    "bodytype": "human",
-    "species": [ "FERAL" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 84,
-    "speed": 100,
-    "material": [ "flesh" ],
     "symbol": "@",
-    "color": "yellow",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 3,
-    "melee_dice": 1,
-    "melee_dice_sides": 6,
-    "weakpoint_sets": [ "wps_humanoid_body" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "dodge": 1,
-    "harvest": "human",
+    "color": "dark_gray",
     "dissect": "dissect_mon_feral_technomancer",
-    "vision_day": 45,
-    "vision_night": 3,
-    "stomach_size": 700,
-    "path_settings": { "max_dist": 45, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
-    "special_attacks": [
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "feral_stormshaper_spell_lightning_blast",
-        "cooldown": 8,
-        "move_cost": 100,
-        "range": 9,
-        "accuracy": 4,
-        "damage_max_instance": [ { "damage_type": "electric", "amount": 20 } ],
-        "dodgeable": true,
-        "blockable": false,
-        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
-        "hit_dmg_u": "%1$s gestures and sparks impact your %2$s!",
-        "hit_dmg_npc": "%1$s gestures and sparks impact <npcname>'s %2$s!",
-        "miss_msg_u": "%1$s gestures and you narrowly avoid a shower of sparks!",
-        "miss_msg_npc": "%1$s gestures and <npcname> narrowly avoids a shower of sparks!",
-        "no_dmg_msg_u": "%1$s gestures and your %2$s is impacted by a shower of sparks bolt, but they do no damage.",
-        "no_dmg_msg_npc": "%1$s gestures and <npcname>'s %2$s is impacted by a shower of sparks bolt, but they do no damage."
-      },
-      {
-        "id": "feral_stormshaper_wall_of_fog",
-        "type": "spell",
-        "spell_data": { "id": "stormshaper_wall_of_fog", "min_level": 5 },
-        "cooldown": 20,
-        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
-        "monster_message": "%1$s gestures and fog rapidly condenses out of the air!"
-      },
-      {
-        "id": "feral_stormshaper_shocking dash",
-        "type": "spell",
-        "spell_data": { "id": "shocking_dash", "min_level": 5 },
-        "cooldown": 25,
-        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
-        "monster_message": "%1$s surges forward in a burst of sparks."
-      },
-      {
-        "id": "feral_stormshaper_blinding_flash",
-        "type": "spell",
-        "spell_data": { "id": "blinding_flash", "min_level": 3 },
-        "cooldown": 45,
-        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
-        "monster_message": "%1$s makes a quick gesture and the air erupts into eye-searing light!"
-      },
-      {
-        "id": "feral_stormshaper_summon_stormhammer",
-        "type": "spell",
-        "spell_data": { "id": "feral_stormshaper_summon_stormhammer_spell", "min_level": 5, "hit_self": true },
-        "cooldown": 50,
-        "condition": {
-          "and": [
-            { "not": { "u_has_effect": "effect_feral_stormshaper_stormhammer_cooldown" } },
-            { "not": { "u_has_flag": "NO_SPELLCASTING" } }
-          ]
+    "death_drops": "mon_feral_technomancer_death_drops",
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "feral_technomancer_summon_mage_blade",
+          "type": "spell",
+          "spell_data": { "id": "feral_technomancer_summon_mage_blade_spell", "min_level": 15, "hit_self": true },
+          "cooldown": 40,
+          "condition": {
+            "and": [
+              { "not": { "u_has_effect": "effect_feral_technomancer_mage_blade_cooldown" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+              { "not": { "u_has_flag": "MUTE" } }
+            ]
+          },
+          "monster_message": "%1$s raises an arm and a blade of glowing light materializes."
         },
-        "monster_message": "%1$s snaps an arm out and a hammer made of lightning crackles into existence."
-      },
-      {
-        "type": "monster_attack",
-        "attack_type": "melee",
-        "id": "feral_stormshaper_stormhammer_attack",
-        "cooldown": 2,
-        "move_cost": 100,
-        "accuracy": 4,
-        "damage_max_instance": [ { "damage_type": "bash", "amount": 30 }, { "damage_type": "electric", "amount": 15 } ],
-        "condition": { "u_has_effect": "effect_feral_stormshaper_stormhammer" },
-        "hit_dmg_u": "%1$s stormhammers your %2$s!",
-        "hit_dmg_npc": "%1$s stormhammers <npcname>'s %2$s!",
-        "miss_msg_u": "%1$s tries to stormhammers you, but you dodge!",
-        "miss_msg_npc": "%1$s tries to stormhammer <npcname>, but they dodge!",
-        "no_dmg_msg_u": "%1$s stormhammers your %2$s, but they do no damage.",
-        "no_dmg_msg_npc": "%1$s stormhammers <npcname>'s %2$s, but they do no damage."
-      },
-      [ "BROWSE", 100 ],
-      [ "EAT_FOOD", 100 ]
-    ],
-    "death_drops": "mon_feral_stormshaper_death_drops",
-    "zombify_into": "mon_zombie",
-    "fungalize_into": "mon_feral_human_pipe_fungal_infected",
-    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER", "EATS" ]
+        {
+          "id": "feral_technomancer_summon_mage_armor",
+          "type": "spell",
+          "spell_data": { "id": "feral_technomancer_summon_mage_armor_spell", "min_level": 15, "hit_self": true },
+          "cooldown": 40,
+          "condition": {
+            "and": [
+              { "not": { "u_has_effect": "effect_feral_technomancer_mage_armor_cooldown" } },
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } }
+            ]
+          },
+          "monster_message": "%1$s raises an arm and a suit of glowing armor appears on their body."
+        },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "feral_technomancer_mageblade_attack",
+          "cooldown": 2,
+          "move_cost": 100,
+          "accuracy": 5,
+          "damage_max_instance": [ { "damage_type": "cut", "amount": 11 }, { "damage_type": "light", "amount": 20 } ],
+          "condition": { "u_has_effect": "effect_feral_technomancer_mage_blade" },
+          "hit_dmg_u": "%1$s hits your %2$s with a blade of light!",
+          "hit_dmg_npc": "%1$s hits <npcname>'s %2$s with a blade of light!",
+          "miss_msg_u": "%1$s swings a blade of light at you, but you dodge!",
+          "miss_msg_npc": "%1$s swings a blade of light at <npcname>, but they dodge!",
+          "no_dmg_msg_u": "%1$s swings a blade of light at your %2$s, but it does no damage.",
+          "no_dmg_msg_npc": "%1$s swings a blade of light at <npcname>'s %2$s, but it does no damage."
+        },
+        {
+          "id": "feral_technomancer_lase",
+          "type": "spell",
+          "spell_data": { "id": "laze", "min_level": 2 },
+          "cooldown": 20,
+          "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+          "monster_message": "%1$s points and fires a beam of light!"
+        },
+        {
+          "id": "feral_technomancer_bless",
+          "type": "spell",
+          "spell_data": { "id": "feral_technomancer_bless_spell", "min_level": 2 },
+          "cooldown": 20,
+          "condition": {
+            "and": [
+              { "not": { "u_has_effect": "effect_feral_technomancer_bless" } },
+              { "not": { "u_has_flag": "MUTE" } },
+              { "not": { "u_has_flag": "NO_SPELLCASTING" } }
+            ]
+          },
+          "monster_message": "%1$s mutters some words and their body is limned in light."
+        }
+      ]
+    }
   }
 ]

--- a/data/mods/Magiclysm/monsters/feral_wizards.json
+++ b/data/mods/Magiclysm/monsters/feral_wizards.json
@@ -1033,7 +1033,7 @@
         {
           "id": "feral_technomancer_summon_mage_blade",
           "type": "spell",
-          "spell_data": { "id": "feral_technomancer_summon_mage_blade_spell", "min_level": 15, "hit_self": true },
+          "spell_data": { "id": "feral_technomancer_summon_mage_blade_spell", "min_level": 5, "hit_self": true },
           "cooldown": 40,
           "condition": {
             "and": [
@@ -1047,7 +1047,7 @@
         {
           "id": "feral_technomancer_summon_mage_armor",
           "type": "spell",
-          "spell_data": { "id": "feral_technomancer_summon_mage_armor_spell", "min_level": 15, "hit_self": true },
+          "spell_data": { "id": "feral_technomancer_summon_mage_armor_spell", "min_level": 5, "hit_self": true },
           "cooldown": 40,
           "condition": {
             "and": [
@@ -1085,7 +1085,7 @@
         {
           "id": "feral_technomancer_bless",
           "type": "spell",
-          "spell_data": { "id": "feral_technomancer_bless_spell", "min_level": 2 },
+          "spell_data": { "id": "feral_technomancer_bless_spell", "min_level": 2, "hit_self": true },
           "cooldown": 20,
           "condition": {
             "and": [

--- a/data/mods/Magiclysm/monsters/mics.json
+++ b/data/mods/Magiclysm/monsters/mics.json
@@ -66,6 +66,15 @@
     "armor": { "bash": 15, "cut": 15, "bullet": 15 }
   },
   {
+    "id": "mon_animated_blade_feral",
+    "type": "MONSTER",
+    "name": "animated blade",
+    "copy-from": "mon_animated_blade",
+    "description": "A conjured glowing longsword that darts and dodges around, slicing and cutting enemies into small pieces.",
+    "looks_like": "longsword",
+    "default_faction": "zombie"
+  },
+  {
     "id": "mon_battle_hologram",
     "type": "MONSTER",
     "name": "hologram",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add feral technomancers"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Continuing adding the feral mages, technomancers are next.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add feral technomancers and feral high technomancers. They can summon conjured weapons and armor, turn invisible (high), zap you, boost their speed (high), summon animated blades (high), buff their attributes, or shoot you with a magical laser beam. They are feral so there is no guarantee they will use these spells in any intelligent fashion.

Magiclysm's world has native CBMs invented by technomancers, so you can dissect these for CBMs. You probably won't find much interesting unless it's a high technomancer, but maybe you'll get lucky. Also your morale will be shot because these are people, not zombies.

Feral technomancers sometimes show up in labs--these are the kind of people that XEDRA would have recruited.

I also implemented the first part of making the feral wizards mostly copy-from, but just on the technomancers here. The other feral wizards will wait for another PR. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Monsters exist, spells work, they cast the spells and behave appropriately, and can be dissected for CBMs.

Since they have a speed buff, a hit/dodge buff, an armor buff, a buff that lets them hit you with a blade of light (does light damage, ignores physical armor), and can shoot you with a laser, you probably want to silence them or dispel their buffs.

Or the classic wizard countermeasure--shoot them in the head before they notice you.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There should probably be augmentation clinics in Magiclysm, but only in major cities.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
