### PR TITLE
[Innawoods] Fixes trails spawning manmade stuff

### DIFF
--- a/data/json/mapgen/trail.json
+++ b/data/json/mapgen/trail.json
@@ -3,6 +3,7 @@
     "type": "mapgen",
     "method": "json",
     "om_terrain": "forest_trail_end",
+    "weight": { "global_val": "vanilla_trail_intersection_weight", "default": 1000 },
     "object": {
       "fallback_predecessor_mapgen": "forest_thick",
       "place_nested": [
@@ -619,6 +620,7 @@
     "type": "mapgen",
     "method": "json",
     "om_terrain": "forest_trail_tee",
+    "weight": { "global_val": "vanilla_trail_intersection_weight", "default": 1000 },
     "object": {
       "fallback_predecessor_mapgen": "forest_thick",
       "place_nested": [
@@ -708,6 +710,7 @@
     "type": "mapgen",
     "method": "json",
     "om_terrain": "forest_trail_four_way",
+    "weight": { "global_val": "vanilla_trail_intersection_weight", "default": 1000 },
     "object": {
       "fallback_predecessor_mapgen": "forest_thick",
       "place_nested": [
@@ -793,6 +796,7 @@
     "type": "mapgen",
     "method": "json",
     "om_terrain": "forest_trail_intersection",
+    "weight": { "global_val": "vanilla_trail_intersection_weight", "default": 1000 },
     "//": "For placing the intersection as part of a special",
     "object": {
       "predecessor_mapgen": "forest_thick",

--- a/data/mods/innawood/mapgen/nested/forest_trail_nested.json
+++ b/data/mods/innawood/mapgen/nested/forest_trail_nested.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "24x24_forest_trail_intersection_inna",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "         4444444        ",
+        "       44333333344      ",
+        "      4332222222334     ",
+        "     432211111112234    ",
+        "    43211000000011234   ",
+        "    43210000000001234   ",
+        "   4321000000000001234  ",
+        "   4321000000000001234  ",
+        "   4321000000000001234  ",
+        "   4321000000000001234  ",
+        "   4321000000000001234  ",
+        "   4321000000000001234  ",
+        "   4321000000000001234  ",
+        "    43210000000001234   ",
+        "    43211000000011234   ",
+        "     432211111112234    ",
+        "      4332222222334     ",
+        "       44333333344      ",
+        "         4444444        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "trail_palette" ],
+      "place_nested": [
+        { "chunks": [ "9x9_forest_trail_intersection_north" ], "x": 8, "y": 0, "neighbors": { "north": "trail" } },
+        { "chunks": [ "9x9_forest_trail_intersection_east" ], "x": 18, "y": 8, "neighbors": { "east": "trail" } },
+        { "chunks": [ "9x9_forest_trail_intersection_south" ], "x": 8, "y": 18, "neighbors": { "south": "trail" } },
+        { "chunks": [ "9x9_forest_trail_intersection_west" ], "x": 0, "y": 8, "neighbors": { "west": "trail" } },
+        {
+          "chunks": [ "11x11_forest_trail_intersection_south_fire_lookout" ],
+          "x": 0,
+          "y": 13,
+          "neighbors": { "south": "ws_fire_lookout_tower_base" }
+        }
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  }
+]

--- a/data/mods/innawood/mapgen/trail.json
+++ b/data/mods/innawood/mapgen/trail.json
@@ -60,13 +60,7 @@
     "//": "For placing the intersection as part of a special",
     "object": {
       "predecessor_mapgen": "forest_thick",
-      "place_nested": [
-        {
-          "chunks": [ "24x24_forest_trail_intersection_inna" ],
-          "x": 0,
-          "y": 0
-        }
-      ]
+      "place_nested": [ { "chunks": [ "24x24_forest_trail_intersection_inna" ], "x": 0, "y": 0 } ]
     }
   }
 ]

--- a/data/mods/innawood/mapgen/trail.json
+++ b/data/mods/innawood/mapgen/trail.json
@@ -1,0 +1,72 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "forest_trail_end",
+    "object": {
+      "fallback_predecessor_mapgen": "forest_thick",
+      "place_nested": [
+        {
+          "chunks": [
+            [ "24x24_forest_trail_end_basic", 3 ],
+            [ "24x24_forest_trail_end_spread", 3 ],
+            [ "24x24_forest_trail_end_split", 3 ],
+            [ "24x24_forest_trail_intersection_inna", 1 ]
+          ],
+          "x": 0,
+          "y": 0
+        }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "forest_trail_tee",
+    "object": {
+      "fallback_predecessor_mapgen": "forest_thick",
+      "place_nested": [
+        {
+          "chunks": [
+            [ "24x24_forest_trail_tee_basic", 2 ],
+            [ "24x24_forest_trail_tee_split", 3 ],
+            [ "24x24_forest_trail_intersection_inna", 1 ]
+          ],
+          "x": 0,
+          "y": 0
+        }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "forest_trail_four_way",
+    "object": {
+      "fallback_predecessor_mapgen": "forest_thick",
+      "place_nested": [
+        {
+          "chunks": [ "24x24_forest_trail_four_way_basic", "24x24_forest_trail_four_way_high_low", "24x24_forest_trail_intersection_inna" ],
+          "x": 0,
+          "y": 0
+        }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "forest_trail_intersection",
+    "//": "For placing the intersection as part of a special",
+    "object": {
+      "predecessor_mapgen": "forest_thick",
+      "place_nested": [
+        {
+          "chunks": [ "24x24_forest_trail_intersection_inna" ],
+          "x": 0,
+          "y": 0
+        }
+      ]
+    }
+  }
+]

--- a/data/mods/innawood/mapgen_palettes/trail.json
+++ b/data/mods/innawood/mapgen_palettes/trail.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "palette",
+    "id": "trail_terrain_furniture_palette",
+    "palettes": [ "trail_path_palette" ],
+    "terrain": {
+      ".": "t_dirt",
+      "t": "t_trunk",
+      "n": "t_stump",
+      "m": "t_dirtmound",
+      "M": "t_moss",
+      ",": "t_forestfloor",
+      "u": "t_underbrush",
+      "f": "t_fungus_colony",
+      "F": "t_fern",
+      "G": [ [ "t_grass_long", 2 ], [ "t_grass_tall", 1 ] ],
+      "6": "t_region_tree_shade",
+      "7": [ "t_tree_dead", "t_tree_very_dead", "t_tree_dead_warped" ]
+    },
+    "furniture": { "_": [ [ "f_null", 17 ], [ "f_boulder_small", 1 ], [ "f_boulder_medium", 1 ], [ "f_boulder_large", 1 ] ] },
+    "nested": {
+      "B": { "chunks": [ "null", 3 ] },
+      "I": { "chunks": [ "null", 3 ] },
+      "T": { "chunks": [ [ "1x1_predecessor_tree", 2 ], [ "1x1_predecessor_groundcover", 1 ] ] },
+      "*": { "chunks": [ "1x1_predecessor_groundcover" ] },
+      "s": { "chunks": [ "1x1_predecessor_shrub" ] },
+      "S": { "chunks": [ [ "1x1_predecessor_groundcover", 2 ], [ "1x1_predecessor_shrub", 3 ] ] },
+      "_": { "chunks": [ [ "1x1_t_dirt", 1 ], [ "1x1_predecessor_groundcover", 3 ] ] },
+      "~": { "chunks": [ [ "1x1_t_mud", 6 ], [ "1x1_t_dirt", 1 ], [ "1x1_predecessor_groundcover", 1 ] ] }
+    }
+  }
+]

--- a/data/mods/innawood/vanilla_map_weight_eocs.json
+++ b/data/mods/innawood/vanilla_map_weight_eocs.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VANILLA_TRAIL_INTERSECTION_WEIGHT",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "effect": [ { "math": [ "vanilla_trail_intersection_weight = 0" ] } ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Innawoods - Fixes trails spawning manmade stuff"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Trails in Innawoods were spawning things like map boards, signs, benches, ect. As indicated by the Innawoods readme.md, having man-made objects present is not within the design goals of the mod.
Here are the precise issues addressed:

- Some segments of forest trails were spawning map boards and signs.
- Some variations of 24x24 trail intersections (which are also called for trail endings, not just intersections) were spawning nests with furniture such as benches, horse posts, a tiny wooden shed with supplies in it, and a fire ring.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
For the parts of the forest trails that were spawning map boards and signs, I simply overwrote the vanilla game's trail palette and removed any nest spawns for man-made objects, using null instead.

The problem with trail intersections required using the solution that aftershock: exoplanet and desert region used to control roads, bridges and lakes spawning:

1. In the base game, assigns a weight global variable to all vanilla trails that include the offending 24x24 intersection in their list for potential chunk spawns with a value of 1000.
2. Creates an EoC in Innawoods that fires at game start that reduces this global variable to 0.
3. Replacement mapgen files within the innawoods mod are then used in lieu of the vanilla mapgen files that were disabled by this EoC.
4. These replacement mapgen files use a modded innawoods-specific variant of the intersection that do not include the man-made objects.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Assigning the global variable to all the individual segments of vanilla trails. I didn't do this because then I would be required to include replacement mapgen for all of those affected trails. I decided that this would be unnecessary, so I kept the weight global variables specific to the parts of trails that were causing issues.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

INNAWOODS:
![image](https://github.com/user-attachments/assets/0d5e90d9-6c69-484d-a0f1-3efaeabc56bc)
The intersections (the big round dirt patches) are no longer spawning furniture, and the other trail segments aren't spawning signs/ect.

VANILLA:
![image](https://github.com/user-attachments/assets/240c2d6c-80bf-4b38-aeae-f75097815333)
The base game is unaffected. Intersections retain the potential to spawn man-made furniture and other trail segments are correctly spawning their signs and map boards.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
