### PR TITLE
Fixes infinite sleeping pill/chamomile tea bug

### DIFF
--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -176,11 +176,7 @@
     "name": { "str_sp": "chamomile tea" },
     "copy-from": "tea",
     "color": "green",
-    "use_action": {
-      "type": "effect_on_conditions",
-      "description": "Can be used to treat insomnia.",
-      "effect_on_conditions": [ "EOC_MINOR_SLEEP" ]
-    },
+    "sleepiness_mod": -20,
     "stim": 0,
     "spoils_in": "10 days",
     "comestible_type": "MED",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1488,11 +1488,8 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "EDIBLE_FROZEN" ],
     "addiction_potential": 40,
     "addiction_type": "sleeping pill",
-    "use_action": {
-      "type": "effect_on_conditions",
-      "description": "Can be used to treat insomnia.",
-      "effect_on_conditions": [ "EOC_SLEEP" ]
-    }
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s." },
+    "sleepiness_mod": -40
   },
   {
     "id": "poppy_pain",
@@ -1531,13 +1528,10 @@
     "symbol": "!",
     "color": "magenta",
     "healthy": -2,
-    "addiction_type": "opiate",
+    "addiction_type": [ "sleeping pill", "opiate" ],
     "flags": [ "EDIBLE_FROZEN" ],
-    "use_action": {
-      "type": "effect_on_conditions",
-      "description": "Can be used to treat insomnia.",
-      "effect_on_conditions": [ "EOC_SLEEP" ]
-    }
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s." },
+    "sleepiness_mod": -40
   },
   {
     "id": "poppysyrup",
@@ -1557,7 +1551,7 @@
     "stim": -3,
     "healthy": -1,
     "addiction_potential": 15,
-    "addiction_type": "sleeping pill",
+    "addiction_type": [ "sleeping pill", "opiate" ],
     "use_action": [ "FLUSLEEP" ]
   },
   {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5700,6 +5700,11 @@ void effect_on_conditons_actor::info( const item &, std::vector<iteminfo> &dump 
 std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
         const tripoint_bub_ms &point ) const
 {
+    if( it.type->comestible ) {
+        debugmsg( "Comestibles are not properly consumed via effect_on_conditions and effect_on_conditions should not be used on items of type comestible until/unless this is resolved." );
+        return 0;
+    }
+
     if( need_worn && !p->is_worn( it ) ) {
         p->add_msg_if_player( m_info, _( "You need to wear the %1$s before activating it." ), it.tname() );
         return std::nullopt;
@@ -5731,6 +5736,10 @@ std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
         }
     }
     // Prevents crash from trying to spend charge with item removed
+    // NOTE: Because this section and/or calling stack does not check if the item exists in the surrounding tiles
+    // it will not properly decrement any item of type `comestible` if consumed via the `E` `Consume item` menu.
+    // Therefore, it is not advised to use items of type `comestible` with a `use_action` of type
+    // `effect_on_conditions` until/unless this section is properly updated to actually consume said item.
     if( p && !p->has_item( it ) ) {
         return 0;
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes infinite sleeping pill/chamomile tea bug"

#### Purpose of change

Items of type `COMESTIBLE` with `use_action` of type `effect_on_conditions` are not properly consumed upon use despite still applying their effect. This meant that the player could consume an infinite amount of sleeping pills or chamomile tea without actually consuming the item.

#### Describe the solution

Changes:
- Adjusted `chamomile tea`, `sleeping pills`, and `poppy sleep` to match the behavior of `caffeine pill`. This meant removing the `use_action` and replacing it with `sleepiness_mod` and a negative value.
- Added a check to `iuseactor.cpp effect_on_conditons_actor::use` that short circuits the function if it used by an item of type `COMESTIBLE` and prints a debug message describing the issue for future developers.
- Added a code comment to `iuseactor.cpp effect_on_conditons_actor::use` describing in detail where the problem lies with using items of type `COMESTIBLE` with `use_action` of type `effect_on_conditions`.
- Adjusted the `addiction_type` for `poppysyrup` and `poppy_sleep` to include both `opiate` and `sleeping_pill`

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/77525 

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/69507

#### Describe alternatives you've considered

I considered updating the affected items to use `effects.json` but I believe that is outside the scope of this simple bugfix.

#### Testing

Loaded the game prior to the changes to ensure those items were not being properly decremented when they are not in the players inventory.

Loaded the game after the changes and observed they are properly decremented when consumed from outside the player's inventory.

Additionally, reviewed the player info to ensure that sleepiness was being properly applied.

See:

```
"sleepiness": 161, // Before
"sleepiness": 201, // After Sleeping Pill
"sleepiness": 271, // After Poppy Pills & Poppy Syrup

"stim": -9, // Before
"stim": -17, // After Sleeping Pill
"stim": -18, // After Poppy Pills & Poppy Syrup
```

#### Additional context

Screenshot of the iuse_actor.cpp debug message:
![cataclysm-tiles_FLejIjW6ec](https://github.com/user-attachments/assets/2738f864-0b7d-4388-85b2-debafb74d11a)


Notes:
- I initially thought to use the same behavior as `poppy cough syrup` and apply the `FLUSLEEP` effect to the player, but I decided against it when I found that the `caffeine pill` had a better mechanism for applying a `sleepiness_mod` effect which allows chamomile tea to retain a smaller `sleepiness_mod` value.
- I think in the long term these items should use the `use_action` type of `consume_drug` and have an effect detailed in `effects.json` so they are aligned with other drugs (ie. `codeine`). This would allow for `sleepiness` to increment over time instead of applying immediately. See `effects.json` id `dermatik` for an example of this behavior.
