### PR TITLE
[Magiclysm] Fix animist convert spell missing damage type

### DIFF
--- a/data/mods/Magiclysm/Spells/animist.json
+++ b/data/mods/Magiclysm/Spells/animist.json
@@ -550,6 +550,7 @@
     "final_casting_time": 1000,
     "casting_time_increment": -200,
     "energy_source": "MANA",
+    "damage_type": "pure",
     "extra_effects": [ { "id": "create_rune_animist", "hit_self": true }, { "id": "eoc_transformation_setup", "hit_self": true } ]
   },
   {


### PR DESCRIPTION

#### Summary

Bugfixes "Fix animist Convert spell missing damage type"

#### Purpose of change

Convert spell causes error because it misses damage type.

#### Describe the solution

Setting damage type to "pure" prevents any resistances decreasing damage.

#### Describe alternatives you've considered

Setting damage to any other type if PERCENTAGE_DAMAGE ignores resistances.

#### Testing

Casting Convert does not cause error anymore.

#### Additional context
