### PR TITLE
Set disassembly range to PICKUP_RANGE: 6

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -648,7 +648,7 @@ class disassemble_inventory_preset : public inventory_selector_preset
 item_location game_menus::inv::disassemble( Character &you )
 {
     return inv_internal( you, disassemble_inventory_preset( you, you.crafting_inventory() ),
-                         _( "Disassemble item" ), 1,
+                         _( "Disassemble item" ), PICKUP_RANGE,
                          _( "You don't have any items you could disassemble." ) );
 }
 


### PR DESCRIPTION
#### Summary
Balance "Set disassembly range to crafting range: 6"

#### Purpose of change

 - Conceptually and eventually, disassembly should be like crafting. Setting them to have same range makes sense.
 - Standing on the central crafting spot in your base (you already have) you can disassemble things from there too now.

#### Describe the solution

 - [x] Increase the range in the `(` disassembly menu to `PICKUP_RANGE`, which is 6.
 ~- [ ] Toggle between 1 and 6 for @moxian.~
    - Hopefully I will do that tomorow.
    - Edit: see https://github.com/CleverRaven/Cataclysm-DDA/pull/78748#issuecomment-2575294983

#### Describe alternatives you've considered

My only concern was:
 > Wouldn't it be weird if you could essentially destroy any disassemable item distant 6 tiles? If an enemy NPC drops a gun, you could just destroy it, right? Or is this not an issue?

_from https://github.com/CleverRaven/Cataclysm-DDA/issues/78737#issuecomment-2560121205_

But now that I think about it, this exploit is a tiny bit more effective thanks to the range increase from 1 to 6, but it was always there and it is not a blocker.            

 - In #78737 I wanted to expand what the disassembly menu shows to the whole bubble so that players see items further than 1 tile. See the PR for more arguments and discussion on that. This PR replaces that QoL improvement in that PR completely and all the display shenanigans around.
- Instead of the item teleporting, avatar could walk to the item and retrieves it somehow. Maybe when crafting does that too.

#### Testing

1. Open the menu.
2. Select an item that is 3N (switch to `;` hierarchy to see the distances).
3. Disassembly starts in your hand / on a workbench next to you.
4. Canceling leaves the partially disassembled item where it is (your hand or the workbench).
5. Finishing the disassembly works as expected too.

#### Additional context
