### PR TITLE
Don't truncate allergy vitamins out of existence

### DIFF
--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -216,8 +216,12 @@ nutrients &nutrients::operator*=( double r )
     calories *= r;
     for( const std::pair<const vitamin_id, std::variant<int, vitamin_units::mass>> &vit : vitamins_ ) {
         std::variant<int, vitamin_units::mass> &here = vitamins_[vit.first];
-        // Note well: This truncates the result!
-        here = static_cast<int>( std::get<int>( here ) * r );
+        cata_assert( std::get<int>( here ) >= 0 );
+        if( std::get<int>( here ) == 0 ) {
+            continue;
+        }
+        // truncates, but always keep at least 1 (for e.g. allergies)
+        here = std::max( static_cast<int>( std::get<int>( here ) * r ), 1 );
     }
     return *this;
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/77825#issuecomment-2481582960
![image](https://github.com/user-attachments/assets/0a481f4e-8597-465f-9bbb-bec1b04bbe65)


#### Describe the solution
Basically camps were doing `1 * some_double_less_than_one` and always receiving `0`, because we truncated to integer. The truncation was intended, but this scenario was not anticipated when I wrote the operator, because we didn't *have* allergies as vitamins.

So now the `*=` operator (double overload) always keeps at least 1 of existing vitamins, instead of fully truncating. For results greater than 1 (e.g. 1.1, or 62.7, or other numbers) it still truncates normally. The only reason for this is make sure we don't truncate allergies out of existence.

This may *slightly* skew the resulting math, but only to a negligible degree.

This does not support being called on negative vitamin values, which are technically possible (via stored character values). The operator is only currently called for faction camps distributing food items, where I added it.

Because the math produced would be VERY, VERY wrong if negative values are used, I added an assertion that the stored value is not negative. The game will crash, loudly and pointedly, which should be sufficient to warn any C++ contributor who might use it in the future without considering this.

#### Describe alternatives you've considered
Require some minimum amount of allergy vitamin to avoid this pitfall, but that just papers over the problem. Besides we'll get more good PRs like #75918 (by @PatrikLundell ) who run into **our** bad math. Asking everyone to dodge around our bad math is not a solution.

Only keep 1 if the vitamin type is actually an allergy? We don't have such a clearly defined `vit_type` at the moment...

#### Testing
Math checks out, I've gone over it several times.
I did not compile this branch.

#### Additional context
