### PR TITLE
Don't assign missions during testing

### DIFF
--- a/data/mods/TEST_DATA/missions.json
+++ b/data/mods/TEST_DATA/missions.json
@@ -27,5 +27,21 @@
     "copy-from": "TEST_MISSION_GOAL_CONDITION1",
     "goal": "MGOAL_CONDITION",
     "origins": [  ]
+  },
+  {
+    "//COMMENT": "Dummy EOCs to prevent the startup chain from triggering missions in the test environment.",
+    "type": "effect_on_condition",
+    "id": "EOC_FACTION_SUCCESSION_COOLDOWN_GAMEBEGIN_CHECK",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "effect": [  ]
+  },
+  {
+    "//COMMENT": "Dummy EOCs to prevent the startup chain from triggering missions in the test environment.",
+    "type": "effect_on_condition",
+    "id": "EOC_FACTION_SUCCESSION_COOLDOWN_GAMESTART_CHECK",
+    "eoc_type": "EVENT",
+    "required_event": "game_start",
+    "effect": [  ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12359934654/job/34493740159?pr=78524#step:19:105

"completed mission MISSION_CAMP_LEADERSHIP_CHANGE was not in the active_missions list"

This has persisted and caused numerous failures despite repeated attempts to resolve it.

#### Describe the solution
Just stop it from running during the tests. We're not testing it, so we don't need it to run.

This is accomplished by overriding the EOCs that call it in the TEST_DATA mod, which is always loaded.

#### Describe alternatives you've considered
Maybe we could configure the EOC/event infrastructure to not listen during testing, but this seems much simpler.

#### Testing


#### Additional context
