### PR TITLE
Use ccache --evict-older-than for more accurate and leaner ccaches.

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -29,6 +29,7 @@ jobs:
       id: get-vars
       run: |
         echo "datetime=$(/bin/date -u "+%Y%m%d%H%M")" >> $GITHUB_OUTPUT
+        echo "datetime-seconds=$(/bin/date +%s)" >> $GITHUB_OUTPUT
         echo "ccache-path=$(echo '~/.cache/ccache')" >> $GITHUB_OUTPUT
 
     - name: ccache cache files
@@ -53,7 +54,7 @@ jobs:
         export EM_CONFIG=$EMSDK/.emscripten
         export CCACHE_COMPILERCHECK=string:3.1.51
         ccache --zero-stats
-        ccache -M 5G
+        ccache -M 20G
         ccache --show-stats
 
         ./build-scripts/build-emscripten.sh
@@ -63,7 +64,11 @@ jobs:
         emsdk activate ccache-git-emscripten-64bit
         export PATH="${PATH%%:*}/../../ccache/git-emscripten_64bit/bin":$PATH
         ccache --show-stats
-        ccache -M 5G
+        NOW=`/bin/date +%s`
+        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
+        ccache --evict-older-than ${DELTA}s
+        ccache --show-stats
+        ccache -M 1G
         ccache -c
         ccache --show-stats
 

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -94,7 +94,7 @@ jobs:
             dont_skip_data_only_changes: 1
             mods: --mods=magiclysm
             title: Basic Build and Test (Clang 10, Ubuntu, Curses)
-            ccache_limit: 5G
+            ccache_limit: 4.5G
             ccache_key: linux-llvm-10-break1
 
           - compiler: clang++
@@ -106,7 +106,7 @@ jobs:
             sound: 1
             localize: 1
             title: Clang 14, macOS 12, Tiles, Sound, x64 and arm64 Universal Binary
-            ccache_limit: 6G
+            ccache_limit: 10G
             ccache_key: macos-llvm-14-universal-break1
 
           - compiler: g++-9
@@ -122,7 +122,7 @@ jobs:
             pch: 1
             cxxflags: -gsplit-dwarf
             title: GCC 9, Curses, LTO
-            ccache_limit: 4.5G
+            ccache_limit: 7.5G
             ccache_key: linux-gcc-9-lto
 
           - compiler: clang++-12
@@ -137,7 +137,7 @@ jobs:
             cxxflags: --gcc-toolchain=/opt/mock-gcc-11
             dont_skip_data_only_changes: 1
             title: Clang 12, Ubuntu, Tiles, ASan
-            ccache_limit: 4.5G
+            ccache_limit: 6G
             ccache_key: linux-llvm-12-asan
 
           - compiler: g++-11
@@ -150,7 +150,7 @@ jobs:
             pch: 1
             sanitize: address
             title: GCC 11, Ubuntu, Curses, ASan
-            ccache_limit: 6G
+            ccache_limit: 6.5G
             ccache_key: linux-gcc-11-asan
 
           - compiler: g++-9
@@ -162,7 +162,7 @@ jobs:
             native: linux64
             pch: 1
             title: GCC 9, Ubuntu, Tiles, Sound, CMake
-            ccache_limit: 3G
+            ccache_limit: 1G
             ccache_key: linux-gcc-9-cmake
 
     name: ${{ matrix.title }}
@@ -221,11 +221,12 @@ jobs:
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.tiles == 1 }}
       run: |
           sudo apt-get install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev
-    - name: install recent ccache on ubuntu 20.04
-      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.os == 'ubuntu-20.04' }}
+    - name: install recent ccache on ubuntu
+      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' }}
       run: |
+          ccache --version
           sudo apt-get remove --purge -y ccache
-          curl -sL https://github.com/ccache/ccache/releases/download/v4.8.3/ccache-4.8.3-linux-x86_64.tar.xz | sudo tar Jxvf - --strip-components 1 -C /usr/bin ccache-4.8.3-linux-x86_64/ccache
+          curl -sL https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz | sudo tar Jxvf - --strip-components 1 -C /usr/bin ccache-4.10.2-linux-x86_64/ccache
           ccache --version
     - name: install Clang 12 (Ubuntu)
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-12') }}
@@ -264,6 +265,7 @@ jobs:
       if: ${{ env.SKIP == 'false' }}
       run: |
         echo "datetime=$(/bin/date -u "+%Y%m%d%H%M")" >> $GITHUB_OUTPUT
+        echo "datetime-seconds=$(/bin/date +%s)" >> $GITHUB_OUTPUT
         echo "ccache-path=$([ "$RUNNER_OS" = "macOS" ] && echo '/Users/runner/Library/Caches/ccache' || echo '~/.cache/ccache')" >> $GITHUB_OUTPUT
       shell: bash
     - name: ccache cache files
@@ -282,6 +284,10 @@ jobs:
     - name: post-build ccache manipulation
       if: ${{ env.SKIP == 'false' && !failure() && (runner.os == 'Linux' || runner.os == 'macOS') }}
       run: |
+        ccache --show-stats --verbose
+        NOW=`/bin/date +%s`
+        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
+        ccache --evict-older-than ${DELTA}s
         ccache --show-stats --verbose
         ccache -M ${{ env.CCACHE_LIMIT }}
         ccache -c

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -111,6 +111,7 @@ jobs:
       id: get-vars
       run: |
         echo "datetime=$(/bin/date -u "+%Y%m%d%H%M")" >> $GITHUB_OUTPUT
+        echo "datetime-seconds=$(/bin/date +%s)" >> $GITHUB_OUTPUT
         echo "ccache-path=$(echo "$APPDATA\\ccache")" >> $GITHUB_OUTPUT
       shell: bash
 
@@ -138,9 +139,19 @@ jobs:
       run: |
           msbuild -m -p:Configuration=Release -p:Platform=x64 "-target:Cataclysm-vcpkg-static;Cataclysm-test-vcpkg-static;JsonFormatter-vcpkg-static" msvc-full-features/Cataclysm-vcpkg-static.sln
 
+    - name: Get ccache cache age cutoff
+      id: get-cache-age
+      run: |
+        NOW=`/bin/date +%s`
+        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
+        echo "ccache-age=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Post-build ccache manipulation
       if: ${{ !failure() }}
       run: |
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe --evict-older-than ${{ steps.get-ccache-age.outputs.ccache-age }}
         ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
         ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -M ${{ env.CCACHE_LIMIT }}
         ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -c

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -40,7 +40,7 @@ fi
 
 ccache --zero-stats
 # Increase cache size because debug builds generate large object files
-ccache -M 10G
+ccache -M 20G
 ccache --show-stats --verbose
 
 function run_test

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -40,7 +40,7 @@ fi
 
 ccache --zero-stats
 # Increase cache size because debug builds generate large object files
-ccache -M 10G
+ccache -M 20G
 ccache --show-stats --verbose
 
 if [ "$CMAKE" = "1" ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Build "Improve ccache performance with age based eviction instead of coarse size limits."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Our matrix builds were still not getting 100% cache hit rates, despite theoretically being size limited to a large enough cache to fit an entire build in. That slows down CI, especially for json only changes. Some builds were getting 0% hit rates even.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The problem was that ccache's manual compaction algorithm does not do a global LRU based trim. It leaks the internal implementation details of the cache a little bit, and as a result, causes non obvious behavior. When setting a cache size to less than the current cache size, and doing a cleanup, it will iterate through its internal 'sub caches'. If it finds any sub cache exceeds the total size divided by the number of sub caches, it will clean up that sub cache to fit into that space. Once the total cache size is below the cutoff, no more evictions happen.

In practice, these sub caches are not perfectly evenly distributed or filled. So you end up evicting newer objects compared to older ones from 'later' caches (which are sorted alphabetically based on the first two hex chars of some hash of the inputs). In the worst case, you end up evicting a pch file, and cause 0% hit rates to happen afterwards. Ew.

ccache supports an explicit age based eviction command. This works out perfectly for us - on each master build, we just want to toss any objects not used or written in the current build. This means we will keep exactly only the freshest objects in cache. The size constraint then becomes a safety check on not overdoing our cache usage on the github side, causing github to evict our objects unnecessarily quickly.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
A lot of builds in my local repo, culminating with this beauty of 100% ccache hit rate (link time is always paid, ccache isn't caching link outputs).
![image](https://github.com/user-attachments/assets/c362bd21-03cb-4047-be57-cd35cdbec38d)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
ccache feedback written up at https://github.com/ccache/ccache/issues/1543
ccache cleanup algorithm source around https://github.com/ccache/ccache/blob/master/src/ccache/storage/local/localstorage.cpp#L1301-L1302 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
