### PR TITLE
Zombified humans are still humans

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -235,7 +235,6 @@ static const skill_id skill_survival( "survival" );
 
 static const species_id species_FERAL( "FERAL" );
 static const species_id species_HUMAN( "HUMAN" );
-static const species_id species_ZOMBIE( "ZOMBIE" );
 
 static const ter_str_id ter_t_dirt( "t_dirt" );
 static const ter_str_id ter_t_tree( "t_tree" );
@@ -621,9 +620,9 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
     }
 
     // TODO: Extract this bool into a function
-    const bool is_human = corpse.id == mtype_id::NULL_ID() || ( ( corpse.in_species( species_HUMAN ) ||
-                          corpse.in_species( species_FERAL ) ) &&
-                          !corpse.in_species( species_ZOMBIE ) );
+    const bool is_human = corpse.id == mtype_id::NULL_ID() ||
+                          corpse.in_species( species_HUMAN ) ||
+                          corpse.in_species( species_FERAL );
 
     // applies to all butchery actions except for dissections
     if( is_human && action != butcher_type::DISSECT && !you.okay_with_eating_humans() ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -126,7 +126,6 @@ static const requirement_id requirement_data_mining_standard( "mining_standard" 
 
 static const species_id species_FERAL( "FERAL" );
 static const species_id species_HUMAN( "HUMAN" );
-static const species_id species_ZOMBIE( "ZOMBIE" );
 
 static const ter_str_id ter_t_stump( "t_stump" );
 static const ter_str_id ter_t_trunk( "t_trunk" );
@@ -1220,9 +1219,9 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             for( item &body : corpses ) {
                 const mtype &corpse = *body.get_mtype();
                 // TODO: Extract this bool into a function
-                const bool is_human = corpse.id == mtype_id::NULL_ID() || ( ( corpse.in_species( species_HUMAN ) ||
-                                      corpse.in_species( species_FERAL ) ) &&
-                                      !corpse.in_species( species_ZOMBIE ) );
+                const bool is_human = corpse.id == mtype_id::NULL_ID() ||
+                                      corpse.in_species( species_HUMAN ) ||
+                                      corpse.in_species( species_FERAL );
                 if( is_human && !you.okay_with_eating_humans() ) {
                     return activity_reason_info::fail( do_activity_reason::REFUSES_THIS_WORK );
                 }


### PR DESCRIPTION
#### Summary
Balance "Zombified humans are still humans for butchery purposes"

#### Purpose of change
NPCs are now properly upset if you butcher a person in front of them, but...

If that person briefly rose from the dead then they are apparently okay with you carving them into meat and turning their fat into tallow??

#### Describe the solution
Remove this lack of distinction. A notably human corpse always causes the butchery morale/relation penalties for those who are not okay with such things. This applies to both the player character's mood, and NPC reactions to your actions.

#### Describe alternatives you've considered
Perhaps butchering zombies should cause an even worse reaction from NPCs reacting to the player's actions, since they are butchering a rotting corpse at that point.

#### Testing

https://github.com/user-attachments/assets/196a511f-23c6-4dd1-8ab0-a29536dc8e4c


#### Additional context
Known issues:
-Dissecting zombies causes the morale hit/relation penalty. MAYBE (very big maybe) there should be some exemption for it, otherwise weakpoint learning is largely relegated to in-combat only. This is troublesome in terms of game mechanics, but if you're joe schmoe slicing up a human corpse, you SHOULD be deeply upset. Even if you're doing it to "learn their weaknesses".

-dismembering causes the morale hit/relation penalty, which means that acid zombies basically mandate acid protection so you can smash them. It looks like it would be much simpler to just make dismembering give nothing at all and give it a blanket exemption from the morale penalties...