### PR TITLE
Make clang-tidy feedback on GitHub much more responsive

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -36,7 +36,11 @@ jobs:
       matrix:
         # To make the run finish in the run time limit, we split it up into two
         # parts: the src directory and everything else
-        subset: [ 'src', 'other' ]
+        subset: [
+            'directly-changed',
+            'indirectly-changed-src',
+            'indirectly-changed-other'
+        ]
 
     runs-on: ubuntu-22.04
     env:
@@ -90,7 +94,7 @@ jobs:
           for (const path of files) {
             console.log(path);
           }
-          fs.writeFileSync("files_changed", files.join('\n'));
+          fs.writeFileSync("files_changed", files.join('\n') + '\n');
     - uses: ammaraskar/gcc-problem-matcher@master
     - name: run clang-tidy
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}

--- a/build-scripts/clang-tidy-wrapper.sh
+++ b/build-scripts/clang-tidy-wrapper.sh
@@ -7,7 +7,9 @@ plugin=build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
 
 if [ -f "$plugin" ]
 then
+    set -x
     LD_PRELOAD=$plugin "$CATA_CLANG_TIDY" --enable-check-profile --store-check-profile=clang-tidy-trace "$@"
 else
+    set -x
     "$CATA_CLANG_TIDY" "$@"
 fi


### PR DESCRIPTION
#### Summary
Infrastructure "Make clang-tidy feedback on GitHub much more responsive"

#### Purpose of change

clang-tidy is a wonderful tool, and we should utilize it more.
Unfortunately, if your PR touches any mildly popular header, then clang-tidy would run on all `.cpp` files that transitvely include it and take hours. This effectively means that the diagnostics are only addressed next day. And if they are not addressed correctly on the first try - then one more day per each attempt.
This is unbearable, and makes people (both authors and maintainers) ignore diagnostics leading to situations such as #78616
This PR makes clang-tidy diagnostic only* (but see below) run on files directly affected, cutting down on latency massively, and increasing up development velocity.

#### Describe the solution

Currently the fileset for clang-tidy to analyze is split into two parts - affected files inside `src/` and affected files outside of `src/`. Each having its own github action jobs.
This PR introduces a third job - files explicitly touched by the PR (and excludes those from the other two). This is usually a much much smaller set of files, so only takes 5 minutes or so to complete (depending on the PR of course), comparable to basic build.

I had a bit of a trouble coming up with a good name for that, so I ended up renaming existing jobs. The new set of names is 
- `directly-changed` (the files explicitly changed in the pr)
- `indirectly-changed-src` (files in `src/` that  are transitively affected by the header changes, but not explicitly touched)
- `indirectly-changed-other` (files outside of `src/`, transitively affected by the header changes, but not explicitly touched)

You can see demo run of how it would look in my fork - https://github.com/moxian/Cataclysm-DDA/pull/2

Drive-by changes: silence log output of things we don't care about (generating the header map that's used to figure out which files are transitively affected or not), and loudening the log output of things we do (actual clang-tidy invocation)

#### Describe alternatives you've considered

Completely exclude the indirectly-changed files from analysis.
Optionally, move them to a daily/weekly job that would post the findings in a bug.

My original rationale for it was that it's very unlikely to make header changes that would break clang-tidy for the files including those *without* breaking the compilation of those files in th first place (and thus neccessiating changes there).
The only such examples I could think of would be `const`-qualifying a method in a header resulting in an opportunity to convert `for ( auto thing : container) { thing.method() }` into `for( const auto thing& : container ) { thing.method() }` , but those are rare and perhaps insignificant.

But thinking more, there's little harm to keep the indirectly-changed checks around. They might prevent the PR from being *merged* for extra hour or four, but they don't really negatively affect PR author. And sometimes they can catch neat stuff. So they can staty.

#### Testing

See the PR in my fork: https://github.com/moxian/Cataclysm-DDA/pull/2
- The base commit is the same as this PR.
- The `demo` commit is one where I do insignificant changes, and checks pass (modified to ignore the changes to `clang-tidy-wrapper.sh` itself, so as not to run on literally all the files) . Run link: https://github.com/moxian/Cataclysm-DDA/actions/runs/12521590012
- The `break it` commit - as the name implies - breaks things, checks fail. Run link: https://github.com/moxian/Cataclysm-DDA/actions/runs/12521740315

Notice the difference in runtime of the checks and how the one that's reporting the error is much faster than the one that's not. (And `achievement.h` is not even a very popular header)

Tested locally on WSL. Does work (analyzing all files), but the script is janky, so perhaps it is not supposed to be run locally (and I would hope it stays this way)

#### Additional context
It annoys me a little bit that clang-tidy is rebuilt (and re-tested) for each of the (now) three jobs, taking 5 minutes per. Would be nice to build it only once, and reuse it across those. This is somewhat easily doable, but out of scope.
Would also be nice to cache the binary across *different PRs* (or same PR, but different commits), but I'm not sure how to approach that one sanely.