### PR TITLE
Fix Small Lighthouse Tower Floor

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -660,7 +660,7 @@
     "connect_groups": [ "INDOORFLOOR", "ROCKFLOOR" ],
     "connects_to": "ROCKFLOOR",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAT", "SUPPORTS_ROOF", "INDOORS", "ROAD"],
+    "flags": [ "TRANSPARENT", "FLAT", "SUPPORTS_ROOF", "INDOORS", "ROAD" ],
     "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -657,7 +657,7 @@
     "symbol": ".",
     "color": "light_gray",
     "looks_like": "t_rock_floor",
-    "connect_groups": ["INDOORFLOOR", "ROCKFLOOR"],
+    "connect_groups": [ "INDOORFLOOR", "ROCKFLOOR" ],
     "connects_to": "ROCKFLOOR",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "SUPPORTS_ROOF", "INDOORS", "ROAD"],

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -657,10 +657,10 @@
     "symbol": ".",
     "color": "light_gray",
     "looks_like": "t_rock_floor",
-    "connect_groups": "ROCKFLOOR",
+    "connect_groups": ["INDOORFLOOR", "ROCKFLOOR"],
     "connects_to": "ROCKFLOOR",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
+    "flags": [ "TRANSPARENT", "FLAT", "SUPPORTS_ROOF", "INDOORS", "ROAD"],
     "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },
   {


### PR DESCRIPTION
#### Fix Small Lighthouse Tower Floor
Bugfixes: Lighthouse tower properly marked as inside space**

---

#### Summary  
Bugfixes "Lighthouse tower properly marked as inside space"

---

#### Purpose of change  
Fixes issue [#78553](https://github.com/CleverRaven/Cataclysm-DDA/issues/78553).  

Currently, the small lighthouse tower is marked as **outside** despite being enclosed with:  
- Stone masonry walls (`t_stone_masonry_floor`),  
- Glass walls at the ladder's top, and  
- A roof.  

This causes unintended behavior, such as rain falling indoors. This PR ensures the lighthouse tower is correctly marked as an **inside space**.

---

#### Describe the solution  
- Adjusted the `t_stone_masonry_floor` tile to be considered an **inside floor**.  
    - This resolves the issue while preserving the aesthetic and structural integrity of the lighthouse.  

**If a global change to `t_stone_masonry_floor` is not acceptable**, I will replace the specific lighthouse floor tiles with an equivalent "inside-compatible" floor tile.

---

#### Describe alternatives you've considered  
1. **Manual tile replacement:**  
   Replace the `t_stone_masonry_floor` tiles specifically for the lighthouse with another floor tile (e.g., `t_wood_floor` or `t_tile`) to mark the space as inside.  

---

#### Testing  
1. **Local testing:**  
   - Verified that the lighthouse tower now registers as an **inside space**.  
   - Confirmed that rain and weather effects no longer occur indoors.  

2. **Impact testing:**  
   - Checked for unintended side effects on other locations using `t_stone_masonry_floor`.  

---

#### Notes  
- If modifying `t_stone_masonry_floor` globally is problematic, I will adjust the tiles specific to the lighthouse area.  
- Maintainers have permission to edit this PR as needed.