### PR TITLE
typified cata_tiles and sdl_tiles

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -1015,7 +1015,7 @@ void game::draw_vpart_override(
     const bool hilite, const point_rel_ms &mount )
 {
     if( use_tiles ) {
-        tilecontext->init_draw_vpart_override( p, id, part_mod, veh_dir, hilite, mount.raw() );
+        tilecontext->init_draw_vpart_override( p, id, part_mod, veh_dir, hilite, mount );
     }
 }
 #else

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1448,10 +1448,10 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     }
     const point half_tile( tile_width / 2, 0 );
     const point quarter_tile( tile_width / 4, tile_height / 4 );
-    const auto apply_visible = [&]( const tripoint & np, const level_cache & ch, map & here ) {
-        return np.y < min_visible.y || np.y > max_visible.y ||
-               np.x < min_visible.x || np.x > max_visible.x ||
-               would_apply_vision_effects( here.get_visibility( ch.visibility_cache[np.x][np.y],
+    const auto apply_visible = [&]( const tripoint_bub_ms & np, const level_cache & ch, map & here ) {
+        return np.y() < min_visible.y || np.y() > max_visible.y ||
+               np.x() < min_visible.x || np.x() > max_visible.x ||
+               would_apply_vision_effects( here.get_visibility( ch.visibility_cache[np.x()][np.y()],
                                            cache ) );
     };
     std::map<tripoint_bub_ms, int> npc_attack_rating_map;
@@ -1478,7 +1478,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                     const point_bub_ms pt = veh_pos + std::get<0>( overlay_data );
                     const int color = std::get<1>( overlay_data );
                     const std::string &text = std::get<2>( overlay_data );
-                    overlay_strings.emplace( player_to_screen( pt.raw() ),
+                    overlay_strings.emplace( player_to_screen( pt ),
                                              formatted_text( text, color,
                                                      text_alignment::left ) );
                 }
@@ -1536,7 +1536,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                         if( g->display_overlay_state( ACTION_DISPLAY_SCENT ) && !invisible[0] ) {
                             const int scent_value = get_scent().get( pos );
                             if( scent_value > 0 ) {
-                                here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
+                                here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ) + half_tile,
                                                                     formatted_text( std::to_string( scent_value ),
                                                                             8 + catacurses::yellow, direction::NORTH ) );
                             }
@@ -1547,7 +1547,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                         if( g->display_overlay_state( ACTION_DISPLAY_SCENT_TYPE ) && !invisible[0] ) {
                             const scenttype_id scent_type = get_scent().get_type( pos.raw() );
                             if( !scent_type.is_empty() ) {
-                                here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
+                                here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ) + half_tile,
                                                                     formatted_text( scent_type.c_str(),
                                                                             8 + catacurses::yellow, direction::NORTH ) );
                             }
@@ -1565,7 +1565,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                                 } else {
                                     col = catacurses::cyan;
                                 }
-                                here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
+                                here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ) + half_tile,
                                                                     formatted_text( std::to_string( rad_value ),
                                                                             8 + col, direction::NORTH ) );
                             }
@@ -1582,7 +1582,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                                 } else {
                                     color = catacurses::white;
                                 }
-                                here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
+                                here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ) + half_tile,
                                                                     formatted_text( std::to_string( val ), color,
                                                                             direction::NORTH ) );
                             }
@@ -1617,7 +1617,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                             } else {
                                 temp_str = string_format( "%.0f", units::to_fahrenheit( temp_value ) );
                             }
-                            here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ),
+                            here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ),
                                                                 formatted_text( temp_str, color,
                                                                         text_alignment::left ) );
                         }
@@ -1631,11 +1631,11 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                                                     SDL_Color{ 192, 192, 192, 255 };
                             block_color.a = 100;
                             here.color_blocks_cache.first = SDL_BLENDMODE_BLEND;
-                            here.color_blocks_cache.second.emplace( player_to_screen( point( x, y ) ), block_color );
+                            here.color_blocks_cache.second.emplace( player_to_screen( point_bub_ms( x, y ) ), block_color );
 
                             // overlay string
                             std::string visibility_str = visibility ? "+" : "-";
-                            here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + quarter_tile,
+                            here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ) + quarter_tile,
                                                                 formatted_text( visibility_str, catacurses::black,
                                                                         direction::NORTH ) );
                         }
@@ -1648,7 +1648,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                                 SDL_Color blue = { 0, 0, 255, 255 };
                                 lighting_colors = color_linear_interpolate( white, blue, 9 );
                             }
-                            point tile_pos = player_to_screen( point( x, y ) );
+                            point tile_pos = player_to_screen( point_bub_ms( x, y ) );
 
                             // color overlay
                             SDL_Color color = lighting_colors[std::min( std::max( 0, color_hue ), 10 )];
@@ -1698,7 +1698,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                     }
                     for( int i = 0; i < 4; i++ ) {
                         const tripoint_bub_ms np = pos + neighborhood[i];
-                        invisible[1 + i] = apply_visible( np.raw(), ch2, here );
+                        invisible[1 + i] = apply_visible( np, ch2, here );
                     }
 
                     here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos.raw(), 0},
@@ -1833,7 +1833,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                     if( more ) {
                         text += "+";
                     }
-                    overlay_strings.emplace( player_to_screen( p.com.pos.xy().raw() ) + half_tile,
+                    overlay_strings.emplace( player_to_screen( p.com.pos.xy() ) + half_tile,
                                              formatted_text( text, catacurses::red,
                                                      direction::NORTH ) );
                 }
@@ -1874,7 +1874,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
             invisible[0] = false;
             for( int i = 0; i < 4; i++ ) {
                 const tripoint_bub_ms np = p + neighborhood[i];
-                invisible[1 + i] = apply_visible( np.raw(), ch, here );
+                invisible[1 + i] = apply_visible( np, ch, here );
             }
             //calling draw to memorize (and only memorize) everything.
             //bypass cache check in case we learn something new about the terrain's connections
@@ -1941,15 +1941,14 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     } else if( you.view_offset != tripoint_rel_ms::zero && !you.in_vehicle ) {
         // check to see if player is located at ter
         draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
-                             tripoint( g->ter_view_p.raw().xy(), center.z() ), 0, 0, lit_level::LIT,
+                             tripoint_bub_ms( g->ter_view_p.xy(), center.z() ), 0, 0, lit_level::LIT,
                              false );
     }
     if( you.controlling_vehicle ) {
         std::optional<tripoint_rel_ms> indicator_offset = g->get_veh_dir_indicator_location( true );
         if( indicator_offset ) {
             draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
-                                 indicator_offset->raw().xy() +
-                                 tripoint( you.posx(), you.posy(), center.z() ),
+                                 tripoint_bub_ms( you.pos_bub().xy(), center.z() ) + indicator_offset->xy(),
                                  0, 0, lit_level::LIT, false );
         }
     }
@@ -2124,7 +2123,7 @@ std::optional<point> cata_tiles::tile_to_player( const point &colrow ) const
     }
 }
 
-point cata_tiles::player_to_tile( const point &pos ) const
+point cata_tiles::player_to_tile( const point_bub_ms &pos ) const
 {
     // (calculate the screen position according to cata_tiles::tile_to_player)
     if( is_isometric() ) {
@@ -2135,21 +2134,21 @@ point cata_tiles::player_to_tile( const point &pos ) const
         // ( col - sx / 2 ) % 2 = ( row - sy / 2 ) % 2
         // ||
         // \/
-        const int col = pos.y + pos.x + screentile_width / 2 - o.y - o.x;
-        const int row = pos.y - pos.x + screentile_height / 2 - o.y + o.x;
+        const int col = pos.y() + pos.x() + screentile_width / 2 - o.y - o.x;
+        const int row = pos.y() - pos.x() + screentile_height / 2 - o.y + o.x;
         return { col, row };
     } else {
-        return pos - o;
+        return pos.raw() - o;
     }
 }
 
-point cata_tiles::player_to_screen( const point &pos ) const
+point cata_tiles::player_to_screen( const point_bub_ms &pos ) const
 {
     const point colrow = player_to_tile( pos );
     if( is_isometric() ) {
         // To ensure the first fully drawn basic tile (col or row = 1, according
         // to the definition in get_window_full_base_tile_range) starts at 0,
-        return op + point {
+        return op + point{
             // left = ( col - 1 ) * ( tw / 2.0 ) =>
             divide_round_down( ( colrow.x - 1 ) * tile_width, 2 ),
             // top = ( row - 1 ) * ( tw / 4.0 ) - th + tw / 2.0 =>
@@ -2158,7 +2157,7 @@ point cata_tiles::player_to_screen( const point &pos ) const
             divide_round_down( ( colrow.y + 1 ) * tile_width, 4 ) - tile_height,
         };
     } else {
-        return op + point { colrow.x * tile_width, colrow.y * tile_height };
+        return op + point{ colrow.x * tile_width, colrow.y * tile_height };
     }
 }
 
@@ -2225,7 +2224,8 @@ point_bub_ms cata_tiles::screen_to_player(
     }
 }
 
-bool cata_tiles::draw_from_id_string( const std::string &id, const tripoint &pos, int subtile,
+bool cata_tiles::draw_from_id_string( const std::string &id, const tripoint_bub_ms &pos,
+                                      int subtile,
                                       int rota,
                                       lit_level ll, bool apply_night_vision_goggles )
 {
@@ -2235,7 +2235,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, const tripoint &pos
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
-                                      const std::string &subcategory, const tripoint &pos,
+                                      const std::string &subcategory, const tripoint_bub_ms &pos,
                                       int subtile, int rota, lit_level ll,
                                       bool apply_night_vision_goggles )
 {
@@ -2244,17 +2244,8 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
                                             ll, apply_night_vision_goggles, nullint, 0 );
 }
 
-bool cata_tiles::draw_from_id_string( const std::string &id, const tripoint &pos, int subtile,
-                                      int rota,
-                                      lit_level ll, bool apply_night_vision_goggles,
-                                      int &height_3d )
-{
-    return cata_tiles::draw_from_id_string( id, TILE_CATEGORY::NONE, empty_string, pos, subtile,
-                                            rota, ll, apply_night_vision_goggles, height_3d, 0 );
-}
-
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
-                                      const std::string &subcategory, const tripoint &pos,
+                                      const std::string &subcategory, const tripoint_bub_ms &pos,
                                       int subtile, int rota, lit_level ll,
                                       bool apply_night_vision_goggles, int &height_3d, int intensity )
 {
@@ -2263,7 +2254,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
-                                      const std::string &subcategory, const tripoint &pos,
+                                      const std::string &subcategory, const tripoint_bub_ms &pos,
                                       int subtile, int rota, lit_level ll,
                                       bool apply_night_vision_goggles, int &height_3d )
 {
@@ -2272,7 +2263,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
-                                      const std::string &subcategory, const tripoint &pos,
+                                      const std::string &subcategory, const tripoint_bub_ms &pos,
                                       int subtile, int rota, lit_level ll,
                                       bool apply_night_vision_goggles, int &height_3d,
                                       int intensity_level, const std::string &variant )
@@ -2283,7 +2274,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
-                                      const std::string &subcategory, const tripoint &pos,
+                                      const std::string &subcategory, const tripoint_bub_ms &pos,
                                       int subtile, int rota, lit_level ll,
                                       bool apply_night_vision_goggles, int &height_3d,
                                       int intensity_level, const std::string &variant,
@@ -2293,7 +2284,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
             ll, -1, apply_night_vision_goggles, height_3d, intensity_level,
             variant, offset );
 }
-bool cata_tiles::draw_from_id_string_internal( const std::string &id, const tripoint &pos,
+bool cata_tiles::draw_from_id_string_internal( const std::string &id, const tripoint_bub_ms &pos,
         int subtile,
         int rota,
         lit_level ll, int retract, bool apply_night_vision_goggles, int &height_3d )
@@ -2533,7 +2524,7 @@ void cata_tiles::set_disable_occlusion( const bool val )
 }
 
 bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEGORY category,
-        const std::string &subcategory, const tripoint &pos,
+        const std::string &subcategory, const tripoint_bub_ms &pos,
         int subtile, int rota, lit_level ll, int retract,
         bool apply_night_vision_goggles, int &height_3d,
         int intensity_level, const std::string &variant,
@@ -2556,9 +2547,9 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         } else if( prevent_occlusion == 1 ) {
             retract = 100;
         } else {
-            const float distance = is_isometric() ? o.distance( pos.xy() ) :
+            const float distance = is_isometric() ? o.distance( pos.raw().xy() ) :
                                    point( static_cast<int>( o.x + ( screentile_width / 2.0f ) ),
-                                          static_cast<int>( o.y - 1 + ( screentile_height / 2.0f ) ) ).distance( pos.xy() );
+                                          static_cast<int>( o.y - 1 + ( screentile_height / 2.0f ) ) ).distance( pos.raw().xy() );
             const float d_min = prevent_occlusion_min_dist > 0.0 ? prevent_occlusion_min_dist :
                                 tileset_ptr->get_prevent_occlusion_min_dist();
             const float d_max = prevent_occlusion_max_dist > 0.0 ? prevent_occlusion_max_dist :
@@ -2851,8 +2842,8 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             if( vp_overridden ) {
                 const vpart_id &vp_id = std::get<0>( vp_override->second );
                 if( vp_id ) {
-                    const point &mount = std::get<4>( vp_override->second );
-                    seed = simple_point_hash( mount );
+                    const point_rel_ms &mount = std::get<4>( vp_override->second );
+                    seed = simple_point_hash( mount.raw() );
                 }
             } else {
                 const optional_vpart_position vp = here.veh_at( pos );
@@ -2880,7 +2871,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         case TILE_CATEGORY::OVERMAP_TERRAIN:
         case TILE_CATEGORY::OVERMAP_VISION_LEVEL:
         case TILE_CATEGORY::MAP_EXTRA:
-            seed = simple_point_hash( pos.xy() );
+            seed = simple_point_hash( pos.raw().xy() );
             break;
         case TILE_CATEGORY::NONE:
             // graffiti
@@ -3189,7 +3180,7 @@ bool cata_tiles::apply_vision_effects( const tripoint_bub_ms &pos,
     }
 
     // lighting is never rotated, though, could possibly add in random rotation?
-    draw_from_id_string( light_name, TILE_CATEGORY::LIGHTING, empty_string, pos.raw(), 0, 0,
+    draw_from_id_string( light_name, TILE_CATEGORY::LIGHTING, empty_string, pos, 0, 0,
                          lit_level::LIT, false, height_3d );
 
     return true;
@@ -3237,7 +3228,8 @@ const memorized_tile &cata_tiles::get_vpart_memory_at( const tripoint_abs_ms &p 
     return mm_submap::default_tile;
 }
 
-void cata_tiles::draw_square_below( const point &p, const nc_color &col, const int sizefactor )
+void cata_tiles::draw_square_below( const point_bub_ms &p, const nc_color &col,
+                                    const int sizefactor )
 {
     const SDL_Color sdlcol = curses_color_to_SDL( col );
     SDL_Rect sdlrect;
@@ -3314,7 +3306,7 @@ bool cata_tiles::draw_terrain_below( const tripoint_bub_ms &p, const lit_level, 
         col = curr_ter.color();
     }
 
-    draw_square_below( pbelow.xy().raw(), col, sizefactor );
+    draw_square_below( pbelow.xy(), col, sizefactor );
     return true;
 }
 
@@ -3361,7 +3353,7 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
         if( !neighborhood_overridden ) {
             return memorize_only
                    ? false
-                   : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p.raw(), subtile,
+                   : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
                                           rotation, ll, nv_goggles_activated, height_3d );
         }
     }
@@ -3390,7 +3382,7 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
             const bool nv = overridden ? false : nv_goggles_activated;
             return memorize_only
                    ? false
-                   : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p.raw(), subtile,
+                   : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
                                           rotation, lit, nv, height_3d );
         }
     } else if( invisible[0] ) {
@@ -3400,7 +3392,7 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
             return memorize_only
                    ? false
                    : draw_from_id_string(
-                       mt.get_ter_id(), TILE_CATEGORY::TERRAIN, empty_string, p.raw(), mt.get_ter_subtile(),
+                       mt.get_ter_id(), TILE_CATEGORY::TERRAIN, empty_string, p, mt.get_ter_subtile(),
                        mt.get_ter_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d );
         }
     }
@@ -3438,9 +3430,9 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
         const std::bitset<NUM_TERCONN> &rotate_group = f.obj().rotate_to_groups;
 
         if( connect_group.any() ) {
-            get_furn_connect_values( p.raw(), subtile, rotation, connect_group, rotate_group, {} );
+            get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
         } else {
-            get_tile_values_with_ter( p.raw(), f.to_i(), neighborhood, subtile, rotation, rotate_group );
+            get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
         }
         const std::string &fname = f.id().str();
         if( !( you.get_grab_type() == object_type::FURNITURE
@@ -3452,7 +3444,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
         if( !neighborhood_overridden ) {
             return memorize_only
                    ? false
-                   : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p.raw(), subtile,
+                   : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
                                           rotation, ll, nv_goggles_activated, height_3d );
         }
     }
@@ -3479,11 +3471,11 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             const std::bitset<NUM_TERCONN> &rotate_group = f.obj().rotate_to_groups;
 
             if( connect_group.any() ) {
-                get_furn_connect_values( p.raw(), subtile, rotation, connect_group, rotate_group, {} );
+                get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
             } else {
-                get_tile_values_with_ter( p.raw(), f.to_i(), neighborhood, subtile, rotation, rotate_group );
+                get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
             }
-            get_tile_values_with_ter( p.raw(), f2.to_i(), neighborhood, subtile, rotation, 0 );
+            get_tile_values_with_ter( p, f2.to_i(), neighborhood, subtile, rotation, 0 );
             const std::string &fname = f2.id().str();
             // tile overrides are never memorized
             // tile overrides are always shown with full visibility
@@ -3491,7 +3483,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             const bool nv = overridden ? false : nv_goggles_activated;
             return memorize_only
                    ? false
-                   : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p.raw(), subtile,
+                   : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
                                           rotation, lit, nv, height_3d );
         }
     } else if( invisible[0] ) {
@@ -3501,7 +3493,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             return memorize_only
                    ? false
                    : draw_from_id_string(
-                       mt.get_dec_id(), TILE_CATEGORY::FURNITURE, empty_string, p.raw(), mt.get_dec_subtile(),
+                       mt.get_dec_id(), TILE_CATEGORY::FURNITURE, empty_string, p, mt.get_dec_subtile(),
                        mt.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d );
         }
     }
@@ -3545,7 +3537,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
         if( !neighborhood_overridden ) {
             return memorize_only
                    ? false
-                   : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p.raw(), subtile,
+                   : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
                                           rotation, ll, nv_goggles_activated, height_3d );
         }
     }
@@ -3577,7 +3569,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
             const bool nv = overridden ? false : nv_goggles_activated;
             return memorize_only
                    ? false
-                   : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p.raw(), subtile,
+                   : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
                                           rotation, lit, nv, height_3d );
         }
     } else if( invisible[0] ) {
@@ -3587,7 +3579,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
             return memorize_only
                    ? false
                    : draw_from_id_string(
-                       mt.get_dec_id(), TILE_CATEGORY::TRAP, empty_string, p.raw(), mt.get_dec_subtile(),
+                       mt.get_dec_id(), TILE_CATEGORY::TRAP, empty_string, p, mt.get_dec_subtile(),
                        mt.get_dec_rotation(),
                        lit_level::MEMORIZED, nv_goggles_activated, height_3d );
         }
@@ -3599,7 +3591,6 @@ bool cata_tiles::draw_part_con( const tripoint_bub_ms &p, const lit_level ll, in
                                 const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     map &here = get_map();
-    // FIXME: fix tripoint type
     if( here.partial_con_at( p ) != nullptr && !invisible[0] ) {
         avatar &you = get_avatar();
         std::string const &trname = tr_unfinished_construction.str();
@@ -3608,7 +3599,7 @@ bool cata_tiles::draw_part_con( const tripoint_bub_ms &p, const lit_level ll, in
         }
         return memorize_only
                ? false
-               : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p.raw(), 0,
+               : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, 0,
                                       0, ll, nv_goggles_activated, height_3d );
     }
     return false;
@@ -3633,7 +3624,7 @@ bool cata_tiles::draw_graffiti( const tripoint_bub_ms &p, const lit_level ll, in
                              to_upper_case( string_replace( remove_punctuations( here.graffiti_at( p ) ), " ",
                                             "_" ) ).substr( 0, 32 );
     return draw_from_id_string( tileset_ptr->find_tile_type( tile ) ? tile : "graffiti",
-                                TILE_CATEGORY::NONE, empty_string, p.raw(), 0, rotation, lit, false, height_3d );
+                                TILE_CATEGORY::NONE, empty_string, p, 0, rotation, lit, false, height_3d );
 }
 
 bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
@@ -3678,7 +3669,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
                     }
 
                     // if we have found info on the item go through and draw its stuff
-                    ret_draw_field = draw_from_id_string( sprite_to_draw, TILE_CATEGORY::FIELD, empty_string, p.raw(),
+                    ret_draw_field = draw_from_id_string( sprite_to_draw, TILE_CATEGORY::FIELD, empty_string, p,
                                                           subtile, rotation, ll, nv, height_3d, fe.get_field_intensity(), "", layer_var.offset );
                     break;
                 }
@@ -3721,7 +3712,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
                             variant += layer_var.append_suffix;
                         }
                         // if we have found info on the item go through and draw its stuff
-                        draw_from_id_string( sprite_to_draw, TILE_CATEGORY::ITEM, layer_it_category, p.raw(), 0,
+                        draw_from_id_string( sprite_to_draw, TILE_CATEGORY::ITEM, layer_it_category, p, 0,
                                              0, layer_lit, layer_nv, height_3d, 0, variant, layer_var.offset );
 
                         // if the top item is already being layered don't draw it later
@@ -3786,7 +3777,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
                 }
                 if( !has_drawn_field ) {
                     draw_from_id_string( fld.id().str(), TILE_CATEGORY::FIELD, empty_string,
-                                         p.raw(), subtile, rotation, ll, nv_goggles_activated, height_3d, intensity );
+                                         p, subtile, rotation, ll, nv_goggles_activated, height_3d, intensity );
                 }
             }
         }
@@ -3816,7 +3807,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
             //get field intensity
             int intensity = fld_overridden ? 0 : here.field_at( p ).displayed_intensity();
             ret_draw_field = draw_from_id_string( fld.id().str(), TILE_CATEGORY::FIELD, empty_string,
-                                                  p.raw(), subtile, rotation, lit, false, height_3d, intensity );
+                                                  p, subtile, rotation, lit, false, height_3d, intensity );
         }
     }
 
@@ -3879,7 +3870,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
                 const lit_level lit = it_overridden ? lit_level::LIT : ll;
                 const bool nv = it_overridden ? false : nv_goggles_activated;
 
-                ret_draw_items = draw_from_id_string( disp_id, TILE_CATEGORY::ITEM, it_category, p.raw(), 0,
+                ret_draw_items = draw_from_id_string( disp_id, TILE_CATEGORY::ITEM, it_category, p, 0,
                                                       0, lit, nv, height_3d, 0, variant );
                 if( ret_draw_items && hilite ) {
                     draw_item_highlight( p, height_3d );
@@ -3954,7 +3945,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
                 const bool ret = memorize_only
                                  ? false
                                  : draw_from_id_string( "vp_" + vd.id.str(), TILE_CATEGORY::VEHICLE_PART,
-                                                        empty_string, p.raw(), subtile, rotation, ll,
+                                                        empty_string, p, subtile, rotation, ll,
                                                         nv_goggles_activated, height_3d_temp, 0, vd.variant.id );
                 if( ret && vd.has_cargo ) {
                     draw_item_highlight( p, height_3d_temp );
@@ -3981,7 +3972,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
             int height_3d_temp = height_3d;
             const bool ret = memorize_only
                              ? false
-                             : draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p.raw(), subtile,
+                             : draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p, subtile,
                                                     rotation, lit_level::LIT, false, height_3d_temp );
             if( ret && draw_highlight ) {
                 draw_item_highlight( p, height_3d_temp );
@@ -4006,7 +3997,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
             return memorize_only
                    ? false
                    : draw_from_id_string(
-                       std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p.raw(), t.get_dec_subtile(),
+                       std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.get_dec_subtile(),
                        t.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp, 0,
                        std::string( tvar ) );
         }
@@ -4046,7 +4037,7 @@ bool cata_tiles::draw_critter_at_below( const tripoint_bub_ms &p, const lit_leve
         return false;
     }
 
-    draw_square_below( pbelow.xy().raw(), c_red, 2 );
+    draw_square_below( pbelow.xy(), c_red, 2 );
 
     return true;
 }
@@ -4077,7 +4068,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
         const std::string &chosen_id = id.str();
         const std::string &ent_subcategory = id.obj().species.empty() ?
                                              empty_string : id.obj().species.begin()->str();
-        result = draw_from_id_string( chosen_id, TILE_CATEGORY::MONSTER, ent_subcategory, p.raw(),
+        result = draw_from_id_string( chosen_id, TILE_CATEGORY::MONSTER, ent_subcategory, p,
                                       corner, 0, lit_level::LIT, false, height_3d );
     } else if( !invisible[0] || always_visible ) {
         if( pcritter == nullptr ) {
@@ -4091,7 +4082,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
             if( !sees_with_special.is_empty() ) {
                 const enchant_cache::special_vision_descriptions special_vis_desc =
                     you.enchantment_cache->get_vision_description_struct( sees_with_special, d );
-                return draw_from_id_string( special_vis_desc.id, TILE_CATEGORY::NONE, empty_string, p.raw(), 0, 0,
+                return draw_from_id_string( special_vis_desc.id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
                                             lit_level::LIT, false, height_3d );
             }
             return false;
@@ -4131,7 +4122,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
                         chosen_id = ridden_id;
                     }
                 }
-                result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p.raw(),
+                result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p,
                                               subtile, rot_facing, ll, false, height_3d );
                 sees_player = m->sees( you );
                 attitude = m->attitude_to( you );
@@ -4162,7 +4153,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
             if( !scope_is_blocking ) {
                 const enchant_cache::special_vision_descriptions special_vis_desc =
                     you.enchantment_cache->get_vision_description_struct( sees_with_special, d );
-                return draw_from_id_string( special_vis_desc.id, TILE_CATEGORY::NONE, empty_string, p.raw(),
+                return draw_from_id_string( special_vis_desc.id, TILE_CATEGORY::NONE, empty_string, p,
                                             0, 0, lit_level::LIT, false, height_3d );
             } else {
                 return false;
@@ -4178,7 +4169,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
             draw_id += "_sees_player";
         }
         if( tileset_ptr->find_tile_type( draw_id ) ) {
-            draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p.raw(), 0, 0,
+            draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
                                  lit_level::LIT, false, height_3d );
         }
     }
@@ -4211,7 +4202,7 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
     const Creature &critter = *pcritter;
 
     // Draw shadow
-    if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p.raw(),
+    if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p,
                              0, 0, ll, false, height_3d ) && scan_p.z() - 1 > you.posz() && you.sees( critter ) ) {
 
         bool is_player = false;
@@ -4243,7 +4234,7 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
                 draw_id += "_sees_player";
             }
             if( tileset_ptr->find_tile_type( draw_id ) ) {
-                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p.raw(), 0, 0,
+                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
                                      lit_level::LIT, false, height_3d );
             }
         }
@@ -4276,7 +4267,7 @@ bool cata_tiles::draw_zone_mark( const tripoint_bub_ms &p, lit_level ll, int &he
         const mark_option *option = dynamic_cast<const mark_option *>( &zone->get_options() );
 
         if( option && !option->get_mark().empty() ) {
-            return draw_from_id_string( option->get_mark(), TILE_CATEGORY::NONE, empty_string, p.raw(),
+            return draw_from_id_string( option->get_mark(), TILE_CATEGORY::NONE, empty_string, p,
                                         0, 0, ll, nv_goggles_activated, height_3d );
         }
     }
@@ -4298,7 +4289,7 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint_bub_ms &pos, con
         for( item &i : here.i_at( pos ) ) {
             if( i.can_revive() ) {
                 return draw_from_id_string( ZOMBIE_REVIVAL_INDICATOR, TILE_CATEGORY::NONE,
-                                            empty_string, pos.raw(), 0, 0, lit_level::LIT, false, height_3d );
+                                            empty_string, pos, 0, 0, lit_level::LIT, false, height_3d );
             }
         }
     }
@@ -4309,7 +4300,7 @@ void cata_tiles::draw_zlevel_overlay( const tripoint_bub_ms &p, const lit_level 
 {
     // Draws zlevel fog using geometry renderer
     // Slower than sprites so only use as fallback when sprite missing
-    const point screen = player_to_screen( p.xy().raw() );
+    const point screen = player_to_screen( p.xy() );
     SDL_Rect draw_rect;
     if( is_isometric() ) {
         // See comments in get_window_base_tile_counts for an explanation of tile width
@@ -4374,10 +4365,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint_
         }
         // depending on the toggle flip sprite left or right
         if( ch.facing == FacingDirection::RIGHT ) {
-            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p.raw(), corner, 0, ll, false,
+            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p, corner, 0, ll, false,
                                  height_3d );
         } else if( ch.facing == FacingDirection::LEFT ) {
-            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p.raw(), corner, -1, ll, false,
+            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p, corner, -1, ll, false,
                                  height_3d );
         }
     } else {
@@ -4391,10 +4382,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint_
             category = TILE_CATEGORY::NONE;
         }
         if( ch.facing == FacingDirection::RIGHT ) {
-            draw_from_id_string( override_look.id, category, "", p.raw(), corner, 0, ll, false,
+            draw_from_id_string( override_look.id, category, "", p, corner, 0, ll, false,
                                  height_3d );
         } else if( ch.facing == FacingDirection::LEFT ) {
-            draw_from_id_string( override_look.id, category, "", p.raw(), corner, -1, ll, false,
+            draw_from_id_string( override_look.id, category, "", p, corner, -1, ll, false,
                                  height_3d );
         }
     }
@@ -4407,10 +4398,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint_
         if( find_overlay_looks_like( ch.male, overlay.first, overlay.second, draw_id ) ) {
             int overlay_height_3d = prev_height_3d;
             if( ch.facing == FacingDirection::RIGHT ) {
-                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p.raw(), corner, /*rota:*/ 0, ll,
+                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, /*rota:*/ 0, ll,
                                      false, overlay_height_3d );
             } else if( ch.facing == FacingDirection::LEFT ) {
-                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p.raw(), corner, /*rota:*/ -1, ll,
+                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, /*rota:*/ -1, ll,
                                      false, overlay_height_3d );
             }
             // the tallest height-having overlay is the one that counts
@@ -4421,7 +4412,7 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint_
 
 bool cata_tiles::draw_item_highlight( const tripoint_bub_ms &pos, int &height_3d )
 {
-    return draw_from_id_string( ITEM_HIGHLIGHT, TILE_CATEGORY::NONE, empty_string, pos.raw(), 0, 0,
+    return draw_from_id_string( ITEM_HIGHLIGHT, TILE_CATEGORY::NONE, empty_string, pos, 0, 0,
                                 lit_level::LIT, false, height_3d );
 }
 
@@ -4529,7 +4520,7 @@ void cata_tiles::init_draw_zones( const tripoint_bub_ms &_start, const tripoint_
     do_draw_zones = true;
     zone_start = _start;
     zone_end = _end;
-    zone_offset = _offset.raw();
+    zone_offset = _offset;
 }
 void cata_tiles::init_draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id )
 {
@@ -4566,7 +4557,7 @@ void cata_tiles::init_draw_item_override( const tripoint_bub_ms &p, const itype_
     item_override.emplace( p, std::make_tuple( id, mid, hilite ) );
 }
 void cata_tiles::init_draw_vpart_override( const tripoint_bub_ms &p, const vpart_id &id,
-        const int part_mod, const units::angle &veh_dir, const bool hilite, const point &mount )
+        const int part_mod, const units::angle &veh_dir, const bool hilite, const point_rel_ms &mount )
 {
     vpart_override.emplace( p, std::make_tuple( id, part_mod, veh_dir, hilite, mount ) );
 }
@@ -4708,27 +4699,27 @@ void cata_tiles::draw_explosion_frame()
         subtile = corner;
         rotation = 0;
 
-        draw_from_id_string( exp_name, exp_pos.raw() + point( -i, -i ),
+        draw_from_id_string( exp_name, exp_pos + point( -i, -i ),
                              subtile, rotation++, lit_level::LIT, nv_goggles_activated );
-        draw_from_id_string( exp_name, exp_pos.raw() + point( -i, i ),
+        draw_from_id_string( exp_name, exp_pos + point( -i, i ),
                              subtile, rotation++, lit_level::LIT, nv_goggles_activated );
-        draw_from_id_string( exp_name, exp_pos.raw() + point( i, i ),
+        draw_from_id_string( exp_name, exp_pos + point( i, i ),
                              subtile, rotation++, lit_level::LIT, nv_goggles_activated );
-        draw_from_id_string( exp_name, exp_pos.raw() + point( i, -i ),
+        draw_from_id_string( exp_name, exp_pos + point( i, -i ),
                              subtile, rotation, lit_level::LIT, nv_goggles_activated );
 
         subtile = edge;
         for( int j = 1 - i; j < 0 + i; j++ ) {
             rotation = 0;
-            draw_from_id_string( exp_name, exp_pos.raw() + point( j, -i ),
+            draw_from_id_string( exp_name, exp_pos + point( j, -i ),
                                  subtile, rotation, lit_level::LIT, nv_goggles_activated );
-            draw_from_id_string( exp_name, exp_pos.raw() + point( j, i ),
+            draw_from_id_string( exp_name, exp_pos + point( j, i ),
                                  subtile, rotation, lit_level::LIT, nv_goggles_activated );
 
             rotation = 1;
-            draw_from_id_string( exp_name, exp_pos.raw() + point( -i, j ),
+            draw_from_id_string( exp_name, exp_pos + point( -i, j ),
                                  subtile, rotation, lit_level::LIT, nv_goggles_activated );
-            draw_from_id_string( exp_name, exp_pos.raw() + point( i, j ),
+            draw_from_id_string( exp_name, exp_pos + point( i, j ),
                                  subtile, rotation, lit_level::LIT, nv_goggles_activated );
         }
     }
@@ -4811,22 +4802,22 @@ void cata_tiles::draw_custom_explosion_frame()
             explosion_tile_id = exp_weak;
         }
 
-        draw_from_id_string( explosion_tile_id, p.raw(), subtile, rotation, lit_level::LIT,
+        draw_from_id_string( explosion_tile_id, p, subtile, rotation, lit_level::LIT,
                              nv_goggles_activated );
     }
 }
 void cata_tiles::draw_bullet_frame()
 {
-    draw_from_id_string( bul_id, TILE_CATEGORY::BULLET, empty_string, bul_pos.raw(), 0, 0,
+    draw_from_id_string( bul_id, TILE_CATEGORY::BULLET, empty_string, bul_pos, 0, 0,
                          lit_level::LIT, false );
 }
 void cata_tiles::draw_hit_frame()
 {
     std::string hit_overlay = "animation_hit";
 
-    draw_from_id_string( hit_entity_id, TILE_CATEGORY::HIT_ENTITY, empty_string, hit_pos.raw(), 0, 0,
+    draw_from_id_string( hit_entity_id, TILE_CATEGORY::HIT_ENTITY, empty_string, hit_pos, 0, 0,
                          lit_level::LIT, false );
-    draw_from_id_string( hit_overlay, hit_pos.raw(), 0, 0, lit_level::LIT, false );
+    draw_from_id_string( hit_overlay, hit_pos, 0, 0, lit_level::LIT, false );
 }
 void cata_tiles::draw_line()
 {
@@ -4836,22 +4827,22 @@ void cata_tiles::draw_line()
     static std::string line_overlay = "animation_line";
     if( !is_target_line || get_player_view().sees( line_pos ) ) {
         for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
-            draw_from_id_string( line_overlay, it->raw(), 0, 0, lit_level::LIT, false );
+            draw_from_id_string( line_overlay, *it, 0, 0, lit_level::LIT, false );
         }
     }
 
-    draw_from_id_string( line_endpoint_id, line_trajectory.back().raw(), 0, 0, lit_level::LIT, false );
+    draw_from_id_string( line_endpoint_id, line_trajectory.back(), 0, 0, lit_level::LIT, false );
 }
 void cata_tiles::draw_cursor()
 {
     for( const tripoint_bub_ms &p : cursors ) {
-        draw_from_id_string( "cursor", p.raw(), 0, 0, lit_level::LIT, false );
+        draw_from_id_string( "cursor", p, 0, 0, lit_level::LIT, false );
     }
 }
 void cata_tiles::draw_highlight()
 {
     for( const tripoint_bub_ms &p : highlights ) {
-        draw_from_id_string( "highlight", p.raw(), 0, 0, lit_level::LIT, false );
+        draw_from_id_string( "highlight", p, 0, 0, lit_level::LIT, false );
     }
 }
 void cata_tiles::draw_weather_frame()
@@ -4868,7 +4859,7 @@ void cata_tiles::draw_weather_frame()
             }
             p = temp.value();
         }
-        const tripoint pos( p, 0 );
+        const tripoint_bub_ms pos( point_bub_ms( p ), 0 );
         draw_from_id_string( weather_name, TILE_CATEGORY::WEATHER, empty_string, pos, 0, 0,
                              lit_level::LIT, nv_goggles_activated );
     }
@@ -4898,7 +4889,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
                                              full_text_length / 2;
 
                 overlay_strings.emplace(
-                    player_to_screen( iD + point( direction_offset, 0 ) ),
+                    player_to_screen( iD + point_bub_ms( direction_offset, 0 ) ),
                     formatted_text( sText, FG, direction ) );
             } else {
                 for( char &it : sText ) {
@@ -4906,7 +4897,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
 
                     if( tileset_ptr->find_tile_type( generic_id ) ) {
                         draw_from_id_string( generic_id, TILE_CATEGORY::NONE, empty_string,
-                                             iD + tripoint( iOffset, player_pos.z() ),
+                                             iD + tripoint_bub_ms( point_bub_ms( iOffset ), player_pos.z() ),
                                              0, 0, lit_level::LIT, false );
                     }
 
@@ -4926,7 +4917,7 @@ void cata_tiles::draw_zones_frame()
     for( int iY = zone_start.y(); iY <= zone_end.y(); ++ iY ) {
         for( int iX = zone_start.x(); iX <= zone_end.x(); ++iX ) {
             draw_from_id_string( "highlight", TILE_CATEGORY::NONE, empty_string,
-                                 zone_offset.xy() + tripoint( iX, iY, player_pos.z() ),
+                                 tripoint_bub_ms( iX, iY, player_pos.z() ) + zone_offset.xy(),
                                  0, 0, lit_level::LIT, false );
         }
     }
@@ -4942,7 +4933,7 @@ void cata_tiles::draw_async_anim()
         const std::string tile_id = anim.second;
         // Only draw if sprite found
         if( find_tile_looks_like( tile_id, TILE_CATEGORY::NONE, "" ) ) {
-            draw_from_id_string( tile_id, p.raw(), 0, 0, lit_level::LIT, nv_goggles_activated );
+            draw_from_id_string( tile_id, p, 0, 0, lit_level::LIT, nv_goggles_activated );
         }
     }
 }
@@ -4958,11 +4949,11 @@ void cata_tiles::draw_footsteps_frame( const tripoint_bub_ms &center )
 
     for( const tripoint_bub_ms &pos : sounds::get_footstep_markers() ) {
         if( pos.z() > center.z() && tl_above ) {
-            draw_from_id_string( id_footstep_above, pos.raw(), 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id_footstep_above, pos, 0, 0, lit_level::LIT, false );
         } else if( pos.z() < center.z() && tl_below ) {
-            draw_from_id_string( id_footstep_below, pos.raw(), 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id_footstep_below, pos, 0, 0, lit_level::LIT, false );
         } else {
-            draw_from_id_string( id_footstep, pos.raw(), 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id_footstep, pos, 0, 0, lit_level::LIT, false );
         }
     }
 }
@@ -5277,9 +5268,9 @@ void cata_tiles::get_connect_values( const tripoint_bub_ms &p, int &subtile, int
     get_rotation_and_subtile( connections, rotation_targets, rotation, subtile );
 }
 
-void cata_tiles::get_furn_connect_values( const tripoint &p, int &subtile, int &rotation,
+void cata_tiles::get_furn_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
         const std::bitset<NUM_TERCONN> &connect_group, const std::bitset<NUM_TERCONN> &rotate_to_group,
-        const std::map<tripoint, furn_id> &furn_override )
+        const std::map<tripoint_bub_ms, furn_id> &furn_override )
 {
     uint8_t connections = get_map().get_known_connections_f( p, connect_group, furn_override );
     uint8_t rotation_targets = get_map().get_known_rotates_to_f( p, rotate_to_group, {}, {} );
@@ -5301,7 +5292,7 @@ void cata_tiles::get_tile_values( const int t, const std::array<int, 4> &tn, int
 }
 
 void cata_tiles::get_tile_values_with_ter(
-    const tripoint &p, const int t, const std::array<int, 4> &tn, int &subtile, int &rotation,
+    const tripoint_bub_ms &p, const int t, const std::array<int, 4> &tn, int &subtile, int &rotation,
     const std::bitset<NUM_TERCONN> &rotate_to_group )
 {
     map &here = get_map();
@@ -5324,7 +5315,7 @@ void cata_tiles::get_tile_values_with_ter(
         if( here.has_flag( ter_furn_flag::TFLAG_ALIGN_WORKBENCH, p ) ) {
             for( int i = 0; i < 4; ++i ) {
                 // align to furniture that has the workbench quality
-                const tripoint &pt = p + four_adjacent_offsets[i];
+                const tripoint_bub_ms &pt = p + four_adjacent_offsets[i];
                 if( here.has_furn( pt ) && here.furn( pt ).obj().workbench ) {
                     val += 1 << i;
                     use_furniture = true;
@@ -5334,7 +5325,7 @@ void cata_tiles::get_tile_values_with_ter(
         // if still unaligned, try aligning to walls
         if( val == 0 ) {
             for( int i = 0; i < 4; ++i ) {
-                const tripoint &pt = p + four_adjacent_offsets[i];
+                const tripoint_bub_ms &pt = p + four_adjacent_offsets[i];
                 if( here.has_flag( ter_furn_flag::TFLAG_WALL, pt ) ||
                     here.has_flag( ter_furn_flag::TFLAG_WINDOW, pt ) ||
                     here.has_flag( ter_furn_flag::TFLAG_DOOR, pt ) ) {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -483,36 +483,56 @@ class cata_tiles
         bool find_overlay_looks_like( bool male, const std::string &overlay, const std::string &variant,
                                       std::string &draw_id );
 
-        bool draw_from_id_string( const std::string &id, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll,
-                                  bool apply_night_vision_goggles );
-        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
-                                  const std::string &subcategory, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles );
-        bool draw_from_id_string( const std::string &id, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll,
-                                  bool apply_night_vision_goggles, int &height_3d );
-        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
-                                  const std::string &subcategory, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d );
-        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
-                                  const std::string &subcategory, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int intensity_level );
-        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
-                                  const std::string &subcategory, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int intensity_level,
-                                  const std::string &variant );
-        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
-                                  const std::string &subcategory, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int intensity_level,
-                                  const std::string &variant, const point &offset );
-        bool draw_from_id_string_internal( const std::string &id, const tripoint &pos, int subtile,
+    private:
+        bool draw_from_id_string_internal( const std::string &id, const tripoint_bub_ms &pos, int subtile,
                                            int rota,
                                            lit_level ll, int retract, bool apply_night_vision_goggles, int &height_3d );
         bool draw_from_id_string_internal( const std::string &id, TILE_CATEGORY category,
-                                           const std::string &subcategory, const tripoint &pos, int subtile, int rota,
+                                           const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
                                            lit_level ll, int retract, bool apply_night_vision_goggles, int &height_3d, int intensity_level,
                                            const std::string &variant, const point &offset );
+    protected:
+        bool draw_from_id_string( const std::string &id, const tripoint_bub_ms &pos, int subtile, int rota,
+                                  lit_level ll,
+                                  bool apply_night_vision_goggles );
+        bool draw_from_id_string( const std::string &id, const tripoint_abs_omt &pos, int subtile, int rota,
+                                  lit_level ll,
+                                  bool apply_night_vision_goggles ) {
+            // A number of operations follow this pattern, i.e. tripoint_abs_omt coordinates are cast to tripoint_bub_ms and the call
+            // is forwarded to the "normal" operation. This relies on the underlying logic being the same regardless of the coordinate
+            // system and scale.
+            return draw_from_id_string( id, tripoint_bub_ms( pos.raw() ), subtile, rota, ll,
+                                        apply_night_vision_goggles );
+        }
+        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
+                                  const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
+                                  lit_level ll, bool apply_night_vision_goggles );
+        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
+                                  const std::string &subcategory, const tripoint_abs_omt &pos, int subtile, int rota,
+                                  lit_level ll, bool apply_night_vision_goggles ) {
+            return draw_from_id_string( id, category, subcategory, tripoint_bub_ms( pos.raw() ), subtile, rota,
+                                        ll, apply_night_vision_goggles );
+        }
+        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
+                                  const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
+                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d );
+        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
+                                  const std::string &subcategory, const tripoint_abs_omt &pos, int subtile, int rota,
+                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d ) {
+            return draw_from_id_string( id, category, subcategory, tripoint_bub_ms( pos.raw() ), subtile, rota,
+                                        ll, apply_night_vision_goggles, height_3d );
+        };
+        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
+                                  const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
+                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int intensity_level );
+        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
+                                  const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
+                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int intensity_level,
+                                  const std::string &variant );
+        bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
+                                  const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
+                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int intensity_level,
+                                  const std::string &variant, const point &offset );
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
             const point &, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
@@ -525,17 +545,17 @@ class cata_tiles
         void get_tile_values( int t, const std::array<int, 4> &tn, int &subtile, int &rotation,
                               char rotation_targets );
         // as get_tile_values, but for unconnected tiles, infer rotation from surrounding walls
-        void get_tile_values_with_ter( const tripoint &p, int t, const std::array<int, 4> &tn,
+        void get_tile_values_with_ter( const tripoint_bub_ms &p, int t, const std::array<int, 4> &tn,
                                        int &subtile, int &rotation,
                                        const std::bitset<NUM_TERCONN> &rotate_to_group );
         static void get_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
                                         const std::bitset<NUM_TERCONN> &connect_group,
                                         const std::bitset<NUM_TERCONN> &rotate_to_group,
                                         const std::map<tripoint_bub_ms, ter_id> &ter_override );
-        static void get_furn_connect_values( const tripoint &p, int &subtile, int &rotation,
+        static void get_furn_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
                                              const std::bitset<NUM_TERCONN> &connect_group,
                                              const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                             const std::map<tripoint, furn_id> &furn_override );
+                                             const std::map<tripoint_bub_ms, furn_id> &furn_override );
         void get_terrain_orientation( const tripoint_bub_ms &p, int &rota, int &subtile,
                                       const std::map<tripoint_bub_ms, ter_id> &ter_override,
                                       const std::array<bool, 5> &invisible,
@@ -556,7 +576,7 @@ class cata_tiles
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;
         bool apply_vision_effects( const tripoint_bub_ms &pos, visibility_type visibility, int &height_3d );
-        void draw_square_below( const point &p, const nc_color &col, int sizefactor );
+        void draw_square_below( const point_bub_ms &p, const nc_color &col, int sizefactor );
         bool draw_terrain( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                            const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_terrain_below( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
@@ -592,6 +612,10 @@ class cata_tiles
         void draw_zlevel_overlay( const tripoint_bub_ms &p, lit_level ll, int &height_3d );
         void draw_entity_with_overlays( const Character &ch, const tripoint_bub_ms &p, lit_level ll,
                                         int &height_3d );
+        void draw_entity_with_overlays( const Character &ch, const tripoint_abs_omt &p, lit_level ll,
+                                        int &height_3d ) {
+            draw_entity_with_overlays( ch, tripoint_bub_ms( p.raw() ), ll, height_3d );
+        }
 
         bool draw_item_highlight( const tripoint_bub_ms &pos, int &height_3d );
 
@@ -669,7 +693,7 @@ class cata_tiles
         void void_item_override();
 
         void init_draw_vpart_override( const tripoint_bub_ms &p, const vpart_id &id, int part_mod,
-                                       const units::angle &veh_dir, bool hilite, const point &mount );
+                                       const units::angle &veh_dir, bool hilite, const point_rel_ms &mount );
         void void_vpart_override();
 
         void init_draw_below_override( const tripoint_bub_ms &p, bool draw );
@@ -720,8 +744,11 @@ class cata_tiles
         static std::optional<point_bub_ms> tile_to_player(
             const point &colrow, const point_bub_ms &o,
             const point &base_tile_cnt, bool iso );
-        point player_to_tile( const point &pos ) const;
-        point player_to_screen( const point &pos ) const;
+        point player_to_tile( const point_bub_ms &pos ) const;
+        point player_to_screen( const point_bub_ms &pos ) const;
+        point player_to_screen( const point_abs_omt &pos ) {
+            return player_to_screen( point_bub_ms( pos.raw() ) );
+        }
         static point_bub_ms screen_to_player(
             const point &scr_pos, const point &tile_size,
             const point &win_size, const point_bub_ms &center,
@@ -820,7 +847,7 @@ class cata_tiles
 
         tripoint_bub_ms zone_start;
         tripoint_bub_ms zone_end;
-        tripoint zone_offset;
+        tripoint_rel_ms zone_offset;
 
         // offset values, in tile coordinates, not pixels
         point o;
@@ -837,7 +864,8 @@ class cata_tiles
         std::map<tripoint_bub_ms, std::tuple<itype_id, mtype_id, bool>> item_override;
         // int, angle, bool represents part_mod, veh_dir, and highlight respectively
         // point represents the mount direction
-        std::map<tripoint_bub_ms, std::tuple<vpart_id, int, units::angle, bool, point>> vpart_override;
+        std::map<tripoint_bub_ms, std::tuple<vpart_id, int, units::angle, bool, point_rel_ms>>
+                vpart_override;
         std::map<tripoint_bub_ms, bool> draw_below_override;
         // int represents spawn count
         std::map<tripoint_bub_ms, std::tuple<mtype_id, int, bool, Creature::Attitude>> monster_override;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -746,7 +746,8 @@ class cata_tiles
             const point &base_tile_cnt, bool iso );
         point player_to_tile( const point_bub_ms &pos ) const;
         point player_to_screen( const point_bub_ms &pos ) const;
-        point player_to_screen( const point_abs_omt &pos ) {
+        point player_to_screen( const point_abs_omt &pos ) const {
+            // This weird type casting relies on the underlying logic being the same regardless of the coordinate system and scale.
             return player_to_screen( point_bub_ms( pos.raw() ) );
         }
         static point_bub_ms screen_to_player(

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2096,19 +2096,6 @@ uint8_t map::get_known_rotates_to( const tripoint_bub_ms &p,
     return val;
 }
 
-uint8_t map::get_known_connections_f( const tripoint &p,
-                                      const std::bitset<NUM_TERCONN> &connect_group,
-                                      const std::map<tripoint, furn_id> &override ) const
-{
-    std::map<tripoint_bub_ms, furn_id> tmp_override;
-
-    for( const auto &element : override ) {
-        tmp_override.insert( {tripoint_bub_ms( element.first ), element.second} );
-    }
-
-    return map::get_known_connections_f( tripoint_bub_ms( p ), connect_group, tmp_override );
-}
-
 uint8_t map::get_known_connections_f( const tripoint_bub_ms &p,
                                       const std::bitset<NUM_TERCONN> &connect_group,
                                       const std::map<tripoint_bub_ms, furn_id> &override ) const

--- a/src/map.h
+++ b/src/map.h
@@ -989,9 +989,6 @@ class map
                                        const std::bitset<NUM_TERCONN> &connect_group,
                                        const std::map<tripoint_bub_ms, ter_id> &override = {} ) const;
         // as above, but for furniture
-        // TODO: Get rid of untyped overload.
-        uint8_t get_known_connections_f( const tripoint &p, const std::bitset<NUM_TERCONN> &connect_group,
-                                         const std::map<tripoint, furn_id> &override = {} ) const;
         uint8_t get_known_connections_f( const tripoint_bub_ms &p,
                                          const std::bitset<NUM_TERCONN> &connect_group,
                                          const std::map<tripoint_bub_ms, furn_id> &override = {} ) const;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -581,7 +581,7 @@ void clear_window_area( const catacurses::window &win_ )
 }
 
 static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow(
-            const inclusive_cuboid<tripoint> &overmap_area, const tripoint_abs_omt &center )
+            const inclusive_cuboid<tripoint_abs_omt> &overmap_area, const tripoint_abs_omt &center )
 {
     if( get_avatar().get_active_mission() == nullptr ) {
         return std::nullopt;
@@ -592,13 +592,13 @@ static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow
     const tripoint_abs_omt mission_target = get_avatar().get_active_mission_target();
 
     std::string mission_arrow_variant;
-    if( overmap_area.contains( mission_target.raw() ) ) {
+    if( overmap_area.contains( mission_target ) ) {
         mission_arrow_variant = "mission_cursor";
         return std::make_pair( mission_target, mission_arrow_variant );
     }
 
-    inclusive_rectangle<point> area_flat( overmap_area.p_min.xy(), overmap_area.p_max.xy() );
-    if( area_flat.contains( mission_target.raw().xy() ) ) {
+    inclusive_rectangle<point_abs_omt> area_flat( overmap_area.p_min.xy(), overmap_area.p_max.xy() );
+    if( area_flat.contains( mission_target.xy() ) ) {
         int area_z = center.z();
         if( mission_target.z() > area_z ) {
             mission_arrow_variant = "mission_arrow_up";
@@ -608,8 +608,8 @@ static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow
         return std::make_pair( tripoint_abs_omt( mission_target.xy(), area_z ), mission_arrow_variant );
     }
 
-    const std::vector<tripoint> traj = line_to( center.raw(),
-                                       tripoint( mission_target.raw().xy(), center.raw().z ) );
+    const std::vector<tripoint_abs_omt> traj = line_to( center,
+            tripoint_abs_omt( mission_target.xy(), center.z() ) );
 
     if( traj.empty() ) {
         debugmsg( "Failed to gen overmap mission trajectory %s %s",
@@ -617,7 +617,7 @@ static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow
         return std::nullopt;
     }
 
-    tripoint arr_pos = traj[0];
+    tripoint_abs_omt arr_pos = traj[0];
     for( auto it = traj.rbegin(); it != traj.rend(); it++ ) {
         if( overmap_area.contains( *it ) ) {
             arr_pos = *it;
@@ -625,24 +625,24 @@ static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow
         }
     }
 
-    const int north_border_y = ( overmap_area.p_max.y - overmap_area.p_min.y ) / 3;
+    const int north_border_y = ( overmap_area.p_max.y() - overmap_area.p_min.y() ) / 3;
     const int south_border_y = north_border_y * 2;
-    const int west_border_x = ( overmap_area.p_max.x - overmap_area.p_min.x ) / 3;
+    const int west_border_x = ( overmap_area.p_max.x() - overmap_area.p_min.x() ) / 3;
     const int east_border_x = west_border_x * 2;
 
-    tripoint north_pmax( overmap_area.p_max );
-    north_pmax.y = overmap_area.p_min.y + north_border_y;
-    tripoint south_pmin( overmap_area.p_min );
-    south_pmin.y += south_border_y;
-    tripoint west_pmax( overmap_area.p_max );
-    west_pmax.x = overmap_area.p_min.x + west_border_x;
-    tripoint east_pmin( overmap_area.p_min );
-    east_pmin.x += east_border_x;
+    tripoint_abs_omt north_pmax( overmap_area.p_max );
+    north_pmax.y() = overmap_area.p_min.y() + north_border_y;
+    tripoint_abs_omt south_pmin( overmap_area.p_min );
+    south_pmin.y() += south_border_y;
+    tripoint_abs_omt west_pmax( overmap_area.p_max );
+    west_pmax.x() = overmap_area.p_min.x() + west_border_x;
+    tripoint_abs_omt east_pmin( overmap_area.p_min );
+    east_pmin.x() += east_border_x;
 
-    const inclusive_cuboid<tripoint> north_sector( overmap_area.p_min, north_pmax );
-    const inclusive_cuboid<tripoint> south_sector( south_pmin, overmap_area.p_max );
-    const inclusive_cuboid<tripoint> west_sector( overmap_area.p_min, west_pmax );
-    const inclusive_cuboid<tripoint> east_sector( east_pmin, overmap_area.p_max );
+    const inclusive_cuboid<tripoint_abs_omt> north_sector( overmap_area.p_min, north_pmax );
+    const inclusive_cuboid<tripoint_abs_omt> south_sector( south_pmin, overmap_area.p_max );
+    const inclusive_cuboid<tripoint_abs_omt> west_sector( overmap_area.p_min, west_pmax );
+    const inclusive_cuboid<tripoint_abs_omt> east_sector( east_pmin, overmap_area.p_max );
 
     mission_arrow_variant = "mission_arrow_";
     if( north_sector.contains( arr_pos ) ) {
@@ -787,7 +787,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     int height_3d = 0;
     avatar &you = get_avatar();
     const tripoint_abs_omt avatar_pos = you.global_omt_location();
-    tripoint_abs_omt center_pos = tripoint_abs_omt( center_abs_omt );
+    tripoint_abs_omt center_pos = center_abs_omt;
     const bool fast_traveling = g->overmap_data.fast_traveling;
     if( fast_traveling ) {
         center_pos = you.global_omt_location();
@@ -795,11 +795,11 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     const tripoint_abs_omt origin = center_pos - point( s.x / 2, s.y / 2 );
     const tripoint_abs_omt corner_NW = origin + any_tile_range.p_min;
     const tripoint_abs_omt corner_SE = origin + any_tile_range.p_max + point::north_west;
-    const inclusive_cuboid<tripoint> overmap_area( corner_NW.raw(), corner_SE.raw() );
+    const inclusive_cuboid<tripoint_abs_omt> overmap_area( corner_NW, corner_SE );
     // Area of fully shown tiles
     const tripoint_abs_omt full_corner_NW = origin + full_base_range.p_min;
     const tripoint_abs_omt full_corner_SE = origin + full_base_range.p_max + point::north_west;
-    const inclusive_cuboid<tripoint> full_om_tile_area( full_corner_NW.raw(), full_corner_SE.raw() );
+    const inclusive_cuboid<tripoint_abs_omt> full_om_tile_area( full_corner_NW, full_corner_SE );
     // Debug vision allows seeing everything
     const bool has_debug_vision = you.has_trait( trait_DEBUG_NIGHTVISION );
     // sight_points is hoisted for speed reasons.
@@ -815,7 +815,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
     const auto global_omt_to_draw_position = []( const tripoint_abs_omt & omp ) {
         // z position is hardcoded to 0 because the things this will be used to draw should not be skipped
-        return tripoint( omp.raw().xy(), 0 );
+        return tripoint_abs_omt( omp.xy(), 0 );
     };
 
     for( int row = min_row; row < max_row; row++ ) {
@@ -857,16 +857,16 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             // light level is now used for choosing between grayscale filter and normal lit tiles.
             draw_from_id_string( id, category,
                                  category == TILE_CATEGORY::OVERMAP_TERRAIN ? "overmap_terrain" : "",
-                                 omp.raw(), subtile, rotation, ll, false, height_3d );
+                                 omp, subtile, rotation, ll, false, height_3d );
             if( !mx.is_empty() && mx->autonote ) {
-                draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp.raw(),
+                draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp,
                                      0, 0, ll, false );
             }
 
             if( draw_overlays && show_map_revealed ) {
                 auto it = revealed_highlights.find( omp );
                 if( it != revealed_highlights.end() ) {
-                    draw_from_id_string( "highlight", omp.raw(), 0, 0, lit_level::LIT, false );
+                    draw_from_id_string( "highlight", omp, 0, 0, lit_level::LIT, false );
                 }
             }
 
@@ -877,7 +877,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                         auto mgroup_iter = mgroups.begin();
                         std::advance( mgroup_iter, rng( 0, mgroups.size() - 1 ) );
                         draw_from_id_string( ( *mgroup_iter )->type->defaultMonster.str(),
-                                             omp.raw(), 0, 0, lit_level::LIT, false );
+                                             omp, 0, 0, lit_level::LIT, false );
                     }
                 }
                 const int horde_size = overmap_buffer.get_horde_size( omp );
@@ -886,31 +886,31 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                     if( find_tile_with_season( id ) ) {
                         // NOLINTNEXTLINE(cata-translate-string-literal)
                         draw_from_id_string( string_format( "overmap_horde_%d", horde_size < 10 ? horde_size : 10 ),
-                                             omp.raw(), 0, 0, lit_level::LIT, false );
+                                             omp, 0, 0, lit_level::LIT, false );
                     } else {
                         switch( horde_size ) {
                             case HORDE_VISIBILITY_SIZE:
-                                draw_from_id_string( "mon_zombie", omp.raw(), 0, 0, lit_level::LIT,
+                                draw_from_id_string( "mon_zombie", omp, 0, 0, lit_level::LIT,
                                                      false );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 1:
-                                draw_from_id_string( "mon_zombie_tough", omp.raw(), 0, 0,
+                                draw_from_id_string( "mon_zombie_tough", omp, 0, 0,
                                                      lit_level::LIT, false );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 2:
-                                draw_from_id_string( "mon_zombie_brute", omp.raw(), 0, 0,
+                                draw_from_id_string( "mon_zombie_brute", omp, 0, 0,
                                                      lit_level::LIT, false );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 3:
-                                draw_from_id_string( "mon_zombie_hulk", omp.raw(), 0, 0,
+                                draw_from_id_string( "mon_zombie_hulk", omp, 0, 0,
                                                      lit_level::LIT, false );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 4:
-                                draw_from_id_string( "mon_zombie_necro", omp.raw(), 0, 0,
+                                draw_from_id_string( "mon_zombie_necro", omp, 0, 0,
                                                      lit_level::LIT, false );
                                 break;
                             default:
-                                draw_from_id_string( "mon_zombie_master", omp.raw(), 0, 0,
+                                draw_from_id_string( "mon_zombie_master", omp, 0, 0,
                                                      lit_level::LIT, false );
                                 break;
                         }
@@ -921,19 +921,19 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             if( ( uistate.place_terrain || uistate.place_special ) &&
                 overmap_ui::is_generated_omt( omp.xy() ) ) {
                 // Highlight areas that already have been generated
-                draw_from_id_string( "highlight", omp.raw(), 0, 0, lit_level::LIT, false );
+                draw_from_id_string( "highlight", omp, 0, 0, lit_level::LIT, false );
             }
 
             if( draw_overlays && overmap_buffer.has_vehicle( omp ) ) {
                 const std::string tile_id = overmap_buffer.get_vehicle_tile_id( omp );
                 if( find_tile_looks_like( tile_id, TILE_CATEGORY::OVERMAP_NOTE, "" ) ) {
                     draw_from_id_string( tile_id, TILE_CATEGORY::OVERMAP_NOTE,
-                                         "overmap_note", omp.raw(), 0, 0, lit_level::LIT, false );
+                                         "overmap_note", omp, 0, 0, lit_level::LIT, false );
                 } else {
                     const std::string ter_sym = overmap_buffer.get_vehicle_ter_sym( omp );
                     std::string note_name = "note_" + ter_sym + "_cyan";
                     draw_from_id_string( note_name, TILE_CATEGORY::OVERMAP_NOTE,
-                                         "overmap_note", omp.raw(), 0, 0, lit_level::LIT, false );
+                                         "overmap_note", omp, 0, 0, lit_level::LIT, false );
                 }
             }
 
@@ -947,10 +947,10 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
                     std::string note_name = "note_" + ter_sym + "_" + string_from_color( ter_color );
                     draw_from_id_string( note_name, TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
-                                         omp.raw(), 0, 0, lit_level::LIT, false );
+                                         omp, 0, 0, lit_level::LIT, false );
                 } else if( overmap_buffer.is_marked_dangerous( omp ) ) {
                     draw_from_id_string( "note_X_red", TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
-                                         omp.raw(), 0, 0, lit_level::LIT, false );
+                                         omp, 0, 0, lit_level::LIT, false );
 
                 }
             }
@@ -970,7 +970,6 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     if( uistate.place_special ) {
         for( const overmap_special_terrain &s_ter : uistate.place_special->preview_terrains() ) {
             if( s_ter.p.z == 0 ) {
-                // TODO: fix point types
                 const point_rel_omt rp( om_direction::rotate( s_ter.p.xy(), uistate.omedit_rotation ) );
                 oter_id rotated_id = s_ter.terrain->get_rotated( uistate.omedit_rotation );
                 const oter_t &terrain = *rotated_id;
@@ -993,14 +992,14 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         const tripoint_abs_omt &guy_loc = guy->global_omt_location();
         if( guy_loc.z() == center_pos.z() && ( has_debug_vision ||
                                                overmap_buffer.seen_more_than( guy_loc, om_vision_level::details ) ) ) {
-            draw_entity_with_overlays( *guy, tripoint_bub_ms( global_omt_to_draw_position( guy_loc ) ),
+            draw_entity_with_overlays( *guy, global_omt_to_draw_position( guy_loc ),
                                        lit_level::LIT,
                                        height_3d );
         }
     }
 
     draw_entity_with_overlays( get_player_character(),
-                               tripoint_bub_ms( global_omt_to_draw_position( avatar_pos ) ),
+                               global_omt_to_draw_position( avatar_pos ),
                                lit_level::LIT, height_3d );
     if( !fast_traveling ) {
         draw_from_id_string( "cursor", global_omt_to_draw_position( center_pos ), 0, 0, lit_level::LIT,
@@ -1037,7 +1036,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     if( !viewing_weather && uistate.overmap_show_city_labels ) {
 
         const auto abs_sm_to_draw_label = [&]( const tripoint_abs_sm & city_pos, const int label_length ) {
-            const point omt_pos = global_omt_to_draw_position( project_to<coords::omt>( city_pos ) ).xy();
+            const point_abs_omt omt_pos = global_omt_to_draw_position( project_to<coords::omt>
+                                          ( city_pos ) ).xy();
             const point draw_point = player_to_screen( omt_pos );
             // center text on the tile
             return draw_point + point( ( tile_width - label_length * fontwidth ) / 2,
@@ -1064,7 +1064,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                  project_to<coords::sm>( center_pos ), radius ) ) {
             const tripoint_abs_omt city_center = project_to<coords::omt>( city.abs_sm_pos );
             if( overmap_buffer.seen_more_than( city_center, om_vision_level::outlines ) &&
-                overmap_area.contains( city_center.raw() ) ) {
+                overmap_area.contains( city_center ) ) {
                 label_bg( city.abs_sm_pos, city.city->name );
             }
         }
@@ -1073,7 +1073,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                  project_to<coords::sm>( center_pos ), radius ) ) {
             const tripoint_abs_omt camp_center = project_to<coords::omt>( camp.abs_sm_pos );
             if( overmap_buffer.seen_more_than( camp_center, om_vision_level::outlines ) &&
-                overmap_area.contains( camp_center.raw() ) ) {
+                overmap_area.contains( camp_center ) ) {
                 label_bg( camp.abs_sm_pos, camp.camp->name );
             }
         }
@@ -1136,7 +1136,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         // Find screen coordinates to the right of the center tile
         auto center_sm = project_to<coords::sm>( tripoint_abs_omt( center_pos.x() + 1,
                          center_pos.y(), center_pos.z() ) );
-        const point omt_pos = global_omt_to_draw_position( project_to<coords::omt>( center_sm ) ).xy();
+        const point_abs_omt omt_pos = global_omt_to_draw_position( project_to<coords::omt>
+                                      ( center_sm ) ).xy();
         point draw_point = player_to_screen( omt_pos );
         draw_point += point( padding, padding );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Convert usage of untyped coordinates into typed ones. This time focusing on cata_tiles.h.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Convert untyped operations into typed ones (typically tripoint_bub_ms) and create overloads with tripoint_abs_omt when needed. The abs_omt operations then call the bub_ms one after an unsavory type conversion, hoping people won't see how the sausage is made.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I initially considered retaining the untyped operations internally and have both the bub_ms and abs_omt operations call that one, but changed my mind and went for having the bub_ms ones as the canonical version.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Since the changed code affects presentation but shouldn't have any functional effect, the tests were limited to zooming the map and overmap, moving to another overmap tile and repeat the process. Nothing odd was noticed.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
sdl_tiles.cpp contains a lot of android specific code, which is "text" to my compiler environment, so I hope the automatic tests will catch any potential errors (I've tried to search for changed operations, but that doesn't catch things internal to the sdl_tiles file itself).
There are a lot of untyped points in the code. As far as I can tell those are in screen and pixel coordinate systems which don't have their own representation. I'm fairly sure some of the untyped points are actually in bub_ms (or abs_omt, in some cases) coordinates, but I've left anything uncertain untouched.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
