### PR TITLE
fix pulping being too fast

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8087,8 +8087,8 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
                 }
 
                 float stamina_ratio = static_cast<float>( you.get_stamina() ) / you.get_stamina_max();
-                moves += 100 / std::max( 0.25f,
-                                         stamina_ratio ) * you.exertion_adjusted_move_multiplier( act.exertion_level() );
+                moves += to_moves<int>( 6_seconds ) / std::max( 0.25f,
+                         stamina_ratio ) * you.exertion_adjusted_move_multiplier( act.exertion_level() );
                 if( stamina_ratio < 0.33 || you.is_npc() ) {
                     you.set_moves( std::min( 0, you.get_moves() - moves ) );
                     return;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
#30253 was a substantial change, but apparently not all stuff that needed update was updated. Apparently pulping speed was left unedited, which shifted then long action to a laughing few seconds
#### Describe the solution
Extend the duration of single corpse punch to 6 seconds instead of 1 second
#### Describe alternatives you've considered
Some another number longer than 1 second
#### Testing
no weapon, default survivor with str 8
| survival level | time before change | time after change |
| -------------- | ------------------ | ----------------- |
| 0               | 8 seconds                | 48 seconds       |
| 5               | 6 seconds                | 36 seconds       |
| 10             | 4 seconds                | 24 seconds       |

the timing is actually pretty inconsistent, there can be cases where you smash the corpse for a 30 seconds, and the second later you smash it for 50 seconds; no real corellation found, but on average it seems to correspond to this table