### PR TITLE
Fix crash when zone-harvesting crops with bad data

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1323,13 +1323,14 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
 
             if( here.has_flag_furn( ter_furn_flag::TFLAG_GROWTH_HARVEST, src_loc ) ) {
                 map_stack items = here.i_at( src_loc );
-                const map_stack::iterator seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
+                const map_stack::iterator seed_iter =
+                std::find_if( items.begin(), items.end(), []( const item & it ) {
                     return it.is_seed();
                 } );
-                if( seed == items.end() ) {
+                if( seed_iter == items.end() ) {
                     debugmsg( "Missing seed item at %s", src_loc.to_string() );
                     return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
-                } else if( seed->has_flag( json_flag_CUT_HARVEST ) ) {
+                } else if( seed_iter->has_flag( json_flag_CUT_HARVEST ) ) {
                     // The plant in this location needs a grass cutting tool.
                     if( you.has_quality( quality_id( qual_GRASS_CUT ), 1 ) ) {
                         return activity_reason_info::ok( do_activity_reason::NEEDS_CUT_HARVESTING );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1326,7 +1326,10 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                 const map_stack::iterator seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
                     return it.is_seed();
                 } );
-                if( seed->has_flag( json_flag_CUT_HARVEST ) ) {
+                if( seed == items.end() ) {
+                    debugmsg( "Missing seed item at %s", src_loc.to_string() );
+                    return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
+                } else if( seed->has_flag( json_flag_CUT_HARVEST ) ) {
                     // The plant in this location needs a grass cutting tool.
                     if( you.has_quality( quality_id( qual_GRASS_CUT ), 1 ) ) {
                         return activity_reason_info::ok( do_activity_reason::NEEDS_CUT_HARVESTING );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix crash when zone-harvesting crops with bad data"

#### Purpose of change
Fixes a crash. A user in the Japanese community discord reported crashing after getting a debugmsg about a seed missing from the a farmed tile. They provided their crash log, and we're unsafely accessing an iterator.

#### Describe the solution
Check if the iterator refers to a valid object before we dereference it with `->`. If we're not referencing a valid object (the seed is missing), still throw an error. Just make sure we don't crash.

Also renamed the local variable while I was here because `seed` is an existing variable name. That sort of overloading can easily cause confusion.

https://github.com/CleverRaven/Cataclysm-DDA/pull/78939/files#diff-4629c96876d1b310426d6e6f9abec605a6477b924994da32377848a88f0547cfL1318

#### Describe alternatives you've considered
Maybe always allow the auto-harvest to succeed on that tile, instead of always fail?

#### Testing
I didn't reproduce or test this, but bad references to iterators are pretty common. Once you've seen one, you've seen 'em all.

#### Additional context
Image of their crash:
![2025-01-04_123954](https://github.com/user-attachments/assets/1253f489-1eb6-4dc3-8c14-c40ced122bf4)

Crash log they provided:
[crash(11).log](https://github.com/user-attachments/files/18306440/crash.11.log)


~~This does not resolve the fact the seed was missing from the plant's tile. I was unable to figure out how that happened.~~ Loss of the seed will be handled in #78960