### PR TITLE
Rename Monster Names

### DIFF
--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -167,7 +167,7 @@
   {
     "id": "mon_civilian_zombiegunner",
     "type": "MONSTER",
-    "name": { "str": "firearmed fighter" },
+    "name": { "str": "armed fighter" },
     "description": "Handgun in hand, this person is determined to make a last stand against the horde.",
     "copy-from": "mon_civilian_panic",
     "chat_topics": [ "TALK_CIVILIAN_GUNNER" ],
@@ -204,7 +204,7 @@
   {
     "id": "mon_civilian_icu",
     "type": "MONSTER",
-    "name": { "str": "hospitalized human" },
+    "name": { "str": "hospitalized person" },
     "description": "This person is severely ill in some form or another, requiring intensive care that is not available anymore after the Cataclysm.  There is nothing you can do for them.",
     "chat_topics": [ "TALK_CIVILIAN_ICU" ],
     "speed": 0,
@@ -218,7 +218,7 @@
   {
     "id": "mon_civilian_parent",
     "type": "MONSTER",
-    "name": { "str": "gawky guardian" },
+    "name": { "str": "terrified parent" },
     "special_attacks": [ [ "PARROT", 0 ] ],
     "description": "Obsessed with finding their offspring, they scour the environment for certain death.",
     "chat_topics": [ "TALK_CIVILIAN_PARENT" ],

--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -1009,7 +1009,7 @@
   {
     "id": "mon_zeindeer_fungus",
     "type": "MONSTER",
-    "name": { "str_sp": "fungideer" },
+    "name": { "str_sp": "fungal reindeer" },
     "description": "This bumpy, discolored reindeer resembles a malformed Rudolph, its nose having a faintly glowing red fungal sprout.  It'd look almost comical if it wasn't mutilating bodies with its innate strength.",
     "copy-from": "mon_zeindeer",
     "default_faction": "fungus",

--- a/data/json/monsters/triffid.json
+++ b/data/json/monsters/triffid.json
@@ -255,7 +255,7 @@
   {
     "id": "mon_fungal_fighter",
     "type": "MONSTER",
-    "name": { "str": "fungal fighter" },
+    "name": { "str": "fungicidal triffid" },
     "description": "A stout, woody plant that can dig through the ground and flick spines from its branches.  The thorns carry a fungicidal compound with paralytic effects.",
     "default_faction": "triffid",
     "species": [ "PLANT" ],

--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -342,7 +342,7 @@
   {
     "id": "mon_zombie_horse_white",
     "type": "MONSTER",
-    "name": { "str": "pestilent prancer" },
+    "name": { "str": "acidic zombie horse" },
     "copy-from": "mon_zombie_horse",
     "description": "The abdomen of this once majestic horse has grown rotund to the point you can see through the skin, at the reservoir of caustic bile inside.  Its neck is equally enlarged as well as slightly longer than normal.",
     "diff": 3,

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -674,7 +674,7 @@
   {
     "id": "mon_zeindeer",
     "type": "MONSTER",
-    "name": { "str": "zeindeer" },
+    "name": { "str": "zombie reindeer" },
     "looks_like": "mon_zeer",
     "description": "Once a majestic caribou, this undead creature barely resembles Santa's helpful reindeer and seems to only be interested in human flesh.",
     "default_faction": "zombie",

--- a/data/json/monsters/zed-medical.json
+++ b/data/json/monsters/zed-medical.json
@@ -21,7 +21,7 @@
   {
     "id": "mon_zombie_medical_regenerating",
     "type": "MONSTER",
-    "name": { "str": "miracle lurker" },
+    "name": { "str": "regenerating zombie medic" },
     "description": "The zombified remains of a practitioner of medicine, you aren't certain what field - your focus is instead drawn to the way that its pink flesh snakes all over it, weaving its way over wounds and injuries.",
     "copy-from": "mon_zombie_regenerating",
     "death_drops": "mon_zombie_medical_death_drops",

--- a/data/json/monsters/zed_amphibian.json
+++ b/data/json/monsters/zed_amphibian.json
@@ -154,7 +154,7 @@
   {
     "id": "mon_zombullfrog",
     "type": "MONSTER",
-    "name": { "str": "zombullfrog" },
+    "name": { "str": "zombie bullfrog" },
     "description": "The wound covered skin of this large bullfrog appears to be peeling in places, revealing a black goop beneath the surface.  Its vacant stare passes by anything that isn't food, and it will leap to devour anything it can.",
     "copy-from": "mon_proxy_frog_zombie",
     "attack_cost": 50,
@@ -164,7 +164,7 @@
   {
     "id": "mon_frog_dad",
     "type": "MONSTER",
-    "name": { "str": "colossal zombullfrog" },
+    "name": { "str": "colossal zombie bullfrog" },
     "description": "This gigantic zombified frog lets out an ear splitting unholy wail as it slowly takes notice of you.  Its mostly lethargic movements are offset by its ability to leap great distances using its gargantuan stout legs.",
     "copy-from": "mon_proxy_frog_zombie",
     "volume": "200 L",
@@ -276,7 +276,7 @@
   {
     "id": "mon_toad_bloat",
     "type": "MONSTER",
-    "name": { "str": "bloated zoad" },
+    "name": { "str": "bloated zombie toad" },
     "description": "This zombified toad wobbles as it drags along its immense, inflated form.  A yellow-brown sludge dribbles from its mouth and seeps out from its bulging, cracking skin.",
     "copy-from": "mon_proxy_frog_zombie",
     "weight": "200 kg",
@@ -463,7 +463,7 @@
   {
     "id": "mon_toad_bone",
     "type": "MONSTER",
-    "name": { "str": "death mask zoad" },
+    "name": { "str": "death mask zombie toad" },
     "description": "The face and head of this enormous once-frog is encased in ossified tissue.  Its dead eyes peer out from this death mask of hardened bone, which curves into a jagged beak around its mouth.  Even its warts appear to have stiffened into dense osteoderms.",
     "copy-from": "mon_proxy_frog_zombie",
     "volume": "240 L",

--- a/data/json/monsters/zed_amphibian.json
+++ b/data/json/monsters/zed_amphibian.json
@@ -154,7 +154,7 @@
   {
     "id": "mon_zombullfrog",
     "type": "MONSTER",
-    "name": { "str": "zombie bullfrog" },
+    "name": { "str": "giant zombie bullfrog" },
     "description": "The wound covered skin of this large bullfrog appears to be peeling in places, revealing a black goop beneath the surface.  Its vacant stare passes by anything that isn't food, and it will leap to devour anything it can.",
     "copy-from": "mon_proxy_frog_zombie",
     "attack_cost": 50,

--- a/data/json/monsters/zed_amphibian.json
+++ b/data/json/monsters/zed_amphibian.json
@@ -322,7 +322,7 @@
   {
     "id": "mon_zombtreefrog",
     "type": "MONSTER",
-    "name": { "str": "croaked climber" },
+    "name": { "str": "zombie treefrog" },
     "description": "The pale, empty eyes of this large, reanimated treefrog still swivel in their sockets, searching for prey.  Its steps are ungainly but its hind legs look capable of great leaps.",
     "copy-from": "mon_proxy_frog_zombie",
     "volume": "108500 ml",

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -939,7 +939,6 @@
     "id": "mon_zombie_fursuit",
     "type": "MONSTER",
     "name": { "str": "fursuited zombie" },
-    "//": "A pun. 'Mane' being an archaic synonym of zombie, which also refers hair on the back of an animals neck.",
     "description": "A human body, swaying awkwardly in a torn cloth suit of an anthropomorphized animal.  Black goo and blood cakes the suit, and it gives off a foul, rotting odor.",
     "copy-from": "mon_zombie",
     "speed": 50,
@@ -949,6 +948,6 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 2 } ],
     "death_drops": { "subtype": "collection", "groups": [ [ "default_zombie_clothes", 100 ], [ "zombie_fursuits", 100 ] ] },
     "armor": { "bash": 5, "cut": 5, "bullet": 1, "electric": 1 },
-    "//1": "The torn fursuit offers slightly more protection."
+    "//": "The torn fursuit offers slightly more protection."
   }
 ]

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -938,7 +938,7 @@
   {
     "id": "mon_zombie_fursuit",
     "type": "MONSTER",
-    "name": { "str": "malicious mane" },
+    "name": { "str": "fursuited zombie" },
     "//": "A pun. 'Mane' being an archaic synonym of zombie, which also refers hair on the back of an animals neck.",
     "description": "A human body, swaying awkwardly in a torn cloth suit of an anthropomorphized animal.  Black goo and blood cakes the suit, and it gives off a foul, rotting odor.",
     "copy-from": "mon_zombie",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
We have a lot of rather forced alliterations, which can both subtract from the experience of playing as you're distracted by the silly names, and confuse people as sometimes to make the alliteration work the name is not descriptive of what the monster is. This PR is also open to change other poorly-named monsters, if you have suggestions please leave them below. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Renames them.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Dawg it's just title changes
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
In case you didn't read this part in the purpose of change, please suggest any other names you'd like changed. Keeping this PR as a draft for suggestions. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
