### PR TITLE
[Magiclysm] Goblins and wargs are best friends

### DIFF
--- a/data/mods/Magiclysm/Spells/fantasy_species.json
+++ b/data/mods/Magiclysm/Spells/fantasy_species.json
@@ -1,0 +1,45 @@
+[
+  {
+    "type": "SPELL",
+    "id": "goblin_tame_warg_spell",
+    "name": "Warg-Friend",
+    "description": "Goblins and wargs have had an innate bond from time immemorial, and even wild wargs will easily heel when a goblin calls…as long as the goblin has some raw meat to feed them with.",
+    "message": "You take control of the animal's mind!",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "flags": [ "NON_MAGICAL", "NO_FAIL", "SILENT", "NO_HANDS", "NO_LEGS" ],
+    "max_level": 1,
+    "spell_class": "GOBLIN_BUILD",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_GOBLIN_WARG_TAMING",
+    "components": "spell_components_goblin_warg_taming",
+    "shape": "blast",
+    "base_casting_time": 10
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GOBLIN_WARG_TAMING",
+    "effect": [
+      { "u_spawn_item": "warg_food", "suppress_message": true },
+      { "run_eocs": "EOC_GOBLIN_WARG_TAMING_01" },
+      { "u_remove_item_with": "warg_food" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GOBLIN_WARG_TAMING_01",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "warg_food" } ],
+        "true_eocs": [ { "id": "EOC_GOBLIN_WARG_TAMING_01_ACTIVATE", "effect": { "u_activate": "PETFOOD" } } ]
+      }
+    ]
+  },
+  {
+    "id": "spell_components_goblin_warg_taming",
+    "type": "requirement",
+    "//": "meat for Warg-Friend",
+    "components": [ [ [ "meat", 1 ], [ "meat_scrap", 9 ], [ "poultry", 1 ], [ "poultry_scrap", 9 ] ] ]
+  }
+]

--- a/data/mods/Magiclysm/items/fake.json
+++ b/data/mods/Magiclysm/items/fake.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "warg_food",
+    "copy-from": "cattlefodder_medium",
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "name": { "str": "warg food", "//~": "NO_I18N" },
+    "description": { "str": "A food that doesn't exist but is necessary for technical reasons.", "//~": "NO_I18N" },
+    "flags": [ "INEDIBLE" ],
+    "use_action": [ "PETFOOD" ],
+    "petfood": [ "WARG_FOOD" ]
+  }
+]

--- a/data/mods/Magiclysm/monsters/goblin.json
+++ b/data/mods/Magiclysm/monsters/goblin.json
@@ -180,7 +180,7 @@
     "default_faction": "goblin",
     "bodytype": "dog",
     "categories": [ "WILDLIFE" ],
-    "species": [ "MAMMAL" ],
+    "species": [ "WARG" ],
     "volume": "200000 ml",
     "weight": "200000 g",
     "hp": 175,
@@ -188,9 +188,9 @@
     "material": [ "flesh" ],
     "symbol": "W",
     "color": "light_gray",
-    "looks_like": "mon_wolf",
+    "looks_like": "mon_direwolf",
     "scents_tracked": [ "sc_human", "sc_fetid" ],
-    "aggression": 20,
+    "aggression": 30,
     "morale": 70,
     "melee_skill": 7,
     "melee_dice": 2,
@@ -214,9 +214,26 @@
       [ "SHRIEK", 12 ],
       [ "EAT_FOOD", 60 ]
     ],
+    "petfood": {
+      "food": [ "WARG_FOOD" ],
+      "feed": "The %s approaches you, acknowledging your ancient bond, and eats the meat you offer.",
+      "pet": "The %s happily wags its tail while you pat its head."
+    },
     "anger_triggers": [ "STALK", "FRIEND_ATTACKED", "FRIEND_DIED", "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "zombify_into": "mon_zombie_dog_fungus",
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "EATS" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PET_MOUNTABLE",
+      "COMBAT_MOUNT",
+      "CANPLAY",
+      "PATH_AVOID_DANGER",
+      "WARM",
+      "KEENNOSE",
+      "EATS"
+    ],
     "armor": { "bash": 8, "cut": 10, "electric": 1 }
   },
   {

--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -505,6 +505,8 @@
     "category": [ "SPECIES_GOBLIN" ],
     "threshreq": [ "THRESH_SPECIES_GOBLIN" ],
     "flags": [ "TINY" ],
+    "anger_relations": [ [ "WARG", -90 ] ],
+    "spells_learned": [ [ "goblin_tame_warg_spell", 1 ] ],
     "enchantments": [
       {
         "values": [

--- a/data/mods/Magiclysm/species.json
+++ b/data/mods/Magiclysm/species.json
@@ -37,6 +37,13 @@
   },
   {
     "type": "SPECIES",
+    "id": "WARG",
+    "description": "a gigantic lupine beast",
+    "fear_triggers": [ "HURT", "FIRE", "FRIEND_DIED" ],
+    "bleeds": "fd_blood"
+  },
+  {
+    "type": "SPECIES",
     "id": "ORC",
     "description": "a stocky, green-skinned humanoid",
     "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "PLAYER_WEAK" ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Goblins and wargs are best friends"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had this idea a bit ago that goblins and wargs have a supernatural bond and finally thought of a good way to implement it. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Give wargs their own species. Add an `anger_relations` to the Goblin Build trait that makes wargs neutral to goblins.

Add a power called Warg-Friend linked to Goblin Build that lets goblins befriend wargs. It requires meat and has a range of 1.

Behind the scenes, the spell takes raw meat as a component and then creates an item of warg food  (does not exist anywhere in the world, just in the files) which the EoC then immediately activates, representing you offering food to the warg. This runs through the normal pet mechanics--if you target the warg, they'll follow you as normal. And since goblins are Tiny, they can ride wargs.

`looks_like` the warg sprite with the dire wolf sprite.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Started a game as a goblin, got the power, used it on a warg, the warg killed some zombies for me.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
