### PR TITLE
Various misc improvements to camp crafting

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -265,6 +265,7 @@ struct availability {
         bool has_proficiencies;
         bool has_all_skills;
         bool is_nested_category;
+        // Used as an indicator to see if crafting is called via camp. if not nullptr, we must be camp crafting
         inventory *inv_override;
     private:
         const recipe *rec;
@@ -488,7 +489,7 @@ static std::vector<std::string> recipe_info(
                   "when it is not</color>.\n" );
     }
     std::string reason;
-    bool npc_cant = avail.crafter.is_npc() && !recp.npc_can_craft( reason );
+    bool npc_cant = avail.crafter.is_npc() && !recp.npc_can_craft( reason ) && !avail.inv_override ;
     if( !can_craft_this && avail.apparently_craftable && !recp.is_nested() && !npc_cant ) {
         oss << _( "<color_red>Cannot be crafted because the same item is needed "
                   "for multiple components.</color>\n" );

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1322,12 +1322,12 @@ bool recipe::npc_can_craft( std::string &reason ) const
         return false;
     }
     if( result()->phase != phase_id::SOLID ) {
-        reason = _( "Ordering NPC to craft non-solid item is not implemented yet." );
+        reason = _( "Ordering NPC to craft non-solid item is currently only implemented for camps." );
         return false;
     }
     for( const auto& [bp, _] : get_byproducts() ) {
         if( bp->phase != phase_id::SOLID ) {
-            reason = _( "Ordering NPC to craft non-solid item is not implemented yet." );
+            reason = _( "Ordering NPC to craft non-solid item is currently only implemented for camps." );
             return false;
         }
     }


### PR DESCRIPTION
#### Summary
Interface "Various misc improvements to camp crafting flow and feedback"

#### Purpose of change

* Closes #78588

#### Describe the solution

-Hide errant message claiming camp NPCs can't craft liquid

-Update non-camp crafting message to say that liquid crafting IS available at camps

-Give the player a notice if there's nobody assigned to work at camp, instead of just silently not crafting

-Extract crafting mission's description for translation

-Pre-check and WARN if we don't have anywhere to store liquid before the crafting is assigned

-Cleaned up a case where I assigned the same `recipe *` to two separate variables in the start_crafting function. Oops. Use only one variable instead

#### Describe alternatives you've considered
Perhaps we could short-circuit the "Choose crafter" hotkey in the crafting GUI to notify the player that crafter selection takes place *afterwards*. But that sounded like a bit more effort than needed.

#### Testing
Compiled, loaded. Tried to craft without anyone assigned at camp, it cancelled and warned me there was nobody available. Assigned someone. Crafted some wooden beams. Crafted some alcohol.

#### Additional context
