### PR TITLE
Revert the comestible safety check 

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5700,11 +5700,6 @@ void effect_on_conditons_actor::info( const item &, std::vector<iteminfo> &dump 
 std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
         const tripoint_bub_ms &point ) const
 {
-    if( it.type->comestible ) {
-        debugmsg( "Comestibles are not properly consumed via effect_on_conditions and effect_on_conditions should not be used on items of type comestible until/unless this is resolved." );
-        return 0;
-    }
-
     if( need_worn && !p->is_worn( it ) ) {
         p->add_msg_if_player( m_info, _( "You need to wear the %1$s before activating it." ), it.tname() );
         return std::nullopt;


### PR DESCRIPTION
#### Summary
Bugfixes "Fixed consuming EoC comestibles from mods"

#### Purpose of change
#78684 added a safety check aimed to prevent infinite-consumable bugs from reoccuring (until the core issue is fixed some other way).

Unfortunately, it turned out that mods do rely on that code path (specifically, any consumables therein that get their effect via EoC), and the "infinite consumables" is a lesser evil than "consumables literally unusable"
This is an alternative to the full revert of #78781

#### Describe the solution
Remove the branch.

#### Describe alternatives you've considered

Full revert, as in #78781 - would break chamomile tea needlessly

Fixing the core problem of EoCs not working well with consumables - I'm not very interested in doing that myself.  This PR is a "short term" fix.

#### Testing

Spawned blood of saints, cubic goblin fruit and pink crystalline elixir, put them on the nearby table, then ate all three.
Got some statuses from Blood of Saints and Pink elixir, no idea what they do, but they seem to work. No debugmsg stopping the use.
Goblinfruit didn't seem to do anything, but perhaps that's intentional (perhaps it was the wrong fruit? I don't know MoM)
![20241226-215154-cataclysm-tiles](https://github.com/user-attachments/assets/421ee5fb-42ad-4fe8-984a-837c42446102)

Blood of Saints and Pink elixir were left on the table after consumption, as expected (albeit not intended)

#### Additional context

Perhaps someone wants to file an issue about EoC consumables not being consumed, for mod purposes. Or reopen one of the PRs closed by #78684 