### PR TITLE
Fix special_vision serialization

### DIFF
--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -747,6 +747,7 @@ void enchant_cache::serialize( JsonOut &jsout ) const
             jsout.member( "id", struc_desc.id );
             jsout.end_object();
         }
+        jsout.end_array();
         jsout.end_object();
     }
     jsout.end_array();


### PR DESCRIPTION
#### Summary

Bugfixes "Fixes jsout.end_array() missing in enchant_cache serialization"

#### Purpose of change

Fixes #78716 and fixes #78329

#### Describe the solution

@GuardianDll showed in #78329 where the error was, I just compiled and tested it.

#### Describe alternatives you've considered


#### Testing

Created profession with MoM psionic glasses, saved, loaded without error.

#### Additional context

All thanks to @GuardianDll actually. Dunno why he didn't post the PR himself.
