### PR TITLE
Bagpipes Volume Change

### DIFF
--- a/data/json/items/tool/musical_instruments.json
+++ b/data/json/items/tool/musical_instruments.json
@@ -511,7 +511,7 @@
     "tick_action": {
       "type": "musical_instrument",
       "speed_penalty": 15,
-      "volume": 24,
+      "volume": 75,
       "fun": 2,
       "fun_bonus": 2,
       "description_frequency": 20,


### PR DESCRIPTION
#### Bagpipes volume change

#### Summary  
Balance "Increase bagpipe volume from 24 to 75"  

#### Purpose of change  
This change addresses the request to make bagpipes significantly louder. The current volume of 24 was too low to match the intended gameplay effect of the instrument. This adjustment increases the volume to **75**, making it more realistic and impactful as a tool for gathering the horde.  

This change relates to issue **#78608**: ["Bagpipes should be LOUD"](https://github.com/CleverRaven/Cataclysm-DDA/issues/78608).  

#### Describe the solution  
The volume for the bagpipes was increased in the JSON file from **24** to **75**. This increase better represents the auditory range of bagpipes.  

File modified:  
`data/json/items/tool/musical_instruments.json`  

#### Describe alternatives you've considered .  
- Intermediate values (50-75) were considered, with **75** chosen as a reasonable compromise for realism and gameplay impact.  

#### Testing  
- Verify the sound range increase in-game.  
- Confirmed that the change is isolated to the bagpipe's volume property.  
- No errors or unexpected behavior occurred during testing.  

#### Additional context  
- Bagpipes are traditionally loud instruments that can be heard across long distances, especially in quiet environments.  
- Apparently they can be about as loud as a chainsaw so 24 seemed way to low