### PR TITLE
Compute can_holser once per save to speed up `d:` filter from ~20s to ~5s

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5994,15 +5994,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     }
 
     // does the item fit in any holsters?
-    std::vector<const itype *> holsters = Item_factory::find( [this]( const itype & e ) {
-        if( !e.can_use( "holster" ) ) {
-            return false;
-        }
-        const holster_actor *ptr = dynamic_cast<const holster_actor *>
-                                   ( e.get_use( "holster" )->get_actor_ptr() );
-        const item holster_item( &e );
-        return ptr->can_holster( holster_item, *this ) && !item_is_blacklisted( holster_item.typeId() );
-    } );
+    std::vector<const itype *> holsters = item_controller->find_holster_for( *type );
 
     if( !holsters.empty() && parts->test( iteminfo_parts::DESCRIPTION_HOLSTERS ) ) {
         insert_separation_line( info );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4832,6 +4832,7 @@ void Item_factory::reset()
 void Item_factory::clear()
 {
     m_template_groups.clear();
+    type_contained_in_holsters.clear();
 
     iuse_function_list.clear();
 
@@ -5467,6 +5468,27 @@ std::vector<const itype *> Item_factory::find( const std::function<bool( const i
     } );
 
     return res;
+}
+
+const std::vector<const itype *> &Item_factory::find_holster_for( const itype &it )
+{
+    const itype_id iid = it.get_id();
+    if( type_contained_in_holsters.count( iid ) > 0 ) {
+        return type_contained_in_holsters.at( iid );
+    }
+    const item itm( &it );
+
+    type_contained_in_holsters[iid] = Item_factory::find( [&itm]( const itype & e ) {
+        if( !e.can_use( "holster" ) ) {
+            return false;
+        }
+        const holster_actor *ptr = dynamic_cast<const holster_actor *>
+                                   ( e.get_use( "holster" )->get_actor_ptr() );
+        const item holster_item( &e );
+        return ptr->can_holster( holster_item, itm );
+    } );
+
+    return type_contained_in_holsters[iid];
 }
 
 std::list<itype_id> Item_factory::subtype_replacement( const itype_id &base ) const

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -266,6 +266,14 @@ class Item_factory
 
         /** Find all item templates (both static and runtime) matching UnaryPredicate function */
         static std::vector<const itype *> find( const std::function<bool( const itype & )> &func );
+        /**
+         * Find all holsters for itype. Uses type_contained_in_holsters cache, so it's much faster
+         * than constructing the result on the fly.
+         *
+         * This internally constructs an empty item from the itype. It should not be used as replacement
+         * for item::can_holster (for non-empty items). Ignores blacklist too.
+         */
+        const std::vector<const itype *> &find_holster_for( const itype & );
 
         std::list<itype_id> subtype_replacement( const itype_id & ) const;
 
@@ -284,6 +292,9 @@ class Item_factory
 
         std::unordered_map<itype_id, ammotype> migrated_ammo;
         std::unordered_map<itype_id, itype_id> migrated_magazines;
+
+        // cache for holsters
+        std::unordered_map<itype_id, std::vector<const itype *>> type_contained_in_holsters;
 
         /** Checks that ammo is listed in ammunition_type::name().
          * At least one instance of this ammo type should be defined.


### PR DESCRIPTION
#### Summary
Performance "Compute can_holser once per save to speed up `d:` filter from ~20s to ~5s"

#### Purpose of change

 - Speed up  `d:` filter from 20s to 5s (all searches after the first search)
   - The speed up from #78945 is included in the 20s.
 - Speed up info for item (untested): #78749
   - My last step towards it, I will likely test it a bit and then close it.

It is not the purpose, but this PR changes the "Can be stored in" item info:

<details>
TODO: recheck after fixing

 - Before this PR, it checks volume etc. of this item and finds anything this can fit in.
   - ![image](https://github.com/user-attachments/assets/98514ccc-8328-473b-96eb-e997bfc4107b)
_Can be stored for half filled camera bag respects the contents of camera bag._

 - After this PR, only the type is checked, so it lists all items that this item would fit into, if this item was empty. Honestly, I think this is an improvement.
   - ![image](https://github.com/user-attachments/assets/74b9bb67-4a44-4b60-93bc-3bf5d689530a)
_Can be stored for half-filled camera bag behaves as if camera bag was empty._

</details>

Honestly, I think this is an improvement. I expect this menu to be "What could this item fit into" rather than "What does this item fit into right now."

Also, I don't use it and it consumes so much resources for this and item_info. This is a way to keep it and have it fast.

#### Describe the solution

Make a new cache for can_contain for holsters in item_factory. The cache stores all items itype fits into. Since itypes are created on loading a save, we can start caching at that point. Since itypes are frozen, the cache is valid until the save is Quit. (See additional context for `m_runtimes`).

To be done:
 - [ ] Make it work again for non-empty items.
    - By (always) iterating over the given vector of containers and eliminating those we don't fit in)
 - [ ] Make it work again for items smaller than itype suggests.
    - I need to find the optimal solution. Probably figure out the gun is foldable. I hope this will lead me to a universal solution.
    - If item < type, don't use the cache. Unless a better option is found.
 - In light of "make it work again":
   - [ ] Document where the cache doesn't work.
   - [ ] Make a new method `item::contained_in` (name pending) using this cache but making it work for the above two problems.

#### Describe alternatives you've considered

To prevent the change described in purpose:
 - It can be changed though (add a parameter to final_info to use this cache; pass that parameter only from the crafting menu)

#### Testing

1. Open the crafting menu and search using `d:` filter - takes about 20 seconds.
2. Wait a turn to invalidate the search cache. (But not the holster cache!)
3. Search again, takes about 5 seconds from now on.
4. Save and Quit. (Do not turn off the game).
5. Load.
6. It Takes 20 the first time again, indicating the holster cache cleared.

<details>

<summary>Profiling</summary>

First search

![d](https://github.com/user-attachments/assets/c85ae33e-8fc2-4767-855f-6093fc4907eb)

Second+ search

![e](https://github.com/user-attachments/assets/a7f6e3f0-0c09-412c-9a1a-a2535afed043)


</details>


#### Additional context

I do not understand what `m_runtimes` in `src/item_factory.h` are, but I assume they are camp-related.

We discussed it here https://discord.com/channels/598523535169945603/598529174302490644/1325252546281078814

As long as they are not actual items that can contain things, this PR doesn't care. If they are, this should invalidate the cache whenever `m_runtimes` changes.

 - `item_factory::add_item_type` is dead code, see #79004.