### PR TITLE
Items in transparent pockets on the map illuminate surroundings

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10248,7 +10248,21 @@ bool item::is_funnel_container( units::volume &bigger_than ) const
 
 bool item::is_emissive() const
 {
-    return light.luminance > 0 || type->light_emission > 0;
+    if( light.luminance > 0 || type->light_emission > 0 ) {
+        return true;
+    }
+
+    for( const item_pocket *pkt : get_all_contained_pockets() ) {
+        if( pkt->transparent() ) {
+            for( const item *it : pkt->all_items_top() ) {
+                if( it->is_emissive() ) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
 }
 
 bool item::is_deployable() const

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -68,19 +68,32 @@ std::string four_quadrants::to_string() const
                           ( *this )[quadrant::SW], ( *this )[quadrant::NW] );
 }
 
+void map::add_item_light_recursive( const tripoint_bub_ms &p, const item &it )
+{
+    float ilum = 0.0f; // brightness
+    units::angle iwidth = 0_degrees; // 0-360 degrees. 0 is a circular light_source
+    units::angle idir = 0_degrees;   // otherwise, it's a light_arc pointed in this direction
+    if( it.getlight( ilum, iwidth, idir ) ) {
+        if( iwidth > 0_degrees ) {
+            apply_light_arc( p, idir, ilum, iwidth );
+        } else {
+            add_light_source( p, ilum );
+        }
+    }
+
+    for( const item_pocket *pkt : it.get_all_contained_pockets() ) {
+        if( pkt->transparent() ) {
+            for( const item *cont : pkt->all_items_top() ) {
+                add_item_light_recursive( p, *cont );
+            }
+        }
+    }
+}
+
 void map::add_light_from_items( const tripoint_bub_ms &p, const item_stack &items )
 {
     for( const item &it : items ) {
-        float ilum = 0.0f; // brightness
-        units::angle iwidth = 0_degrees; // 0-360 degrees. 0 is a circular light_source
-        units::angle idir = 0_degrees;   // otherwise, it's a light_arc pointed in this direction
-        if( it.getlight( ilum, iwidth, idir ) ) {
-            if( iwidth > 0_degrees ) {
-                apply_light_arc( p, idir, ilum, iwidth );
-            } else {
-                add_light_source( p, ilum );
-            }
-        }
+        add_item_light_recursive( p, it );
     }
 }
 

--- a/src/map.h
+++ b/src/map.h
@@ -2397,6 +2397,7 @@ class map
         void apply_light_ray( cata::mdarray<bool, point_bub_ms, MAPSIZE_X, MAPSIZE_Y> &lit,
                               const tripoint &s, const tripoint &e, float luminance );
         void add_light_from_items( const tripoint_bub_ms &p, const item_stack &items );
+        void add_item_light_recursive( const tripoint_bub_ms &p, const item &it );
         std::unique_ptr<vehicle> add_vehicle_to_map( std::unique_ptr<vehicle> veh, bool merge_wrecks );
 
         // Internal methods used to bash just the selected features


### PR DESCRIPTION
#### Summary
Bugfixes "Items in transparent pockets on the map illuminate surroundings"

#### Purpose of change

Currently only top level items on the map are considered as light sources. This excludes for example candles in candle sticks.

#### Describe the solution

Map items also check contents of transparent pockets for light sources.
Straight up cherry-picked from #67595, only fixed conflicts from typed tripoints.

#### Describe alternatives you've considered

Do the work again and still end up with the same solution?

#### Testing

Put candle in candlestick and place on floor.

#### Additional context
