### PR TITLE
[XE] Chronomagic Adjustments

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3015,7 +3015,6 @@
     "id": "effect_xedra_time_loop",
     "name": [ "Time Looped" ],
     "desc": [ "Every few seconds every change to your person reverts." ],
-    "remove_message": "Your time loop ends!",
     "rating": "good",
     "flags": [ "CANNOT_CHANGE_TEMPERATURE", "FREEZE_EFFECTS", "CANNOT_GAIN_EFFECTS" ],
     "enchantments": [ { "values": [ { "value": "EQUIPMENT_DAMAGE_CHANCE", "multiply": -1 } ] } ],

--- a/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
@@ -505,7 +505,10 @@
         "popup_w_interrupt_query": true,
         "interrupt_type": "eoc"
       },
-      { "run_eocs": "EOC_XEDRA_TIME_LOAD_VARIABLES_DYNAMIC", "variables": { "xedra_chronomancer_prefix": "time_loop" } }
+      {
+        "run_eocs": "EOC_XEDRA_TIME_LOAD_VARIABLES_DYNAMIC",
+        "variables": { "xedra_chronomancer_prefix": "time_loop" }
+      }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
@@ -493,6 +493,23 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_XEDRA_TIME_LOOP_ENDED_LOOP",
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": { "compare_string": [ "effect_xedra_time_loop", { "context_val": "effect" } ] },
+    "effect": [
+      {
+        "u_message": "Your time loop ends!",
+        "type": "neutral",
+        "popup": true,
+        "popup_w_interrupt_query": true,
+        "interrupt_type": "eoc"
+      },
+      { "run_eocs": "EOC_XEDRA_TIME_LOAD_VARIABLES_DYNAMIC", "variables": { "xedra_chronomancer_prefix": "time_loop" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_XEDRA_CHRONOMANCER_OPEN_INSIGHT_MENU",
     "effect": [
       { "math": [ "u_xedra_chronomancer_insight_count=u_vitamin('xedra_chronomancer_insight')" ] },

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -32,6 +32,18 @@
   },
   {
     "type": "jmath_function",
+    "id": "xedra_chronomancer_formula_get_level",
+    "num_args": 1,
+    "return": "( sqrt( ( 2 / 375 ) * _0 + 0.25 )  ) - 0.5"
+  },
+  {
+    "type": "jmath_function",
+    "id": "xedra_chronomancer_formula_exp_for_level",
+    "num_args": 1,
+    "return": "375 * 0.5 * _0 * (_0 + 1)"
+  },
+  {
+    "type": "jmath_function",
     "id": "spell_train_factor",
     "num_args": 1,
     "//": "accept the spell _cost, return how much spellcasts required to level the spell",

--- a/data/mods/Xedra_Evolved/spells/chronomancer.json
+++ b/data/mods/Xedra_Evolved/spells/chronomancer.json
@@ -20,6 +20,8 @@
     "min_duration": { "math": [ "xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_time_freeze_target'), 60000, 0 )" ] },
     "max_duration": { "math": [ "xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_time_freeze_target'), 60000, 0 )" ] },
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 200,
     "final_energy_cost": 50,
     "energy_increment": -5,
@@ -46,6 +48,8 @@
     "min_range": { "math": [ "min( xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_normalize_time'), 2, 1 ), 80 )" ] },
     "max_range": 80,
     "energy_source": "NONE",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 0,
     "base_casting_time": 200,
     "final_casting_time": 50,
@@ -117,6 +121,8 @@
     "min_duration": { "math": [ "xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_entropic_burst'), 50, 200 )" ] },
     "max_duration": { "math": [ "xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_entropic_burst'), 50, 200 )" ] },
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 600,
     "final_energy_cost": 150,
     "energy_increment": -15,
@@ -203,6 +209,8 @@
     "min_duration": { "math": [ "xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_time_bubble'), 60000, 0 )" ] },
     "max_duration": { "math": [ "xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_time_bubble'), 60000, 0 )" ] },
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 600,
     "final_energy_cost": 150,
     "energy_increment": -15,
@@ -226,6 +234,8 @@
     "effect_str": "EOC_XEDRA_DAMAGE_REVERSAL",
     "shape": "blast",
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 200,
     "final_energy_cost": 50,
     "energy_increment": -5,
@@ -251,6 +261,8 @@
     "min_duration": { "math": [ "xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_time_loop'), 3000, 0 )" ] },
     "max_duration": { "math": [ "xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_time_loop'), 3000, 0 )" ] },
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 300,
     "final_energy_cost": 100,
     "energy_increment": -10,
@@ -275,6 +287,8 @@
     "min_damage": { "math": [ "xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_time_stop'), 200, 0 )" ] },
     "max_damage": { "math": [ "xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_time_stop'), 200, 0 )" ] },
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 1000,
     "final_energy_cost": 800,
     "energy_increment": -10,
@@ -295,6 +309,8 @@
     "effect": "translocate",
     "shape": "blast",
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 1000,
     "final_energy_cost": 500,
     "energy_increment": -25,
@@ -314,6 +330,10 @@
     "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX", "NO_FAIL" ],
     "difficulty": 0,
     "max_level": 0,
+    "energy_source": "MANA",
+    "base_energy_cost": 0,
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "effect": "ter_transform",
     "effect_str": "xedra_chronomancer_memorize_terrain_switch",
     "shape": "blast",
@@ -350,6 +370,8 @@
     "min_range": 1,
     "max_range": 1,
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 1000,
     "final_energy_cost": 800,
     "energy_increment": -10,
@@ -405,6 +427,8 @@
     "effect_str": "EOC_XEDRA_CHRONOMANCER_STABLE_TIMELOOP_INITIATE",
     "shape": "blast",
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": {
       "math": [
         "u_effect_intensity('effect_xedra_chronomancer_stable_timeloop') > -1 ? 0 : max( ( 1000 - ( 25 * u_spell_level('xedra_chronomancer_stable_loop') ) ), 250 ) "
@@ -432,6 +456,8 @@
     "effect_str": "EOC_XEDRA_CHRONOMANCER_CHRONAL_ACCEL_INITIATE",
     "shape": "blast",
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": {
       "math": [
         "u_effect_intensity('effect_xedra_chronomancer_chronal_accel') > -1 ? 0 : max( ( 1000 - ( 25 * u_spell_level('xedra_chronomancer_chronal_acceleration') ) ), 250 ) "
@@ -459,6 +485,8 @@
     "effect_str": "EOC_XEDRA_CHRONOMANCER_DESTABILIZING_STRIKES_INITIATE",
     "shape": "blast",
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": {
       "math": [
         "u_effect_intensity('effect_xedra_chronomancer_destabilizing_strikes') > -1 ? 0 : max( ( 1000 - ( 25 * u_spell_level('xedra_chronomancer_destabilizing_strikes') ) ), 250 ) "
@@ -503,6 +531,8 @@
     "effect_str": "EOC_XEDRA_CHRONOMANCER_STABILIZE_TIMELINE_INITIATE",
     "shape": "blast",
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": {
       "math": [
         "u_effect_intensity('effect_xedra_chronomancer_stabilize_timeline') > -1 ? 0 : max( ( 500 - ( 12.5 * u_spell_level('xedra_chronomancer_stabilize_timeline') ) ), 125 ) "
@@ -530,6 +560,8 @@
     "effect_str": "EOC_XEDRA_CHRONOMANCER_REVERSE_ENTROPY_INITIATE",
     "shape": "blast",
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": {
       "math": [
         "u_effect_intensity('effect_xedra_chronomancer_reverse_entropy') > -1 ? 0 : max( ( 1000 - ( 25 * u_spell_level('xedra_chronomancer_reverse_entropy') ) ), 250 ) "
@@ -557,6 +589,8 @@
     "effect_str": "EOC_XEDRA_CHRONOMANCER_REWRITE_WOUND_CAUSALITY",
     "shape": "blast",
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 20,
     "base_casting_time": { "math": [ " max( ( 200 - ( 5 * u_spell_level('xedra_chronomancer_rewrite_wound_causality') ) ), 50 )" ] }
   },
@@ -576,6 +610,8 @@
     "effect_str": "EOC_XEDRA_CHRONOMANCER_REWRITE_EQUIPMENT_CAUSALITY",
     "shape": "blast",
     "energy_source": "MANA",
+    "get_level_formula_id": "xedra_chronomancer_formula_get_level",
+    "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level",
     "base_energy_cost": 20,
     "base_casting_time": { "math": [ " max( ( 200 - ( 5 * u_spell_level('xedra_chronomancer_rewrite_equipment_causality') ) ), 50 )" ] }
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[XE] Chronomagic Adjustments"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Implement custom spell xp requirements and makes the timeloop end more visible
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Implement custom spell xp requirements and makes the timeloop end more visible
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Looked at the spell tab and the experience requirements looked correct
Observed timeloop end message
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
