### PR TITLE
Add keybindings for throw and blind throw of wielded item

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2606,10 +2606,22 @@
   },
   {
     "type": "keybinding",
+    "name": "Throw wielded item",
+    "category": "DEFAULTMODE",
+    "id": "throw_wielded"
+  },
+  {
+    "type": "keybinding",
     "name": "Blind throw item",
     "category": "LOOK",
     "id": "throw_blind",
     "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+  },
+  {
+    "type": "keybinding",
+    "name": "Blind throw wielded item",
+    "category": "LOOK",
+    "id": "throw_blind_wielded"
   },
   {
     "type": "keybinding",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -248,6 +248,8 @@ std::string action_ident( action_id act )
             return "mend";
         case ACTION_THROW:
             return "throw";
+        case ACTION_THROW_WIELDED:
+            return "throw_wielded";
         case ACTION_FIRE:
             return "fire";
         case ACTION_FIRE_BURST:
@@ -980,6 +982,7 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_SELECT_FIRE_MODE );
             REGISTER_ACTION( ACTION_SELECT_DEFAULT_AMMO );
             REGISTER_ACTION( ACTION_THROW );
+            REGISTER_ACTION( ACTION_THROW_WIELDED );
             REGISTER_ACTION( ACTION_FIRE_BURST );
             REGISTER_ACTION( ACTION_PICK_STYLE );
             REGISTER_ACTION( ACTION_TOGGLE_AUTO_TRAVEL_MODE );

--- a/src/action.h
+++ b/src/action.h
@@ -176,6 +176,8 @@ enum action_id : int {
     ACTION_MEND,
     /** Open the throw menu */
     ACTION_THROW,
+    /** Throw the currently wielded item */
+    ACTION_THROW_WIELDED,
     /** Fire the wielded weapon, or open fire menu if none */
     ACTION_FIRE,
     /** Burst-fire the current weapon */

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1092,6 +1092,17 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     g->reenter_fullscreen();
 }
 
+void avatar_action::plthrow_wielded( avatar &you,
+                                     const std::optional<tripoint_bub_ms> &blind_throw_from_pos )
+{
+    item_location weapon = you.get_wielded_item();
+    if( !weapon ) {
+        add_msg( _( "You aren't holding something you can throw." ) );
+        return;
+    }
+    avatar_action::plthrow( you, weapon, blind_throw_from_pos );
+}
+
 static void update_lum( item_location loc, bool add )
 {
     switch( loc.where() ) {

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -68,6 +68,11 @@ bool fire_turret_manual( avatar &you, map &m, turret_data &turret );
 // Throw an item  't'
 void plthrow( avatar &you, item_location loc,
               const std::optional<tripoint_bub_ms> &blind_throw_from_pos = std::nullopt );
+
+// Throw the wielded item
+void plthrow_wielded( avatar &you,
+                      const std::optional<tripoint_bub_ms> &blind_throw_from_pos = std::nullopt );
+
 /**
  * Opens up a menu to Unload a container, gun, or tool
  * If it's a gun, some gunmods can also be loaded

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2654,6 +2654,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "insert" );
     ctxt.register_action( "unload" );
     ctxt.register_action( "throw" );
+    ctxt.register_action( "throw_wielded" );
     ctxt.register_action( "fire" );
     ctxt.register_action( "cast_spell" );
     ctxt.register_action( "fire_burst" );
@@ -6319,9 +6320,13 @@ void game::peek( const tripoint_bub_ms &p )
         u.setpos( prev );
     }
 
-    if( result.peek_action && *result.peek_action == PA_BLIND_THROW ) {
-        item_location loc;
-        avatar_action::plthrow( u, loc, p );
+    if( result.peek_action ) {
+        if( *result.peek_action == PA_BLIND_THROW ) {
+            item_location loc;
+            avatar_action::plthrow( u, loc, p );
+        } else if( *result.peek_action == PA_BLIND_THROW_WIELDED ) {
+            avatar_action::plthrow_wielded( u, p );
+        }
     }
     m.invalidate_map_cache( p.z() );
     m.invalidate_visibility_cache();
@@ -7661,6 +7666,7 @@ look_around_result game::look_around(
     ctxt.register_action( "SELECT" );
     if( peeking ) {
         ctxt.register_action( "throw_blind" );
+        ctxt.register_action( "throw_blind_wielded" );
     }
     if( !select_zone ) {
         ctxt.register_action( "TRAVEL_TO" );
@@ -7915,6 +7921,8 @@ look_around_result game::look_around(
             center.y() = center.y() + vec->y();
         } else if( action == "throw_blind" ) {
             result.peek_action = PA_BLIND_THROW;
+        } else if( action == "throw_blind_wielded" ) {
+            result.peek_action = PA_BLIND_THROW_WIELDED;
         } else if( action == "zoom_in" ) {
             center.xy() = lp.xy();
             zoom_in();
@@ -7925,7 +7933,7 @@ look_around_result game::look_around(
             mark_main_ui_adaptor_resize();
         }
     } while( action != "QUIT" && action != "CONFIRM" && action != "SELECT" && action != "TRAVEL_TO" &&
-             action != "throw_blind" );
+             action != "throw_blind" && action != "throw_blind_wielded" );
 
     if( center.z() != old_levz ) {
         m.invalidate_map_cache( old_levz );

--- a/src/game.h
+++ b/src/game.h
@@ -107,7 +107,8 @@ using item_filter = std::function<bool ( const item & )>;
 using item_location_filter = std::function<bool ( const item_location & )>;
 
 enum peek_act : int {
-    PA_BLIND_THROW
+    PA_BLIND_THROW,
+    PA_BLIND_THROW_WIELDED,
     // obvious future additional value is PA_BLIND_FIRE
 };
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2616,6 +2616,11 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
         }
 
+        case ACTION_THROW_WIELDED: {
+            avatar_action::plthrow_wielded( player_character );
+            break;
+        }
+
         case ACTION_FIRE:
             fire();
             break;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add keybind to throw your wielded item"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Manually selecting the wielded knife pulled from the bag of infinite throwing knives is annoying.

Resolve #69113
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Look what #36658 did for reloading and do the same for throwing. Then find out that peek-throwing is a separate keybind, so duplicate that for wielded as well.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Continue waiting for someone else to implement my suggestion.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
normal throw
1. load character with no config/keybinds.json, check for unbound "Throw wielded item" ✔️ 
2. bind a key, make sure nothing is wielded, press the key => "You aren't holding something you can throw." message is logged ✔️ 
3. wield something, then press the key => throw-aiming screen for the wielded item opens, wielded item can be thrown ✔️ 

blind throw while peeking
1. peek, then check for unbound "Blind throw wielded item" ✔️ 
2. bind a key, make sure nothing is wielded, press the key => "You aren't holding something you can throw." message is logged ✔️ 
3. wield something, peek, then press the key => blind-throw-aiming screen for the wielded item opens, wielded item can be blind-thrown ✔️ 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
My random test character was a tourist swimmer with a beach volleyball which made for great throwing practice 😄 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
