### PR TITLE
Allow proper overlaying of weather_generator

### DIFF
--- a/data/mods/TEST_DATA/regions.json
+++ b/data/mods/TEST_DATA/regions.json
@@ -263,32 +263,5 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH" ],
     "examine_action": "flower_cactus"
-  },
-  {
-    "type": "region_settings",
-    "id": "river",
-    "default_oter": [
-      "open_air",
-      "open_air",
-      "open_air",
-      "open_air",
-      "open_air",
-      "open_air",
-      "open_air",
-      "open_air",
-      "open_air",
-      "open_air",
-      "field",
-      "solid_earth",
-      "empty_rock",
-      "empty_rock",
-      "empty_rock",
-      "empty_rock",
-      "empty_rock",
-      "empty_rock",
-      "empty_rock",
-      "empty_rock",
-      "empty_rock"
-    ]
   }
 ]

--- a/data/mods/TEST_DATA/regions.json
+++ b/data/mods/TEST_DATA/regions.json
@@ -143,7 +143,14 @@
         "s_lot": 6
       }
     },
-    "weather": { "base_temperature": 8.0, "base_humidity": 40.0, "base_pressure": 1015.0 },
+    "weather": {
+      "base_temperature": 8.0,
+      "base_humidity": 40.0,
+      "base_pressure": 1015.0,
+      "base_wind": 0,
+      "base_wind_distrib_peaks": 0,
+      "base_wind_season_variation": 0
+    },
     "overmap_feature_flag_settings": { "clear_blacklist": false, "blacklist": [  ], "clear_whitelist": false, "whitelist": [  ] }
   },
   {

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -592,7 +592,7 @@ void load_region_settings( const JsonObject &jo )
         jo.throw_error( "\"weather\": { … } required for default" );
     } else {
         JsonObject wjo = jo.get_object( "weather" );
-        new_region.weather = weather_generator::load( wjo );
+        new_region.weather.load( wjo, false );
     }
 
     load_overmap_feature_flag_settings( jo, new_region.overmap_feature_flag, strict, false );
@@ -746,10 +746,9 @@ void apply_region_overlay( const JsonObject &jo, regional_settings &region )
     load_building_types( "shops", region.city_spec.shops );
     load_building_types( "parks", region.city_spec.parks );
 
-    // TODO: Support overwriting only some values
     if( jo.has_object( "weather" ) ) {
         JsonObject wjo = jo.get_object( "weather" );
-        region.weather = weather_generator::load( wjo );
+        region.weather.load( wjo, true );
     }
 
     load_overmap_feature_flag_settings( jo, region.overmap_feature_flag, false, true );

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -13,6 +13,7 @@
 #include "condition.h"
 #include "dialogue.h"
 #include "game_constants.h"
+#include "generic_factory.h"
 #include "json.h"
 #include "math_defines.h"
 #include "point.h"
@@ -335,27 +336,25 @@ void weather_generator::sort_weather()
     } );
 }
 
-weather_generator weather_generator::load( const JsonObject &jo )
+void weather_generator::load( const JsonObject &jo, const bool was_loaded )
 {
-    weather_generator ret;
-    ret.base_temperature = jo.get_float( "base_temperature", 0.0 );
-    ret.base_humidity = jo.get_float( "base_humidity", 50.0 );
-    ret.base_pressure = jo.get_float( "base_pressure", 0.0 );
-    ret.base_wind = jo.get_float( "base_wind", 0.0 );
-    ret.base_wind_distrib_peaks = jo.get_int( "base_wind_distrib_peaks", 0 );
-    ret.base_wind_season_variation = jo.get_int( "base_wind_season_variation", 0 );
-    ret.summer_temp_manual_mod = jo.get_int( "summer_temp_manual_mod", 0 );
-    ret.spring_temp_manual_mod = jo.get_int( "spring_temp_manual_mod", 0 );
-    ret.autumn_temp_manual_mod = jo.get_int( "autumn_temp_manual_mod", 0 );
-    ret.winter_temp_manual_mod = jo.get_int( "winter_temp_manual_mod", 0 );
-    ret.spring_humidity_manual_mod = jo.get_int( "spring_humidity_manual_mod", 0 );
-    ret.summer_humidity_manual_mod = jo.get_int( "summer_humidity_manual_mod", 0 );
-    ret.autumn_humidity_manual_mod = jo.get_int( "autumn_humidity_manual_mod", 0 );
-    ret.winter_humidity_manual_mod = jo.get_int( "winter_humidity_manual_mod", 0 );
-    ret.weather_black_list = jo.get_string_array( "weather_black_list" );
-    ret.weather_white_list = jo.get_string_array( "weather_white_list" );
-    if( !ret.weather_black_list.empty() && !ret.weather_white_list.empty() ) {
+    mandatory( jo, was_loaded, "base_temperature", base_temperature );
+    mandatory( jo, was_loaded, "base_humidity", base_humidity );
+    mandatory( jo, was_loaded, "base_pressure", base_pressure );
+    mandatory( jo, was_loaded, "base_wind", base_wind );
+    mandatory( jo, was_loaded, "base_wind_distrib_peaks", base_wind_distrib_peaks );
+    mandatory( jo, was_loaded, "base_wind_season_variation", base_wind_season_variation );
+    optional( jo, was_loaded, "summer_temp_manual_mod", summer_temp_manual_mod, 0 );
+    optional( jo, was_loaded, "spring_temp_manual_mod", spring_temp_manual_mod, 0 );
+    optional( jo, was_loaded, "autumn_temp_manual_mod", autumn_temp_manual_mod, 0 );
+    optional( jo, was_loaded, "winter_temp_manual_mod", winter_temp_manual_mod, 0 );
+    optional( jo, was_loaded, "spring_humidity_manual_mod", spring_humidity_manual_mod, 0 );
+    optional( jo, was_loaded, "summer_humidity_manual_mod", summer_humidity_manual_mod, 0 );
+    optional( jo, was_loaded, "autumn_humidity_manual_mod", autumn_humidity_manual_mod, 0 );
+    optional( jo, was_loaded, "winter_humidity_manual_mod", winter_humidity_manual_mod, 0 );
+    optional( jo, was_loaded, "weather_black_list", weather_black_list );
+    optional( jo, was_loaded, "weather_white_list", weather_white_list );
+    if( !weather_black_list.empty() && !weather_white_list.empty() ) {
         jo.throw_error( "weather_black_list and weather_white_list are mutually exclusive" );
     }
-    return ret;
 }

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -73,7 +73,7 @@ class weather_generator
         void sort_weather();
         units::temperature get_weather_temperature( const tripoint &, const time_point &, unsigned ) const;
 
-        void load( const JsonObject &jo, const bool was_loaded );
+        void load( const JsonObject &jo, bool was_loaded );
 };
 
 #endif // CATA_SRC_WEATHER_GEN_H

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -73,7 +73,7 @@ class weather_generator
         void sort_weather();
         units::temperature get_weather_temperature( const tripoint &, const time_point &, unsigned ) const;
 
-        static weather_generator load( const JsonObject &jo );
+        void load( const JsonObject &jo, const bool was_loaded );
 };
 
 #endif // CATA_SRC_WEATHER_GEN_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[No Hope] Fixes worse than intended weather"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #78678
Fixes #78719
I derped in #78375 and removed needed dupe weather fields bc weather_generator has old school loading
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rather than just reverting https://github.com/CleverRaven/Cataclysm-DDA/pull/78375/commits/199750b906b8b34f29cd0fa8c5b25b68b75ed034 adds proper generic factory style loading to weather_generator
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I still want to scrutinise weather code in general but don't want to get started on that rn
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
There's conveniently a debug function to dump a year's worth of weather, tested before and after with No Hope (here's the after)
[weather.xlsx](https://github.com/user-attachments/files/18222711/weather.xlsx)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
