### PR TITLE
whitelist test failing terrains

### DIFF
--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -14,7 +14,17 @@
       "ravine_floor",
       "ravine_floor_edge",
       "rock_border",
-      "s_restaurant_deserted_test"
+      "s_restaurant_deserted_test",
+      "gunshow_0",
+      "gunshow_1",
+      "gunshow_0_roof",
+      "gunshow_1_roof",
+      "s_reststop_1",
+      "s_reststop_2",
+      "s_reststop_1_roof",
+      "s_reststop_2_roof",
+      "s_restparking_1",
+      "s_restparking_2"
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
Bugfixes "whitelist test failing terrains"

#### Purpose of change

Fix build

#### Describe the solution

Adds the ten terrains that most reliably kill the terrain build test, grabbed from this recent unrelated PR https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12602732715/job/35130919349?pr=78875

#### Describe alternatives you've considered

Just keep rerunning the test until it finally passes
Increase the spawn likelihood for all ten

#### Testing

N/A

#### Additional context

Following these instructions from the test failure output:
To resolve errors about missing terrains you can either give the terrain the
([slow] ~starting_items)=>   SHOULD_NOT_SPAWN flag, intended for terrains that should never spawn, for
([slow] ~starting_items)=>   example test terrains or work in progress, or tweak the constraints so that
([slow] ~starting_items)=>   the terrain can spawn more reliably, or add them to the whitelist at /data/
([slow] ~starting_items)=>   mods/TEST_DATA/overmap_terrain_coverage_test/
([slow] ~starting_items)=>   overmap_terrain_coverage_whitelist.json intended for terrains that sometimes
([slow] ~starting_items)=>   spawn, but cannot be expected to spawn reliably enough for this test.