### PR TITLE
pianos give piano wire on disassembly

### DIFF
--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -7848,7 +7848,7 @@
     "components": [
       [ [ "2x4", 12 ] ],
       [ [ "nail", 12 ] ],
-      [ [ "qt_wire", 26 ] ],
+      [ [ "piano_wire", 26 ] ],
       [ [ "wheel_caster", 1 ] ],
       [ [ "steel_chunk", 3 ] ],
       [ [ "plastic_chunk", 10 ] ]


### PR DESCRIPTION
#### Summary
Content "Pianos give tempered wire instead of regular wire & string upon disassembly"

#### Purpose of change

When I made PR #61371 I changed the strings and wires given by disassembling a piano to tempered steel wires, since that was the closest thing to piano wire at the time. We have piano wire now so I'm making it now.

#### Describe the solution

changed `qt_wire` to `piano_wire` in the disassembly recipe

No, that's it. thats the whole PR.