### PR TITLE
eoc: clear deferred math on type errors too

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -609,12 +609,12 @@ void finalize_conditions()
         deferred_math &math = dfr.front();
         try {
             math.exp->parse( math.str, false );
+            math._validate_type();
         } catch( math::exception const &ex ) {
             JsonObject jo{ std::move( math.jo ) };
             clear_deferred_math();
             jo.throw_error_at( "math", ex.what() );
         }
-        math._validate_type();
         dfr.pop();
     }
 }
@@ -2483,10 +2483,10 @@ void deferred_math::_validate_type() const
 {
     math_type_t exp_type = exp->get_type();
     if( exp_type == math_type_t::assign && type != math_type_t::assign ) {
-        jo.throw_error_at( "math",
-                           R"(Assignment operators can't be used in this context.  Did you mean to use "=="? )" );
+        throw math::syntax_error(
+            R"(Assignment operators can't be used in this context.  Did you mean to use "=="? )" );
     } else if( exp_type != math_type_t::assign && type == math_type_t::assign ) {
-        jo.throw_error_at( "math", R"(Eval statement in assignment context has no effect)" );
+        throw math::syntax_error( R"(Eval statement in assignment context has no effect)" );
     }
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Deferred math still sticks in memory for a certain error so people can't fix their JSON without restarting the game
- Fixup for #77445

#### Describe the solution
Clear deferred math on type errors too

#### Describe alternatives you've considered
N/A

#### Testing
Add a return/comparison math statement as an EOC effect, or an assignment statement as a condition
Try to start a game and get an error
Without closing the game, fix the EOC and try again.

#### Additional context