### PR TITLE
General map editor improvements

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -765,8 +765,8 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     for( auto &fld : here.get_field( target ) ) {
         const field_entry &cur = fld.second;
         mvwputch( w_info, point( 1, off ), cur.color(), cur.symbol() );
-        mvwprintw( w_info, point( 2, off++ ), _( "Field: %s; Intensity:%d (%s); Age:%d" ),
-                   cur.get_field_type().id().str(), cur.get_field_intensity(), cur.name(),
+        mvwprintw( w_info, point( 2, off++ ), _( "Field: %s (%d); Intensity:%d (%s); Age:%d" ),
+                   cur.get_field_type().id().str(), cur.get_field_type().to_i(), cur.get_field_intensity(), cur.name(),
                    to_turns<int>( cur.get_field_age() ) ); // 5 (+1 for each field)
     }
 

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -741,6 +741,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     int off = 1;
     draw_border( w_info );
 
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w_info, point( 1, 0 ), c_light_gray, "< %d,%d,%d >", target.x(), target.y(),
                target.z() );
 

--- a/src/editmap.h
+++ b/src/editmap.h
@@ -12,6 +12,7 @@
 #include "color.h"
 #include "coordinates.h"
 #include "cursesdef.h"
+#include "input_context.h"
 #include "point.h"
 #include "type_id.h"
 
@@ -49,7 +50,8 @@ class editmap
 {
     public:
         tripoint pos2screen( const tripoint_bub_ms &p );
-        bool eget_direction( tripoint_rel_ms &p, const std::string &action ) const;
+        bool eget_direction( tripoint_rel_ms &p, const std::string &action,
+                             const input_context &ctxt ) const;
         std::optional<tripoint_bub_ms> edit();
         void uber_draw_ter( const catacurses::window &w, map *m );
         void update_view_with_help( const std::string &txt, const std::string &title );
@@ -74,7 +76,7 @@ class editmap
         catacurses::window w_info;
 
         void recalc_target( shapetype shape );
-        bool move_target( const std::string &action, int moveorigin = -1 );
+        bool move_target( const std::string &action, const input_context &ctxt, int moveorigin = -1 );
 
         int sel_field;
         int sel_field_intensity;
@@ -105,7 +107,7 @@ class editmap
 
         tinymap *tmpmap_ptr = nullptr;
 
-        const int width = 45;
+        const int width = 60;
         const int offsetX = 0;
         const int infoHeight = 20;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I were annoyed that traps were shown by name and not id
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Normalise ter/furn/trap/field formatting and order them together
Add mouse movement
Remove curses only bind from being displayed on tiles
Remove non useful bind descriptors from the menu (Quitting the menu, HJKL fast movement)
Remove omt cycle binds from omt editor submenu bc they don't mesh at all well with the newish list functionality that supercedes them
Increase the width of the main window a bit so it overflows less often (still frequently overflows with long ids or lots of flags etc)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Removing int_ids?
Doing more but I feel that'd be best left for when it's imguified
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested all changes on tiles and curses
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Before tiles/curses
![image](https://github.com/user-attachments/assets/a5114c91-c800-4fab-a4fb-ec8b6abc97fe) ![image](https://github.com/user-attachments/assets/c16b8b12-2302-4946-92f8-856958b27677)

After tiles/curses
![image](https://github.com/user-attachments/assets/a573a59c-6875-44b6-9bd8-6df408213fe6) ![image](https://github.com/user-attachments/assets/a6967d58-2e96-447d-bda1-e4df5ae459e3)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
