### PR TITLE
Make font hinting user-configurable.

### DIFF
--- a/data/fontdata.json
+++ b/data/fontdata.json
@@ -5,7 +5,7 @@
     "data/font/unifont.ttf"
   ],
   "gui_typeface": [
-    { "path": "data/font/Roboto-Medium.ttf", "hinting": "Auto" },
+    { "path": "data/font/Roboto-Medium.ttf", "hinting": "Light" },
     { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
     "data/font/unifont.ttf"
   ],

--- a/data/fontdata.json
+++ b/data/fontdata.json
@@ -1,21 +1,20 @@
 {
-  "//1": "If more than one font is specified for a typeface the list is treated as a fallback order.",
-  "//2": "unifont will always be used as a 'last resort' fallback even if not listed here.",
+  "//1": "See docs/FONT_OPTIONS.md for how to configure your fonts.",
   "typeface": [
-    "data/font/Terminus.ttf",
+    { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
     "data/font/unifont.ttf"
   ],
   "gui_typeface": [
-    "data/font/Roboto-Medium.ttf",
-    "data/font/Terminus.ttf",
+    { "path": "data/font/Roboto-Medium.ttf", "hinting": "Auto" },
+    { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
     "data/font/unifont.ttf"
   ],
   "map_typeface": [
-    "data/font/Terminus.ttf",
+    { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
     "data/font/unifont.ttf"
   ],
   "overmap_typeface": [
-    "data/font/Terminus.ttf",
+    { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
     "data/font/unifont.ttf"
   ]
 }

--- a/doc/FONT_OPTIONS.md
+++ b/doc/FONT_OPTIONS.md
@@ -1,0 +1,52 @@
+# Configuring Fonts
+
+Fonts can be configured through changing the config/fonts.json file. This file is created with
+default options on game load, so if it doesn't exist try loading the game. 
+
+The default options (available in data/fontdata.json) might look like the following:
+```json
+{
+  "typeface": [
+    { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
+    "data/font/unifont.ttf"
+  ],
+  "gui_typeface": [
+    { "path": "data/font/Roboto-Medium.ttf", "hinting": "Auto" },
+    { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
+    "data/font/unifont.ttf"
+  ],
+  "map_typeface": [
+    { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
+    "data/font/unifont.ttf"
+  ],
+  "overmap_typeface": [
+    { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
+    "data/font/unifont.ttf"
+  ]
+}
+```
+
+There are four different font categories: `typeface`, `gui_typeface`, `map_typeface`, and `overmap_typeface`, 
+which are used for the old-style game interface, ImGui menus, the game display and the overmap, respectively. 
+If more than one font is specified for a typeface the list is treated as a fallback order. Unifont will always
+be used as a 'last resort' fallback even if not listed here. 
+
+Fonts can be provided as a list, as seen above, or as single entries, e.g.:
+```json
+"typeface": { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
+"map_typeface": "unifont.ttf"
+```
+Each entry may be a string or an object. If a string is provided it is interpreted as the path to the typeface file.
+If an object is provided, then it must have a path attribute, which provides the path to the font. It may also have 
+a 'hinting' attribute, which determines the font hinting mode. If it's not specified then 'Default' is used.
+Hinting may be one of: Auto, NoAuto, Default, Light, or Bitmap. Antialiasing may also be provided and is default set
+to true, but can be disabled by setting to off.
+
+A full object may look like the following:
+```json
+"gui_typeface": {
+	"path": "data/font/Roboto-Medium.ttf",
+	"hinting": "Auto",
+	"antialiasing": true,
+}
+```

--- a/doc/FONT_OPTIONS.md
+++ b/doc/FONT_OPTIONS.md
@@ -53,9 +53,9 @@ A full object may look like the following:
 
 ## Hinting
 
-Hinting is a process of modifying the shapes of the glyphs so that
+Hinting is the process of modifying the shapes of glyphs so that
 they line up better with the pixels in the display device. This
-improves readability a low resolutions while potentially changing the
+improves readability at low resolutions while potentially changing the
 shape of the glyphs. Six different settings are available:
 
 ### Default
@@ -91,9 +91,8 @@ font doesn’t have any hinting tables.
 ### None
 
 This completely skips the hinting step. This will likely produce
-blurry text on ordinary, but the glyph shapes will always be
-correct. On very high resolution monitors the lack of hinting may not
-be noticable.
+blurry text, but the glyph shapes will always be correct. On very
+high resolution monitors the lack of hinting may not be noticable.
 
 ### Bitmap
 

--- a/doc/FONT_OPTIONS.md
+++ b/doc/FONT_OPTIONS.md
@@ -1,7 +1,7 @@
 # Configuring Fonts
 
 Fonts can be configured through changing the config/fonts.json file. This file is created with
-default options on game load, so if it doesn't exist try loading the game. 
+default options on game load, so if it doesn't exist try loading the game.
 
 The default options (available in data/fontdata.json) might look like the following:
 ```json
@@ -11,7 +11,7 @@ The default options (available in data/fontdata.json) might look like the follow
     "data/font/unifont.ttf"
   ],
   "gui_typeface": [
-    { "path": "data/font/Roboto-Medium.ttf", "hinting": "Auto" },
+    { "path": "data/font/Roboto-Medium.ttf", "hinting": "Light" },
     { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
     "data/font/unifont.ttf"
   ],
@@ -26,10 +26,10 @@ The default options (available in data/fontdata.json) might look like the follow
 }
 ```
 
-There are four different font categories: `typeface`, `gui_typeface`, `map_typeface`, and `overmap_typeface`, 
-which are used for the old-style game interface, ImGui menus, the game display and the overmap, respectively. 
+There are four different font categories: `typeface`, `gui_typeface`, `map_typeface`, and `overmap_typeface`,
+which are used for the old-style game interface, ImGui menus, the game display and the overmap, respectively.
 If more than one font is specified for a typeface the list is treated as a fallback order. Unifont will always
-be used as a 'last resort' fallback even if not listed here. 
+be used as a 'last resort' fallback even if not listed here.
 
 Fonts can be provided as a list, as seen above, or as single entries, e.g.:
 ```json
@@ -37,7 +37,7 @@ Fonts can be provided as a list, as seen above, or as single entries, e.g.:
 "map_typeface": "unifont.ttf"
 ```
 Each entry may be a string or an object. If a string is provided it is interpreted as the path to the typeface file.
-If an object is provided, then it must have a path attribute, which provides the path to the font. It may also have 
+If an object is provided, then it must have a path attribute, which provides the path to the font. It may also have
 a 'hinting' attribute, which determines the font hinting mode. If it's not specified then 'Default' is used.
 Hinting may be one of: Auto, NoAuto, Default, Light, or Bitmap. Antialiasing may also be provided and is default set
 to true, but can be disabled by setting to off.
@@ -46,7 +46,61 @@ A full object may look like the following:
 ```json
 "gui_typeface": {
 	"path": "data/font/Roboto-Medium.ttf",
-	"hinting": "Auto",
+	"hinting": "Light",
 	"antialiasing": true,
 }
 ```
+
+## Hinting
+
+Hinting is a process of modifying the shapes of the glyphs so that
+they line up better with the pixels in the display device. This
+improves readability a low resolutions while potentially changing the
+shape of the glyphs. Six different settings are available:
+
+### Default
+
+The default hinter uses tables built into the font by the font
+designer. Many fonts look best with this hinter because the font
+designer has meticulously crafted the hinting tables so that the font
+looks as good as possible.
+
+If the font has no hinting tables at all, then this mode falls back to
+using the autohinter.
+
+### Light
+
+Many generated glyphs are fuzzier but better resemble their original
+shape. This is achieved by snapping glyphs to the pixel grid only
+vertically (Y-axis), as is done by Microsoft's ClearType and Adobe's
+proprietary font renderer. This preserves inter-glyph spacing in
+horizontal text.
+
+### Auto
+
+This mode ignores the font’s hinting tables in favor of
+heuristics. The autohinter produces acceptable results for most fonts,
+but may produce terrible results on some fonts. Usually this is only
+used when the font doesn’t have any hinting tables of its own.
+
+### NoAuto
+
+This is like the Default setting, but won’t use the autohinter if the
+font doesn’t have any hinting tables.
+
+### None
+
+This completely skips the hinting step. This will likely produce
+blurry text on ordinary, but the glyph shapes will always be
+correct. On very high resolution monitors the lack of hinting may not
+be noticable.
+
+### Bitmap
+
+This setting turns off hinting just like None does, but additionally
+tells the renderer to ignore any vector glyphs in the font in favor of
+bitmapped glyphs. As bitmapped glyphs are never antialiased at all
+they will be extremely sharp, but also pixelated. In most contexts the
+pixelation would be inappropriate, but it may lend the game a retro
+aesthetic that many find appealing. Currently the game defaults to
+using the Terminus font with this setting.

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <unordered_map>
 
+#include "font_loader.h"
+
 class nc_color;
 struct input_event;
 using ImGuiInputTextFlags = int;
@@ -74,7 +76,7 @@ class client
                 const GeometryRenderer_Ptr &sdl_geometry );
         void load_fonts( const std::unique_ptr<Font> &gui_font, const std::unique_ptr<Font> &mono_font,
                          const std::array<SDL_Color, color_loader<SDL_Color>::COLOR_NAMES_COUNT> &windowsPalette,
-                         const std::vector<std::string> &gui_typeface, const std::vector<std::string> &mono_typeface );
+                         const std::vector<font_config> &gui_typeface, const std::vector<font_config> &mono_typeface );
 #endif
         ~client();
 

--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -85,7 +85,7 @@ static void load_font_from_config( const JsonObject &config, const std::string &
         if( path.find( "Terminus.ttf" ) != std::string::npos ) {
             typefaces.emplace_back( path, ImGuiFreeTypeBuilderFlags_Bitmap );
         }  else if( path.find( "Roboto-Medium.ttf" ) != std::string::npos ) {
-            typefaces.emplace_back( path, ImGuiFreeTypeBuilderFlags_ForceAutoHint );
+            typefaces.emplace_back( path, ImGuiFreeTypeBuilderFlags_LightHinting );
         } else {
             typefaces.emplace_back( path );
         }
@@ -106,7 +106,7 @@ static void load_font_from_config( const JsonObject &config, const std::string &
                 if( path.find( "Terminus.ttf" ) != std::string::npos ) {
                     typefaces.emplace_back( path, ImGuiFreeTypeBuilderFlags_Bitmap );
                 } else if( path.find( "Roboto-Medium.ttf" ) != std::string::npos ) {
-                    typefaces.emplace_back( path, ImGuiFreeTypeBuilderFlags_ForceAutoHint );
+                    typefaces.emplace_back( path, ImGuiFreeTypeBuilderFlags_LightHinting );
                 } else {
                     typefaces.emplace_back( path );
                 }

--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -5,6 +5,16 @@
 #include "json_loader.h"
 
 // Ensure that unifont is always loaded as a fallback font to prevent users from shooting themselves in the foot
+void ensure_unifont_loaded( std::vector<font_config> &font_list )
+{
+    const std::string unifont = PATH_INFO::fontdir() + "unifont.ttf";
+    if( std::find_if( font_list.begin(), font_list.end(), [&]( const font_config & conf ) {
+    return conf.path == unifont;
+} ) == font_list.end() ) {
+        font_list.emplace_back( unifont );
+    }
+}
+
 void ensure_unifont_loaded( std::vector<std::string> &font_list )
 {
     const std::string unifont = PATH_INFO::fontdir() + "unifont.ttf";
@@ -13,42 +23,167 @@ void ensure_unifont_loaded( std::vector<std::string> &font_list )
     }
 }
 
+unsigned int font_config::imgui_config() const
+{
+    unsigned int ret = 0;
+    if( !antialiasing ) {
+        ret |= ImGuiFreeTypeBuilderFlags_Monochrome;
+        ret |= ImGuiFreeTypeBuilderFlags_MonoHinting;
+    }
+    if( hinting != std::nullopt ) {
+        ret |= *hinting;
+    }
+    return ret;
+}
+
+std::optional<ImGuiFreeTypeBuilderFlags> hint_to_fonthint( const std::string_view hinting )
+{
+    if( hinting == "Auto" ) {
+        return ImGuiFreeTypeBuilderFlags_ForceAutoHint;
+    }
+    if( hinting == "NoAuto" ) {
+        return ImGuiFreeTypeBuilderFlags_NoAutoHint;
+    }
+    if( hinting == "Light" ) {
+        return ImGuiFreeTypeBuilderFlags_LightHinting;
+    }
+    if( hinting == "Bitmap" ) {
+        return ImGuiFreeTypeBuilderFlags_Bitmap;
+    }
+    if( hinting == "Default" ) {
+        return std::nullopt;
+    }
+    debugmsg( "'%s' is an invalid font hinting value.", hinting );
+    return std::nullopt;
+}
+
+void font_config::deserialize( const JsonObject &jo )
+{
+    bool has_path = jo.read( "path", path, true );
+    if( !( has_path ) ) {
+        jo.throw_error( "Dummy error - force config read to return false." );
+    }
+    // Manually read hinting.
+    // Specifying enum traits for would allow all options, and we want only
+    // some to be available to the user.
+    if( jo.has_string( "hinting" ) ) {
+        hinting = hint_to_fonthint( jo.get_string( "hinting" ) );
+    }
+    jo.read( "antialiasing", antialiasing, false );
+}
+
+static void load_font_from_config( const JsonObject &config, const std::string &key,
+                                   std::vector<font_config> &typefaces )
+{
+
+    if( config.has_string( key ) ) {
+        std::string path = config.get_string( key );
+        // Migrate old font config files. Remove after 0.I
+        if( path.find( "Terminus.ttf" ) != std::string::npos ) {
+            typefaces.emplace_back( path, ImGuiFreeTypeBuilderFlags_Bitmap );
+        }  else if( path.find( "Roboto-Medium.ttf" ) != std::string::npos ) {
+            typefaces.emplace_back( path, ImGuiFreeTypeBuilderFlags_ForceAutoHint );
+        } else {
+            typefaces.emplace_back( path );
+        }
+    } else if( config.has_object( key ) ) {
+        // TODO: This should be doable without having to instantiate a fake path.
+        font_config conf = font_config( "dummy" );
+        if( !config.read( key, conf, false ) ) {
+            debugmsg( "Key '%s' should contain a path entry.", key );
+        } else {
+            typefaces.push_back( conf );
+        }
+    } else if( config.has_array( key ) ) {
+        JsonArray array = config.get_array( key );
+        for( JsonValue value : array ) {
+            if( value.test_string() ) {
+                std::string path = value.get_string();
+                // Migrate old font config files. Remove after 0.I
+                if( path.find( "Terminus.ttf" ) != std::string::npos ) {
+                    typefaces.emplace_back( path, ImGuiFreeTypeBuilderFlags_Bitmap );
+                } else if( path.find( "Roboto-Medium.ttf" ) != std::string::npos ) {
+                    typefaces.emplace_back( path, ImGuiFreeTypeBuilderFlags_ForceAutoHint );
+                } else {
+                    typefaces.emplace_back( path );
+                }
+            } else if( value.test_object() ) {
+                font_config conf = font_config( "dummy" );
+                if( !value.read( conf, false ) ) {
+                    debugmsg( "Key '%s' has an invalid array entry in the font config file.", key );
+                } else {
+                    typefaces.push_back( conf );
+                }
+            } else {
+                // Value is neither a string nor an object.
+                debugmsg( "Invalid font entry for key '%s'. Font array entries should be objects or strings.",
+                          key );
+            }
+        }
+    } else {
+        debugmsg( "Font specifiers must be an array, object, or string." );
+    }
+
+    ensure_unifont_loaded( typefaces );
+}
+
+
 void font_loader::load_throws( const cata_path &path )
 {
     try {
         JsonValue json = json_loader::from_path( path );
         JsonObject config = json.get_object();
-        if( config.has_string( "typeface" ) ) {
-            typeface.emplace_back( config.get_string( "typeface" ) );
-        } else {
-            config.read( "typeface", typeface );
-        }
-        if( config.has_string( "gui_typeface" ) ) {
-            gui_typeface.emplace_back( config.get_string( "gui_typeface" ) );
-        } else {
-            config.read( "gui_typeface", gui_typeface );
-        }
-        if( config.has_string( "map_typeface" ) ) {
-            map_typeface.emplace_back( config.get_string( "map_typeface" ) );
-        } else {
-            config.read( "map_typeface", map_typeface );
-        }
-        if( config.has_string( "overmap_typeface" ) ) {
-            overmap_typeface.emplace_back( config.get_string( "overmap_typeface" ) );
-        } else {
-            config.read( "overmap_typeface", overmap_typeface );
-        }
-
-        ensure_unifont_loaded( typeface );
-        ensure_unifont_loaded( gui_typeface );
-        ensure_unifont_loaded( map_typeface );
-        ensure_unifont_loaded( overmap_typeface );
-
+        config.allow_omitted_members(); // We do actually visit every member, but over several functions.
+        load_font_from_config( config, "typeface", typeface );
+        load_font_from_config( config, "gui_typeface", gui_typeface );
+        load_font_from_config( config, "map_typeface", map_typeface );
+        load_font_from_config( config, "overmap_typeface", overmap_typeface );
     } catch( const std::exception &err ) {
         throw std::runtime_error( std::string( "loading font settings from " ) + path.generic_u8string() +
                                   " failed: " +
                                   err.what() );
     }
+}
+
+// Convenience function for font_loader::save. Assumes that this is a member of
+// an object.
+void write_font_config( JsonOut &json, const std::vector<font_config> &typefaces )
+{
+    json.start_array();
+    for( const font_config &config : typefaces ) {
+        json.start_object();
+        json.member( "path", config.path );
+
+        if( config.hinting == std::nullopt ) {
+            json.member( "hinting", "Default" );
+        } else {
+            switch( *config.hinting ) {
+                case ImGuiFreeTypeBuilderFlags_ForceAutoHint:
+                    json.member( "hinting", "Auto" );
+                    break;
+                case ImGuiFreeTypeBuilderFlags_Bitmap:
+                    json.member( "hinting", "Bitmap" );
+                    break;
+                case ImGuiFreeTypeBuilderFlags_LightHinting:
+                    json.member( "hinting", "Light" );
+                    break;
+                case ImGuiFreeTypeBuilderFlags_NoHinting:
+                    json.member( "hinting", "NoAuto" );
+                    break;
+                default:
+                    // This should never be reached.
+                    json.member( "hinting", "Default" );
+                    break;
+            }
+        }
+
+        if( !config.antialiasing ) {
+            json.member( "antialiasing", false );
+        }
+
+        json.end_object();
+    }
+    json.end_array();
 }
 
 void font_loader::save( const cata_path &path ) const
@@ -57,10 +192,15 @@ void font_loader::save( const cata_path &path ) const
         write_to_file( path, [&]( std::ostream & stream ) {
             JsonOut json( stream, true ); // pretty-print
             json.start_object();
-            json.member( "typeface", typeface );
-            json.member( "gui_typeface", typeface );
-            json.member( "map_typeface", map_typeface );
-            json.member( "overmap_typeface", overmap_typeface );
+            json.member( "//", "See docs/FONT_OPTIONS.md for an explanation of this file." );
+            json.member( "typeface" );
+            write_font_config( json, typeface );
+            json.member( "gui_typeface" );
+            write_font_config( json, gui_typeface );
+            json.member( "map_typeface" );
+            write_font_config( json, map_typeface );
+            json.member( "overmap_typeface" );
+            write_font_config( json, overmap_typeface );
             json.end_object();
             stream << "\n";
         } );
@@ -74,6 +214,9 @@ void font_loader::load()
     const cata_path fontdata = PATH_INFO::fontdata();
     if( file_exist( fontdata ) ) {
         load_throws( fontdata );
+        // Migrate old font files to the new format.
+        // Remove after 0.I.
+        save( fontdata );
     } else {
         const cata_path legacy_fontdata = PATH_INFO::legacy_fontdata();
         load_throws( legacy_fontdata );

--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -63,7 +63,7 @@ static std::optional<ImGuiFreeTypeBuilderFlags> hint_to_fonthint( const std::str
 void font_config::deserialize( const JsonObject &jo )
 {
     bool has_path = jo.read( "path", path, true );
-    if( !( has_path ) ) {
+    if( !has_path ) {
         jo.throw_error( "Dummy error - force config read to return false." );
     }
     // Manually read hinting.

--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -36,7 +36,7 @@ unsigned int font_config::imgui_config() const
     return ret;
 }
 
-std::optional<ImGuiFreeTypeBuilderFlags> hint_to_fonthint( const std::string_view hinting )
+static std::optional<ImGuiFreeTypeBuilderFlags> hint_to_fonthint( const std::string_view hinting )
 {
     if( hinting == "Auto" ) {
         return ImGuiFreeTypeBuilderFlags_ForceAutoHint;
@@ -46,6 +46,9 @@ std::optional<ImGuiFreeTypeBuilderFlags> hint_to_fonthint( const std::string_vie
     }
     if( hinting == "Light" ) {
         return ImGuiFreeTypeBuilderFlags_LightHinting;
+    }
+    if( hinting == "None" ) {
+        return ImGuiFreeTypeBuilderFlags_NoHinting;
     }
     if( hinting == "Bitmap" ) {
         return ImGuiFreeTypeBuilderFlags_Bitmap;
@@ -147,7 +150,7 @@ void font_loader::load_throws( const cata_path &path )
 
 // Convenience function for font_loader::save. Assumes that this is a member of
 // an object.
-void write_font_config( JsonOut &json, const std::vector<font_config> &typefaces )
+static void write_font_config( JsonOut &json, const std::vector<font_config> &typefaces )
 {
     json.start_array();
     for( const font_config &config : typefaces ) {

--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -90,8 +90,7 @@ static void load_font_from_config( const JsonObject &config, const std::string &
             typefaces.emplace_back( path );
         }
     } else if( config.has_object( key ) ) {
-        // TODO: This should be doable without having to instantiate a fake path.
-        font_config conf = font_config( "dummy" );
+        font_config conf;
         if( !config.read( key, conf, false ) ) {
             debugmsg( "Key '%s' should contain a path entry.", key );
         } else {
@@ -111,7 +110,7 @@ static void load_font_from_config( const JsonObject &config, const std::string &
                     typefaces.emplace_back( path );
                 }
             } else if( value.test_object() ) {
-                font_config conf = font_config( "dummy" );
+                font_config conf;
                 if( !value.read( conf, false ) ) {
                     debugmsg( "Key '%s' has an invalid array entry in the font config file.", key );
                 } else {

--- a/src/font_loader.h
+++ b/src/font_loader.h
@@ -2,6 +2,10 @@
 #ifndef CATA_SRC_FONT_LOADER_H
 #define CATA_SRC_FONT_LOADER_H
 
+#define IMGUI_DEFINE_MATH_OPERATORS
+#include <imgui/imgui_freetype.h>
+#undef IMGUI_DEFINE_MATH_OPERATORS
+
 #if defined( TILES )
 
 #include <algorithm>
@@ -15,16 +19,40 @@
 #include "json.h"
 #include "path_info.h"
 
+// The font-configuration values modifiable by the user.
+struct font_config {
+    // Path to the font file.
+    std::string path;
+    // The type of hinting to apply.
+    std::optional<ImGuiFreeTypeBuilderFlags> hinting = std::nullopt;
+    // In practice, antialiasing will be ignored when hinting is set to FontHint::Bitmap.
+    bool antialiasing = true;
+
+    explicit font_config( std::string path ) : path( path ) {}
+    font_config( std::string path, std::optional<ImGuiFreeTypeBuilderFlags> hinting ) : path( path ),
+        hinting( hinting ) {}
+    font_config( std::string path, std::optional<ImGuiFreeTypeBuilderFlags> hinting,
+                 bool antialiasing ) : path( path ), hinting( hinting ), antialiasing( antialiasing ) {}
+
+    // Returns the font flags that should be passed to an ImFontConfig.
+    unsigned int imgui_config() const;
+
+    void deserialize( const JsonObject &jo );
+};
+
+
+extern void ensure_unifont_loaded( std::vector<font_config> &font_list );
 extern void ensure_unifont_loaded( std::vector<std::string> &font_list );
+
 
 class font_loader
 {
     public:
         bool fontblending = false;
-        std::vector<std::string> typeface;
-        std::vector<std::string> gui_typeface;
-        std::vector<std::string> map_typeface;
-        std::vector<std::string> overmap_typeface;
+        std::vector<font_config> typeface;
+        std::vector<font_config> map_typeface;
+        std::vector<font_config> gui_typeface;
+        std::vector<font_config> overmap_typeface;
         int fontwidth = 8;
         int fontheight = 16;
         int fontsize = 16;

--- a/src/font_loader.h
+++ b/src/font_loader.h
@@ -28,6 +28,8 @@ struct font_config {
     // In practice, antialiasing will be ignored when hinting is set to FontHint::Bitmap.
     bool antialiasing = true;
 
+    font_config() = default;
+
     explicit font_config( std::string path ) : path( std::move( path ) ) {}
     font_config( std::string path,
                  const std::optional<ImGuiFreeTypeBuilderFlags> hinting ) : path( std::move( path ) ),

--- a/src/font_loader.h
+++ b/src/font_loader.h
@@ -28,11 +28,13 @@ struct font_config {
     // In practice, antialiasing will be ignored when hinting is set to FontHint::Bitmap.
     bool antialiasing = true;
 
-    explicit font_config( std::string path ) : path(std::move(path)) {}
-    font_config( std::string path, const std::optional<ImGuiFreeTypeBuilderFlags> hinting ) : path( std::move(path) ),
+    explicit font_config( std::string path ) : path( std::move( path ) ) {}
+    font_config( std::string path,
+                 const std::optional<ImGuiFreeTypeBuilderFlags> hinting ) : path( std::move( path ) ),
         hinting( hinting ) {}
     font_config( std::string path, const std::optional<ImGuiFreeTypeBuilderFlags> hinting,
-                 const bool antialiasing ) : path(std::move(path)), hinting( hinting ), antialiasing( antialiasing ) {}
+                 const bool antialiasing ) : path( std::move( path ) ), hinting( hinting ),
+        antialiasing( antialiasing ) {}
 
     // Returns the font flags that should be passed to an ImFontConfig.
     unsigned int imgui_config() const;

--- a/src/font_loader.h
+++ b/src/font_loader.h
@@ -28,11 +28,11 @@ struct font_config {
     // In practice, antialiasing will be ignored when hinting is set to FontHint::Bitmap.
     bool antialiasing = true;
 
-    explicit font_config( std::string path ) : path( path ) {}
-    font_config( std::string path, std::optional<ImGuiFreeTypeBuilderFlags> hinting ) : path( path ),
+    explicit font_config( std::string path ) : path(std::move(path)) {}
+    font_config( std::string path, const std::optional<ImGuiFreeTypeBuilderFlags> hinting ) : path( std::move(path) ),
         hinting( hinting ) {}
-    font_config( std::string path, std::optional<ImGuiFreeTypeBuilderFlags> hinting,
-                 bool antialiasing ) : path( path ), hinting( hinting ), antialiasing( antialiasing ) {}
+    font_config( std::string path, const std::optional<ImGuiFreeTypeBuilderFlags> hinting,
+                 const bool antialiasing ) : path(std::move(path)), hinting( hinting ), antialiasing( antialiasing ) {}
 
     // Returns the font flags that should be passed to an ImFontConfig.
     unsigned int imgui_config() const;

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -20,6 +20,7 @@
 
 #define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
 
+
     // bitmap font size test
     // return face index that has this size or below
     static int test_face_size( const std::string &f, int size, int faceIndex )
@@ -584,15 +585,15 @@ FontFallbackList::FontFallbackList(
     SDL_Renderer_Ptr &renderer, SDL_PixelFormat_Ptr &format,
     const int w, const int h,
     const palette_array &palette,
-    const std::vector<std::string> &typefaces,
+    const std::vector<font_config> &typefaces,
     const int fontsize, const bool fontblending )
     : Font( w, h, palette )
 {
-    for( const std::string &typeface : typefaces ) {
-        std::unique_ptr<Font> font = Font::load_font( renderer, format, typeface, fontsize, w, h, palette,
-                                     fontblending );
+    for( const font_config &font_config : typefaces ) {
+        std::unique_ptr<Font> font = Font::load_font( renderer, format, font_config.path, fontsize, w, h,
+                                     palette, fontblending );
         if( !font ) {
-            throw std::runtime_error( "Cannot load font " + typeface );
+            throw std::runtime_error( "Cannot load font " + font_config.path );
         }
         fonts.emplace_back( std::move( font ) );
     }

--- a/src/sdl_font.h
+++ b/src/sdl_font.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifndef CATA_SRC_SDL_FONT_H
 #define CATA_SRC_SDL_FONT_H
+#include "font_loader.h"
 
 #if defined(TILES)
 
@@ -156,7 +157,7 @@ class FontFallbackList : public Font
             SDL_Renderer_Ptr &renderer, SDL_PixelFormat_Ptr &format,
             int w, int h,
             const palette_array &palette,
-            const std::vector<std::string> &typefaces,
+            const std::vector<font_config> &typefaces,
             int fontsize, bool fontblending );
         ~FontFallbackList() override = default;
 


### PR DESCRIPTION
#### Summary
Interface "Make font-hinting user-configurable"

#### Purpose of change

Fixes the slight blurriness of Terminus on ImGui windows which was caused by not hinting in bitmap mode.

fixes #73120 

#### Describe the solution

The font is loaded through the same `fontdata.json` file that was always used.

I'm not really happy with the clarity of the error messages, but I am not sure how to make them clearer. I don't think it's possible to use `JsonWithPath.throw_error()` because if it occurs before the first typeface is loaded the game will crash before load.

#### Describe alternatives you've considered

None.

#### Testing

Loaded the game. Checked that error messages were displayed appropriately for incorrect sizes.

#### Additional context

**Current**
![image](https://github.com/user-attachments/assets/fd709bde-2ab6-469c-bd26-005b4ebb8bd3)

**Previous**
![image](https://github.com/user-attachments/assets/66a070b3-566e-43ae-ade7-c8df72e9ca5b)

