### PR TITLE
typified stuff

### DIFF
--- a/src/action.h
+++ b/src/action.h
@@ -531,11 +531,7 @@ std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &messa
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
-// TODO: Get rid of untyped version and change name of typed one.
-std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
-        const std::string &failure_message, action_id action,
-        bool allow_vertical = false, bool allow_autoselect = true );
-std::optional<tripoint_bub_ms> choose_adjacent_highlight_bub_ms( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
         const std::string &failure_message, action_id action,
         bool allow_vertical = false, bool allow_autoselect = true );
 
@@ -556,16 +552,8 @@ std::optional<tripoint_bub_ms> choose_adjacent_highlight_bub_ms( const std::stri
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
-// TODO: Get rid of untyped overload.
-std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
-        const std::string &failure_message, const std::function<bool( const tripoint & )> &allowed,
-        bool allow_vertical = false, bool allow_autoselect = true );
 std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
-        bool allow_vertical = false, bool allow_autoselect = true );
-// TODO: Get rid of untyped overload.
-std::optional<tripoint> choose_adjacent_highlight( const tripoint &pos, const std::string &message,
-        const std::string &failure_message, const std::function<bool( const tripoint & )> &allowed,
         bool allow_vertical = false, bool allow_autoselect = true );
 std::optional<tripoint_bub_ms> choose_adjacent_highlight( const tripoint_bub_ms &pos,
         const std::string &message,

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1632,7 +1632,7 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
         liquid.charges = std::min( charges_per_second, liquid.charges );
         const int original_charges = liquid.charges;
         if( liquid.has_temperature() && units::to_joule_per_gram( liquid.specific_energy ) < 0 ) {
-            liquid.set_item_temperature( std::max( get_weather().get_temperature( you->pos() ),
+            liquid.set_item_temperature( std::max( get_weather().get_temperature( you->pos_bub() ),
                                                    temperatures::cold ) );
         }
 

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -173,7 +173,7 @@ static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
 
         const trap &tr = here.tr_at( pt );
         if( tr.triggered_by_item( dropped_item ) ) {
-            tr.trigger( pt.raw(), dropped_item );
+            tr.trigger( pt, dropped_item );
         }
     }
 }
@@ -314,7 +314,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg,
 
         if( first ) {
             sfx::play_variant_sound( "bullet_hit", "hit_wall", sfx::get_heard_volume( target ),
-                                     sfx::get_heard_angle( target.raw() ) );
+                                     sfx::get_heard_angle( target ) );
         }
         // TODO: Z dispersion
     }
@@ -554,7 +554,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg,
             z.add_effect( effect_bounced, 1_turns );
             projectile_attack( proj, tp, z.pos_bub(), dispersion, origin, in_veh );
             sfx::play_variant_sound( "fire_gun", "bio_lightning_tail",
-                                     sfx::get_heard_volume( z.pos_bub() ), sfx::get_heard_angle( z.pos() ) );
+                                     sfx::get_heard_volume( z.pos_bub() ), sfx::get_heard_angle( z.pos_bub() ) );
         }
     }
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -710,7 +710,7 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
             if( is_armed() ) {
                 stow_item( *weapon );
             }
-            add_msg_if_player_sees( pos(), m_info, _( "%s activates their %s." ),
+            add_msg_if_player_sees( pos_bub(), m_info, _( "%s activates their %s." ),
                                     disp_name(), bio.info().name );
 
             set_wielded_item( cbm_weapon );
@@ -1068,7 +1068,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         const oter_id &cur_om_ter = overmap_buffer.ter( global_omt_location() );
         /* cache g->get_temperature( player location ) since it is used twice. No reason to recalc */
         weather_manager &weather = get_weather();
-        const units::temperature player_local_temp = weather.get_temperature( player_character.pos() );
+        const units::temperature player_local_temp = weather.get_temperature( player_character.pos_bub() );
         const int windpower = get_local_windpower( weather.windspeed + vehwindspeed,
                               cur_om_ter, get_location(), weather.winddirection, g->is_sheltered( pos_bub() ) );
         add_msg_if_player( m_info, _( "Temperature: %s." ), print_temperature( player_local_temp ) );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -440,13 +440,13 @@ class cata_tiles
         }
 
         /** Draw to screen */
-        void draw( const point &dest, const tripoint &center, int width, int height,
+        void draw( const point &dest, const tripoint_bub_ms &center, int width, int height,
                    std::multimap<point, formatted_text> &overlay_strings,
                    color_block_overlay_container &color_blocks );
         void draw_om( const point &dest, const tripoint_abs_omt &center_abs_omt, bool blink );
 
         /** Minimap functionality */
-        void draw_minimap( const point &dest, const tripoint &center, int width, int height );
+        void draw_minimap( const point &dest, const tripoint_bub_ms &center, int width, int height );
 
     protected:
         /** How many rows and columns of tiles fit into given dimensions, fully
@@ -555,45 +555,45 @@ class cata_tiles
 
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;
-        bool apply_vision_effects( const tripoint &pos, visibility_type visibility, int &height_3d );
+        bool apply_vision_effects( const tripoint_bub_ms &pos, visibility_type visibility, int &height_3d );
         void draw_square_below( const point &p, const nc_color &col, int sizefactor );
-        bool draw_terrain( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_terrain( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                            const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_terrain_below( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_terrain_below( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_furniture( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_furniture( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                              const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_graffiti( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_graffiti( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                             const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_trap( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_trap( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                         const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_part_con( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_part_con( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                             const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_field_or_item( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_field_or_item( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                          const std::array<bool, 5> &invisible, bool roof, bool memorize_only );
-        bool draw_vpart_no_roof( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_vpart_no_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_vpart_roof( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_vpart_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                               const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_vpart_below( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_vpart_below( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_critter_at( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                               const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_critter_at_below( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_critter_at_below( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                     const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_critter_above( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible );
-        bool draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_zone_mark( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                              const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_zombie_revival_indicators( const tripoint &pos, lit_level ll, int &height_3d,
+        bool draw_zombie_revival_indicators( const tripoint_bub_ms &pos, lit_level ll, int &height_3d,
                                              const std::array<bool, 5> &invisible, bool memorize_only );
-        void draw_zlevel_overlay( const tripoint &p, lit_level ll, int &height_3d );
-        void draw_entity_with_overlays( const Character &ch, const tripoint &p, lit_level ll,
+        void draw_zlevel_overlay( const tripoint_bub_ms &p, lit_level ll, int &height_3d );
+        void draw_entity_with_overlays( const Character &ch, const tripoint_bub_ms &p, lit_level ll,
                                         int &height_3d );
 
-        bool draw_item_highlight( const tripoint &pos, int &height_3d );
+        bool draw_item_highlight( const tripoint_bub_ms &pos, int &height_3d );
 
     public:
         // Animation layers
@@ -613,7 +613,7 @@ class cata_tiles
         void draw_hit_frame();
         void void_hit();
 
-        void draw_footsteps_frame( const tripoint &center );
+        void draw_footsteps_frame( const tripoint_bub_ms &center );
 
         // pseudo-animated layer, not really though.
         void init_draw_line( const tripoint_bub_ms &p, std::vector<tripoint_bub_ms> trajectory,
@@ -679,7 +679,7 @@ class cata_tiles
                                          bool more, Creature::Attitude att );
         void void_monster_override();
 
-        bool has_draw_override( const tripoint &p ) const;
+        bool has_draw_override( const tripoint_bub_ms &p ) const;
 
         void set_disable_occlusion( bool val );
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5261,7 +5261,7 @@ needs_rates Character::calc_needs_rates() const
     if( has_trait( trait_TRANSPIRATION ) ) {
         // Transpiration, the act of moving nutrients with evaporating water, can take a very heavy toll on your thirst when it's really hot.
         rates.thirst *= ( ( units::to_fahrenheit( get_weather().get_temperature(
-                                pos() ) ) - 32.5f ) / 40.0f );
+                                pos_bub() ) ) - 32.5f ) / 40.0f );
     }
 
     rates.hunger = enchantment_cache->modify_value( enchant_vals::mod::HUNGER, rates.hunger );
@@ -12910,7 +12910,7 @@ void Character::search_surroundings()
             continue;
         }
         // Chance to detect traps we haven't yet seen.
-        if( tr.detect_trap( tp.raw(), *this ) ) {
+        if( tr.detect_trap( tp, *this ) ) {
             if( !tr.is_trivial_to_spot() ) {
                 // Only bug player about traps that aren't trivial to spot.
                 const std::string direction = direction_name(

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -426,7 +426,7 @@ void Character::update_bodytemp()
     }
     weather_manager &weather_man = get_weather();
     /* Cache calls to g->get_temperature( player position ), used in several places in function */
-    const units::temperature player_local_temp = weather_man.get_temperature( pos() );
+    const units::temperature player_local_temp = weather_man.get_temperature( pos_bub() );
     const w_point weather = *weather_man.weather_precise;
     int vehwindspeed = 0;
     map &here = get_map();
@@ -849,7 +849,7 @@ void Character::update_frostbite( const bodypart_id &bp, const int FBwindPower,
     Less than -35F, more than 10 mp
     **/
 
-    const float player_local_temp = units::to_fahrenheit( get_weather().get_temperature( pos() ) );
+    const float player_local_temp = units::to_fahrenheit( get_weather().get_temperature( pos_bub() ) );
     const units::temperature temp_after = get_part_temp_cur( bp );
 
     if( bp == body_part_mouth || bp == body_part_foot_r ||
@@ -1368,7 +1368,7 @@ void Character::update_heartrate_index()
     // The following code was adapted from the heartrate function, which will now probably need to be rewritten to be based on the heartrate index.
 
     //COLDBLOOD dependencies, works almost same way as temperature effect for speed.
-    const float player_local_temp = units::to_fahrenheit( get_weather().get_temperature( pos() ) );
+    const float player_local_temp = units::to_fahrenheit( get_weather().get_temperature( pos_bub() ) );
     float temperature_modifier = 0.0f;
     if( has_flag( json_flag_COLDBLOOD ) ) {
         temperature_modifier = 0.002f;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2121,11 +2121,11 @@ void construct::do_turn_deconstruct( const tripoint_bub_ms &p, Character &who )
 void construct::do_turn_shovel( const tripoint_bub_ms &p, Character &who )
 {
     // TODO: fix point types
-    sfx::play_activity_sound( "tool", "shovel", sfx::get_heard_volume( p.raw() ) );
+    sfx::play_activity_sound( "tool", "shovel", sfx::get_heard_volume( p ) );
     if( calendar::once_every( 1_minutes ) ) {
         // TODO: fix point types
         //~ Sound of a shovel digging a pit at work!
-        sounds::sound( p.raw(), 10, sounds::sound_t::activity, _( "hsh!" ) );
+        sounds::sound( p, 10, sounds::sound_t::activity, _( "hsh!" ) );
     }
     if( !who.knows_trap( p ) ) {
         get_map().maybe_trigger_trap( p, who, true );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -143,7 +143,7 @@ void craft_command::execute( bool only_cache_comps )
 
     bool need_selections = true;
     inventory map_inv;
-    map_inv.form_from_map( crafter->pos(), PICKUP_RANGE, crafter );
+    map_inv.form_from_map( crafter->pos_bub(), PICKUP_RANGE, crafter );
 
     if( has_cached_selections() ) {
         std::vector<comp_selection<item_comp>> missing_items = check_item_components_missing( map_inv );
@@ -455,7 +455,7 @@ item craft_command::create_in_progress_craft()
     }
 
     inventory map_inv;
-    map_inv.form_from_map( crafter->pos(), PICKUP_RANGE, crafter );
+    map_inv.form_from_map( crafter->pos_bub(), PICKUP_RANGE, crafter );
 
     if( !check_item_components_missing( map_inv ).empty() ) {
         debugmsg( "Aborting crafting: couldn't find cached components" );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -133,7 +133,7 @@ static bool crafting_allowed( const Character &p, const recipe &rec )
         if( p.is_avatar() ) {
             add_msg( m_info, _( "Your morale is too low to craft such a difficult thing…" ) );
         } else {
-            add_msg_if_player_sees( p.pos(), m_info,
+            add_msg_if_player_sees( p.pos_bub(), m_info,
                                     _( "%s's morale is too low to craft such a difficult thing…" ),
                                     p.get_name() );
         }
@@ -144,7 +144,7 @@ static bool crafting_allowed( const Character &p, const recipe &rec )
         if( p.is_avatar() ) {
             add_msg( m_info, _( "You can't see to craft!" ) );
         } else {
-            add_msg_if_player_sees( p.pos(), m_info, _( "%s can't see to craft!" ),
+            add_msg_if_player_sees( p.pos_bub(), m_info, _( "%s can't see to craft!" ),
                                     p.get_name() );
         }
         return false;
@@ -653,7 +653,7 @@ const inventory &Character::crafting_inventory( const tripoint_bub_ms &src_pos, 
     }
     crafting_cache.crafting_inventory->clear();
     if( radius >= 0 ) {
-        crafting_cache.crafting_inventory->form_from_map( inv_pos.raw(), radius, this, false, clear_path );
+        crafting_cache.crafting_inventory->form_from_map( inv_pos, radius, this, false, clear_path );
     }
 
     std::map<itype_id, int> tmp_liq_list;
@@ -997,14 +997,14 @@ bool Character::craft_skill_gain( const item &craft, const int &num_practice_tic
                 if( is_avatar() ) {
                     add_msg( m_info, _( "%s assists with crafting…" ), helper->get_name() );
                 } else {
-                    add_msg_if_player_sees( pos(), m_info, _( "%s assists with crafting…" ), helper->get_name() );
+                    add_msg_if_player_sees( pos_bub(), m_info, _( "%s assists with crafting…" ), helper->get_name() );
                 }
             }
             if( batch_size == 1 && one_in( 300 ) ) {
                 if( is_avatar() ) {
                     add_msg( m_info, _( "%s could assist you with a batch…" ), helper->get_name() );
                 } else {
-                    add_msg_if_player_sees( pos(), m_info, _( "%1s could assist %2s with a batch…" ),
+                    add_msg_if_player_sees( pos_bub(), m_info, _( "%1s could assist %2s with a batch…" ),
                                             helper->get_name(), get_name() );
                 }
             }
@@ -1015,7 +1015,7 @@ bool Character::craft_skill_gain( const item &craft, const int &num_practice_tic
                 if( is_avatar() ) {
                     add_msg( m_info, _( "%s watches you craft…" ), helper->get_name() );
                 } else {
-                    add_msg_if_player_sees( pos(), m_info, _( "%1s watches %2s crafts…" ), helper->get_name(),
+                    add_msg_if_player_sees( pos_bub(), m_info, _( "%1s watches %2s crafts…" ), helper->get_name(),
                                             get_name() );
                 }
             }
@@ -1544,7 +1544,7 @@ void Character::complete_craft( item &craft, const std::optional<tripoint_bub_ms
                     add_msg( m_good, _( "You memorized the recipe for %s!" ),
                              making.result_name() );
                 } else {
-                    add_msg_if_player_sees( pos(), m_good, _( "%1s memorized the recipe for %2s!" ),
+                    add_msg_if_player_sees( pos_bub(), m_good, _( "%1s memorized the recipe for %2s!" ),
                                             get_name(), making.result_name() );
                 }
             }
@@ -1641,7 +1641,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
         }
 
         inventory map_inv;
-        map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+        map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
 
         auto filter = [&]( const item & it ) {
             return std_filter( it ) &&
@@ -1659,7 +1659,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
                 if( this->is_avatar() ) {
                     add_msg( _( "You stop crafting." ) );
                 } else {
-                    add_msg_if_player_sees( pos(), _( "%s stops crafting." ), get_name() );
+                    add_msg_if_player_sees( pos_bub(), _( "%s stops crafting." ), get_name() );
                 }
                 return false;
             }
@@ -1709,7 +1709,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
         }
 
         inventory map_inv;
-        map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+        map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
 
         std::vector<comp_selection<tool_comp>> new_tool_selections;
         for( const std::vector<tool_comp> &alternatives : tool_reqs ) {
@@ -2171,7 +2171,7 @@ std::list<item> Character::consume_items( const std::vector<item_comp> &componen
         const std::function<bool( const itype_id & )> &select_ind )
 {
     inventory map_inv;
-    map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
     comp_selection<item_comp> sel = select_item_component( components, batch, map_inv, false, filter );
     return consume_items( sel, batch, filter, select_ind( sel.comp.type ) );
 }
@@ -2361,7 +2361,7 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
                 craft.get_cached_tool_selections();
 
     inventory map_inv;
-    map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
 
     for( const comp_selection<tool_comp> &tool_sel : cached_tool_selections ) {
         itype_id type = tool_sel.comp.type;
@@ -2482,7 +2482,7 @@ to consume_tools */
 void Character::consume_tools( const std::vector<tool_comp> &tools, int batch )
 {
     inventory map_inv;
-    map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
     consume_tools( select_tool_component( tools, batch, map_inv ), batch );
 }
 
@@ -2931,7 +2931,7 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
 
             if( act_item.has_temperature() ) {
                 // TODO: fix point types
-                act_item.set_item_temperature( get_weather().get_temperature( loc.raw() ) );
+                act_item.set_item_temperature( get_weather().get_temperature( loc ) );
             }
 
             // Refitted clothing disassembles into refitted components (when applicable)

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3572,13 +3572,13 @@ static void show_sound()
             player_character.view_offset.xy().raw() + point( POSX - player_character.posx(), POSY - player_character.posy() )
         };
         wattron( g->w_terrain, c_yellow );
-        for( const tripoint &sound : sounds_to_draw.first ) {
-            mvwaddch( g->w_terrain, offset + sound.xy(), '?' );
+        for( const tripoint_bub_ms &sound : sounds_to_draw.first ) {
+            mvwaddch( g->w_terrain, sound.xy().raw() + offset, '?' );
         }
         wattroff( g->w_terrain, c_yellow );
         wattron( g->w_terrain, c_red );
-        for( const tripoint &sound : sounds_to_draw.second ) {
-            mvwaddch( g->w_terrain, offset + sound.xy(), '?' );
+        for( const tripoint_bub_ms &sound : sounds_to_draw.second ) {
+            mvwaddch( g->w_terrain, sound.xy().raw() + offset, '?' );
         }
         wattroff( g->w_terrain, c_red );
     } );

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -140,7 +140,7 @@ std::string display::get_temp( const Character &u )
     std::string temp;
     if( u.cache_has_item_with( json_flag_THERMOMETER ) ||
         u.has_flag( STATIC( json_character_flag( "THERMOMETER" ) ) ) ) {
-        temp = print_temperature( get_weather().get_temperature( u.pos() ) );
+        temp = print_temperature( get_weather().get_temperature( u.pos_bub() ) );
     }
     if( temp.empty() ) {
         return "-";

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3836,13 +3836,13 @@ void game::disp_NPCs()
 static void draw_footsteps( const catacurses::window &window, const tripoint_rel_ms &offset )
 {
     wattron( window, c_yellow );
-    for( const tripoint &footstep : sounds::get_footstep_markers() ) {
+    for( const tripoint_bub_ms &footstep : sounds::get_footstep_markers() ) {
         char glyph = '?';
-        if( footstep.z != offset.z() ) { // Here z isn't an offset, but a coordinate
-            glyph = footstep.z > offset.z() ? '^' : 'v';
+        if( footstep.z() != offset.z() ) { // Here z isn't an offset, but a coordinate
+            glyph = footstep.z() > offset.z() ? '^' : 'v';
         }
 
-        mvwaddch( window, footstep.xy() + offset.raw().xy(), glyph );
+        mvwaddch( window, footstep.raw().xy() + offset.raw().xy(), glyph );
     }
     wattroff( window, c_yellow );
 }
@@ -5984,14 +5984,14 @@ void game::examine( bool with_pickup )
     std::optional<tripoint_bub_ms> examp;
     if( with_pickup ) {
         // Examine and/or pick up items
-        examp = choose_adjacent_highlight_bub_ms( _( "Examine terrain, furniture, or items where?" ),
-                _( "There is nothing that can be examined nearby." ),
-                ACTION_EXAMINE_AND_PICKUP, false );
+        examp = choose_adjacent_highlight( _( "Examine terrain, furniture, or items where?" ),
+                                           _( "There is nothing that can be examined nearby." ),
+                                           ACTION_EXAMINE_AND_PICKUP, false );
     } else {
         // Examine but do not pick up items
-        examp = choose_adjacent_highlight_bub_ms( _( "Examine terrain or furniture where?" ),
-                _( "There is nothing that can be examined nearby." ),
-                ACTION_EXAMINE, false );
+        examp = choose_adjacent_highlight( _( "Examine terrain or furniture where?" ),
+                                           _( "There is nothing that can be examined nearby." ),
+                                           ACTION_EXAMINE, false );
     }
 
     if( !examp ) {
@@ -6248,7 +6248,7 @@ bool game::warn_player_maybe_anger_local_faction( bool really_bad_offense,
 void game::pickup()
 {
     // Prompt for which adjacent/current tile to pick up items from
-    const std::optional<tripoint_bub_ms> where_ = choose_adjacent_highlight_bub_ms(
+    const std::optional<tripoint_bub_ms> where_ = choose_adjacent_highlight(
                 _( "Pick up items where?" ),
                 _( "There is nothing to pick up nearby." ),
                 ACTION_PICKUP, false );
@@ -6462,7 +6462,7 @@ void game::print_all_tile_info( const tripoint_bub_ms &lp, const catacurses::win
     }
     const int max_width = getmaxx( w_look ) - column - 1;
 
-    std::string this_sound = sounds::sound_at( lp.raw() );
+    std::string this_sound = sounds::sound_at( lp );
     if( !this_sound.empty() ) {
         const int lines = fold_and_print( w_look, point( 1, ++line ), max_width, c_light_gray,
                                           _( "From here you heard %s" ),
@@ -6476,7 +6476,7 @@ void game::print_all_tile_info( const tripoint_bub_ms &lp, const catacurses::win
                 continue;
             }
 
-            std::string zlev_sound = sounds::sound_at( tmp.raw() );
+            std::string zlev_sound = sounds::sound_at( tmp );
             if( !zlev_sound.empty() ) {
                 const int lines = fold_and_print( w_look, point( 1, ++line ), max_width, c_light_gray,
                                                   tmp.z() > lp.z() ?
@@ -9266,7 +9266,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
 
         if( iActive >= 0 && static_cast<size_t>( iActive ) < monster_list.size() ) {
             cCurMon = monster_list[iActive];
-            iActivePos = cCurMon->pos() - u.pos();
+            iActivePos = ( cCurMon->pos_bub() - u.pos_bub() ).raw();
             centerlistview( iActivePos, width );
             trail_start = u.pos_bub();
             trail_end = cCurMon->pos_bub();
@@ -11905,13 +11905,13 @@ void game::water_affect_items( Character &ch ) const
         }
         // check flag first because its cheaper
         if( loc->has_flag( flag_WATER_DISSOLVE ) && !loc.protected_from_liquids() ) {
-            add_msg_if_player_sees( ch.pos(), m_bad, _( "%1$s %2$s dissolved in the water!" ),
+            add_msg_if_player_sees( ch.pos_bub(), m_bad, _( "%1$s %2$s dissolved in the water!" ),
                                     ch.disp_name( true, true ), loc->display_name() );
             loc.remove_item();
         } else if( loc->has_flag( flag_WATER_BREAK ) && !loc->is_broken()
                    && !loc.protected_from_liquids() ) {
 
-            add_msg_if_player_sees( ch.pos(), m_bad, _( "The water destroyed %1$s %2$s!" ),
+            add_msg_if_player_sees( ch.pos_bub(), m_bad, _( "The water destroyed %1$s %2$s!" ),
                                     ch.disp_name( true ), loc->display_name() );
             loc->deactivate();
             // TODO: Maybe different types of wet faults? But I can't think of any.

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -580,14 +580,14 @@ static void pldrive( point d )
 static void open()
 {
     avatar &player_character = get_avatar();
-    const std::optional<tripoint> openp_ = choose_adjacent_highlight( _( "Open where?" ),
-                                           pgettext( "no door, gate, curtain, etc.", "There is nothing that can be opened nearby." ),
-                                           ACTION_OPEN, false );
+    const std::optional<tripoint_bub_ms> openp_ = choose_adjacent_highlight( _( "Open where?" ),
+            pgettext( "no door, gate, curtain, etc.", "There is nothing that can be opened nearby." ),
+            ACTION_OPEN, false );
 
     if( !openp_ ) {
         return;
     }
-    const tripoint_bub_ms openp = tripoint_bub_ms( *openp_ );
+    const tripoint_bub_ms openp = *openp_;
     map &here = get_map();
 
     player_character.mod_moves( -to_moves<int>( 1_seconds ) );
@@ -665,7 +665,7 @@ static void open()
 
 static void close()
 {
-    if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent_highlight_bub_ms(
+    if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent_highlight(
                 _( "Close where?" ),
                 pgettext( "no door, gate, etc.", "There is nothing that can be closed nearby." ),
                 ACTION_CLOSE, false ) ) {

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -154,7 +154,7 @@ static bool get_liquid_target( item &liquid, const item *const source, const int
     if( test_mode ) {
         switch( test_mode_spilling_action ) {
             case test_mode_spilling_action_t::spill_all:
-                target.pos = player_character.pos();
+                target.pos = player_character.pos_bub().raw();
                 target.dest_opt = LD_GROUND;
                 return true;
             case test_mode_spilling_action_t::cancel_spill:

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2265,7 +2265,7 @@ void iexamine_helper::handle_harvest( Character &you, const std::string &itemid,
 {
     item harvest = item( itemid );
     if( harvest.has_temperature() ) {
-        harvest.set_item_temperature( get_weather().get_temperature( you.pos() ) );
+        harvest.set_item_temperature( get_weather().get_temperature( you.pos_bub() ) );
     }
     if( !force_drop && you.can_pickVolume( harvest, true ) &&
         you.can_pickWeight( harvest, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
@@ -4598,7 +4598,7 @@ void iexamine::shrub_wildveggies( Character &you, const tripoint_bub_ms &examp )
     you.activity.auto_resume = true;
 }
 
-void trap::examine( const tripoint &examp ) const
+void trap::examine( const tripoint_bub_ms &examp ) const
 {
     avatar &player_character = get_avatar();
     map &here = get_map();
@@ -4689,11 +4689,6 @@ void trap::examine( const tripoint &examp ) const
 
         return;
     }
-}
-
-void trap::examine( const tripoint_bub_ms &examp ) const
-{
-    trap::examine( examp.raw() );
 }
 
 void iexamine::part_con( Character &you, tripoint_bub_ms const &examp )
@@ -6763,7 +6758,7 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
 
     Character &player_character = get_player_character();
     // select from where to get the items from and place them
-    inv.form_from_map( player_character.pos(), PICKUP_RANGE, &player_character );
+    inv.form_from_map( player_character.pos_bub(), PICKUP_RANGE, &player_character );
     inv.remove_items_with( []( const item & it ) {
         return it.rotten();
     } );

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -482,7 +482,7 @@ static int count_charges_in_list( const ammotype *ammotype, const map_stack &ite
     return 0;
 }
 
-void inventory::form_from_map( const tripoint &origin, int range, const Character *pl,
+void inventory::form_from_map( const tripoint_bub_ms &origin, int range, const Character *pl,
                                bool assign_invlet,
                                bool clear_path )
 {
@@ -492,40 +492,41 @@ void inventory::form_from_map( const tripoint &origin, int range, const Characte
 void inventory::form_from_zone( map &m, std::unordered_set<tripoint_abs_ms> &zone_pts,
                                 const Character *pl, bool assign_invlet )
 {
-    std::vector<tripoint> pts;
+    std::vector<tripoint_bub_ms> pts;
     pts.reserve( zone_pts.size() );
     for( const tripoint_abs_ms &elem : zone_pts ) {
-        pts.push_back( m.bub_from_abs( elem ).raw() );
+        pts.push_back( m.bub_from_abs( elem ) );
     }
     form_from_map( m, pts, pl, assign_invlet );
 }
 
-void inventory::form_from_map( map &m, const tripoint &origin, int range, const Character *pl,
+void inventory::form_from_map( map &m, const tripoint_bub_ms &origin, int range,
+                               const Character *pl,
                                bool assign_invlet,
                                bool clear_path )
 {
     // populate a grid of spots that can be reached
-    std::vector<tripoint> reachable_pts = {};
+    std::vector<tripoint_bub_ms> reachable_pts = {};
     // If we need a clear path we care about the reachability of points
     if( clear_path ) {
         m.reachable_flood_steps( reachable_pts, origin, range, 1, 100 );
     } else {
         // Fill reachable points with points_in_radius
-        tripoint_range<tripoint> in_radius = m.points_in_radius( origin, range );
-        for( const tripoint &p : in_radius ) {
+        tripoint_range<tripoint_bub_ms> in_radius = m.points_in_radius( origin, range );
+        for( const tripoint_bub_ms &p : in_radius ) {
             reachable_pts.emplace_back( p );
         }
     }
     form_from_map( m, reachable_pts, pl, assign_invlet );
 }
 
-void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Character *pl,
+void inventory::form_from_map( map &m, std::vector<tripoint_bub_ms> pts, const Character *pl,
                                bool assign_invlet )
 {
     items.clear();
     provisioned_pseudo_tools.clear();
 
-    for( const tripoint &p : pts ) {
+    for( const tripoint_bub_ms &p : pts ) {
         const ter_id &t = m.ter( p );
         // a temporary hack while trees are terrain
         if( t->has_flag( ter_furn_flag::TFLAG_TREE ) ) {

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -162,13 +162,13 @@ class inventory : public visitable
         void restack( Character &p );
         void form_from_zone( map &m, std::unordered_set<tripoint_abs_ms> &zone_pts,
                              const Character *pl = nullptr, bool assign_invlet = true );
-        void form_from_map( const tripoint &origin, int range, const Character *pl = nullptr,
+        void form_from_map( const tripoint_bub_ms &origin, int range, const Character *pl = nullptr,
                             bool assign_invlet = true,
                             bool clear_path = true );
-        void form_from_map( map &m, const tripoint &origin, int range, const Character *pl = nullptr,
+        void form_from_map( map &m, const tripoint_bub_ms &origin, int range, const Character *pl = nullptr,
                             bool assign_invlet = true,
                             bool clear_path = true );
-        void form_from_map( map &m, std::vector<tripoint> pts, const Character *pl,
+        void form_from_map( map &m, std::vector<tripoint_bub_ms> pts, const Character *pl,
                             bool assign_invlet = true );
         /**
          * Remove a specific item from the inventory. The item is compared

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1883,10 +1883,10 @@ const item_category *inventory_selector::naturalize_category( const item_categor
         return iter != categories.end() ? &*iter : nullptr;
     };
 
-    const int dist = rl_dist( u.pos(), pos );
+    const int dist = rl_dist( u.pos_bub().raw(), pos );
 
     if( dist != 0 ) {
-        const std::string suffix = direction_suffix( u.pos(), pos );
+        const std::string suffix = direction_suffix( u.pos_bub().raw(), pos );
         const item_category_id id = item_category_id( string_format( "%s_%s", category.get_id().c_str(),
                                     suffix.c_str() ) );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13068,7 +13068,7 @@ bool item::process_temperature_rot( float insulation, const tripoint_bub_ms &pos
         return false;
     }
 
-    units::temperature temp = get_weather().get_temperature( pos.raw() );
+    units::temperature temp = get_weather().get_temperature( pos );
 
     switch( flag ) {
         case temperature_flag::NORMAL:
@@ -13135,7 +13135,7 @@ bool item::process_temperature_rot( float insulation, const tripoint_bub_ms &pos
             // Use weather if above ground, use map temp if below
             units::temperature env_temperature;
             if( pos.z() >= 0 && flag != temperature_flag::ROOT_CELLAR ) {
-                env_temperature = wgen.get_weather_temperature( pos.raw(), time, seed );
+                env_temperature = wgen.get_weather_temperature( get_map().getglobal( pos ), time, seed );
             } else {
                 env_temperature = AVERAGE_ANNUAL_TEMPERATURE;
             }
@@ -14008,7 +14008,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
     // Handle links to items in the inventory.
     if( link().source == link_state::solarpack ) {
         if( carrier == nullptr || !carrier->worn_with_flag( flag_SOLARPACK_ON ) ) {
-            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %s has come loose from the solar pack." ),
+            add_msg_if_player_sees( pos, m_bad, _( "The %s has come loose from the solar pack." ),
                                     link_name() );
             reset_link( true, carrier );
             return false;
@@ -14019,7 +14019,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
     };
     if( link().source == link_state::ups ) {
         if( carrier == nullptr || !carrier->cache_has_item_with( flag_IS_UPS, used_ups ) ) {
-            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %s has come loose from the UPS." ), link_name() );
+            add_msg_if_player_sees( pos, m_bad, _( "The %s has come loose from the UPS." ), link_name() );
             reset_link( true, carrier );
             return false;
         }
@@ -14049,7 +14049,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
             if( carrier != nullptr ) {
                 carrier->add_msg_if_player( m_bad, _( "Your %s breaks loose!" ), cable_name );
             } else {
-                add_msg_if_player_sees( pos.raw(), m_bad, _( "Your %s breaks loose!" ), cable_name );
+                add_msg_if_player_sees( pos, m_bad, _( "Your %s breaks loose!" ), cable_name );
             }
             return true;
         } else if( link().length + M_SQRT2 >= link().max_length + 1 && carrier != nullptr ) {
@@ -14129,7 +14129,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
     }
 
     if( link().last_processed <= t_veh->part( link_vp_index ).last_disconnected ) {
-        add_msg_if_player_sees( pos.raw(), m_warning, string_format( _( "You detached the %s." ),
+        add_msg_if_player_sees( pos, m_warning, string_format( _( "You detached the %s." ),
                                 type_name() ) );
         return reset_link( true, carrier, -2 );
     }
@@ -14278,7 +14278,7 @@ bool item::reset_link( bool unspool_if_too_long, Character *p, int vpart_index,
         if( p != nullptr ) {
             p->add_msg_if_player( m_warning, _( "Your %s has come loose." ), link_name() );
         } else {
-            add_msg_if_player_sees( cable_position.raw(), m_warning, _( "The %s has come loose." ),
+            add_msg_if_player_sees( cable_position, m_warning, _( "The %s has come loose." ),
                                     link_name() );
         }
     }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1774,7 +1774,8 @@ static void move_to_parent_pocket_recursive( const tripoint &pos, item &it,
         carrier->add_msg_player_or_npc( m_bad, _( "Your %s falls to the ground." ),
                                         _( "<npcname>'s %s falls to the ground." ), it.display_name() );
     } else {
-        add_msg_if_player_sees( pos, m_bad, _( "The %s falls to the ground." ), it.display_name() );
+        add_msg_if_player_sees( tripoint_bub_ms( pos ), m_bad, _( "The %s falls to the ground." ),
+                                it.display_name() );
     }
     here.add_item_or_charges( pos, it );
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -729,7 +729,7 @@ std::optional<int> iuse::fungicide( Character *p, item *, const tripoint_bub_ms 
                 if( monster *const mon_ptr = creatures.creature_at<monster>( dest ) ) {
                     monster &critter = *mon_ptr;
                     if( !critter.type->in_species( species_FUNGUS ) ) {
-                        add_msg_if_player_sees( dest.raw(), m_warning, _( "The %s is covered in tiny spores!" ),
+                        add_msg_if_player_sees( dest, m_warning, _( "The %s is covered in tiny spores!" ),
                                                 critter.name() );
                     }
                     if( !critter.make_fungus() ) {
@@ -3342,7 +3342,7 @@ std::optional<int> iuse::can_goo( Character *p, item *it, const tripoint_bub_ms 
             found = here.passable( goop ) && here.tr_at( goop ).is_null();
         } while( !found && tries < 10 );
         if( found ) {
-            add_msg_if_player_sees( goop.raw(), m_warning,
+            add_msg_if_player_sees( goop, m_warning,
                                     _( "A nearby splatter of goo forms into a goo pit." ) );
             here.trap_set( goop, tr_goo );
         } else {
@@ -7864,7 +7864,7 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
             meal.heat_up();
         } else {
             meal.set_item_temperature( std::max( temperatures::cold,
-                                                 get_weather().get_temperature( pos.raw() ) ) );
+                                                 get_weather().get_temperature( pos ) ) );
         }
 
         it->active = false;
@@ -7896,7 +7896,7 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
     const w_point weatherPoint = *weather.weather_precise;
 
     /* Possibly used twice. Worth spending the time to precalculate. */
-    const units::temperature player_local_temp = weather.get_temperature( p->pos_bub().raw() );
+    const units::temperature player_local_temp = weather.get_temperature( p->pos_bub() );
 
     if( it->typeId() == itype_weather_reader ) {
         p->add_msg_if_player( m_neutral, _( "The %s's monitor slowly outputs the data…" ),
@@ -8218,8 +8218,8 @@ heating_requirements heating_requirements_for_weight( const units::mass &frozen,
 
 static std::optional<std::pair<tripoint, itype_id>> appliance_heater_selector( Character *p )
 {
-    const std::optional<tripoint> pt = choose_adjacent_highlight( _( "Select an appliance." ),
-                                       _( "There is no appliance nearby." ), ACTION_EXAMINE, false );
+    const std::optional<tripoint_bub_ms> pt = choose_adjacent_highlight( _( "Select an appliance." ),
+            _( "There is no appliance nearby." ), ACTION_EXAMINE, false );
     if( !pt ) {
         p->add_msg_if_player( m_info, _( "You haven't selected any appliance." ) );
         return std::nullopt;
@@ -8251,7 +8251,7 @@ static std::optional<std::pair<tripoint, itype_id>> appliance_heater_selector( C
                     p->add_msg_if_player( m_info, _( "You haven't selected any heater." ) );
                     return std::nullopt;
                 } else {
-                    return std::make_pair( pt.value(), pseudo_tools[app_menu.ret] );
+                    return std::make_pair( pt.value().raw(), pseudo_tools[app_menu.ret] );
                 }
 
             }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -406,7 +406,7 @@ ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
 
     std::map<quality_id, int> unmet_reqs;
     inventory inv;
-    inv.form_from_map( p.pos(), 1, &p, true, true );
+    inv.form_from_map( p.pos_bub(), 1, &p, true, true );
     for( const auto &quality : qualities_needed ) {
         if( !p.has_quality( quality.first, quality.second ) &&
             !inv.has_quality( quality.first, quality.second ) ) {
@@ -3957,7 +3957,7 @@ bool place_trap_actor::is_allowed( Character &p, const tripoint_bub_ms &pos,
                                  name );
         } else {
             p.add_msg_if_player( m_bad, _( "You trigger a %s!" ), existing_trap.name() );
-            existing_trap.trigger( pos.raw(), p );
+            existing_trap.trigger( pos, p );
         }
         return false;
     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1221,7 +1221,7 @@ void spell::use_components( Character &guy ) const
     const requirement_data &spell_components = type->spell_components.obj();
     // if we're here, we're assuming the Character has the correct components (using can_cast())
     inventory map_inv;
-    map_inv.form_from_map( guy.pos(), 0, &guy, true, false );
+    map_inv.form_from_map( guy.pos_bub(), 0, &guy, true, false );
     for( const std::vector<item_comp> &comp_vec : spell_components.get_components() ) {
         guy.consume_items( guy.select_item_component( comp_vec, 1, map_inv ), 1 );
     }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -617,7 +617,7 @@ static void damage_targets( const spell &sp, Creature &caster,
             }
         } else if( sp.damage( caster ) < 0 ) {
             sp.heal( target, caster );
-            add_msg_if_player_sees( cr->pos(), m_good, _( "%s wounds are closing up!" ),
+            add_msg_if_player_sees( cr->pos_bub(), m_good, _( "%s wounds are closing up!" ),
                                     cr->disp_name( true ) );
         }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3125,7 +3125,7 @@ void map::drop_items( const tripoint_bub_ms &p )
             } else if( creature_hit_chance < 100 ) {
                 hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::leg );
             } else {
-                add_msg_if_player_sees( creature_below->pos(), _( "Falling %1$s misses %2$s!" ), i.tname(),
+                add_msg_if_player_sees( creature_below->pos_bub(), _( "Falling %1$s misses %2$s!" ), i.tname(),
                                         creature_below->disp_name() );
             }
             // Did we hit at all? Then run the message.
@@ -3133,10 +3133,10 @@ void map::drop_items( const tripoint_bub_ms &p )
                 if( hit_part.is_valid() && !creature_below->is_monster() ) {
                     //~First positional argument: Item name. Second: Name of a person (e.g. "Jane") or player (e.g. "you"). Third: Body part name, accusative.
                     const std::string msg = _( "Falling %1$s hits %2$s on the %3$s for %4$i damage!" );
-                    add_msg_if_player_sees( creature_below->pos(), msg,
+                    add_msg_if_player_sees( creature_below->pos_bub(), msg,
                                             i.tname(), creature_below->disp_name(), hit_part->accusative, static_cast<int>( damage ) );
                 } else {
-                    add_msg_if_player_sees( creature_below->pos(), _( "Falling %1$s hits %2$s for %3$i damage!" ),
+                    add_msg_if_player_sees( creature_below->pos_bub(), _( "Falling %1$s hits %2$s for %3$i damage!" ),
                                             i.tname(), creature_below->disp_name(), static_cast<int>( damage ) );
                 }
                 // FIXME: Hardcoded damage type!
@@ -4147,16 +4147,16 @@ void map::smash_items( const tripoint_bub_ms &p, const int power, const std::str
 
     // Let the player know that the item was damaged if they can see it.
     if( items_destroyed > 1 ) {
-        add_msg_if_player_sees( p.raw(), m_bad, _( "The %s destroys several items!" ), cause_message );
+        add_msg_if_player_sees( p, m_bad, _( "The %s destroys several items!" ), cause_message );
     } else if( items_destroyed == 1 && items_damaged == 1 ) {
         //~ %1$s: the cause of destruction, %2$s: destroyed item name
-        add_msg_if_player_sees( p.raw(), m_bad, _( "The %1$s destroys the %2$s!" ), cause_message,
+        add_msg_if_player_sees( p, m_bad, _( "The %1$s destroys the %2$s!" ), cause_message,
                                 damaged_item_name );
     } else if( items_damaged > 1 ) {
-        add_msg_if_player_sees( p.raw(), m_bad, _( "The %s damages several items." ), cause_message );
+        add_msg_if_player_sees( p, m_bad, _( "The %s damages several items." ), cause_message );
     } else if( items_damaged == 1 ) {
         //~ %1$s: the cause of damage, %2$s: damaged item name
-        add_msg_if_player_sees( p.raw(), m_bad, _( "The %1$s damages the %2$s." ), cause_message,
+        add_msg_if_player_sees( p, m_bad, _( "The %1$s damages the %2$s." ), cause_message,
                                 damaged_item_name );
     }
 
@@ -4882,7 +4882,7 @@ bool map::hit_with_acid( const tripoint_bub_ms &p )
                t == ter_t_bars ||
                t == ter_t_reb_cage ) {
         ter_set( p, ter_t_floor );
-        add_msg_if_player_sees( p.raw(), m_warning, _( "The metal bars melt!" ) );
+        add_msg_if_player_sees( p, m_warning, _( "The metal bars melt!" ) );
     } else if( t == ter_t_door_b ) {
         if( one_in( 4 ) ) {
             ter_set( p, ter_t_door_frame );
@@ -5671,7 +5671,7 @@ item map::liquid_from( const tripoint_bub_ms &p ) const
         source_terrain.liquid_source_count == std::make_pair( 0, 0 ) ) {
 
         item ret( source_terrain.liquid_source_item_id, calendar::turn, item::INFINITE_CHARGES );
-        ret.set_item_temperature( std::max( weather.get_temperature( p.raw() ),
+        ret.set_item_temperature( std::max( weather.get_temperature( p ),
                                             units::from_celsius( source_terrain.liquid_source_min_temp ) ) );
         return ret;
     }
@@ -7184,7 +7184,7 @@ void map::update_visibility_cache( const int zlev )
 {
     Character &player_character = get_player_character();
     if( !visibility_variables_cache.visibility_cache_dirty &&
-        player_character.pos_bub().raw() == visibility_variables_cache.last_pos ) {
+        player_character.pos_bub() == visibility_variables_cache.last_pos ) {
         return;
     }
 
@@ -7239,7 +7239,7 @@ void map::update_visibility_cache( const int zlev )
     }
 #endif
 
-    visibility_variables_cache.last_pos = player_character.pos();
+    visibility_variables_cache.last_pos = player_character.pos_bub();
     visibility_variables_cache.visibility_cache_dirty = false;
 }
 
@@ -8995,7 +8995,7 @@ void map::produce_sap( const tripoint_bub_ms &p, const time_duration &time_since
 
     item sap( "maple_sap", calendar::turn );
 
-    sap.set_item_temperature( get_weather().get_temperature( p.raw() ) );
+    sap.set_item_temperature( get_weather().get_temperature( p ) );
     sap.charges = new_charges;
 
     // Is there a proper container?
@@ -10459,7 +10459,7 @@ void map::maybe_trigger_prox_trap( const tripoint_bub_ms &pos, Creature &c,
         c.add_msg_player_or_npc( m_bad, tr.get_trigger_message_u(), tr.get_trigger_message_npc(),
                                  tr.name() );
     }
-    tr.trigger( pos.raw(), c );
+    tr.trigger( pos, c );
 }
 
 // TODO: Should be moved to submap or Creature?
@@ -10622,7 +10622,7 @@ void map::maybe_trigger_trap( const tripoint_bub_ms &pos, Creature &c, const boo
         c.add_msg_player_or_npc( m_bad, tr.get_trigger_message_u(), tr.get_trigger_message_npc(),
                                  tr.name() );
     }
-    tr.trigger( c.pos(), c );
+    tr.trigger( c.pos_bub(), c );
 }
 
 template<typename Functor>

--- a/src/map.h
+++ b/src/map.h
@@ -133,7 +133,7 @@ struct visibility_variables {
     int u_clairvoyance = 0;
     float vision_threshold = 0.0f;
     std::optional<field_type_id> clairvoyance_field;
-    tripoint last_pos;
+    tripoint_bub_ms last_pos;
 };
 
 struct bash_params {
@@ -304,7 +304,7 @@ struct drawsq_params {
 
 struct tile_render_info {
     struct common {
-        const tripoint pos;
+        const tripoint_bub_ms pos;
         // accumulator for 3d tallness of sprites rendered here so far;
         int height_3d = 0;
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3134,7 +3134,7 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
             if( is_boring_wall || act_trap == apply_action::act_erase ) {
                 dat.m.remove_trap( p );
             } else if( act_trap == apply_action::act_dismantle ) {
-                dat.m.tr_at( p ).on_disarmed( dat.m, p.raw() );
+                dat.m.tr_at( p ).on_disarmed( dat.m, p );
             }
 
             if( is_boring_wall || act_item == apply_action::act_erase ) {

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -302,7 +302,7 @@ bool mon_spellcasting_actor::call( monster &mon ) const
         target_name = target_monster->disp_name();
     }
 
-    add_msg_if_player_sees( target.raw(), spell_instance.message(), mon.disp_name(),
+    add_msg_if_player_sees( target, spell_instance.message(), mon.disp_name(),
                             spell_instance.name(), target_name );
 
     avatar fake_player;
@@ -723,7 +723,7 @@ bool melee_actor::call( monster &z ) const
     if( uncanny_dodgeable && target->uncanny_dodge() ) {
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
         sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos_bub() ),
-                                 sfx::get_heard_angle( z.pos() ) );
+                                 sfx::get_heard_angle( z.pos_bub() ) );
         target->add_msg_player_or_npc( msg_type, miss_msg_u,
                                        get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : translation(),
                                        z.name(), body_part_name_accusative( bp_id ) );
@@ -733,7 +733,7 @@ bool melee_actor::call( monster &z ) const
     if( dodgeable ) {
         if( hitspread < 0 ) {
             sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos_bub() ),
-                                     sfx::get_heard_angle( z.pos() ) );
+                                     sfx::get_heard_angle( z.pos_bub() ) );
             target->add_msg_player_or_npc( msg_type, miss_msg_u,
                                            get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : translation(),
                                            mon_name, body_part_name_accusative( bp_id ) );
@@ -868,7 +868,7 @@ bool melee_actor::call( monster &z ) const
         on_damage( z, *target, dealt_damage );
     } else {
         sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos_bub() ),
-                                 sfx::get_heard_angle( z.pos() ) );
+                                 sfx::get_heard_angle( z.pos_bub() ) );
         target->add_msg_player_or_npc( msg_type, no_dmg_msg_u,
                                        get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? no_dmg_msg_npc : translation(),
                                        mon_name, body_part_name_accusative( grabbed_bp_id.value_or( bp_id ) ) );
@@ -934,7 +934,7 @@ void melee_actor::on_damage( monster &z, Creature &target, dealt_damage_instance
 {
     if( target.is_avatar() ) {
         sfx::play_variant_sound( "mon_bite", "bite_hit", sfx::get_heard_volume( z.pos_bub() ),
-                                 sfx::get_heard_angle( z.pos() ) );
+                                 sfx::get_heard_angle( z.pos_bub() ) );
         sfx::do_player_death_hurt( dynamic_cast<Character &>( target ), false );
     }
     game_message_type msg_type = target.attitude_to( get_player_character() ) ==

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -661,7 +661,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     Character &player_character = get_player_character();
     if( !hits ) {
         int stumble_pen = stumble( *this, cur_weapon );
-        sfx::generate_melee_sound( pos(), t.pos(), false, false );
+        sfx::generate_melee_sound( pos_bub(), t.pos_bub(), false, false );
 
         const ma_technique miss_recovery = martial_arts_data->get_miss_recovery( *this );
 
@@ -873,7 +873,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
                     material = "steel";
                 }
             }
-            sfx::generate_melee_sound( pos(), t.pos(), true, t.is_monster(), material );
+            sfx::generate_melee_sound( pos_bub(), t.pos_bub(), true, t.is_monster(), material );
             int dam = dealt_dam.total_damage();
             melee::melee_stats.damage_amount += dam;
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -1001,11 +1001,6 @@ void add_msg( const game_message_params &params, std::string msg )
     Messages::add_msg( params, std::move( msg ) );
 }
 
-void add_msg_if_player_sees( const tripoint &target, std::string msg )
-{
-    add_msg_if_player_sees( tripoint_bub_ms( target ), std::move( msg ) );
-}
-
 void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg )
 {
     if( get_player_view().sees( target ) ) {
@@ -1018,12 +1013,6 @@ void add_msg_if_player_sees( const Creature &target, std::string msg )
     if( get_player_view().sees( target ) ) {
         Messages::add_msg( std::move( msg ) );
     }
-}
-
-void add_msg_if_player_sees( const tripoint &target, const game_message_params &params,
-                             std::string msg )
-{
-    add_msg_if_player_sees( tripoint_bub_ms( target ), params, std::move( msg ) );
 }
 
 void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_params &params,

--- a/src/messages.h
+++ b/src/messages.h
@@ -78,12 +78,10 @@ inline void add_msg( const game_message_params &params, const char *const msg, A
     return add_msg( params, string_format( msg, std::forward<Args>( args )... ) );
 }
 
-// TODO: Get rid of untyped overload
-void add_msg_if_player_sees( const tripoint &target, std::string msg );
 void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg );
 void add_msg_if_player_sees( const Creature &target, std::string msg );
 template<typename ...Args>
-inline void add_msg_if_player_sees( const tripoint &target, const std::string &msg,
+inline void add_msg_if_player_sees( const tripoint_bub_ms &target, const std::string &msg,
                                     Args &&... args )
 {
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
@@ -91,11 +89,6 @@ inline void add_msg_if_player_sees( const tripoint &target, const std::string &m
 template<typename ...Args>
 inline void add_msg_if_player_sees( const Creature &target, const std::string &msg,
                                     Args &&... args )
-{
-    return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
-}
-template<typename ...Args>
-inline void add_msg_if_player_sees( const tripoint &target, const char *const msg, Args &&... args )
 {
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
 }
@@ -111,7 +104,7 @@ inline void add_msg_if_player_sees( const Creature &target, const char *const ms
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
 }
 template<typename ...Args>
-inline void add_msg_if_player_sees( const tripoint &target, const translation &msg,
+inline void add_msg_if_player_sees( const tripoint_bub_ms &target, const translation &msg,
                                     Args &&... args )
 {
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
@@ -123,15 +116,13 @@ inline void add_msg_if_player_sees( const Creature &target, const translation &m
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
 }
 
-// TODO: Get rid of untyped overload
-void add_msg_if_player_sees( const tripoint &target, const game_message_params &params,
-                             std::string msg );
 void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_params &params,
                              std::string msg );
 void add_msg_if_player_sees( const Creature &target, const game_message_params &params,
                              std::string msg );
 template<typename ...Args>
-inline void add_msg_if_player_sees( const tripoint &target, const game_message_params &params,
+inline void add_msg_if_player_sees( const tripoint_bub_ms &target,
+                                    const game_message_params &params,
                                     const std::string &msg, Args &&... args )
 {
     if( params.type == m_debug && !debug_mode ) {
@@ -151,7 +142,8 @@ inline void add_msg_if_player_sees( const Creature &target, const game_message_p
                                    std::forward<Args>( args )... ) );
 }
 template<typename ...Args>
-inline void add_msg_if_player_sees( const tripoint &target, const game_message_params &params,
+inline void add_msg_if_player_sees( const tripoint_bub_ms &target,
+                                    const game_message_params &params,
                                     const char *const msg, Args &&... args )
 {
     if( params.type == m_debug && !debug_mode ) {

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4460,7 +4460,7 @@ bool mattack::kamikaze( monster *z )
     */
     // END HORRIBLE HACK
 
-    add_msg_if_player_sees( z->pos(), m_bad, _( "The %s lights up menacingly." ), z->name() );
+    add_msg_if_player_sees( z->pos_bub(), m_bad, _( "The %s lights up menacingly." ), z->name() );
 
     return true;
 }

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -212,7 +212,7 @@ item_location mdeath::splatter( monster &z )
 void mdeath::disappear( monster &z )
 {
     if( !z.type->has_flag( mon_flag_SILENT_DISAPPEAR ) ) {
-        add_msg_if_player_sees( z.pos(), m_good, _( "The %s disappears." ), z.name() );
+        add_msg_if_player_sees( z.pos_bub(), m_good, _( "The %s disappears." ), z.name() );
     }
 }
 
@@ -274,9 +274,9 @@ void mdeath::broken( monster &z )
 
     // TODO: make mdeath::splatter work for robots
     if( broken_mon.damage() >= broken_mon.max_damage() ) {
-        add_msg_if_player_sees( z.pos(), m_good, _( "The %s is destroyed!" ), z.name() );
+        add_msg_if_player_sees( z.pos_bub(), m_good, _( "The %s is destroyed!" ), z.name() );
     } else {
-        add_msg_if_player_sees( z.pos(), m_good, _( "The %s collapses!" ), z.name() );
+        add_msg_if_player_sees( z.pos_bub(), m_good, _( "The %s collapses!" ), z.name() );
     }
 }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1419,7 +1419,7 @@ void monster::footsteps( const tripoint_bub_ms &p )
         return;
     }
     int dist = rl_dist( p, get_player_character().pos_bub() );
-    sounds::add_footstep( p.raw(), volume, dist, this, type->get_footsteps() );
+    sounds::add_footstep( p, volume, dist, this, type->get_footsteps() );
 }
 
 tripoint_bub_ms monster::scent_move()
@@ -2433,7 +2433,7 @@ void monster::shove_vehicle( const tripoint_bub_ms &remote_destination,
             }
             if( shove_velocity > 0 ) {
                 //~ %1$s - monster name, %2$s - vehicle name
-                add_msg_if_player_sees( this->pos(), m_bad, _( "%1$s shoves %2$s out of their way!" ),
+                add_msg_if_player_sees( this->pos_bub(), m_bad, _( "%1$s shoves %2$s out of their way!" ),
                                         this->disp_name(),
                                         veh.disp_name() );
                 int shove_moves = shove_veh_mass_moves_factor * veh_mass / 10_kilogram;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2868,10 +2868,10 @@ void monster::process_turn()
                 if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
                     if( one_in( 4 ) ) {
                         explosion_handler::explosion( this, pos_bub(), 40, 0.8, true );
-                        add_msg_if_player_sees( zap.raw(), m_warning, _( "The %s explodes in a fiery inferno!" ),
+                        add_msg_if_player_sees( zap, m_warning, _( "The %s explodes in a fiery inferno!" ),
                                                 here.tername( zap ) );
                     } else {
-                        add_msg_if_player_sees( zap.raw(), m_warning, _( "Lightning from %1$s engulfs the %2$s!" ),
+                        add_msg_if_player_sees( zap, m_warning, _( "Lightning from %1$s engulfs the %2$s!" ),
                                                 name(), here.tername( zap ) );
                         here.add_field( zap, fd_fire, 1, 2_turns );
                     }
@@ -3531,7 +3531,7 @@ bool monster::make_fungus()
     const std::string old_name = name();
     poly( type->fungalize_into );
 
-    add_msg_if_player_sees( pos(), m_info, _( "The spores transform %1$s into a %2$s!" ),
+    add_msg_if_player_sees( pos_bub(), m_info, _( "The spores transform %1$s into a %2$s!" ),
                             old_name, name() );
 
     return true;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1396,7 +1396,7 @@ void npc::do_npc_read( bool ebook )
 
     book = book.obtain( *npc_character );
     if( can_read( *book, fail_reasons ) ) {
-        add_msg_if_player_sees( pos(), _( "%s starts reading." ), disp_name() );
+        add_msg_if_player_sees( pos_bub(), _( "%s starts reading." ), disp_name() );
 
         // NPCs can't read to other NPCs yet
         const time_duration time_taken = time_to_read( *book, *this );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4790,7 +4790,7 @@ void npc::reach_omt_destination()
             if( rl_dist( player_character.pos_bub(), pos_bub() ) > SEEX * 2 ) {
                 if( player_character.cache_has_item_with_flag( flag_TWO_WAY_RADIO, true ) &&
                     cache_has_item_with_flag( flag_TWO_WAY_RADIO, true ) ) {
-                    add_msg_if_player_sees( pos(), m_info, _( "From your two-way radio you hear %s reporting in, "
+                    add_msg_if_player_sees( pos_bub(), m_info, _( "From your two-way radio you hear %s reporting in, "
                                             "'I've arrived, boss!'" ), disp_name() );
                 }
             }
@@ -5367,7 +5367,7 @@ void npc::do_reload( const item_location &it )
     if( get_player_view().sees( *this ) ) {
         add_msg( _( "%1$s reloads their %2$s." ), get_name(), it->tname() );
         sfx::play_variant_sound( "reload", it->typeId().str(), sfx::get_heard_volume( pos_bub() ),
-                                 sfx::get_heard_angle( pos() ) );
+                                 sfx::get_heard_angle( pos_bub() ) );
     }
 
     // Otherwise the NPC may not equip the weapon until they see danger

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -548,7 +548,7 @@ void pixel_minimap::render_critters( const tripoint &center )
 }
 
 //the main call for drawing the pixel minimap to the screen
-void pixel_minimap::draw( const SDL_Rect &screen_rect, const tripoint &center )
+void pixel_minimap::draw( const SDL_Rect &screen_rect, const tripoint_bub_ms &center )
 {
     if( !g ) {
         return;
@@ -559,8 +559,8 @@ void pixel_minimap::draw( const SDL_Rect &screen_rect, const tripoint &center )
     }
 
     set_screen_rect( screen_rect );
-    process_cache( center );
-    render( center );
+    process_cache( center.raw() );
+    render( center.raw() );
 }
 
 void pixel_minimap::draw_beacon( const SDL_Rect &rect, const SDL_Color &color )

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 
+#include "coords_fwd.h"
 #include "point.h"
 #include "sdl_wrappers.h"
 #include "sdl_geometry.h"
@@ -40,7 +41,7 @@ class pixel_minimap
         void set_type( pixel_minimap_type type );
         void set_settings( const pixel_minimap_settings &settings );
 
-        void draw( const SDL_Rect &screen_rect, const tripoint &center );
+        void draw( const SDL_Rect &screen_rect, const tripoint_bub_ms &center );
 
     private:
         struct submap_cache;

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1283,7 +1283,7 @@ void Character::hardcoded_effects( effect &it )
                          body_part_name_accusative( bp ) );
             } else {
                 //~ 1$s is NPC name, 2$s is bodypart in accusative.
-                add_msg_if_player_sees( pos(), _( "%1$s starts scratching their %2$s!" ), get_name(),
+                add_msg_if_player_sees( pos_bub(), _( "%1$s starts scratching their %2$s!" ), get_name(),
                                         body_part_name_accusative( bp ) );
             }
             mod_moves( -to_moves<int>( 1_seconds ) * 1.5 );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2268,7 +2268,7 @@ static void cycle_action( item &weap, const itype_id &ammo, const tripoint &pos 
     tiles.erase( std::remove_if( tiles.begin(), tiles.end(), [&]( const tripoint & e ) {
         return !here.passable( e );
     } ), tiles.end() );
-    tripoint eject = tiles.empty() ? pos : random_entry( tiles );
+    tripoint_bub_ms eject{ tiles.empty() ? pos : random_entry( tiles ) };
 
     // for turrets try and drop casings or linkages directly to any CARGO part on the same tile
     const std::optional<vpart_reference> ovp_cargo = weap.has_flag( flag_VEHICLE )

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -993,12 +993,14 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         const tripoint_abs_omt &guy_loc = guy->global_omt_location();
         if( guy_loc.z() == center_pos.z() && ( has_debug_vision ||
                                                overmap_buffer.seen_more_than( guy_loc, om_vision_level::details ) ) ) {
-            draw_entity_with_overlays( *guy, global_omt_to_draw_position( guy_loc ), lit_level::LIT,
+            draw_entity_with_overlays( *guy, tripoint_bub_ms( global_omt_to_draw_position( guy_loc ) ),
+                                       lit_level::LIT,
                                        height_3d );
         }
     }
 
-    draw_entity_with_overlays( get_player_character(), global_omt_to_draw_position( avatar_pos ),
+    draw_entity_with_overlays( get_player_character(),
+                               tripoint_bub_ms( global_omt_to_draw_position( avatar_pos ) ),
                                lit_level::LIT, height_3d );
     if( !fast_traveling ) {
         draw_from_id_string( "cursor", global_omt_to_draw_position( center_pos ), 0, 0, lit_level::LIT,
@@ -1348,7 +1350,7 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
         // skip the normal drawing code for it.
         tilecontext->draw(
             point( win->pos.x * fontwidth, win->pos.y * fontheight ),
-            g->ter_view_p.raw(),
+            g->ter_view_p,
             TERRAIN_WINDOW_TERM_WIDTH * font->width,
             TERRAIN_WINDOW_TERM_HEIGHT * font->height,
             overlay_strings,
@@ -1459,8 +1461,8 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
         clear_window_area( w );
         tilecontext->draw_minimap(
             point( win->pos.x * fontwidth, win->pos.y * fontheight ),
-            tripoint( get_player_character().pos_bub().raw().xy(), g->ter_view_p.z() ),
-            win->width * font->width, win->height * font->height );
+        { get_player_character().pos_bub().xy(), g->ter_view_p.z() },
+        win->width * font->width, win->height * font->height );
         update = true;
 
     } else {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -238,11 +238,11 @@ std::string enum_to_string<sounds::sound_t>( sounds::sound_t data )
 
 // Static globals tracking sounds events of various kinds.
 // The sound events since the last monster turn.
-static std::vector<std::pair<tripoint, monster_sound_event>> recent_sounds;
+static std::vector<std::pair<tripoint_bub_ms, monster_sound_event>> recent_sounds;
 // The sound events since the last interactive player turn. (doesn't count sleep etc)
-static std::vector<std::pair<tripoint, sound_event>> sounds_since_last_turn;
+static std::vector<std::pair<tripoint_bub_ms, sound_event>> sounds_since_last_turn;
 // The sound events currently displayed to the player.
-static std::unordered_map<tripoint, sound_event> sound_markers;
+static std::unordered_map<tripoint_bub_ms, sound_event> sound_markers;
 
 // This is an attempt to handle attenuation of sound for underground areas.
 // The main issue it addresses is that you can hear activity
@@ -250,10 +250,10 @@ static std::unordered_map<tripoint, sound_event> sound_markers;
 // My research indicates that attenuation through soil-like materials is as
 // high as 100x the attenuation through air, plus vertical distances are
 // roughly five times as large as horizontal ones.
-static int sound_distance( const tripoint &source, const tripoint &sink )
+static int sound_distance( const tripoint_bub_ms &source, const tripoint_bub_ms &sink )
 {
-    const int lower_z = std::min( source.z, sink.z );
-    const int upper_z = std::max( source.z, sink.z );
+    const int lower_z = std::min( source.z(), sink.z() );
+    const int upper_z = std::max( source.z(), sink.z() );
     const int vertical_displacement = upper_z - lower_z;
     int vertical_attenuation = vertical_displacement;
     if( lower_z < 0 && vertical_displacement > 0 ) {
@@ -308,19 +308,14 @@ static bool is_provocative( sounds::sound_t category )
     cata_fatal( "Invalid sound_t category" );
 }
 
-void sounds::ambient_sound( const tripoint &p, int vol, sound_t category,
+void sounds::ambient_sound( const tripoint_bub_ms &p, int vol, sound_t category,
                             const std::string &description )
 {
     sound( p, vol, category, description, true );
 }
 
-void sounds::ambient_sound( const tripoint_bub_ms &p, int vol, sound_t category,
-                            const std::string &description )
-{
-    sounds::ambient_sound( p.raw(), vol, category, description );
-}
-
-void sounds::sound( const tripoint &p, int vol, sound_t category, const std::string &description,
+void sounds::sound( const tripoint_bub_ms &p, int vol, sound_t category,
+                    const std::string &description,
                     bool ambient, const std::string &id, const std::string &variant )
 {
     if( vol < 0 ) {
@@ -330,37 +325,24 @@ void sounds::sound( const tripoint &p, int vol, sound_t category, const std::str
     }
     // Description is not an optional parameter
     if( description.empty() ) {
-        debugmsg( "Sound at %d:%d has no description!", p.x, p.y );
+        debugmsg( "Sound at %d:%d has no description!", p.x(), p.y() );
     }
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
     recent_sounds.emplace_back( p, monster_sound_event{ vol, is_provocative( category ) } );
     sounds_since_last_turn.emplace_back( p,
-                                         sound_event { vol, category, description, ambient,
+                                         sound_event{ vol, category, description, ambient,
                                                  false, id, variant, seas_str } );
-}
-
-void sounds::sound( const tripoint_bub_ms &p, int vol, sound_t category,
-                    const std::string &description,
-                    bool ambient, const std::string &id, const std::string &variant )
-{
-    sounds::sound( p.raw(), vol, category, description, ambient, id, variant );
-}
-
-void sounds::sound( const tripoint &p, int vol, sound_t category, const translation &description,
-                    bool ambient, const std::string &id, const std::string &variant )
-{
-    sounds::sound( p, vol, category, description.translated(), ambient, id, variant );
 }
 
 void sounds::sound( const tripoint_bub_ms &p, int vol, sound_t category,
                     const translation &description,
                     bool ambient, const std::string &id, const std::string &variant )
 {
-    sounds::sound( p.raw(), vol, category, description, ambient, id, variant );
+    sounds::sound( p, vol, category, description.translated(), ambient, id, variant );
 }
 
-void sounds::add_footstep( const tripoint &p, int volume, int, monster *,
+void sounds::add_footstep( const tripoint_bub_ms &p, int volume, int, monster *,
                            const std::string &footstep )
 {
     const season_type seas = season_of_year( calendar::turn );
@@ -380,8 +362,9 @@ static void vector_quick_remove( std::vector<C> &source, int index )
     source.pop_back();
 }
 
-static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, monster_sound_event>>
-        input_sounds )
+static std::vector<centroid> cluster_sounds(
+    std::vector<std::pair<tripoint_bub_ms, monster_sound_event>>
+    input_sounds )
 {
     // If there are too many monsters and too many noise sources (which can be monsters, go figure),
     // applying sound events to monsters can dominate processing time for the whole game,
@@ -395,8 +378,8 @@ static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, mon
         std::max( std::min( input_sounds.size(), static_cast<size_t>( 10 ) ),
                   static_cast<size_t>( std::log( input_sounds.size() ) ) );
     const size_t stopping_point = input_sounds.size() - num_seed_clusters;
-    const size_t max_map_distance = sound_distance( tripoint( point::zero, OVERMAP_DEPTH ),
-                                    tripoint( MAPSIZE_X, MAPSIZE_Y, OVERMAP_HEIGHT ) );
+    const size_t max_map_distance = sound_distance( { point_bub_ms::zero, OVERMAP_DEPTH },
+    { MAPSIZE_X, MAPSIZE_Y, OVERMAP_HEIGHT } );
     // Randomly choose cluster seeds.
     for( size_t i = input_sounds.size(); i > stopping_point; i-- ) {
         size_t index = rng( 0, i - 1 );
@@ -404,8 +387,8 @@ static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, mon
         sound_clusters.push_back(
             // Assure the compiler that these int->float conversions are safe.
         {
-            static_cast<float>( input_sounds[index].first.x ), static_cast<float>( input_sounds[index].first.y ),
-            static_cast<float>( input_sounds[index].first.z ),
+            static_cast<float>( input_sounds[index].first.x() ), static_cast<float>( input_sounds[index].first.y() ),
+            static_cast<float>( input_sounds[index].first.z() ),
             static_cast<float>( input_sounds[index].second.volume ), static_cast<float>( input_sounds[index].second.volume ),
             input_sounds[index].second.provocative
         } );
@@ -418,8 +401,8 @@ static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, mon
         for( auto centroid_iter = sound_clusters.begin(); centroid_iter != cluster_end;
              ++centroid_iter ) {
             // Scale the distance between the two by the max possible distance.
-            tripoint centroid_pos { static_cast<int>( centroid_iter->x ), static_cast<int>( centroid_iter->y ), static_cast<int>( centroid_iter->z ) };
-            const int dist = sound_distance( sound_event_pair.first, centroid_pos );
+            tripoint_bub_ms centroid_pos { static_cast<int>( centroid_iter->x ), static_cast<int>( centroid_iter->y ), static_cast<int>( centroid_iter->z ) };
+            const int dist = sound_distance( tripoint_bub_ms( sound_event_pair.first ), centroid_pos );
             if( dist * dist < dist_factor ) {
                 found_centroid = centroid_iter;
                 dist_factor = dist * dist;
@@ -428,13 +411,13 @@ static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, mon
         const float volume_sum = static_cast<float>( sound_event_pair.second.volume ) +
                                  found_centroid->weight;
         // Set the centroid location to the average of the two locations, weighted by volume.
-        found_centroid->x = static_cast<float>( ( sound_event_pair.first.x *
+        found_centroid->x = static_cast<float>( ( sound_event_pair.first.x() *
                                                 sound_event_pair.second.volume ) +
                                                 ( found_centroid->x * found_centroid->weight ) ) / volume_sum;
-        found_centroid->y = static_cast<float>( ( sound_event_pair.first.y *
+        found_centroid->y = static_cast<float>( ( sound_event_pair.first.y() *
                                                 sound_event_pair.second.volume ) +
                                                 ( found_centroid->y * found_centroid->weight ) ) / volume_sum;
-        found_centroid->z = static_cast<float>( ( sound_event_pair.first.z *
+        found_centroid->z = static_cast<float>( ( sound_event_pair.first.z() *
                                                 sound_event_pair.second.volume ) +
                                                 ( found_centroid->z * found_centroid->weight ) ) / volume_sum;
         // Set the centroid volume to the larger of the volumes.
@@ -497,7 +480,7 @@ void sounds::process_sounds()
         // Alert all monsters (that can hear) to the sound.
         for( monster &critter : g->all_monsters() ) {
             // TODO: Generalize this to Creature::hear_sound
-            const int dist = sound_distance( source.raw(), critter.pos() );
+            const int dist = sound_distance( source, critter.pos_bub() );
             if( vol * 2 > dist ) {
                 // Exclude monsters that certainly won't hear the sound
                 critter.hear_sound( source, vol, dist, this_centroid.provocative );
@@ -506,12 +489,12 @@ void sounds::process_sounds()
         // Trigger sound-triggered traps and ensure they are still valid
         for( const trap *trapType : trap::get_sound_triggered_traps() ) {
             for( const tripoint_bub_ms &tp : get_map().trap_locations( trapType->id ) ) {
-                const int dist = sound_distance( source.raw(), tp.raw() );
+                const int dist = sound_distance( source, tp );
                 const trap &tr = get_map().tr_at( tp );
                 // Exclude traps that certainly won't hear the sound
                 if( vol * 2 > dist ) {
                     if( tr.triggered_by_sound( vol, dist ) ) {
-                        tr.trigger( tp.raw() );
+                        tr.trigger( tp );
                     }
                 }
             }
@@ -582,7 +565,7 @@ void sounds::process_sound_markers( Character *you )
         // so the references may become invalid after the vector enlarged its internal buffer
         const tripoint_bub_ms pos = tripoint_bub_ms( sounds_since_last_turn[i].first );
         const sound_event sound = sounds_since_last_turn[i].second;
-        const int distance_to_sound = sound_distance( you->pos_bub().raw(), pos.raw() );
+        const int distance_to_sound = sound_distance( you->pos_bub(), pos );
         const int raw_volume = sound.volume;
 
         // The felt volume of a sound is not affected by negative multipliers, such as already
@@ -769,10 +752,10 @@ void sounds::process_sound_markers( Character *you )
         // Enumerate the valid points the player *cannot* see.
         // Unless the source is on a different z-level, then any point is fine
         // Also show sensory sounds like SONAR even if we can see the point.
-        std::vector<tripoint> unseen_points;
+        std::vector<tripoint_bub_ms> unseen_points;
         for( const tripoint_bub_ms &newp : get_map().points_in_radius( pos, err_offset ) ) {
             if( diff_z || sound.category == sound_t::sensory || !you->sees( newp ) ) {
-                unseen_points.emplace_back( newp.raw() );
+                unseen_points.emplace_back( newp );
             }
         }
 
@@ -798,10 +781,10 @@ void sounds::reset_markers()
     sound_markers.clear();
 }
 
-std::vector<tripoint> sounds::get_footstep_markers()
+std::vector<tripoint_bub_ms> sounds::get_footstep_markers()
 {
     // Optimization, make this static and clear it in reset_markers?
-    std::vector<tripoint> footsteps;
+    std::vector<tripoint_bub_ms> footsteps;
     footsteps.reserve( sound_markers.size() );
     for( const auto &mark : sound_markers ) {
         footsteps.push_back( mark.first );
@@ -809,15 +792,15 @@ std::vector<tripoint> sounds::get_footstep_markers()
     return footsteps;
 }
 
-std::pair<std::vector<tripoint>, std::vector<tripoint>> sounds::get_monster_sounds()
+std::pair<std::vector<tripoint_bub_ms>, std::vector<tripoint_bub_ms>> sounds::get_monster_sounds()
 {
     auto sound_clusters = cluster_sounds( recent_sounds );
-    std::vector<tripoint> sound_locations;
+    std::vector<tripoint_bub_ms> sound_locations;
     sound_locations.reserve( recent_sounds.size() );
     for( const auto &sound : recent_sounds ) {
         sound_locations.push_back( sound.first );
     }
-    std::vector<tripoint> cluster_centroids;
+    std::vector<tripoint_bub_ms> cluster_centroids;
     cluster_centroids.reserve( sound_clusters.size() );
     for( const centroid &sound : sound_clusters ) {
         cluster_centroids.emplace_back( static_cast<int>( sound.x ), static_cast<int>( sound.y ),
@@ -826,7 +809,7 @@ std::pair<std::vector<tripoint>, std::vector<tripoint>> sounds::get_monster_soun
     return { sound_locations, cluster_centroids };
 }
 
-std::string sounds::sound_at( const tripoint &location )
+std::string sounds::sound_at( const tripoint_bub_ms &location )
 {
     auto this_sound = sound_markers.find( location );
     if( this_sound == sound_markers.end() ) {
@@ -1025,7 +1008,7 @@ void sfx::do_vehicle_engine_sfx()
         add_msg_debug( debugmode::DF_SOUND, "STOP speed %d =/= %d", current_speed, previous_speed );
         play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                     seas_str, indoors, night,
-                                    sfx::get_heard_volume( player_character.pos() ), ch, 1000, pitch );
+                                    sfx::get_heard_volume( player_character.pos_bub() ), ch, 1000, pitch );
         add_msg_debug( debugmode::DF_SOUND, "PITCH %f", pitch );
     }
     previous_speed = current_speed;
@@ -1063,10 +1046,10 @@ void sfx::do_vehicle_exterior_engine_sfx()
     for( wrapped_vehicle vehicle : vehs ) {
         if( vehicle.v->vehicle_noise > 0 &&
             vehicle.v->vehicle_noise -
-            sound_distance( player_character.pos_bub().raw(), vehicle.v->pos_bub().raw() ) > noise_factor ) {
+            sound_distance( player_character.pos_bub(), vehicle.v->pos_bub() ) > noise_factor ) {
 
-            noise_factor = vehicle.v->vehicle_noise - sound_distance( player_character.pos_bub().raw(),
-                           vehicle.v->pos_bub().raw() );
+            noise_factor = vehicle.v->vehicle_noise - sound_distance( player_character.pos_bub(),
+                           vehicle.v->pos_bub() );
             veh = vehicle.v;
         }
     }
@@ -1105,7 +1088,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
 
     if( is_channel_playing( ch ) ) {
         if( engine_external_id_and_variant == id_and_variant ) {
-            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub().raw() ) ), 0 );
+            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub() ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg_debug( debugmode::DF_SOUND, "PLAYING exterior_engine_sound, vol: ex:%d true:%d", vol,
                            Mix_Volume( ch_int, -1 ) );
@@ -1115,7 +1098,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
             add_msg_debug( debugmode::DF_SOUND, "STOP exterior_engine_sound, change id/var" );
             play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                         seas_str, indoors, night, 128, ch, 0 );
-            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub().raw() ) ), 0 );
+            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub() ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg_debug( debugmode::DF_SOUND, "START exterior_engine_sound %s %s vol: %d",
                            id_and_variant.first,
@@ -1126,7 +1109,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
         play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                     seas_str, indoors, night, 128, ch, 0 );
         add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
-        Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub().raw() ) ), 0 );
+        Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub() ) ), 0 );
         add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
         set_channel_volume( ch, vol );
         add_msg_debug( debugmode::DF_SOUND, "START exterior_engine_sound NEW %s %s vol: ex:%d true:%d",
@@ -1327,7 +1310,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
     if( std::chrono::duration_cast<std::chrono::milliseconds> ( sfx_time ).count() < 80 ) {
         return;
     }
-    const tripoint source = source_arg.pos();
+    const tripoint_bub_ms source = source_arg.pos_bub();
     int heard_volume = get_heard_volume( source );
     if( heard_volume <= 30 ) {
         heard_volume = 30;
@@ -1343,7 +1326,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
     const bool indoors = !is_creature_outside( player_character );
     const bool night = is_night( calendar::turn );
     // this does not mean p == avatar (it could be a vehicle turret)
-    if( player_character.pos() == source ) {
+    if( player_character.pos_bub() == source ) {
         selected_sound = "fire_gun";
 
         const auto mods = firing.gunmods();
@@ -1356,7 +1339,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
 
     } else {
         angle = get_heard_angle( source );
-        distance = sound_distance( player_character.pos(), source );
+        distance = sound_distance( player_character.pos_bub(), source );
         if( distance <= 17 ) {
             selected_sound = "fire_gun";
         } else {
@@ -1372,7 +1355,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
 namespace sfx
 {
 struct sound_thread {
-    sound_thread( const tripoint &source, const tripoint &target, bool hit, bool targ_mon,
+    sound_thread( const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit, bool targ_mon,
                   const std::string &material );
 
     bool hit;
@@ -1392,7 +1375,8 @@ struct sound_thread {
 };
 } // namespace sfx
 
-void sfx::generate_melee_sound( const tripoint &source, const tripoint &target, bool hit,
+void sfx::generate_melee_sound( const tripoint_bub_ms &source, const tripoint_bub_ms &target,
+                                bool hit,
                                 bool targ_mon,
                                 const std::string &material )
 {
@@ -1417,7 +1401,8 @@ void sfx::generate_melee_sound( const tripoint &source, const tripoint &target, 
     }
 }
 
-sfx::sound_thread::sound_thread( const tripoint &source, const tripoint &target, const bool hit,
+sfx::sound_thread::sound_thread( const tripoint_bub_ms &source, const tripoint_bub_ms &target,
+                                 const bool hit,
                                  const bool targ_mon, const std::string &material )
     : hit( hit )
     , targ_mon( targ_mon )
@@ -1509,7 +1494,7 @@ void sfx::do_projectile_hit( const Creature &target )
     }
 
     const int heard_volume = sfx::get_heard_volume( target.pos_bub() );
-    const units::angle angle = get_heard_angle( target.pos() );
+    const units::angle angle = get_heard_angle( target.pos_bub() );
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
     const bool indoors = !is_creature_outside( get_player_character() );
@@ -2008,7 +1993,7 @@ void sfx::play_ambient_variant_sound( const std::string &, const std::string &, 
 void sfx::play_activity_sound( const std::string &, const std::string &, int ) { }
 void sfx::end_activity_sounds() { }
 void sfx::generate_gun_sound( const Character &, const item & ) { }
-void sfx::generate_melee_sound( const tripoint &, const tripoint &, bool, bool,
+void sfx::generate_melee_sound( const tripoint_bub_ms &, const tripoint_bub_ms &, bool, bool,
                                 const std::string & ) { }
 void sfx::do_hearing_loss( int ) { }
 void sfx::remove_hearing_loss() { }
@@ -2046,9 +2031,9 @@ void sfx::play_variant_sound( const std::string &, const std::string &, const st
 /** Functions from sfx that do not use the SDL_mixer API at all. They can be used in builds
   * without sound support. */
 /*@{*/
-int sfx::get_heard_volume( const tripoint &source )
+int sfx::get_heard_volume( const tripoint_bub_ms &source )
 {
-    int distance = sound_distance( get_player_character().pos(), source );
+    int distance = sound_distance( get_player_character().pos_bub(), source );
     // fract = -100 / 24
     const float fract = -4.166666f;
     int heard_volume = fract * distance - 1 + 100;
@@ -2059,14 +2044,9 @@ int sfx::get_heard_volume( const tripoint &source )
     return heard_volume;
 }
 
-int sfx::get_heard_volume( const tripoint_bub_ms &source )
+units::angle sfx::get_heard_angle( const tripoint_bub_ms &source )
 {
-    return sfx::get_heard_volume( source.raw() );
-}
-
-units::angle sfx::get_heard_angle( const tripoint &source )
-{
-    units::angle angle = coord_to_angle( get_player_character().pos(), source ) + 90_degrees;
+    units::angle angle = coord_to_angle( get_player_character().pos_bub(), source ) + 90_degrees;
     //add_msg(m_warning, "angle: %i", angle);
     return angle;
 }

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -53,27 +53,17 @@ enum class sound_t : int {
  * @param variant Variant of sound effect given in id
  * @returns true if the player could hear the sound.
  */
-// TODO: Get rid of untyped overload.
-void sound( const tripoint &p, int vol, sound_t category, const std::string &description,
-            bool ambient = false, const std::string &id = "",
-            const std::string &variant = "default" );
 void sound( const tripoint_bub_ms &p, int vol, sound_t category, const std::string &description,
-            bool ambient = false, const std::string &id = "",
-            const std::string &variant = "default" );
-// TODO: Get rid of untyped overload.
-void sound( const tripoint &p, int vol, sound_t category, const translation &description,
             bool ambient = false, const std::string &id = "",
             const std::string &variant = "default" );
 void sound( const tripoint_bub_ms &p, int vol, sound_t category, const translation &description,
             bool ambient = false, const std::string &id = "",
             const std::string &variant = "default" );
 /** Functions identical to sound(..., true). */
-// TODO: Get rid of untyped overload
-void ambient_sound( const tripoint &p, int vol, sound_t category, const std::string &description );
 void ambient_sound( const tripoint_bub_ms &p, int vol, sound_t category,
                     const std::string &description );
 /** Creates a list of coordinates at which to draw footsteps. */
-void add_footstep( const tripoint &p, int volume, int distance, monster *source,
+void add_footstep( const tripoint_bub_ms &p, int volume, int distance, monster *source,
                    const std::string &footstep );
 
 /* Make sure the sounds are all reset when we start a new game. */
@@ -87,11 +77,11 @@ void process_sounds();
 void process_sound_markers( Character *you );
 
 // Return list of points that have sound events the player can hear.
-std::vector<tripoint> get_footstep_markers();
+std::vector<tripoint_bub_ms> get_footstep_markers();
 // Return list of all sounds and the list of sound cluster centroids.
-std::pair<std::vector<tripoint>, std::vector<tripoint>> get_monster_sounds();
+std::pair<std::vector<tripoint_bub_ms>, std::vector<tripoint_bub_ms>> get_monster_sounds();
 // retrieve the sound event(s?) at a location.
-std::string sound_at( const tripoint &location );
+std::string sound_at( const tripoint_bub_ms &location );
 /** Tells us if sound has been enabled in options */
 extern bool sound_enabled;
 } // namespace sounds
@@ -171,15 +161,13 @@ void play_activity_sound( const std::string &id, const std::string &variant,
                           const std::string &season, int volume );
 void end_activity_sounds();
 void generate_gun_sound( const Character &source_arg, const item &firing );
-void generate_melee_sound( const tripoint &source, const tripoint &target, bool hit,
+void generate_melee_sound( const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit,
                            bool targ_mon = false, const std::string &material = "flesh" );
 void do_hearing_loss( int turns = -1 );
 void remove_hearing_loss();
 void do_projectile_hit( const Creature &target );
-// TODO: Get rid of untyped overload
-int get_heard_volume( const tripoint &source );
 int get_heard_volume( const tripoint_bub_ms &source );
-units::angle get_heard_angle( const tripoint &source );
+units::angle get_heard_angle( const tripoint_bub_ms &source );
 void do_footstep();
 void do_danger_music();
 void do_ambient();

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -600,7 +600,7 @@ void suffer::from_asthma( Character &you, const int current_stim )
     map &here = get_map();
     if( you.in_sleep_state() && !you.has_effect( effect_narcosis ) ) {
         inventory map_inv;
-        map_inv.form_from_map( you.pos(), 2, &you );
+        map_inv.form_from_map( you.pos_bub(), 2, &you );
         // check if an inhaler is somewhere near
         bool nearby_use = auto_use || oxygenator || map_inv.has_charges( itype_inhaler, 1 ) ||
                           map_inv.has_charges( itype_oxygen_tank, 1 ) ||
@@ -702,7 +702,7 @@ void suffer::in_sunlight( Character &you )
         const float weather_factor = std::min( incident_sun_irradiance( get_weather().weather_id,
                                                calendar::turn ) / irradiance::moderate, 1.f );
         const int player_local_temp = units::to_fahrenheit( get_weather().get_temperature(
-                                          position.raw() ) );
+                                          position ) );
         const int flux = ( player_local_temp - 65 ) / 2;
         if( !has_hat ) {
             sunlight_nutrition += ( 100 + flux ) * weather_factor;

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -259,7 +259,7 @@ bool trap::detected_by_echolocation() const
     return has_flag( json_flag_ECHOLOCATION_DETECTABLE );
 }
 
-bool trap::detect_trap( const tripoint &pos, const Character &p ) const
+bool trap::detect_trap( const tripoint_bub_ms &pos, const Character &p ) const
 {
     // * Buried landmines, the silent killer, have a visibility of 10.
     // Assuming no knowledge of traps or proficiencies, and average per/int (8 each),
@@ -280,7 +280,7 @@ bool trap::detect_trap( const tripoint &pos, const Character &p ) const
 
     // The further away the trap is, the harder it is to spot.
     // Subtract 1 so that we don't get an unfair penalty when not quite on top of the trap.
-    const int distance_penalty = rl_dist( p.pos(), pos ) - 1;
+    const int distance_penalty = rl_dist( p.pos_bub(), pos ) - 1;
 
     int proficiency_effect = -1;
     // Without at least a basic traps proficiency, your skill level is effectively three levels lower.
@@ -314,18 +314,6 @@ bool trap::detect_trap( const tripoint &pos, const Character &p ) const
 }
 
 // Whether or not, in the current state, the player can see the trap.
-bool trap::can_see( const tripoint &pos, const Character &p ) const
-{
-    if( is_null() ) {
-        // There is no trap at all, so logically one can not see it.
-        return false;
-    }
-    if( is_always_invisible() ) {
-        return false;
-    }
-    return visibility < 0 || p.knows_trap( tripoint_bub_ms( pos ) );
-}
-
 bool trap::can_see( const tripoint_bub_ms &pos, const Character &p ) const
 {
     if( is_null() ) {
@@ -338,7 +326,7 @@ bool trap::can_see( const tripoint_bub_ms &pos, const Character &p ) const
     return visibility < 0 || p.knows_trap( pos );
 }
 
-void trap::trigger( const tripoint &pos ) const
+void trap::trigger( const tripoint_bub_ms &pos ) const
 {
     if( is_null() ) {
         return;
@@ -346,17 +334,17 @@ void trap::trigger( const tripoint &pos ) const
     act( pos, nullptr, nullptr );
 }
 
-void trap::trigger( const tripoint &pos, Creature &creature ) const
+void trap::trigger( const tripoint_bub_ms &pos, Creature &creature ) const
 {
     return trigger( pos, &creature, nullptr );
 }
 
-void trap::trigger( const tripoint &pos, item &item ) const
+void trap::trigger( const tripoint_bub_ms &pos, item &item ) const
 {
     return trigger( pos, nullptr, &item );
 }
 
-void trap::trigger( const tripoint &pos, Creature *creature, item *item ) const
+void trap::trigger( const tripoint_bub_ms &pos, Creature *creature, item *item ) const
 {
     if( is_null() ) {
         return;
@@ -412,7 +400,7 @@ bool trap::triggered_by_sound( int vol, int dist ) const
     return !is_null() && ( rng( 0, 100 ) <= sound_chance );
 }
 
-void trap::on_disarmed( map &m, const tripoint &p ) const
+void trap::on_disarmed( map &m, const tripoint_bub_ms &p ) const
 {
     for( const auto &i : components ) {
         const itype_id &item_type = std::get<0>( i );

--- a/src/trap.h
+++ b/src/trap.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "color.h"
+#include "coords_fwd.h"
 #include "effect_on_condition.h"
 #include "flat_set.h"
 #include "magic.h"
@@ -31,41 +32,41 @@ namespace trapfunc
 // creature is the creature that triggered the trap,
 // item is the item that triggered the trap,
 // creature and item can be nullptr.
-bool none( const tripoint &, Creature *, item * );
-bool bubble( const tripoint &p, Creature *c, item *i );
-bool glass( const tripoint &p, Creature *c, item *i );
-bool cot( const tripoint &p, Creature *c, item *i );
-bool beartrap( const tripoint &p, Creature *c, item *i );
-bool snare_light( const tripoint &p, Creature *c, item *i );
-bool snare_heavy( const tripoint &p, Creature *c, item *i );
-bool snare_species( const tripoint &p, Creature *critter, item *trap_item );
-bool board( const tripoint &p, Creature *c, item *i );
-bool caltrops( const tripoint &p, Creature *c, item *i );
-bool caltrops_glass( const tripoint &p, Creature *c, item *i );
-bool eocs( const tripoint &p, Creature *critter, item * );
-bool tripwire( const tripoint &p, Creature *c, item *i );
-bool crossbow( const tripoint &p, Creature *c, item *i );
-bool shotgun( const tripoint &p, Creature *c, item *i );
-bool blade( const tripoint &p, Creature *c, item *i );
-bool landmine( const tripoint &p, Creature *c, item *i );
-bool goo( const tripoint &p, Creature *c, item *i );
-bool dissector( const tripoint &p, Creature *c, item *i );
-bool sinkhole( const tripoint &p, Creature *c, item *i );
-bool pit( const tripoint &p, Creature *c, item *i );
-bool pit_spikes( const tripoint &p, Creature *c, item *i );
-bool pit_glass( const tripoint &p, Creature *c, item *i );
-bool lava( const tripoint &p, Creature *c, item *i );
-bool boobytrap( const tripoint &p, Creature *c, item *i );
-bool temple_flood( const tripoint &p, Creature *c, item *i );
-bool temple_toggle( const tripoint &p, Creature *c, item *i );
-bool glow( const tripoint &p, Creature *c, item *i );
-bool hum( const tripoint &p, Creature *c, item *i );
-bool shadow( const tripoint &p, Creature *c, item *i );
-bool map_regen( const tripoint &p, Creature *c, item *i );
-bool drain( const tripoint &p, Creature *c, item *i );
-bool snake( const tripoint &p, Creature *c, item *i );
-bool cast_spell( const tripoint &p, Creature *critter, item * );
-bool dummy_trap( const tripoint &p, Creature *critter, item * );
+bool none( const tripoint_bub_ms &, Creature *, item * );
+bool bubble( const tripoint_bub_ms &p, Creature *c, item *i );
+bool glass( const tripoint_bub_ms &p, Creature *c, item *i );
+bool cot( const tripoint_bub_ms &p, Creature *c, item *i );
+bool beartrap( const tripoint_bub_ms &p, Creature *c, item *i );
+bool snare_light( const tripoint_bub_ms &p, Creature *c, item *i );
+bool snare_heavy( const tripoint_bub_ms &p, Creature *c, item *i );
+bool snare_species( const tripoint_bub_ms &p, Creature *critter, item *trap_item );
+bool board( const tripoint_bub_ms &p, Creature *c, item *i );
+bool caltrops( const tripoint_bub_ms &p, Creature *c, item *i );
+bool caltrops_glass( const tripoint_bub_ms &p, Creature *c, item *i );
+bool eocs( const tripoint_bub_ms &p, Creature *critter, item * );
+bool tripwire( const tripoint_bub_ms &p, Creature *c, item *i );
+bool crossbow( const tripoint_bub_ms &p, Creature *c, item *i );
+bool shotgun( const tripoint_bub_ms &p, Creature *c, item *i );
+bool blade( const tripoint_bub_ms &p, Creature *c, item *i );
+bool landmine( const tripoint_bub_ms &p, Creature *c, item *i );
+bool goo( const tripoint_bub_ms &p, Creature *c, item *i );
+bool dissector( const tripoint_bub_ms &p, Creature *c, item *i );
+bool sinkhole( const tripoint_bub_ms &p, Creature *c, item *i );
+bool pit( const tripoint_bub_ms &p, Creature *c, item *i );
+bool pit_spikes( const tripoint_bub_ms &p, Creature *c, item *i );
+bool pit_glass( const tripoint_bub_ms &p, Creature *c, item *i );
+bool lava( const tripoint_bub_ms &p, Creature *c, item *i );
+bool boobytrap( const tripoint_bub_ms &p, Creature *c, item *i );
+bool temple_flood( const tripoint_bub_ms &p, Creature *c, item *i );
+bool temple_toggle( const tripoint_bub_ms &p, Creature *c, item *i );
+bool glow( const tripoint_bub_ms &p, Creature *c, item *i );
+bool hum( const tripoint_bub_ms &p, Creature *c, item *i );
+bool shadow( const tripoint_bub_ms &p, Creature *c, item *i );
+bool map_regen( const tripoint_bub_ms &p, Creature *c, item *i );
+bool drain( const tripoint_bub_ms &p, Creature *c, item *i );
+bool snake( const tripoint_bub_ms &p, Creature *c, item *i );
+bool cast_spell( const tripoint_bub_ms &p, Creature *critter, item * );
+bool dummy_trap( const tripoint_bub_ms &p, Creature *critter, item * );
 } // namespace trapfunc
 
 struct vehicle_handle_trap_data {
@@ -84,7 +85,7 @@ struct vehicle_handle_trap_data {
     trap_str_id set_trap = trap_str_id::NULL_ID();
 };
 
-using trap_function = std::function<bool( const tripoint &, Creature *, item * )>;
+using trap_function = std::function<bool( const tripoint_bub_ms &, Creature *, item * )>;
 
 /**
  * Some traps aren't actually traps in the usual sense of the word. We use traps to implement
@@ -204,8 +205,6 @@ struct trap {
          * called on the null trap.
          */
         // Implemented for historical reasons in iexamine.cpp
-        // TODO: Get rid of untyped overload.
-        void examine( const tripoint &examp ) const;
         void examine( const tripoint_bub_ms &examp ) const;
 
         update_mapgen_id map_regen_target() const;
@@ -250,13 +249,11 @@ struct trap {
         bool detected_by_echolocation() const;
         /** Player has not yet seen the trap and returns the variable chance, at this moment,
          of whether the trap is seen or not. */
-        bool detect_trap( const tripoint &pos, const Character &p ) const;
+        bool detect_trap( const tripoint_bub_ms &pos, const Character &p ) const;
         /**
          * Can player/npc p see this kind of trap, either by their memory (they known there is
          * the trap) or by the visibility of the trap (the trap is not hidden at all)?
          */
-        // TODO: Get rid of untyped overload.
-        bool can_see( const tripoint &pos, const Character &p ) const;
         bool can_see( const tripoint_bub_ms &pos, const Character &p ) const;
 
         bool has_trigger_msg() const {
@@ -285,7 +282,7 @@ struct trap {
          * @param item The item that triggered the trap
          */
         // Don't call from outside this class. Add a wrapper like the ones below instead.
-        void trigger( const tripoint &pos, Creature *creature, item *item ) const;
+        void trigger( const tripoint_bub_ms &pos, Creature *creature, item *item ) const;
     public:
         /*@{*/
         /**
@@ -296,11 +293,11 @@ struct trap {
          * caller has already checked whether the trap should be activated
          * (e.g. the creature has had a chance to avoid the trap, but it failed).
          */
-        void trigger( const tripoint &pos, Creature &creature ) const;
-        void trigger( const tripoint &pos, item &item ) const;
+        void trigger( const tripoint_bub_ms &pos, Creature &creature ) const;
+        void trigger( const tripoint_bub_ms &pos, item &item ) const;
         /*@}*/
 
-        void trigger( const tripoint &pos ) const;
+        void trigger( const tripoint_bub_ms &pos ) const;
 
         /**
          * If the given item is throw onto the trap, does it trigger the trap?
@@ -312,7 +309,7 @@ struct trap {
          * It should spawn trap items (if any) and remove the trap from the map via
          * @ref map::remove_trap.
          */
-        void on_disarmed( map &m, const tripoint &p ) const;
+        void on_disarmed( map &m, const tripoint_bub_ms &p ) const;
         /**
          * This is used when defining area this trap occupies. A value of 0 means trap occupies exactly 1 tile.
          */

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -98,7 +98,7 @@ static const trap_str_id tr_shotgun_2( "tr_shotgun_2" );
 static const trap_str_id tr_temple_flood( "tr_temple_flood" );
 
 // A pit becomes less effective as it fills with corpses.
-static float pit_effectiveness( const tripoint &p )
+static float pit_effectiveness( const tripoint_bub_ms &p )
 {
     units::volume corpse_volume = 0_ml;
     for( item &pit_content : get_map().i_at( p ) ) {
@@ -113,12 +113,12 @@ static float pit_effectiveness( const tripoint &p )
     return std::max( 0.0f, 1.0f - corpse_volume / filled_volume );
 }
 
-bool trapfunc::none( const tripoint &, Creature *, item * )
+bool trapfunc::none( const tripoint_bub_ms &, Creature *, item * )
 {
     return false;
 }
 
-bool trapfunc::bubble( const tripoint &p, Creature *c, item * )
+bool trapfunc::bubble( const tripoint_bub_ms &p, Creature *c, item * )
 {
     // tiny animals don't trigger bubble wrap
     if( c != nullptr && c->get_size() == creature_size::tiny ) {
@@ -136,7 +136,7 @@ bool trapfunc::bubble( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::glass( const tripoint &p, Creature *c, item * )
+bool trapfunc::glass( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -160,7 +160,7 @@ bool trapfunc::glass( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::cot( const tripoint &, Creature *c, item * )
+bool trapfunc::cot( const tripoint_bub_ms &, Creature *c, item * )
 {
     monster *z = dynamic_cast<monster *>( c );
     if( z != nullptr ) {
@@ -172,7 +172,7 @@ bool trapfunc::cot( const tripoint &, Creature *c, item * )
     return false;
 }
 
-bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
+bool trapfunc::beartrap( const tripoint_bub_ms &p, Creature *c, item * )
 {
     // tiny animals don't trigger bear traps
     if( c != nullptr && c->get_size() == creature_size::tiny ) {
@@ -216,7 +216,7 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-static void mount_step_on_trap_make_slow_give_msg( monster *z, const tripoint &p )
+static void mount_step_on_trap_make_slow_give_msg( monster *z, const tripoint_bub_ms &p )
 {
     if( !z ) { // should never happen
         debugmsg( "non-monster creature passed to mount_step_on_trap_make_slow_give_msg" );
@@ -225,7 +225,7 @@ static void mount_step_on_trap_make_slow_give_msg( monster *z, const tripoint &p
     map &here = get_map();
     Character *rider = nullptr;
     for( npc &guy : g->all_npcs() ) {
-        if( guy.pos() == p && guy.pos_bub() == z->pos_bub() ) {
+        if( guy.pos_bub() == p && guy.pos_bub() == z->pos_bub() ) {
             rider = &guy;
             break;
         }
@@ -254,7 +254,7 @@ static void try_apply_tetanus( Character *you, int total_cut_dmg )
     }
 }
 
-bool trapfunc::board( const tripoint &p, Creature *c, item * )
+bool trapfunc::board( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -294,7 +294,7 @@ bool trapfunc::board( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::caltrops( const tripoint &p, Creature *c, item * )
+bool trapfunc::caltrops( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -336,7 +336,7 @@ bool trapfunc::caltrops( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::caltrops_glass( const tripoint &p, Creature *c, item * )
+bool trapfunc::caltrops_glass( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -365,7 +365,7 @@ bool trapfunc::caltrops_glass( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::eocs( const tripoint &p, Creature *critter, item * )
+bool trapfunc::eocs( const tripoint_bub_ms &p, Creature *critter, item * )
 {
     if( !critter ) {
         //TODO: Pass the item as a talker somehow taking into account we don't have the item's tripoint in the case of ranged traps so something like get_talker_for( item_location( map_cursor( tripoint_bub_ms( p ) ), it ) ) isn't enough (and didn't work for non ranged traps on testing anyway)
@@ -388,7 +388,7 @@ bool trapfunc::eocs( const tripoint &p, Creature *critter, item * )
 }
 
 
-bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
+bool trapfunc::tripwire( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -407,8 +407,8 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
     if( z != nullptr ) {
         if( z->has_effect( effect_ridden ) ) {
             add_msg( m_bad, _( "Your %s trips over a tripwire!" ), z->get_name() );
-            std::vector<tripoint> valid;
-            for( const tripoint &jk : here.points_in_radius( p, 1 ) ) {
+            std::vector<tripoint_bub_ms> valid;
+            for( const tripoint_bub_ms &jk : here.points_in_radius( p, 1 ) ) {
                 if( g->is_empty( jk ) ) {
                     valid.push_back( jk );
                 }
@@ -427,8 +427,8 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
                             4 ) ) );
         }
     } else if( you != nullptr ) {
-        std::vector<tripoint> valid;
-        for( const tripoint &jk : here.points_in_radius( p, 1 ) ) {
+        std::vector<tripoint_bub_ms> valid;
+        for( const tripoint_bub_ms &jk : here.points_in_radius( p, 1 ) ) {
             if( g->is_empty( jk ) ) {
                 valid.push_back( jk );
             }
@@ -451,7 +451,7 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::crossbow( const tripoint &p, Creature *c, item * )
+bool trapfunc::crossbow( const tripoint_bub_ms &p, Creature *c, item * )
 {
     bool add_bolt = true;
     if( c != nullptr ) {
@@ -549,7 +549,7 @@ bool trapfunc::crossbow( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
+bool trapfunc::shotgun( const tripoint_bub_ms &p, Creature *c, item * )
 {
     map &here = get_map();
     sounds::sound( p, 60, sounds::sound_t::combat, _( "Kerblam!" ), false, "fire_gun",
@@ -651,7 +651,7 @@ bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::blade( const tripoint &, Creature *c, item * )
+bool trapfunc::blade( const tripoint_bub_ms &, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -669,7 +669,7 @@ bool trapfunc::blade( const tripoint &, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::snare_light( const tripoint &p, Creature *c, item * )
+bool trapfunc::snare_light( const tripoint_bub_ms &p, Creature *c, item * )
 {
     sounds::sound( p, 4, sounds::sound_t::combat, _( "Snap!" ), false, "trap", "snare" );
     map &here = get_map();
@@ -695,7 +695,7 @@ bool trapfunc::snare_light( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::snare_heavy( const tripoint &p, Creature *c, item * )
+bool trapfunc::snare_heavy( const tripoint_bub_ms &p, Creature *c, item * )
 {
     sounds::sound( p, 4, sounds::sound_t::combat, _( "Snap!" ), false, "trap", "snare" );
     get_map().remove_trap( p );
@@ -738,7 +738,7 @@ bool trapfunc::snare_heavy( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::snare_species( const tripoint &p, Creature *critter, item * )
+bool trapfunc::snare_species( const tripoint_bub_ms &p, Creature *critter, item * )
 {
     map &here = get_map();
     const trap &laid_trap = here.tr_at( p );
@@ -800,7 +800,7 @@ bool trapfunc::snare_species( const tripoint &p, Creature *critter, item * )
     return true;
 }
 
-bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
+bool trapfunc::landmine( const tripoint_bub_ms &p, Creature *c, item * )
 {
     // tiny animals are too light to trigger land mines
     if( c != nullptr && c->get_size() == creature_size::tiny ) {
@@ -810,12 +810,12 @@ bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
         c->add_msg_player_or_npc( m_bad, _( "You trigger a land mine!" ),
                                   _( "<npcname> triggers a land mine!" ) );
     }
-    explosion_handler::explosion( c, tripoint_bub_ms( p ), 18, 0.5, false, 8 );
+    explosion_handler::explosion( c, p, 18, 0.5, false, 8 );
     get_map().remove_trap( p );
     return true;
 }
 
-bool trapfunc::boobytrap( const tripoint &p, Creature *c, item * )
+bool trapfunc::boobytrap( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c != nullptr ) {
         c->add_msg_player_or_npc( m_bad, _( "You trigger a booby trap!" ),
@@ -830,7 +830,7 @@ bool trapfunc::boobytrap( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::goo( const tripoint &p, Creature *c, item * )
+bool trapfunc::goo( const tripoint_bub_ms &p, Creature *c, item * )
 {
     get_map().remove_trap( p );
     if( c == nullptr ) {
@@ -878,7 +878,7 @@ bool trapfunc::goo( const tripoint &p, Creature *c, item * )
     cata_fatal( "c must be either a monster or a Character" );
 }
 
-bool trapfunc::dissector( const tripoint &p, Creature *c, item * )
+bool trapfunc::dissector( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -936,7 +936,7 @@ bool trapfunc::dissector( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::pit( const tripoint &p, Creature *c, item * )
+bool trapfunc::pit( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -985,7 +985,7 @@ bool trapfunc::pit( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::pit_spikes( const tripoint &p, Creature *c, item * )
+bool trapfunc::pit_spikes( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -1070,7 +1070,7 @@ bool trapfunc::pit_spikes( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::pit_glass( const tripoint &p, Creature *c, item * )
+bool trapfunc::pit_glass( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -1160,7 +1160,7 @@ bool trapfunc::pit_glass( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::lava( const tripoint &p, Creature *c, item * )
+bool trapfunc::lava( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -1209,10 +1209,10 @@ static bool query_for_item( const Character *pl, const itype_id &itemname, const
     return pl->has_amount( itemname, 1 ) && ( !pl->is_avatar() || query_yn( que ) );
 }
 
-static tripoint random_neighbor( tripoint center )
+static tripoint_bub_ms random_neighbor( tripoint_bub_ms center )
 {
-    center.x += rng( -1, 1 );
-    center.y += rng( -1, 1 );
+    center.x() += rng( -1, 1 );
+    center.y() += rng( -1, 1 );
     return center;
 }
 
@@ -1229,7 +1229,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     if( roll < diff ) {
         you.add_msg_if_player( m_bad, _( "You fail to attach it…" ) );
         you.use_amount( itemname, 1 );
-        here.spawn_item( tripoint_bub_ms( random_neighbor( you.pos() ) ), itemname );
+        here.spawn_item( random_neighbor( you.pos_bub() ), itemname );
         return false;
     }
 
@@ -1242,7 +1242,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     if( safe.empty() ) {
         you.add_msg_if_player( m_bad, _( "There's nowhere to pull yourself to, and you sink!" ) );
         you.use_amount( itemname, 1 );
-        here.spawn_item( tripoint_bub_ms( random_neighbor( you.pos() ) ), itemname );
+        here.spawn_item( random_neighbor( you.pos_bub() ), itemname );
         return false;
     } else {
         you.add_msg_player_or_npc( m_good, _( "You pull yourself to safety!" ),
@@ -1256,7 +1256,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     }
 }
 
-bool trapfunc::sinkhole( const tripoint &p, Creature *c, item *i )
+bool trapfunc::sinkhole( const tripoint_bub_ms &p, Creature *c, item *i )
 {
     // tiny creatures don't trigger the sinkhole to collapse
     if( c == nullptr || c->get_size() == creature_size::tiny ) {
@@ -1302,7 +1302,7 @@ bool trapfunc::sinkhole( const tripoint &p, Creature *c, item *i )
     return true;
 }
 
-bool trapfunc::temple_flood( const tripoint &p, Creature *c, item * )
+bool trapfunc::temple_flood( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -1310,7 +1310,7 @@ bool trapfunc::temple_flood( const tripoint &p, Creature *c, item * )
     // Monsters and npcs are completely ignored here, should they?
     if( c->is_avatar() ) {
         add_msg( m_warning, _( "You step on a loose tile, and water starts to flood the room!" ) );
-        tripoint_bub_ms tmp = tripoint_bub_ms( p );
+        tripoint_bub_ms tmp = p;
         int &i = tmp.x();
         int &j = tmp.y();
         map &here = get_map();
@@ -1327,7 +1327,7 @@ bool trapfunc::temple_flood( const tripoint &p, Creature *c, item * )
     return false;
 }
 
-bool trapfunc::temple_toggle( const tripoint &p, Creature *c, item * )
+bool trapfunc::temple_toggle( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -1337,9 +1337,9 @@ bool trapfunc::temple_toggle( const tripoint &p, Creature *c, item * )
         add_msg( _( "You hear the grinding of shifting rock." ) );
         map &here = get_map();
         const ter_id &type = here.ter( p );
-        tripoint tmp = p;
-        int &i = tmp.x;
-        int &j = tmp.y;
+        tripoint_bub_ms tmp = p;
+        int &i = tmp.x();
+        int &j = tmp.y();
         for( i = 0; i < MAPSIZE_X; i++ ) {
             for( j = 0; j < MAPSIZE_Y; j++ ) {
                 const ter_id &t = here.ter( tmp );
@@ -1366,8 +1366,8 @@ bool trapfunc::temple_toggle( const tripoint &p, Creature *c, item * )
         }
 
         // In case we're completely encircled by walls, replace random wall around the player with floor tile
-        std::vector<tripoint> blocked_tiles;
-        for( const tripoint &pnt : here.points_in_radius( p, 1 ) ) {
+        std::vector<tripoint_bub_ms> blocked_tiles;
+        for( const tripoint_bub_ms &pnt : here.points_in_radius( p, 1 ) ) {
             if( here.impassable( pnt ) ) {
                 blocked_tiles.push_back( pnt );
             }
@@ -1382,7 +1382,7 @@ bool trapfunc::temple_toggle( const tripoint &p, Creature *c, item * )
                     blocked_tiles.erase( blocked_tiles.begin() + i );
                 }
             }
-            const tripoint &pnt = random_entry( blocked_tiles );
+            const tripoint_bub_ms &pnt = random_entry( blocked_tiles );
             const ter_id &t = here.ter( pnt );
             if( t == ter_t_rock_red ) {
                 here.ter_set( pnt, ter_t_floor_red );
@@ -1398,7 +1398,7 @@ bool trapfunc::temple_toggle( const tripoint &p, Creature *c, item * )
     return false;
 }
 
-bool trapfunc::glow( const tripoint &p, Creature *c, item * )
+bool trapfunc::glow( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -1417,7 +1417,7 @@ bool trapfunc::glow( const tripoint &p, Creature *c, item * )
                 get_player_character().irradiate( rng( 10, 30 ) );
             } else if( one_in( 4 ) ) {
                 add_msg( m_bad, _( "A blinding flash strikes you!" ) );
-                explosion_handler::flashbang( tripoint_bub_ms( p ) );
+                explosion_handler::flashbang( p );
             } else {
                 add_msg( _( "Small flashes surround you." ) );
             }
@@ -1429,7 +1429,7 @@ bool trapfunc::glow( const tripoint &p, Creature *c, item * )
             you->irradiate( rng( 10, 30 ) );
         } else if( one_in( 4 ) ) {
             you->add_msg_if_player( m_bad, _( "A blinding flash strikes you!" ) );
-            explosion_handler::flashbang( tripoint_bub_ms( p ) );
+            explosion_handler::flashbang( p );
         } else {
             c->add_msg_if_player( _( "Small flashes surround you." ) );
         }
@@ -1438,7 +1438,7 @@ bool trapfunc::glow( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::hum( const tripoint &p, Creature *, item * )
+bool trapfunc::hum( const tripoint_bub_ms &p, Creature *, item * )
 {
     int volume = rng( 1, 200 );
     std::string sfx;
@@ -1459,7 +1459,7 @@ bool trapfunc::hum( const tripoint &p, Creature *, item * )
     return true;
 }
 
-bool trapfunc::shadow( const tripoint &p, Creature *c, item * )
+bool trapfunc::shadow( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr || !c->is_avatar() ) {
         return false;
@@ -1469,13 +1469,13 @@ bool trapfunc::shadow( const tripoint &p, Creature *c, item * )
     for( int tries = 0; tries < 10; tries++ ) {
         tripoint_bub_ms monp{ p };
         if( one_in( 2 ) ) {
-            monp.x() = p.x + rng( -5, +5 );
-            monp.y() = p.y + ( one_in( 2 ) ? -5 : +5 );
+            monp.x() = p.x() + rng( -5, +5 );
+            monp.y() = p.y() + ( one_in( 2 ) ? -5 : +5 );
         } else {
-            monp.x() = p.x + ( one_in( 2 ) ? -5 : +5 );
-            monp.y() = p.y + rng( -5, +5 );
+            monp.x() = p.x() + ( one_in( 2 ) ? -5 : +5 );
+            monp.y() = p.y() + rng( -5, +5 );
         }
-        if( !here.sees( monp, tripoint_bub_ms( p ), 10 ) ) {
+        if( !here.sees( monp, p, 10 ) ) {
             continue;
         }
         if( monster *const spawned = g->place_critter_at( mon_shadow, monp ) ) {
@@ -1488,7 +1488,7 @@ bool trapfunc::shadow( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::map_regen( const tripoint &p, Creature *c, item * )
+bool trapfunc::map_regen( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c ) {
         Character *you = dynamic_cast<Character *>( c );
@@ -1507,15 +1507,15 @@ bool trapfunc::map_regen( const tripoint &p, Creature *c, item * )
                 return false;
             }
             set_queued_points();
-            here.set_seen_cache_dirty( tripoint_bub_ms( p ) );
-            here.set_transparency_cache_dirty( p.z );
+            here.set_seen_cache_dirty( p );
+            here.set_transparency_cache_dirty( p.z() );
             return true;
         }
     }
     return false;
 }
 
-bool trapfunc::drain( const tripoint &, Creature *c, item * )
+bool trapfunc::drain( const tripoint_bub_ms &, Creature *c, item * )
 {
     if( c != nullptr ) {
         c->add_msg_if_player( m_bad, _( "You feel your life force sapping away." ) );
@@ -1532,7 +1532,7 @@ bool trapfunc::drain( const tripoint &, Creature *c, item * )
     return false;
 }
 
-bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
+bool trapfunc::cast_spell( const tripoint_bub_ms &p, Creature *critter, item * )
 {
     if( critter == nullptr ) {
         map &here = get_map();
@@ -1544,9 +1544,9 @@ bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
         }
         if( tr.has_flag( json_flag_PROXIMITY ) ) {
             // remove all traps in 3-3 area area
-            for( int x = p.x - 1; x <= p.x + 1; x++ ) {
-                for( int y = p.y - 1; y <= p.y + 1; y++ ) {
-                    tripoint_bub_ms pt( x, y, p.z );
+            for( int x = p.x() - 1; x <= p.x() + 1; x++ ) {
+                for( int y = p.y() - 1; y <= p.y() + 1; y++ ) {
+                    tripoint_bub_ms pt( x, y, p.z() );
                     if( here.tr_at( pt ).loadid == tr.loadid ) {
                         here.remove_trap( pt );
                     }
@@ -1554,8 +1554,8 @@ bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
             }
         }
         // we remove the trap before casting the spell because otherwise if we teleport we might be elsewhere at the end and p is no longer valid
-        trap_spell.cast_all_effects( dummy, tripoint_bub_ms( p ) );
-        trap_spell.make_sound( tripoint_bub_ms( p ), get_player_character() );
+        trap_spell.cast_all_effects( dummy, p );
+        trap_spell.make_sound( p, get_player_character() );
         return true;
     } else {
         map &here = get_map();
@@ -1567,9 +1567,9 @@ bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
         }
         if( tr.has_flag( json_flag_PROXIMITY ) ) {
             // remove all traps in 3-3 area area
-            for( int x = p.x - 1; x <= p.x + 1; x++ ) {
-                for( int y = p.y - 1; y <= p.y + 1; y++ ) {
-                    tripoint_bub_ms pt( x, y, p.z );
+            for( int x = p.x() - 1; x <= p.x() + 1; x++ ) {
+                for( int y = p.y() - 1; y <= p.y() + 1; y++ ) {
+                    tripoint_bub_ms pt( x, y, p.z() );
                     if( here.tr_at( pt ).loadid == tr.loadid ) {
                         here.remove_trap( pt );
                     }
@@ -1578,12 +1578,12 @@ bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
         }
         // we remove the trap before casting the spell because otherwise if we teleport we might be elsewhere at the end and p is no longer valid
         trap_spell.cast_all_effects( dummy, critter->pos_bub() );
-        trap_spell.make_sound( tripoint_bub_ms( p ), get_player_character() );
+        trap_spell.make_sound( p, get_player_character() );
         return true;
     }
 }
 
-bool trapfunc::snake( const tripoint &p, Creature *, item * )
+bool trapfunc::snake( const tripoint_bub_ms &p, Creature *, item * )
 {
     //~ the sound a snake makes
     sounds::sound( p, 10, sounds::sound_t::movement, _( "ssssssss" ), false, "misc", "snake_hiss" );
@@ -1595,13 +1595,13 @@ bool trapfunc::snake( const tripoint &p, Creature *, item * )
         for( int tries = 0; tries < 10; tries++ ) {
             tripoint_bub_ms monp{ p };
             if( one_in( 2 ) ) {
-                monp.x() = p.x + rng( -5, +5 );
-                monp.y() = p.y + ( one_in( 2 ) ? -5 : +5 );
+                monp.x() = p.x() + rng( -5, +5 );
+                monp.y() = p.y() + ( one_in( 2 ) ? -5 : +5 );
             } else {
-                monp.x() = p.x + ( one_in( 2 ) ? -5 : +5 );
-                monp.y() = p.y + rng( -5, +5 );
+                monp.x() = p.x() + ( one_in( 2 ) ? -5 : +5 );
+                monp.y() = p.y() + rng( -5, +5 );
             }
-            if( !here.sees( monp, tripoint_bub_ms( p ), 10 ) ) {
+            if( !here.sees( monp, p, 10 ) ) {
                 continue;
             }
             if( monster *const spawned = g->place_critter_at( mon_shadow_snake, monp ) ) {
@@ -1615,7 +1615,7 @@ bool trapfunc::snake( const tripoint &p, Creature *, item * )
     return true;
 }
 
-bool trapfunc::dummy_trap( const tripoint &, Creature *, item * )
+bool trapfunc::dummy_trap( const tripoint_bub_ms &, Creature *, item * )
 {
     return true;
 }

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -104,7 +104,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who )
     // allow NPCs to use welding rigs they can't see ( on the other side of a vehicle )
     // as they have the handicap of not being able to use the veh interaction menu
     // or able to drag a welding cart etc.
-    map_inv.form_from_map( who.pos(), PICKUP_RANGE, &who, false, !who.is_npc() );
+    map_inv.form_from_map( who.pos_bub(), PICKUP_RANGE, &who, false, !who.is_npc() );
     if( !reqs.can_make_with_inventory( inv, is_crafting_component ) ) {
         who.add_msg_if_player( m_info, _( "You don't meet the requirements to repair the %s." ),
                                pt.name() );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6385,7 +6385,7 @@ bool vehicle::decrement_summon_timer()
             }
             vp.items.clear();
         }
-        add_msg_if_player_sees( pos_bub().raw(), m_info, _( "Your %s winks out of existence." ), name );
+        add_msg_if_player_sees( pos_bub(), m_info, _( "Your %s winks out of existence." ), name );
         get_map().destroy_vehicle( this );
         return true;
     } else {
@@ -7264,7 +7264,7 @@ void vehicle::shed_loose_parts( const trinary shed_cables, const tripoint_bub_ms
             const int max_dist = vp_loose.get_base().max_link_length();
 
             if( distance > max_dist || shed_cables == trinary::ALL ) {
-                add_msg_if_player_sees( bub_part_pos( vp_loose ).raw(), m_warning,
+                add_msg_if_player_sees( bub_part_pos( vp_loose ), m_warning,
                                         _( "The %s's %s was detached!" ), name, vp_loose.name( false ) );
                 remove_remote = true;
             } else {
@@ -7615,23 +7615,23 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
                 continue; // Ignore the frame being destroyed
             } else if( vpi_here.has_flag( "TOW_CABLE" ) ) {
                 // Tow cables - remove it in one piece, remove remote part, and remove towing data
-                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+                add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
                                         vp_here.name() );
                 invalidate_towing( true );
             } else if( vpi_here.has_flag( VPFLAG_POWER_TRANSFER ) ) {
                 // Electrical cables - remove it in one piece and remove remote part
-                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+                add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
                                         vp_here.name() );
                 here.add_item_or_charges( pos, part_to_item( vp_here ) );
                 remove_remote_part( vp_here );
             } else if( vp_here.is_broken() ) {
                 // Tearing off a broken part - break it up
-                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %s's %s breaks into pieces!" ), name,
+                add_msg_if_player_sees( pos, m_bad, _( "The %s's %s breaks into pieces!" ), name,
                                         vp_here.name() );
                 scatter_parts( vp_here );
             } else {
                 // Intact (but possibly damaged) part - remove it in one piece
-                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is torn off!" ), name,
+                add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is torn off!" ), name,
                                         vp_here.name() );
                 if( !magic ) {
                     here.add_item_or_charges( pos, part_to_item( vp_here ) );
@@ -7640,25 +7640,25 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
             remove_part( vp_here, *handler_ptr );
         }
         // After clearing the frame, remove it.
-        add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
+        add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
         scatter_parts( vp );
         remove_part( vp, *handler_ptr );
         find_and_split_vehicles( here, { index_of_part( &vp, /* include_removed = */ true ) } );
     } else {
         if( vpi.has_flag( "TOW_CABLE" ) ) {
             // Tow cables - remove it in one piece, remove remote part, and remove towing data
-            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+            add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
                                     vp.name() );
             invalidate_towing( true );
         } else if( vpi.has_flag( VPFLAG_POWER_TRANSFER ) ) {
             // Electrical cables - remove it in one piece and remove remote part
-            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+            add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
                                     vp.name() );
             here.add_item_or_charges( pos, part_to_item( vp ) );
             remove_remote_part( vp );
         } else {
             //Just break it off
-            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
+            add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
             scatter_parts( vp );
         }
         const point_rel_ms position = vp.mount;
@@ -7798,7 +7798,7 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
             invalidate_towing( true );
         } else {
             item part_as_item = part_to_item( vp );
-            add_msg_if_player_sees( vppos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+            add_msg_if_player_sees( vppos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
                                     vp.name() );
             if( vpi.has_flag( VPFLAG_POWER_TRANSFER ) ) {
                 remove_remote_part( vp );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2288,7 +2288,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
                                                "the power of the impact!" ), veh.name );
                 unboard_vehicle( part_pos );
             } else {
-                add_msg_if_player_sees( part_pos.raw(), m_bad,
+                add_msg_if_player_sees( part_pos, m_bad,
                                         _( "The %s is hurled from %s's by the power of the impact!" ),
                                         pet->disp_name(), veh.name );
             }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -580,7 +580,7 @@ double vehicle::engine_cold_factor( const vehicle_part &vp ) const
     }
 
     const tripoint_bub_ms pos = bub_part_pos( vp );
-    double eff_temp = units::to_fahrenheit( get_weather().get_temperature( pos.raw() ) );
+    double eff_temp = units::to_fahrenheit( get_weather().get_temperature( pos ) );
     if( !vp.has_fault_flag( "BAD_COLD_START" ) ) {
         eff_temp = std::min( eff_temp, 20.0 );
     }
@@ -1584,7 +1584,8 @@ void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
         return;
     }
     creature_tracker &creatures = get_creature_tracker();
-    const std::function<bool( const tripoint & )> f = [&creatures]( const tripoint & pnt ) {
+    const std::function<bool( const tripoint_bub_ms & )> f = [&creatures](
+    const tripoint_bub_ms & pnt ) {
         monster *mon_ptr = creatures.creature_at<monster>( pnt );
         if( mon_ptr == nullptr ) {
             return false;
@@ -1594,14 +1595,14 @@ void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
                                     f.has_flag( mon_flag_PET_HARNESSABLE ) );
     };
 
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-            _( "Where is the creature to harness?" ), _( "There is no creature to harness nearby." ), f,
-            false );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Where is the creature to harness?" ), _( "There is no creature to harness nearby." ), f,
+                false );
     if( !pnt_ ) {
         add_msg( m_info, _( "Never mind." ) );
         return;
     }
-    const tripoint &target = *pnt_;
+    const tripoint_bub_ms &target = *pnt_;
     monster *mon_ptr = creatures.creature_at<monster>( target );
     if( mon_ptr == nullptr ) {
         add_msg( m_info, _( "No creature there." ) );

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -870,7 +870,7 @@ rl_vec2d convert_wind_to_coord( const int angle )
 bool warm_enough_to_plant( const tripoint_bub_ms &pos )
 {
     // semi-appropriate temperature for most plants
-    return get_weather().get_temperature( pos.raw() ) >= units::from_fahrenheit( 50 );
+    return get_weather().get_temperature( pos ) >= units::from_fahrenheit( 50 );
 }
 
 bool warm_enough_to_plant( const tripoint_abs_omt &pos )
@@ -949,7 +949,7 @@ void weather_manager::set_nextweather( time_point t )
     update_weather();
 }
 
-units::temperature weather_manager::get_temperature( const tripoint &location )
+units::temperature weather_manager::get_temperature( const tripoint_bub_ms &location )
 {
     if( forced_temperature ) {
         return *forced_temperature;
@@ -961,13 +961,13 @@ units::temperature weather_manager::get_temperature( const tripoint &location )
     }
 
     //underground temperature = average New England temperature = 43F/6C
-    units::temperature temp = location.z < 0 ? AVERAGE_ANNUAL_TEMPERATURE : temperature;
+    units::temperature temp = location.z() < 0 ? AVERAGE_ANNUAL_TEMPERATURE : temperature;
 
     if( !g->new_game ) {
         units::temperature_delta temp_mod;
-        temp_mod = get_heat_radiation( tripoint_bub_ms( location ) );
-        temp_mod += get_convection_temperature( tripoint_bub_ms( location ) );
-        temp_mod += get_map().get_temperature_mod( tripoint_bub_ms( location ) );
+        temp_mod = get_heat_radiation( location );
+        temp_mod += get_convection_temperature( location );
+        temp_mod += get_map().get_temperature_mod( location );
 
         temp += temp_mod;
     }

--- a/src/weather.h
+++ b/src/weather.h
@@ -222,9 +222,9 @@ class weather_manager
         // The time at which weather will shift next.
         time_point nextweather;
         /** temperature cache, cleared every turn, sparse map of map tripoints to temperatures */
-        std::unordered_map< tripoint, units::temperature > temperature_cache;
+        std::unordered_map< tripoint_bub_ms, units::temperature > temperature_cache;
         // Returns outdoor or indoor temperature of given location
-        units::temperature get_temperature( const tripoint &location );
+        units::temperature get_temperature( const tripoint_bub_ms &location );
         // Returns outdoor or indoor temperature of given location
         units::temperature get_temperature( const tripoint_abs_omt &location ) const;
         void clear_temp_cache();

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -48,15 +48,16 @@ struct weather_gen_common {
     season_type season = season_type::SPRING;
 };
 
-static weather_gen_common get_common_data( const tripoint &location, const time_point &real_t,
+static weather_gen_common get_common_data( const tripoint_abs_ms &location,
+        const time_point &real_t,
         unsigned seed )
 {
     season_effective_time t( real_t );
     weather_gen_common result;
     // Integer x position / widening factor of the Perlin function.
-    result.x = location.x / 2000.0;
+    result.x = location.x() / 2000.0;
     // Integer y position / widening factor of the Perlin function.
-    result.y = location.y / 2000.0;
+    result.y = location.y() / 2000.0;
     // Integer turn / widening factor of the Perlin function.
     result.z = to_days<double>( real_t - calendar::turn_zero );
     // Limit the random seed during noise calculation, a large value flattens the noise generator to zero
@@ -107,7 +108,7 @@ static units::temperature weather_temperature_from_common_data( const weather_ge
 }
 
 units::temperature weather_generator::get_weather_temperature(
-    const tripoint &location, const time_point &real_t, unsigned seed ) const
+    const tripoint_abs_ms &location, const time_point &real_t, unsigned seed ) const
 {
     return weather_temperature_from_common_data( *this, get_common_data( location, real_t, seed ),
             season_effective_time( real_t ) );
@@ -116,7 +117,7 @@ w_point weather_generator::get_weather( const tripoint_abs_ms &location, const t
                                         unsigned seed ) const
 {
     season_effective_time t( real_t );
-    const weather_gen_common common = get_common_data( location.raw(), real_t, seed );
+    const weather_gen_common common = get_common_data( location, real_t, seed );
 
     const double x( common.x );
     const double y( common.y );

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -71,7 +71,8 @@ class weather_generator
         units::temperature get_water_temperature() const;
         void test_weather( unsigned seed ) const;
         void sort_weather();
-        units::temperature get_weather_temperature( const tripoint &, const time_point &, unsigned ) const;
+        units::temperature get_weather_temperature( const tripoint_abs_ms &, const time_point &,
+                unsigned ) const;
 
         void load( const JsonObject &jo, bool was_loaded );
 };

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -168,7 +168,7 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         weather_manager &weather = get_weather();
         weather.temperature = units::from_fahrenheit( 0 );
         weather.clear_temp_cache();
-        REQUIRE( units::to_fahrenheit( weather.get_temperature( test_npc.pos() ) ) == Approx( 0 ) );
+        REQUIRE( units::to_fahrenheit( weather.get_temperature( test_npc.pos_bub() ) ) == Approx( 0 ) );
         test_npc.update_bodytemp();
         REQUIRE( oracle.needs_warmth_badly( "" ) == behavior::status_t::running );
         CHECK( npc_needs.tick( &oracle ) == "idle" );

--- a/tests/fake_messages.cpp
+++ b/tests/fake_messages.cpp
@@ -66,19 +66,11 @@ void add_msg( const game_message_params &, std::string m )
 {
     Messages::add_msg( std::move( m ) );
 }
-void add_msg_if_player_sees( const tripoint &, std::string m )
-{
-    Messages::add_msg( std::move( m ) );
-}
 void add_msg_if_player_sees( const tripoint_bub_ms &, std::string m )
 {
     Messages::add_msg( std::move( m ) );
 }
 void add_msg_if_player_sees( const Creature &, std::string m )
-{
-    Messages::add_msg( std::move( m ) );
-}
-void add_msg_if_player_sees( const tripoint &, const game_message_params &, std::string m )
 {
     Messages::add_msg( std::move( m ) );
 }

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -220,7 +220,7 @@ TEST_CASE( "milk_rotting", "[active_item][map]" )
     restore_on_out_of_scope restore_temp(
         get_weather().forced_temperature );
     get_weather().forced_temperature = units::from_celsius( 21 );
-    REQUIRE( units::to_celsius( get_weather().get_temperature( test_loc.raw() ) ) == 21 );
+    REQUIRE( units::to_celsius( get_weather().get_temperature( test_loc ) ) == 21 );
 
     item almond_milk( "almond_milk" );
     item *bp = nullptr;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Change usages of untyped coordinated into typed ones.
This time some "random" header files and dependents including:
- weather.h
- weather_gen.h
- trap.h
- sound.h
- messages.h

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed usages of untyped operation to typed ones and deleting the untyped ones when no dependents remain.
Discovered a bugged usage of get_weather_temperature, with one feeding in an untyped abs coordinate and the other an untyped bubble coordinate. item.cpp operation item::process_temperature_rot was changed to get the abs coordinate for the bubble coordinate it previously used. This ought to cause the rot processing to differ in different locations, rather than always get processing for (0, 0) (there's a division by 2000 of the coordinates to create some sort of grid).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded save, walked up ramp, hopped into car, drove through hay stacks, over zombie corpse with inventory, and ran over a turkey, smashed into stationary vehicle. Nothing odd seen.
The bug wasn't tested, as I don't know how to do it. The effect should be subtle, as the rot would be affected by the temperature in a different location, and the weather is, over all, similar everywhere (we don't have a "world" spanning from the poles to the tropics) at any given time of the year.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
cata_tiles is going to require a bit of work to entangle, but may be the focus for the next PR. The current code happily is used both by bubble coordinates and by omt coordinates. I'm considering hiding the current operations as private and use typed "skins" to separate the two use cases, but would be grateful for advice.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
