### PR TITLE
[Magiclysm] Add a couple more CBMs

### DIFF
--- a/data/mods/Magiclysm/Spells/bionic_spells.json
+++ b/data/mods/Magiclysm/Spells/bionic_spells.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "bio_ley_energy_blaster_spell",
+    "type": "SPELL",
+    "name": { "str": "Levinbolt Projector Targeting", "//~": "NO_I18N" },
+    "description": { "str": "Blast someone with magical energy just like in anime.", "//~": "NO_I18N" },
+    "message": "You unleash a levinbolt.",
+    "valid_targets": [ "ally", "hostile", "ground" ],
+    "flags": [ "SILENT", "RANDOM_DAMAGE", "NO_FAIL" ],
+    "spell_class": "NONE",
+    "effect": "attack",
+    "shape": "line",
+    "damage_type": "nether",
+    "min_damage": 25,
+    "max_damage": 60,
+    "min_range": 8,
+    "max_range": 8,
+    "field_id": "fd_laser",
+    "energy_source": "MANA",
+    "base_casting_time": 25,
+    "base_energy_cost": 75,
+    "min_field_intensity": 2,
+    "max_field_intensity": 2,
+    "field_chance": 1
+  }
+]

--- a/data/mods/Magiclysm/effects/effect_bionics.json
+++ b/data/mods/Magiclysm/effects/effect_bionics.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "effect_bio_mana_to_bionic_power",
+    "type": "effect_type",
+    "//": "Empty effect, used as a tracker",
+    "name": [ "" ],
+    "desc": [ "" ]
+  }
+]

--- a/data/mods/Magiclysm/itemgroups/bionics.json
+++ b/data/mods/Magiclysm/itemgroups/bionics.json
@@ -25,6 +25,7 @@
           { "item": "bio_ethanol", "prob": 50 },
           { "item": "bio_fuel_cell_gasoline", "prob": 50 },
           { "item": "bio_torsionratchet", "prob": 200 },
+          { "item": "bio_mana_to_bionic_power", "prob": 25 },
           { "item": "bio_fuel_cell_blood", "prob": 5 }
         ],
         "prob": 50
@@ -80,9 +81,22 @@
     ]
   },
   {
+    "id": "Zomborg_CBM_harvest_ranged_weapons",
+    "copy-from": "Zomborg_CBM_harvest_ranged_weapons",
+    "type": "item_group",
+    "subtype": "distribution",
+    "extend": { "items": [ { "item": "bio_ley_energy_blaster", "prob": 5 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "EXODII_CBM_Store_Tier2",
+    "copy-from": "EXODII_CBM_Store_Tier2",
+    "extend": { "items": [ { "item": "bio_mana_to_bionic_power", "prob": 10 } ] }
+  },
+  {
     "type": "item_group",
     "id": "EXODII_CBM_Store_Tier3",
     "copy-from": "EXODII_CBM_Store_Tier3",
-    "extend": { "items": [ { "item": "bio_see_wizards_eyes", "prob": 10 } ] }
+    "extend": { "items": [ { "item": "bio_see_wizards_eyes", "prob": 10 }, { "item": "bio_ley_energy_blaster", "prob": 10 } ] }
   }
 ]

--- a/data/mods/Magiclysm/itemgroups/harvest_cbm.json
+++ b/data/mods/Magiclysm/itemgroups/harvest_cbm.json
@@ -20,6 +20,7 @@
     "entries": [
       { "item": "bio_ethanol", "prob": 50 },
       { "item": "bio_fuel_cell_gasoline", "prob": 50 },
+      { "item": "bio_mana_to_bionic_power", "prob": 25 },
       { "item": "bio_fuel_cell_blood", "prob": 5 },
       { "item": "bio_torsionratchet", "prob": 200 }
     ]

--- a/data/mods/Magiclysm/items/bionics.json
+++ b/data/mods/Magiclysm/items/bionics.json
@@ -139,15 +139,5 @@
     "occupied_bodyparts": [ [ "arm_l", 2 ], [ "arm_r", 2 ], [ "hand_l", 1 ], [ "hand_r", 1 ] ],
     "spell_on_activation": "bio_ley_energy_blaster_spell",
     "activated_close_ui": true
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_BIO_LEY_ENERGY_BLASTER",
-    "condition": { "math": [ "u_val('mana')", ">", "75" ] },
-    "effect": [
-      { "u_cast_spell": { "id": "bio_ley_energy_blaster_spell" }, "targeted": true },
-      { "math": [ "u_val('mana')", "-=", "75" ] }
-    ],
-    "false_effect": { "u_message": "You don't have enough mana to power your levinbolt projector!", "type": "bad" }
   }
 ]

--- a/data/mods/Magiclysm/items/bionics.json
+++ b/data/mods/Magiclysm/items/bionics.json
@@ -137,7 +137,7 @@
     "name": { "str": "Levinbolt Projector" },
     "description": "Implants in your arm's ley lines allow you to project bolts of magical energy from your hands.  This draws on your personal mana stores, not your bionic power.",
     "occupied_bodyparts": [ [ "arm_l", 2 ], [ "arm_r", 2 ], [ "hand_l", 1 ], [ "hand_r", 1 ] ],
-    "spell_on_activation": "bio_ley_energy_blaster_spell",
+    "spell_on_activation": { "id": "bio_ley_energy_blaster_spell" },
     "activated_close_ui": true
   }
 ]

--- a/data/mods/Magiclysm/items/bionics.json
+++ b/data/mods/Magiclysm/items/bionics.json
@@ -74,5 +74,81 @@
         "descriptions": [ { "id": "fae_sense", "symbol": "?", "color": "cyan", "text": "You see the ley lines of a wielder of magic." } ]
       }
     ]
+  },
+  {
+    "id": "bio_mana_to_bionic_power",
+    "copy-from": "bionic_general",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Corporeal Ley Tap CBM" },
+    "description": "For those who have no use for their mana, this bionic allows the user to convert mana directly into bionic power.  Though the conversion rate is inefficient, mana is free.",
+    "price": "5 kUSD 500 USD",
+    "weight": "500 g",
+    "difficulty": 6
+  },
+  {
+    "id": "bio_mana_to_bionic_power",
+    "type": "bionic",
+    "name": { "str": "Corporeal Ley Tap" },
+    "description": "Tiny bits of orichalcum have been implanted at important intersections in your ley lines, allowing you to turn your mana into bionic power.  Activate to begin the conversion process.",
+    "occupied_bodyparts": [ [ "head", 1 ], [ "torso", 1 ], [ "arm_l", 1 ], [ "arm_r", 1 ], [ "leg_l", 1 ], [ "leg_r", 1 ] ],
+    "mutation_conflicts": [ "EARTHSHAPER" ],
+    "activated_eocs": [ "EOC_BIO_MANA_TO_BIONIC_POWER_ON" ],
+    "deactivated_eocs": [ "EOC_BIO_MANA_TO_BIONIC_POWER_OFF" ],
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BIO_MANA_TO_BIONIC_POWER_ON",
+    "effect": [
+      { "u_add_effect": "effect_bio_mana_to_bionic_power", "duration": "PERMANENT" },
+      { "run_eocs": "EOC_BIO_MANA_TO_BIONIC_POWER_PROCESSING", "time_in_future": 10 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BIO_MANA_TO_BIONIC_POWER_PROCESSING",
+    "condition": { "u_has_effect": "effect_bio_mana_to_bionic_power" },
+    "effect": [
+      {
+        "if": { "math": [ "u_val('mana')", ">", "0" ] },
+        "then": [ { "math": [ "u_val('mana')", "--" ] }, { "math": [ "u_val('power')", "+=", "energy('35  J')" ] } ]
+      },
+      { "run_eocs": "EOC_BIO_MANA_TO_BIONIC_POWER_PROCESSING", "time_in_future": 10 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BIO_MANA_TO_BIONIC_POWER_OFF",
+    "effect": [ { "u_lose_effect": "effect_bio_mana_to_bionic_power" } ]
+  },
+  {
+    "id": "bio_ley_energy_blaster",
+    "copy-from": "bionic_general",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Levinbolt Projector CBM" },
+    "description": "The ultimate in concealable personal defense, thin filaments are implanted along the ley lines in both of your arms leading to embedded mana crystals in your hands, allowing you to launch blasts of pure magical energy at nearby targets.  The only disadvantage is that it draws on your own personal mana supply rather than bionic power.",
+    "price": "3 kUSD",
+    "weight": "500 g",
+    "difficulty": 4
+  },
+  {
+    "id": "bio_ley_energy_blaster",
+    "type": "bionic",
+    "name": { "str": "Levinbolt Projector" },
+    "description": "Implants in your arm's ley lines allow you to project bolts of magical energy from your hands.  This draws on your personal mana stores, not your bionic power.",
+    "occupied_bodyparts": [ [ "arm_l", 2 ], [ "arm_r", 2 ], [ "hand_l", 1 ], [ "hand_r", 1 ] ],
+    "mutation_conflicts": [ "ANIMIST" ],
+    "spell_on_activation": "bio_ley_energy_blaster_spell",
+    "activated_close_ui": true
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BIO_LEY_ENERGY_BLASTER",
+    "condition": { "math": [ "u_val('mana')", ">", "75" ] },
+    "effect": [
+      { "u_cast_spell": { "id": "bio_ley_energy_blaster_spell" }, "targeted": true },
+      { "math": [ "u_val('mana')", "-=", "75" ] }
+    ],
+    "false_effect": { "u_message": "You don't have enough mana to power your levinbolt projector!", "type": "bad" }
   }
 ]

--- a/data/mods/Magiclysm/items/bionics.json
+++ b/data/mods/Magiclysm/items/bionics.json
@@ -137,7 +137,6 @@
     "name": { "str": "Levinbolt Projector" },
     "description": "Implants in your arm's ley lines allow you to project bolts of magical energy from your hands.  This draws on your personal mana stores, not your bionic power.",
     "occupied_bodyparts": [ [ "arm_l", 2 ], [ "arm_r", 2 ], [ "hand_l", 1 ], [ "hand_r", 1 ] ],
-    "mutation_conflicts": [ "ANIMIST" ],
     "spell_on_activation": "bio_ley_energy_blaster_spell",
     "activated_close_ui": true
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add a couple more CBMs"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had more CBM ideas, since Magiclysm's world would have some magitech CBMs available.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add two CBMs. Have more ideas but I'm trying to pull back on "here's 30 new things, good luck with that reviewers" PRs

1. Corporeal Ley Tap CBM--convert mana into bionic power. The conversion rate is not great--every 10 seconds, 1 mana becomes 35 J of power, so a 1500 mana bar is only 52.5 kJ--but on the other hand, mana is always available and comes back to you for free, so if you don't need it you can just turn it into CBM juice. 
2. Levinbolt Projector CBM--shoot magical bolts from your hands. This CBM is powered by actual mana, so if you're fully cybered up it's not that useful. 

You can find the former in the augmentation clinic, but the latter has to be bought from the Exodii or pulled out of people (something tells me Massachusetts law would frown on fully-concealed cybernetic weapons in a world where those exist, so it'd need military CBM locations for it to be found in the world).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Both CBMs work. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Spells cast by CBM activation are full spells with costs and everything, not `fake_spell`s, which made this a lot easier. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
