### PR TITLE
Make monsters being able to evaluate enchantment conditions

### DIFF
--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -317,11 +317,15 @@ bool enchantment::is_active( const Character &guy, const bool active ) const
 bool enchantment::is_active( const monster &mon ) const
 {
     //This is very limited at the moment. Basically, we can't use any conditions except "ALWAYS"
-    if( active_conditions.second == condition::ALWAYS && !mon.is_fake() ) {
+    if( active_conditions.second == condition::ALWAYS ) {
         return true;
     }
-    // Dialogue conditions for monsters seems like overkill.
-    // Definitely not an excuse for not knowing how to add them. Nope! Sure isn't!
+
+    if( active_conditions.second == condition::DIALOG_CONDITION ) {
+        const_dialogue d( get_const_talker_for( mon ), nullptr );
+        return dialog_condition( d );
+    }
+
     return false;
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #78597
#### Describe the solution
fix
also make hallucinations affected by enchantments (i assume fake = hallu), because if you slow down something magically, it should be slower, even if you imagine it
#### Testing
Using test json in issue, making one zombie super slow
![GIF 23-12-2024 21-53-12](https://github.com/user-attachments/assets/c71ae735-5f42-4fc5-8274-082e4021ca78)
Making one zombie super fast
![GIF 23-12-2024 21-55-38](https://github.com/user-attachments/assets/852c993f-f3f6-4378-bd2d-ad1d7a5b81ec)
#### Additional context
Love being able to fix something by copypasting a code ten lines above the issue