### PR TITLE
Make clang-tidy diagnostics on windows a tad more manageable

### DIFF
--- a/src/cata_assert.h
+++ b/src/cata_assert.h
@@ -28,7 +28,7 @@
         if( expression ) { \
             break; \
         } \
-        fprintf( stderr, "%s at %s:%d: Assertion `%s` failed.\n", __func__, __FILE__, __LINE__, #expression ); \
+        (void) fprintf( stderr, "%s at %s:%d: Assertion `%s` failed.\n", __func__, __FILE__, __LINE__, #expression ); \
         std::abort(); \
     } while( false )
 #else

--- a/src/debug.h
+++ b/src/debug.h
@@ -66,7 +66,7 @@
  * a printf style format string.
  */
 
-#define debugmsg(...) realDebugmsg(__FILE__, STRING(__LINE__), CATA_FUNCTION_NAME, __VA_ARGS__)
+#define debugmsg(...) realDebugmsg(__FILE__, STRING(__LINE__), CATA_FUNCTION_NAME, __VA_ARGS__) // NOLINT(bugprone-lambda-function-name)
 
 // Don't use this, use debugmsg instead.
 void realDebugmsg( const char *filename, const char *line, const char *funcname,


### PR DESCRIPTION
#### Summary
Infrastructure "clang-tidy output is a bit more readable on windows"

#### Purpose of change

clang-tidy is a great tool. It works on windows (it works on Linux and WSL too of course, but it also works on windows natively). Sadly, the windows output is full of spam to the point of being unusable.
This PR fixes two big causes of said spam (with the third remaining still, for another time)

#### Describe the solution

1) `cata_assert()` is a common macro that invokes `fprintf(stderr)`. clang-tidy is upset that the return value of fprintf is never used ([cert-err33-c](https://clang.llvm.org/extra/clang-tidy/checks/cert/err33-c.html)), but there's no meaningful way to use it here. So I silence it by casting the return value to `void`, as suggested. 
<details>
<summary>(Sample error)</summary>

```cpp
.\src\activity_actor.cpp:1123:25: error: the value returned by this function should be used [cert-err33-c,-warnings-as-errors]
 1123 |                         cata_assert( quality_s.size() == 1 );
      |                         ^
.\src/cata_assert.h:31:9: note: expanded from macro 'cata_assert'
   31 |         fprintf( stderr, "%s at %s:%d: Assertion `%s` failed.\n", __func__, __FILE__, __LINE__, #expression ); \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.\src\activity_actor.cpp:1123:25: note: cast the expression to void to silence this warning
 1123 |                         cata_assert( quality_s.size() == 1 );
      |                         ^
.\src/cata_assert.h:31:9: note: expanded from macro 'cata_assert'
   31 |         fprintf( stderr, "%s at %s:%d: Assertion `%s` failed.\n", __func__, __FILE__, __LINE__, #expression ); \
```
</details>

2) `debugmsg` internally uses `__func__` ~~macro~~ built-in on windows, which, apparently, does not work well in lambdas ([bugprone-lambda-function-name](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/lambda-function-name.html)). It is unfortunate, but the alternative is explicitly specifying the function name each time `debugmsg` is called, and that sounds worse.
We still get the file and line number, and we still have the error message, so it's rather trivial to track down the function in practice.
So, silencing this diagnostic via same-line `// NOLINT(bugprone-lambda-function-name)`. Sample error (note that this is emitted for *every* debugmsg call in the file):

<details>
<summary>(Sample error)</summary>
```cpp
.\src\achievement.cpp:364:9: error: inside a lambda, '__func__' expands to the name of the function call operator; consider capturing the name of the enclosing function explicitly [bugprone-lambda-function-name,-warnings-as-errors]
  364 |         cata_fatal( "Invalid epoch" );
      |         ^
.\src/debug.h:85:9: note: expanded from macro 'cata_fatal'
   85 |         debugmsg(__VA_ARGS__); \
      |         ^
.\src/debug.h:69:64: note: expanded from macro 'debugmsg'
   69 | #define debugmsg(...) realDebugmsg(__FILE__, STRING(__LINE__), CATA_FUNCTION_NAME, __VA_ARGS__)
      |                                                                ^
.\src/debug.h:60:28: note: expanded from macro 'CATA_FUNCTION_NAME'
   60 | #define CATA_FUNCTION_NAME __func__
```
</details>

#### Describe alternatives you've considered

N/A

#### Testing

clang-tidy no longer complains about those.
Game seems to compile and run fine.

#### Additional context

The third big cause of clang-tidy spam is the exception-safety of move constructors.

<details>
<summary>Her's an example of `action.cpp` analysis:</summary>

```cpp
H:/work/github/cdda/cata-3/src/creature.h:1262:43: error: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor,-warnings-as-errors]
 1262 |         Creature( Creature && ) noexcept( map_is_noexcept );
      |                                           ^
H:/work/github/cdda/cata-3/src\monster.h:93:41: error: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor,-warnings-as-errors]
   93 |         monster( monster && ) noexcept( map_is_noexcept );
      |                                         ^
H:\work\github\cdda\cata-3\src/character.h:330:5: error: an exception may be thrown in function 'queued_eocs' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
  330 |     queued_eocs( queued_eocs &&rhs ) noexcept {
      |     ^
H:\work\github\cdda\cata-3\src/character.h:3887:45: error: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor,-warnings-as-errors]
 3887 |         Character( Character && ) noexcept( map_is_noexcept );
      |                                             ^
H:\work\github\cdda\cata-3\src/clzones.h:578:9: error: move constructors should be marked noexcept [performance-noexcept-move-constructor,-warnings-as-errors]
  578 |         zone_manager( zone_manager && ) = default;
      |         ^
      |                                          noexcept 
H:\work\github\cdda\cata-3\src/input_enums.h:63:8: error: an exception may be thrown in function 'input_event' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
   63 | struct input_event {
      |        ^
H:\work\github\cdda\cata-3\src/json.h:1062:9: error: move constructors should be marked noexcept [performance-noexcept-move-constructor,-warnings-as-errors]
 1062 |         TextJsonObject( TextJsonObject && ) = default;
      |         ^
      |                                              noexcept 
H:\work\github\cdda\cata-3\src/stomach.h:36:8: error: an exception may be thrown in function 'nutrients' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
   36 | struct nutrients {
      |        ^
H:\work\github\cdda\cata-3\src/ui.h:63:8: error: an exception may be thrown in function 'uilist_entry' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
   63 | struct uilist_entry {
      |        ^

```

</details>

We already try to do the right thing by marking move constructors `noexcept (map_is_noexcept)`, but
1) not all of them are marked
2) sometimes the markings are wrong 
3) clang-tidy *still* complains about it if `map_is_noexcept` evaluates to false ([performance-noexcept-move-constructor](https://clang.llvm.org/extra/clang-tidy/checks/performance/noexcept-move-constructor.html))
4) sometimes it doesn't complain about exception safety when it is in fact violated.

It's a bit tangled, and I'm not sure I can fully solve it quickly, so limiting scope-creep for now.