### PR TITLE
Prevent segfault from `EOC_random_mutate`

### DIFF
--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -569,7 +569,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_random_mutate",
-    "condition": { "and": [ { "math": [ "_proj_damage + _damage > 0" ] }, "npc_is_character", "has_beta" ] },
+    "condition": { "and": [ { "math": [ "_proj_damage + _damage > 0" ] }, "has_beta", "npc_is_character" ] },
     "effect": [
       { "set_string_var": "<random_category>", "target_var": { "context_val": "dart_mutation_category" }, "parse_tags": true },
       { "npc_mutate_category": { "context_val": "dart_mutation_category" }, "use_vitamins": false }


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent segfault from EOC_random_mutate"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents segfault from `EOC_random_mutate` when yugg shot misses. Fixes #78629 . Fixes #78481 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Running `npc_is_character` requires that there is an actual beta talker. And as specified by `EFFECT_ON_CONDITION.md`, it might be null for `ammo_effect: "eoc"`, which yugg shots use:

https://github.com/CleverRaven/Cataclysm-DDA/blob/248e05815f19b1b8fd3ca4a70335aec0361db882/doc/EFFECT_ON_CONDITION.md?plain=1#L88


Prevents the following logging:
```
ERROR : src/npctalk.cpp:2603 [const_talker* const_dialogue::const_actor(bool) const] Tried to use an invalid beta talker.  Callstack: EOC: EOC_random_mutate
```


<details>
  <summary>Gdb backtrace from above debugmsg</summary>

```
 #0  const_dialogue::const_actor (this=0x7fffffff87d8, is_beta=true) at src/npctalk.cpp:2603
 #1  0x0000555555cbf6db in operator() (__closure=<optimized out>, d=...) at src/condition.cpp:1362
 #2  std::__invoke_impl<const Character*, conditional_fun::(anonymous namespace)::f_is_character(bool)::<lambda(const const_dialogue&)>&, const const_dialogue&> (__f=...) at /usr/include/c++/14/bits/invoke.h:61
 #3  std::__invoke_r<bool, conditional_fun::(anonymous namespace)::f_is_character(bool)::<lambda(const const_dialogue&)>&, const const_dialogue&> (__fn=...) at /usr/include/c++/14/bits/invoke.h:114
 #4  std::_Function_handler<bool(const const_dialogue&), conditional_fun::(anonymous namespace)::f_is_character(bool)::<lambda(const const_dialogue&)> >::_M_invoke(const std::_Any_data &, const const_dialogue &) (__functor=..., __args#0=...) at /usr/include/c++/14/bits/std_function.h:290
 #5  0x0000555555cc013c in operator() (__closure=<synthetic pointer>, cond=...) at src/condition.cpp:2698
 #6  __gnu_cxx::__ops::_Iter_negate<conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>::<lambda(const conditional_t&)> >::operator()<__gnu_cxx::__normal_iterator<const conditional_t*, std::vector<conditional_t> > > (this=<synthetic pointer>, __it=...)
    at /usr/include/c++/14/bits/predefined_ops.h:395
 #7  std::__find_if<__gnu_cxx::__normal_iterator<const conditional_t*, std::vector<conditional_t> >, __gnu_cxx::__ops::_Iter_negate<conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>::<lambda(const conditional_t&)> > > (__first=..., __last=..., __pred=...)
    at /usr/include/c++/14/bits/stl_algobase.h:2122
 #8  std::__find_if_not<__gnu_cxx::__normal_iterator<const conditional_t*, std::vector<conditional_t> >, __gnu_cxx::__ops::_Iter_pred<conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>::<lambda(const conditional_t&)> > > (__first=..., __last=..., __pred=...)
    at /usr/include/c++/14/bits/stl_algo.h:112
 #9  std::find_if_not<__gnu_cxx::__normal_iterator<const conditional_t*, std::vector<conditional_t> >, conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>::<lambda(const conditional_t&)> > (__first=..., __last=..., __pred=...) at /usr/include/c++/14/bits/stl_algo.h:471
 #10 std::all_of<__gnu_cxx::__normal_iterator<const conditional_t*, std::vector<conditional_t> >, conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>::<lambda(const conditional_t&)> > (__first=..., __last=..., __pred=...) at /usr/include/c++/14/bits/stl_algo.h:411
 #11 operator() (__closure=<optimized out>, d=...) at src/condition.cpp:2697
 #12 std::__invoke_impl<bool, conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>&, const const_dialogue&> (__f=...) at /usr/include/c++/14/bits/invoke.h:61
 #13 std::__invoke_r<bool, conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>&, const const_dialogue&> (__fn=...) at /usr/include/c++/14/bits/invoke.h:114
 #14 std::_Function_handler<bool(const const_dialogue&), conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)> >::_M_invoke(const std::_Any_data &, const const_dialogue &) (__functor=..., __args#0=...) at /usr/include/c++/14/bits/std_function.h:290
 #15 0x0000555555e3be3e in effect_on_condition::activate (this=0x555565c6e990, d=..., require_callstack_check=require_callstack_check@entry=true) at src/effect_on_condition.cpp:327
 #16 0x000055555675d8ef in apply_ammo_effects (source=source@entry=0x7fffffffa0a8, p=..., effects=std::set with 1 element = {...}, dealt_damage=5) at src/projectile.cpp:202
 #17 0x0000555555b2c46a in projectile_attack (proj_arg=..., source=..., target_arg=..., dispersion=..., origin=origin@entry=0x7fffffffa0a8, in_veh=0x0, wp_attack=..., first=true) at src/ballistics.cpp:527
 #18 0x0000555556772f6d in Character::fire_gun (this=this@entry=0x7fffffffa0a8, target=..., shots=shots@entry=1, gun=..., ammo=...) at src/ranged.cpp:1069
 #19 0x00005555567748b8 in Character::fire_gun (this=this@entry=0x7fffffffa0a8, target=..., shots=1) at src/ranged.cpp:960
 #20 0x00005555563d7565 in gun_actor::shoot (this=this@entry=0x55555bd48e80, z=..., target=..., mode=..., inital_recoil=inital_recoil@entry=0) at src/mattack_actors.cpp:1297
 #21 0x00005555563d7dd1 in gun_actor::call (this=0x55555bd48e80, z=...) at src/mattack_actors.cpp:1173
 #22 0x00005555564858fa in monster::move (this=0x55559f931640) at src/monmove.cpp:873
 #23 0x0000555555dfdfce in (anonymous namespace)::monmove () at src/do_turn.cpp:321
 #24 do_turn () at src/do_turn.cpp:657
 #25 0x0000555555808cad in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:863
```

</details>

<details>
<summary>Segfault being fixed</summary>

```
Thread 1 "cataclysm-tiles" received signal SIGSEGV, Segmentation fault.
0x0000555555cbf6de in operator() (__closure=<optimized out>, d=...) at src/condition.cpp:1362
1362            return d.const_actor( is_npc )->get_const_character();
(gdb) bt
 #0  0x0000555555cbf6de in operator() (__closure=<optimized out>, d=...) at src/condition.cpp:1362
 #1  std::__invoke_impl<const Character*, conditional_fun::(anonymous namespace)::f_is_character(bool)::<lambda(const const_dialogue&)>&, const const_dialogue&> (__f=...) at /usr/include/c++/14/bits/invoke.h:61
 #2  std::__invoke_r<bool, conditional_fun::(anonymous namespace)::f_is_character(bool)::<lambda(const const_dialogue&)>&, const const_dialogue&> (__fn=...) at /usr/include/c++/14/bits/invoke.h:114
 #3  std::_Function_handler<bool(const const_dialogue&), conditional_fun::(anonymous namespace)::f_is_character(bool)::<lambda(const const_dialogue&)> >::_M_invoke(const std::_Any_data &, const const_dialogue &) (__functor=..., __args#0=...) at /usr/include/c++/14/bits/std_function.h:290
 #4  0x0000555555cc013c in operator() (__closure=<synthetic pointer>, cond=...) at src/condition.cpp:2698
 #5  __gnu_cxx::__ops::_Iter_negate<conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>::<lambda(const conditional_t&)> >::operator()<__gnu_cxx::__normal_iterator<const conditional_t*, std::vector<conditional_t> > > (this=<synthetic pointer>, __it=...)
    at /usr/include/c++/14/bits/predefined_ops.h:395
 #6  std::__find_if<__gnu_cxx::__normal_iterator<const conditional_t*, std::vector<conditional_t> >, __gnu_cxx::__ops::_Iter_negate<conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>::<lambda(const conditional_t&)> > > (__first=..., __last=..., __pred=...)
    at /usr/include/c++/14/bits/stl_algobase.h:2122
 #7  std::__find_if_not<__gnu_cxx::__normal_iterator<const conditional_t*, std::vector<conditional_t> >, __gnu_cxx::__ops::_Iter_pred<conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>::<lambda(const conditional_t&)> > > (__first=..., __last=..., __pred=...)
    at /usr/include/c++/14/bits/stl_algo.h:112
 #8  std::find_if_not<__gnu_cxx::__normal_iterator<const conditional_t*, std::vector<conditional_t> >, conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>::<lambda(const conditional_t&)> > (__first=..., __last=..., __pred=...) at /usr/include/c++/14/bits/stl_algo.h:471
 #9  std::all_of<__gnu_cxx::__normal_iterator<const conditional_t*, std::vector<conditional_t> >, conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>::<lambda(const conditional_t&)> > (__first=..., __last=..., __pred=...) at /usr/include/c++/14/bits/stl_algo.h:411
 #10 operator() (__closure=<optimized out>, d=...) at src/condition.cpp:2697
 #11 std::__invoke_impl<bool, conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>&, const const_dialogue&> (__f=...) at /usr/include/c++/14/bits/invoke.h:61
 #12 std::__invoke_r<bool, conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)>&, const const_dialogue&> (__fn=...) at /usr/include/c++/14/bits/invoke.h:114
 #13 std::_Function_handler<bool(const const_dialogue&), conditional_t::conditional_t(const JsonObject&)::<lambda(const const_dialogue&)> >::_M_invoke(const std::_Any_data &, const const_dialogue &) (__functor=..., __args#0=...) at /usr/include/c++/14/bits/std_function.h:290
 #14 0x0000555555e3be3e in effect_on_condition::activate (this=0x555565c6e990, d=..., require_callstack_check=require_callstack_check@entry=true) at src/effect_on_condition.cpp:327
 #15 0x000055555675d8ef in apply_ammo_effects (source=source@entry=0x7fffffffa0a8, p=..., effects=std::set with 1 element = {...}, dealt_damage=5) at src/projectile.cpp:202
 #16 0x0000555555b2c46a in projectile_attack (proj_arg=..., source=..., target_arg=..., dispersion=..., origin=origin@entry=0x7fffffffa0a8, in_veh=0x0, wp_attack=..., first=true) at src/ballistics.cpp:527
 #17 0x0000555556772f6d in Character::fire_gun (this=this@entry=0x7fffffffa0a8, target=..., shots=shots@entry=1, gun=..., ammo=...) at src/ranged.cpp:1069
 #18 0x00005555567748b8 in Character::fire_gun (this=this@entry=0x7fffffffa0a8, target=..., shots=1) at src/ranged.cpp:960
 #19 0x00005555563d7565 in gun_actor::shoot (this=this@entry=0x55555bd48e80, z=..., target=..., mode=..., inital_recoil=inital_recoil@entry=0) at src/mattack_actors.cpp:1297
 #20 0x00005555563d7dd1 in gun_actor::call (this=0x55555bd48e80, z=...) at src/mattack_actors.cpp:1173
 #21 0x00005555564858fa in monster::move (this=0x55559f931640) at src/monmove.cpp:873
 #22 0x0000555555dfdfce in (anonymous namespace)::monmove () at src/do_turn.cpp:321
 #23 do_turn () at src/do_turn.cpp:657
 #24 0x0000555555808cad in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:863
```

</details>

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

The eoc `has_beta` is only used in one place - on the line that this commit touches. Another alternative would therefore be to remove the `has_beta` eoc condition and instead make `npc_is_character` handle null by instead returning false if beta talker is null.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Can no longer reproduce the segfault from savegame in #78629 .

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
