### PR TITLE
Fix enchantment

### DIFF
--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -1466,12 +1466,18 @@ void enchant_cache::clear()
     skill_values_multiply.clear();
     damage_values_add.clear();
     damage_values_multiply.clear();
+    armor_values_add.clear();
+    armor_values_multiply.clear();
+    extra_damage_add.clear();
+    extra_damage_multiply.clear();
     special_vision_vector.clear();
     hit_me_effect.clear();
     hit_you_effect.clear();
     ench_effects.clear();
+    emitter.reset();
     mutations.clear();
     modified_bodyparts.clear();
+    intermittent_activation.clear();
     details.clear();
 }
 

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -1472,6 +1472,7 @@ void enchant_cache::clear()
     ench_effects.clear();
     mutations.clear();
     modified_bodyparts.clear();
+    details.clear();
 }
 
 bool enchant_cache::operator==( const enchant_cache &rhs ) const


### PR DESCRIPTION
#### Summary
Bugfixes "Fix enchantment"
#### Purpose of change
Fix #78735
Fix CI `monster_throwing_sanity_test` failure
#### Describe the solution
Fix `enchant_cache::clear()`.
#### Describe alternatives you've considered
Use
```
enchant_cache tmp;
*enchantment_cache = tmp;
```
#### Testing
`monster_throwing_sanity_test` passed.
Tested rm13, phase immersion suit, and bio_night, all worked as expected.
#### Additional context
The old initial process
```
*enchantment_cache = inv->get_active_enchantment_cache( *this )
```
is equal to
```
enchant_cache tmp;
*enchantment_cache = tmp;
```
🤔
Maybe I can write a test case in another PR.