### PR TITLE
make disease immune prevent incipient cold and flu as well

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3246,6 +3246,7 @@
     "apply_message": "You feel a sickness coming on…",
     "rating": "bad",
     "resist_effects": [ "took_flumed" ],
+    "immune_flags": [ "NO_DISEASE" ],
     "base_mods": {
       "thirst_tick": [ 3600 ],
       "thirst_min": [ 1 ],
@@ -3267,6 +3268,7 @@
     "apply_message": "You feel a sickness coming on…",
     "rating": "bad",
     "resist_effects": [ "took_flumed" ],
+    "immune_flags": [ "NO_DISEASE" ],
     "base_mods": {
       "thirst_tick": [ 3600 ],
       "thirst_min": [ 1 ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #78604 
If you're immune to disease you shouldn't get sniffles, just nothing. 

#### Describe the solution
Add the immunity override to pre_cold and pre_flu

#### Describe alternatives you've considered
Some kind of labeling system to mark things as diseases? I don't think that's any easier to maintain than just putting the immunity on there explicitly. 

#### Testing
Ehhhhh...

SMOKEBOMB!