### PR TITLE
Subtle Foreshadowing: Quiet Farm Edition

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -12,7 +12,7 @@
     },
     "effect": [
       {
-        "u_message": "There is a soft, sonorous tone filling the air, like wind over brittle ice.  It sets your teeth on edge.",
+        "u_message": "<color_red>There is a soft, sonorous tone filling the air, like wind over brittle ice.  It sets your teeth on edge.</color>",
         "type": "neutral",
         "popup": true
       },


### PR DESCRIPTION


#### Summary
None

#### Purpose of change

I feel like the popup message that pops up when getting near the Quiet Farm mapgen could do with some red coloring to make folks double think about approaching the place, so i added it.

#### Describe the solution

Make said popup message i mentioned red.

#### Describe alternatives you've considered

Not doing so.

#### Testing

![Screenshot_20241217_205607](https://github.com/user-attachments/assets/029a9ad4-c752-46aa-9041-3ef0080ecc26)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
