### PR TITLE
Expand and use cataimgui scrolling function

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -684,12 +684,19 @@ static void PushOrPopColor( const std::string_view seg, int minimumColorStackSiz
  */
 void cataimgui::set_scroll( scroll &s )
 {
+    int scroll_px_begin = ImGui::GetScrollY();
     int scroll_px = 0;
     int line_height = ImGui::GetTextLineHeightWithSpacing();
-    int page_height = ImGui::GetContentRegionAvail().y;
+    int page_height = ImGui::GetWindowSize().y;
 
     switch( s ) {
         case scroll::none:
+            break;
+        case scroll::begin:
+            scroll_px_begin = 0;
+            break;
+        case scroll::end:
+            scroll_px_begin = ImGui::GetScrollMaxY();
             break;
         case scroll::line_up:
             scroll_px = -line_height;
@@ -705,7 +712,7 @@ void cataimgui::set_scroll( scroll &s )
             break;
     }
 
-    ImGui::SetScrollY( ImGui::GetScrollY() + scroll_px );
+    ImGui::SetScrollY( scroll_px_begin + scroll_px );
 
     s = scroll::none;
 }

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -52,6 +52,8 @@ enum class dialog_result {
 
 enum class scroll : int {
     none = 0,
+    begin,
+    end,
     line_up,
     line_down,
     page_up,

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2308,10 +2308,7 @@ game_menus::inv::compare_item_menu::compare_item_menu( const item &first, const 
         ctxt.register_action( "CONFIRM" );
     }
     ctxt.register_action( "QUIT" );
-    ctxt.register_action( "UP" );
-    ctxt.register_action( "DOWN" );
-    ctxt.register_action( "PAGE_UP" );
-    ctxt.register_action( "PAGE_DOWN" );
+    ctxt.register_navigate_ui_list();
     ctxt.set_timeout( 10 );
 
     // todo: regen info when toggling language?
@@ -2388,6 +2385,10 @@ bool game_menus::inv::compare_item_menu::show()
             s = cataimgui::scroll::page_up;
         } else if( action == "PAGE_DOWN" ) {
             s = cataimgui::scroll::page_down;
+        } else if( action == "HOME" ) {
+            s = cataimgui::scroll::begin;
+        } else if( action == "END" ) {
+            s = cataimgui::scroll::end;
         } else if( action == "CONFIRM" ) {
             return true;
         } else if( action == "QUIT" ) {

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -2202,7 +2202,7 @@ class ma_details_ui_impl : public cataimgui::window
         void init_data();
 
     private:
-        void draw_ma_details_text() const;
+        void draw_ma_details_text();
 
         size_t window_width = ImGui::GetMainViewport()->Size.x * 8 / 9;
         size_t window_height = ImGui::GetMainViewport()->Size.y * 8 / 9;
@@ -2219,6 +2219,8 @@ class ma_details_ui_impl : public cataimgui::window
         std::map<std::string, std::string> weapons_text;
         int buffs_total = 0;
         int weapons_total = 0;
+
+        cataimgui::scroll s = cataimgui::scroll::none;
 
     protected:
         void draw_controls() override;
@@ -2411,7 +2413,7 @@ void ma_details_ui_impl::init_data()
     }
 }
 
-void ma_details_ui_impl::draw_ma_details_text() const
+void ma_details_ui_impl::draw_ma_details_text()
 {
 
     if( !general_info_text.empty() &&
@@ -2466,6 +2468,8 @@ void ma_details_ui_impl::draw_ma_details_text() const
             ImGui::Separator();
         }
     }
+
+    cataimgui::set_scroll( s );
 }
 
 void ma_details_ui_impl::draw_controls()
@@ -2483,21 +2487,21 @@ void ma_details_ui_impl::draw_controls()
     } else if( last_action == "TOGGLE_WEAPONS_GROUP" ) {
         weapons_group_collapsed = !weapons_group_collapsed;
     } else if( last_action == "UP" ) {
-        ImGui::SetScrollY( ImGui::GetScrollY() - ImGui::GetTextLineHeightWithSpacing() );
+        s = cataimgui::scroll::line_up;
     } else if( last_action == "DOWN" ) {
-        ImGui::SetScrollY( ImGui::GetScrollY() + ImGui::GetTextLineHeightWithSpacing() );
+        s = cataimgui::scroll::line_down;
     } else if( last_action == "LEFT" ) {
         ImGui::SetScrollX( ImGui::GetScrollX() - ImGui::CalcTextSize( "x" ).x );
     } else if( last_action == "RIGHT" ) {
         ImGui::SetScrollX( ImGui::GetScrollX() + ImGui::CalcTextSize( "x" ).x );
     } else if( last_action == "PAGE_UP" ) {
-        ImGui::SetScrollY( ImGui::GetScrollY() - window_height );
+        s = cataimgui::scroll::page_up;
     } else if( last_action == "PAGE_DOWN" ) {
-        ImGui::SetScrollY( ImGui::GetScrollY() + window_height );
+        s = cataimgui::scroll::page_down;
     } else if( last_action == "HOME" ) {
-        ImGui::SetScrollY( 0 );
+        s = cataimgui::scroll::begin;
     } else if( last_action == "END" ) {
-        ImGui::SetScrollY( ImGui::GetScrollMaxY() );
+        s = cataimgui::scroll::end;
     }
 
     draw_ma_details_text();

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -75,6 +75,8 @@ class mission_ui_impl : public cataimgui::window
         size_t window_height = str_height_to_pixels( TERMY ) / 2;
         size_t table_column_width = window_width / 2;
 
+        cataimgui::scroll s = cataimgui::scroll::none;
+
     protected:
         void draw_controls() override;
 };
@@ -131,19 +133,21 @@ void mission_ui_impl::draw_controls()
     } else if( last_action == "NEXT_TAB" || last_action == "RIGHT" ) {
         adjust_selected = true;
         selected_mission = 0;
+        s = cataimgui::scroll::begin;
         switch_tab = selected_tab;
         ++switch_tab;
     } else if( last_action == "PREV_TAB" || last_action == "LEFT" ) {
         adjust_selected = true;
         selected_mission = 0;
+        s = cataimgui::scroll::begin;
         switch_tab = selected_tab;
         --switch_tab;
     } else if( last_action == "PAGE_UP" ) {
         ImGui::SetWindowFocus(); // Dumb hack! Clear our focused item so listbox selection isn't nav highlighted.
-        ImGui::SetScrollY( ImGui::GetScrollY() - ( window_height / 5.0f ) );
+        s = cataimgui::scroll::page_up;
     } else if( last_action == "PAGE_DOWN" ) {
         ImGui::SetWindowFocus(); // Dumb hack! Clear our focused item so listbox selection isn't nav highlighted.
-        ImGui::SetScrollY( ImGui::GetScrollY() + ( window_height / 5.0f ) );
+        s = cataimgui::scroll::page_down;
     }
 
     ImGuiTabItemFlags_ flags = ImGuiTabItemFlags_None;
@@ -225,6 +229,8 @@ void mission_ui_impl::draw_controls()
         draw_selected_description( umissions, selected_mission );
         ImGui::EndTable();
     }
+
+    cataimgui::set_scroll( s );
 }
 
 void mission_ui_impl::draw_mission_names( std::vector<mission *> missions, int &selected_mission,

--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -81,6 +81,8 @@ class scores_ui_impl : public cataimgui::window
         int npc_kills = 0;
         int total_kills = 0;
 
+        cataimgui::scroll s = cataimgui::scroll::none;
+
     protected:
         void draw_controls() override;
 };
@@ -290,25 +292,25 @@ void scores_ui_impl::draw_controls()
     } else if( last_action == "TOGGLE_NPC_GROUP" ) {
         npc_group_collapsed = !npc_group_collapsed;
     } else if( last_action == "UP" ) {
-        ImGui::SetScrollY( ImGui::GetScrollY() - ImGui::GetTextLineHeightWithSpacing() );
+        s = cataimgui::scroll::line_up;
     } else if( last_action == "DOWN" ) {
-        ImGui::SetScrollY( ImGui::GetScrollY() + ImGui::GetTextLineHeightWithSpacing() );
+        s = cataimgui::scroll::line_down;
     } else if( last_action == "NEXT_TAB" || last_action == "RIGHT" ) {
-        ImGui::SetScrollY( 0 );
+        s = cataimgui::scroll::begin;
         switch_tab = selected_tab;
         ++switch_tab;
     } else if( last_action == "PREV_TAB" || last_action == "LEFT" ) {
-        ImGui::SetScrollY( 0 );
+        s = cataimgui::scroll::begin;
         switch_tab = selected_tab;
         --switch_tab;
     } else if( last_action == "PAGE_UP" ) {
-        ImGui::SetScrollY( ImGui::GetScrollY() - window_height );
+        s = cataimgui::scroll::page_up;
     } else if( last_action == "PAGE_DOWN" ) {
-        ImGui::SetScrollY( ImGui::GetScrollY() + window_height );
+        s = cataimgui::scroll::page_down;
     } else if( last_action == "HOME" ) {
-        ImGui::SetScrollY( 0 );
+        s = cataimgui::scroll::begin;
     } else if( last_action == "END" ) {
-        ImGui::SetScrollY( ImGui::GetScrollMaxY() );
+        s = cataimgui::scroll::end;
     }
 
     ImGuiTabItemFlags_ flags = ImGuiTabItemFlags_None;
@@ -366,6 +368,7 @@ void scores_ui_impl::draw_controls()
         draw_kills_text();
     }
 
+    cataimgui::set_scroll( s );
 }
 
 void show_scores_ui()

--- a/src/ui_iteminfo.cpp
+++ b/src/ui_iteminfo.cpp
@@ -14,11 +14,14 @@ iteminfo_window::iteminfo_window( item_info_data &info, point pos, int width, in
     if( info.handle_scrolling ) {
         ctxt.register_action( "PAGE_UP" );
         ctxt.register_action( "PAGE_DOWN" );
+        ctxt.register_action( "HOME" );
+        ctxt.register_action( "END" );
         if( info.arrow_scrolling ) {
             ctxt.register_action( "UP" );
             ctxt.register_action( "DOWN" );
         }
     }
+    ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
     if( info.any_input ) {
@@ -72,6 +75,10 @@ void iteminfo_window::execute()
             s = cataimgui::scroll::page_up;
         } else if( data.handle_scrolling && action == "PAGE_DOWN" ) {
             s = cataimgui::scroll::page_down;
+        } else if( data.handle_scrolling && action == "HOME" ) {
+            s = cataimgui::scroll::begin;
+        } else if( data.handle_scrolling && action == "END" ) {
+            s = cataimgui::scroll::end;
         } else if( action == "CONFIRM" || action == "QUIT" ||
                    ( data.any_input && action == "ANY_INPUT" && !ctxt.get_raw_input().sequence.empty() ) ) {
             break;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Expand and use cataimgui scrolling function.

#### Describe the solution

1. Added possibility to scroll to the beginning (`HOME`) and end (`END`) of the window in addition to existing line (`UP` and `DOWN`) and page scrolling (`PAGE UP` and `PAGE DOWN`).
2. Utilize scroll function in migrated menus:

- martial arts details;
- missions;
- scores;
- item compare;
- item info.

#### Testing

Make sure scrolling works in martial arts details, missions, scores, item compare and item info menus.