### PR TITLE
Revert "pianos give piano wire on disassembly"

### DIFF
--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -7864,7 +7864,7 @@
     "components": [
       [ [ "2x4", 12 ] ],
       [ [ "nail", 12 ] ],
-      [ [ "piano_wire", 26 ] ],
+      [ [ "qt_wire", 26 ] ],
       [ [ "wheel_caster", 1 ] ],
       [ [ "steel_chunk", 3 ] ],
       [ [ "plastic_chunk", 10 ] ]


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

#76204 obsoleted piano wire and replaced it with qt_wire in favor of uniformity, and I inadvertently reverted that, so I'm fixing that here.

#### Additional context

None