### PR TITLE
Better skill requirement UI for martial arts

### DIFF
--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -795,6 +795,16 @@ bool ma_requirements::is_valid_weapon( const item &i ) const
     return true;
 }
 
+static std::string required_skill_as_string( const skill_id &skill, const int required_skill, const int player_skill ) {
+    std::string difficulty_tag;
+    if( required_skill <= player_skill ) {
+        difficulty_tag = "good";
+    } else {
+        difficulty_tag = "bad";
+    }
+    return string_format( "<info>%s</info> <%s>(%d/%d)</%s>", skill->name(), difficulty_tag, player_skill, required_skill, difficulty_tag );
+}
+
 std::string ma_requirements::get_description( bool buff ) const
 {
     std::string dump;
@@ -812,8 +822,7 @@ std::string ma_requirements::get_description( bool buff ) const
             if( u.has_active_bionic( bio_cqb ) ) {
                 player_skill = BIO_CQB_LEVEL;
             }
-            return string_format( "%s: <stat>%d</stat>/<stat>%d</stat>", pr.first->name(), player_skill,
-                                  pr.second );
+            return required_skill_as_string( pr.first, pr.second, player_skill );
         }, enumeration_conjunction::none ) + "\n";
     }
 
@@ -2293,8 +2302,8 @@ void ma_details_ui_impl::init_data()
                     _( "You can <info>arm block</info> by installing the <info>Arms Alloy Plating CBM</info>" ) );
             } else if( ma.arm_block != 99 ) {
                 general_info_text.emplace_back( string_format(
-                                                    _( "You can <info>arm block</info> at <info>unarmed combat:</info> <stat>%s</stat>/<stat>%s</stat>" ),
-                                                    unarmed_skill, ma.arm_block ) );
+                                                    _( "You can <info>arm block</info> at %s" ),
+                                                    required_skill_as_string( skill_unarmed, ma.arm_block, unarmed_skill) ) );
             }
 
             if( ma.leg_block_with_bio_armor_legs ) {
@@ -2302,12 +2311,12 @@ void ma_details_ui_impl::init_data()
                     _( "You can <info>leg block</info> by installing the <info>Legs Alloy Plating CBM</info>" ) );
             } else if( ma.leg_block != 99 ) {
                 general_info_text.emplace_back( string_format(
-                                                    _( "You can <info>leg block</info> at <info>unarmed combat:</info> <stat>%s</stat>/<stat>%s</stat>" ),
-                                                    unarmed_skill, ma.leg_block ) );
+                                                    _( "You can <info>leg block</info> at %s" ),
+                                                    required_skill_as_string( skill_unarmed, ma.leg_block, unarmed_skill ) ) );
                 if( ma.nonstandard_block != 99 ) {
                     general_info_text.emplace_back( string_format(
-                                                        _( "You can <info>block with mutated limbs</info> at <info>unarmed combat:</info> <stat>%s</stat>/<stat>%s</stat>" ),
-                                                        unarmed_skill, ma.nonstandard_block ) );
+                                                        _( "You can <info>block with mutated limbs</info> at %s" ),
+                                                        required_skill_as_string( skill_unarmed, ma.nonstandard_block, unarmed_skill ) ) );
                 }
             }
         }

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -795,14 +795,17 @@ bool ma_requirements::is_valid_weapon( const item &i ) const
     return true;
 }
 
-static std::string required_skill_as_string( const skill_id &skill, const int required_skill, const int player_skill ) {
+static std::string required_skill_as_string( const skill_id &skill, const int required_skill,
+        const int player_skill )
+{
     std::string difficulty_tag;
     if( required_skill <= player_skill ) {
         difficulty_tag = "good";
     } else {
         difficulty_tag = "bad";
     }
-    return string_format( "<info>%s</info> <%s>(%d/%d)</%s>", skill->name(), difficulty_tag, player_skill, required_skill, difficulty_tag );
+    return string_format( "<info>%s</info> <%s>(%d/%d)</%s>", skill->name(), difficulty_tag,
+                          player_skill, required_skill, difficulty_tag );
 }
 
 std::string ma_requirements::get_description( bool buff ) const
@@ -2303,7 +2306,7 @@ void ma_details_ui_impl::init_data()
             } else if( ma.arm_block != 99 ) {
                 general_info_text.emplace_back( string_format(
                                                     _( "You can <info>arm block</info> at %s" ),
-                                                    required_skill_as_string( skill_unarmed, ma.arm_block, unarmed_skill) ) );
+                                                    required_skill_as_string( skill_unarmed, ma.arm_block, unarmed_skill ) ) );
             }
 
             if( ma.leg_block_with_bio_armor_legs ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Better skill requirement UI for martial arts"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Every time I ask myself what actual techniques my character can do, and while 1/2 is informative, I have to mentally parse that every time. We already have a good convention at crafting menu,, which shows skill requirements as green/yellow/red.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Borrow strings from crafting UI to show skills that you have minimum requirements to show as green/red. Yellow not included as AFAICT techniques are binary in you can or you cannot do.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Not truly alternative, as can be complementary, but sort techniques so ones that match will be at the top, potentially "gray out" not matched ones.

#### Testing

Open MA menu from existing char, looks fine so far.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I'm not a C++ dev myself so hope this code is fine. Thanks in advance for any corrections pointed by experienced devs.

The function for requirements string can be further generalized and reused so both crafting menu and martial arts menu use same implementation. Not sure if that's desired. 

Here how the UI looks like:

<img width="1044" alt="Screenshot 2024-12-30 at 13 22 49" src="https://github.com/user-attachments/assets/dace5016-dc41-4ae3-ba01-cc9da204a74a" /> 


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
