### PR TITLE
Corrects recipe for water purifying

### DIFF
--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -98,7 +98,7 @@
     "charges": 4,
     "//": "See pur_tablets item definition for documentation and discussion",
     "autolearn": true,
-    "components": [ [ [ "water_murky", 1 ] ], [ [ "pur_tablets", 1 ] ] ]
+    "components": [ [ [ "water_murky", 4 ] ], [ [ "pur_tablets", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Bugfixes "Correct recipe for water purifying to use correct quantity of water"

#### Purpose of change
At present the recipe for purifying water using a water purification tablet requires only one water as a material but produces four. As such it quadruples the water used to craft it. This is relatively inconsistent with reality where water tends not to duplicate itself under standard lab conditions.

#### Describe the solution
The recipe has been corrected to take four water as materials and yield four water as product.

#### Describe alternatives you've considered
Considered adding recipes for 1, 2, and 3 water as input as well, but that seems like needless recipe bloat when having four water is a rather low hurdle.

#### Testing
Tried using the recipe, it took four water and yielded four water.
