### PR TITLE
Basic beach decorations

### DIFF
--- a/data/json/connect_groups.json
+++ b/data/json/connect_groups.json
@@ -134,5 +134,9 @@
   {
     "type": "connect_group",
     "id": "INDOORFLOOR"
+  },
+  {
+    "type": "connect_group",
+    "id": "BEACH_FORMATIONS"
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-beach.json
+++ b/data/json/furniture_and_terrain/furniture-beach.json
@@ -1,0 +1,64 @@
+[
+  {
+    "id": "f_beach_seaweed",
+    "type": "furniture",
+    "name": "scattered seaweed",
+    "description": "Seaweed and other detritus, scattered along the high water line of the beach.",
+    "symbol": "{",
+    "looks_like": "f_leaves_pile",
+    "color": "green",
+    "move_cost_mod": 0,
+    "required_str": -1,
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC" ]
+  },
+  {
+    "id": "f_beach_log",
+    "type": "furniture",
+    "name": "driftwood log",
+    "description": "A small log, bleached white by sun and salt.",
+    "symbol": "-",
+    "looks_like": "t_trunk",
+    "color": "white",
+    "move_cost_mod": 1,
+    "required_str": 12,
+    "bash": {
+      "str_min": 80,
+      "str_max": 180,
+      "sound": "crunch!",
+      "sound_fail": "whack!",
+      "items": [ { "item": "splinter", "count": [ 25, 100 ] } ]
+    },
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE" ]
+  },
+  {
+    "type": "furniture",
+    "id": "f_broken_boat",
+    "name": "broken boat",
+    "symbol": "<",
+    "description": "A section of old, sun-bleached boat, half-buried in the ground.  There's no restoring it, but parts could be salvaged.",
+    "color": "white",
+    "move_cost_mod": 5,
+    "coverage": 35,
+    "required_str": -1,
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "CONTAINER", "PLACE_ITEM", "ORGANIC", "MOUNTABLE", "SMALL_HIDE" ],
+    "deconstruct": {
+      "items": [
+        { "item": "2x4", "count": [ 3, 6 ] },
+        { "item": "wood_panel", "count": [ 0, 1 ] },
+        { "item": "nail", "charges": [ 6, 10 ] },
+        { "item": "splinter", "count": [ 10, 20 ] }
+      ]
+    },
+    "bash": {
+      "str_min": 8,
+      "str_max": 15,
+      "sound": "smash!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "2x4", "count": [ 1, 2 ] },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 15, 30 ] }
+      ]
+    }
+  }
+]

--- a/data/json/furniture_and_terrain/terrain-beach.json
+++ b/data/json/furniture_and_terrain/terrain-beach.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "t_coast_rock_surf",
+    "type": "terrain",
+    "name": "rocky coastline",
+    "description": "This is a section of eroded natural stone formations along the beach, the water lapping and splashing at the edges.",
+    "symbol": "-",
+    "looks_like": "t_rock_floor",
+    "color": "cyan",
+    "move_cost": 3,
+    "connect_groups": "BEACH_FORMATIONS",
+    "connects_to": "BEACH_FORMATIONS",
+    "flags": [ "TRANSPARENT" ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_tidepool",
+    "name": "tide pool",
+    "description": "A shallow pool of salt water, often filled with interesting life.",
+    "looks_like": "t_swater_sh",
+    "symbol": "~",
+    "color": "cyan",
+    "move_cost": 4,
+    "connect_groups": "BEACH_FORMATIONS",
+    "flags": [ "TRANSPARENT", "LIQUIDCONT", "SALT_WATER" ],
+    "examine_action": "finite_water_source",
+    "liquid_source": { "id": "salt_water", "min_temp": 2.2, "count": [ 40, 240 ] }
+  }
+]

--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -232,8 +232,8 @@
     "looks_like": "t_swater_sh",
     "move_cost": 4,
     "liquid_source": { "id": "salt_water", "min_temp": 2.2 },
-    "connect_groups": [ "SAND", "WATER" ],
-    "connects_to": [ "SAND", "SANDMOUND", "SANDGLASS", "WATER" ],
+    "connect_groups": [ "WATER" ],
+    "connects_to": [ "WATER" ],
     "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "DIGGABLE", "FLAT" ],
     "examine_action": "water_source"
   },

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -715,5 +715,16 @@
     "sym": "o",
     "color": "red",
     "autonote": true
+  },
+  {
+    "id": "mx_sandy_beach",
+    "type": "map_extra",
+    "name": { "str": "Sandy beach" },
+    "description": "A sandy beach.",
+    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_sandy_beach" },
+    "min_max_zlevel": [ 0, 0 ],
+    "sym": "~",
+    "color": "yellow",
+    "flags": [ "CLASSIC" ]
   }
 ]

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -675,6 +675,7 @@
         }
       },
       "ocean_bed": { "chance": 30, "extras": { "mx_kelp_patch": 1 } },
+      "ocean_shore": { "chance": 1, "extras": { "mx_sandy_beach": 100 } },
       "road": {
         "chance": 100,
         "extras": {

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -67,7 +67,13 @@ static const flag_id json_flag_FILTHY( "FILTHY" );
 
 static const furn_str_id furn_f_ash( "f_ash" );
 static const furn_str_id furn_f_barricade_road( "f_barricade_road" );
+static const furn_str_id furn_f_beach_log( "f_beach_log" );
+static const furn_str_id furn_f_beach_seaweed( "f_beach_seaweed" );
 static const furn_str_id furn_f_bench( "f_bench" );
+static const furn_str_id furn_f_boulder_large( "f_boulder_large" );
+static const furn_str_id furn_f_boulder_medium( "f_boulder_medium" );
+static const furn_str_id furn_f_boulder_small( "f_boulder_small" );
+static const furn_str_id furn_f_broken_boat( "f_broken_boat" );
 static const furn_str_id furn_f_camp_chair( "f_camp_chair" );
 static const furn_str_id furn_f_canvas_door( "f_canvas_door" );
 static const furn_str_id furn_f_canvas_wall( "f_canvas_wall" );
@@ -132,6 +138,7 @@ static const map_extra_id map_extra_mx_pond( "mx_pond" );
 static const map_extra_id map_extra_mx_portal_in( "mx_portal_in" );
 static const map_extra_id map_extra_mx_reed( "mx_reed" );
 static const map_extra_id map_extra_mx_roadworks( "mx_roadworks" );
+static const map_extra_id map_extra_mx_sandy_beach( "mx_sandy_beach" );
 static const map_extra_id map_extra_mx_shrubbery( "mx_shrubbery" );
 
 static const mongroup_id GROUP_FISH( "GROUP_FISH" );
@@ -153,6 +160,7 @@ static const oter_type_str_id oter_type_road( "road" );
 static const relic_procgen_id relic_procgen_data_alien_reality( "alien_reality" );
 
 static const ter_str_id ter_t_clay( "t_clay" );
+static const ter_str_id ter_t_coast_rock_surf( "t_coast_rock_surf" );
 static const ter_str_id ter_t_dirt( "t_dirt" );
 static const ter_str_id ter_t_dirtmound( "t_dirtmound" );
 static const ter_str_id ter_t_fence_barbed( "t_fence_barbed" );
@@ -169,7 +177,10 @@ static const ter_str_id ter_t_pavement( "t_pavement" );
 static const ter_str_id ter_t_pavement_y( "t_pavement_y" );
 static const ter_str_id ter_t_pit( "t_pit" );
 static const ter_str_id ter_t_pit_shallow( "t_pit_shallow" );
+static const ter_str_id ter_t_sand( "t_sand" );
 static const ter_str_id ter_t_stump( "t_stump" );
+static const ter_str_id ter_t_swater_surf( "t_swater_surf" );
+static const ter_str_id ter_t_tidepool( "t_tidepool" );
 static const ter_str_id ter_t_tree_birch( "t_tree_birch" );
 static const ter_str_id ter_t_tree_birch_harvested( "t_tree_birch_harvested" );
 static const ter_str_id ter_t_tree_dead( "t_tree_dead" );
@@ -2177,6 +2188,32 @@ static bool mx_fungal_zone( map &m, const tripoint &abs_sub )
     return true;
 }
 
+static bool mx_sandy_beach( map &m, const tripoint &abs_sub )
+{
+    weighted_int_list<furn_id> detritus;
+    detritus.add( furn_f_beach_log, 10 );
+    detritus.add( furn_f_beach_seaweed, 25 );
+    detritus.add( furn_f_boulder_small, 20 );
+    detritus.add( furn_f_boulder_medium, 10 );
+    detritus.add( furn_f_boulder_large, 3 );
+    detritus.add( furn_f_broken_boat, 1 );
+
+    for( int i = 0; i < SEEX * 2; i++ ) {
+        for( int j = 0; j < SEEY * 2; j++ ) {
+            const tripoint_bub_ms loc( i, j, abs_sub.z );
+            const ter_id &ter_loc = m.ter( loc );
+            if( ter_loc == ter_t_sand && one_in( 20 ) ) {
+                !one_in( 10 ) ? m.furn_set( loc, detritus.pick()->id() ) : m.ter_set( loc, ter_t_tidepool );
+            }
+            if( ter_loc == ter_t_swater_surf && one_in( 10 ) ) {
+                m.ter_set( loc, ter_t_coast_rock_surf );
+            }
+        }
+    }
+
+    return true;
+}
+
 static FunctionMap builtin_functions = {
     { map_extra_mx_null, mx_null },
     { map_extra_mx_roadworks, mx_roadworks },
@@ -2196,6 +2233,7 @@ static FunctionMap builtin_functions = {
     { map_extra_mx_city_trap, mx_city_trap },
     { map_extra_mx_reed, mx_reed },
     { map_extra_mx_fungal_zone, mx_fungal_zone },
+    { map_extra_mx_sandy_beach, mx_sandy_beach },
 };
 
 map_extra_pointer get_function( const map_extra_id &name )


### PR DESCRIPTION
#### Summary
Content "Basic beach decorations"

#### Purpose of change
Resurrect #70173 by @I-am-Erk.

#### Describe the solution
Big part of work was already done by @I-am-Erk, kudos to him, I just made the whole thing work and fixed some errors along the way.

Added most of the beach furniture and terrain from that PR:
- f_beach_log: an old log on the beach.
- f_broken_boat: a washed up chunk of an abandoned boat
- f_beach_seaweed: seaweed piled at the high waterline
- t_coast_rock_surf: a rocky coastline on the edge of the water, to connect to the surf and create a graphically interesting edge
- t_tidepool: a small basin of salt water in the sand.

Added the `beach_formations` connection group so that coast rock can connect to itself and its other versions, and sand can connect to it (but it doesn't connect to sand).

Instead of non-finished json version of map extra from that PR, I added a hardcoded version (for the time being). It doesn't create any "directional lines" of beach terrain or furniture, it just randomly populates the sandy beaches and surf line with various beach decorations.

Also, while I'm here, I made surf line look pretty instead of "straight cut" where it meets the sand.

#### Describe alternatives you've considered
Try to understand the idea of json mapgen of map extra from the PR and make it work.

#### Testing
Teleported to the ocean shore, hiked along the water, checked that sandy beaches are no longer empty.

#### Additional context
Before: 
![изображение](https://github.com/user-attachments/assets/bd1b1e8e-53dc-4468-adea-e621b92cbae3)

After:
![изображение](https://github.com/user-attachments/assets/93349649-fb64-497f-9b01-ecd91c9fa133)

Note: all sprites for the new terrain and furniture are placeholders.