### PR TITLE
Selkies - Set up all of their skin effects.

### DIFF
--- a/data/mods/Xedra_Evolved/enchantments/armor.json
+++ b/data/mods/Xedra_Evolved/enchantments/armor.json
@@ -186,5 +186,10 @@
     "condition": { "not": "u_has_weapon" },
     "melee_damage_bonus": [ { "type": "bash", "add": { "math": [ "10 * (1 + (u_has_trait('IERDE_SKIN_3') * 0.5) )" ] } } ],
     "values": [ { "value": "ATTACK_SPEED", "multiply": 0.15 } ]
+  },
+  {
+    "id": "selkieskinworn",
+    "type": "enchantment",
+    "has": "WORN"
   }
 ]

--- a/data/mods/Xedra_Evolved/eocs/selkieskineocs.json
+++ b/data/mods/Xedra_Evolved/eocs/selkieskineocs.json
@@ -1,0 +1,62 @@
+[
+    {
+      "type": "effect_on_condition",
+      "id": "selkiecheck",
+      "condition": { "u_has_trait": "FAIR_FOLK_COMMONER_SELKIE_SKIN_CRAFTED" },
+      "eoc_type": "RECURRING",
+      "recurrence": 300,
+      "effect": {
+        "run_eocs": [
+          {
+            "id": "selkieheld",
+            "effect": [ { "u_add_trait": "FAIR_FOLK_COMMONER_SELKIE_SKIN_VITALITY" }, { "u_mod_healthy": 5, "cap": 200 } ]
+          }
+        ]
+      },
+      "false_effect": {
+        "run_eocs": [
+          {
+            "id": "selkienotheld",
+            "condition": { "u_has_trait": "THRESH_FAIR_FOLK_COMMONER_SELKIE" },
+            "effect": [ { "u_lose_trait": "FAIR_FOLK_COMMONER_SELKIE_SKIN_VITALITY" }, { "u_mod_healthy": 5, "cap": -200 } ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "effect_on_condition",
+      "id": "learnselkie",
+      "eoc_type": "EVENT",
+      "required_event": "character_wakes_up",
+      "condition": {
+        "and": [
+          { "u_has_trait": "THRESH_FAIR_FOLK_COMMONER_SELKIE" },
+          { "math": [ "u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE')>10" ] },
+          { "not": { "u_has_trait": "knownselkieskin" } }
+        ]
+      },
+      "effect": [ { "u_learn_recipe": "selkie_skin_selkie" }, { "u_add_trait": "knownselkieskin" } ]
+    },
+    {
+      "type": "effect_on_condition",
+      "id": "selkieskinWEARING",
+      "condition": {
+        "and": [
+          { "u_has_trait": "THRESH_FAIR_FOLK_COMMONER_SELKIE" },
+          { "u_has_effect": "selkieskinworn" },
+          { "u_has_item": "selkie_skin" }
+        ]
+      },
+      "eoc_type": "RECURRING",
+      "recurrence": 1,
+      "effect": [ { "u_add_trait": "FANGS" }, { "u_add_trait": "FAT" }, { "u_add_trait": "WHISKERS" } ],
+      "false_effect": {
+        "run_eocs": {
+          "id": "selkieloseseal",
+          "condition": { "u_has_trait": "THRESH_FAIR_FOLK_COMMONER_SELKIE" },
+          "effect": [ { "u_lose_trait": "FANGS" }, { "u_lose_trait": "FAT" }, { "u_lose_trait": "WHISKERS" } ]
+        }
+      }
+    }
+  ]
+  

--- a/data/mods/Xedra_Evolved/items/clothes.json
+++ b/data/mods/Xedra_Evolved/items/clothes.json
@@ -444,5 +444,20 @@
     "copy-from": "holy_symbol_wood",
     "name": { "str": "handmade holy symbol" },
     "extend": { "flags": [ "WARDING_SYMBOL" ] }
+  },
+  {
+    "id": "selkie_skin",
+    "type": "ARMOR",
+    "name": { "str": "your true skin", "str_pl": "sets of your true skin" },
+    "description": "Your true skin. Having it in your possession soothes you and enhances your capabilities. Wearing it restores you to your true form as a monstrously large seal - losing it, however, has devastating effects.",
+    "price": "0 USD",
+    "price_postapoc": "0 USD",
+    "material": [ "leather", "fae_fur" ],
+    "color": "light_gray",
+    "symbol": "@",
+    "weight": "1000 g",
+    "volume": "25000 ml",
+    "relic_data": { "passive_effects": [ { "id": "selkieskinworn" } ] },
+    "flags": [ "ITEM_WATERPROOFING", "MORPHIC" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -1413,7 +1413,7 @@
     "description": "These are the selkie enhancements.",
     "starting_trait": false,
     "purifiable": false,
-    "player_display": true,
+    "player_display": false,
     "//": "player display's true during testing, will be replaced once I get a better handle on effects.",
     "enchantments": [ { "values": [ { "value": "REGEN_MANA", "multiply": 2 }, { "value": "CARDIO_MULTIPLIER", "multiply": 1 } ] } ]
   },

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -1404,5 +1404,37 @@
       "THRESH_FAIR_FOLK_COMMONER_TROW"
     ],
     "flags": [ "MEND_ALL" ]
+  },
+  {
+    "type": "mutation",
+    "id": "FAIR_FOLK_COMMONER_SELKIE_SKIN_VITALITY",
+    "points": 99,
+    "name": "selkie vitality",
+    "description": "These are the selkie enhancements.",
+    "starting_trait": false,
+    "purifiable": false,
+    "player_display": true,
+    "//": "player display's true during testing, will be replaced once I get a better handle on effects.",
+    "enchantments": [ { "values": [ { "value": "REGEN_MANA", "multiply": 2 }, { "value": "CARDIO_MULTIPLIER", "multiply": 1 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "knownselkieskin",
+    "points": 99,
+    "name": "selkie skin recipe known checker",
+    "description": "This is just for the Selkie Skin EOC to check whether or not you know the recipe. Will be replaced immediately if I find a better way to track this.",
+    "starting_trait": false,
+    "purifiable": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "FAIR_FOLK_COMMONER_SELKIE_SKIN_CRAFTED",
+    "points": 99,
+    "name": "selkie skin crafted crafted.",
+    "description": "this is just to track whether or not you've crafted the selkie skin recipe. will be replaced if I can find a more elegant solution.",
+    "starting_trait": false,
+    "purifiable": false,
+    "player_display": false
   }
 ]

--- a/data/mods/Xedra_Evolved/recipes/changeling/selkie.json
+++ b/data/mods/Xedra_Evolved/recipes/changeling/selkie.json
@@ -1,0 +1,24 @@
+[
+    {
+      "type": "recipe",
+      "activity_level": "LIGHT_EXERCISE",
+      "result": "selkie_skin",
+      "category": "CC_XEDRA",
+      "subcategory": "CSC_XEDRA_MISC",
+      "skill_used": "survival",
+      "difficulty": 0,
+      "time": "480 m",
+      "components": [ [ [ "scrap_dreamdross", 300 ] ] ],
+      "result_eocs": [
+        {
+          "id": "selkieforget",
+          "effect": [
+            { "u_forget_recipe": "selkie_skin" },
+            { "run_eocs": "selkiecheck" },
+            { "u_add_trait": "FAIR_FOLK_COMMONER_SELKIE_SKIN_CRAFTED" }
+          ]
+        }
+      ]
+    }
+  ]
+  


### PR DESCRIPTION


#### Summary
Mods "Add selkie skin held & worn effects."


#### Purpose of change

Adds selkie skin recipe & its held & worn effects as per #76602. 

#### Describe the solution

- [x] Add recipe. When you craft it, you lose the recipe.
- [x] Add held effects - 3x mana regen multiplier (maybe even higher when I add selkie storm spells & effects that enhance them while in weather conditions, idea's to have thunder spells that cost insanely high amounts of mana but selkies with their skin regenerate the mana so quickly it may as well not matter), 2x cardio multiplier, constant health increase. When it's not worn, you lose health and your mana regen gets cut. 
- [x] Add worn effects - Minor effects, swimming speed modifier.
- [ ] MAKE SURE WORN EFFECTS WORK - This is the big hitch right now. No idea why it's not working, I'll fix it later.

#### Describe alternatives you've considered

Keep selkies sad.
#### Testing

Recipe, held effects work. Worn effects do not, will fix when possible. 

#### Additional context

i like all of the species traits.
