### PR TITLE
typified stuff

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6611,7 +6611,7 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
         }
     }
 
-    here.cut_down_tree( pos, direction.xy().raw() );
+    here.cut_down_tree( pos, direction.xy() );
 
     who.add_msg_if_player( m_good, _( "You finish chopping down a tree." ) );
     // sound of falling tree

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -46,20 +46,20 @@
 
 static const zone_type_id zone_type_CAMP_STORAGE( "CAMP_STORAGE" );
 
-const std::map<point, base_camps::direction_data> base_camps::all_directions = {
+const std::map<point_rel_omt, base_camps::direction_data> base_camps::all_directions = {
     // direction, direction id, tab order, direction abbreviation with bracket, direction tab title
     { base_camps::base_dir, { "[B]", base_camps::TAB_MAIN, to_translation( "base camp: base", "[B]" ), to_translation( "base camp: base", " MAIN " ) } },
-    { point::north, { "[N]", base_camps::TAB_N, to_translation( "base camp: north", "[N]" ), to_translation( "base camp: north", "  [N] " ) } },
-    { point::north_east, { "[NE]", base_camps::TAB_NE, to_translation( "base camp: northeast", "[NE]" ), to_translation( "base camp: northeast", " [NE] " ) } },
-    { point::east, { "[E]", base_camps::TAB_E, to_translation( "base camp: east", "[E]" ), to_translation( "base camp: east", "  [E] " ) } },
-    { point::south_east, { "[SE]", base_camps::TAB_SE, to_translation( "base camp: southeast", "[SE]" ), to_translation( "base camp: southeast", " [SE] " ) } },
-    { point::south, { "[S]", base_camps::TAB_S, to_translation( "base camp: south", "[S]" ), to_translation( "base camp: south", "  [S] " ) } },
-    { point::south_west, { "[SW]", base_camps::TAB_SW, to_translation( "base camp: southwest", "[SW]" ), to_translation( "base camp: southwest", " [SW] " ) } },
-    { point::west, { "[W]", base_camps::TAB_W, to_translation( "base camp: west", "[W]" ), to_translation( "base camp: west", "  [W] " ) } },
-    { point::north_west, { "[NW]", base_camps::TAB_NW, to_translation( "base camp: northwest", "[NW]" ), to_translation( "base camp: northwest", " [NW] " ) } },
+    { point_rel_omt::north, { "[N]", base_camps::TAB_N, to_translation( "base camp: north", "[N]" ), to_translation( "base camp: north", "  [N] " ) } },
+    { point_rel_omt::north_east, { "[NE]", base_camps::TAB_NE, to_translation( "base camp: northeast", "[NE]" ), to_translation( "base camp: northeast", " [NE] " ) } },
+    { point_rel_omt::east, { "[E]", base_camps::TAB_E, to_translation( "base camp: east", "[E]" ), to_translation( "base camp: east", "  [E] " ) } },
+    { point_rel_omt::south_east, { "[SE]", base_camps::TAB_SE, to_translation( "base camp: southeast", "[SE]" ), to_translation( "base camp: southeast", " [SE] " ) } },
+    { point_rel_omt::south, { "[S]", base_camps::TAB_S, to_translation( "base camp: south", "[S]" ), to_translation( "base camp: south", "  [S] " ) } },
+    { point_rel_omt::south_west, { "[SW]", base_camps::TAB_SW, to_translation( "base camp: southwest", "[SW]" ), to_translation( "base camp: southwest", " [SW] " ) } },
+    { point_rel_omt::west, { "[W]", base_camps::TAB_W, to_translation( "base camp: west", "[W]" ), to_translation( "base camp: west", "  [W] " ) } },
+    { point_rel_omt::north_west, { "[NW]", base_camps::TAB_NW, to_translation( "base camp: northwest", "[NW]" ), to_translation( "base camp: northwest", " [NW] " ) } },
 };
 
-point base_camps::direction_from_id( const std::string &id )
+point_rel_omt base_camps::direction_from_id( const std::string &id )
 {
     for( const auto &dir : all_directions ) {
         if( dir.second.id == id ) {
@@ -132,9 +132,9 @@ basecamp::basecamp( const std::string &name_, const tripoint_abs_omt &omt_pos_ )
 {
 }
 
-basecamp::basecamp( const std::string &name_, const tripoint &bb_pos_,
-                    const std::vector<point> &directions_,
-                    const std::map<point, expansion_data> &expansions_ )
+basecamp::basecamp( const std::string &name_, const tripoint_abs_ms &bb_pos_,
+                    const std::vector<point_rel_omt> &directions_,
+                    const std::map<point_rel_omt, expansion_data> &expansions_ )
     : directions( directions_ ), name( name_ ), bb_pos( bb_pos_ ), expansions( expansions_ )
 {
 }
@@ -171,14 +171,14 @@ void basecamp::add_expansion( const std::string &terrain, const tripoint_abs_omt
         return;
     }
 
-    const point dir = talk_function::om_simple_dir( omt_pos, new_pos );
+    const point_rel_omt dir = talk_function::om_simple_dir( omt_pos, new_pos );
     expansions[ dir ] = parse_expansion( terrain, new_pos );
     update_provides( terrain, expansions[ dir ] );
     directions.push_back( dir );
 }
 
 void basecamp::add_expansion( const std::string &bldg, const tripoint_abs_omt &new_pos,
-                              const point &dir )
+                              const point_rel_omt &dir )
 {
     expansion_data e;
     e.type = base_camps::faction_decode( bldg );
@@ -270,7 +270,7 @@ std::string basecamp::om_upgrade_description( const std::string &bldg, const map
 
 // upgrade levels
 // legacy next upgrade
-std::string basecamp::next_upgrade( const point &dir, const int offset ) const
+std::string basecamp::next_upgrade( const point_rel_omt &dir, const int offset ) const
 {
     const auto &e = expansions.find( dir );
     if( e == expansions.end() ) {
@@ -303,7 +303,7 @@ bool basecamp::has_provides( const std::string &req, const expansion_data &e_dat
     return false;
 }
 
-bool basecamp::has_provides( const std::string &req, const std::optional<point> &dir,
+bool basecamp::has_provides( const std::string &req, const std::optional<point_rel_omt> &dir,
                              int level ) const
 {
     if( !dir ) {
@@ -345,7 +345,7 @@ bool basecamp::allowed_access_by( Character &guy, bool water_request ) const
     return false;
 }
 
-std::vector<basecamp_upgrade> basecamp::available_upgrades( const point &dir )
+std::vector<basecamp_upgrade> basecamp::available_upgrades( const point_rel_omt &dir )
 {
     std::vector<basecamp_upgrade> ret_data;
     auto e = expansions.find( dir );
@@ -434,7 +434,7 @@ std::unordered_set<recipe_id> basecamp::recipe_deck_all() const
 }
 
 // recipes and craft support functions
-std::map<recipe_id, translation> basecamp::recipe_deck( const point &dir ) const
+std::map<recipe_id, translation> basecamp::recipe_deck( const point_rel_omt &dir ) const
 {
     std::map<recipe_id, translation> recipes;
 
@@ -492,7 +492,7 @@ void basecamp::update_provides( const std::string &bldg, expansion_data &e_data 
     }
 }
 
-void basecamp::update_in_progress( const std::string &bldg, const point &dir )
+void basecamp::update_in_progress( const std::string &bldg, const point_rel_omt &dir )
 {
     if( !recipe_id( bldg ).is_valid() ) {
         return;
@@ -945,7 +945,7 @@ void basecamp::form_crafting_inventory()
 }
 
 // display names
-std::string basecamp::expansion_tab( const point &dir ) const
+std::string basecamp::expansion_tab( const point_rel_omt &dir ) const
 {
     if( dir == base_camps::base_dir ) {
         return _( "Base Missions" );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -96,11 +96,11 @@ struct direction_data {
 };
 
 // base_dir and the eight directional points
-extern const std::map<point, direction_data> all_directions;
+extern const std::map<point_rel_omt, direction_data> all_directions;
 
-point direction_from_id( const std::string &id );
+point_rel_omt direction_from_id( const std::string &id );
 
-constexpr point base_dir;
+constexpr point_rel_omt base_dir;
 const std::string prefix = "faction_base_";
 const std::string id = "FACTION_CAMP";
 const int prefix_len = 13;
@@ -139,8 +139,8 @@ struct expansion_salt_water_pipe_segment {
 };
 
 struct expansion_salt_water_pipe {
-    point expansion;
-    point connection_direction;
+    point_rel_omt expansion;
+    point_rel_omt connection_direction;
     std::vector<expansion_salt_water_pipe_segment> segments;
 };
 
@@ -160,9 +160,9 @@ class basecamp
     public:
         basecamp();
         basecamp( const std::string &name_, const tripoint_abs_omt &omt_pos );
-        basecamp( const std::string &name_, const tripoint &bb_pos_,
-                  const std::vector<point> &directions_,
-                  const std::map<point, expansion_data> &expansions_ );
+        basecamp( const std::string &name_, const tripoint_abs_ms &bb_pos_,
+                  const std::vector<point_rel_omt> &directions_,
+                  const std::map<point_rel_omt, expansion_data> &expansions_ );
         inline bool is_valid() const {
             return !name.empty() && omt_pos != tripoint_abs_omt();
         }
@@ -178,8 +178,8 @@ class basecamp
         inline const std::string &camp_name() const {
             return name;
         }
-        tripoint get_bb_pos() const {
-            return bb_pos.raw();
+        tripoint_abs_ms get_bb_pos() const {
+            return bb_pos;
         }
         tripoint_abs_ms get_bb_pos_abs() const {
             return bb_pos;
@@ -195,7 +195,7 @@ class basecamp
         void set_by_radio( bool access_by_radio );
 
         std::string board_name() const;
-        std::vector<point> directions; // NOLINT(cata-serialize)
+        std::vector<point_rel_omt> directions; // NOLINT(cata-serialize)
         std::vector<std::vector<ui_mission_id>> hidden_missions;
         std::vector<tripoint_abs_omt> fortifications;
         std::vector<expansion_salt_water_pipe *> salt_water_pipes;
@@ -212,25 +212,25 @@ class basecamp
         void scan_pseudo_items();
         void add_expansion( const std::string &terrain, const tripoint_abs_omt &new_pos );
         void add_expansion( const std::string &bldg, const tripoint_abs_omt &new_pos,
-                            const point &dir );
+                            const point_rel_omt &dir );
         void define_camp( const tripoint_abs_omt &p, std::string_view camp_type,
                           bool player_founded = true );
 
-        std::string expansion_tab( const point &dir ) const;
+        std::string expansion_tab( const point_rel_omt &dir ) const;
         // check whether the point is the part of camp
         bool point_within_camp( const tripoint_abs_omt &p ) const;
         // upgrade levels
         bool has_provides( const std::string &req, const expansion_data &e_data, int level = 0 ) const;
-        bool has_provides( const std::string &req, const std::optional<point> &dir = std::nullopt,
+        bool has_provides( const std::string &req, const std::optional<point_rel_omt> &dir = std::nullopt,
                            int level = 0 ) const;
         void update_resources( const std::string &bldg );
         void update_provides( const std::string &bldg, expansion_data &e_data );
-        void update_in_progress( const std::string &bldg, const point &dir );
+        void update_in_progress( const std::string &bldg, const point_rel_omt &dir );
 
         /// Returns the name of the building the current building @ref dir upgrades into,
         /// "null" if there isn't one
-        std::string next_upgrade( const point &dir, int offset = 1 ) const;
-        std::vector<basecamp_upgrade> available_upgrades( const point &dir );
+        std::string next_upgrade( const point_rel_omt &dir, int offset = 1 ) const;
+        std::vector<basecamp_upgrade> available_upgrades( const point_rel_omt &dir );
 
         // camp utility functions
         int recruit_evaluation() const;
@@ -266,8 +266,8 @@ class basecamp
         /// food_supply
         bool distribute_food( bool player_command = true );
         std::string name_display_of( const mission_id &miss_id );
-        void handle_hide_mission( const point &dir );
-        void handle_reveal_mission( const point &dir );
+        void handle_hide_mission( const point_rel_omt &dir );
+        void handle_reveal_mission( const point_rel_omt &dir );
         bool has_water() const;
         /// The number of days the current camp supplies lasts at the given exertion level.
         int camp_food_supply_days( float exertion_level ) const;
@@ -286,7 +286,7 @@ class basecamp
         void handle_takeover_by( faction_id new_owner, bool violent_takeover );
         // recipes, gathering, and craft support functions
         // from a direction
-        std::map<recipe_id, translation> recipe_deck( const point &dir ) const;
+        std::map<recipe_id, translation> recipe_deck( const point_rel_omt &dir ) const;
         // from a building
         std::map<recipe_id, translation> recipe_deck( const std::string &bldg ) const;
         // All recipes known by NPCs stationed here + all recipes provided by all expansions
@@ -338,7 +338,8 @@ class basecamp
         void place_results( const item &result );
 
         // mission description functions
-        void add_available_recipes( mission_data &mission_key, mission_kind kind, const point &dir );
+        void add_available_recipes( mission_data &mission_key, mission_kind kind,
+                                    const point_rel_omt &dir );
 
         std::string recruit_description( int npc_count ) const;
         /// Provides a "guess" for some of the things your gatherers will return with
@@ -346,7 +347,7 @@ class basecamp
         std::string gathering_description();
         /// Returns a string for the number of plants that are harvestable, plots ready to plant,
         /// and ground that needs tilling
-        std::string farm_description( const point &dir, size_t &plots_count,
+        std::string farm_description( const point_rel_omt &dir, size_t &plots_count,
                                       farm_ops operation );
         /// Returns the description of a camp crafting options. converts fire charges to charcoal,
         /// allows dark crafting
@@ -354,7 +355,7 @@ class basecamp
 
         // main mission description collection
         void get_available_missions( mission_data &mission_key, map &here );
-        void get_available_missions_by_dir( mission_data &mission_key, const point &dir );
+        void get_available_missions_by_dir( mission_data &mission_key, const point_rel_omt &dir );
         void choose_new_leader();
         // available companion list manipulation
         void reset_camp_workers();
@@ -407,7 +408,7 @@ class basecamp
         void start_salt_water_pipe( const mission_id &miss_id );
         void continue_salt_water_pipe( const mission_id &miss_id );
         void start_combat_mission( const mission_id &miss_id, float exertion_level );
-        void start_farm_op( const point &dir, const mission_id &miss_id,
+        void start_farm_op( const point_rel_omt &dir, const mission_id &miss_id,
                             float exertion_level );
         ///Display items listed in @ref equipment to let the player pick what to give the departing
         ///NPC, loops until quit or empty.
@@ -416,7 +417,7 @@ class basecamp
         drop_locations give_equipment( Character *pc, const inventory_filter_preset &preset,
                                        const std::string &msg, const std::string &title, units::volume &total_volume,
                                        units::mass &total_mass );
-        drop_locations get_equipment( tinymap *target_bay, const tripoint &target, Character *pc,
+        drop_locations get_equipment( tinymap *target_bay, const tripoint_omt_ms &target, Character *pc,
                                       const inventory_filter_preset &preset,
                                       const std::string &msg, const std::string &title, units::volume &total_volume,
                                       units::mass &total_mass );
@@ -457,8 +458,8 @@ class basecamp
         * @param omt_tgt the overmap pos3 of the farm_ops
         * @param op whether to plow, plant, or harvest
         */
-        bool farm_return( const mission_id &miss_id, const point &dir );
-        std::pair<size_t, std::string> farm_action( const point &dir, farm_ops op,
+        bool farm_return( const mission_id &miss_id, const point_rel_omt &dir );
+        std::pair<size_t, std::string> farm_action( const point_rel_omt &dir, farm_ops op,
                 const npc_ptr &comp = nullptr );
         void fortifications_return( const mission_id &miss_id );
         bool salt_water_pipe_swamp_return( const mission_id &miss_id,
@@ -504,7 +505,7 @@ class basecamp
         std::vector<npc_ptr> assigned_npcs; // NOLINT(cata-serialize)
         // location of associated bulletin board
         tripoint_abs_ms bb_pos;
-        std::map<point, expansion_data> expansions;
+        std::map<point_rel_omt, expansion_data> expansions;
         comp_list camp_workers; // NOLINT(cata-serialize)
         basecamp_map camp_map; // NOLINT(cata-serialize)
         // dumping spot in absolute co-ords

--- a/src/climbing.cpp
+++ b/src/climbing.cpp
@@ -327,7 +327,7 @@ static void detect_conditions_sub( climbing_aid::condition_list &list,
 }
 
 climbing_aid::condition_list climbing_aid::detect_conditions( Character &you,
-        const tripoint &examp )
+        const tripoint_bub_ms &examp )
 {
     condition_list list;
 
@@ -346,8 +346,8 @@ climbing_aid::condition_list climbing_aid::detect_conditions( Character &you,
         return cond.uses_item > 0;
     };
     auto detect_ter_furn_flag = [&here, &fall]( condition & cond ) {
-        tripoint pos = fall.pos_furniture_or_floor();
-        cond.range = fall.pos_top().z - pos.z;
+        tripoint_bub_ms pos = fall.pos_furniture_or_floor();
+        cond.range = fall.pos_top().z() - pos.z();
         return here.has_flag( cond.flag, pos );
     };
     auto detect_vehicle = [&fall]( condition & cond ) {
@@ -365,7 +365,7 @@ climbing_aid::condition_list climbing_aid::detect_conditions( Character &you,
     return list;
 }
 
-climbing_aid::fall_scan::fall_scan( const tripoint &examp )
+climbing_aid::fall_scan::fall_scan( const tripoint_bub_ms &examp )
 {
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();

--- a/src/climbing.h
+++ b/src/climbing.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "coordinates.h"
 #include "point.h"
 #include "translation.h"
 #include "type_id.h"
@@ -73,7 +74,7 @@ class climbing_aid
         bool was_loaded = false;
 
 
-        static condition_list detect_conditions( Character &you, const tripoint &examp );
+        static condition_list detect_conditions( Character &you, const tripoint_bub_ms &examp );
 
         static aid_list list( const condition_list &cond );
         static aid_list list_all( const condition_list &cond );
@@ -88,9 +89,9 @@ class climbing_aid
         class fall_scan
         {
             public:
-                explicit fall_scan( const tripoint &examp );
+                explicit fall_scan( const tripoint_bub_ms &examp );
 
-                tripoint examp; // Initial position of scan (usually a ledge / open air tile)
+                tripoint_bub_ms examp; // Initial position of scan (usually a ledge / open air tile)
                 int height; // Z-levels to "ground" based on here.valid_move
                 int height_until_creature; // Z-levels below that are free of creatures
                 int height_until_furniture; // Z-levels below that are free of furniture
@@ -101,22 +102,22 @@ class climbing_aid
                     return height != 0;
                 }
 
-                tripoint pos_top() const {
+                tripoint_bub_ms pos_top() const {
                     return examp;
                 }
-                tripoint pos_bottom() const {
-                    tripoint ret = examp;
-                    ret.z -= height;
+                tripoint_bub_ms pos_bottom() const {
+                    tripoint_bub_ms ret = examp;
+                    ret.z() -= height;
                     return ret;
                 }
-                tripoint pos_just_below() const {
-                    tripoint ret = examp;
-                    ret.z -= 1;
+                tripoint_bub_ms pos_just_below() const {
+                    tripoint_bub_ms ret = examp;
+                    ret.z() -= 1;
                     return ret;
                 }
-                tripoint pos_furniture_or_floor() const {
-                    tripoint ret = examp;
-                    ret.z -= std::min( height, height_until_furniture + 1 );
+                tripoint_bub_ms pos_furniture_or_floor() const {
+                    tripoint_bub_ms ret = examp;
+                    ret.z() -= std::min( height, height_until_furniture + 1 );
                     return ret;
                 }
 

--- a/src/computer.cpp
+++ b/src/computer.cpp
@@ -63,7 +63,7 @@ void computer_failure::deserialize( const JsonObject &jo )
     type = jo.get_enum_value<computer_failure_type>( "action" );
 }
 
-computer::computer( const std::string &new_name, int new_security, tripoint new_loc )
+computer::computer( const std::string &new_name, int new_security, tripoint_bub_ms new_loc )
     : name( new_name ), mission_id( -1 ), security( new_security ), alerts( 0 ),
       next_attempt( calendar::before_time_starts ),
       access_denied( _( "ERROR!  Access denied!" ) )

--- a/src/computer.h
+++ b/src/computer.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "calendar.h"
+#include "coordinates.h"
 #include "point.h"
 #include "type_id.h"
 
@@ -119,7 +120,7 @@ struct computer_failure {
 class computer
 {
     public:
-        computer( const std::string &new_name, int new_security, tripoint new_loc );
+        computer( const std::string &new_name, int new_security, tripoint_bub_ms new_loc );
 
         // Initialization
         void set_security( int Security );
@@ -137,7 +138,7 @@ class computer
         void deserialize( const JsonValue &jv );
 
         friend class computer_session;
-        tripoint loc;
+        tripoint_bub_ms loc;
         // "Jon's Computer", "Lab 6E77-B Terminal Omega"
         std::string name;
         // Linked to a mission?

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2148,7 +2148,7 @@ conditional_t::func f_can_see_location( const JsonObject &jo, std::string_view m
     str_or_var target = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, target]( const_dialogue const & d ) {
         tripoint_abs_ms target_pos = tripoint_abs_ms( tripoint::from_string( target.evaluate( d ) ) );
-        return d.const_actor( is_npc )->can_see_location( get_map().bub_from_abs( target_pos ).raw() );
+        return d.const_actor( is_npc )->can_see_location( get_map().bub_from_abs( target_pos ) );
     };
 }
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -245,7 +245,7 @@ static int om_harvest_ter_break( npc &comp, const tripoint_abs_omt &omt_tgt, con
 static mass_volume om_harvest_itm( const npc_ptr &comp, const tripoint_abs_omt &omt_tgt,
                                    int chance = 100,
                                    bool take = true );
-static void apply_camp_ownership( map &here, const tripoint &camp_pos, int radius );
+static void apply_camp_ownership( map &here, const tripoint_bub_ms &camp_pos, int radius );
 /*
  * Counts or cuts trees into trunks and trunks into logs
  * @param omt_tgt the targeted OM tile
@@ -514,7 +514,7 @@ static bool update_emergency_recall( std::string &entry, const comp_list &npc_li
 }
 
 static bool extract_and_check_orientation_flags( const recipe_id &recipe,
-        const point &dir,
+        const point_rel_omt &dir,
         bool &mirror_horizontal,
         bool &mirror_vertical,
         int &rotation,
@@ -552,23 +552,23 @@ static bool extract_and_check_orientation_flags( const recipe_id &recipe,
         return false;
     }
 
-    if( dir == point::north_west ) {
+    if( dir == point_rel_omt::north_west ) {
         dir_string = "NW";
-    } else if( dir == point::north ) {
+    } else if( dir == point_rel_omt::north ) {
         dir_string = "N";
-    } else if( dir == point::north_east ) {
+    } else if( dir == point_rel_omt::north_east ) {
         dir_string = "NE";
-    } else if( dir == point::west ) {
+    } else if( dir == point_rel_omt::west ) {
         dir_string = "W";
-    } else if( dir == point::zero ) {
+    } else if( dir == point_rel_omt::zero ) {
         dir_string.clear();  //  Will result in "hidden" flags that can actually affect the core.
-    } else if( dir == point::east ) {
+    } else if( dir == point_rel_omt::east ) {
         dir_string = "E";
-    } else if( dir == point::south_west ) {
+    } else if( dir == point_rel_omt::south_west ) {
         dir_string = "SW";
-    } else if( dir == point::south ) {
+    } else if( dir == point_rel_omt::south ) {
         dir_string = "S";
-    } else if( dir == point::south_east ) {
+    } else if( dir == point_rel_omt::south_east ) {
         dir_string = "SE";
     }
 
@@ -766,7 +766,7 @@ void talk_function::basecamp_mission( npc &p )
 }
 
 void basecamp::add_available_recipes( mission_data &mission_key, mission_kind kind,
-                                      const point &dir )
+                                      const point_rel_omt &dir )
 {
     const mission_id miss_id = {kind, "DUMMY_RECIPE_REPLACED_IN_CAMP", {}, dir};
     std::string miss_desc = string_format( _( "Notes:\n"
@@ -776,7 +776,7 @@ void basecamp::add_available_recipes( mission_data &mission_key, mission_kind ki
     mission_key.add_start( miss_id, _( "Crafting" ), miss_desc, true );
 }
 
-void basecamp::get_available_missions_by_dir( mission_data &mission_key, const point &dir )
+void basecamp::get_available_missions_by_dir( mission_data &mission_key, const point_rel_omt &dir )
 {
     std::string entry;
 
@@ -1376,7 +1376,7 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
 {
     std::string entry;
 
-    const point &base_dir = base_camps::base_dir;
+    const point_rel_omt &base_dir = base_camps::base_dir;
     const base_camps::direction_data &base_data = base_camps::all_directions.at( base_dir );
     const std::string base_dir_id = base_data.id;
     reset_camp_resources( here );
@@ -1538,7 +1538,7 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
     get_available_missions_by_dir( mission_key, base_camps::base_dir );
 
     // Loop over expansions
-    for( const point &dir : directions ) {
+    for( const point_rel_omt &dir : directions ) {
         get_available_missions_by_dir( mission_key, dir );
     }
 
@@ -1708,7 +1708,7 @@ bool basecamp::handle_mission( const ui_mission_id &miss_id )
         return true;
     }
 
-    const point &miss_dir = miss_id.id.dir.value();
+    const point_rel_omt &miss_dir = miss_id.id.dir.value();
     //  All missions should supply dir. Bug if they don't, so blow up during testing.
 
     switch( miss_id.id.id ) {
@@ -2118,7 +2118,7 @@ void basecamp::start_upgrade( const mission_id &miss_id )
             return;
         }
         components.consume_components();
-        const point dir = miss_id.dir.value();  //  Will always have a value
+        const point_rel_omt dir = miss_id.dir.value();  //  Will always have a value
 
         update_in_progress( miss_id.parameters,
                             dir );
@@ -2187,8 +2187,7 @@ void basecamp::scan_pseudo_items()
 {
     for( auto &expansion : expansions ) {
         expansion.second.available_pseudo_items.clear();
-        tripoint_abs_omt tile = tripoint_abs_omt( omt_pos.x() + expansion.first.x,
-                                omt_pos.y() + expansion.first.y, omt_pos.z() );
+        tripoint_abs_omt tile = omt_pos + expansion.first;
         tinymap expansion_map;
         expansion_map.load( tile, false );
 
@@ -2684,7 +2683,7 @@ void basecamp::start_relay_hide_site( const mission_id &miss_id, float exertion_
         units::volume total_import_volume;
         units::mass total_import_mass;
 
-        drop_locations gaining_equipment = get_equipment( &target_bay, relay_site_stash.raw(), pc, preset,
+        drop_locations gaining_equipment = get_equipment( &target_bay, relay_site_stash, pc, preset,
                                            _( "These are the items you've selected so far." ), _( "Select items to bring back" ),
                                            total_import_volume, total_import_mass );
 
@@ -2728,7 +2727,7 @@ void basecamp::start_relay_hide_site( const mission_id &miss_id, float exertion_
 // Stupid "the const qualified parameter 'comp' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param,-warnings-as-errors]" demands the pointer to be referenced...
 static void apply_fortifications( const mission_id &miss_id, const npc_ptr *comp, bool start )
 {
-    auto &build_point = comp[0]->companion_mission_points;
+    std::vector<tripoint_abs_omt> &build_point = comp[0]->companion_mission_points;
     static const std::array<std::pair<update_mapgen_id, update_mapgen_id>, 4> pits { {
             { update_mapgen_faction_wall_level_S_0, update_mapgen_faction_wall_level_N_0 },
             { update_mapgen_faction_wall_level_E_0,  update_mapgen_faction_wall_level_W_0 },
@@ -2911,46 +2910,51 @@ using PathMap = cata::mdarray<double, point, path_map_size, path_map_size>;
 //  odd paths. At the time of this writing there is no corresponding
 //  construction cost difference, though, as that doesn't match with the fixed
 //  recipe approach taken.
-static point check_salt_pipe_neighbors( PathMap &path_map, point pt )
+static point_rel_omt check_salt_pipe_neighbors( PathMap &path_map, point_rel_omt pt )
 {
-    point found = point::invalid;
+    point_rel_omt found = point_rel_omt::invalid;
     double lowest_found = -10000.0;
     double cost;
 
     for( int i = -1; i <= 1; i++ ) {
         for( int k = -1; k <= 1; k++ ) {
-            if( pt.x + i > -max_salt_water_pipe_distance &&
-                pt.x + i < max_salt_water_pipe_distance &&
-                pt.y + k > -max_salt_water_pipe_distance &&
-                pt.y + k < max_salt_water_pipe_distance ) {
+            if( pt.x() + i > -max_salt_water_pipe_distance &&
+                pt.x() + i < max_salt_water_pipe_distance &&
+                pt.y() + k > -max_salt_water_pipe_distance &&
+                pt.y() + k < max_salt_water_pipe_distance ) {
                 if( i != 0 && k != 0 ) {
                     cost = diagonal_salt_pipe_cost;
                 } else {
                     cost = 1.0;
                 }
 
-                if( path_map[max_salt_water_pipe_distance + pt.x + i][max_salt_water_pipe_distance + pt.y + k] ==
+                if( path_map[max_salt_water_pipe_distance + pt.x() + i][max_salt_water_pipe_distance + pt.y() + k]
+                    ==
                     salt_pipe_legal ||
-                    ( path_map[max_salt_water_pipe_distance + pt.x + i][max_salt_water_pipe_distance + pt.y + k] >
+                    ( path_map[max_salt_water_pipe_distance + pt.x() + i][max_salt_water_pipe_distance + pt.y() + k] >
                       0.0 &&
-                      path_map[max_salt_water_pipe_distance + pt.x + i][max_salt_water_pipe_distance + pt.y + k] >
-                      path_map[max_salt_water_pipe_distance + pt.x][max_salt_water_pipe_distance + pt.y] + cost ) ) {
-                    path_map[max_salt_water_pipe_distance + pt.x + i][max_salt_water_pipe_distance + pt.y + k] =
-                        path_map[max_salt_water_pipe_distance + pt.x][max_salt_water_pipe_distance + pt.y] + cost;
+                      path_map[max_salt_water_pipe_distance + pt.x() + i][max_salt_water_pipe_distance + pt.y() + k] >
+                      path_map[max_salt_water_pipe_distance + pt.x()][max_salt_water_pipe_distance + pt.y()] + cost ) ) {
+                    path_map[max_salt_water_pipe_distance + pt.x() + i][max_salt_water_pipe_distance + pt.y() + k] =
+                        path_map[max_salt_water_pipe_distance + pt.x()][max_salt_water_pipe_distance + pt.y()] + cost;
 
-                } else if( path_map[max_salt_water_pipe_distance + pt.x + i][max_salt_water_pipe_distance + pt.y +
+                } else if( path_map[max_salt_water_pipe_distance + pt.x() + i][max_salt_water_pipe_distance + pt.y()
+                           +
                            k] <=
                            salt_pipe_swamp ) {
-                    if( path_map[max_salt_water_pipe_distance + pt.x + i][max_salt_water_pipe_distance + pt.y + k] ==
+                    if( path_map[max_salt_water_pipe_distance + pt.x() + i][max_salt_water_pipe_distance + pt.y() + k]
+                        ==
                         salt_pipe_swamp ||
-                        path_map[max_salt_water_pipe_distance + pt.x + i][max_salt_water_pipe_distance + pt.y + k] < -
-                        ( path_map[max_salt_water_pipe_distance + pt.x][max_salt_water_pipe_distance + pt.y] + cost ) ) {
-                        path_map[max_salt_water_pipe_distance + pt.x + i][max_salt_water_pipe_distance + pt.y + k] = -
-                                ( path_map[max_salt_water_pipe_distance + pt.x][max_salt_water_pipe_distance + pt.y] + cost );
+                        path_map[max_salt_water_pipe_distance + pt.x() + i][max_salt_water_pipe_distance + pt.y() + k] < -
+                        ( path_map[max_salt_water_pipe_distance + pt.x()][max_salt_water_pipe_distance + pt.y()] +
+                          cost ) ) {
+                        path_map[max_salt_water_pipe_distance + pt.x() + i][max_salt_water_pipe_distance + pt.y() + k] = -
+                                ( path_map[max_salt_water_pipe_distance + pt.x()][max_salt_water_pipe_distance + pt.y()] + cost );
 
-                        if( path_map[max_salt_water_pipe_distance + pt.x + i][max_salt_water_pipe_distance + pt.y + k] >
+                        if( path_map[max_salt_water_pipe_distance + pt.x() + i][max_salt_water_pipe_distance + pt.y() + k] >
                             lowest_found ) {
-                            lowest_found = path_map[max_salt_water_pipe_distance + pt.x + i][max_salt_water_pipe_distance + pt.y
+                            lowest_found = path_map[max_salt_water_pipe_distance + pt.x() + i][max_salt_water_pipe_distance +
+                                           pt.y()
                                            + k];
                             found = pt + point( i, k );
                         }
@@ -3010,43 +3014,43 @@ int salt_water_pipe_segment_of( const recipe &making )
 //  The operation (ab)uses the conditional rotation/mirror flags of a recipe that uses a blueprint that isn't
 //  actually going to be used as a blueprint for something constructed in the expansion itself to determine
 //  the direction of the tile to connect to.
-static point connection_direction_of( const point &dir, const recipe &making );
+static point_rel_omt connection_direction_of( const point_rel_omt &dir, const recipe &making );
 
-point connection_direction_of( const point &dir, const recipe &making )
+point_rel_omt connection_direction_of( const point_rel_omt &dir, const recipe &making )
 {
-    point connection_dir = point::north;
+    point_rel_omt connection_dir = point_rel_omt::north;
     const std::string suffix = base_camps::all_directions.at( dir ).id.substr( 1,
                                base_camps::all_directions.at( dir ).id.length() - 2 );
     int count = 0;
 
     if( making.has_flag( "MAP_ROTATE_90_IF_" + suffix ) ) {
-        connection_dir = point::east;
+        connection_dir = point_rel_omt::east;
         count++;
     }
     if( making.has_flag( "MAP_ROTATE_180_IF_" + suffix ) ) {
-        connection_dir = point::south;
+        connection_dir = point_rel_omt::south;
         count++;
     }
     if( making.has_flag( "MAP_ROTATE_270_IF_" + suffix ) ) {
-        connection_dir = point::west;
+        connection_dir = point_rel_omt::west;
         count++;
     }
     if( count > 1 ) {
         popup( _( "Bug, Incorrect recipe: More than one rotation per orientation isn't valid" ) );
-        return point::invalid;
+        return point_rel_omt::invalid;
     }
 
     if( making.has_flag( "MAP_MIRROR_HORIZONTAL_IF_" + suffix ) ) {
-        connection_dir.x = -connection_dir.x;
+        connection_dir.x() = -connection_dir.x();
     }
     if( making.has_flag( "MAP_MIRROR_VERTICALL_IF_" + suffix ) ) {
-        connection_dir.y = -connection_dir.y;
+        connection_dir.y() = -connection_dir.y();
     }
 
     return connection_dir;
 }
 
-static void salt_water_pipe_orientation_adjustment( const point &dir, bool &orthogonal,
+static void salt_water_pipe_orientation_adjustment( const point_rel_omt &dir, bool &orthogonal,
         bool &mirror_vertical, bool &mirror_horizontal, int &rotation )
 {
     orthogonal = true;
@@ -3119,13 +3123,13 @@ bool basecamp::common_salt_water_pipe_construction(
                                     _( "Start constructing salt water pipes…" ),
                                     making.required_skills );
 
-        point connection_dir = pipe->connection_direction;
+        point_rel_omt connection_dir = pipe->connection_direction;
         const int segment_number = 0;
 
-        point next_construction_direction;
+        point_rel_omt next_construction_direction;
 
         if( segment_number == pipe->segments.size() - 1 ) {
-            next_construction_direction = { -connection_dir.x, -connection_dir.y };
+            next_construction_direction = { -connection_dir.x(), -connection_dir.y()};
         } else {
             next_construction_direction = { pipe->segments[segment_number + 1].point.x() - pipe->segments[segment_number].point.x(),
                                             pipe->segments[segment_number + 1].point.y() - pipe->segments[segment_number].point.y()
@@ -3157,16 +3161,16 @@ bool basecamp::common_salt_water_pipe_construction(
                                     _( "Continue constructing salt water pipes…" ),
                                     making.required_skills );
 
-        point connection_dir = pipe->connection_direction;
+        point_rel_omt connection_dir = pipe->connection_direction;
 
-        const point previous_construction_direction = { pipe->segments[segment_number - 1].point.x() - pipe->segments[segment_number].point.x(),
-                                                        pipe->segments[segment_number - 1].point.y() - pipe->segments[segment_number].point.y()
-                                                      };
+        const point_rel_omt previous_construction_direction = { pipe->segments[segment_number - 1].point.x() - pipe->segments[segment_number].point.x(),
+                                                                pipe->segments[segment_number - 1].point.y() - pipe->segments[segment_number].point.y()
+                                                              };
 
-        point next_construction_direction;
+        point_rel_omt next_construction_direction;
 
         if( segment_number == static_cast<int>( pipe->segments.size() - 1 ) ) {
-            next_construction_direction = { -connection_dir.x, -connection_dir.y };
+            next_construction_direction = { -connection_dir.x(), -connection_dir.y()};
         } else {
             next_construction_direction = { pipe->segments[segment_number + 1].point.x() - pipe->segments[segment_number].point.x(),
                                             pipe->segments[segment_number + 1].point.y() - pipe->segments[segment_number].point.y()
@@ -3220,9 +3224,9 @@ bool basecamp::common_salt_water_pipe_construction(
 
 void basecamp::start_salt_water_pipe( const mission_id &miss_id )
 {
-    const point dir = miss_id.dir.value();  //  Will always have a value
+    const point_rel_omt dir = miss_id.dir.value();  //  Will always have a value
     const recipe &making = recipe_id( miss_id.parameters ).obj();
-    point connection_dir = connection_direction_of( dir, making );
+    point_rel_omt connection_dir = connection_direction_of( dir, making );
 
     if( connection_dir.is_invalid() ) {
         return;
@@ -3249,8 +3253,8 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
 
     for( int i = -max_salt_water_pipe_distance; i <= max_salt_water_pipe_distance; i++ ) {
         for( int k = -max_salt_water_pipe_distance; k <= max_salt_water_pipe_distance; k++ ) {
-            tripoint_abs_omt tile = tripoint_abs_omt( omt_pos.x() + dir.x + connection_dir.x + i,
-                                    omt_pos.y() + dir.y + connection_dir.y + k, omt_pos.z() );
+            tripoint_abs_omt tile = tripoint_abs_omt( omt_pos.x() + dir.x() + connection_dir.x() + i,
+                                    omt_pos.y() + dir.y() + connection_dir.y() + k, omt_pos.z() );
             const oter_type_str_id &omt_ref = overmap_buffer.ter( tile )->get_type_id();
             if( allowed_locations.find( omt_ref ) != allowed_locations.end() ) {
                 path_map[max_salt_water_pipe_distance + i][max_salt_water_pipe_distance + k] = salt_pipe_legal;
@@ -3260,8 +3264,8 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
                 path_map[max_salt_water_pipe_distance + i][max_salt_water_pipe_distance + k] = salt_pipe_illegal;
             }
             //  if this is an expansion tile, forbid it. Only allocated ones have their type changed.
-            if( i >= -dir.x - connection_dir.x - 1 && i <= -dir.x - connection_dir.x + 1 &&
-                k >= -dir.y - connection_dir.y - 1 && k <= -dir.y - connection_dir.y + 1 ) {
+            if( i >= -dir.x() - connection_dir.x() - 1 && i <= -dir.x() - connection_dir.x() + 1 &&
+                k >= -dir.y() - connection_dir.y() - 1 && k <= -dir.y() - connection_dir.y() + 1 ) {
                 path_map[max_salt_water_pipe_distance + i][max_salt_water_pipe_distance + k] = salt_pipe_illegal;
             }
         }
@@ -3278,13 +3282,13 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
         return;
     }
 
-    point destination;
+    point_rel_omt destination;
     double destination_cost = -10000.0;
     bool path_found = false;
 
     if( path_map[max_salt_water_pipe_distance][max_salt_water_pipe_distance] ==
         salt_pipe_swamp ) { //  The connection_dir tile is a swamp tile
-        destination = point::zero;
+        destination = point_rel_omt::zero;
         path_found = true;
     } else {
         path_map[max_salt_water_pipe_distance][max_salt_water_pipe_distance] =
@@ -3296,12 +3300,12 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
                 for( int k = -dist; k <= dist; k++ ) {
                     if( path_map[max_salt_water_pipe_distance + i][max_salt_water_pipe_distance + k] >
                         0.0 ) { // Tile has been assigned a distance and isn't a swamp
-                        point temp = check_salt_pipe_neighbors( path_map, { i, k } );
+                        point_rel_omt temp = check_salt_pipe_neighbors( path_map, { i, k } );
                         if( !temp.is_invalid() ) {
-                            if( path_map[max_salt_water_pipe_distance + temp.x][max_salt_water_pipe_distance + temp.y] >
+                            if( path_map[max_salt_water_pipe_distance + temp.x()][max_salt_water_pipe_distance + temp.y()] >
                                 destination_cost ) {
-                                destination_cost = path_map[max_salt_water_pipe_distance + temp.x][max_salt_water_pipe_distance +
-                                                   temp.y];
+                                destination_cost = path_map[max_salt_water_pipe_distance + temp.x()][max_salt_water_pipe_distance +
+                                                   temp.y()];
                                 destination = temp;
                                 path_found = true;
                             }
@@ -3323,31 +3327,32 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
         return;
     };
 
-    point candidate;
+    point_rel_omt candidate;
     //  Flip the sign of the starting swamp tile to fit the logic expecting positive values rather than check that it isn't the first one every time.
-    path_map[max_salt_water_pipe_distance + destination.x][max_salt_water_pipe_distance + destination.y]
-        = -path_map[max_salt_water_pipe_distance + destination.x][max_salt_water_pipe_distance +
-                destination.y];
+    path_map[max_salt_water_pipe_distance + destination.x()][max_salt_water_pipe_distance +
+            destination.y()]
+        = -path_map[max_salt_water_pipe_distance + destination.x()][max_salt_water_pipe_distance +
+                destination.y()];
 
-    while( destination != point::zero ) {
-        pipe->segments.push_back( { tripoint_abs_omt( omt_pos.x() + dir.x + connection_dir.x + destination.x, omt_pos.y() + dir.y + connection_dir.y + destination.y, omt_pos.z() ), false, false } );
+    while( destination != point_rel_omt::zero ) {
+        pipe->segments.push_back( { tripoint_abs_omt( omt_pos.x() + dir.x() + connection_dir.x() + destination.x(), omt_pos.y() + dir.y() + connection_dir.y() + destination.y(), omt_pos.z() ), false, false} );
         path_found = false;  //  Reuse of existing variable after its original usability has been passed.
         for( int i = -1; i <= 1; i++ ) {
             for( int k = -1; k <= 1; k++ ) {
-                if( destination.x + i > -max_salt_water_pipe_distance &&
-                    destination.x + i < max_salt_water_pipe_distance &&
-                    destination.y + k > -max_salt_water_pipe_distance &&
-                    destination.y + k < max_salt_water_pipe_distance ) {
-                    if( path_map[max_salt_water_pipe_distance + destination.x + i][max_salt_water_pipe_distance +
-                            destination.y + k] > 0.0 &&
-                        path_map[max_salt_water_pipe_distance + destination.x + i][max_salt_water_pipe_distance +
-                                destination.y + k] < path_map[max_salt_water_pipe_distance +
-                                        destination.x][max_salt_water_pipe_distance + destination.y] ) {
+                if( destination.x() + i > -max_salt_water_pipe_distance &&
+                    destination.x() + i < max_salt_water_pipe_distance &&
+                    destination.y() + k > -max_salt_water_pipe_distance &&
+                    destination.y() + k < max_salt_water_pipe_distance ) {
+                    if( path_map[max_salt_water_pipe_distance + destination.x() + i][max_salt_water_pipe_distance +
+                            destination.y() + k] > 0.0 &&
+                        path_map[max_salt_water_pipe_distance + destination.x() + i][max_salt_water_pipe_distance +
+                                destination.y() + k] < path_map[max_salt_water_pipe_distance +
+                                        destination.x()][max_salt_water_pipe_distance + destination.y()] ) {
                         if( path_found ) {
-                            if( path_map [max_salt_water_pipe_distance + candidate.x][max_salt_water_pipe_distance +
-                                    candidate.y] >
-                                path_map[max_salt_water_pipe_distance + destination.x + i][max_salt_water_pipe_distance +
-                                        destination.y + k] ) {
+                            if( path_map [max_salt_water_pipe_distance + candidate.x()][max_salt_water_pipe_distance +
+                                    candidate.y()] >
+                                path_map[max_salt_water_pipe_distance + destination.x() + i][max_salt_water_pipe_distance +
+                                        destination.y() + k] ) {
                                 candidate = destination + point( i, k );
                             }
                         } else {
@@ -3361,7 +3366,7 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
         destination = candidate;
     }
 
-    pipe->segments.push_back( { tripoint_abs_omt( omt_pos.x() + dir.x + connection_dir.x, omt_pos.y() + dir.y + connection_dir.y, omt_pos.z() ), false, false } );
+    pipe->segments.push_back( { tripoint_abs_omt( omt_pos.x() + dir.x() + connection_dir.x(), omt_pos.y() + dir.y() + connection_dir.y(), omt_pos.z() ), false, false} );
 
     if( common_salt_water_pipe_construction( miss_id, pipe, 0 ) ) {
         pipe->segments[0].started = true;
@@ -3388,7 +3393,7 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
 
 void basecamp::continue_salt_water_pipe( const mission_id &miss_id )
 {
-    const point dir = miss_id.dir.value();  //  Dir will always have a value
+    const point_rel_omt dir = miss_id.dir.value();  //  Dir will always have a value
     const recipe &making = recipe_id( miss_id.parameters ).obj();
 
     expansion_salt_water_pipe *pipe = nullptr;
@@ -3585,7 +3590,7 @@ static bool farm_valid_seed( const item &itm )
     return itm.is_seed() && itm.typeId() != itype_marloss_seed && itm.typeId() != itype_fungal_seeds;
 }
 
-std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops op,
+std::pair<size_t, std::string> basecamp::farm_action( const point_rel_omt &dir, farm_ops op,
         const npc_ptr &comp )
 {
     size_t plots_cnt = 0;
@@ -3753,7 +3758,7 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
     return std::make_pair( plots_cnt, crops );
 }
 
-void basecamp::start_farm_op( const point &dir, const mission_id &miss_id,
+void basecamp::start_farm_op( const point_rel_omt &dir, const mission_id &miss_id,
                               float exertion_level )
 {
     farm_ops op = farm_ops::plow;
@@ -3958,7 +3963,7 @@ npc_ptr basecamp::emergency_recall( const mission_id &miss_id )
 
 bool basecamp::upgrade_return( const mission_id &miss_id )
 {
-    const point dir = miss_id.dir.value();  //  Will always have a value
+    const point_rel_omt dir = miss_id.dir.value();  //  Will always have a value
     const std::string bldg = miss_id.parameters.empty() ? next_upgrade( dir, 1 ) : miss_id.parameters;
     if( bldg == "null" ) {
         return false;
@@ -4126,7 +4131,7 @@ void basecamp::fortifications_return( const mission_id &miss_id )
 {
     npc_ptr comp = companion_choose_return( miss_id, 3_hours );
     if( comp != nullptr ) {
-        auto &build_point = comp->companion_mission_points;
+        std::vector<tripoint_abs_omt> &build_point = comp->companion_mission_points;
         for( std::vector<tripoint_abs_omt>::iterator::value_type point : build_point ) {
             if( miss_id.parameters == faction_wall_level_n_0_string ||
                 //  Handling of old format (changed mid 0.F) below
@@ -4147,7 +4152,7 @@ void basecamp::fortifications_return( const mission_id &miss_id )
 bool basecamp::salt_water_pipe_swamp_return( const mission_id &miss_id,
         const comp_list &npc_list )
 {
-    const point dir = miss_id.dir.value();  //  Will always have a value
+    const point_rel_omt dir = miss_id.dir.value();  //  Will always have a value
 
     expansion_salt_water_pipe *pipe = nullptr;
 
@@ -4165,13 +4170,13 @@ bool basecamp::salt_water_pipe_swamp_return( const mission_id &miss_id,
         return false;
     }
 
-    point connection_dir = pipe->connection_direction;
+    point_rel_omt connection_dir = pipe->connection_direction;
     const int segment_number = 0;
 
-    point next_construction_direction;
+    point_rel_omt next_construction_direction;
 
     if( segment_number == pipe->segments.size() - 1 ) {
-        next_construction_direction = { -connection_dir.x, -connection_dir.y };
+        next_construction_direction = { -connection_dir.x(), -connection_dir.y()};
     } else {
         next_construction_direction = { pipe->segments[segment_number + 1].point.x() - pipe->segments[segment_number].point.x(),
                                         pipe->segments[segment_number + 1].point.y() - pipe->segments[segment_number].point.y()
@@ -4210,7 +4215,7 @@ bool basecamp::salt_water_pipe_swamp_return( const mission_id &miss_id,
     //  Should be safe as the caller has already checked the result. Repeating rather than adding an additional parameter to the function.
 
     size_t finished_segments = 0;
-    for( std::vector<expansion_salt_water_pipe_segment>::iterator::value_type element :
+    for( const std::vector<expansion_salt_water_pipe_segment>::iterator::value_type &element :
          pipe->segments ) {
         if( element.finished ) {
             finished_segments++;
@@ -4241,7 +4246,7 @@ bool basecamp::salt_water_pipe_return( const mission_id &miss_id,
                                        const comp_list &npc_list )
 {
     const recipe &making = recipe_id( miss_id.parameters ).obj();
-    const point dir = miss_id.dir.value();  //  Will always have a value
+    const point_rel_omt dir = miss_id.dir.value();  //  Will always have a value
 
     expansion_salt_water_pipe *pipe = nullptr;
 
@@ -4259,21 +4264,21 @@ bool basecamp::salt_water_pipe_return( const mission_id &miss_id,
         return false;
     }
 
-    point connection_dir = pipe->connection_direction;
+    point_rel_omt connection_dir = pipe->connection_direction;
     const int segment_number = salt_water_pipe_segment_of( making );
 
     if( segment_number == -1 ) {
         return false;
     }
 
-    const point previous_construction_direction = { pipe->segments[segment_number - 1].point.x() - pipe->segments[segment_number].point.x(),
-                                                    pipe->segments[segment_number - 1].point.y() - pipe->segments[segment_number].point.y()
-                                                  };
+    const point_rel_omt previous_construction_direction = { pipe->segments[segment_number - 1].point.x() - pipe->segments[segment_number].point.x(),
+                                                            pipe->segments[segment_number - 1].point.y() - pipe->segments[segment_number].point.y()
+                                                          };
 
-    point next_construction_direction;
+    point_rel_omt next_construction_direction;
 
     if( segment_number == static_cast<int>( pipe->segments.size() - 1 ) ) {
-        next_construction_direction = { -connection_dir.x, -connection_dir.y };
+        next_construction_direction = { -connection_dir.x(), -connection_dir.y()};
     } else {
         next_construction_direction = { pipe->segments[segment_number + 1].point.x() - pipe->segments[segment_number].point.x(),
                                         pipe->segments[segment_number + 1].point.y() - pipe->segments[segment_number].point.y()
@@ -4333,7 +4338,7 @@ bool basecamp::salt_water_pipe_return( const mission_id &miss_id,
     //  Should be safe as the caller has already checked the result. Repeating rather than adding an additional parameter to the function.
 
     size_t finished_segments = 0;
-    for( std::vector<expansion_salt_water_pipe_segment>::iterator::value_type element :
+    for( const std::vector<expansion_salt_water_pipe_segment>::iterator::value_type &element :
          pipe->segments ) {
         if( element.finished ) {
             finished_segments++;
@@ -4545,7 +4550,7 @@ bool basecamp::survey_field_return( const mission_id &miss_id )
             popup( _( "Expansions must be on the same level as the camp" ) );
             continue;
         }
-        const point dir = talk_function::om_simple_dir( omt_pos, where );
+        const point_rel_omt dir = talk_function::om_simple_dir( omt_pos, where );
         if( expansions.find( dir ) != expansions.end() ) {
             if( query_yn(
                     _( "You already have an expansion at that location.  Do you want to finish this mission?  If not, another tile can be checked." ) ) ) {
@@ -4627,7 +4632,7 @@ bool basecamp::survey_return( const mission_id &miss_id )
             popup( _( "Expansions must be on the same level as the camp" ) );
             continue;
         }
-        const point dir = talk_function::om_simple_dir( omt_pos, where );
+        const point_rel_omt dir = talk_function::om_simple_dir( omt_pos, where );
         if( expansions.find( dir ) != expansions.end() ) {
             if( query_yn(
                     _( "You already have an expansion at that location.  Do you want to finish this mission?  If not, another tile can be checked." ) ) ) {
@@ -4701,7 +4706,7 @@ bool basecamp::survey_return( const mission_id &miss_id )
     }
 }
 
-bool basecamp::farm_return( const mission_id &miss_id, const point &dir )
+bool basecamp::farm_return( const mission_id &miss_id, const point_rel_omt &dir )
 {
     farm_ops op;
     if( miss_id.id == Camp_Plow ) {
@@ -4950,9 +4955,9 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
                 continue;
             }
             // get a random number that is either 1 or -1
-            point dir( 3 * ( 2 * rng( 0, 1 ) - 1 ) + rng( -1, 1 ), 3 * rng( -1, 1 ) + rng( -1, 1 ) );
+            point_rel_ms dir( 3 * ( 2 * rng( 0, 1 ) - 1 ) + rng( -1, 1 ), 3 * rng( -1, 1 ) + rng( -1, 1 ) );
 
-            target_bay.cut_down_tree( tripoint_omt_ms( p ), dir );
+            target_bay.cut_down_tree( p, dir );
             target_bay.collapse_at( p, true, true, false );
             harvested++;
         }
@@ -5374,7 +5379,8 @@ drop_locations basecamp::give_equipment( Character *pc, const inventory_filter_p
     return selected;
 }
 
-drop_locations basecamp::get_equipment( tinymap *target_bay, const tripoint &target, Character *pc,
+drop_locations basecamp::get_equipment( tinymap *target_bay, const tripoint_omt_ms &target,
+                                        Character *pc,
                                         const inventory_filter_preset &preset,
                                         const std::string &msg, const std::string &title, units::volume &total_volume,
                                         units::mass &total_mass )
@@ -5409,7 +5415,7 @@ drop_locations basecamp::get_equipment( tinymap *target_bay, const tripoint &tar
     inventory_multiselector inv_s( *pc, preset, msg,
                                    make_raw_stats, /*allow_select_contained =*/ true );
 
-    inv_s.add_remote_map_items( target_bay, target );
+    inv_s.add_remote_map_items( target_bay, target.raw() );
     inv_s.set_title( title );
     inv_s.set_hint( _( "To select items, type a number before selecting." ) );
 
@@ -5463,8 +5469,8 @@ std::vector<std::pair<std::string, tripoint_abs_omt>> talk_function::om_building
     return om_camp_region;
 }
 
-point talk_function::om_simple_dir( const tripoint_abs_omt &omt_pos,
-                                    const tripoint_abs_omt &omt_tar )
+point_rel_omt talk_function::om_simple_dir( const tripoint_abs_omt &omt_pos,
+        const tripoint_abs_omt &omt_tar )
 {
     point_rel_omt diff = omt_tar.xy() - omt_pos.xy();
     return { clamp( diff.x(), -1, 1 ), clamp( diff.y(), -1, 1 ) };
@@ -5537,7 +5543,7 @@ int basecamp::recruit_evaluation( int &sbase, int &sexpansions, int &sfaction, i
     //How could we ever starve?
     //More than 5 farms at recruiting base
     int farm = 0;
-    for( const point &dir : directions ) {
+    for( const point_rel_omt &dir : directions ) {
         if( has_provides( "farming", dir ) ) {
             farm++;
         }
@@ -5623,7 +5629,7 @@ std::string basecamp::gathering_description()
     return output;
 }
 
-std::string basecamp::farm_description( const point &dir, size_t &plots_count,
+std::string basecamp::farm_description( const point_rel_omt &dir, size_t &plots_count,
                                         farm_ops operation )
 {
     std::pair<size_t, std::string> farm_data = farm_action( dir, operation );
@@ -6043,7 +6049,7 @@ std::string basecamp::name_display_of( const mission_id &miss_id )
     }
 }
 
-void basecamp::handle_reveal_mission( const point &dir )
+void basecamp::handle_reveal_mission( const point_rel_omt &dir )
 {
     if( hidden_missions.empty() ) { //  Should never happen
         return;
@@ -6071,7 +6077,7 @@ void basecamp::handle_reveal_mission( const point &dir )
     }
 }
 
-void basecamp::handle_hide_mission( const point &dir )
+void basecamp::handle_hide_mission( const point_rel_omt &dir )
 {
     const base_camps::direction_data &base_data = base_camps::all_directions.at( dir );
     const size_t previously_hidden_count = hidden_missions[size_t( base_data.tab_order )].size();
@@ -6151,15 +6157,15 @@ void basecamp::place_results( const item &result )
         }
     }
     target_bay.add_item_or_charges( new_spot, result, true );
-    apply_camp_ownership( target_bay, new_spot.raw(), 10 );
+    apply_camp_ownership( target_bay, new_spot, 10 );
     target_bay.save();
 }
 
-void apply_camp_ownership( map &here, const tripoint &camp_pos, int radius )
+void apply_camp_ownership( map &here, const tripoint_bub_ms &camp_pos, int radius )
 {
-    for( const tripoint_bub_ms &p : here.points_in_rectangle( tripoint_bub_ms( camp_pos ) + point(
+    for( const tripoint_bub_ms &p : here.points_in_rectangle( camp_pos + point(
                 -radius, -radius ),
-            tripoint_bub_ms( camp_pos ) + point( radius, radius ) ) ) {
+            camp_pos + point( radius, radius ) ) ) {
         map_stack items = here.i_at( p.xy() );
         for( item &elem : items ) {
             elem.set_owner( get_player_character() );

--- a/src/faction_camp.h
+++ b/src/faction_camp.h
@@ -50,6 +50,6 @@ std::string name_mission_tabs( const tripoint_abs_omt &omt_pos, const std::strin
 std::vector<std::pair<std::string, tripoint_abs_omt>> om_building_region(
             const tripoint_abs_omt &omt_pos, int range, bool purge = false );
 /// Returns the x and y coordinates of ( omt_tar - omt_pos ), clamped to [-1, 1]
-point om_simple_dir( const tripoint_abs_omt &omt_pos, const tripoint_abs_omt &omt_tar );
+point_rel_omt om_simple_dir( const tripoint_abs_omt &omt_pos, const tripoint_abs_omt &omt_tar );
 } // namespace talk_function
 #endif // CATA_SRC_FACTION_CAMP_H

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13730,7 +13730,7 @@ void game::climb_down_menu_gen( const tripoint_bub_ms &examp, uilist &cmenu )
     }
 
     // Scan the height of the drop and what's in the way.
-    const climbing_aid::fall_scan fall( examp.raw() );
+    const climbing_aid::fall_scan fall( examp );
 
     add_msg_debug( debugmode::DF_IEXAMINE, "Ledge height %d", fall.height );
     if( fall.height == 0 ) {
@@ -13741,7 +13741,7 @@ void game::climb_down_menu_gen( const tripoint_bub_ms &examp, uilist &cmenu )
     // This is used to mention object names.  TODO make this more flexible.
     std::string target_disp_name = m.disp_name( fall.pos_furniture_or_floor() );
 
-    climbing_aid::condition_list conditions = climbing_aid::detect_conditions( you, examp.raw() );
+    climbing_aid::condition_list conditions = climbing_aid::detect_conditions( you, examp );
 
     climbing_aid::aid_list aids = climbing_aid::list( conditions );
 
@@ -13838,7 +13838,7 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
     }
 
     // Scan the height of the drop and what's in the way.
-    const climbing_aid::fall_scan fall( examp.raw() );
+    const climbing_aid::fall_scan fall( examp );
 
     int estimated_climb_cost = you.climbing_cost( tripoint_bub_ms( fall.pos_bottom() ), examp );
     const float fall_mod = you.fall_damage_mod();

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -661,7 +661,6 @@ void iexamine::attunement_altar( Character &you, const tripoint_bub_ms & )
 
 void iexamine::translocator( Character &, const tripoint_bub_ms &examp )
 {
-    /// @todo fix point types
     const tripoint_abs_omt omt_loc( coords::project_to<coords::omt>( get_map().getglobal( examp ) ) );
     avatar &player_character = get_avatar();
     const bool activated = player_character.translocators.knows_translocator( omt_loc );
@@ -1221,11 +1220,11 @@ int _get_rot_delta( tripoint_abs_omt const &this_omt, tripoint_abs_omt const &th
     return diff >= 0 ? diff : 4 + diff;
 }
 
-tripoint _rotate_point_sm( tripoint const &p, int erot, tripoint const &orig )
+tripoint_bub_ms _rotate_point_sm( tripoint_bub_ms const &p, int erot, tripoint_bub_ms const &orig )
 {
-    tripoint const p_sm( p - orig.xy() );
-    tripoint const rd = p_sm.rotate( erot, { SEEX * 2, SEEY * 2 } );
-    return tripoint{ rd + orig.xy() };
+    tripoint_rel_ms const p_sm( p - orig.xy() );
+    tripoint_rel_ms const rd = p_sm.rotate( erot, {SEEX * 2, SEEY * 2} );
+    return rd + orig.xy();
 }
 
 constexpr int uilist_positive = 10000; // workaround for uilist retval autoassign when retval == -1
@@ -1239,8 +1238,8 @@ int _choose_elevator_destz( tripoint_bub_ms const &examp, tripoint_abs_omt const
     for( int z = OVERMAP_HEIGHT; z >= -OVERMAP_DEPTH; z-- ) {
         tripoint_abs_omt const that_omt( this_omt.xy(), z );
         tripoint_bub_ms const zp =
-            tripoint_bub_ms( _rotate_point_sm( { examp.xy().raw(), z}, _get_rot_delta( this_omt, that_omt ),
-                                               sm_orig.raw() ) );
+            _rotate_point_sm( { examp.xy(), z}, _get_rot_delta( this_omt, that_omt ),
+                              sm_orig );
 
         if( here.ter( zp )->has_examine( iexamine::elevator ) ) {
             std::string const omt_name = overmap_buffer.ter_existing( that_omt )->get_name(
@@ -1322,7 +1321,7 @@ void iexamine::elevator( Character &you, const tripoint_bub_ms &examp )
     std::vector<tripoint_bub_ms> that_elevator;
     std::transform( this_elevator.begin(), this_elevator.end(), std::back_inserter( that_elevator ),
     [&erot, &sm_orig, &movez]( tripoint_bub_ms const & p ) {
-        return tripoint_bub_ms( _rotate_point_sm( { p.xy().raw(), movez}, erot, sm_orig.raw() ) );
+        return _rotate_point_sm( { p.xy(), movez}, erot, sm_orig );
     } );
 
     creature_tracker &creatures = get_creature_tracker();
@@ -1366,9 +1365,9 @@ void iexamine::elevator( Character &you, const tripoint_bub_ms &examp )
     }
 
     for( vehicle *v : vehs.v ) {
-        tripoint_bub_ms const p = tripoint_bub_ms( _rotate_point_sm( { v->pos_bub().xy().raw(), movez},
+        tripoint_bub_ms const p = _rotate_point_sm( { v->pos_bub().xy(), movez},
                                   erot,
-                                  sm_orig.raw() ) );
+                                  sm_orig );
         here.displace_vehicle( *v, p - v->pos_bub() );
         v->turn( erot * 90_degrees );
         v->face = tileray( v->turn_dir );
@@ -2003,7 +2002,6 @@ void iexamine::bulletin_board( Character &you, const tripoint_bub_ms &examp )
 {
     g->validate_camps();
     map &here = get_map();
-    // TODO: fix point types
     point_abs_omt omt( coords::project_to<coords::omt>( here.getglobal( examp ) ).xy() );
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( omt );
     if( bcp ) {
@@ -4698,11 +4696,6 @@ void trap::examine( const tripoint_bub_ms &examp ) const
     trap::examine( examp.raw() );
 }
 
-void iexamine::part_con( Character &you, tripoint const &examp )
-{
-    iexamine::part_con( you, tripoint_bub_ms( examp ) );
-}
-
 void iexamine::part_con( Character &you, tripoint_bub_ms const &examp )
 {
     map &here = get_map();
@@ -6427,7 +6420,7 @@ static void smoker_activate( Character &you, const tripoint_bub_ms &examp )
     }
 }
 
-void iexamine::mill_finalize( Character &, const tripoint &examp )
+void iexamine::mill_finalize( Character &, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
     const furn_id &cur_mill_type = here.furn( examp );
@@ -6543,7 +6536,8 @@ void iexamine::mill_finalize( Character &, const tripoint &examp )
     here.furn_set( examp, next_mill_type );
 }
 
-static void smoker_finalize( Character &, const tripoint &examp, const time_point &start_time )
+static void smoker_finalize( Character &, const tripoint_bub_ms &examp,
+                             const time_point &start_time )
 {
     map &here = get_map();
     const furn_id &cur_smoker_type = here.furn( examp );
@@ -6786,7 +6780,7 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
     you.invalidate_crafting_inventory();
 }
 
-void iexamine::on_smoke_out( const tripoint &examp, const time_point &start_time )
+void iexamine::on_smoke_out( const tripoint_bub_ms &examp, const time_point &start_time )
 {
     const furn_id &f = get_map().furn( examp );
     if( f == furn_f_smoking_rack_active ||

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -51,7 +51,7 @@ bool can_hack( Character &you );
 
 bool try_start_hacking( Character &you, const tripoint_bub_ms &examp );
 
-void egg_sack_generic( Character &you, const tripoint &examp, const mtype_id &montype );
+void egg_sack_generic( Character &you, const tripoint_bub_ms &examp, const mtype_id &montype );
 
 void none( Character &you, const tripoint_bub_ms &examp );
 
@@ -66,7 +66,7 @@ void vending( Character &you, const tripoint_bub_ms &examp );
 void elevator( Character &you, const tripoint_bub_ms &examp );
 void nanofab( Character &you, const tripoint_bub_ms &examp );
 void controls_gate( Character &you, const tripoint_bub_ms &examp );
-void cardreader( Character &you, const tripoint &examp );
+void cardreader( Character &you, const tripoint_bub_ms &examp );
 void cardreader_robofac( Character &you, const tripoint_bub_ms &examp );
 void cardreader_foodplace( Character &you, const tripoint_bub_ms &examp );
 void intercom( Character &you, const tripoint_bub_ms &examp );
@@ -93,11 +93,11 @@ void pedestal_wyrm( Character &you, const tripoint_bub_ms &examp );
 void pedestal_temple( Character &you, const tripoint_bub_ms &examp );
 void door_peephole( Character &you, const tripoint_bub_ms &examp );
 void fswitch( Character &you, const tripoint_bub_ms &examp );
-void flower_tulip( Character &you, const tripoint &examp );
-void flower_spurge( Character &you, const tripoint &examp );
+void flower_tulip( Character &you, const tripoint_bub_ms &examp );
+void flower_spurge( Character &you, const tripoint_bub_ms &examp );
 void flower_poppy( Character &you, const tripoint_bub_ms &examp );
 void flower_cactus( Character &you, const tripoint_bub_ms &examp );
-void flower_bluebell( Character &you, const tripoint &examp );
+void flower_bluebell( Character &you, const tripoint_bub_ms &examp );
 void flower_dahlia( Character &you, const tripoint_bub_ms &examp );
 void flower_marloss( Character &you, const tripoint_bub_ms &examp );
 void fungus( Character &you, const tripoint_bub_ms &examp );
@@ -109,8 +109,6 @@ void tree_maple_tapped( Character &you, const tripoint_bub_ms &examp );
 void shrub_marloss( Character &you, const tripoint_bub_ms &examp );
 void tree_marloss( Character &you, const tripoint_bub_ms &examp );
 void shrub_wildveggies( Character &you, const tripoint_bub_ms &examp );
-// TODO: Get rid of untyped overload.
-void part_con( Character &you, const tripoint &examp );
 void part_con( Character &you, const tripoint_bub_ms &examp );
 void water_source( Character &, const tripoint_bub_ms &examp );
 void finite_water_source( Character &, const tripoint_bub_ms &examp );
@@ -136,9 +134,9 @@ void ledge( Character &you, const tripoint_bub_ms &examp );
 void autodoc( Character &you, const tripoint_bub_ms &examp );
 void attunement_altar( Character &you, const tripoint_bub_ms &examp );
 void translocator( Character &you, const tripoint_bub_ms &examp );
-void on_smoke_out( const tripoint &examp,
+void on_smoke_out( const tripoint_bub_ms &examp,
                    const time_point &start_time ); //activates end of smoking effects
-void mill_finalize( Character &, const tripoint &examp );
+void mill_finalize( Character &, const tripoint_bub_ms &examp );
 void quern_examine( Character &you, const tripoint_bub_ms &examp );
 void smoker_options( Character &you, const tripoint_bub_ms &examp );
 void open_safe( Character &you, const tripoint_bub_ms &examp );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13522,7 +13522,7 @@ bool item::process_fake_mill( map &here, Character * /*carrier*/, const tripoint
         return true; //destroy fake mill
     }
     if( age() >= 6_hours || item_counter == 0 ) {
-        iexamine::mill_finalize( get_avatar(), pos.raw() ); //activate effects when timers goes to zero
+        iexamine::mill_finalize( get_avatar(), pos ); //activate effects when timers goes to zero
         return true; //destroy fake mill item
     }
 
@@ -13539,7 +13539,7 @@ bool item::process_fake_smoke( map &here, Character * /*carrier*/, const tripoin
     }
 
     if( age() >= 6_hours || item_counter == 0 ) {
-        iexamine::on_smoke_out( pos.raw(), birthday() ); //activate effects when timers goes to zero
+        iexamine::on_smoke_out( pos, birthday() ); //activate effects when timers goes to zero
         return true; //destroy fake smoke when it 'burns out'
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9017,7 +9017,7 @@ void map::produce_sap( const tripoint_bub_ms &p, const time_duration &time_since
     }
 }
 
-void map::cut_down_tree( tripoint_bub_ms p, point dir )
+void map::cut_down_tree( tripoint_bub_ms p, point_rel_ms dir )
 {
     if( !zlevels ) {
         debugmsg( "Call to cut_down_tree from a map that doesn't support zlevels." );

--- a/src/map.h
+++ b/src/map.h
@@ -2204,7 +2204,7 @@ class map
         * Removes the tree at 'p' and produces a trunk_yield length line of trunks in the 'dir'
         * direction from 'p', leaving a stump behind at 'p'.
         */
-        void cut_down_tree( tripoint_bub_ms p, point dir );
+        void cut_down_tree( tripoint_bub_ms p, point_rel_ms dir );
     protected:
         /**
          * Radiation-related plant (and fungus?) death.
@@ -2614,7 +2614,7 @@ class tinymap : private map
         tinymap( int mapsize, bool zlev ) : map( mapsize, zlev ) {};
 
         // This operation cannot be used with tinymap due to a lack of zlevel support, but are carried through for use by smallmap.
-        void cut_down_tree( tripoint_omt_ms p, point dir ) {
+        void cut_down_tree( tripoint_omt_ms p, point_rel_ms dir ) {
             map::cut_down_tree( rebase_bub( p ), dir );
         };
 
@@ -2920,7 +2920,7 @@ class smallmap : public tinymap
     public:
         smallmap() : tinymap( 2, true ) {}
 
-        void cut_down_tree( tripoint_omt_ms p, point dir ) {
+        void cut_down_tree( tripoint_omt_ms p, point_rel_ms dir ) {
             tinymap::cut_down_tree( p, dir );
         };
 };

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7042,10 +7042,10 @@ computer *map::add_computer( const tripoint_bub_ms &p, const std::string &name, 
     submap *const place_on_submap = get_submap_at( p, l );
     if( place_on_submap == nullptr ) {
         debugmsg( "Tried to add computer at (%d,%d) but the submap is not loaded", l.x(), l.y() );
-        static computer null_computer = computer( name, security, p.raw() );
+        static computer null_computer = computer( name, security, p );
         return &null_computer;
     }
-    place_on_submap->set_computer( l, computer( name, security, p.raw() ) );
+    place_on_submap->set_computer( l, computer( name, security, p ) );
     return place_on_submap->get_computer( l );
 }
 

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2915,7 +2915,7 @@ void mission_data::add( const ui_mission_id &id, const std::string &name_display
     if( !possible ) {
         entries[10].push_back( miss );
     }
-    const point direction = id.id.dir ? *id.id.dir : base_camps::base_dir;
+    const point_rel_omt direction = id.id.dir ? *id.id.dir : base_camps::base_dir;
     const int tab_order = base_camps::all_directions.at( direction ).tab_order;
     entries[tab_order + 1].emplace_back( miss );
 }

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -103,7 +103,7 @@ struct mission_id {
     mission_kind id = No_Mission;
     std::string parameters;
     mapgen_arguments mapgen_args;
-    std::optional<point> dir;
+    std::optional<point_rel_omt> dir;
 
     void serialize( JsonOut & ) const;
     void deserialize( const JsonValue & );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4414,7 +4414,7 @@ void basecamp::deserialize( const JsonObject &data )
     for( JsonObject edata : data.get_array( "expansions" ) ) {
         edata.allow_omitted_members();
         expansion_data e;
-        point dir;
+        point_rel_omt dir;
         if( edata.has_string( "dir" ) ) {
             // old save compatibility
             const std::string dir_id = edata.get_string( "dir" );
@@ -5260,7 +5260,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                 point loc;
                 computers_json.next_value().read( loc );
                 auto new_comp_it = computers.emplace( loc, computer( "BUGGED_COMPUTER", -100,
-                                                      tripoint::zero ) ).first;
+                                                      tripoint_bub_ms::zero ) ).first;
                 computers_json.next_value().read( new_comp_it->second );
             }
         }

--- a/src/talker.h
+++ b/src/talker.h
@@ -324,7 +324,7 @@ class const_talker
         virtual bool can_see() const {
             return false;
         }
-        virtual bool can_see_location( const tripoint & ) const {
+        virtual bool can_see_location( const tripoint_bub_ms & ) const {
             return false;
         }
         virtual bool is_mute() const {

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -872,7 +872,7 @@ bool talker_character_const::can_see() const
                                           me_chr_const->has_flag( json_flag_SEESLEEP ) );
 }
 
-bool talker_character_const::can_see_location( const tripoint &pos ) const
+bool talker_character_const::can_see_location( const tripoint_bub_ms &pos ) const
 {
     return me_chr_const->sees( pos );
 }

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -190,7 +190,7 @@ class talker_character_const: virtual public const_talker
         bool is_warm() const override;
 
         bool can_see() const override;
-        bool can_see_location( const tripoint &pos ) const override;
+        bool can_see_location( const tripoint_bub_ms &pos ) const override;
         int morale_cur() const override;
         int focus_cur() const override;
         int get_rad() const override;

--- a/src/talker_furniture.cpp
+++ b/src/talker_furniture.cpp
@@ -15,27 +15,27 @@ std::string talker_furniture_const::disp_name() const
 
 int talker_furniture_const::posx() const
 {
-    return me_comp->loc.x;
+    return me_comp->loc.x();
 }
 
 int talker_furniture_const::posy() const
 {
-    return me_comp->loc.y;
+    return me_comp->loc.y();
 }
 
 int talker_furniture_const::posz() const
 {
-    return me_comp->loc.z;
+    return me_comp->loc.z();
 }
 
 tripoint talker_furniture_const::pos() const
 {
-    return me_comp->loc;
+    return me_comp->loc.raw();
 }
 
 tripoint_bub_ms talker_furniture_const::pos_bub() const
 {
-    return tripoint_bub_ms( me_comp->loc );
+    return me_comp->loc;
 }
 
 tripoint_abs_ms talker_furniture_const::global_pos() const

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -190,7 +190,7 @@ int talker_monster_const::get_grab_strength() const
     return  me_mon_const->get_grab_strength();
 }
 
-bool talker_monster_const::can_see_location( const tripoint &pos ) const
+bool talker_monster_const::can_see_location( const tripoint_bub_ms &pos ) const
 {
     return me_mon_const->sees( pos );
 }

--- a/src/talker_monster.h
+++ b/src/talker_monster.h
@@ -81,7 +81,7 @@ class talker_monster_const: public const_talker_cloner<talker_monster_const>
         int get_hp_max( const bodypart_id & ) const override;
         double armor_at( damage_type_id &dt, bodypart_id &bp ) const override;
 
-        bool can_see_location( const tripoint &pos ) const override;
+        bool can_see_location( const tripoint_bub_ms &pos ) const override;
         int get_volume() const override;
         int get_weight() const override;
         bool is_warm() const override;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -759,7 +759,7 @@ TEST_CASE( "dialogue_copy", "[eoc]" )
 
     item hammer( "hammer" ) ;
     item_location hloc( map_cursor( tripoint_bub_ms::zero ), &hammer );
-    computer comp( "test_computer", 0, tripoint::zero );
+    computer comp( "test_computer", 0, tripoint_bub_ms::zero );
     dialogue d2( get_talker_for( hloc ), get_talker_for( comp ) );
     dialogue d2_copy( d2 );
     d2_copy.set_value( "suppress", "1" );
@@ -783,7 +783,7 @@ TEST_CASE( "EOC_meta_test", "[eoc]" )
     monster zombie( mon_zombie );
     item hammer( "hammer" ) ;
     item_location hloc( map_cursor( tripoint_bub_ms::zero ), &hammer );
-    computer comp( "test_computer", 0, tripoint::zero );
+    computer comp( "test_computer", 0, tripoint_bub_ms::zero );
 
     dialogue d_empty( std::make_unique<talker>(), std::make_unique<talker>() );
     dialogue d_avatar( get_talker_for( get_avatar() ), std::make_unique<talker>() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Replace usage of untyped coordinates with typed ones. This time processing:
- base_camp.h
- climbing.h
- computer.h
- faction_camp.h
- iexamine.h
and dependents.
The iexamine.h changes were to typify operations that don't have any implementation, and thus weren't processed when the rest of the operations were dealt with.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Do the conversion of the .h file operations (and fields) and take care of the implementations and usages, removing some orphaned operations in the process.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Remove the implementation less unused operations in iexamine.h. However, I don't know why they were introduced, so I don't know if there's a valid reason for them to remain or not.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded save. walked up ramp, jumped into car, drove through hay bales, ran over zombie corpse with inventory, smashed into but failed to kill some turkeys, ran into a stationary vehicle. Didn't see anything odd.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
