### PR TITLE
Mark some specific furnitures/terrains examine as always allowed in faction territory

### DIFF
--- a/data/json/furniture_and_terrain/furniture-alien.json
+++ b/data/json/furniture_and_terrain/furniture-alien.json
@@ -202,7 +202,7 @@
     "move_cost_mod": 1,
     "coverage": 35,
     "required_str": -1,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SIGN" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SIGN", "FREE_TO_EXAMINE" ],
     "deconstruct": { "items": [ { "item": "sheet_metal_small", "count": 2 }, { "item": "nail", "charges": [ 2, 5 ] } ] },
     "bash": {
       "str_min": 6,

--- a/data/json/furniture_and_terrain/furniture-signs.json
+++ b/data/json/furniture_and_terrain/furniture-signs.json
@@ -36,7 +36,7 @@
     "move_cost_mod": 1,
     "coverage": 35,
     "required_str": -1,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SIGN", "SIGN_ALWAYS" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SIGN", "SIGN_ALWAYS", "FREE_TO_EXAMINE" ],
     "deconstruct": { "items": [ { "item": "2x4", "count": 3 }, { "item": "nail", "charges": [ 2, 5 ] } ] },
     "bash": {
       "str_min": 6,

--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -975,6 +975,7 @@
     "likes_u": 0,
     "respects_u": 0,
     "known_by_u": true,
+    "limited_area_claim": true,
     "size": 100,
     "power": 100,
     "//": "7 days worth of food for 10 people, at 3000kcal/day and *half* RDA of iron/calcium/vitC",

--- a/data/mods/Magiclysm/furniture.json
+++ b/data/mods/Magiclysm/furniture.json
@@ -8,7 +8,7 @@
     "description": "A gate for translocation.  Cast the translocation spell or use a translocator to choose this gate as a destination.",
     "color": "light_gray",
     "required_str": 25,
-    "flags": [ "TRANSLOCATOR", "MOUNTABLE", "ALLOW_FIELD_EFFECT" ],
+    "flags": [ "TRANSLOCATOR", "MOUNTABLE", "ALLOW_FIELD_EFFECT", "FREE_TO_EXAMINE" ],
     "examine_action": "translocator"
   },
   {

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -642,6 +642,7 @@ List of known flags, used in both `furniture` and `terrain`.  Some work for both
 - ```FLAT``` Player can build and move furniture on.
 - ```FORAGE_HALLU``` This item can be found with the `HIDDEN_HALLU` flag when found through foraging.
 - ```FORAGE_POISION``` This item can be found with the `HIDDEN_POISON` flag when found through foraging.
+- ```FREE_TO_EXAMINE``` Examining this furniture/terrain won't upset the local faction (if any).
 - ```FRESH_WATER``` Source of fresh water.  Will spawn fresh water (once) on terrains with `SPAWN_WITH_LIQUID` flag.
 - ```GOES_DOWN``` Can use <kbd>></kbd> to go down a level.
 - ```GOES_UP``` Can use <kbd><</kbd> to go up a level.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6141,14 +6141,16 @@ void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
 
     if( m.has_furn( examp ) ) {
         if( !u.cant_do_mounted() ) {
-            if( !warn_player_maybe_anger_local_faction( false, true ) ) {
+            if( !m.has_flag( "FREE_TO_EXAMINE", examp ) &&
+                !warn_player_maybe_anger_local_faction( false, true ) ) {
                 return; // player declined to mess with faction's stuff
             }
             xfurn_t.examine( u, examp );
         }
     } else {
         if( xter_t.can_examine( examp ) && !u.is_mounted() ) {
-            if( !warn_player_maybe_anger_local_faction( false, true ) ) {
+            if( !m.has_flag( "FREE_TO_EXAMINE", examp ) &&
+                !warn_player_maybe_anger_local_faction( false, true ) ) {
                 return; // player declined to mess with faction's stuff
             }
             xter_t.examine( u, examp );


### PR DESCRIPTION
#### Summary
Bugfixes "Mark some specific furnitures/terrains examine as always allowed in faction territory"

#### Purpose of change
* Closes #77239

#### Describe the solution
Add a flag `FREE_TO_EXAMINE` to the common furniture/terrain that should always be examinable.

If that flag is present, the locals will never care about you examining it.

Added to the following furniture/terrain:
Translocator (magiclysm)
Exodii sign at their main base and all other `f_sign` by extension
Exodii sign at their barns (not faction territory atm, but just in case)


#### Describe alternatives you've considered
Tying it to the examine actor/function

Uh it turns out that a flag was incredibly simple, so the flag was chosen instead.

#### Testing
Spawned a sign at a faction territory

Examined glass display case, got warned

Examined sign, no warning

#### Additional context
https://github.com/CleverRaven/Cataclysm-DDA/issues/77239#issuecomment-2451984463 is a problem with the design. There's no way in and the prisoners SHOULD be upset about you forcing your way in (they're barricaded to keep the zombies out). I don't know what to do there 🤷 

This PR was way easier than I thought.