### PR TITLE
Eggplants can be smoked in the rack

### DIFF
--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -1255,7 +1255,8 @@
     "description": "A normal and healthy purple eggplant.  Needs to be disassembled before being useful for cooking.",
     "healthy": -1,
     "symbol": "e",
-    "flags": [ "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
+    "flags": [ "RAW", "SMOKABLE", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
+    "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "12100 μg" ], [ "iron", "1300 μg" ], [ "calcium", "49300 μg" ], [ "veggy_allergen", 1 ] ],
     "fun": -8
   },
@@ -1276,7 +1277,8 @@
     "healthy": -1,
     "symbol": "e",
     "looks_like": "eggplant",
-    "flags": [ "RAW" ],
+    "flags": [ "RAW", "SMOKABLE" ],
+    "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "60500 μg" ], [ "iron", "650 μg" ], [ "calcium", "24650 μg" ], [ "veggy_allergen", 1 ] ],
     "fun": -5
   },

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -1094,6 +1094,8 @@
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "corn_kernels", "name": { "str_sp": "%s, corn kernels" } },
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "cucumber", "name": { "str_sp": "%s, cucumber" } },
       { "type": "COMPONENT_ID", "condition": "dandelion_cooked", "name": { "str_sp": "%s, cooked dandelion greens" } },
+      { "type": "COMPONENT_ID", "condition": "eggplant", "name": { "str_sp": "%s, eggplant" } },
+      { "type": "COMPONENT_ID", "condition": "eggplant_cut", "name": { "str_sp": "%s, cut eggplant" } },
       { "type": "COMPONENT_ID", "condition": "grape_leaves", "name": { "str_sp": "%s, grape leaves" } },
       { "type": "COMPONENT_ID", "condition": "groundnut_prepared", "name": { "str_sp": "%s, ground nuts" } },
       { "type": "COMPONENT_ID", "condition": "horseradish_greens", "name": { "str_sp": "%s, horseradish greens" } },

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -8861,6 +8861,7 @@
         [ "seed_rose", 3 ],
         [ "seed_cattail", 3 ],
         [ "seed_dahlia", 3 ],
+        [ "seed_eggplant", 3 ],
         [ "seed_flower", 3 ],
         [ "seed_cactus", 3 ],
         [ "seed_hops", 3 ],


### PR DESCRIPTION
#### Summary
Bugfixes "Eggplants can now be smoked via the smoking rack"
Bugfixes "Birdfood can be made out of eggplant seeds"

#### Purpose of change

Eggplants presently can be smoked via the crafting menu, but cannot be put into the smoking rack. This is an oversight.
Birdfood can be crafted out of all kinds of seeds, but not eggplant ones. This is an oversight as well.

#### Describe the solution
Json change.

#### Describe alternatives you've considered

Drive-by prettify `eggplant_cut` somewhat by making it `copy-from`, instead of copy-pasted from base `eggplant`. I can try and do that if requested, but I decided to take the lazy route for now.

#### Testing

Inserted whole eggplant, and cut eggplant into the smoking rack, lit it, waited 6 hours, collected "dehydrated vegetable (fresh)".
Made birdfood out of eggplant seeds.

#### Additional context
N/A