### PR TITLE
Removes damage from archery bracers, adds weakpoint accuracy.

### DIFF
--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1704,8 +1704,8 @@
   {
     "type": "effect_type",
     "id": "archerybracers",
-    "name": [""],
-    "desc": [""],
+    "name": [ "" ],
+    "desc": [ "" ],
     "rating": "good",
     "enchantments": [ { "values": [ {"value": "WEAKPOINT_ACCURACY", "multiply": {"math": [ "1+(u_skill('archery'))" ]}}]}]
 

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1707,8 +1707,7 @@
     "name": [ "" ],
     "desc": [ "" ],
     "rating": "good",
-    "enchantments": [ { "values": [ {"value": "WEAKPOINT_ACCURACY", "multiply": {"math": [ "1+((u_skill('archery'))/3)" ]}}]}]
-
+    "enchantments": [ { "values": [ { "value": "WEAKPOINT_ACCURACY", "multiply": { "math": [ "1+((u_skill('archery'))/3)" ] } } ] } ]
   },
   {
     "type": "effect_type",

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1707,7 +1707,7 @@
     "name": [ "" ],
     "desc": [ "" ],
     "rating": "good",
-    "enchantments": [ { "values": [ {"value": "WEAKPOINT_ACCURACY", "multiply": {"math": [ "1+(u_skill('archery'))" ]}}]}]
+    "enchantments": [ { "values": [ {"value": "WEAKPOINT_ACCURACY", "multiply": {"math": [ "1+((u_skill('archery'))/3)" ]}}]}]
 
   },
   {

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1703,6 +1703,15 @@
   },
   {
     "type": "effect_type",
+    "id": "archerybracers",
+    "name": [""],
+    "desc": [""],
+    "rating": "good",
+    "enchantments": [ { "values": [ {"value": "WEAKPOINT_ACCURACY", "multiply": {"math": [ "1+(u_skill('archery'))" ]}}]}]
+
+  },
+  {
+    "type": "effect_type",
     "id": "effect_feral_stormshaper_stormhammer",
     "name": [ { "str": "Wielding Stormhammer", "//~": "NO_I18N" } ],
     "desc": [ { "str": "You are a monster wielding a stormhammer, as this effect indicates.", "//~": "NO_I18N" } ],

--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -121,7 +121,7 @@
           "values": [
             { "value": "RANGE", "multiply": 0.2 },
             { "value": "WEAPON_DISPERSION", "multiply": -0.33 },
-            { "value": "WEAKPOINT_ACCURACY", "multiply": 2.5}
+            { "value": "WEAKPOINT_ACCURACY", "multiply": 2.5 }
           ],
           "ench_effects": [ { "effect": "effect_plus_two_to_hit", "intensity": 1 } ]
         }

--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -120,10 +120,9 @@
           "condition": { "u_has_wielded_with_flag": "SHEATH_BOW" },
           "values": [
             { "value": "RANGE", "multiply": 0.2 },
-            { "value": "WEAPON_DISPERSION", "multiply": -0.33 },
-            { "value": "WEAKPOINT_ACCURACY", "multiply": 2.5}
+            { "value": "WEAPON_DISPERSION", "multiply": -0.33 }
           ],
-          "ench_effects": [ { "effect": "effect_plus_two_to_hit", "intensity": 1 } ]
+          "ench_effects": [ { "effect": "effect_plus_two_to_hit", "intensity": 1 }, {"effect": "archerybracers", "intensity": 1}]
         }
       ]
     }

--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -118,11 +118,8 @@
         {
           "has": "WORN",
           "condition": { "u_has_wielded_with_flag": "SHEATH_BOW" },
-          "values": [
-            { "value": "RANGE", "multiply": 0.2 },
-            { "value": "WEAPON_DISPERSION", "multiply": -0.33 }
-          ],
-          "ench_effects": [ { "effect": "effect_plus_two_to_hit", "intensity": 1 }, {"effect": "archerybracers", "intensity": 1}]
+          "values": [ { "value": "RANGE", "multiply": 0.2 }, { "value": "WEAPON_DISPERSION", "multiply": -0.33 } ],
+          "ench_effects": [ { "effect": "effect_plus_two_to_hit", "intensity": 1 }, { "effect": "archerybracers", "intensity": 1 } ]
         }
       ]
     }

--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -119,7 +119,6 @@
           "has": "WORN",
           "condition": { "u_has_wielded_with_flag": "SHEATH_BOW" },
           "values": [
-            { "value": "RANGED_DAMAGE", "multiply": 0.25 },
             { "value": "RANGE", "multiply": 0.2 },
             { "value": "WEAPON_DISPERSION", "multiply": -0.33 },
             { "value": "WEAKPOINT_ACCURACY", "multiply": 2.5}

--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -122,7 +122,7 @@
             { "value": "RANGED_DAMAGE", "multiply": 0.25 },
             { "value": "RANGE", "multiply": 0.2 },
             { "value": "WEAPON_DISPERSION", "multiply": -0.33 },
-            { "value": "WEAKPOINT_ACCURACY", "multiply": 3}
+            { "value": "WEAKPOINT_ACCURACY", "multiply": 2.5}
           ],
           "ench_effects": [ { "effect": "effect_plus_two_to_hit", "intensity": 1 } ]
         }

--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -121,7 +121,8 @@
           "values": [
             { "value": "RANGED_DAMAGE", "multiply": 0.25 },
             { "value": "RANGE", "multiply": 0.2 },
-            { "value": "WEAPON_DISPERSION", "multiply": -0.33 }
+            { "value": "WEAPON_DISPERSION", "multiply": -0.33 },
+            { "value": "WEAKPOINT_ACCURACY", "multiply": 1 }
           ],
           "ench_effects": [ { "effect": "effect_plus_two_to_hit", "intensity": 1 } ]
         }

--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -122,7 +122,7 @@
             { "value": "RANGED_DAMAGE", "multiply": 0.25 },
             { "value": "RANGE", "multiply": 0.2 },
             { "value": "WEAPON_DISPERSION", "multiply": -0.33 },
-            { "value": "WEAKPOINT_ACCURACY", "multiply": 1 }
+            { "value": "WEAKPOINT_ACCURACY", "multiply": 3}
           ],
           "ench_effects": [ { "effect": "effect_plus_two_to_hit", "intensity": 1 } ]
         }


### PR DESCRIPTION


#### Summary
Mods "Changes a straight damage on archery bracers to weakpoint accuracy."

#### Purpose of change

#76663 Standing Storm wished to change straight damage to weakpoint accuracy when possible, so this change does that.

#### Describe the solution

Adds weakpoint accuracy to archery bracers. I'm not exactly sure _just how likely you are_ to hit weakpoints, but given high armor values & investment into archery to start hitting weakpoints to begin with (skill training, proficiency training) and the original wording of "making archery competitive with guns", I can only assume a high weakpoint accuracy modifier's the way to do it.

#### Describe alternatives you've considered

Adding flat armorpiercing value, adding multiple pairs of bracers with tiered effects from minor to "this is actually better than a gun". I tried making the weakpoint multiplier scale heavily off of archery skill, but the game didn't like me putting a math function in the multiply field.

#### Testing
Set Weakpoint Accuracy in the JSON to 1, all proficiencies & all skills to 10. Shoot a skeletal juggernaut a few times, notice that _I'm not hitting their eyes?_ Set it to 99, notice lots of eye hits, set it to 2.5 as a nice middle ground when compared to expected lilin Ruach pool as per #77576

#### Additional context


