### PR TITLE
Remove Dragonskin Vest and WS-47G Suit

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -3205,7 +3205,6 @@
       [ "tireplate", 10 ],
       [ "ballistic_vest_esapi", 2 ],
       { "group": "military_ballistic_vest", "prob": 4 },
-      [ "dragonskin", 1 ],
       [ "corset", 1 ],
       [ "corset_waist", 1 ],
       [ "football_armor", 18 ],

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -620,7 +620,6 @@
       [ "motorbike_armor", 2 ],
       [ "motorbike_pants", 2 ],
       [ "motorbike_boots", 2 ],
-      [ "dragonskin", 2 ],
       [ "kittel", 1 ],
       [ "kippah", 3 ],
       [ "thawb", 2 ],

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1351,7 +1351,6 @@
       [ "petrified_eye", 5 ],
       [ "talking_doll", 40 ],
       [ "bondage_mask", 20 ],
-      [ "dragonskin", 2 ],
       [ "knife_hunting", 25 ],
       [ "throwing_knife", 25 ],
       { "item": "throwing_knife", "count": [ 1, 6 ], "entry-wrapper": "leg_sheath6", "prob": 5 },

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -21,7 +21,6 @@
       { "item": "can_sealer", "prob": 10 },
       { "item": "hk_g80", "prob": 10 },
       { "item": "hk_g80mag", "prob": 10 },
-      { "item": "stillsuit", "prob": 10 },
       { "item": "hk_g80mag", "prob": 10 },
       { "item": "emp_gun", "prob": 10 },
       { "item": "laser_rifle", "prob": 10 },

--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -1319,42 +1319,6 @@
     ]
   },
   {
-    "id": "dragonskin",
-    "type": "ARMOR",
-    "category": "armor",
-    "name": { "str": "dragon skin vest" },
-    "//": "Based on a true story related to the real-world design",
-    "description": "This type of ballistic vest once promised to be the future of body armor, claiming to allow a greater range of movement than conventional ballistic vests as well as better protection.  Created by the now-defunct company Meridian Ballistics, it features a unique design consisting of overlapping ceramic disks, and was once famously demonstrated on TV absorbing high-energy rifle rounds at point blank.\n\nThe US Army quickly snapped up several hundred units of the armor, but testing soon revealed that they were extremely heavy, weighing almost fifty pounds, and that the design failed spectacularly in environmental tests.  After a series of investigations, claims of fraud, and court hearings, Meridian went bankrupt, and the Department of Justice subsequently dropped this design from its certifications.\n\nThere were no known users of these vests by the time that the world ended; this one was either an original production in the hands of a collector, or a similar design from a different company.  Whatever the case may be, you have one now, in all its unwieldy glory.",
-    "weight": "21545 g",
-    "volume": "6 L",
-    "price": "5000 USD",
-    "price_postapoc": "60 USD",
-    "to_hit": { "grip": "bad", "length": "short", "surface": "any", "balance": "uneven" },
-    "material": [ "ceramic", "nylon" ],
-    "symbol": "[",
-    "looks_like": "kevlar",
-    "color": "yellow",
-    "warmth": 12,
-    "flags": [ "STURDY", "OUTER", "NO_REPAIR" ],
-    "use_action": [ { "type": "attach_molle", "size": 10 }, { "type": "detach_molle" } ],
-    "//2": "Ceramic disks in real-life dragon skin are 6.4mm thick; the actual fabric itself wasn't intended to provide high-grade protection, and so it's quite thin here.",
-    "//3": "The double instance of ceramic here represents possible hits on parts where the disks themselves are overlapping, providing enhanced protection.",
-    "armor": [
-      {
-        "material": [
-          { "type": "nylon", "covered_by_mat": 100, "thickness": 1.0 },
-          { "type": "ceramic", "covered_by_mat": 90, "thickness": 6.4 },
-          { "type": "ceramic", "covered_by_mat": 30, "thickness": 6.4 }
-        ],
-        "encumbrance": 8,
-        "coverage": 100,
-        "cover_vitals": 90,
-        "covers": [ "torso" ]
-      }
-    ],
-    "melee_damage": { "bash": 6 }
-  },
-  {
     "id": "xl_ballistic_vest",
     "type": "ARMOR",
     "category": "armor",

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -3071,27 +3071,6 @@
     }
   },
   {
-    "id": "stillsuit",
-    "type": "ARMOR",
-    "name": { "str": "WS-47G moisture retention suit" },
-    "description": "The WebbStar moisture retention suit utilizes advanced technology to prevent up to 30% of moisture loss through perspiration.  The suit is powered by the micro-motions of the body, especially breathing and walking motions.  Because of this, your walking speed is impaired while wearing it.",
-    "weight": "3481 g",
-    "volume": "7500 ml",
-    "price": "45 kUSD",
-    "price_postapoc": "20 USD",
-    "material": [ "lycra", "neoprene" ],
-    "symbol": "[",
-    "looks_like": "jumpsuit",
-    "color": "dark_gray",
-    "warmth": 15,
-    "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "HOOD", "WATERPROOF", "MUNDANE", "ONLY_ONE" ],
-    "relic_data": {
-      "passive_effects": [ { "has": "WORN", "values": [ { "value": "THIRST", "multiply": -0.3 }, { "value": "MOVE_COST", "multiply": 0.1 } ] } ]
-    },
-    "armor": [ { "encumbrance": 18, "coverage": 95, "covers": [ "foot_l", "foot_r", "leg_l", "leg_r", "torso", "arm_l", "arm_r" ] } ]
-  },
-  {
     "id": "suit",
     "type": "ARMOR",
     "name": { "str": "suit" },

--- a/data/json/monsterdrops/zombie_survivor.json
+++ b/data/json/monsterdrops/zombie_survivor.json
@@ -388,7 +388,6 @@
       [ "vest_leather", 20 ],
       [ "vest_leather_mod", 8 ],
       [ "stab_vest", 15 ],
-      [ "dragonskin", 1 ],
       [ "chainmail_junk_vest", 1 ],
       [ "chestguard_hard", 10 ],
       [ "armor_riot_torso", 10 ],

--- a/data/json/obsoletion_and_migration_0.I/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.I/migration_items.json
@@ -2159,5 +2159,15 @@
     "id": "peanutbutter_imitation",
     "type": "MIGRATION",
     "replace": "peanutbutter"
+  },
+  {
+    "id": "dragonskin",
+    "type": "MIGRATION",
+    "replace": "ballistic_vest_esapi"
+  },
+  {
+    "id": "stillsuit",
+    "type": "MIGRATION",
+    "replace": "h20survivor_jumpsuit"
   }
 ]

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -13,7 +13,6 @@
       "bot_gasbomb_hack",
       "tailoring_pattern_set",
       "k_gambeson_vest_xs",
-      "dragonskin",
       "mutant_cracklins",
       "venom_wasp",
       "cooked_marrow",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The dragonskin vest never saw any adoption in any military, police, or civilian presence. They'd be rare to the point that they'd be non-existent so there's not much a point in keeping them in. They're also old, and so any one of them would be likely out of date and less-than-functional.

The stillsuit was just a Dune reference. It doesn't provide any meaningful gameplay choices, is quite clearly some left over sci-fi stuff from the old lore, and to boot is only accessible through the nano-fab.  
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Migrates em. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Moving the moisture suit to aftershock
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Before/afters
![image](https://github.com/user-attachments/assets/7c86c6b3-1c52-4cff-ab68-5428bcc33e85)
![image](https://github.com/user-attachments/assets/3a00bc5d-aff6-4bf6-8d95-f21672731032)
What a template for the nanofab looks like post-migration
![image](https://github.com/user-attachments/assets/bee16e8f-792a-4688-b7c0-d8930bf50e83)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Yes I know that there's a dupe entry for the G80 mag in the nanofab recipes. I'll fix that, and other issues with that group in another PR
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
