### PR TITLE
Add recast last spell (Repeat last supernatural ability)

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3283,6 +3283,12 @@
   },
   {
     "type": "keybinding",
+    "id": "recast_spell",
+    "name": "Repeat last supernatural ability",
+    "category": "DEFAULTMODE"
+  },
+  {
+    "type": "keybinding",
     "id": "diary",
     "name": "Open diary / achievements / scores",
     "category": "DEFAULTMODE",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -256,6 +256,8 @@ std::string action_ident( action_id act )
             return "fire_burst";
         case ACTION_CAST_SPELL:
             return "cast_spell";
+        case ACTION_RECAST_SPELL:
+            return "recast_spell";
         case ACTION_SELECT_FIRE_MODE:
             return "select_fire_mode";
         case ACTION_SELECT_DEFAULT_AMMO:
@@ -979,6 +981,7 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_RELOAD_WEAPON );
             REGISTER_ACTION( ACTION_RELOAD_WIELDED );
             REGISTER_ACTION( ACTION_CAST_SPELL );
+            REGISTER_ACTION( ACTION_RECAST_SPELL );
             REGISTER_ACTION( ACTION_SELECT_FIRE_MODE );
             REGISTER_ACTION( ACTION_SELECT_DEFAULT_AMMO );
             REGISTER_ACTION( ACTION_THROW );

--- a/src/action.h
+++ b/src/action.h
@@ -188,6 +188,8 @@ enum action_id : int {
     ACTION_SELECT_DEFAULT_AMMO,
     /** Cast a spell (only if any spells are known) */
     ACTION_CAST_SPELL,
+    /** Recast last spell */
+    ACTION_RECAST_SPELL,
     /** Open the insert-item menu */
     ACTION_INSERT_ITEM,
     /** Unload container in a given direction */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2658,6 +2658,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "throw_wielded" );
     ctxt.register_action( "fire" );
     ctxt.register_action( "cast_spell" );
+    ctxt.register_action( "recast_spell" );
     ctxt.register_action( "fire_burst" );
     ctxt.register_action( "select_fire_mode" );
     ctxt.register_action( "select_default_ammo" );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2489,7 +2489,7 @@ std::vector<spell> Character::spells_known_of_class( const trait_id &spell_class
     return ret;
 }
 
-static void reflesh_favorite( uilist *menu, std::vector<spell *> known_spells )
+static void refresh_favorite( uilist *menu, std::vector<spell *> known_spells )
 {
     for( uilist_entry &entry : menu->entries ) {
         if( get_player_character().magic->is_favorite( known_spells[entry.retval]->id() ) ) {
@@ -2544,7 +2544,7 @@ class spellcasting_callback : public uilist_callback
                 return true;
             } else if( action == "SCROLL_FAVORITE" ) {
                 get_player_character().magic->toggle_favorite( known_spells[entnum]->id() );
-                reflesh_favorite( menu, known_spells );
+                refresh_favorite( menu, known_spells );
             } else if( action == "SCROLL_UP_SPELL_MENU" ) {
                 spell_info_scroll = cataimgui::scroll::line_up;
             } else if( action == "SCROLL_DOWN_SPELL_MENU" ) {
@@ -3045,7 +3045,7 @@ spell &known_magic::select_spell( Character &guy )
         spell_menu.addentry( static_cast<int>( i ), known_spells_sorted[i]->can_cast( guy ),
                              get_invlet( known_spells_sorted[i]->id(), used_invlets ), known_spells_sorted[i]->name() );
     }
-    reflesh_favorite( &spell_menu, known_spells_sorted );
+    refresh_favorite( &spell_menu, known_spells_sorted );
 
     spell_menu.query( true, 50, true );
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -729,6 +729,8 @@ class known_magic
         spell &select_spell( Character &guy );
         // get all known spells
         std::vector<spell *> get_spells();
+        // Last spell casted
+        spell_id last_spell = spell_id::NULL_ID(); // NOLINT(cata-serialize)
         // directly get the character known spells
         std::map<spell_id, spell> &get_spellbook() {
             return spellbook;


### PR DESCRIPTION
#### Summary
Interface "Add recast last spell (Repeat last supernatural ability)"

#### Purpose of change

 - Resolve #78885.
 - Fix typo.

#### Describe the solution

 - Add new variable `spell_id last_spell` to `class known magic` that is not serialized.
 - When a spell is cast from the spell book, the `spell_id` of that spell is saved there.
 - Action for recast reuses `cast_spell`
 - On `recast`
   - If `last_spell` is null, tell the player `Cast a spell first`, just like when recrafting the last recipe.
   - Otherwise, get the spell and cast it. (This should work correctly on level up etc.)

#### Describe alternatives you've considered

Give it a default keybinding.

Expose more keybindings: let the player bind "favourite spell", that is too much noise in the keybindings.

#### Testing

1. Load game.
2. Bind a key to recasting.
3. Use recast.
4. Observe: popup `Cast a spell first` pops up.
5. Cast a spell normally.
6. Recast - works.
7. Cast a different spell.
8. Recast - works.
9. Save & load.
10. Recast.
11. Observe: popup `Cast a spell first` pops up.

I didn't test levelling up.

I don't use spells so I don't know what to test.

#### Additional context

Recrafting a recipe is similar to recasting a spell.

It seems that a lot can be optimized in `src/magic.cpp`.

Probably related: casting Teleportitis 20 times and waiting a while slows the game extremely. It also tears your character apart on the nearest barbered wire.