### PR TITLE
Make pillowcase volume in line with pillow volume

### DIFF
--- a/data/json/items/generic/bedding.json
+++ b/data/json/items/generic/bedding.json
@@ -12,7 +12,7 @@
     "price_postapoc": "2 cent",
     "material": [ "cotton" ],
     "flags": [ "SLEEP_AID_CONTAINER" ],
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "42 L", "max_contains_weight": "15 kg", "moves": 400 } ],
+    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "22 L", "max_contains_weight": "15 kg", "moves": 400 } ],
     "symbol": ")",
     "color": "white",
     "//": "Based on https://www.amazon.com/dp/B01MUDQUN9"


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Close #78645
#### Describe the solution
Since we assuming pillows are now twice as compressed by default, and makeshift pillow is 11L compressed, it would resolve into pillowcase being able to hold 22L
#### Describe alternatives you've considered
Some another number