### PR TITLE
Disassembly menu: highlight filtered components, always show required & components

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -623,10 +623,10 @@ void inventory_entry::cache_denial( inventory_selector_preset const &preset ) co
 {
     if( !denial ) {
         denial.emplace( preset.get_denial( *this ) );
-        enabled = denial->empty();
+        enabled = is_item() && preset.get_enabled( any_item() );
     }
     if( is_collation_header() ) {
-        collation_meta->enabled = denial->empty();
+        collation_meta->enabled = is_item() && preset.get_enabled( any_item() );
     }
 }
 
@@ -1712,6 +1712,7 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
             }
         }
 
+        // TODO: make denial empty and make extra column for denial
         size_t count = denial.empty() ? cells.size() : 1;
 
         for( size_t cell_index = 0; cell_index < count; ++cell_index ) {
@@ -1754,7 +1755,9 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
                     trim_and_print( win, point( text_x - 1, yy ), 1, col,
                                     stat ? "▶" : "▼" );
                 }
-                if( entry.is_item() && ( selected || !entry.is_selectable() ) ) {
+                /*if( entry.is_item() && !selected && !entry.is_selectable() && denial.empty() ) {
+                    trim_and_print( win, point( text_x, yy ), text_width, entry_cell_cache.color, text );
+                } else*/ if( entry.is_item() && ( selected || ( !entry.is_selectable() && !denial.empty() ) ) ) {
                     trim_and_print( win, point( text_x, yy ), text_width, selected ? h_white : c_dark_gray,
                                     remove_color_tags( text ) );
                 } else if( entry.is_item() && entry.highlight_as_parent ) {
@@ -3001,6 +3004,7 @@ inventory_input inventory_selector::process_input( const std::string &action, in
                 if( res.entry != nullptr && res.entry->is_selectable() ) {
                     return res;
                 }
+                // todo denial popup
                 if( res.entry == nullptr && res.action == "SELECT" ) {
                     p.x++;
                     res.entry = find_entry_by_coordinate( p );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -734,6 +734,8 @@ std::function<bool( const inventory_entry & )> inventory_selector_preset::get_fi
     };
 }
 
+void inventory_selector_preset::on_filter_change( const std::string &/*filter*/ ) const {};
+
 std::string inventory_selector_preset::get_caption( const inventory_entry &entry ) const
 {
     size_t count = entry.get_stack_size();
@@ -839,6 +841,33 @@ void inventory_selector_preset::append_cell( const
         return;
     }
     cells.emplace_back( func, title, stub );
+}
+
+// TODO should not be const
+void inventory_selector_preset::replace_cell( const
+        std::function<std::string( const item_location & )> &func,
+        const std::string &title, const std::string &stub ) const
+{
+    // Don't capture by reference here. The func should be able to die earlier than the object itself
+    replace_cell( std::function<std::string( const inventory_entry & )>( [ func ](
+    const inventory_entry & entry ) {
+        return func( entry.any_item() );
+    } ), title, stub );
+}
+
+void inventory_selector_preset::replace_cell( const
+        std::function<std::string( const inventory_entry & )> &func,
+        const std::string &title, const std::string &stub ) const
+{
+    const auto iter = std::find_if( cells.begin(), cells.end(), [ &title ]( const cell_t &cell ) {
+        return cell.title == title;
+    } );
+    if( iter == cells.end() ) {
+        debugmsg( "Tried to replace a non duplicate cell \"%s\": ignored.", title.c_str() );
+        return;
+    }
+    *iter = {func, title, stub};
+    //reset_entry_cell_cache();
 }
 
 std::string inventory_selector_preset::cell_t::get_text( const inventory_entry &entry ) const
@@ -1779,6 +1808,7 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
                     }
                     entry.highlight_as_child = false;
                 } else {
+                    // TODO this screws the colors of `,`, `, and`
                     trim_and_print( win, point( text_x, yy ), text_width, entry_cell_cache.color, text );
                 }
             }
@@ -2769,7 +2799,9 @@ void inventory_selector::set_filter( const std::string &str )
     filter = str;
     for( inventory_column *const elem : columns ) {
         elem->set_filter( filter );
+        // reset_entry_cell_cache();
     }
+    preset.on_filter_change( filter );
 }
 
 std::string inventory_selector::get_filter() const
@@ -3149,6 +3181,8 @@ void inventory_selector::on_input( const inventory_input &input )
 
 void inventory_selector::on_change( const inventory_entry &entry )
 {
+    // TODO does not reset. Workaround during testing: use "Toggle language to English" option
+    entry.reset_entry_cell_cache();
     for( inventory_column *&elem : columns ) {
         elem->on_change( entry );
     }

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -248,6 +248,13 @@ class inventory_selector_preset
         virtual std::string get_denial( const item_location & ) const {
             return std::string();
         }
+        /**
+         * Can this entry be selected?
+         * By default, it cannot be if get_denial returns an empty string.
+         */
+        virtual bool get_enabled( const item_location &loc ) const {
+            return get_denial( loc ).empty();
+        }
         /** Whether the first item is considered to go before the second. */
         virtual bool sort_compare( const inventory_entry &lhs, const inventory_entry &rhs ) const;
         virtual bool cat_sort_compare( const inventory_entry &lhs, const inventory_entry &rhs ) const;

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -281,6 +281,7 @@ class inventory_selector_preset
 
         virtual std::function<bool( const inventory_entry & )> get_filter( const std::string &filter )
         const;
+        virtual void on_filter_change( const std::string &filter ) const;
 
         bool indent_entries() const {
             return _indent_entries;
@@ -307,6 +308,15 @@ class inventory_selector_preset
         void append_cell( const std::function<std::string( const inventory_entry & )> &func,
                           const std::string &title = std::string(),
                           const std::string &stub = std::string() );
+        /**
+         * Replace an existing cell.
+         */
+        void replace_cell( const std::function<std::string( const item_location & )> &func,
+                           const std::string &title = std::string(),
+                           const std::string &stub = std::string() ) const;
+        void replace_cell( const std::function<std::string( const inventory_entry & )> &func,
+                           const std::string &title = std::string(),
+                           const std::string &stub = std::string() ) const;
         bool check_components = false;
 
         // whether to indent contained entries in the menu
@@ -334,7 +344,7 @@ class inventory_selector_preset
                 std::function<std::string( const inventory_entry & )> func;
         };
 
-        std::vector<cell_t> cells;
+        mutable std::vector<cell_t> cells;
 };
 
 /**


### PR DESCRIPTION
#### Summary
Interface "Disassembly menu: highlight filtered components, always show required & components"

#### Purpose of change

Part of #73808

#### Describe the solution

I don't like my solution. I need to set cells to mutable and replace_cell to const so that it compiles. I am listening to any better solution!

 - Add `on_filter_change` to inventory_selector_preset
 - use it in the disassembly menu to highlight components from the filter e.g. `d:copper wire`
   - <img width="1326" height="1036" alt="image" src="https://github.com/user-attachments/assets/568d93a0-4aa4-4810-9978-337e16dcab38" />

Needs work
 - Now, it shows things you should not see, such as items behind a wall. It should use `all_known_items()` - just like the crafting menu.
   - ~Check that things behind a wall cannot be seen. Tools too.~
   - [x] Do not change the distance, that is what #78748 is for. Also, remove all displays related to changing distance.
 - [ ] Numerous TODOs I added across the code. Almost all of them need solving before this is ready.

#### Describe alternatives you've considered

Expand the capabilities more sustainably by implementing this somewhere else in the call chain. I would like that!

#### Testing

1. Open the `(` disassembly menu.
3. Observe: each column has its colour.
4. Observe: New column `CAN DISASSEMBLE`.
7. Filter for `d:copper wire`
   - Currently, it doesn't update the cache automatically as it should.
   - Cache can be updated manually by "Toggle language to English" option.
8. Observe (if cache was updated) components are highlighted.

#### Additional context
