### PR TITLE
Make auto-whitelist logic also auto-collapse the container

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -143,8 +143,7 @@
     "material": [ "plastic" ],
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "18 L", "max_contains_weight": "22 kg", "moves": 500 } ],
     "symbol": ")",
-    "color": "white",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "white"
   },
   {
     "id": "bag_durasack_cement",
@@ -181,8 +180,7 @@
     "material": [ "canvas" ],
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "15 L", "max_contains_weight": "15 kg", "moves": 400 } ],
     "symbol": ")",
-    "color": "brown",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "brown"
   },
   {
     "id": "bag_canvas_small",
@@ -199,8 +197,7 @@
     "material": [ "canvas" ],
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 400 } ],
     "symbol": ")",
-    "color": "brown",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "brown"
   },
   {
     "id": "bag_plastic",
@@ -224,8 +221,7 @@
     ],
     "material": [ "plastic" ],
     "symbol": ")",
-    "color": "light_gray",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "light_gray"
   },
   {
     "id": "bag_plastic_small",
@@ -250,8 +246,7 @@
       }
     ],
     "symbol": ")",
-    "color": "light_gray",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "light_gray"
   },
   {
     "id": "bag_garbage",
@@ -329,8 +324,7 @@
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "2 kg", "moves": 200 } ],
     "material": [ "paper" ],
     "symbol": ")",
-    "color": "white",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "white"
   },
   {
     "id": "bag_paper_powder_bulk",
@@ -347,8 +341,7 @@
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "10000 ml", "max_contains_weight": "15 kg", "moves": 200 } ],
     "material": [ "paper" ],
     "symbol": ")",
-    "color": "white",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "white"
   },
   {
     "id": "bag_zipper",
@@ -375,8 +368,7 @@
       }
     ],
     "symbol": ")",
-    "color": "light_gray",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "light_gray"
   },
   {
     "id": "bag_zipper_gallon",
@@ -722,7 +714,7 @@
     "material": [ "plastic" ],
     "symbol": ")",
     "color": "white",
-    "flags": [ "NO_RELOAD", "NO_UNLOAD", "COLLAPSE_CONTENTS" ],
+    "flags": [ "NO_RELOAD", "NO_UNLOAD" ],
     "variant_type": "generic",
     "variants": [
       {
@@ -760,8 +752,7 @@
     "price_postapoc": "0 cent",
     "material": [ "plastic" ],
     "symbol": ")",
-    "color": "brown",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "brown"
   },
   {
     "id": "bottle_plastic_pill_painkiller",
@@ -811,8 +802,7 @@
     "price_postapoc": "10 cent",
     "material": [ "plastic" ],
     "symbol": ")",
-    "color": "light_cyan",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "light_cyan"
   },
   {
     "id": "bottle_plastic_seasoning_small",
@@ -842,8 +832,7 @@
     "price_postapoc": "0 cent",
     "material": [ "plastic" ],
     "symbol": ")",
-    "color": "white",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "white"
   },
   {
     "id": "bottle_glass_seasoning",
@@ -875,7 +864,6 @@
     "symbol": ")",
     "color": "light_cyan",
     "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -906,7 +894,6 @@
         "moves": 200
       }
     ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "melee_damage": { "bash": 1 }
   },
   {
@@ -1089,8 +1076,7 @@
     "material": [ "paper" ],
     "symbol": ")",
     "color": "white",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "90 ml", "max_contains_weight": "3 kg" } ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "pocket_data": [ { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "90 ml", "max_contains_weight": "3 kg" } ]
   },
   {
     "id": "case_cigar",
@@ -1140,8 +1126,7 @@
     "price_postapoc": "0 cent",
     "material": [ "cardboard" ],
     "symbol": ")",
-    "color": "brown",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "brown"
   },
   {
     "id": "box_small",
@@ -1175,8 +1160,7 @@
       "type": "transform",
       "moves": 500,
       "need_empty": true
-    },
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    }
   },
   {
     "id": "box_small_folded",
@@ -1783,8 +1767,7 @@
       }
     ],
     "qualities": [ [ "BOIL", 1 ] ],
-    "use_action": [ "HEAT_LIQUID_ITEMS" ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "use_action": [ "HEAT_LIQUID_ITEMS" ]
   },
   {
     "id": "carton_sealed",
@@ -1839,8 +1822,7 @@
         "max_contains_weight": "5 kg",
         "sealed_data": { "spoil_multiplier": 0.5 }
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "carton_egg",
@@ -1866,8 +1848,7 @@
         "max_contains_weight": "1 kg",
         "max_item_length": "45 mm"
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "plastic_bag_vac",
@@ -1892,8 +1873,7 @@
         "max_contains_weight": "1 kg",
         "sealed_data": { "spoil_multiplier": 0.5 }
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "can_food",
@@ -1924,8 +1904,7 @@
       }
     ],
     "qualities": [ [ "BOIL", 1 ] ],
-    "use_action": [ "HEAT_LIQUID_ITEMS" ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "use_action": [ "HEAT_LIQUID_ITEMS" ]
   },
   {
     "id": "can_medium",
@@ -1951,8 +1930,7 @@
     ],
     "qualities": [ [ "BOIL", 1 ] ],
     "use_action": [ "HEAT_LIQUID_ITEMS" ],
-    "volume": "525 ml",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "volume": "525 ml"
   },
   {
     "id": "canteen",
@@ -2179,8 +2157,7 @@
         "max_contains_volume": "250 ml",
         "max_contains_weight": "1 kg"
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "cup_foil",
@@ -2207,7 +2184,7 @@
     ],
     "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
     "use_action": [ "HEAT_LIQUID_ITEMS" ],
-    "flags": [ "SOFT", "NO_REPAIR", "COLLAPSE_CONTENTS" ]
+    "flags": [ "SOFT", "NO_REPAIR" ]
   },
   {
     "id": "flask_glass",
@@ -2236,8 +2213,7 @@
       }
     ],
     "qualities": [ [ "BOIL", 1 ] ],
-    "use_action": [ "HEAT_LIQUID_ITEMS" ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "use_action": [ "HEAT_LIQUID_ITEMS" ]
   },
   {
     "id": "test_tube",
@@ -2390,7 +2366,6 @@
     ],
     "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
     "use_action": [ "HEAT_LIQUID_ITEMS" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "//": "Based on https://www.amazon.com/dp/B074Y6GD2R"
   },
   {
@@ -3673,7 +3648,7 @@
     "symbol": ",",
     "color": "light_gray",
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "6 kg" } ],
-    "flags": [ "COLLAPSE_CONTENTS", "TINDER" ]
+    "flags": [ "TINDER" ]
   },
   {
     "id": "wrapper_foil",
@@ -3694,7 +3669,7 @@
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "6 kg" } ],
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
-    "flags": [ "SOFT", "NO_REPAIR", "COLLAPSE_CONTENTS" ]
+    "flags": [ "SOFT", "NO_REPAIR" ]
   },
   {
     "id": "wrapper_foil_roll",
@@ -3732,8 +3707,7 @@
     },
     "ascii_picture": "wrapper_pr",
     "copy-from": "wrapper",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "225 ml", "max_contains_weight": "1 kg" } ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "225 ml", "max_contains_weight": "1 kg" } ]
   },
   {
     "id": "styrofoam_cup",
@@ -3959,7 +3933,6 @@
     ],
     "qualities": [ [ "BOIL", 1 ] ],
     "use_action": [ "HEAT_LIQUID_ITEMS" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -4663,7 +4636,7 @@
       }
     ],
     "charges_per_use": 1,
-    "flags": [ "GAS_TANK", "COLLAPSE_CONTENTS", "NO_SALVAGE" ],
+    "flags": [ "GAS_TANK", "NO_SALVAGE" ],
     "melee_damage": { "bash": 3 }
   },
   {
@@ -4694,7 +4667,7 @@
       }
     ],
     "charges_per_use": 1,
-    "flags": [ "GAS_TANK", "COLLAPSE_CONTENTS", "NO_SALVAGE" ],
+    "flags": [ "GAS_TANK", "NO_SALVAGE" ],
     "melee_damage": { "bash": 7 }
   },
   {
@@ -4725,7 +4698,7 @@
       }
     ],
     "charges_per_use": 1,
-    "flags": [ "GAS_TANK", "COLLAPSE_CONTENTS", "NO_SALVAGE" ],
+    "flags": [ "GAS_TANK", "NO_SALVAGE" ],
     "melee_damage": { "bash": 11 }
   },
   {
@@ -4756,7 +4729,7 @@
       }
     ],
     "charges_per_use": 1,
-    "flags": [ "GAS_TANK", "COLLAPSE_CONTENTS", "NO_SALVAGE" ],
+    "flags": [ "GAS_TANK", "NO_SALVAGE" ],
     "melee_damage": { "bash": 15 }
   },
   {
@@ -4886,7 +4859,6 @@
     ],
     "use_action": [ "HEAT_LIQUID_ITEMS" ],
     "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "melee_damage": { "bash": 8 }
   },
   {
@@ -4943,7 +4915,6 @@
       }
     ],
     "qualities": [ [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "melee_damage": { "bash": 1 }
   },
   {

--- a/data/json/items/containers/generic.json
+++ b/data/json/items/containers/generic.json
@@ -12,7 +12,7 @@
     "material": [ "plastic" ],
     "symbol": ")",
     "color": "light_gray",
-    "flags": [ "COLLAPSE_CONTENTS", "NO_RELOAD" ]
+    "flags": [ "NO_RELOAD" ]
   },
   {
     "id": "trashcan",
@@ -225,7 +225,6 @@
         "max_contains_weight": "2 kg",
         "sealed_data": { "spoil_multiplier": 0.5 }
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   }
 ]

--- a/data/json/items/containers/military.json
+++ b/data/json/items/containers/military.json
@@ -260,7 +260,6 @@
     "category": "container",
     "name": "grenade container",
     "description": "A small, thick cylindrical container.  Designed to store a single grenade, it seems.",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "411 g",
     "volume": "590 ml",
     "material": [ { "type": "cardboard" } ],
@@ -292,7 +291,6 @@
     "name": "double 84mm HEDP container",
     "description": "Huge metal container, in a shape of two massive rockets.",
     "//": "84mm heat 551 container, 265x700x124mm",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "1400 g",
     "volume": "23000 ml",
     "pocket_data": [
@@ -340,7 +338,6 @@
     "description": "Relatively small metal box.  On one side it has label \"EXPLOSIVE\"",
     "//": "84mm heat551 transport box, 610x400x290mm",
     "looks_like": "box_oversize_metal",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "1400 g",
     "volume": "70760 ml",
     "pocket_data": [
@@ -401,7 +398,6 @@
     "symbol": "#",
     "color": "brown",
     "material": [ "paper" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "14 g",
     "volume": "105 ml",
     "pocket_data": [
@@ -490,7 +486,6 @@
     "symbol": "#",
     "color": "brown",
     "material": [ "paper" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "34 g",
     "volume": "175 ml",
     "pocket_data": [
@@ -542,7 +537,6 @@
     "symbol": "#",
     "color": "brown",
     "material": [ "paper" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "28 g",
     "volume": "235 ml",
     "pocket_data": [
@@ -643,7 +637,6 @@
     "symbol": "#",
     "color": "brown",
     "material": [ "paper" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "44 g",
     "volume": "480 ml",
     "longest_side": "14 cm",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -3774,7 +3774,7 @@
     "name": { "str": "duct tape wallet" },
     "description": "A wallet made entirely out of duct tape.",
     "material": [ "plastic" ],
-    "flags": [ "NO_REPAIR" ]
+    "extend": { "flags": [ "NO_REPAIR" ] }
   },
   {
     "id": "wallet_leather",

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -834,8 +834,7 @@
         "max_contains_volume": "22712 ml",
         "max_contains_weight": "6 kg"
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "toilet_travel_folded",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1293,6 +1293,7 @@ void item::add_automatic_whitelist()
     if( pkts.size() == 1 && contents_only_one_type() ) {
         pkts.front()->settings.whitelist_item( contents.first_item().typeId() );
         pkts.front()->settings.set_priority( 100 );
+        pkts.front()->settings.set_collapse( true );
     }
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I got annoyed by having to step past the MRE subcontainers _and_ their contents sealed within when grabbing what I wanted...
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Initially, I just added the COLLAPSE_CONTENT flag to the MRE subcontainers, but @andrei8l made the convincing argument to extend the auto-whitelist logic to also do "sensible" collapsing.

So after implementing the recommended C++ changes, I went over each COLLAPSE_CONTENT entry and culled them if deemed unneccessary. Deemed neccessary are:
- containers expected to contain multiple things that fall under a category/theme that is clearly discernible from the container's name kept the flag
    - stuff like wallets (expected to contain various coins, bank notes, ID cards, etc.), survival knives (survival stuff) and "kit" boxes (MRE package, first aid box/IFAK pouch, lunch box, pencil case, etc.)
- "intended for liquids" containers (bottles, canteens, barrels, etc.) kept their flag (so that a player doesn't have to manually collapse their previously empty barrel now that they poured water into it)

I also made the `wallet_duct_tape` use "extend" for its NO_REPAIR flag instead of overwriting the COLLAPSE_CONTENTS it's inheriting from `wallet`
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Remove COLLAPSE_CONTENTS from the various "ammo can"s, but they can contain "military 5.56 bandolier" which has 4 pockets (that can contain an ammo box each), which the auto-whitelist code ignores, leading to the screenshot below. Changing the auto-whitelist code to go over each pocket of an item seems out-of-scope for this PR (and I'm unsure if it'd be *desired* behavior).
<details>
  <summary>how they can look without the flag</summary>

  ![ammo_can_alternative](https://github.com/user-attachments/assets/34655405-84bd-49b2-abd0-05d2da64733b)


</details>
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
spawned and killed zombie soldiers until they had a full MRE package:

before
![before](https://github.com/user-attachments/assets/0ff03aae-3e44-45d7-b1a6-79931da6d85a)

after
![new_after](https://github.com/user-attachments/assets/8596613b-fc58-44a6-b9db-8032302ecfd5)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
