### PR TITLE
Butter is now just as unfun and nauseating to eat as cooking oil

### DIFF
--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -126,7 +126,6 @@
     "symbol": "%",
     "quench": -1,
     "calories": 101,
-    "healthy": -1,
     "container": "wrapper",
     "description": "A yellow stick of milkfat and milk solids, usually made from cow's milk.",
     "price": "9 cent",
@@ -134,7 +133,8 @@
     "material": [ "milk" ],
     "volume": "15 ml",
     "flags": [ "NO_AUTO_CONSUME" ],
-    "fun": -1,
+    "fun": -25,
+    "use_action": [ "BLECH" ],
     "vitamins": [ [ "milk_allergen", 1 ] ]
   },
   {

--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -126,6 +126,7 @@
     "symbol": "%",
     "quench": -1,
     "calories": 101,
+    "healthy": -1,
     "container": "wrapper",
     "description": "A yellow stick of milkfat and milk solids, usually made from cow's milk.",
     "price": "9 cent",


### PR DESCRIPTION
#### Summary
Balance "Butter is now just as unfun and nauseating to eat as cooking oil"


#### Purpose of change
Butter existence in residential fridges creates a degenerate gameplay.
It spawns plenty, has a high energy density, and used in a lot of recipes, which looks like a great food to grab and haul back to the main base when raiding. However, each individual recipe calls for only a little bit of it, and most of the butter is unused.
Butter also spawns with slightly random spoilage state, so it never goes bad all at the same time, but rather it does so gradually. So when I get hungry, and wonder what should I eat today, I go stand next to my perishable food tile press `E` and the answer is always "eat butter - it'll go bad soon, you can't be wasting food!".
![20241221-232633-cataclysm-tiles](https://github.com/user-attachments/assets/fe37baa1-32c5-4d81-bc10-7188e65f7d16)

This is dumb, and I feel really bad that the game forces me to do the dumb thing. The in-game consequences for eating it is only just "-1" morale which is who cares, so that becomes the correct thing to do. Anecdotally, it seems to get presented as a "correct" gameplay on the discords.
IRL I think would not feel very well for a day or so if I had to eat a full butter stick.

So this PR aims to change this and align cata experience *somewhat* with IRL experience by ~~disincentivizing~~ no longer incentivizing gorging on butter [as much].

#### Describe the solution

Buter has now -25 fun and gives you nausea, exactly the same as animal/vegetable cooking oils.

#### Describe alternatives you've considered

- reduce it's "healthy" stat. This was the original implementation of the PR, but the feedback (below) didn't like it.
- make it completely unedible when raw - overkill for purpose, and a bit silly
- make it have much less calories when raw - kinda unrealistic, but also doesn't really do anything to fix the problem (I'd still be eating it)


#### Testing
![20241222-140802-cataclysm-tiles](https://github.com/user-attachments/assets/c8a5987e-88d4-4b35-80bc-55d1ab25b400)



#### Additional context
