### PR TITLE
Set minimum sizes for missions menu window

### DIFF
--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -21,9 +21,6 @@
 #include "cata_imgui.h"
 #include "imgui/imgui.h"
 
-static const float minimum_window_width = 640;
-static const float minimum_window_height = 384;
-
 enum class mission_ui_tab_enum : int {
     ACTIVE = 0,
     COMPLETED,
@@ -74,8 +71,13 @@ class mission_ui_impl : public cataimgui::window
         mission_ui_tab_enum selected_tab = mission_ui_tab_enum::ACTIVE;
         mission_ui_tab_enum switch_tab = mission_ui_tab_enum::num_tabs;
 
-        float window_width = std::max( ImGui::GetMainViewport()->Size.x / 2, minimum_window_width );
-        float window_height = std::max( ImGui::GetMainViewport()->Size.y / 2, minimum_window_height );
+        float viewport_width = ImGui::GetMainViewport()->Size.x;
+        float viewport_height = ImGui::GetMainViewport()->Size.y;
+
+        float minimum_window_width = str_width_to_pixels( 80 );
+        float minimum_window_height = str_height_to_pixels( 24 );
+        float window_width = std::clamp( viewport_width / 2, minimum_window_width, viewport_width );
+        float window_height = std::clamp( viewport_height / 2, minimum_window_height, viewport_height );
         float table_column_width = window_width / 2;
 
         cataimgui::scroll s = cataimgui::scroll::none;

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -21,6 +21,9 @@
 #include "cata_imgui.h"
 #include "imgui/imgui.h"
 
+static const float minimum_window_width = 640;
+static const float minimum_window_height = 384;
+
 enum class mission_ui_tab_enum : int {
     ACTIVE = 0,
     COMPLETED,
@@ -71,9 +74,9 @@ class mission_ui_impl : public cataimgui::window
         mission_ui_tab_enum selected_tab = mission_ui_tab_enum::ACTIVE;
         mission_ui_tab_enum switch_tab = mission_ui_tab_enum::num_tabs;
 
-        size_t window_width = str_width_to_pixels( TERMX ) / 2;
-        size_t window_height = str_height_to_pixels( TERMY ) / 2;
-        size_t table_column_width = window_width / 2;
+        float window_width = std::max(ImGui::GetMainViewport()->Size.x / 2, minimum_window_width);
+        float window_height = std::max(ImGui::GetMainViewport()->Size.y / 2, minimum_window_height);
+        float table_column_width = window_width / 2;
 
         cataimgui::scroll s = cataimgui::scroll::none;
 

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -71,11 +71,11 @@ class mission_ui_impl : public cataimgui::window
         mission_ui_tab_enum selected_tab = mission_ui_tab_enum::ACTIVE;
         mission_ui_tab_enum switch_tab = mission_ui_tab_enum::num_tabs;
 
-        float window_width = std::clamp( ImGui::GetMainViewport()->Size.x / 2,
-                                         float( str_width_to_pixels( 80 ) ),
+        float window_width = std::clamp( float( str_width_to_pixels( 80 ) ),
+                                         ImGui::GetMainViewport()->Size.x / 2,
                                          ImGui::GetMainViewport()->Size.x );
-        float window_height = std::clamp( ImGui::GetMainViewport()->Size.y / 2,
-                                          float( str_height_to_pixels( 24 ) ),
+        float window_height = std::clamp( float( str_height_to_pixels( 24 ) ),
+                                          ImGui::GetMainViewport()->Size.y / 2,
                                           ImGui::GetMainViewport()->Size.y );
         float table_column_width = window_width / 2;
 

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -71,13 +71,12 @@ class mission_ui_impl : public cataimgui::window
         mission_ui_tab_enum selected_tab = mission_ui_tab_enum::ACTIVE;
         mission_ui_tab_enum switch_tab = mission_ui_tab_enum::num_tabs;
 
-        float viewport_width = ImGui::GetMainViewport()->Size.x;
-        float viewport_height = ImGui::GetMainViewport()->Size.y;
-
-        float minimum_window_width = str_width_to_pixels( 80 );
-        float minimum_window_height = str_height_to_pixels( 24 );
-        float window_width = std::clamp( viewport_width / 2, minimum_window_width, viewport_width );
-        float window_height = std::clamp( viewport_height / 2, minimum_window_height, viewport_height );
+        float window_width = std::clamp( ImGui::GetMainViewport()->Size.x / 2,
+                                         float( str_width_to_pixels( 80 ) ),
+                                         ImGui::GetMainViewport()->Size.x );
+        float window_height = std::clamp( ImGui::GetMainViewport()->Size.y / 2,
+                                          float( str_height_to_pixels( 24 ) ),
+                                          ImGui::GetMainViewport()->Size.y );
         float table_column_width = window_width / 2;
 
         cataimgui::scroll s = cataimgui::scroll::none;

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -71,10 +71,10 @@ class mission_ui_impl : public cataimgui::window
         mission_ui_tab_enum selected_tab = mission_ui_tab_enum::ACTIVE;
         mission_ui_tab_enum switch_tab = mission_ui_tab_enum::num_tabs;
 
-        float window_width = std::clamp( float( str_width_to_pixels( 80 ) ),
+        float window_width = std::clamp( float( str_width_to_pixels( EVEN_MINIMUM_TERM_WIDTH ) ),
                                          ImGui::GetMainViewport()->Size.x / 2,
                                          ImGui::GetMainViewport()->Size.x );
-        float window_height = std::clamp( float( str_height_to_pixels( 24 ) ),
+        float window_height = std::clamp( float( str_height_to_pixels( EVEN_MINIMUM_TERM_HEIGHT ) ),
                                           ImGui::GetMainViewport()->Size.y / 2,
                                           ImGui::GetMainViewport()->Size.y );
         float table_column_width = window_width / 2;

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -74,8 +74,8 @@ class mission_ui_impl : public cataimgui::window
         mission_ui_tab_enum selected_tab = mission_ui_tab_enum::ACTIVE;
         mission_ui_tab_enum switch_tab = mission_ui_tab_enum::num_tabs;
 
-        float window_width = std::max(ImGui::GetMainViewport()->Size.x / 2, minimum_window_width);
-        float window_height = std::max(ImGui::GetMainViewport()->Size.y / 2, minimum_window_height);
+        float window_width = std::max( ImGui::GetMainViewport()->Size.x / 2, minimum_window_width );
+        float window_height = std::max( ImGui::GetMainViewport()->Size.y / 2, minimum_window_height );
         float table_column_width = window_width / 2;
 
         cataimgui::scroll s = cataimgui::scroll::none;


### PR DESCRIPTION
#### Summary
`SUMMARY: Interface "Set minimum sizes for missions menu UI"`

#### Purpose of change

Set a minimum width and height for the missions window so information does not become unreadable at small terminal sizes
Fixes #78806
Fixes #74766 

#### Describe the solution

Set the window to not go below the minimum terminal sizes of 80 by 24. Otherwise, it'll retain its current behavior.
Update the affected code as per @moxian's comment in linked issue.

#### Describe alternatives you've considered

Set a static size for the missions window

#### Testing

Game compiles and loads
Open missions window at maximum terminal size, minimum terminal size, 640x480 pixels size, and a bunch of random sizes
Test again on notiles

#### Additional context

Max terminal size
![Screenshot 2024-12-28 013306](https://github.com/user-attachments/assets/b32c657d-dc36-4d32-8cda-12054ac2e164)

Min terminal size
![Screenshot 2024-12-28 013249](https://github.com/user-attachments/assets/c0bee333-0f88-4ac8-893a-2d2dcf167d97)

A random size
![Screenshot 2024-12-28 031542](https://github.com/user-attachments/assets/062399f1-fcbe-4f26-895c-83595e70ac56)



