### PR TITLE
remove a bit of dead code

### DIFF
--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -901,27 +901,6 @@ bool item_pocket::detonate( const tripoint &pos, std::vector<item> &drops )
     return false;
 }
 
-bool item_pocket::process( const itype &type, map &here, Character *carrier, const tripoint &pos,
-                           float insulation, temperature_flag flag, bool watertight_container )
-{
-    const tripoint_bub_ms p{pos}; // TODO get rid of this when operation typified.
-    bool processed = false;
-    float spoil_multiplier = 1.0f;
-    for( auto it = contents.begin(); it != contents.end(); ) {
-        if( _sealed ) {
-            spoil_multiplier = 0.0f;
-        }
-        if( it->process( here, carrier, p, type.insulation_factor * insulation, flag,
-                         spoil_multiplier, watertight_container ) ) {
-            it->spill_contents( p );
-            it = contents.erase( it );
-            processed = true;
-        } else {
-            ++it;
-        }
-    }
-    return processed;
-}
 
 void item_pocket::remove_all_ammo( Character &guy )
 {

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -278,8 +278,7 @@ class item_pocket
 
         std::string translated_sealed_prefix() const;
         bool detonate( const tripoint &p, std::vector<item> &drops );
-        bool process( const itype &type, map &here, Character *carrier, const tripoint &pos,
-                      float insulation, temperature_flag flag, bool watertight_container );
+
         void remove_all_ammo( Character &guy );
         void remove_all_mods( Character &guy );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

I was wondering how do zipper bags slow the rate of spoilage, and came across this `item_pocket::process` overload that was seemingly doing it wrong. Turns out it is never actually invoked, so to the void it goes.

#### Describe the solution

Select code, press delete

#### Describe alternatives you've considered

None

#### Testing

The binary builds and launches successfully. Tests compile.
