### PR TITLE
Allow duplicate keys in JSON comments

### DIFF
--- a/data/json/monsters/singularities.json
+++ b/data/json/monsters/singularities.json
@@ -12,7 +12,7 @@
     "weight": "100 kg",
     "phase": "GAS",
     "hp": 250,
-    "//6": "Slowed and weakened by light of sufficient brightness. (It lurks outside of flashlight range) Luring it into a trap is a viable path to killing it.",
+    "//": "Slowed and weakened by light of sufficient brightness. (It lurks outside of flashlight range) Luring it into a trap is a viable path to killing it.",
     "speed": 200,
     "attack_cost": 200,
     "regenerates": 1,
@@ -22,17 +22,17 @@
     "aggression": 100,
     "morale": 300,
     "melee_skill": 10,
-    "//00": "Unfortunately, we do need some melee damage so that it can bash through terrain and the like.",
+    "//": "Unfortunately, we do need some melee damage so that it can bash through terrain and the like.",
     "melee_dice": 2,
     "melee_dice_sides": 2,
-    "//0": "Blob bullshit laughs at concepts like armor. This is basically just here as anti-cheese. It should rarely if ever directly attack you.",
+    "//": "Blob bullshit laughs at concepts like armor. This is basically just here as anti-cheese. It should rarely if ever directly attack you.",
     "melee_damage": [ { "damage_type": "pure", "amount": 1, "armor_penetration": 999 } ],
     "dodge": 10,
     "bleed_rate": 0,
     "vision_day": 50,
     "vision_night": 50,
     "melee_training_cap": 0,
-    "//1": "Try to stay this far away from the player with your regular moves, very important",
+    "//": "Try to stay this far away from the player with your regular moves, very important",
     "tracking_distance": 10,
     "path_settings": {
       "max_dist": 10,
@@ -42,7 +42,7 @@
       "avoid_sharp": true,
       "allow_climb_stairs": true
     },
-    "//2": "TODO? Upgrade doesn't actually work because amalgamations do not have evolutions. Ideally this would upgrade them one step *and also remove their timed lifespan*. If this is added/resolved the spell cooldowns probably need to be nerfed.",
+    "//": "TODO? Upgrade doesn't actually work because amalgamations do not have evolutions. Ideally this would upgrade them one step *and also remove their timed lifespan*. If this is added/resolved the spell cooldowns probably need to be nerfed.",
     "special_attacks": [
       [ "UPGRADE", 20 ],
       {
@@ -103,7 +103,7 @@
       "NOT_HALLUCINATION",
       "PATH_AVOID_DANGER"
     ],
-    "//3": "Explicitly resistant to bullets, meant to be lured into a close encounter(if you can see/engage it at all)",
+    "//": "Explicitly resistant to bullets, meant to be lured into a close encounter(if you can see/engage it at all)",
     "armor": { "cut": 25, "stab": 25, "bash": 25, "bullet": 100 }
   },
   {

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -121,7 +121,7 @@ TextJsonObject::TextJsonObject( TextJsonIn &j )
     while( !jsin->end_object() ) {
         std::string n = jsin->get_member_name();
         int p = jsin->tell();
-        if( positions.count( n ) > 0 ) {
+        if( positions.count( n ) > 0 && !string_starts_with( n, "//" ) ) {
             j.error( "duplicate entry in json object" );
         }
         positions[n] = p;

--- a/src/third-party/flatbuffers/flexbuffers.h
+++ b/src/third-party/flatbuffers/flexbuffers.h
@@ -1137,6 +1137,7 @@ class Builder FLATBUFFERS_FINAL_CLASS {
                 auto bs = reinterpret_cast<const char *>(
                     flatbuffers::vector_data(buf_) + b.key.u_);
                 auto comp = strcmp(as, bs);
+                bool dupe_cdda_json_comment = !strncmp(as, "//", 2) && !strncmp(bs, "//", 2);
                 // We want to disallow duplicate keys, since this results in a
                 // map where values cannot be found.
                 // But we can't assert here (since we don't want to fail on
@@ -1146,7 +1147,7 @@ class Builder FLATBUFFERS_FINAL_CLASS {
                 // TODO: Have to check for pointer equality, as some sort
                 // implementation apparently call this function with the same
                 // element?? Why?
-                if (!comp && &a != &b) has_duplicate_keys_ = true;
+                if (!comp && !dupe_cdda_json_comment && &a != &b) has_duplicate_keys_ = true;
                 return comp < 0;
               });
     // First create a vector out of all keys.


### PR DESCRIPTION
#### Summary
Infrastructure "Allow duplicate keys in JSON comments"

#### Purpose of change
Having to write `//0` and then `//1` and then `//2` for a heavily-commented json object is tedious, often threw errors when editing, and invites pointless reordering of the comments should one of them ever be removed.

#### Describe the solution
Completely ignore all comments for the purposes of checking for duplicate keys. We're not actually reading the values, so we don't care that they're unreachable.

Note: This required a patch to the third-party flatbuffers library. I have separated it out into a separate commit, so it can be easily re-applied if we ever need to change our flatbuffers version. 

To mergers: That means, please do not squash!

#### Describe alternatives you've considered
Doing something more productive with my time than making our JSON comments prettier

#### Testing
I have intentionally duplicated some json comment keys in singularities.json to demonstrate that it no longer throws an error.

#### Additional context
Once more: Please do not squash on merge!
