### PR TITLE
Fix EOC vitamin evaluation for items

### DIFF
--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1666,8 +1666,10 @@ diag_eval_dbl_f vitamin_eval( char scope, std::vector<diag_value> const &params,
             return chr->vitamin_get( vitamin_id( id.str( d ) ) );
         }
         if( item_location const *const itm = actor->get_const_item(); itm != nullptr ) {
-            const nutrients &nutrient_data = default_character_compute_effective_nutrients( *itm->get_item() );
-            return static_cast<int>( nutrient_data.vitamins().count( vitamin_id( id.str( d ) ) ) );
+            const std::map<vitamin_id, int> &vitamin_data =
+                default_character_compute_effective_nutrients( *itm->get_item() ).vitamins();
+            const auto &v = vitamin_data.find( vitamin_id( id.str( d ) ) );
+            return v != vitamin_data.end() ? v->second : 0;
         }
         throw math::runtime_error( "Tried to access vitamins of a non-Character/non-item talker" );
     };


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #77981

#### Describe the solution
Properly return the vitamin's stored value, rather than `1` or `0`. std::map::count was NOT the right thing to use here.

#### Describe alternatives you've considered
std::map::at (This is not a serious suggestion)

A better approach might be to use talker overloads so that we can just call `actor->get_vitamin(vitamin_name)` and it sorts out whether the actor is an item (check the computed nutrients), a creature/other unsupported actor (always 0), or a character (check their stored value).

#### Testing
I tested it sometime around when I posted it, I believe. I did not recompile and test for this PR, but I realized it hadn't gotten fixed. So here I am, opening the PR.

#### Additional context
