### PR TITLE
Update weapon_copy_extensions.json

### DIFF
--- a/data/mods/Xedra_Evolved/items/weapon_copy_extensions.json
+++ b/data/mods/Xedra_Evolved/items/weapon_copy_extensions.json
@@ -120,6 +120,13 @@
   },
   {
     "type": "GENERIC",
+    "id": "spear_wood_simple",
+    "copy-from": "spear_wood_simple",
+    "name": { "str": "wooden spear" },
+    "extend": { "flags": [ "WOODEN_WEAPON" ] }
+  },
+  {
+    "type": "GENERIC",
     "id": "spear_forked",
     "copy-from": "spear_forked",
     "name": { "str": "forked spear" },


### PR DESCRIPTION
#### Summary
Mods "Adding the "WOODEN_WEAPON" flag to the wooden spear"

#### Purpose of change

The wooden spear was missing the "WOODEN_WEAPON" flag that Xedra Evolved adds to other wooden weapons.

#### Describe the solution

Adding the "WOODEN_WEAPON" flag to the wooden spear.

#### Describe alternatives you've considered

Informing someone more experienced about this.

#### Testing

The weapon was missing a text clarifying that "This weapon is primarily or mostly made of wood".
After extending the "WOODEN_WEAPON" flag to the wooden spear, the text shows up.
Unable to find any issues after testing the weapon a bit.

#### Additional context

Wooden spear description before adding the flag.
![Skärmbild 2024-12-31 163912](https://github.com/user-attachments/assets/1a6e2d5e-f6d9-4930-b783-dc0e0f36866d)

Wooden spear description after adding the flag.
![Skärmbild 2024-12-31 164113](https://github.com/user-attachments/assets/1bb6f756-9a92-48f4-a09e-aad117953984)
