### PR TITLE
fix duplicate integrated armor

### DIFF
--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -378,8 +378,8 @@ void Character::unset_mutation( const trait_id &trait_ )
         cached_mutations.erase( trait_ );
         if( !mut.enchantments.empty() ) {
             recalculate_enchantment_cache();
-            mutation_loss_effect( trait );
         }
+        mutation_loss_effect( trait );
     }
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "fix duplicate integrated armor"
#### Purpose of change
Fix #78761
#### Describe the solution
I accidentally‌ put `mutation_loss_effect( trait )` in the if conditional, move it out.
Now character lose the integrated armors provided by mutations when they got removed.
#### Describe alternatives you've considered
#### Testing
Load the sav in the issue, toggle the Gnarled Claws, works as expected.
#### Additional context

