### PR TITLE
Fix compact aim window

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1954,13 +1954,13 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
     nc_color col = c_light_gray;
 
 
-	const auto &current_steadiness_it = std::find_if( sorted.begin(),
-	sorted.end(), []( const aim_type_prediction & atp ) {
-		return atp.is_default;
-	} );
-	if( current_steadiness_it != sorted.end() ) {
-		line_number = print_steadiness( w, line_number, current_steadiness_it->steadiness );
-	}
+    const auto &current_steadiness_it = std::find_if( sorted.begin(),
+    sorted.end(), []( const aim_type_prediction & atp ) {
+        return atp.is_default;
+    } );
+    if( current_steadiness_it != sorted.end() ) {
+        line_number = print_steadiness( w, line_number, current_steadiness_it->steadiness );
+    }
 
     // Start printing by available width of aim window
     if( narrow ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -321,10 +321,9 @@ class target_ui
 
         // Compact layout
         bool compact = false;
-        // Tiny layout - when extremely short on space
+        // Tiny layout - when extremely short on height
         bool tiny = false;
-        // Narrow layout - to keep in theme with
-        // "compact" and "labels-narrow" sidebar styles.
+        // Narrow layout - when short on width
         bool narrow = false;
 
         // Create window and set up input context
@@ -1951,14 +1950,20 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
     int width = getmaxx( w ) - 2; // window width minus borders
     const int bars_pad = 3;
     bool display_numbers = get_option<std::string>( "ACCURACY_DISPLAY" ) == "numbers";
-    std::string panel_type = panel_manager::get_manager().get_current_layout_id();
+    bool narrow = panel_manager::get_manager().get_current_layout().panels().begin()->get_width() <= 42;
     nc_color col = c_light_gray;
 
-    // Start printing by panel type, inside each branch whether to output numbers or "bars"
-    if( panel_type == "legacy_labels_narrow_sidebar" || panel_type == "legacy_compact_sidebar" ) {
-        bool narrow = panel_type == "legacy_labels_narrow_sidebar";
-        // TODO: who uses this? this is broken likely since work started
-        // on sidebar widgets and yet nobody complains...
+
+	const auto &current_steadiness_it = std::find_if( sorted.begin(),
+	sorted.end(), []( const aim_type_prediction & atp ) {
+		return atp.is_default;
+	} );
+	if( current_steadiness_it != sorted.end() ) {
+		line_number = print_steadiness( w, line_number, current_steadiness_it->steadiness );
+	}
+
+    // Start printing by available width of aim window
+    if( narrow ) {
         std::vector<std::string> t_aims( 4 );
         std::vector<std::string> t_confidence( 20 );
         int aim_iter = 0;
@@ -2020,19 +2025,10 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
             line_number = line_number + 4; // 4 to account for the tables
         }
         return line_number;
-    } else { // print the "legacy classic" one
-        // there's more legacy sidebars but appear to not be used
-
-        const auto &current_steadiness_it = std::find_if( sorted.begin(),
-        sorted.end(), []( const aim_type_prediction & atp ) {
-            return atp.is_default;
-        } );
-        if( current_steadiness_it != sorted.end() ) {
-            line_number = print_steadiness( w, line_number, current_steadiness_it->steadiness );
-        }
+    } else { // print normally
 
         int column_number = 1;
-        if( !( panel_type == "compact" || panel_type == "labels-narrow" ) ) {
+        if( !narrow ) {
             std::string label = _( "Symbols:" );
             mvwprintw( w, point( column_number, line_number ), label );
             column_number += utf8_width( label ) + 1; // 1 for whitespace after 'Symbols:'
@@ -2880,16 +2876,14 @@ target_handler::trajectory target_ui::run()
 
 void target_ui::init_window_and_input()
 {
-    std::string panel_type = panel_manager::get_manager().get_current_layout_id();
-    narrow = ( panel_type == "compact" || panel_type == "labels-narrow" );
-
     int top = 0;
-    int width;
+    int width = panel_manager::get_manager().get_current_layout().panels().begin()->get_width();
     int height;
+    narrow = width <= 42;
     if( narrow ) {
-        // Narrow layout removes the list of controls. This allows us
-        // to have small window size and not suffer from it.
-        width = 34;
+        if( width < 34 ) {
+            width = 34;
+        }
         height = 24;
         compact = true;
     } else {
@@ -3801,6 +3795,9 @@ void target_ui::draw_ui_window()
         }
     }
 
+    // Narrow layout removes the list of controls. This allows us
+    // to have small window size and not suffer from it.
+    bool narrow = panel_manager::get_manager().get_current_layout().panels().begin()->get_width() <= 42;
     if( !narrow ) {
         draw_controls_list( text_y );
     }


### PR DESCRIPTION
#### Summary
`SUMMARY: Interface "Fix compact aim window"`

#### Purpose of change

My (very) old merged PRs #37715 and #40236 have been not working properly for a couple years because strings were changed in some places but not others. All the code still exists and works fine. It just needs to be updated.  
As the aim window can obscure targets on small terminal sizes, this should be fixed, and who better to do it than the original author :) 

#### Describe the solution

Remove all references to hardcoded strings of sidebars, and instead check sidebar width. This should help future-proof against any arbitrary name changes and generally improve compatibility. 
See additional context for more.

#### Describe alternatives you've considered

Just update the strings referencing the two relevant legacy sidebars.

#### Testing

Game compiles and loads
Open the aim window for "numbers" and "bars" for every sidebar option

#### Additional context

Compact aim window will activate when a sidebar's width is 42 and below. This number was chosen as it's the point in which the controls help text will be cut off.  
The aim window's width will change dynamically to match the sidebar's width (finally fulfilling the original PR's dream). 
The minimum width of the aim window is 34. This was determined to be a good width in the past.

Also fix a bug in which compact layout did not remove the controls help text. This feature has been around since prior to my previous PR's, apparently. While the relevant code was updated at some point, no one caught the bug since compact aim window did not function. 

Example screenshots are available in the mentioned PR's, but I'll put some new ones. These are taken at the smallest terminal size.
Before. This is the standard, current layout:
![Screenshot 2024-12-23 202637](https://github.com/user-attachments/assets/cfff8315-9a5c-4ed5-a399-18a066734d6d)
![Screenshot 2024-12-23 202615](https://github.com/user-attachments/assets/62e6cb03-cd3e-4376-9032-e5bb7258a4d2)

After. This is the compact layout that will activate under certain conditions. Currently, "custom", "compact" and "labels narrow" fulfill this condition:
![Screenshot 2024-12-23 204919](https://github.com/user-attachments/assets/e28dfa9d-2ca8-45ce-a097-412aeccd624c)
![Screenshot 2024-12-23 204942](https://github.com/user-attachments/assets/2e3beb2f-294e-4d2d-ae89-7a5e740fbe87)
