### PR TITLE
Typified zones

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1500,8 +1500,7 @@ static std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> requirements_map(
         already_there_spots.push_back( elem );
         combined_spots.push_back( elem );
     }
-    // TODO: fix point types
-    for( const tripoint &elem : mgr.get_point_set_loot(
+    for( const tripoint_bub_ms &elem : mgr.get_point_set_loot(
              you.get_location(), distance, you.is_npc(), _fac_id( you ) ) ) {
         // if there is a loot zone that's already near the work spot, we don't want it to be added twice.
         if( std::find( already_there_spots.begin(), already_there_spots.end(),
@@ -2804,8 +2803,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
         requirement_id what_we_need;
         std::vector<tripoint_bub_ms> loot_zone_spots;
         std::vector<tripoint_bub_ms> combined_spots;
-        // TODO: fix point types
-        for( const tripoint &elem : mgr.get_point_set_loot(
+        for( const tripoint_bub_ms &elem : mgr.get_point_set_loot(
                  abspos, ACTIVITY_SEARCH_DISTANCE, you.is_npc(), _fac_id( you ) ) ) {
             loot_zone_spots.emplace_back( elem );
             combined_spots.emplace_back( elem );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1461,8 +1461,7 @@ void zone_manager::add( const std::string &name, const zone_type_id &type, const
 
 void zone_manager::add( const std::string &name, const zone_type_id &type, const faction_id &fac,
                         const bool invert, const bool enabled, const tripoint_rel_ms &start,
-                        const tripoint_rel_ms &end, const shared_ptr_fast<zone_options> &options,
-                        bool silent, map *pmap )
+                        const tripoint_rel_ms &end, const shared_ptr_fast<zone_options> &options )
 {
     zone_data new_zone = zone_data( name, type, fac, invert, enabled, start, end, options );
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1464,7 +1464,6 @@ void zone_manager::add( const std::string &name, const zone_type_id &type, const
                         const tripoint_rel_ms &end, const shared_ptr_fast<zone_options> &options,
                         bool silent, map *pmap )
 {
-    map &here = pmap == nullptr ? get_map() : *pmap;
     zone_data new_zone = zone_data( name, type, fac, invert, enabled, start, end, options );
 
     //Create a regular zone

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -670,13 +670,19 @@ bool zone_data::set_type()
     return false;
 }
 
-void zone_data::set_position( const std::pair<tripoint, tripoint> &position,
+void zone_data::set_position( const std::pair<tripoint_abs_ms, tripoint_abs_ms> &position,
                               const bool manual, bool update_avatar, bool skip_cache_update, bool suppress_display_update )
 {
     if( is_vehicle && manual ) {
         debugmsg( "Tried moving a lootzone bound to a vehicle part" );
         return;
     }
+
+    if( is_personal ) {
+        debugmsg( "Tried moving a personal lootzone to absolute location" );
+        return;
+    }
+
     bool adjust_display = is_displayed && !suppress_display_update;
 
     if( adjust_display ) {
@@ -685,6 +691,37 @@ void zone_data::set_position( const std::pair<tripoint, tripoint> &position,
 
     start = position.first;
     end = position.second;
+
+    if( adjust_display ) {
+        toggle_display();
+    }
+
+    if( !skip_cache_update ) {
+        zone_manager::get_manager().cache_data( update_avatar );
+    }
+}
+
+void zone_data::set_position( const std::pair<tripoint_rel_ms, tripoint_rel_ms> &position,
+                              const bool manual, bool update_avatar, bool skip_cache_update, bool suppress_display_update )
+{
+    if( is_vehicle && manual ) {
+        debugmsg( "Tried moving a lootzone bound to a vehicle part" );
+        return;
+    }
+
+    if( !is_personal ) {
+        debugmsg( "Tried moving a normal lootzone to relative location" );
+        return;
+    }
+
+    bool adjust_display = is_displayed && !suppress_display_update;
+
+    if( adjust_display ) {
+        toggle_display();
+    }
+
+    personal_start = position.first;
+    personal_end = position.second;
 
     if( adjust_display ) {
         toggle_display();
@@ -792,28 +829,32 @@ void zone_data::toggle_display()
     // Take care of the situation where parts of overlapping zones were erased by the toggling.
     if( !is_displayed ) {
 
-        const point_abs_ms start = point_abs_ms( std::min( this->start.x, this->end.x ),
-                                   std::min( this->start.y, this->end.y ) );
+        const point_abs_ms start = { std::min( this->start.x(), this->end.x() ),
+                                     std::min( this->start.y(), this->end.y() )
+                                   };
 
-        const point_abs_ms end = point_abs_ms( std::max( this->start.x, this->end.x ),
-                                               std::max( this->start.y, this->end.y ) );
+        const point_abs_ms end = { std::max( this->start.x(), this->end.x() ),
+                                   std::max( this->start.y(), this->end.y() )
+                                 };
 
         const inclusive_rectangle<point_abs_ms> zone_rectangle( start, end );
 
         for( zone_manager::ref_zone_data zone : zone_manager::get_manager().get_zones() ) {
             // Assumes zones are a single Z level only. Also, inclusive_cuboid doesn't have an overlap function...
             if( zone.get().get_is_displayed() && zone.get().get_type() == this->get_type() &&
-                this->start.z == zone.get().get_start_point().z() ) {
+                this->start.z() == zone.get().get_start_point().z() ) {
                 const point_abs_ms candidate_begin = zone.get().get_start_point().xy();
                 const point_abs_ms candidate_stop = zone.get().get_end_point().xy();
 
-                const point_abs_ms candidate_start = point_abs_ms( std::min( candidate_begin.x(),
-                                                     candidate_stop.x() ),
-                                                     std::min( candidate_begin.y(), candidate_stop.y() ) );
+                const point_abs_ms candidate_start = { std::min( candidate_begin.x(),
+                                                       candidate_stop.x() ),
+                                                       std::min( candidate_begin.y(), candidate_stop.y() )
+                                                     };
 
-                const point_abs_ms candidate_end = point_abs_ms( std::max( candidate_begin.x(),
-                                                   candidate_stop.x() ),
-                                                   std::max( candidate_begin.y(), candidate_stop.y() ) );
+                const point_abs_ms candidate_end = { std::max( candidate_begin.x(),
+                                                     candidate_stop.x() ),
+                                                     std::max( candidate_begin.y(), candidate_stop.y() )
+                                                   };
 
                 const inclusive_rectangle<point_abs_ms> candidate_rectangle( candidate_start, candidate_end );
 
@@ -945,16 +986,16 @@ std::unordered_set<tripoint_abs_ms> zone_manager::get_point_set( const zone_type
     return type_iter->second;
 }
 
-std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_abs_ms &where,
+std::unordered_set<tripoint_bub_ms> zone_manager::get_point_set_loot( const tripoint_abs_ms &where,
         int radius, const faction_id &fac ) const
 {
     return get_point_set_loot( where, radius, false, fac );
 }
 
-std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_abs_ms &where,
+std::unordered_set<tripoint_bub_ms> zone_manager::get_point_set_loot( const tripoint_abs_ms &where,
         int radius, bool npc_search, const faction_id &fac ) const
 {
-    std::unordered_set<tripoint> res;
+    std::unordered_set<tripoint_bub_ms> res;
     map &here = get_map();
     for( const std::pair<std::string, std::unordered_set<tripoint_abs_ms>> cache : area_cache ) {
         zone_type_id type = zone_data::unhash_type( cache.first );
@@ -962,7 +1003,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_ab
         if( fac == z_fac && type.str().substr( 0, 4 ) == "LOOT" ) {
             for( tripoint_abs_ms point : cache.second ) {
                 if( square_dist( where, point ) <= radius ) {
-                    res.emplace( here.bub_from_abs( point ).raw() );
+                    res.emplace( here.bub_from_abs( point ) );
                 }
             }
         }
@@ -973,7 +1014,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_ab
         if( fac == z_fac && type.str().substr( 0, 4 ) == "LOOT" ) {
             for( tripoint_abs_ms point : cache.second ) {
                 if( square_dist( where, point ) <= radius ) {
-                    res.emplace( here.bub_from_abs( point ).raw() );
+                    res.emplace( here.bub_from_abs( point ) );
                 }
             }
         }
@@ -984,7 +1025,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_ab
             zone_type_id type = zone_data::unhash_type( cache.first );
             if( type == zone_type_NO_NPC_PICKUP ) {
                 for( tripoint_abs_ms point : cache.second ) {
-                    res.erase( here.bub_from_abs( point ).raw() );
+                    res.erase( here.bub_from_abs( point ) );
                 }
             }
         }
@@ -1375,7 +1416,7 @@ const zone_data *zone_manager::get_bottom_zone(
 // which constructor of the key-value pair we use which depends on new_zone being an rvalue or lvalue and constness.
 // If you are passing new_zone from a non-const iterator, be prepared for a move! This
 // may break some iterators like map iterators if you are less specific!
-void zone_manager::create_vehicle_loot_zone( vehicle &vehicle, const point &mount_point,
+void zone_manager::create_vehicle_loot_zone( vehicle &vehicle, const point_rel_ms &mount_point,
         zone_data &new_zone, map *pmap )
 {
     //create a vehicle loot zone
@@ -1388,38 +1429,47 @@ void zone_manager::create_vehicle_loot_zone( vehicle &vehicle, const point &moun
 }
 
 void zone_manager::add( const std::string &name, const zone_type_id &type, const faction_id &fac,
-                        const bool invert, const bool enabled, const tripoint &start,
-                        const tripoint &end, const shared_ptr_fast<zone_options> &options, const bool personal,
+                        const bool invert, const bool enabled, const tripoint_abs_ms &start,
+                        const tripoint_abs_ms &end, const shared_ptr_fast<zone_options> &options,
                         bool silent, map *pmap )
 {
     map &here = pmap == nullptr ? get_map() : *pmap;
-    zone_data new_zone = zone_data( name, type, fac, invert, enabled, start, end, options, personal );
+    zone_data new_zone = zone_data( name, type, fac, invert, enabled, start, end, options );
     // only non personal zones can be vehicle zones
-    if( !personal ) {
-        optional_vpart_position const vp = here.veh_at( here.bub_from_abs( tripoint_abs_ms( start ) ) );
-        if( vp && vp->vehicle().get_owner() == fac && vp.cargo() ) {
-            // TODO:Allow for loot zones on vehicles to be larger than 1x1
-            if( start == end &&
-                ( silent || query_yn( _( "Bind this zone to the cargo part here?" ) ) ) ) {
-                // TODO: refactor zone options for proper validation code
-                if( !silent &&
-                    ( type == zone_type_FARM_PLOT || type == zone_type_CONSTRUCTION_BLUEPRINT ) ) {
-                    popup( _( "You cannot add that type of zone to a vehicle." ), PF_NONE );
-                    return;
-                }
-
-                create_vehicle_loot_zone( vp->vehicle(), vp->mount_pos().raw(), new_zone, pmap );
+    optional_vpart_position const vp = here.veh_at( here.bub_from_abs( start ) );
+    if( vp && vp->vehicle().get_owner() == fac && vp.cargo() ) {
+        // TODO:Allow for loot zones on vehicles to be larger than 1x1
+        if( start == end &&
+            ( silent || query_yn( _( "Bind this zone to the cargo part here?" ) ) ) ) {
+            // TODO: refactor zone options for proper validation code
+            if( !silent &&
+                ( type == zone_type_FARM_PLOT || type == zone_type_CONSTRUCTION_BLUEPRINT ) ) {
+                popup( _( "You cannot add that type of zone to a vehicle." ), PF_NONE );
                 return;
             }
+
+            create_vehicle_loot_zone( vp->vehicle(), vp->mount_pos(), new_zone, pmap );
+            return;
         }
     }
 
     //Create a regular zone
     zones.push_back( new_zone );
 
-    if( personal ) {
-        num_personal_zones++;
-    }
+    cache_data();
+}
+
+void zone_manager::add( const std::string &name, const zone_type_id &type, const faction_id &fac,
+                        const bool invert, const bool enabled, const tripoint_rel_ms &start,
+                        const tripoint_rel_ms &end, const shared_ptr_fast<zone_options> &options,
+                        bool silent, map *pmap )
+{
+    map &here = pmap == nullptr ? get_map() : *pmap;
+    zone_data new_zone = zone_data( name, type, fac, invert, enabled, start, end, options );
+
+    //Create a regular zone
+    zones.push_back( new_zone );
+    num_personal_zones++;
     cache_data();
 }
 
@@ -1507,7 +1557,7 @@ void _rotate_zone( map &target_map, zone_data &zone, int turns )
             target_map.getglobal( tripoint_bub_ms( std::max( z_l_start.x(), z_l_end.x() ),
                                   std::max( z_l_start.y(), z_l_end.y() ),
                                   z_end.z() ) );
-        zone.set_position( std::make_pair( first.raw(), second.raw() ), false, true, false, true );
+        zone.set_position( std::make_pair( first, second ), false, true, false, true );
     }
 }
 
@@ -1622,8 +1672,13 @@ void zone_data::serialize( JsonOut &json ) const
     json.member( "is_vehicle", is_vehicle );
     json.member( "is_personal", is_personal );
     json.member( "cached_shift", cached_shift );
-    json.member( "start", start );
-    json.member( "end", end );
+    if( is_personal ) {
+        json.member( "start", personal_start );
+        json.member( "end", personal_end );
+    } else {
+        json.member( "start", start );
+        json.member( "end", end );
+    }
     json.member( "is_displayed", is_displayed );
     options->serialize( json );
     json.end_object();
@@ -1664,19 +1719,29 @@ void zone_data::deserialize( const JsonObject &data )
     }
     //Legacy support
     if( data.has_member( "start_x" ) ) {
-        tripoint s;
-        tripoint e;
-        data.read( "start_x", s.x );
-        data.read( "start_y", s.y );
-        data.read( "start_z", s.z );
-        data.read( "end_x", e.x );
-        data.read( "end_y", e.y );
-        data.read( "end_z", e.z );
-        start = s;
-        end = e;
+        tripoint_abs_ms s;
+        tripoint_abs_ms e;
+        data.read( "start_x", s.x() );
+        data.read( "start_y", s.y() );
+        data.read( "start_z", s.z() );
+        data.read( "end_x", e.x() );
+        data.read( "end_y", e.y() );
+        data.read( "end_z", e.z() );
+        if( is_personal ) {
+            personal_start = tripoint_rel_ms( s.raw() );
+            personal_end = tripoint_rel_ms( e.raw() );
+        } else {
+            start = s;
+            end = e;
+        }
     } else {
-        data.read( "start", start );
-        data.read( "end", end );
+        if( is_personal ) {
+            data.read( "start", personal_start );
+            data.read( "end", personal_end );
+        } else {
+            data.read( "start", start );
+            data.read( "end", end );
+        }
     }
     if( data.has_member( "is_displayed" ) ) {
         data.read( "is_displayed", is_displayed );
@@ -1804,18 +1869,19 @@ void zone_manager::revert_vzones()
     }
 }
 
-void mapgen_place_zone( tripoint const &start, tripoint const &end, zone_type_id const &type,
+void mapgen_place_zone( tripoint_abs_ms const &start, tripoint_abs_ms const &end,
+                        zone_type_id const &type,
                         faction_id const &fac, std::string const &name, std::string const &filter,
                         map *pmap )
 {
     zone_manager &mgr = zone_manager::get_manager();
     auto options = zone_options::create( type );
-    tripoint const s_ = std::min( start, end );
-    tripoint const e_ = std::max( start, end );
+    tripoint_abs_ms const s_ = std::min( start, end );
+    tripoint_abs_ms const e_ = std::max( start, end );
     if( type == zone_type_LOOT_CUSTOM || type == zone_type_LOOT_ITEM_GROUP ) {
         if( dynamic_cast<loot_options *>( &*options ) != nullptr ) {
             dynamic_cast<loot_options *>( &*options )->set_mark( filter );
         }
     }
-    mgr.add( name, type, fac, false, true, s_, e_, options, false, true, pmap );
+    mgr.add( name, type, fac, false, true, s_, e_, options, true, pmap );
 }

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -356,10 +356,12 @@ class zone_data
         // if the zone has been turned off for an action
         bool temporarily_disabled; // NOLINT(cata-serialize)
         bool is_vehicle;
-        tripoint start;
-        tripoint end;
+        tripoint_abs_ms start;
+        tripoint_abs_ms end;
         //centered on the player
         bool is_personal;
+        tripoint_rel_ms personal_start;
+        tripoint_rel_ms personal_end;
         // for personal zones a cached value for the global shift to where the player was at activity start
         tripoint_abs_ms cached_shift;
         shared_ptr_fast<zone_options> options;
@@ -373,17 +375,19 @@ class zone_data
             temporarily_disabled = false;
             is_vehicle = false;
             is_personal = false;
-            start = tripoint::zero;
-            end = tripoint::zero;
-            cached_shift = {};
+            start = tripoint_abs_ms::zero;
+            end = tripoint_abs_ms::zero;
+            personal_start = tripoint_rel_ms::zero;
+            personal_end = tripoint_rel_ms::zero;
+            cached_shift = tripoint_abs_ms::zero;
             options = nullptr;
             is_displayed = false;
         }
 
         zone_data( const std::string &_name, const zone_type_id &_type, const faction_id &_faction,
                    bool _invert, const bool _enabled,
-                   const tripoint &_start, const tripoint &_end,
-                   const shared_ptr_fast<zone_options> &_options = nullptr, bool personal = false,
+                   const tripoint_abs_ms &_start, const tripoint_abs_ms &_end,
+                   const shared_ptr_fast<zone_options> &_options = nullptr,
                    bool _is_displayed = false ) {
             name = _name;
             type = _type;
@@ -391,9 +395,33 @@ class zone_data
             invert = _invert;
             enabled = _enabled;
             is_vehicle = false;
-            is_personal = personal;
+            is_personal = false;
             start = _start;
             end = _end;
+            is_displayed = _is_displayed;
+
+            // ensure that supplied options is of correct class
+            if( _options == nullptr || !zone_options::is_valid( type, *_options ) ) {
+                options = zone_options::create( type );
+            } else {
+                options = _options;
+            }
+        }
+
+        zone_data( const std::string &_name, const zone_type_id &_type, const faction_id &_faction,
+                   bool _invert, const bool _enabled,
+                   const tripoint_rel_ms &_start, const tripoint_rel_ms &_end,
+                   const shared_ptr_fast<zone_options> &_options = nullptr,
+                   bool _is_displayed = false ) {
+            name = _name;
+            type = _type;
+            faction = _faction;
+            invert = _invert;
+            enabled = _enabled;
+            is_vehicle = false;
+            is_personal = true;
+            personal_start = _start;
+            personal_end = _end;
             is_displayed = _is_displayed;
 
             // ensure that supplied options is of correct class
@@ -410,7 +438,10 @@ class zone_data
         bool set_type();
         // We need to be able to suppress the display of zones when the movement is part of a map rotation, as the underlying
         // field is automatically rotated by the map rotation itself.
-        void set_position( const std::pair<tripoint, tripoint> &position, bool manual = true,
+        // One version for personal zones and one for the rest
+        void set_position( const std::pair<tripoint_abs_ms, tripoint_abs_ms> &position, bool manual = true,
+                           bool update_avatar = true, bool skip_cache_update = false, bool suppress_display_update = false );
+        void set_position( const std::pair<tripoint_rel_ms, tripoint_rel_ms> &position, bool manual = true,
                            bool update_avatar = true, bool skip_cache_update = false, bool suppress_display_update = false );
         void set_enabled( bool enabled_arg );
         void set_temporary_disabled( bool enabled_arg );
@@ -472,15 +503,15 @@ class zone_data
         }
         tripoint_abs_ms get_start_point() const {
             if( is_personal ) {
-                return start + cached_shift;
+                return cached_shift + personal_start;
             }
-            return tripoint_abs_ms{ start };
+            return start;
         }
         tripoint_abs_ms get_end_point() const {
             if( is_personal ) {
-                return end + cached_shift;
+                return cached_shift + personal_end;
             }
-            return tripoint_abs_ms{ end };
+            return end;
         }
         void update_cached_shift( const tripoint_abs_ms &player_loc ) {
             cached_shift = player_loc;
@@ -503,9 +534,9 @@ class zone_data
             // if it is personal then the zone is local
             if( is_personal ) {
                 return inclusive_cuboid<tripoint_abs_ms>(
-                           start + cached_shift, end + cached_shift ).contains( p );
+                           cached_shift + personal_start, cached_shift + personal_end ).contains( p );
             }
-            return inclusive_cuboid<tripoint>( start, end ).contains( p.raw() );
+            return inclusive_cuboid<tripoint_abs_ms>( start, end ).contains( p );
         }
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &data );
@@ -556,18 +587,27 @@ class zone_manager
 
         void clear();
 
+        // For addition of regular and vehicle zones
         void add( const std::string &name, const zone_type_id &type, const faction_id &faction,
                   bool invert, bool enabled,
-                  const tripoint &start, const tripoint &end,
-                  const shared_ptr_fast<zone_options> &options = nullptr, bool personal = false,
+                  const tripoint_abs_ms &start, const tripoint_abs_ms &end,
+                  const shared_ptr_fast<zone_options> &options = nullptr,
                   bool silent = false, map *pmap = nullptr );
+
+        // For addition of personal zones
+        void add( const std::string &name, const zone_type_id &type, const faction_id &faction,
+                  bool invert, bool enabled,
+                  const tripoint_rel_ms &start, const tripoint_rel_ms &end,
+                  const shared_ptr_fast<zone_options> &options = nullptr,
+                  bool silent = false, map *pmap = nullptr );
+
         // get first matching zone
         const zone_data *get_zone_at( const tripoint_abs_ms &where, const zone_type_id &type,
                                       const faction_id &fac = your_fac ) const;
         // get all matching zones (useful for LOOT_CUSTOM and LOOT_ITEM_GROUP)
         std::vector<zone_data const *> get_zones_at( const tripoint_abs_ms &where, const zone_type_id &type,
                 const faction_id &fac = your_fac ) const;
-        void create_vehicle_loot_zone( class vehicle &vehicle, const point &mount_point,
+        void create_vehicle_loot_zone( class vehicle &vehicle, const point_rel_ms &mount_point,
                                        zone_data &new_zone, map *pmap = nullptr );
 
         bool remove( zone_data &zone );
@@ -614,9 +654,9 @@ class zone_manager
         void swap( zone_data &a, zone_data &b );
         void rotate_zones( map &target_map, int turns );
         // list of tripoints of zones that are loot zones only
-        std::unordered_set<tripoint> get_point_set_loot(
+        std::unordered_set<tripoint_bub_ms> get_point_set_loot(
             const tripoint_abs_ms &where, int radius, const faction_id &fac = your_fac ) const;
-        std::unordered_set<tripoint> get_point_set_loot(
+        std::unordered_set<tripoint_bub_ms> get_point_set_loot(
             const tripoint_abs_ms &where, int radius, bool npc_search,
             const faction_id &fac = your_fac ) const;
 
@@ -636,7 +676,8 @@ class zone_manager
         void deserialize( const JsonValue &jv );
 };
 
-void mapgen_place_zone( tripoint const &start, tripoint const &end, zone_type_id const &type,
+void mapgen_place_zone( tripoint_abs_ms const &start, tripoint_abs_ms const &end,
+                        zone_type_id const &type,
                         faction_id const &fac = your_fac, std::string const &name = {},
                         std::string const &filter = {}, map *pmap = nullptr );
 

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -598,8 +598,7 @@ class zone_manager
         void add( const std::string &name, const zone_type_id &type, const faction_id &faction,
                   bool invert, bool enabled,
                   const tripoint_rel_ms &start, const tripoint_rel_ms &end,
-                  const shared_ptr_fast<zone_options> &options = nullptr,
-                  bool silent = false, map *pmap = nullptr );
+                  const shared_ptr_fast<zone_options> &options = nullptr );
 
         // get first matching zone
         const zone_data *get_zone_at( const tripoint_abs_ms &where, const zone_type_id &type,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7049,7 +7049,7 @@ void game::zones_manager()
     // In C++20 we could have the return type depend on the parameter using
     // if constexpr( personal ) but for now it will just return tripoints.
     auto query_position =
-    [&]( bool personal = false ) -> std::optional<std::pair<tripoint, tripoint>> {
+    [&]( ) -> std::optional<std::pair<tripoint_abs_ms, tripoint_abs_ms>> {
         on_out_of_scope invalidate_current_ui( [&]()
         {
             ui.mark_resize();
@@ -7077,31 +7077,64 @@ void game::zones_manager()
             const look_around_result second = look_around( /*show_window=*/false, center, *first.position,
                     true, true, false );
             if( second.position ) {
-                if( personal ) {
-                    tripoint first_rel(
-                        std::min( first.position->x() - u.posx(), second.position->x() - u.posx() ),
-                        std::min( first.position->y() - u.posy(), second.position->y() - u.posy() ),
-                        std::min( first.position->z() - u.posz(), second.position->z() - u.posz() ) );
-                    tripoint second_rel(
-                        std::max( first.position->x() - u.posx(), second.position->x() - u.posx() ),
-                        std::max( first.position->y() - u.posy(), second.position->y() - u.posy() ),
-                        std::max( first.position->z() - u.posz(), second.position->z() - u.posz() ) );
-                    return { { first_rel, second_rel } };
-                }
                 tripoint_abs_ms first_abs =
-                    m.getglobal(
-                        tripoint_bub_ms(
-                            std::min( first.position->x(), second.position->x() ),
-                            std::min( first.position->y(), second.position->y() ),
-                            std::min( first.position->z(), second.position->z() ) ) );
+                m.getglobal(
+                    tripoint_bub_ms(
+                        std::min( first.position->x(), second.position->x() ),
+                        std::min( first.position->y(), second.position->y() ),
+                        std::min( first.position->z(), second.position->z() ) ) );
                 tripoint_abs_ms second_abs =
-                    m.getglobal(
-                        tripoint_bub_ms(
-                            std::max( first.position->x(), second.position->x() ),
-                            std::max( first.position->y(), second.position->y() ),
-                            std::max( first.position->z(), second.position->z() ) ) );
+                m.getglobal(
+                    tripoint_bub_ms(
+                        std::max( first.position->x(), second.position->x() ),
+                        std::max( first.position->y(), second.position->y() ),
+                        std::max( first.position->z(), second.position->z() ) ) );
 
-                return { { first_abs.raw(), second_abs.raw() } };
+                return { { first_abs, second_abs } };
+            }
+        }
+
+        return std::nullopt;
+    };
+
+    auto query_personal_position =
+    [&]() -> std::optional<std::pair<tripoint_rel_ms, tripoint_rel_ms>> {
+        on_out_of_scope invalidate_current_ui( [&]()
+        {
+            ui.mark_resize();
+        } );
+        restore_on_out_of_scope show_prev( show );
+        restore_on_out_of_scope zone_start_prev( zone_start );
+        restore_on_out_of_scope zone_end_prev( zone_end );
+        show = false;
+        zone_start = std::nullopt;
+        zone_end = std::nullopt;
+        ui.mark_resize();
+
+        static_popup popup;
+        popup.on_top( true );
+        popup.message( "%s", _( "Select first point." ) );
+
+        tripoint_bub_ms center = u.pos_bub() + u.view_offset;
+
+        const look_around_result first =
+        look_around( /*show_window=*/false, center, center, false, true, false );
+        if( first.position )
+        {
+            popup.message( "%s", _( "Select second point." ) );
+
+            const look_around_result second = look_around( /*show_window=*/false, center, *first.position,
+                    true, true, false );
+            if( second.position ) {
+                tripoint_rel_ms first_rel(
+                    std::min( first.position->x() - u.posx(), second.position->x() - u.posx() ),
+                    std::min( first.position->y() - u.posy(), second.position->y() - u.posy() ),
+                    std::min( first.position->z() - u.posz(), second.position->z() - u.posz() ) );
+                tripoint_rel_ms second_rel(
+                    std::max( first.position->x() - u.posx(), second.position->x() - u.posx() ),
+                    std::max( first.position->y() - u.posy(), second.position->y() - u.posy() ),
+                    std::max( first.position->z() - u.posz(), second.position->z() - u.posz() ) );
+                return { { first_rel, second_rel } };
             }
         }
 
@@ -7236,9 +7269,8 @@ void game::zones_manager()
                     }
                 }
 
-                // TODO: fix point types
                 mgr.add( name, id, get_player_character().get_faction()->id, false, true,
-                         position->first, position->second, options, false );
+                         position->first, position->second, options );
 
                 zones = get_zones();
                 active_index = zone_cnt - 1;
@@ -7282,15 +7314,15 @@ void game::zones_manager()
                 }
                 const std::string &name = maybe_name.value();
 
-                const auto position = query_position( true );
+                const std::optional<std::pair<tripoint_rel_ms, tripoint_rel_ms>> position =
+                            query_personal_position( );
                 if( !position ) {
                     break;
                 }
 
                 //add a zone that is relative to the avatar position
-                // TODO: fix point types
                 mgr.add( name, id, get_player_character().get_faction()->id, false, true,
-                         position->first, position->second, options, true );
+                         position->first, position->second, options );
                 zones = get_zones();
                 active_index = zone_cnt - 1;
 
@@ -7386,14 +7418,21 @@ void game::zones_manager()
                         }
                         break;
                     case 4: {
-                        const auto pos = query_position( zone.get_is_personal() );
-                        // FIXME: this comparison is nonsensival in the
-                        // personal zone case because it's between different
-                        // coordinate systems.
-                        if( pos && ( pos->first != zone.get_start_point().raw() ||
-                                     pos->second != zone.get_end_point().raw() ) ) {
-                            zone.set_position( *pos );
-                            stuff_changed = true;
+                        if( zone.get_is_personal() ) {
+                            const std::optional<std::pair<tripoint_rel_ms, tripoint_rel_ms>> pos = query_personal_position();
+                            if( pos && ( u.get_location() + pos->first != zone.get_start_point() ||
+                                         u.get_location() + pos->second != zone.get_end_point() ) ) {
+                                zone.set_position( { pos->first, pos->second } );
+                                stuff_changed = true;
+
+                            }
+                        } else {
+                            const std::optional<std::pair<tripoint_abs_ms, tripoint_abs_ms>> pos = query_position();
+                            if( pos && ( pos->first != zone.get_start_point() ||
+                                         pos->second != zone.get_end_point() ) ) {
+                                zone.set_position( { pos->first, pos->second } );
+                                stuff_changed = true;
+                            }
                         }
                         break;
                     }
@@ -7429,9 +7468,9 @@ void game::zones_manager()
                             if( zone.get_is_personal() ) {
                                 const tripoint_rel_ms new_start_point_rl = new_start_point - u.get_location();
                                 const tripoint_rel_ms new_end_point_rl = new_end_point - u.get_location();
-                                zone.set_position( std::make_pair( new_start_point_rl.raw(), new_end_point_rl.raw() ) );
+                                zone.set_position( std::make_pair( new_start_point_rl, new_end_point_rl ) );
                             } else {
-                                zone.set_position( std::make_pair( new_start_point.raw(), new_end_point.raw() ) );
+                                zone.set_position( std::make_pair( new_start_point, new_end_point ) );
                             }
                             stuff_changed = true;
                         }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3485,7 +3485,7 @@ class jmapgen_zone : public jmapgen_piece
                                           dat.zlevel() + z.get() ) );
             const tripoint_abs_ms end = dat.m.getglobal( tripoint_bub_ms( int( x.valmax ), int( y.valmax ),
                                         dat.zlevel() + z.get() ) );
-            mapgen_place_zone( start.raw(), end.raw(), chosen_zone_type, chosen_faction, name, filter, &dat.m );
+            mapgen_place_zone( start, end, chosen_zone_type, chosen_faction, name, filter, &dat.m );
         }
 
         void check( const std::string &oter_name, const mapgen_parameters &parameters,

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -1292,9 +1292,9 @@ void talk_function::distribute_food_auto( npc &p )
     const tripoint_abs_ms bottom_right = npc_abs_loc + point::south_east;
     std::string zone_name = "ERROR IF YOU SEE THIS (dummy zone talk_function::distribute_food_auto)";
     const faction_id &fac_id = p.get_fac_id();
-    mgr.add( zone_name, zone_type_CAMP_FOOD, fac_id, false, true, top_left.raw(), bottom_right.raw() );
-    mgr.add( zone_name, zone_type_CAMP_STORAGE, fac_id, false, true, top_left.raw(),
-             bottom_right.raw() );
+    mgr.add( zone_name, zone_type_CAMP_FOOD, fac_id, false, true, top_left, bottom_right );
+    mgr.add( zone_name, zone_type_CAMP_STORAGE, fac_id, false, true, top_left,
+             bottom_right );
     npc_camp->distribute_food( false );
     // Now we clean up all camp zones, though there SHOULD only be the two we just made
     auto lambda_remove_zones = [&mgr, &fac_id]( zone_type_id type_to_remove ) {

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -104,11 +104,11 @@ void add_fallback_zone( npc &guy )
 
     if( points.empty() ) {
         zmgr.add( fallback_name, zone_type_LOOT_UNSORTED, fac_id, false, true,
-                  loc.raw() + tripoint::north_west, loc.raw() + tripoint::south_east );
+                  loc + tripoint::north_west, loc + tripoint::south_east );
     } else {
         for( tripoint_abs_ms const &t : points ) {
-            zmgr.add( fallback_name, zone_type_LOOT_UNSORTED, fac_id, false, true, t.raw(),
-                      t.raw() );
+            zmgr.add( fallback_name, zone_type_LOOT_UNSORTED, fac_id, false, true, t,
+                      t );
         }
     }
     DebugLog( DebugLevel::D_WARNING, DebugClass::D_GAME )
@@ -157,13 +157,13 @@ std::list<item> distribute_items_to_npc_zones( std::list<item> &items, npc &guy 
 
 void consume_items_in_zones( npc &guy, time_duration const &elapsed )
 {
-    std::unordered_set<tripoint> const src = zone_manager::get_manager().get_point_set_loot(
+    std::unordered_set<tripoint_bub_ms> const src = zone_manager::get_manager().get_point_set_loot(
                 guy.get_location(), PICKUP_RANGE, guy.get_fac_id() );
 
     consume_cache cache;
     map &here = get_map();
 
-    for( tripoint const &pt : src ) {
+    for( tripoint_bub_ms const &pt : src ) {
         consume_queue consumed;
         std::list<item_location> stack =
         here.items_with( pt, [&guy]( item const & it ) {

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -121,12 +121,12 @@ trade_ui::trade_ui( party_t &you, npc &trader, currency_t cost, std::string titl
 
         zone_manager &zmgr = zone_manager::get_manager();
 
-        std::unordered_set<tripoint> const src =
+        std::unordered_set<tripoint_bub_ms> const src =
             zmgr.get_point_set_loot( trader.get_location(), PICKUP_RANGE, trader.get_fac_id() );
 
-        for( tripoint const &pt : src ) {
-            _panes[_trader]->add_map_items( pt );
-            _panes[_trader]->add_vehicle_items( pt );
+        for( tripoint_bub_ms const &pt : src ) {
+            _panes[_trader]->add_map_items( pt.raw() );
+            _panes[_trader]->add_vehicle_items( pt.raw() );
         }
     } else if( !trader.is_player_ally() ) {
         _panes[_trader]->add_nearby_items( 1 );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1898,7 +1898,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
 
         for( auto &new_zone : new_zones ) {
             zone_manager::get_manager().create_vehicle_loot_zone(
-                *this, new_zone.first.raw(), new_zone.second );
+                *this, new_zone.first, new_zone.second );
         }
 
         // Now that we've added zones to this vehicle, we need to make sure their positions
@@ -2635,7 +2635,7 @@ bool vehicle::split_vehicles( map &here,
         // because we need only to move the zone once per mount, not per part. If we move per
         // part, we will end up with duplicates of the zone per part on the same mount
         for( std::pair<point_rel_ms, zone_data> zone : new_zones ) {
-            zone_manager::get_manager().create_vehicle_loot_zone( *new_vehicle, zone.first.raw(), zone.second );
+            zone_manager::get_manager().create_vehicle_loot_zone( *new_vehicle, zone.first, zone.second );
         }
 
         // create_vehicle_loot_zone marks the vehicle as not dirty but since we got these zones
@@ -6306,7 +6306,7 @@ void vehicle::place_zones( map &pmap ) const
     for( vehicle_prototype::zone_def const &d : type->zone_defs ) {
         tripoint_abs_ms const pt = pmap.getglobal( tripoint_bub_ms( rebase_bub( pos.raw() + d.pt ),
                                    pmap.get_abs_sub().z() ) );
-        mapgen_place_zone( pt.raw(), pt.raw(), d.zone_type, get_owner(), d.name, d.filter, &pmap );
+        mapgen_place_zone( pt, pt, d.zone_type, get_owner(), d.name, d.filter, &pmap );
     }
 }
 
@@ -8580,7 +8580,7 @@ bool vehicle::refresh_zones()
             }
             tripoint_abs_ms zone_pos = here.getglobal( bub_part_pos( part_idx ) );
             //Set the position of the zone to that part
-            zone.set_position( std::pair<tripoint, tripoint>( zone_pos.raw(), zone_pos.raw() ), false, false,
+            zone.set_position( std::pair<tripoint_abs_ms, tripoint_abs_ms>( zone_pos, zone_pos ), false, false,
                                true );
             new_zones.emplace( z.first, zone );
         }

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -86,11 +86,11 @@ construction setup_testcase( Character &u, std::string const &constr,
     tripoint_abs_ms const build_abs = here.getglobal( build_loc );
     faction_id const fac = u.get_faction()->id;
 
-    zmgr.add( constr + " loot zone", zone_type_LOOT_UNSORTED, fac, false, true, loot_abs.raw(),
-              loot_abs.raw() );
+    zmgr.add( constr + " loot zone", zone_type_LOOT_UNSORTED, fac, false, true, loot_abs,
+              loot_abs );
 
     zmgr.add( constr + " construction zone", zone_type_CONSTRUCTION_BLUEPRINT, fac, false,
-              true, build_abs.raw(), build_abs.raw(), options );
+              true, build_abs, build_abs, options );
 
     for( auto const *cons : constructions_by_group( build.group ) ) {
         for( auto const &comp : cons->requirements->get_components() ) {

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -53,11 +53,11 @@ int count_items_or_charges( const tripoint src, const itype_id &id,
     return _count_items_or_charges( get_map().i_at( src ), id );
 }
 
-void create_tile_zone( const std::string &name, const zone_type_id &zone_type, tripoint pos,
+void create_tile_zone( const std::string &name, const zone_type_id &zone_type, tripoint_abs_ms pos,
                        bool veh = false )
 {
     zone_manager &zm = zone_manager::get_manager();
-    zm.add( name, zone_type, faction_your_followers, false, true, pos, pos, nullptr, false, veh );
+    zm.add( name, zone_type, faction_your_followers, false, true, pos, pos, nullptr, veh );
 }
 
 } // namespace
@@ -85,8 +85,8 @@ TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][u
         vp->vehicle().set_owner( dummy );
     }
 
-    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start.raw(), in_vehicle );
-    create_tile_zone( "Unload All", zone_type_UNLOAD_ALL, start.raw(), in_vehicle );
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start, in_vehicle );
+    create_tile_zone( "Unload All", zone_type_UNLOAD_ALL, start, in_vehicle );
 
     item ammo_belt = item( itype_belt223, calendar::turn );
     ammo_belt.ammo_set( ammo_belt.ammo_default() );
@@ -126,8 +126,8 @@ TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
     zone_manager &zm = zone_manager::get_manager();
 
     const tripoint_abs_ms origin_pos;
-    create_tile_zone( "Food", zone_type_LOOT_FOOD, tripoint::east );
-    create_tile_zone( "Drink", zone_type_LOOT_DRINK, tripoint::west );
+    create_tile_zone( "Food", zone_type_LOOT_FOOD, tripoint_abs_ms::zero + tripoint::east );
+    create_tile_zone( "Drink", zone_type_LOOT_DRINK, tripoint_abs_ms::zero + tripoint::west );
 
     SECTION( "without perishable zones" ) {
         GIVEN( "a non-perishable food" ) {
@@ -176,8 +176,8 @@ TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
     }
 
     SECTION( "with perishable zones" ) {
-        create_tile_zone( "PFood", zone_type_LOOT_PFOOD, tripoint::north );
-        create_tile_zone( "PDrink", zone_type_LOOT_PDRINK, tripoint::south );
+        create_tile_zone( "PFood", zone_type_LOOT_PFOOD, tripoint_abs_ms::zero + tripoint::north );
+        create_tile_zone( "PDrink", zone_type_LOOT_PDRINK, tripoint_abs_ms::zero + tripoint::south );
 
         GIVEN( "a non-perishable food" ) {
             item nonperishable_food( "test_bitter_almond" );

--- a/tests/faction_camp_test.cpp
+++ b/tests/faction_camp_test.cpp
@@ -26,9 +26,9 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     clear_map();
     map &m = get_map();
     const tripoint_abs_ms zone_loc = m.getglobal( tripoint_bub_ms{ 5, 5, 0 } );
-    mapgen_place_zone( zone_loc.raw(), zone_loc.raw(), zone_type_CAMP_FOOD, your_fac, {},
+    mapgen_place_zone( zone_loc, zone_loc, zone_type_CAMP_FOOD, your_fac, {},
                        "food" );
-    mapgen_place_zone( zone_loc.raw(), zone_loc.raw(), zone_type_CAMP_STORAGE, your_fac, {},
+    mapgen_place_zone( zone_loc, zone_loc, zone_type_CAMP_STORAGE, your_fac, {},
                        "storage" );
     faction *camp_faction = get_player_character().get_faction();
     const tripoint_abs_omt this_omt = project_to<coords::omt>( zone_loc );

--- a/tests/zones_custom_test.cpp
+++ b/tests/zones_custom_test.cpp
@@ -31,18 +31,18 @@ TEST_CASE( "zones_custom", "[zones]" )
         }
         CAPTURE( num, bag_plastic.display_name() );
 
-        mapgen_place_zone( zone_loc.raw() + tripoint::north_west, zone_loc.raw() + tripoint::south_east,
+        mapgen_place_zone( zone_loc + tripoint::north_west, zone_loc + tripoint::south_east,
                            zone_type_LOOT_CUSTOM, your_fac, {}, "completely unrelated overlap" );
-        mapgen_place_zone( zone_loc.raw(), zone_hammer_end.raw(), zone_type_LOOT_CUSTOM, your_fac, {},
+        mapgen_place_zone( zone_loc, zone_hammer_end, zone_type_LOOT_CUSTOM, your_fac, {},
                            "hammer" );
-        mapgen_place_zone( zone_loc.raw(), zone_bowsaw_end.raw(), zone_type_LOOT_CUSTOM, your_fac, {},
+        mapgen_place_zone( zone_loc, zone_bowsaw_end, zone_type_LOOT_CUSTOM, your_fac, {},
                            "c:tools,-hammer" );
-        mapgen_place_zone( zone_loc.raw(), zone_testgroup_end.raw(), zone_type_LOOT_ITEM_GROUP, your_fac, {},
+        mapgen_place_zone( zone_loc, zone_testgroup_end, zone_type_LOOT_ITEM_GROUP, your_fac, {},
                            "test_event_item_spawn" );
-        mapgen_place_zone( zone_loc.raw(), zone_groupbatt_end.raw(), zone_type_LOOT_ITEM_GROUP, your_fac, {},
+        mapgen_place_zone( zone_loc, zone_groupbatt_end, zone_type_LOOT_ITEM_GROUP, your_fac, {},
                            "test_group_disp" );
         tripoint_abs_ms const m_zone_loc = m.getglobal( tripoint_bub_ms{-5, -5, 0 } );
-        mapgen_place_zone( m_zone_loc.raw(), m_zone_loc.raw(), zone_type_LOOT_CUSTOM, your_fac, {},
+        mapgen_place_zone( m_zone_loc, m_zone_loc, zone_type_LOOT_CUSTOM, your_fac, {},
                            "plastic bag" );
 
         zone_manager &zmgr = zone_manager::get_manager();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Change usage of untyped coordinates to typed ones. This time (cl)zones.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Split relative coordinates for personal zones from absolute coordinates used for the rest of the zones.
- Untangled the resulting mess when trying to split addition of zones relying on a defaulted parameter buried within a set of defaulted parameters. It isn't visible in the results, but the replacement versions were given different names to ensure each usage of the original one was assigned to one or the other. Once sorted out they were refactored back to the original name as operations overloading each other.
- Split a weirdo operation that returned untyped relative or absolute parameters depending on whether the zone that was going to use them was personal or not.
- Corrected broken logic (acknowledged by comment) for determining if personal zone updates changed them or not (previously the broken logic would result in a "yes" answer unless you happened to be in a very specific location in the world, in which case the answer would probably be incorrect anyway. The broken logic just resulted in a little extra work, so it wasn't a major issue).
- Kept the overload of relative/absolute coordinates in the save/load logic so as to not affect existing saves (but adding further processing to save the correct data and load it into the correct fields).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Do more, but while this shouldn't have any functional changes (except for the broken logic), the things needed to be done are a bit more complicated than the standard "replace types and adjust variables and parameters" routine. Thus, a bit more review work might be warranted.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Loaded a save, moved a normal zone and then back again using the two different movement methods.
- Created a personal zone (never used those before) and verified it followed my character when moving over several overmaps.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Noted that neither of the two usages of zone_data creation specifies the _is_displayed parameter, leaving it at default. Thus, it could be removed, but it doesn't cause any harm (the display functionality is controlled after zone creation, so it's not a case of broken/unused underlying functionality).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
