### PR TITLE
Structure Damage: Car Crashes, migration to ter_furn_transform to retain terrains

### DIFF
--- a/data/json/mapgen/house/bungalow09.json
+++ b/data/json/mapgen/house/bungalow09.json
@@ -52,7 +52,7 @@
       },
       "place_nested": [
         { "chunks": [ "rolling_trash_can_1x1" ], "x": 9, "y": 0 },
-        { "chunks": [ [ "null", 10 ], [ "carcrash_8x8_straight", 90 ] ], "x": [ 14, 15 ], "y": 0 }
+        { "chunks": [ [ "null", 95 ], [ "carcrash_8x8_straight", 5 ] ], "x": [ 14, 15 ], "y": 0 }
       ],
       "place_loot": [ { "item": "laptop", "x": 17, "y": 5, "chance": 100 }, { "item": "television", "x": 9, "y": 7, "chance": 100 } ]
     }

--- a/data/json/mapgen/nested/structure_damage_nested.json
+++ b/data/json/mapgen/nested/structure_damage_nested.json
@@ -2,25 +2,153 @@
   {
     "type": "palette",
     "id": "struc_damage",
-    "parameters": { "crashvariant": { "type": "string", "scope": "omt", "default": { "distribution": [ "fromleft", "fromright" ] } } },
-    "terrain": {
-      "c": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_dirtmoundfloor", "fromright": "t_null" } },
-      "v": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_null", "fromright": "t_dirtmoundfloor" } },
-      "d": "t_dirtmoundfloor",
-      "r": "t_dirtmoundfloor",
-      "w": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_dirtmoundfloor", "fromright": "t_null" } },
-      "j": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "t_null", "fromright": "t_dirtmoundfloor" } }
+    "parameters": {
+      "crashvariant": {
+        "type": "string",
+        "scope": "omt",
+        "default": { "distribution": [ "fromleft", "fromright" ] }
+      }
+    },
+    "ter_furn_transforms": {
+      "c": {
+        "transform": {
+          "switch": { "param": "crashvariant" },
+          "cases": {
+            "fromleft": "struc_carcrash_dirt",
+            "fromright": "tft_null"
+          }
+        }
+      },
+      "v": {
+        "transform": {
+          "switch": { "param": "crashvariant" },
+          "cases": {
+            "fromleft": "tft_null",
+            "fromright": "struc_carcrash_dirt"
+          }
+        }
+      },
+      "w": {
+        "transform": {
+          "switch": { "param": "crashvariant" },
+          "cases": {
+            "fromleft": "struc_carcrash_rubble",
+            "fromright": "tft_null"
+          }
+        }
+      },
+      "j": {
+        "transform": {
+          "switch": { "param": "crashvariant" },
+          "cases": {
+            "fromleft": "tft_null",
+            "fromright": "struc_carcrash_rubble"
+          }
+        }
+      },
+      "r": { "transform": "struc_carcrash_rubble" },
+      "x": { "transform": "struc_carcrash_clear" },
+      "d": { "transform": "struc_carcrash_dirt" }
     },
     "fields": {
-      "m": { "field": "fd_blood", "intensity": 2 },
-      "h": { "field": "fd_blood", "intensity": 3 },
-      "k": { "field": "fd_blood", "intensity": 3 }
-    },
-    "furniture": {
-      "r": "f_rubble",
-      "w": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "f_rubble", "fromright": "f_null" } },
-      "j": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "f_null", "fromright": "f_rubble" } }
+      "m": {
+        "field": "fd_blood",
+        "intensity": 2
+      },
+      "h": {
+        "field": "fd_blood",
+        "intensity": 3
+      },
+      "k": {
+        "field": "fd_blood",
+        "intensity": 3
+      }
     }
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "tft_null",
+    "//": "transform won't accept null in a switch statement, so for now this is the solution. Does nothing.",
+    "terrain": [
+      {
+        "result": "t_null",
+        "valid_terrain": [ "t_null" ]
+      }
+    ]
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "struc_carcrash_rubble",
+    "terrain": [
+      {
+        "result": "t_floor",
+        "valid_terrain": [
+          "t_door_white_frame",
+          "t_door_frame",
+          "t_door_lab_frame",
+          "t_door_red_frame",
+          "t_door_green_frame",
+          "t_door_gray_frame",
+          "t_mdoor_lab_frame",
+          "t_mdoor_frame"
+        ],
+        "valid_flags": [ "DOOR", "WALL", "WINDOW", "BARRICADABLE_DOOR", "BARRICADABLE_DOOR_DAMAGED" ]
+      },
+      {
+        "result": "t_dirtmoundfloor",
+        "valid_terrain": [ "t_gutter_downspout" ],
+        "valid_flags": [ "DIGGABLE", "TREE", "SHRUB", "FLOWER" ]
+      }
+    ],
+    "furniture": [
+      {
+        "result": "f_rubble",
+        "valid_furniture": [ "f_null" ],
+        "valid_flags": [ "BLOCKSDOOR", "TRANSPARENT" ]
+      }
+    ]
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "struc_carcrash_dirt",
+    "terrain": [
+      {
+        "result": "t_dirtmoundfloor",
+        "valid_flags": [ "DIGGABLE", "TREE", "SHRUB", "FLOWER" ]
+      }
+    ],
+    "furniture": [
+      {
+        "result": "f_null",
+        "valid_flags": [ "BLOCKSDOOR", "TRANSPARENT" ]
+      }
+    ]
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "struc_carcrash_clear",
+    "terrain": [
+      {
+        "result": "t_floor",
+        "valid_terrain": [
+          "t_door_white_frame",
+          "t_door_frame",
+          "t_door_lab_frame",
+          "t_door_red_frame",
+          "t_door_green_frame",
+          "t_door_gray_frame",
+          "t_mdoor_lab_frame",
+          "t_mdoor_frame"
+        ],
+        "valid_flags": [ "DOOR", "WINDOW", "WALL", "BARRICADABLE_DOOR", "BARRICADABLE_DOOR_DAMAGED" ]
+      }
+    ],
+    "furniture": [
+      {
+        "result": "f_null",
+        "valid_flags": [ "BLOCKSDOOR", "TRANSPARENT" ]
+      }
+    ]
   },
   {
     "type": "mapgen",
@@ -32,7 +160,11 @@
       "palettes": [ "struc_damage" ],
       "place_nested": [
         {
-          "chunks": [ [ "carcrash_10x10_straight", 33 ], [ "carcrash_10x10_diag_fromleft", 33 ], [ "carcrash_10x10_diag_fromright", 33 ] ],
+          "chunks": [
+            [ "carcrash_10x10_straight", 33 ],
+            [ "carcrash_10x10_diag_fromleft", 33 ],
+            [ "carcrash_10x10_diag_fromright", 33 ]
+          ],
           "x": 0,
           "y": 0
         }
@@ -47,7 +179,13 @@
     "object": {
       "mapgensize": [ 10, 10 ],
       "palettes": [ "struc_damage" ],
-      "place_nested": [ { "chunks": [ "carcrash_8x8_straight" ], "x": [ 0, 2 ], "y": 0 } ]
+      "place_nested": [
+        {
+          "chunks": [ "carcrash_8x8_straight" ],
+          "x": [ 0, 2 ],
+          "y": 0
+        }
+      ]
     }
   },
   {
@@ -61,16 +199,35 @@
         " cccdvvv",
         " ccdddvv",
         " ccdddv ",
-        " jddddw ",
-        " jddddw ",
-        "jvddddcw",
-        "jvddddcw",
+        " jxxxxw ",
+        " jxxxxw ",
+        "jjxxxxww",
+        "jjxxxxww",
         "jjrrrrww"
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "struc_damage" ],
-      "place_vehicles": [ { "chance": 100, "fuel": 10, "rotation": 90, "status": 1, "vehicle": "cars_only", "x": 4, "y": 4 } ],
-      "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_8x8_straight_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
+      "place_vehicles": [
+        {
+          "chance": 100,
+          "fuel": 10,
+          "rotation": 90,
+          "status": 1,
+          "vehicle": "cars_only",
+          "x": 4,
+          "y": 4
+        }
+      ],
+      "place_nested": [
+        {
+          "chunks": [
+            [ "null", 50 ],
+            [ "carcrash_8x8_straight_bloodcorpse", 50 ]
+          ],
+          "x": 0,
+          "y": 0
+        }
+      ]
     }
   },
   {
@@ -84,18 +241,37 @@
         "dddd      ",
         "ddddd     ",
         "dddddddd  ",
-        "rdddddddw ",
-        "rdddddddrw",
-        "jrddddddrw",
-        "jjrrddddr ",
+        "rrrrxrrrw ",
+        "rrrxxxxrrw",
+        "jrxxxxxrrw",
+        "jjrrxxxrr ",
         "  jjjrrrw ",
         "          ",
         "          "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "struc_damage" ],
-      "place_vehicles": [ { "chance": 100, "fuel": 10, "rotation": 35, "status": 1, "vehicle": "cars_only", "x": 5, "y": 3 } ],
-      "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_10x10_diag_fromleft_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
+      "place_vehicles": [
+        {
+          "chance": 100,
+          "fuel": 10,
+          "rotation": 35,
+          "status": 1,
+          "vehicle": "cars_only",
+          "x": 5,
+          "y": 3
+        }
+      ],
+      "place_nested": [
+        {
+          "chunks": [
+            [ "null", 50 ],
+            [ "carcrash_10x10_diag_fromleft_bloodcorpse", 50 ]
+          ],
+          "x": 0,
+          "y": 0
+        }
+      ]
     }
   },
   {
@@ -109,18 +285,37 @@
         "      dddd",
         "     ddddd",
         "  dddddddd",
-        " wdddddddr",
-        "wrdddddddr",
-        "wrddddddrj",
-        " rddddrrjj",
+        " wrrrxrrrr",
+        "wrrxxxxrrr",
+        "wrrxxxxxrj",
+        " rrxxxrrjj",
         " wrrrjjj  ",
         "          ",
         "          "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "struc_damage" ],
-      "place_vehicles": [ { "chance": 100, "fuel": 10, "rotation": 145, "status": 1, "vehicle": "cars_only", "x": 4, "y": 4 } ],
-      "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_10x10_diag_fromright_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
+      "place_vehicles": [
+        {
+          "chance": 100,
+          "fuel": 10,
+          "rotation": 145,
+          "status": 1,
+          "vehicle": "cars_only",
+          "x": 4,
+          "y": 4
+        }
+      ],
+      "place_nested": [
+        {
+          "chunks": [
+            [ "null", 50 ],
+            [ "carcrash_10x10_diag_fromright_bloodcorpse", 50 ]
+          ],
+          "x": 0,
+          "y": 0
+        }
+      ]
     }
   },
   {
@@ -139,8 +334,23 @@
         "    mm  ",
         "    mm  "
       ],
-      "place_items": [ { "item": "corpses_verydead", "x": [ 6, 7 ], "y": [ 1, 2 ], "chance": 100 } ],
-      "place_fields": [ { "field": "fd_gibs_flesh", "x": [ 6, 7 ], "y": [ 1, 2 ], "intensity": [ 1, 2 ], "repeat": [ 1, 3 ] } ],
+      "place_items": [
+        {
+          "item": "corpses_verydead",
+          "x": [ 6, 7 ],
+          "y": [ 1, 2 ],
+          "chance": 100
+        }
+      ],
+      "place_fields": [
+        {
+          "field": "fd_gibs_flesh",
+          "x": [ 6, 7 ],
+          "y": [ 1, 2 ],
+          "intensity": [ 1, 2 ],
+          "repeat": [ 1, 3 ]
+        }
+      ],
       "palettes": [ "struc_damage" ]
     }
   },
@@ -162,8 +372,23 @@
         "          ",
         "          "
       ],
-      "place_items": [ { "item": "corpses_verydead", "x": [ 0, 1 ], "y": [ 0, 1 ], "chance": 100 } ],
-      "place_fields": [ { "field": "fd_gibs_flesh", "x": [ 0, 1 ], "y": [ 0, 1 ], "intensity": [ 1, 2 ], "repeat": [ 1, 3 ] } ],
+      "place_items": [
+        {
+          "item": "corpses_verydead",
+          "x": [ 0, 1 ],
+          "y": [ 0, 1 ],
+          "chance": 100
+        }
+      ],
+      "place_fields": [
+        {
+          "field": "fd_gibs_flesh",
+          "x": [ 0, 1 ],
+          "y": [ 0, 1 ],
+          "intensity": [ 1, 2 ],
+          "repeat": [ 1, 3 ]
+        }
+      ],
       "palettes": [ "struc_damage" ]
     }
   },
@@ -185,8 +410,23 @@
         "          ",
         "          "
       ],
-      "place_items": [ { "item": "corpses_verydead", "x": [ 8, 9 ], "y": [ 0, 1 ], "chance": 100 } ],
-      "place_fields": [ { "field": "fd_gibs_flesh", "x": [ 8, 9 ], "y": [ 0, 1 ], "intensity": [ 1, 2 ], "repeat": [ 1, 3 ] } ],
+      "place_items": [
+        {
+          "item": "corpses_verydead",
+          "x": [ 8, 9 ],
+          "y": [ 0, 1 ],
+          "chance": 100
+        }
+      ],
+      "place_fields": [
+        {
+          "field": "fd_gibs_flesh",
+          "x": [ 8, 9 ],
+          "y": [ 0, 1 ],
+          "intensity": [ 1, 2 ],
+          "repeat": [ 1, 3 ]
+        }
+      ],
       "palettes": [ "struc_damage" ]
     }
   }

--- a/data/json/mapgen/nested/structure_damage_nested.json
+++ b/data/json/mapgen/nested/structure_damage_nested.json
@@ -5,13 +5,7 @@
     "parameters": { "crashvariant": { "type": "string", "scope": "omt", "default": { "distribution": [ "fromleft", "fromright" ] } } },
     "ter_furn_transforms": {
       "c": {
-        "transform": {
-          "switch": { "param": "crashvariant" },
-          "cases": {
-            "fromleft": "struc_carcrash_dirt",
-            "fromright": "tft_null"
-          }
-        }
+        "transform": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "struc_carcrash_dirt", "fromright": "tft_null" } }
       },
       "v": {
         "transform": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "tft_null", "fromright": "struc_carcrash_dirt" } }
@@ -20,43 +14,23 @@
         "transform": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "struc_carcrash_rubble", "fromright": "tft_null" } }
       },
       "j": {
-        "transform": {
-          "switch": { "param": "crashvariant" },
-          "cases": {
-            "fromleft": "tft_null",
-            "fromright": "struc_carcrash_rubble"
-          }
-        }
+        "transform": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "tft_null", "fromright": "struc_carcrash_rubble" } }
       },
       "r": { "transform": "struc_carcrash_rubble" },
       "x": { "transform": "struc_carcrash_clear" },
       "d": { "transform": "struc_carcrash_dirt" }
     },
     "fields": {
-      "m": {
-        "field": "fd_blood",
-        "intensity": 2
-      },
-      "h": {
-        "field": "fd_blood",
-        "intensity": 3
-      },
-      "k": {
-        "field": "fd_blood",
-        "intensity": 3
-      }
+      "m": { "field": "fd_blood", "intensity": 2 },
+      "h": { "field": "fd_blood", "intensity": 3 },
+      "k": { "field": "fd_blood", "intensity": 3 }
     }
   },
   {
     "type": "ter_furn_transform",
     "id": "tft_null",
     "//": "transform won't accept null in a switch statement, so for now this is the solution. Does nothing.",
-    "terrain": [
-      {
-        "result": "t_null",
-        "valid_terrain": [ "t_null" ]
-      }
-    ]
+    "terrain": [ { "result": "t_null", "valid_terrain": [ "t_null" ] } ]
   },
   {
     "type": "ter_furn_transform",
@@ -82,29 +56,13 @@
         "valid_flags": [ "DIGGABLE", "TREE", "SHRUB", "FLOWER" ]
       }
     ],
-    "furniture": [
-      {
-        "result": "f_rubble",
-        "valid_furniture": [ "f_null" ],
-        "valid_flags": [ "BLOCKSDOOR", "TRANSPARENT" ]
-      }
-    ]
+    "furniture": [ { "result": "f_rubble", "valid_furniture": [ "f_null" ], "valid_flags": [ "BLOCKSDOOR", "TRANSPARENT" ] } ]
   },
   {
     "type": "ter_furn_transform",
     "id": "struc_carcrash_dirt",
-    "terrain": [
-      {
-        "result": "t_dirtmoundfloor",
-        "valid_flags": [ "DIGGABLE", "TREE", "SHRUB", "FLOWER" ]
-      }
-    ],
-    "furniture": [
-      {
-        "result": "f_null",
-        "valid_flags": [ "BLOCKSDOOR", "TRANSPARENT" ]
-      }
-    ]
+    "terrain": [ { "result": "t_dirtmoundfloor", "valid_flags": [ "DIGGABLE", "TREE", "SHRUB", "FLOWER" ] } ],
+    "furniture": [ { "result": "f_null", "valid_flags": [ "BLOCKSDOOR", "TRANSPARENT" ] } ]
   },
   {
     "type": "ter_furn_transform",
@@ -125,12 +83,7 @@
         "valid_flags": [ "DOOR", "WINDOW", "WALL", "BARRICADABLE_DOOR", "BARRICADABLE_DOOR_DAMAGED" ]
       }
     ],
-    "furniture": [
-      {
-        "result": "f_null",
-        "valid_flags": [ "BLOCKSDOOR", "TRANSPARENT" ]
-      }
-    ]
+    "furniture": [ { "result": "f_null", "valid_flags": [ "BLOCKSDOOR", "TRANSPARENT" ] } ]
   },
   {
     "type": "mapgen",
@@ -142,11 +95,7 @@
       "palettes": [ "struc_damage" ],
       "place_nested": [
         {
-          "chunks": [
-            [ "carcrash_10x10_straight", 33 ],
-            [ "carcrash_10x10_diag_fromleft", 33 ],
-            [ "carcrash_10x10_diag_fromright", 33 ]
-          ],
+          "chunks": [ [ "carcrash_10x10_straight", 33 ], [ "carcrash_10x10_diag_fromleft", 33 ], [ "carcrash_10x10_diag_fromright", 33 ] ],
           "x": 0,
           "y": 0
         }
@@ -161,13 +110,7 @@
     "object": {
       "mapgensize": [ 10, 10 ],
       "palettes": [ "struc_damage" ],
-      "place_nested": [
-        {
-          "chunks": [ "carcrash_8x8_straight" ],
-          "x": [ 0, 2 ],
-          "y": 0
-        }
-      ]
+      "place_nested": [ { "chunks": [ "carcrash_8x8_straight" ], "x": [ 0, 2 ], "y": 0 } ]
     }
   },
   {
@@ -189,27 +132,8 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "struc_damage" ],
-      "place_vehicles": [
-        {
-          "chance": 100,
-          "fuel": 10,
-          "rotation": 90,
-          "status": 1,
-          "vehicle": "cars_only",
-          "x": 4,
-          "y": 4
-        }
-      ],
-      "place_nested": [
-        {
-          "chunks": [
-            [ "null", 50 ],
-            [ "carcrash_8x8_straight_bloodcorpse", 50 ]
-          ],
-          "x": 0,
-          "y": 0
-        }
-      ]
+      "place_vehicles": [ { "chance": 100, "fuel": 10, "rotation": 90, "status": 1, "vehicle": "cars_only", "x": 4, "y": 4 } ],
+      "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_8x8_straight_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
     }
   },
   {
@@ -233,27 +157,8 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "struc_damage" ],
-      "place_vehicles": [
-        {
-          "chance": 100,
-          "fuel": 10,
-          "rotation": 35,
-          "status": 1,
-          "vehicle": "cars_only",
-          "x": 5,
-          "y": 3
-        }
-      ],
-      "place_nested": [
-        {
-          "chunks": [
-            [ "null", 50 ],
-            [ "carcrash_10x10_diag_fromleft_bloodcorpse", 50 ]
-          ],
-          "x": 0,
-          "y": 0
-        }
-      ]
+      "place_vehicles": [ { "chance": 100, "fuel": 10, "rotation": 35, "status": 1, "vehicle": "cars_only", "x": 5, "y": 3 } ],
+      "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_10x10_diag_fromleft_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
     }
   },
   {
@@ -277,27 +182,8 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "struc_damage" ],
-      "place_vehicles": [
-        {
-          "chance": 100,
-          "fuel": 10,
-          "rotation": 145,
-          "status": 1,
-          "vehicle": "cars_only",
-          "x": 4,
-          "y": 4
-        }
-      ],
-      "place_nested": [
-        {
-          "chunks": [
-            [ "null", 50 ],
-            [ "carcrash_10x10_diag_fromright_bloodcorpse", 50 ]
-          ],
-          "x": 0,
-          "y": 0
-        }
-      ]
+      "place_vehicles": [ { "chance": 100, "fuel": 10, "rotation": 145, "status": 1, "vehicle": "cars_only", "x": 4, "y": 4 } ],
+      "place_nested": [ { "chunks": [ [ "null", 50 ], [ "carcrash_10x10_diag_fromright_bloodcorpse", 50 ] ], "x": 0, "y": 0 } ]
     }
   },
   {
@@ -316,23 +202,8 @@
         "    mm  ",
         "    mm  "
       ],
-      "place_items": [
-        {
-          "item": "corpses_verydead",
-          "x": [ 6, 7 ],
-          "y": [ 1, 2 ],
-          "chance": 100
-        }
-      ],
-      "place_fields": [
-        {
-          "field": "fd_gibs_flesh",
-          "x": [ 6, 7 ],
-          "y": [ 1, 2 ],
-          "intensity": [ 1, 2 ],
-          "repeat": [ 1, 3 ]
-        }
-      ],
+      "place_items": [ { "item": "corpses_verydead", "x": [ 6, 7 ], "y": [ 1, 2 ], "chance": 100 } ],
+      "place_fields": [ { "field": "fd_gibs_flesh", "x": [ 6, 7 ], "y": [ 1, 2 ], "intensity": [ 1, 2 ], "repeat": [ 1, 3 ] } ],
       "palettes": [ "struc_damage" ]
     }
   },
@@ -354,23 +225,8 @@
         "          ",
         "          "
       ],
-      "place_items": [
-        {
-          "item": "corpses_verydead",
-          "x": [ 0, 1 ],
-          "y": [ 0, 1 ],
-          "chance": 100
-        }
-      ],
-      "place_fields": [
-        {
-          "field": "fd_gibs_flesh",
-          "x": [ 0, 1 ],
-          "y": [ 0, 1 ],
-          "intensity": [ 1, 2 ],
-          "repeat": [ 1, 3 ]
-        }
-      ],
+      "place_items": [ { "item": "corpses_verydead", "x": [ 0, 1 ], "y": [ 0, 1 ], "chance": 100 } ],
+      "place_fields": [ { "field": "fd_gibs_flesh", "x": [ 0, 1 ], "y": [ 0, 1 ], "intensity": [ 1, 2 ], "repeat": [ 1, 3 ] } ],
       "palettes": [ "struc_damage" ]
     }
   },
@@ -392,23 +248,8 @@
         "          ",
         "          "
       ],
-      "place_items": [
-        {
-          "item": "corpses_verydead",
-          "x": [ 8, 9 ],
-          "y": [ 0, 1 ],
-          "chance": 100
-        }
-      ],
-      "place_fields": [
-        {
-          "field": "fd_gibs_flesh",
-          "x": [ 8, 9 ],
-          "y": [ 0, 1 ],
-          "intensity": [ 1, 2 ],
-          "repeat": [ 1, 3 ]
-        }
-      ],
+      "place_items": [ { "item": "corpses_verydead", "x": [ 8, 9 ], "y": [ 0, 1 ], "chance": 100 } ],
+      "place_fields": [ { "field": "fd_gibs_flesh", "x": [ 8, 9 ], "y": [ 0, 1 ], "intensity": [ 1, 2 ], "repeat": [ 1, 3 ] } ],
       "palettes": [ "struc_damage" ]
     }
   }

--- a/data/json/mapgen/nested/structure_damage_nested.json
+++ b/data/json/mapgen/nested/structure_damage_nested.json
@@ -14,13 +14,7 @@
         }
       },
       "v": {
-        "transform": {
-          "switch": { "param": "crashvariant" },
-          "cases": {
-            "fromleft": "tft_null",
-            "fromright": "struc_carcrash_dirt"
-          }
-        }
+        "transform": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "tft_null", "fromright": "struc_carcrash_dirt" } }
       },
       "w": {
         "transform": {

--- a/data/json/mapgen/nested/structure_damage_nested.json
+++ b/data/json/mapgen/nested/structure_damage_nested.json
@@ -17,13 +17,7 @@
         "transform": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "tft_null", "fromright": "struc_carcrash_dirt" } }
       },
       "w": {
-        "transform": {
-          "switch": { "param": "crashvariant" },
-          "cases": {
-            "fromleft": "struc_carcrash_rubble",
-            "fromright": "tft_null"
-          }
-        }
+        "transform": { "switch": { "param": "crashvariant" }, "cases": { "fromleft": "struc_carcrash_rubble", "fromright": "tft_null" } }
       },
       "j": {
         "transform": {

--- a/data/json/mapgen/nested/structure_damage_nested.json
+++ b/data/json/mapgen/nested/structure_damage_nested.json
@@ -2,13 +2,7 @@
   {
     "type": "palette",
     "id": "struc_damage",
-    "parameters": {
-      "crashvariant": {
-        "type": "string",
-        "scope": "omt",
-        "default": { "distribution": [ "fromleft", "fromright" ] }
-      }
-    },
+    "parameters": { "crashvariant": { "type": "string", "scope": "omt", "default": { "distribution": [ "fromleft", "fromright" ] } } },
     "ter_furn_transforms": {
       "c": {
         "transform": {


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Structure damage from car crashes now retain the terrains of the original structure such as floorboards, carpets, ect."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Continuation of #78382
(See above PR for comparison screenshots)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changes the manually defined overriding terrains to ter_furn_transform, allowing for better control over the environments that are being overwritten. This allows the building's original floorboards, carpets, ect, to be maintained rather than just changing all the terrains to upturned dirt.
Also, one of the bungalows spawn rates for the car crash nest was messed up, so I fixed it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://github.com/user-attachments/assets/6b3d18c9-a0af-426c-9b19-54b503e25c9b)
![image](https://github.com/user-attachments/assets/e0757676-325b-4846-985b-0238103dbb88)
![image](https://github.com/user-attachments/assets/3bbc8d94-78bd-44ce-8b5e-d56ba3243c09)
![image](https://github.com/user-attachments/assets/4e7fa47a-b7c7-47c0-94fc-1d25521e8582)
![image](https://github.com/user-attachments/assets/636bbea7-20d7-4f4a-8ba3-72af4bb5b3cc)
![image](https://github.com/user-attachments/assets/eaaed915-69b6-4c82-8b5a-46cc0fd317a9)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

- This uses parameter switch statements in ter_furn_transform transform statements, which to my knowledge hasn't been done before in this project. It seems to work just fine.
- Transform won't accept null as a valid string, so I ended up having to make a ter_furn_transform that changes t_null into t_null (essentially, it does nothing). In my testing, this didn't cause any issues.
- Does this version look better than the one that's just upturned dirt? I'm not sure.
- Thank you to @Milopetilo for the idea to use ter_furn_transform as a solution.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
