### PR TITLE
fix: color tags texts drawn in item info

### DIFF
--- a/src/text.cpp
+++ b/src/text.cpp
@@ -223,16 +223,16 @@ static void TextEx( const std::string_view str, float wrap_width, uint32_t color
             // a paragraph, undo just that small extra spacing.
             ImGui::GetCurrentWindow()->DC.CursorPos.y -= ImGui::GetStyle().ItemSpacing.y;
             drawEnd = Font->CalcWordWrapPositionA( 1.0f, textStart, textEnd, widthRemaining );
-        }
-
-        if( color ) {
-            ImGui::PushStyleColor( ImGuiCol_Text, color );
-        }
-        ImGui::TextUnformatted( textStart, textStart == drawEnd ? nullptr : drawEnd );
-        // see above
-        ImGui::GetCurrentWindow()->DC.CursorPos.y -= ImGui::GetStyle().ItemSpacing.y;
-        if( color ) {
-            ImGui::PopStyleColor();
+        } else {
+            if( color ) {
+                ImGui::PushStyleColor( ImGuiCol_Text, color );
+            }
+            ImGui::TextUnformatted( textStart, textStart == drawEnd ? nullptr : drawEnd );
+            // see above
+            ImGui::GetCurrentWindow()->DC.CursorPos.y -= ImGui::GetStyle().ItemSpacing.y;
+            if( color ) {
+                ImGui::PopStyleColor();
+            }
         }
 
         if( textStart == drawEnd || drawEnd == textEnd ) {


### PR DESCRIPTION
#### Summary
Bugfixes "color tags texts drawn in item info"

#### Purpose of change

 - Fixes #77744
 - Fixes #78601
 - Fixes #78738

Item info colour tags would render if they are the first character after a line wrap.

The bug also needed the window to be sufficiently high. That is why it is reproducible in `(` disassembly menu.

#### Describe the solution

Don't draw the text when `textStart == drawEnd`. When the text starts with a color tag, `textStart == drawEnd` is true.

I don't really get the code. @db48x, as the author of that code, could you check if my change makes sense?

#### Describe alternatives you've considered

Waiting for somebody else. This took way too long.

#### Testing

 - Did reproduce #78738 before, didn't after.
 - I didn't reproduce #78601 after. #77744 is the same issue.
 - I opened some ImGui windows looking for what I could have broken. Didn't find anything.

#### Additional context

