### PR TITLE
Clear npcs before terrain and vehicles

### DIFF
--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -149,8 +149,8 @@ void clear_map( int zmin, int zmax )
         clear_fields( z );
     }
     clear_zones();
-    wipe_map_terrain();
     clear_npcs();
+    wipe_map_terrain();
     clear_creatures();
     here.clear_traps();
     for( int z = zmin; z <= zmax; ++z ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

GCC9, Curses, LTO test fails when clearing npcs.
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12429756955/job/34703884138?pr=78676#step:19:102

There were also rare older issues when npcs were underground. I'm not sure if those still happen, but they should be fixed by this, too.

#### Describe the solution

Simply swap `clear_npcs` and `wipe_map_terrain` in `clear_map`.

#### Describe alternatives you've considered



#### Testing

I couldn't easily find a reproduction case to test this, as it appears to be linked to compiling with LTO. But it seems to be guaranteed with that currently, so if it passes here it should be good?

#### Additional context

