### PR TITLE
Improve test coverage of mod combinations with mod_interactions

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -7,6 +7,7 @@
 
 import glob
 import json
+import os
 
 mods_this_time = []
 
@@ -61,6 +62,26 @@ for info in glob.glob('data/mods/*/modinfo.json'):
             all_mod_dependencies[ident] = e.get("dependencies", [])
             if e["category"] == "total_conversion":
                 total_conversions.add(ident)
+
+for r, d, f in os.walk('data/mods'):
+    if 'mod_interactions' not in d:
+        continue
+    if 'modinfo.json' not in f:
+        continue
+    ident = ""
+    info_path = os.path.join(r, 'modinfo.json')
+    mod_info = json.load(open(info_path, encoding='utf-8'))
+    for e in mod_info:
+        if(e["type"] == "MOD_INFO" and
+                ("obsolete" not in e or not e["obsolete"])):
+            ident = e["id"]
+    if ident == "":
+        continue
+    add_mods([ident])
+    for mod in os.scandir(os.path.join(r, 'mod_interactions')):
+        mods_this_time.append(os.path.basename(mod.path))
+    print(','.join(mods_this_time))
+    mods_this_time.clear()
 
 mods_remaining = set(all_mod_dependencies)
 


### PR DESCRIPTION
#### Summary
Infrastructure "Improve test coverage of mod combinations with mod_interactions"

#### Purpose of change

Make issues like #78657 more obvious.

#### Describe the solution

Find all mods with `mod_interactions`, then put each of them in a group with their dependencies and the mods from mod_interactions. This relies on folders in `mod_interactions` being named after the mod id, which is how it works anyway from what I understand.
It's about the simplest solution I could think of and can't add more tests than we have mods, so there's no immediate danger of it exploding in our face, but also only limited coverage of potential issues with interactions and load order.

This slightly more than doubles the amount of mod tests run, but with around 15s per run (except MA mod, which takes longer), it shouldn't be much of an issue.

#### Describe alternatives you've considered

Think of a more complex logic.

#### Testing

Just ran `build_scripts\get_all_mods.py` locally. ~I assume because of #77479 this won't even be used in this PR.~ CI actually ran all the new combos.

#### Additional context

Example output from get_all_mods:

```
dda,aftershock,defense_mode
dda,crazy_cataclysm,mindovermatter
dda,defense_mode,aftershock,bombastic_perks,DinoMod,magiclysm,megafauna,mindovermatter,Mythos-Creatures,my_sweet_cataclysm,xedra_evolved
dda,limb_wip,mindovermatter
dda,magiclysm,bombastic_perks,defense_mode,innawood
dda,megafauna,defense_mode
dda,mindovermatter,bombastic_perks,defense_mode,magiclysm,xedra_evolved
dda,Mythos-Creatures,defense_mode
dda,my_sweet_cataclysm,defense_mode
dda,skyisland,mindovermatter,xedra_evolved
dda,xedra_evolved,bombastic_perks,defense_mode,DinoMod,innawood,magiclysm
dda,aftershock
dda,Mythos-Creatures,sees_player_retro,crazy_cataclysm,Isolation_Protocol,deadly_bites,mindovermatter,no_hope,package_bionic_professions,Only_Wildlife,DinoMod,no_fungal_growth,my_sweet_cataclysm,stats_through_kills,megafauna,alt_map_key,standard_combat_test,personal_portal_storms,MMA,speedydex,translate_dialogue,Tamable_Wildlife,bombastic_perks,no_npc_food,railroads,perk_melee_system,extra_mut_scens,cbm_slots,StatsThroughSkills,xedra_evolved,limb_wip,tropicata,generic_guns,magiclysm
dda,MA
dda,backrooms
dda,defense_mode
dda,skyisland
dda,aftershock,aftershock_exoplanet
dda,innawood
dda,classic_zombies
```