### PR TITLE
Cache item info, reducing time of crafting filter `d:` to ~32%

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6085,7 +6085,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         // with the inventory display allowing you to select items, showing the things you could make with contained items could be confusing.
         const itype_id &tid = typeId();
         const inventory &crafting_inv = player_character.crafting_inventory();
-        const recipe_subset available_recipe_subset = player_character.get_group_available_recipes();
+        const recipe_subset &available_recipe_subset = player_character.get_group_available_recipes();
         const std::set<const recipe *> &item_recipes = available_recipe_subset.of_component( tid );
 
         insert_separation_line( info );
@@ -6093,6 +6093,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
             info.emplace_back( "DESCRIPTION", _( "You know of nothing you could craft with it." ) );
         } else {
             std::vector<std::string> crafts;
+            crafts.reserve( item_recipes.size() );
             for( const recipe *r : item_recipes ) {
                 const bool can_make = r->deduped_requirements()
                                       .can_make_with_inventory( crafting_inv, r->get_component_filter() );


### PR DESCRIPTION
#### Summary
Performance "Cache item info, reducing time of crafting filter `d:` to ~32%"

#### Purpose of change

 - Crafting filter `d:` is notoriously slow.
 - Item info generates too long #78749 - Didn't measure the results, and there is more to be done.

#### Describe the solution

 - Instead of the copy `const recipe_subset available_recipe_subset`, make it a reference. See testing.
 - Make cache for `can_craft_recipe`, like in #77914
   - With the same impossible-to-achieve bugs https://github.com/CleverRaven/Cataclysm-DDA/pull/77914#issuecomment-2562937420.

#### Describe alternatives you've considered


#### Testing

I had it on for a while and noticed this makes a significant difference for `d:` filter, as shown by profiling:

![image](https://github.com/user-attachments/assets/4dc3d943-920d-445c-bfbb-f230bcc168de)
_Original code._

Note:
1. Line 6102 Makes a copy, but get_group_available_recipes returns a const reference. Takes 20.3 seconds
2. Line 6121 Destroying the copies takes another 9.2 seconds.

![image](https://github.com/user-attachments/assets/ce412e15-fb2f-46cc-bfd4-96df1f4b8155)
_Making it a reference - first commit._

Note:
1. Times on 6102 and (now) 6122 are next to 0 ms, which is 30.4 seconds (or 50%) improvement.
2. But line 6112 now takes 9500ms up from 8500ms.

![image](https://github.com/user-attachments/assets/ef33e112-5bf5-46fc-bdaf-625d662fc7cf)
_Making cache - second commit._

Note:
1. Line (now) 6130 takes only 900ms, which is 9 to 11 times improvement.
2. This line is responsible for making and calling for the cache. Clearly, a single search asks for each `can_make` about 10 times.


#### Additional context

 - This could speed up #78749 too, but I don't care to test it now.
 - More to be done. Can contain is next. Will explain in a future PR.
 - This might be my 100th merged PR for cdda :tada: https://github.com/pulls?q=is%3Amerged+author%3ABrambor+org%3ACleverraven
