### PR TITLE
Fixed atmic smarphone and intergrated AR unable to read stored books.

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1462,7 +1462,8 @@ class read_inventory_preset: public pickup_inventory_preset
 
             return ( loc->is_book() || loc->type->can_use( "learn_spell" ) ) &&
                    ( p_loc.where() == item_location::type::invalid || !p_loc->is_ebook_storage() ||
-                     p_loc->energy_remaining() >= 1_kJ );
+                     !p_loc->uses_energy() ||
+                     p_loc->energy_remaining( p_loc.carrier(), false ) >= 1_kJ );
         }
 
         std::string get_denial( const item_location &loc ) const override {


### PR DESCRIPTION
#### Summary

Bugfixes "Fixed atmic smarphone and intergrated AR unable to read stored books."

#### Purpose of change

Fixes #78245 and fixes #78615

#### Describe the solution

The cause of the error was that the atomic smartphone doesnt use or store energy and that the intergrated AR uses bionic energy stored in the carrier character. This was fixed by not checking energy on parent items that don't consume energy and by also getting the energy stored in the parent item carrier character."

#### Testing

I tested that books stored in the smartphone can be read only when it has enough energy, I also tested that books stored in the atomic smartphone can be read. Finally I also tested that books stored in the integrated AR can also be read only when the character has enough bionic power. I also suggest testing similar magical items and the Flawless memory item from Bombastic perk, but I think these should also work because they also dont consume energy similarly to the atomic smartphone.