### PR TITLE
Fixes SegFault w/ flashlights & attached power

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12273,6 +12273,18 @@ int item::getlight_emit() const
         return 0;
     }
     if( has_flag( flag_CHARGEDIM ) && is_tool() && !has_flag( flag_USE_UPS ) ) {
+        // check if there's a link and it has a charge rate or charge interval
+        // if so, use its power supply
+        if( has_link_data() && ( link().charge_rate > 0 || link().charge_interval > 0 ) ) {
+            return lumint;
+        }
+
+        // If we somehow got this far without a battery/power,
+        // return an illumination value of 0
+        if( !has_ammo() ) {
+            return 0;
+        }
+
         // Falloff starts at 1/5 total charge and scales linearly from there to 0.
         const ammotype &loaded_ammo = ammo_data()->ammo->type;
         if( ammo_capacity( loaded_ammo ) &&


### PR DESCRIPTION
#### Summary

Bugfixes "Fixes SegFault w/ flashlights & attached power"

#### Purpose of change

There was a segfault occuring on
https://github.com/CleverRaven/Cataclysm-DDA/blob/de687d39f5a946b7585d2d73c337c3960b5907ac/src/item.cpp#L12277 when turning on a heavy-duty flashlight while it is simultaneously connected to a power source (ie. a vehicle) and does not have a battery. See #78580

#### Describe the solution

Added:

-   a short circuit check for ammo to address this issue in the future in
    case there are any other edge cases where this occurs.
-   a check for a linked power source so the light source uses the
    power source's linked power when determining the illumination value.

#### Describe alternatives you've considered

I didn't consider any other alternatives.

#### Testing

I loaded CDDA in a dev environment prior to this fix and created a test world and saved it once I had the conditions necessary to reproduce the bug. In that test world, I then turned on the flashlight and successfully reproduced the bug.

After applying the fix, I loaded the same save and attempted the same action. This time successfully due to the fix. In addition, I spawned a normal vehicle, attached the flashlight to it, and ensured there was a power draw occurring (there was). Then I removed the battery while the flashlight was on to ensure that it both turned off (it did) and that the game did not crash (it did not).

#### Additional context

I used https://github.com/CleverRaven/Cataclysm-DDA/blob/de687d39f5a946b7585d2d73c337c3960b5907ac/src/item.cpp#L14177 as a reference for the linked power check above. This means the two power checks are extremely similar and it makes me believe that it would be beneficial to have a function such as `has_link_power` that returns a boolean (true for has power, false otherwise). My only hesitation is that I do not know where else that sort of power check is done and what the complete scope of the checks against `charge_rate` / `charge_interval` are for.
