### PR TITLE
Apply Clang-Tidy and VS static analysis suggestions.

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -550,7 +550,7 @@ class requirement_watcher : stat_watcher
 
         void new_value( const cata_variant &new_value, stats_tracker & ) override;
 
-        bool is_satisfied( stats_tracker &/*stats*/ ) {
+        bool is_satisfied( stats_tracker &/*stats*/ ) const {
             return requirement_->satisfied_by( current_value_ );
         }
 

--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -80,7 +80,7 @@ bool string_id<achievement>::is_valid() const
     return achievement_factory.is_valid( *this );
 }
 
-enum class requirement_visibility : int {
+enum class requirement_visibility : std::uint8_t {
     always,
     when_requirement_completed,
     when_achievement_completed,

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -33,7 +33,7 @@ class event;
 class requirement_watcher;
 class stats_tracker;
 
-enum class achievement_comparison : int {
+enum class achievement_comparison : std::uint8_t {
     equal,
     less_equal,
     greater_equal,
@@ -46,7 +46,7 @@ struct enum_traits<achievement_comparison> {
     static constexpr achievement_comparison last = achievement_comparison::last;
 };
 
-enum class achievement_completion : int {
+enum class achievement_completion : std::uint8_t {
     pending,
     completed,
     failed,
@@ -94,7 +94,7 @@ class achievement
         class time_bound
         {
             public:
-                enum class epoch : int {
+                enum class epoch : std::uint8_t {
                     cataclysm,
                     game_start,
                     last

--- a/src/action.h
+++ b/src/action.h
@@ -574,7 +574,7 @@ std::string press_x( action_id act, const std::string &act_desc );
 std::optional<std::string> press_x_if_bound( action_id act );
 
 // only has effect in iso mode
-enum class iso_rotate : int {
+enum class iso_rotate : std::uint8_t {
     no,
     yes
 };

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -25,7 +25,7 @@ struct item_reference {
     bool has_watertight_container() const;
 };
 
-enum class special_item_type : int {
+enum class special_item_type : std::uint8_t {
     none,
     corpse,
     explosive

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -818,14 +818,14 @@ void hacking_activity_actor::start( player_activity &act, Character & )
     act.moves_left = to_moves<int>( 5_minutes );
 }
 
-enum class hack_result : int {
+enum class hack_result : std::uint8_t {
     UNABLE,
     FAIL,
     NOTHING,
     SUCCESS
 };
 
-enum class hack_type : int {
+enum class hack_type : std::uint8_t {
     SAFE,
     DOOR,
     GAS,
@@ -7220,7 +7220,7 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
 
 void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
 {
-    enum activity_stage : int {
+    enum activity_stage : std::uint8_t {
         //Initial stage
         INIT = 0,
         //Think about what to do first: choose destination

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4166,7 +4166,7 @@ static void debug_drop_list( const std::vector<drop_or_stash_item_info> &items )
 
     std::string res( "Items ordered to drop:\n" );
     for( const drop_or_stash_item_info &it : items ) {
-        item_location loc = it.loc();
+        const item_location &loc = it.loc();
         if( !loc ) {
             // some items could have been destroyed by e.g. monster attack
             continue;
@@ -5730,7 +5730,7 @@ void outfit_swap_actor::finish( player_activity &act, Character &who )
     // Taken-off items are put in this temporary list, then naturally deleted from the world when the function returns.
     std::list<item> it_list;
     for( item_location &worn_item : who.get_visible_worn_items() ) {
-        item outfit_component( *worn_item );
+        const item &outfit_component( *worn_item );
         if( who.takeoff( worn_item, &it_list ) ) {
             ground->force_insert_item( outfit_component, pocket_type::CONTAINER );
         }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -467,7 +467,7 @@ class bikerack_unracking_activity_actor : public activity_actor
 class read_activity_actor : public activity_actor
 {
     public:
-        enum class book_type : int { normal, martial_art };
+        enum class book_type : std::uint8_t { normal, martial_art };
 
         read_activity_actor() = default;
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3105,7 +3105,7 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
     - str_values[2]: installer_name
     - str_values[3]: bool autodoc
     */
-    enum operation_values_ids {
+    enum operation_values_ids : std::uint8_t {
         operation_type = 0,
         cbm_id = 1,
         installer_name = 2,

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -39,7 +39,7 @@ std::vector<Point> get_sorted_tiles_by_distance( const Point &center, const Cont
 
 std::vector<tripoint_bub_ms> route_adjacent( const Character &you, const tripoint_bub_ms &dest );
 
-enum class requirement_check_result : int {
+enum class requirement_check_result : std::uint8_t {
     SKIP_LOCATION = 0,
     SKIP_LOCATION_NO_ZONE,  // Zone activity but no zone found
     SKIP_LOCATION_NO_SKILL, // Insufficient npc skill for task.
@@ -51,7 +51,7 @@ enum class requirement_check_result : int {
     RETURN_EARLY       //another activity like a fetch activity has been started.
 };
 
-enum class butcher_type : int {
+enum class butcher_type : std::uint8_t {
     BLEED,          // bleeding a corpse
     QUICK,          // quick butchery
     FULL,           // full workshop butchery
@@ -63,7 +63,7 @@ enum class butcher_type : int {
     NUM_TYPES       // always keep at the end, number of butchery types
 };
 
-enum class do_activity_reason : int {
+enum class do_activity_reason : std::uint8_t {
     CAN_DO_CONSTRUCTION,    // Can do construction.
     CAN_DO_FETCH,           // Can do fetch - this is usually the default result for fetch task
     NO_COMPONENTS,          // can't do the activity there due to lack of components /tools
@@ -176,7 +176,7 @@ int get_auto_consume_moves( Character &you, bool food );
 bool try_fuel_fire( player_activity &act, Character &you, bool starting_fire = false );
 double butcher_get_progress( const item &corpse_item, butcher_type action );
 
-enum class item_drop_reason : int {
+enum class item_drop_reason : std::uint8_t {
     deliberate,
     too_large,
     too_heavy,

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2008,7 +2008,7 @@ static bool chop_plank_activity( Character &you, const tripoint_bub_ms &src_loc 
 
 void activity_on_turn_move_loot( player_activity &act, Character &you )
 {
-    enum activity_stage : int {
+    enum activity_stage : std::uint8_t {
         //Initial stage
         INIT = 0,
         //Think about what to do first: choose destination

--- a/src/activity_type.h
+++ b/src/activity_type.h
@@ -22,7 +22,7 @@ using activity_id = string_id<activity_type>;
 template<>
 const activity_type &string_id<activity_type>::obj() const;
 
-enum class based_on_type : int {
+enum class based_on_type : std::uint8_t {
     TIME = 0,
     SPEED,
     NEITHER,

--- a/src/advanced_inv.h
+++ b/src/advanced_inv.h
@@ -50,7 +50,7 @@ class advanced_inventory
         /**
          * Refers to the two panes, used as index into @ref panes.
          */
-        enum side {
+        enum side : std::uint8_t {
             left  = 0,
             right = 1,
             NUM_PANES = 2

--- a/src/advanced_inv_pane.h
+++ b/src/advanced_inv_pane.h
@@ -19,7 +19,7 @@ struct advanced_inv_pane_save_state;
 
 enum aim_location : char;
 
-enum advanced_inv_sortby {
+enum advanced_inv_sortby : std::uint8_t {
     SORTBY_NONE,
     SORTBY_NAME,
     SORTBY_WEIGHT,

--- a/src/animation.h
+++ b/src/animation.h
@@ -7,7 +7,7 @@
 
 #include "color.h"
 
-enum explosion_neighbors {
+enum explosion_neighbors : std::uint8_t {
     N_NO_NEIGHBORS = 0,
     N_NORTH = 1,
 

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -376,7 +376,7 @@ void avatar::on_mission_finished( mission &cur_mission )
     }
 }
 
-bool avatar::has_mission_id( const mission_type_id &miss_id )
+bool avatar::has_mission_id( const mission_type_id &miss_id ) const
 {
     for( mission *miss : active_missions ) {
         if( miss->mission_id() == miss_id ) {

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -190,7 +190,7 @@ class avatar : public Character
         /**
          * Returns true if character has the mission in their active missions list.
          */
-        bool has_mission_id( const mission_type_id &miss_id );
+        bool has_mission_id( const mission_type_id &miss_id ) const;
 
         void remove_active_mission( mission &cur_mission );
 

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -54,7 +54,7 @@ namespace debug_menu
 {
 class mission_debug;
 }  // namespace debug_menu
-enum class pool_type;
+enum class pool_type : std::uint8_t;
 
 // Monster visible in different directions (safe mode & compass)
 // Suppressions due to a bug in clang-tidy 12

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -605,7 +605,7 @@ std::vector<npc_ptr> basecamp::get_npcs_assigned()
     return assigned_npcs;
 }
 
-void basecamp::hide_mission( ui_mission_id id )
+void basecamp::hide_mission( const ui_mission_id &id )
 {
     const base_camps::direction_data &base_data = base_camps::all_directions.at( id.id.dir.value() );
     for( ui_mission_id &miss_id : hidden_missions[size_t( base_data.tab_order )] ) {
@@ -616,7 +616,7 @@ void basecamp::hide_mission( ui_mission_id id )
     hidden_missions[size_t( base_data.tab_order )].push_back( id );
 }
 
-void basecamp::reveal_mission( ui_mission_id id )
+void basecamp::reveal_mission( const ui_mission_id &id )
 {
     const base_camps::direction_data &base_data = base_camps::all_directions.at( id.id.dir.value() );
     for( auto it = hidden_missions[size_t( base_data.tab_order )].begin();
@@ -629,7 +629,7 @@ void basecamp::reveal_mission( ui_mission_id id )
     debugmsg( "Trying to reveal revealed mission.  Has no effect." );
 }
 
-bool basecamp::is_hidden( ui_mission_id id )
+bool basecamp::is_hidden( const ui_mission_id &id )
 {
     if( hidden_missions.empty() ) {
         return false;

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -472,9 +472,9 @@ class basecamp
         void add_assignee( character_id id );
         void remove_assignee( character_id id );
         std::vector<npc_ptr> get_npcs_assigned();
-        void hide_mission( ui_mission_id id );
-        void reveal_mission( ui_mission_id id );
-        bool is_hidden( ui_mission_id id );
+        void hide_mission( const ui_mission_id &id );
+        void reveal_mission( const ui_mission_id &id );
+        bool is_hidden( const ui_mission_id &id );
         // Save/load
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &data );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -42,7 +42,7 @@ class recipe;
 class time_duration;
 class zone_data;
 struct MonsterGroupResult;
-enum class farm_ops;
+enum class farm_ops : std::uint8_t;
 
 using faction_id = string_id<faction>;
 
@@ -72,7 +72,7 @@ class window;
 namespace base_camps
 {
 
-enum tab_mode : int {
+enum tab_mode : std::uint8_t {
     TAB_MAIN,
     TAB_N,
     TAB_NE,

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -55,11 +55,11 @@ bionic_chars( "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\"#&()*+./:;@
 
 namespace
 {
-enum bionic_tab_mode {
+enum bionic_tab_mode : std::uint8_t {
     TAB_ACTIVE,
     TAB_PASSIVE
 };
-enum bionic_menu_mode {
+enum bionic_menu_mode : std::uint8_t {
     ACTIVATING,
     EXAMINING,
     REASSIGNING

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -48,7 +48,7 @@ extern const bodypart_str_id body_part_foot_r;
 extern const sub_bodypart_str_id sub_body_part_sub_limb_debug;
 
 // The order is important ; pldata.h has to be in the same order
-enum body_part : int {
+enum body_part : std::uint8_t {
     bp_torso = 0,
     bp_head,
     bp_eyes,
@@ -72,7 +72,7 @@ struct enum_traits<body_part> {
 enum class side : int;
 
 // Drench cache
-enum water_tolerance {
+enum water_tolerance : std::uint8_t {
     WT_IGNORED = 0,
     WT_NEUTRAL,
     WT_GOOD,
@@ -176,7 +176,7 @@ struct body_part_type {
          * the different types of body parts there are.
          * this allows for the ability to group limbs or determine a limb of a certain type
          */
-        enum class type {
+        enum class type : std::uint8_t {
             // this is where helmets go, and is a vital part.
             head,
             // the torso is generally the center of mass of a creature

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -69,7 +69,7 @@ struct enum_traits<body_part> {
     static constexpr body_part last = body_part::num_bp;
 };
 
-enum class side : int;
+enum class side : std::uint8_t;
 
 // Drench cache
 enum water_tolerance : std::uint8_t {

--- a/src/bonuses.h
+++ b/src/bonuses.h
@@ -12,7 +12,7 @@ class Character;
 class JsonArray;
 class JsonObject;
 
-enum scaling_stat : int {
+enum scaling_stat : std::uint8_t {
     STAT_NULL = 0,
     STAT_STR,
     STAT_DEX,
@@ -39,7 +39,7 @@ enum scaling_stat : int {
     NUM_STATS
 };
 
-enum class affected_stat : int {
+enum class affected_stat : std::uint8_t {
     NONE = 0,
     HIT,
     CRITICAL_HIT_CHANCE,

--- a/src/butchery_requirements.h
+++ b/src/butchery_requirements.h
@@ -13,7 +13,7 @@
 class JsonObject;
 class read_only_visitable;
 
-enum class butcher_type : int;
+enum class butcher_type : std::uint8_t;
 enum class creature_size : int;
 
 /**

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -39,7 +39,7 @@ extern std::vector<std::string> damage_indicators;
 // test_mode is not a regular game option; it's true when we are running unit
 // tests.
 extern bool test_mode;
-enum class test_mode_spilling_action_t {
+enum class test_mode_spilling_action_t : std::uint8_t {
     spill_all,
     cancel_spill,
 };
@@ -47,7 +47,7 @@ extern test_mode_spilling_action_t test_mode_spilling_action;
 
 extern bool direct3d_mode;
 
-enum class error_log_format_t {
+enum class error_log_format_t : std::uint8_t {
     human_readable,
     // Output error messages in github action command format (currently json only)
     // See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
@@ -59,7 +59,7 @@ extern error_log_format_t error_log_format;
 constexpr error_log_format_t error_log_format = error_log_format_t::human_readable;
 #endif
 
-enum class check_plural_t {
+enum class check_plural_t : std::uint8_t {
     none,
     certain, // report strings that certainly have a non-regular plural form, such as those ending in "s"
     possible, // report strings that may or may not have a non-regular plural form, such as those containing the word "of"

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -18,7 +18,7 @@ class time_point;
 template<typename T> struct enum_traits;
 
 /** Real world seasons */
-enum season_type {
+enum season_type : std::uint8_t {
     SPRING = 0,
     SUMMER = 1,
     AUTUMN = 2,
@@ -32,7 +32,7 @@ struct enum_traits<season_type> {
 };
 
 /** Phases of the moon */
-enum moon_phase {
+enum moon_phase : std::uint8_t {
     /** New (completely dark) moon */
     MOON_NEW = 0,
     /** One quarter of moon lit, amount lit is increasing every day */
@@ -53,7 +53,7 @@ enum moon_phase {
     MOON_PHASE_MAX
 };
 
-enum class time_accuracy {
+enum class time_accuracy : std::uint8_t {
     /** No accuracy, no idea what time it is **/
     NONE = 0,
     /** Estimated time, can see the sky **/
@@ -400,13 +400,13 @@ constexpr time_duration operator""_weeks( const unsigned long long int v )
  */
 std::string to_string( const time_duration &d, bool compact = false );
 
-enum class clipped_align : int {
+enum class clipped_align : std::uint8_t {
     none,
     right,
     compact
 };
 
-enum class clipped_unit : int {
+enum class clipped_unit : std::uint8_t {
     forever,
     second,
     minute,
@@ -637,7 +637,7 @@ std::pair<units::angle, units::angle> sun_azimuth_altitude( time_point );
  */
 std::optional<rl_vec2d> sunlight_angle( const time_point & );
 
-enum class weekdays : int {
+enum class weekdays : std::uint8_t {
     SUNDAY = 0,
     MONDAY,
     TUESDAY,

--- a/src/calendar_ui.h
+++ b/src/calendar_ui.h
@@ -10,7 +10,7 @@
 namespace calendar_ui
 {
 
-enum class granularity : int {
+enum class granularity : std::uint8_t {
     year,
     season,
     day,

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -37,14 +37,14 @@ struct bounds {
     float h;
 };
 
-enum class mbox_btn {
+enum class mbox_btn : std::uint8_t {
     BT_OK = 0,
     BT_OKCancel = 1,
     BT_YesNoCancel = 2,
     BT_YesNo = 3
 };
 
-enum class dialog_result {
+enum class dialog_result : std::uint8_t {
     None = 0,
     OKClicked,
     CancelClicked,
@@ -52,7 +52,7 @@ enum class dialog_result {
     NoClicked
 };
 
-enum class scroll : int {
+enum class scroll : std::uint8_t {
     none = 0,
     begin,
     end,

--- a/src/cata_path.h
+++ b/src/cata_path.h
@@ -36,7 +36,7 @@ class cata_path
         // All of these represent configurable filesystem locations for various pieces
         // of data. The default locations may all be subfolders of `base`, but they can
         // be overridden or default to other filesystem locations.
-        enum class root_path {
+        enum class root_path : std::uint8_t {
             base,
             config,
             data,

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -108,10 +108,10 @@ class tile_lookup_res
         tile_type *_tile;
     public:
         tile_lookup_res( const std::string &id, tile_type &tile ): _id( &id ), _tile( &tile ) {}
-        inline const std::string &id() {
+        inline const std::string &id() const {
             return *_id;
         }
-        inline tile_type &tile() {
+        inline tile_type &tile() const {
             return *_tile;
         }
 };
@@ -435,7 +435,7 @@ class cata_tiles
         void on_options_changed();
 
         // checks if the tileset_ptr is valid
-        bool is_valid() {
+        bool is_valid() const {
             return tileset_ptr != nullptr;
         }
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -52,7 +52,7 @@ struct tile_type {
 };
 
 // Make sure to change TILE_CATEGORY_IDS if this changes!
-enum class TILE_CATEGORY {
+enum class TILE_CATEGORY : std::uint8_t {
     NONE,
     VEHICLE_PART,
     TERRAIN,
@@ -93,7 +93,7 @@ const std::unordered_map<std::string, TILE_CATEGORY> to_TILE_CATEGORY = {
     {"overmap_note", TILE_CATEGORY::OVERMAP_NOTE}
 };
 
-enum class NEIGHBOUR {
+enum class NEIGHBOUR : std::uint8_t {
     SOUTH = 1,
     EAST = 2,
     WEST = 4,
@@ -393,7 +393,7 @@ class tileset_cache::loader
                    bool terrain = false );
 };
 
-enum class text_alignment : int {
+enum class text_alignment : std::uint8_t {
     left,
     center,
     right,

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -51,7 +51,7 @@ struct null_deleter {
  * Type of object that a measurement is taken on.  Used, for example, to display wind speed in m/s
  * while displaying vehicle speed in km/h.
  */
-enum units_type {
+enum units_type : std::uint8_t {
     VU_VEHICLE,
     VU_WIND
 };

--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -23,17 +23,17 @@ class JsonOut;
 class JsonValue;
 template <typename E> struct enum_traits;
 
-enum class mutagen_technique : int;
+enum class mutagen_technique : std::uint8_t;
 
 namespace debug_menu
 {
-enum class debug_menu_index : int;
+enum class debug_menu_index : std::uint8_t;
 } // namespace debug_menu
 
 // cata_variant is a variant-like type that stores a variety of different cata
 // types.  All types are stored by converting them to a string.
 
-enum class cata_variant_type : int {
+enum class cata_variant_type : std::uint8_t {
     void_, // Special type for empty variants
     achievement_id,
     activity_id,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13365,7 +13365,7 @@ static std::string wrap60( const std::string &text )
 
 bool character_martial_arts::pick_style( const Character &you ) // Style selection menu
 {
-    enum style_selection {
+    enum style_selection : std::uint8_t {
         KEEP_HANDS_FREE = 0,
         STYLE_OFFSET
     };

--- a/src/character.h
+++ b/src/character.h
@@ -4054,7 +4054,7 @@ class Character : public Creature, public visitable
          * Clothing layers are multiplied, ex. two layers of 50% coverage will leave only 25% exposed.
          * Used to determine suffering effects of albinism and solar sensitivity.
          */
-        std::map<bodypart_id, float> bodypart_exposure();
+        std::map<bodypart_id, float> bodypart_exposure() const;
     private:
         /**
          * Check whether the other creature is in range and can be seen by this creature.

--- a/src/character.h
+++ b/src/character.h
@@ -129,7 +129,7 @@ constexpr float KCAL_PER_KG = 3500 * 2.20462;
 
 /// @brief type of conditions that effect vision
 /// @note vision modes do not necessarily match json ids or flags
-enum vision_modes {
+enum vision_modes : std::uint8_t {
     DEBUG_NIGHTVISION,
     NV_GOGGLES,
     NIGHTVISION_1,
@@ -234,7 +234,7 @@ constexpr inline int operator-( const T &lhs, const sleepiness_levels &rhs )
     long periods of time
     @see https://github.com/CleverRaven/Cataclysm-DDA/blob/master/src/character.cpp#L5566
 */
-enum sleep_deprivation_levels {
+enum sleep_deprivation_levels : int {
     /// 2 days
     SLEEP_DEPRIVATION_HARMLESS = 2 * 24 * 60,
     /// 4 days
@@ -247,7 +247,7 @@ enum sleep_deprivation_levels {
     SLEEP_DEPRIVATION_MASSIVE = 14 * 24 * 60
 };
 
-enum class blood_type {
+enum class blood_type : std::uint8_t {
     blood_O,
     blood_A,
     blood_B,
@@ -263,7 +263,7 @@ struct enum_traits<blood_type> {
 /// @brief how digestible or palatable an item is
 /// @details This tries to represent both rating and character's decision to respect said rating
 /// (ie "they can eat it, though they are disgusted by it")
-enum edible_rating {
+enum edible_rating : std::uint8_t {
     /// Edible or we pretend it is
     EDIBLE,
     /// Not food at all
@@ -288,7 +288,7 @@ enum edible_rating {
     NO_TOOL
 };
 
-enum crush_tool_type {
+enum crush_tool_type : std::uint8_t {
     CRUSH_EMPTY_HANDS,
     CRUSH_HAMMER,
     CRUSH_DRILL_OR_HAMMER_AND_SCREW,
@@ -443,21 +443,21 @@ enum class character_stat : char {
     DUMMY_STAT
 };
 
-enum class customize_appearance_choice : int {
+enum class customize_appearance_choice : std::uint8_t {
     EYES, // customize eye color
     HAIR, // customize hair
     HAIR_F, // customize facial hair
     SKIN  // customize skin color
 };
 
-enum class book_mastery {
+enum class book_mastery : std::uint8_t {
     CANT_DETERMINE, // book not yet identified, so you don't know yet
     CANT_UNDERSTAND, // does not have enough skill to read
     LEARNING,
     MASTERED // can no longer increase skill by reading
 };
 
-enum class read_condition_result {
+enum class read_condition_result : std::uint16_t {
     SUCCESS = 0,
     NOT_BOOK = 1 << 0,
     CANT_UNDERSTAND = 1 << 1,

--- a/src/character.h
+++ b/src/character.h
@@ -112,11 +112,11 @@ struct trap;
 struct w_point;
 template <typename E> struct enum_traits;
 
-enum npc_attitude : int;
+enum npc_attitude : std::uint8_t;
 enum action_id : int;
-enum class recipe_filter_flags : int;
-enum class steed_type : int;
-enum class proficiency_bonus_type : int;
+enum class recipe_filter_flags : std::uint8_t;
+enum class steed_type : std::uint8_t;
+enum class proficiency_bonus_type : std::uint8_t;
 
 using drop_location = std::pair<item_location, int>;
 using drop_locations = std::list<drop_location>;

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2473,7 +2473,7 @@ void outfit::write_text_memorial( std::ostream &file, const std::string &indent,
                                   const char *eol ) const
 {
     for( const item &elem : worn ) {
-        item next_item = elem;
+        const item &next_item = elem;
         file << indent << next_item.invlet << " - " << next_item.tname( 1, false );
         if( next_item.charges > 0 ) {
             file << " (" << next_item.charges << ")";

--- a/src/character_modifier.h
+++ b/src/character_modifier.h
@@ -18,7 +18,7 @@ template <typename T> class generic_factory;
 
 struct character_modifier {
     public:
-        enum mod_type {
+        enum mod_type : std::uint8_t {
             NONE,
             ADD,
             MULT

--- a/src/climbing.cpp
+++ b/src/climbing.cpp
@@ -219,7 +219,7 @@ void climbing_aid::down_t::deserialize( const JsonObject &jo )
                 jo.throw_error( str_cat( "failed to read optional member \"menu_hotkey\"" ) );
             }
         }
-        if( menu_hotkey_str.length() ) {
+        if( menu_hotkey_str.empty() ) {
             menu_hotkey = std::uint8_t( menu_hotkey_str[ 0 ] );
         }
 

--- a/src/climbing.h
+++ b/src/climbing.h
@@ -26,7 +26,7 @@ class JsonObject;
 class climbing_aid
 {
     public:
-        enum class category {
+        enum class category : std::uint8_t {
             special = 0,
             ter_furn,
             veh,

--- a/src/clothing_mod.h
+++ b/src/clothing_mod.h
@@ -16,7 +16,7 @@ class JsonObject;
 class item;
 template<typename T> struct enum_traits;
 
-enum clothing_mod_type : int {
+enum clothing_mod_type : std::uint8_t {
     clothing_mod_type_acid,
     clothing_mod_type_fire,
     clothing_mod_type_bash,

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -127,7 +127,7 @@ class plot_options : public zone_options, public mark_option
         itype_id mark;
         itype_id seed;
 
-        enum query_seed_result {
+        enum query_seed_result : std::uint8_t {
             canceled,
             successful,
             changed,
@@ -166,7 +166,7 @@ class blueprint_options : public zone_options, public mark_option
         construction_group_str_id group = construction_group_str_id::NULL_ID();
         construction_id index;
 
-        enum query_con_result {
+        enum query_con_result : std::uint8_t {
             canceled,
             successful,
             changed,
@@ -213,7 +213,7 @@ class ignorable_options : public zone_options
     private:
         bool ignore_contents;
 
-        enum query_ignorable_result {
+        enum query_ignorable_result : std::uint8_t {
             canceled,
             successful,
             changed,
@@ -245,7 +245,7 @@ class loot_options : public zone_options, public mark_option
         // basic item filter.
         std::string mark;
 
-        enum query_loot_result {
+        enum query_loot_result : std::uint8_t {
             canceled,
             successful,
             changed,
@@ -288,7 +288,7 @@ class unload_options : public zone_options, public mark_option
         int sparse_threshold = 20;
         bool always_unload;
 
-        enum query_unload_result {
+        enum query_unload_result : std::uint8_t {
             canceled,
             successful,
             changed,

--- a/src/color.h
+++ b/src/color.h
@@ -176,7 +176,7 @@
 #define c_neutral all_colors.get(def_c_yellow)
 
 // def_x is a color that maps to x with default settings
-enum color_id {
+enum color_id : std::uint16_t {
     def_c_black = 0,
     def_c_white,
     def_c_light_gray,
@@ -342,7 +342,7 @@ class JsonOut;
 void init_colors();
 
 // Index for highlight cache
-enum hl_enum {
+enum hl_enum : std::uint8_t {
     HL_BLUE = 0,
     HL_RED,
     HL_WHITE,
@@ -419,7 +419,7 @@ struct hash<nc_color> {
 };
 } // namespace std
 
-enum class report_color_error {
+enum class report_color_error : std::uint8_t {
     no, yes
 };
 
@@ -511,7 +511,7 @@ struct note_color {
 };
 
 struct color_tag_parse_result {
-    enum tag_type {
+    enum tag_type : std::uint8_t {
         open_color_tag,
         close_color_tag,
         non_color_tag,

--- a/src/computer.h
+++ b/src/computer.h
@@ -18,7 +18,7 @@ class JsonOut;
 class JsonValue;
 class talker;
 
-enum computer_action {
+enum computer_action : std::uint8_t {
     COMPACT_NULL = 0,
     COMPACT_AMIGARA_LOG,
     COMPACT_AMIGARA_START,
@@ -75,7 +75,7 @@ enum computer_action {
     NUM_COMPUTER_ACTIONS
 };
 
-enum computer_failure_type {
+enum computer_failure_type : std::uint8_t {
     COMPFAIL_NULL = 0,
     COMPFAIL_ALARM,
     COMPFAIL_AMIGARA,

--- a/src/computer_session.h
+++ b/src/computer_session.h
@@ -69,7 +69,7 @@ class computer_session
         template<typename ...Args>
         void print_text( const std::string &text, Args &&... args );
         // Prints a line and waits for Y/N/Q
-        enum class ynq : int {
+        enum class ynq : std::uint8_t {
             yes,
             no,
             quit,

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2166,7 +2166,7 @@ conditional_t::func f_using_martial_art( const JsonObject &jo, std::string_view 
 
 template<class T>
 static std::function<T( const_dialogue const & )> get_get_str_( const JsonObject &jo,
-        std::function<T( const std::string & )> ret_func )
+        const std::function<T( const std::string & )> &ret_func )
 {
     const std::string &mutator = jo.get_string( "mutator" );
     if( mutator == "mon_faction" ) {
@@ -2220,7 +2220,7 @@ static std::function<T( const_dialogue const & )> get_get_str_( const JsonObject
 
 template<class T>
 static std::function<T( const_dialogue const & )> get_get_translation_( const JsonObject &jo,
-        std::function<T( const translation & )> ret_func )
+        const std::function<T( const translation & )> &ret_func )
 {
     if( jo.get_string( "mutator" ) == "ma_technique_description" ) {
         str_or_var ma = get_str_or_var( jo.get_member( "matec_id" ), "matec_id" );

--- a/src/condition.h
+++ b/src/condition.h
@@ -25,7 +25,7 @@ const std::unordered_set<std::string> &simple_string_conds();
 const std::unordered_set<std::string> &complex_conds();
 } // namespace dialogue_data
 
-enum class jarg {
+enum class jarg : std::uint8_t {
     member = 1,
     object = 1 << 1,
     string = 1 << 2,

--- a/src/coords_fwd.h
+++ b/src/coords_fwd.h
@@ -10,7 +10,7 @@ struct tripoint;
 namespace coords
 {
 
-enum class origin {
+enum class origin : std::uint8_t {
     relative, // this is a special origin that can be added to any other
     abs, // the global absolute origin for the entire game
     submap, // from corner of submap
@@ -19,7 +19,7 @@ enum class origin {
     reality_bubble, // from corner of a reality bubble (aka 'map' or 'tinymap')
 };
 
-enum class scale {
+enum class scale : std::uint8_t {
     map_square,
     submap,
     overmap_terrain,

--- a/src/craft_command.h
+++ b/src/craft_command.h
@@ -23,7 +23,7 @@ template<typename T> struct enum_traits;
 /**
 *   enum used by comp_selection to indicate where a component should be consumed from.
 */
-enum class usage_from : int {
+enum class usage_from : std::uint8_t {
     none = 0,
     map = 1,
     player = 2,

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -874,7 +874,7 @@ static item_location place_craft_or_disassembly(
                 put_into_vehicle_or_drop( ch, item_drop_reason::tumbling, {craft} );
             }
         } else {
-            enum option : int {
+            enum option : std::uint8_t {
                 WIELD_CRAFT = 0,
                 DROP_CRAFT,
                 STASH,
@@ -1900,7 +1900,7 @@ comp_selection<item_comp> Character::select_item_component( const std::vector<it
             is_food = !!rec->result()->comestible;
             remove_raw = rec->hot_result() || rec->removes_raw();
         }
-        enum class inventory_source : int {
+        enum class inventory_source : std::uint8_t {
             SELF = 0,
             MAP,
             BOTH

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -8,7 +8,7 @@ class Character;
 class item;
 template <typename E> struct enum_traits;
 
-enum class craft_flags : int {
+enum class craft_flags : std::uint8_t {
     none = 0,
     start_only = 1, // Only require 5% (plus remainder) of tool charges
 };

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -70,13 +70,13 @@ static const std::string flag_BLIND_HARD( "BLIND_HARD" );
 static const std::string flag_NO_ENCHANTMENT( "NO_ENCHANTMENT" );
 static const std::string flag_NO_MANIP( "NO_MANIP" );
 
-enum TAB_MODE {
+enum TAB_MODE : std::uint8_t {
     NORMAL,
     FILTERED,
     BATCH
 };
 
-enum CRAFTING_SPEED_STATE {
+enum CRAFTING_SPEED_STATE : std::uint8_t {
     TOO_DARK_TO_CRAFT,
     TOO_SLOW_TO_CRAFT,
     SLOW_BUT_CRAFTABLE,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2801,7 +2801,7 @@ static void sort_body_parts( std::vector<bodypart_id> &bps, const Creature *c )
         pending.pop();
         result.push_back( next );
 
-        const cata::flat_set<bodypart_id> children_set = parts_connected_to.at( next );
+        const cata::flat_set<bodypart_id> &children_set = parts_connected_to.at( next );
         std::vector<bodypart_id> children( children_set.begin(), children_set.end() );
         std::sort( children.begin(), children.end(), compare_children );
         for( const bodypart_id &child : children ) {

--- a/src/creature.h
+++ b/src/creature.h
@@ -208,13 +208,13 @@ constexpr bool operator==( const I lhs, const creature_size rhs )
     return lhs == static_cast<I>( rhs );
 }
 
-enum class FacingDirection : int {
+enum class FacingDirection : std::uint8_t {
     NONE = 0,
     LEFT = 1,
     RIGHT = 2
 };
 
-enum class get_body_part_flags : int {
+enum class get_body_part_flags : std::uint8_t {
     none = 0,
     only_main = 1 << 0,
     sorted = 1 << 1,
@@ -227,7 +227,7 @@ struct enum_traits<get_body_part_flags> {
     static constexpr bool is_flag_enum = true;
 };
 
-enum class body_part_filter : int {
+enum class body_part_filter : std::uint8_t {
     strict = 0,
     equivalent = 1,
     next_best = 2
@@ -356,7 +356,7 @@ class Creature : public viewer
          * friendly - avoid harming it, maybe even help.
          * any - any of the above, used in safemode_ui
          */
-        enum class Attitude : int {
+        enum class Attitude : std::uint8_t {
             HOSTILE,
             NEUTRAL,
             FRIENDLY,

--- a/src/cube_direction.h
+++ b/src/cube_direction.h
@@ -16,7 +16,7 @@ enum class type : int;
 // We have other direction enums, but for this purpose we need to have one for
 // the six rectilinear directions.  These correspond to the faces of a cube, so
 // I've called it cube_direction
-enum class cube_direction : int {
+enum class cube_direction : std::uint8_t {
     north,
     east,
     south,

--- a/src/cube_direction.h
+++ b/src/cube_direction.h
@@ -34,7 +34,7 @@ struct enum_traits<cube_direction> {
 namespace std
 {
 template <> struct hash<cube_direction> {
-    std::size_t operator()( const cube_direction &d ) const {
+    std::size_t operator()( const cube_direction &d ) const noexcept {
         return static_cast<std::size_t>( d );
     }
 };

--- a/src/cube_direction.h
+++ b/src/cube_direction.h
@@ -10,7 +10,7 @@ struct tripoint;
 
 namespace om_direction
 {
-enum class type : int;
+enum class type : std::int8_t;
 } // namespace om_direction
 
 // We have other direction enums, but for this purpose we need to have one for

--- a/src/damage.h
+++ b/src/damage.h
@@ -60,12 +60,12 @@ struct damage_type {
 };
 
 struct damage_info_order {
-    enum class info_disp : int {
+    enum class info_disp : std::uint8_t {
         NONE,
         BASIC,
         DETAILED
     };
-    enum class info_type : int {
+    enum class info_type : std::uint8_t {
         NONE = 0,
         BIO,
         PROT,

--- a/src/debug.h
+++ b/src/debug.h
@@ -136,7 +136,7 @@ std::string game_report();
  * If you add an entry, add an entry in that function:
  * std::ostream &operator<<(std::ostream &out, DebugLevel lev)
  */
-enum DebugLevel {
+enum DebugLevel : std::uint8_t {
     D_INFO          = 1,
     D_WARNING       = 1 << 2,
     D_ERROR         = 1 << 3,
@@ -175,7 +175,7 @@ enum DebugClass {
     DC_ALL    = ( 1 << 30 ) - 1
 };
 
-enum class DebugOutput : int {
+enum class DebugOutput : std::uint8_t {
     std_err,
     file,
 };
@@ -234,7 +234,7 @@ extern bool debug_mode;
 namespace debugmode
 {
 // Please try to keep this alphabetically sorted
-enum debug_filter : int {
+enum debug_filter : std::uint8_t {
     DF_ACT_BUTCHER = 0, // butcher activity handler
     DF_ACT_EBOOK, // ebook activity actor
     DF_ACT_HARVEST, // harvest activity actor

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3079,7 +3079,8 @@ static void debug_menu_game_state()
             creature_names_sorted.emplace_back( it );
         }
 
-        std::stable_sort( creature_names_sorted.begin(), creature_names_sorted.end(), []( auto a, auto b ) {
+        std::stable_sort( creature_names_sorted.begin(), creature_names_sorted.end(), []( const auto & a,
+        const auto & b ) {
             return a.second > b.second;
         } );
 
@@ -3200,7 +3201,7 @@ static void display_talk_topic()
             }
             talk_topic_menu.query();
             if( talk_topic_menu.ret >= 0 && talk_topic_menu.ret < static_cast<int>( dialogue_ids.size() ) ) {
-                const std::string selected_topic = dialogue_ids[talk_topic_menu.ret];
+                const std::string &selected_topic = dialogue_ids[talk_topic_menu.ret];
                 a.talk_to( get_talker_for( selected_npc ), false, false, false, selected_topic );
             }
         }

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -19,7 +19,7 @@ template <typename E> struct enum_traits;
 namespace debug_menu
 {
 
-enum class debug_menu_index : int {
+enum class debug_menu_index : std::uint8_t {
     WISH,
     SHORT_TELEPORT,
     LONG_TELEPORT,

--- a/src/dependency_tree.h
+++ b/src/dependency_tree.h
@@ -9,7 +9,7 @@
 
 #include "type_id.h"
 
-enum NODE_ERROR_TYPE {
+enum NODE_ERROR_TYPE : std::uint8_t {
     DEPENDENCY,
     CYCLIC,
     OTHER

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -182,7 +182,7 @@ void diary::show_diary_ui( diary *c_diary )
     catacurses::window w_desc;
     catacurses::window w_head;
     catacurses::window w_info;
-    enum class window_mode : int {PAGE_WIN = 0, CHANGE_WIN, TEXT_WIN, NUM_WIN, FIRST_WIN = 0, LAST_WIN = NUM_WIN - 1};
+    enum class window_mode : std::uint8_t {PAGE_WIN = 0, CHANGE_WIN, TEXT_WIN, NUM_WIN, FIRST_WIN = 0, LAST_WIN = NUM_WIN - 1};
     window_mode currwin = window_mode::PAGE_WIN;
 
     const int diary_last_page = c_diary->pages.empty() ? 0 : ( c_diary->pages.size() - 1 );

--- a/src/display.h
+++ b/src/display.h
@@ -23,7 +23,7 @@ class translation;
 class vehicle;
 
 // These are the supported data variables for coloring bodygraphs.
-enum class bodygraph_var : int {
+enum class bodygraph_var : std::uint8_t {
     hp = 0,      // hitpoints
     temp,        // temperature
     encumb,      // encumbrance

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1384,7 +1384,7 @@ void editmap::edit_fld()
 /*
  * edit items in target square. WIP
  */
-enum editmap_imenu_ent {
+enum editmap_imenu_ent : int {
     imenu_bday,
     imenu_damage,
     imenu_degradation,

--- a/src/editmap.h
+++ b/src/editmap.h
@@ -26,7 +26,7 @@ class ui_adaptor;
 class uilist;
 class vehicle;
 
-enum shapetype {
+enum shapetype : std::uint8_t {
     editmap_rect, editmap_rect_filled, editmap_line, editmap_circle,
 };
 

--- a/src/effect.h
+++ b/src/effect.h
@@ -106,7 +106,7 @@ class effect_type
         friend void load_effect_type( const JsonObject &jo, std::string_view src );
         friend class effect;
     public:
-        enum class memorial_gender : int {
+        enum class memorial_gender : std::uint8_t {
             male,
             female,
         };

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -26,7 +26,7 @@ struct effect_on_condition;
 template <typename E> struct enum_traits;
 template <typename T> class generic_factory;
 
-enum eoc_type {
+enum eoc_type : std::uint8_t {
     ACTIVATION,
     RECURRING,
     SCENARIO_SPECIFIC,

--- a/src/enums.h
+++ b/src/enums.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_ENUMS_H
 
 #include <type_traits>
+#include <cstdint>
 
 template<typename T> struct enum_traits;
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -12,7 +12,7 @@ constexpr inline int sgn( const T x )
     return x < 0 ? -1 : ( x > 0 ? 1 : 0 );
 }
 
-enum class aim_exit : int {
+enum class aim_exit : std::uint8_t {
     none = 0,
     okay,
     re_entry,
@@ -61,7 +61,7 @@ inline constexpr aim_entry operator-( const aim_entry &lhs, const I &rhs )
     return static_cast<aim_entry>( static_cast<I>( lhs ) - rhs );
 }
 
-enum class bionic_ui_sort_mode : int {
+enum class bionic_ui_sort_mode : std::uint8_t {
     NONE   = 0,
     POWER  = 1,
     NAME   = 2,
@@ -75,13 +75,13 @@ struct enum_traits<bionic_ui_sort_mode> {
 };
 
 // When bool is not enough. NONE, SOME or ALL
-enum class trinary : int {
+enum class trinary : std::uint8_t {
     NONE = 0,
     SOME = 1,
     ALL  = 2
 };
 
-enum class holiday : int {
+enum class holiday : std::uint8_t {
     none = 0,
     new_year,
     easter,
@@ -97,7 +97,7 @@ struct enum_traits<holiday> {
     static constexpr holiday last = holiday::num_holiday;
 };
 
-enum class temperature_flag : int {
+enum class temperature_flag : std::uint8_t {
     NORMAL = 0,
     HEATER,
     FRIDGE,
@@ -106,13 +106,13 @@ enum class temperature_flag : int {
 };
 
 //Used for autopickup and safemode rules
-enum class rule_state : int {
+enum class rule_state : std::uint8_t {
     NONE,
     WHITELISTED,
     BLACKLISTED
 };
 
-enum class visibility_type : int {
+enum class visibility_type : std::uint8_t {
     HIDDEN,
     CLEAR,
     LIT,
@@ -122,7 +122,7 @@ enum class visibility_type : int {
 };
 
 // Matching rules for comparing a string to an overmap terrain id.
-enum class ot_match_type : int {
+enum class ot_match_type : std::uint8_t {
     // The provided string must completely match the overmap terrain id, including
     // linear direction suffixes for linear terrain types or rotation suffixes
     // for rotated terrain types.
@@ -150,13 +150,13 @@ struct enum_traits<ot_match_type> {
     static constexpr ot_match_type last = ot_match_type::num_ot_match_type;
 };
 
-enum class special_game_type : int {
+enum class special_game_type : std::uint8_t {
     NONE = 0,
     TUTORIAL,
     NUM_SPECIAL_GAME_TYPES
 };
 
-enum art_effect_passive : int {
+enum art_effect_passive : std::uint8_t {
     AEP_NULL = 0,
     // Good
     AEP_STR_UP, // Strength + 4
@@ -209,7 +209,7 @@ struct enum_traits<art_effect_passive> {
     static constexpr art_effect_passive last = art_effect_passive::NUM_AEPS;
 };
 
-enum artifact_natural_property {
+enum artifact_natural_property : std::uint8_t {
     ARTPROP_NULL,
     ARTPROP_WRIGGLING, //
     ARTPROP_GLOWING, //
@@ -231,7 +231,7 @@ enum artifact_natural_property {
     ARTPROP_MAX
 };
 
-enum class phase_id : int {
+enum class phase_id : std::uint8_t {
     PNULL,
     SOLID,
     LIQUID,
@@ -248,7 +248,7 @@ struct enum_traits<phase_id> {
 // Return the class an in-world object uses to interact with the world.
 //   ex; if ( player.grab_type == object_type::VEHICLE ) { ...
 //   or; if ( baseactor_just_shot_at.object_type() == object_type::NPC ) { ...
-enum class object_type : int {
+enum class object_type : std::uint8_t {
     NONE,      // Nothing, invalid.
     ITEM,      // item.h
     ACTOR,     // potential virtual base class, get_object_type() would return one of the types below
@@ -263,14 +263,14 @@ enum class object_type : int {
     NUM_OBJECT_TYPES,
 };
 
-enum class liquid_source_type : int {
+enum class liquid_source_type : std::uint8_t {
     INFINITE_MAP = 1,
     MAP_ITEM = 2,
     VEHICLE = 3,
     MONSTER = 4
 };
 
-enum class liquid_target_type : int {
+enum class liquid_target_type : std::uint8_t {
     CONTAINER = 1,
     VEHICLE = 2,
     MAP = 3,
@@ -286,7 +286,7 @@ enum class liquid_target_type : int {
  *  and by @ref profession to place the characters' clothing in a sane order
  *  when starting the game.
  */
-enum class layer_level : int {
+enum class layer_level : std::uint8_t {
     /* "Personal effects" layer, corresponds to PERSONAL flag */
     PERSONAL = 0,
     /* "Close to skin" layer, corresponds to SKINTIGHT flag. */
@@ -317,7 +317,7 @@ inline layer_level &operator++( layer_level &l )
 }
 
 /** Possible reasons to interrupt an activity. */
-enum class distraction_type : int {
+enum class distraction_type : std::uint8_t {
     noise,
     pain,
     attacked,
@@ -344,7 +344,7 @@ struct enum_traits<distraction_type> {
     static constexpr distraction_type last = distraction_type::last;
 };
 
-enum game_message_type : int {
+enum game_message_type : std::uint8_t {
     m_good,    /* something good happened to the player character, e.g. health boost, increasing in skill */
     m_bad,      /* something bad happened to the player character, e.g. damage, decreasing in skill */
     m_mixed,   /* something happened to the player character which is mixed (has good and bad parts),
@@ -369,7 +369,7 @@ struct enum_traits<game_message_type> {
     static constexpr game_message_type last = game_message_type::num_game_message_type;
 };
 
-enum game_message_flags {
+enum game_message_flags : std::uint8_t {
     /* No specific game message flags */
     gmf_none = 0,
     /* Allow the message to bypass message cooldown. */
@@ -407,7 +407,7 @@ struct social_modifiers {
     }
 };
 
-enum MULTITILE_TYPE {
+enum MULTITILE_TYPE : std::uint8_t {
     center,
     corner,
     edge,
@@ -419,7 +419,7 @@ enum MULTITILE_TYPE {
     num_multitile_types
 };
 
-enum class reachability_cache_quadrant : int {
+enum class reachability_cache_quadrant : std::uint8_t {
     NE, SE, NW, SW
 };
 
@@ -435,7 +435,7 @@ struct enum_traits<reachability_cache_quadrant> {
     }
 };
 
-enum class monotonically : int {
+enum class monotonically : std::uint8_t {
     constant,
     increasing,
     decreasing,
@@ -452,7 +452,7 @@ constexpr bool is_decreasing( monotonically m )
     return m == monotonically::constant || m == monotonically::decreasing;
 }
 
-enum class character_type : int {
+enum class character_type : std::uint8_t {
     CUSTOM,
     RANDOM,
     TEMPLATE,
@@ -460,7 +460,7 @@ enum class character_type : int {
     FULL_RANDOM,
 };
 
-enum class aggregate_type : int {
+enum class aggregate_type : std::uint8_t {
     FIRST,
     LAST,
     MIN,
@@ -475,7 +475,7 @@ struct enum_traits<aggregate_type> {
     static constexpr aggregate_type last = aggregate_type::num_aggregate_types;
 };
 
-enum class link_state : int {
+enum class link_state : std::uint8_t {
     no_link = 0,     // No connection, the default state
     needs_reeling,   // Cable has been disconnected and needs to be manually reeled in before it can be used again
     ups,             // Linked to a UPS the cable holder is holding
@@ -492,7 +492,7 @@ struct enum_traits<link_state> {
     static constexpr link_state last = link_state::last;
 };
 
-enum mut_count_type {
+enum mut_count_type : std::uint8_t {
     POSITIVE,
     NEGATIVE,
     ALL

--- a/src/event.h
+++ b/src/event.h
@@ -21,7 +21,7 @@ template <typename E> struct enum_traits;
 //
 // Each event is of a specific type, taken from the event_type enum.
 
-enum class event_type : int {
+enum class event_type : std::uint8_t {
     activates_artifact,
     activates_mininuke,
     administers_mutagen,

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -173,7 +173,7 @@ class event_statistic::impl
 };
 
 struct value_constraint {
-    enum comparator { lt, lteq, gteq, gt };
+    enum comparator : std::uint8_t { lt, lteq, gteq, gt };
     std::vector<cata_variant> equals_any_;
     std::optional<string_id<event_statistic>> equals_statistic_;
     std::optional<std::pair<comparator, cata_variant>> val_comp_;

--- a/src/event_statistics.h
+++ b/src/event_statistics.h
@@ -15,13 +15,13 @@
 
 class cata_variant;
 
-enum class cata_variant_type : int;
+enum class cata_variant_type : std::uint8_t;
 class event_multiset;
 
-enum class event_type : int;
+enum class event_type : std::uint8_t;
 class JsonObject;
 
-enum class monotonically : int;
+enum class monotonically : std::uint8_t;
 class stats_tracker;
 class stats_tracker_state;
 

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -880,7 +880,7 @@ void faction_manager::display() const
     } );
     ui.mark_resize();
 
-    enum class tab_mode : int {
+    enum class tab_mode : std::uint8_t {
         TAB_MYFACTION = 0,
         TAB_FOLLOWERS,
         TAB_OTHERFACTIONS,

--- a/src/faction.h
+++ b/src/faction.h
@@ -46,7 +46,7 @@ using faction_id = string_id<faction>;
 namespace npc_factions
 {
 void finalize();
-enum class relationship : int {
+enum class relationship : std::uint8_t {
     kill_on_sight,
     watch_your_back,
     share_my_stuff,

--- a/src/faction_camp.h
+++ b/src/faction_camp.h
@@ -20,10 +20,10 @@ struct mission_entry;
 struct point;
 namespace base_camps
 {
-enum tab_mode : int;
+enum tab_mode : std::uint8_t;
 } // namespace base_camps
 
-enum class farm_ops : int {
+enum class farm_ops : std::uint8_t {
     plow = 1,
     plant = 2,
     harvest = 4

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -31,7 +31,7 @@ template <typename E> struct enum_traits;
 class field_entry;
 struct field_proc_data;
 
-enum class description_affix : int {
+enum class description_affix : std::uint8_t {
     DESCRIPTION_AFFIX_IN,
     DESCRIPTION_AFFIX_COVERED_IN,
     DESCRIPTION_AFFIX_ON,

--- a/src/flat_set.h
+++ b/src/flat_set.h
@@ -189,22 +189,35 @@ class flat_set : private Compare, Data
             return 0;
         }
 
-        friend void swap( flat_set &l, flat_set &r ) {
-            using std::swap;
-            swap( static_cast<Compare &>( l ), static_cast<Compare &>( r ) );
-            swap( static_cast<Data &>( l ), static_cast<Data &>( r ) );
+        friend void swap( flat_set &l, flat_set &r ) noexcept {
+            std::swap( static_cast<Compare &>( l ), static_cast<Compare &>( r ) );
+            std::swap( static_cast<Data &>( l ), static_cast<Data &>( r ) );
         }
-#define FLAT_SET_OPERATOR( op ) \
-    friend bool operator op( const flat_set &l, const flat_set &r ) { \
-        return l.data() op r.data(); \
-    }
-        FLAT_SET_OPERATOR( == )
-        FLAT_SET_OPERATOR( != )
-        FLAT_SET_OPERATOR( < )
-        FLAT_SET_OPERATOR( <= )
-        FLAT_SET_OPERATOR( > )
-        FLAT_SET_OPERATOR( >= )
-#undef FLAT_SET_OPERATOR
+
+        friend bool operator ==( const flat_set &l, const flat_set &r ) {
+            return l.data() == r.data();
+        }
+
+        friend bool operator !=( const flat_set &l, const flat_set &r ) {
+            return l.data() != r.data();
+        }
+
+        friend bool operator <( const flat_set &l, const flat_set &r ) {
+            return l.data() < r.data();
+        }
+
+        friend bool operator <=( const flat_set &l, const flat_set &r ) {
+            return l.data() <= r.data();
+        }
+
+        friend bool operator >( const flat_set &l, const flat_set &r ) {
+            return l.data() > r.data();
+        }
+
+        friend bool operator >=( const flat_set &l, const flat_set &r ) {
+            return l.data() >= r.data();
+        }
+
     private:
         const Data &data() const {
             return *this;

--- a/src/fragment_cloud.h
+++ b/src/fragment_cloud.h
@@ -2,7 +2,7 @@
 #ifndef CATA_SRC_FRAGMENT_CLOUD_H
 #define CATA_SRC_FRAGMENT_CLOUD_H
 
-enum class quadrant : int;
+enum class quadrant : std::uint8_t;
 /*
  * fragment_cloud represents the density and velocity of fragments passing through a square.
  */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9580,7 +9580,7 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
         return true;
     };
 
-    const std::string cannot_see = colorize( _( "can't see!" ), c_red );
+    std::string cannot_see = colorize( _( "can't see!" ), c_red );
     auto time_or_disabledreason = [&]( butcher_type bt ) {
         if( bt == butcher_type::DISMEMBER ) {
             return cut_time( bt );

--- a/src/game.h
+++ b/src/game.h
@@ -50,7 +50,7 @@ class input_context;
 
 input_context get_default_mode_input_context();
 
-enum quit_status {
+enum quit_status : std::uint8_t {
     QUIT_NO = 0,    // Still playing
     QUIT_SUICIDE,   // Quit with 'Q'
     QUIT_SAVED,     // Saved and quit
@@ -61,7 +61,7 @@ enum quit_status {
     QUIT_EXIT_PENDING, // same as above, used temporarily so input_context doesn't get confused
 };
 
-enum safe_mode_type {
+enum safe_mode_type : std::uint8_t {
     SAFE_MODE_OFF = 0, // Moving always allowed
     SAFE_MODE_ON = 1, // Moving allowed, but if a new monsters spawns, go to SAFE_MODE_STOP
     SAFE_MODE_STOP = 2, // New monsters spotted, no movement allowed
@@ -106,7 +106,7 @@ template <typename Tripoint> class tripoint_range;
 using item_filter = std::function<bool ( const item & )>;
 using item_location_filter = std::function<bool ( const item_location & )>;
 
-enum peek_act : int {
+enum peek_act : std::uint8_t {
     PA_BLIND_THROW,
     PA_BLIND_THROW_WIELDED,
     // obvious future additional value is PA_BLIND_FIRE
@@ -683,7 +683,7 @@ class game
 
         void draw_trail_to_square( const tripoint_rel_ms &t, bool bDrawX );
 
-        enum inventory_item_menu_position {
+        enum inventory_item_menu_position : std::uint8_t {
             RIGHT_TERMINAL_EDGE,
             LEFT_OF_INFO,
             RIGHT_OF_INFO,
@@ -874,7 +874,7 @@ class game
         // V Menu Functions and helpers:
         void list_items_monsters(); // Called when you invoke the `V`-menu
 
-        enum class vmenu_ret : int {
+        enum class vmenu_ret : std::uint8_t {
             CHANGE_TAB,
             QUIT,
             FIRE, // Who knew, apparently you can do that in list_monsters
@@ -1258,7 +1258,7 @@ class game
         /** Passed to climbing-related functions (slip_down) to
         *   indicate the climbing action being attempted.
         */
-        enum class climb_maneuver {
+        enum class climb_maneuver : std::uint8_t {
             down,          // climb up one Z-level
             up,            // climb down one Z-level
             over_obstacle, // climb over an obstacle (horizontal move)

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2636,7 +2636,7 @@ class bionic_install_preset: public inventory_selector_preset
                                   chance_of_failure );
         }
 
-        std::string get_anesth_amount( const item_location &loc ) {
+        std::string get_anesth_amount( const item_location &loc ) const {
 
             const int weight = units::to_kilogram( pa.bodyweight() ) / 10;
             const int duration = loc.get_item()->type->bionic->difficulty * 2;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2898,8 +2898,8 @@ class select_ammo_inventory_preset : public inventory_selector_preset
 
         // sort in order of move cost (ascending), then remaining ammo (descending) with empty magazines always last
         bool sort_compare( const inventory_entry &lhs, const inventory_entry &rhs ) const override {
-            item_location left = lhs.any_item();
-            item_location right = rhs.any_item();
+            const item_location &left = lhs.any_item();
+            const item_location &right = rhs.any_item();
 
             if( left->ammo_remaining() == 0 || right->ammo_remaining() == 0 ) {
                 return ( left->ammo_remaining() != 0 ) > ( right->ammo_remaining() != 0 );

--- a/src/gamemode_tutorial.h
+++ b/src/gamemode_tutorial.h
@@ -13,7 +13,7 @@ template <typename E> struct enum_traits;
 
 enum action_id : int;
 
-enum class tut_lesson : int {
+enum class tut_lesson : std::uint8_t {
     LESSON_INTRO = 0,
     LESSON_MOVE, LESSON_MOVEMENT_MODES, LESSON_LOOK, LESSON_OPEN, LESSON_CLOSE, LESSON_SMASH,
     LESSON_WINDOW, LESSON_PICKUP, LESSON_EXAMINE, LESSON_INTERACT,

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -1273,7 +1273,7 @@ inline bool legacy_volume_reader( const JsonObject &jo, const std::string_view m
 class text_style_check_reader : public generic_typed_reader<text_style_check_reader>
 {
     public:
-        enum class allow_object : int {
+        enum class allow_object : std::uint8_t {
             no,
             yes,
         };

--- a/src/global_vars.h
+++ b/src/global_vars.h
@@ -5,7 +5,7 @@
 
 #include "json.h"
 
-enum class var_type : int {
+enum class var_type : std::uint8_t {
     u,
     npc,
     global,

--- a/src/handle_liquid.h
+++ b/src/handle_liquid.h
@@ -11,7 +11,7 @@ class item;
 class monster;
 class vehicle;
 
-enum liquid_dest : int {
+enum liquid_dest : std::uint8_t {
     LD_NULL,
     LD_CONSUME,
     LD_ITEM,

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -26,7 +26,7 @@ class harvest_drop_type
         void load( const JsonObject &jo, std::string_view src );
         static const std::vector<harvest_drop_type> &get_all();
 
-        const harvest_drop_type_id &getId() {
+        const harvest_drop_type_id &getId() const {
             return id;
         }
         // Get skills required for harvesting rolls

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -683,7 +683,7 @@ class atm_menu
 {
     public:
         // menu choices
-        enum options : int {
+        enum options : std::uint8_t {
             cancel, purchase_card, deposit_money, withdraw_money, exchange_cash, transfer_all_money
         };
 
@@ -1878,7 +1878,7 @@ void iexamine::locked_object( Character &you, const tripoint_bub_ms &examp )
     const bool can_pick = ( here.has_flag( ter_furn_flag::TFLAG_PICKABLE, examp ) ||
                             locked_part >= 0 ) &&
                           ( !best_lockpick.is_null() || you.has_bionic( bio_lockpick ) );
-    enum act {
+    enum act : std::uint8_t {
         pick = 0,
         pry = 1,
         none = 2

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -38,7 +38,7 @@ struct iexamine_actor {
     virtual ~iexamine_actor() = default;
 };
 
-enum fuel_station_fuel_type {
+enum fuel_station_fuel_type : std::uint8_t {
     FUEL_TYPE_NONE,
     FUEL_TYPE_GASOLINE,
     FUEL_TYPE_DIESEL

--- a/src/item.h
+++ b/src/item.h
@@ -50,7 +50,7 @@ class item;
 class iteminfo_query;
 class monster;
 class nc_color;
-enum class pocket_type;
+enum class pocket_type : std::uint8_t;
 class recipe;
 class relic;
 struct part_material;
@@ -71,7 +71,7 @@ class vehicle;
 
 namespace enchant_vals
 {
-enum class mod : int;
+enum class mod : std::uint8_t;
 } // namespace enchant_vals
 
 using bodytype_id = std::string;
@@ -81,7 +81,7 @@ struct islot_armor;
 struct use_function;
 
 enum art_effect_passive : std::uint8_t;
-enum class side : int;
+enum class side : std::uint8_t;
 class body_part_set;
 class map;
 struct damage_instance;
@@ -151,7 +151,7 @@ struct iteminfo {
         /** info is ASCII art (prefer monospaced font) */
         bool bIsArt;
 
-        enum flags {
+        enum flags : std::uint8_t {
             no_flags = 0,
             is_decimal = 1 << 0, ///< Print as decimal rather than integer
             is_three_decimal = 1 << 1, ///< Print as decimal with three points of precision
@@ -2270,7 +2270,7 @@ class item : public visitable
         int get_coverage( const sub_bodypart_id &bodypart,
                           const cover_type &type = cover_type::COVER_DEFAULT ) const;
 
-        enum class encumber_flags : int {
+        enum class encumber_flags : std::uint8_t {
             none = 0,
             assume_full = 1,
             assume_empty = 2

--- a/src/item.h
+++ b/src/item.h
@@ -80,16 +80,16 @@ class item_category;
 struct islot_armor;
 struct use_function;
 
-enum art_effect_passive : int;
+enum art_effect_passive : std::uint8_t;
 enum class side : int;
 class body_part_set;
 class map;
 struct damage_instance;
 struct damage_unit;
 struct fire_data;
-enum class link_state : int;
+enum class link_state : std::uint8_t;
 
-enum clothing_mod_type : int;
+enum clothing_mod_type : std::uint8_t;
 
 struct light_emission {
     unsigned short luminance;

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -22,7 +22,7 @@ class time_point;
 struct itype;
 template <typename E> struct enum_traits;
 
-enum class spawn_flags {
+enum class spawn_flags : std::uint8_t {
     none = 0,
     maximized = 1,
     use_spawn_rate = 2,

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -29,7 +29,7 @@ template<typename T> class ret_val;
 class item_location
 {
     public:
-        enum class type : int {
+        enum class type : std::uint8_t {
             invalid = 0,
             character = 1,
             map = 2,

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2696,7 +2696,7 @@ const std::optional<std::string> &item_pocket::favorite_settings::get_preset_nam
 }
 
 template<typename T>
-std::string enumerate( cata::flat_set<T> container )
+std::string enumerate( const cata::flat_set<T> &container )
 {
     std::vector<std::string> output;
     for( const T &id : container ) {

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -19,8 +19,8 @@ static std::pair<std::string, std::string> get_both( std::string_view a );
 
 template<typename Unit>
 static std::function< bool( const item & )> can_contain_filter( std::string_view hint,
-        std::string_view filter, Unit max, std::vector<std::pair<std::string, Unit>> units,
-        std::function<item( itype *, Unit u )> set_function )
+        std::string_view filter, Unit max, const std::vector<std::pair<std::string, Unit>> &units,
+        const std::function<item( itype *, Unit u )> &set_function )
 {
     auto const error = [hint, filter]( char const *, size_t /* offset */ ) {
         throw math::runtime_error( _( string_format( hint, filter ) ) );

--- a/src/item_search.h
+++ b/src/item_search.h
@@ -15,7 +15,7 @@
  */
 template<typename T>
 std::function<bool( const T & )> filter_from_string( std::string filter,
-        std::function<std::function<bool( const T & )>( const std::string & )> basic_filter )
+        const std::function<std::function<bool( const T & )>( const std::string & )> &basic_filter )
 {
     if( filter.empty() ) {
         // Variable without name prevents unused parameter warning

--- a/src/item_stack.cpp
+++ b/src/item_stack.cpp
@@ -69,17 +69,17 @@ item_stack::const_reverse_iterator item_stack::rend() const
     return items->crend();
 }
 
-item_stack::iterator item_stack::get_iterator_from_pointer( item *it )
+item_stack::iterator item_stack::get_iterator_from_pointer( item *it ) const
 {
     return items->get_iterator_from_pointer( it );
 }
 
-item_stack::iterator item_stack::get_iterator_from_index( size_t idx )
+item_stack::iterator item_stack::get_iterator_from_index( size_t idx ) const
 {
     return items->get_iterator_from_index( idx );
 }
 
-size_t item_stack::get_index_from_iterator( const item_stack::const_iterator &it )
+size_t item_stack::get_index_from_iterator( const item_stack::const_iterator &it ) const
 {
     return items->get_index_from_iterator( it );
 }

--- a/src/item_stack.h
+++ b/src/item_stack.h
@@ -45,9 +45,9 @@ class item_stack
 
         // While iterators to colonies are stable, indexes are not.
         // These functions should only be used for serialization/deserialization
-        iterator get_iterator_from_pointer( item *it );
-        iterator get_iterator_from_index( size_t idx );
-        size_t get_index_from_iterator( const const_iterator &it );
+        iterator get_iterator_from_pointer( item *it ) const;
+        iterator get_iterator_from_index( size_t idx ) const;
+        size_t get_index_from_iterator( const const_iterator &it ) const;
 
         iterator begin();
         iterator end();

--- a/src/itype.h
+++ b/src/itype.h
@@ -40,7 +40,7 @@ template <typename E> struct enum_traits;
 enum art_effect_active : int;
 enum art_charge : int;
 enum art_charge_req : int;
-enum art_effect_passive : int;
+enum art_effect_passive : std::uint8_t;
 
 class gun_modifier_data
 {

--- a/src/itype.h
+++ b/src/itype.h
@@ -270,7 +270,7 @@ struct part_material {
 };
 
 // values for attributes related to encumbrance
-enum class encumbrance_modifier : int {
+enum class encumbrance_modifier : std::uint8_t {
     IMBALANCED = 0,
     RESTRICTS_NECK,
     WELL_SUPPORTED,
@@ -284,7 +284,7 @@ struct enum_traits<encumbrance_modifier> {
 };
 
 // if it is a multiplier or flat modifier
-enum class encumbrance_modifier_type : int {
+enum class encumbrance_modifier_type : std::uint8_t {
     MULT = 0,
     FLAT,
     last
@@ -674,7 +674,7 @@ struct islot_wheel {
         void deserialize( const JsonObject &jo );
 };
 
-enum class itype_variant_kind : int {
+enum class itype_variant_kind : std::uint8_t {
     gun,
     generic,
     drug,
@@ -1164,7 +1164,7 @@ struct islot_seed {
     islot_seed() = default;
 };
 
-enum condition_type {
+enum condition_type : std::uint8_t {
     FLAG,
     VITAMIN,
     COMPONENT_ID,

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1900,7 +1900,7 @@ bool inscribe_actor::item_inscription( item &tool, item &cut ) const
         return false;
     }
 
-    enum inscription_type {
+    enum inscription_type : std::uint8_t {
         INSCRIPTION_LABEL,
         INSCRIPTION_NOTE,
     };
@@ -3228,7 +3228,7 @@ repair_item_actor::attempt_hint repair_item_actor::repair( Character &pl, item &
     const auto chance = repair_chance( pl, *fix, action );
     int practice_amount = repair_recipe_difficulty( *fix ) / 2 + 1;
     float roll_value = rng_float( 0.0, 1.0 );
-    enum roll_result {
+    enum roll_result : std::uint8_t {
         SUCCESS,
         FAILURE,
         NEUTRAL

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5485,7 +5485,7 @@ std::optional<int> sew_advanced_actor::use( Character *p, item &it, const tripoi
 
     int index = 0;
     for( const clothing_mod_id &cm : clothing_mods ) {
-        clothing_mod obj = cm.obj();
+        const clothing_mod &obj = cm.obj();
         item temp_item = modded_copy( mod, obj.flag );
         temp_item.update_clothing_mod_val();
 

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -792,7 +792,7 @@ class repair_item_actor : public iuse_actor
         /** Move cost for every attempt */
         int move_cost = 0;
 
-        enum attempt_hint : int {
+        enum attempt_hint : std::uint8_t {
             AS_SUCCESS = 0,     // Success, but can retry
             AS_RETRY,           // Failed, but can retry
             AS_FAILURE,         // Failed hard, don't retry
@@ -802,7 +802,7 @@ class repair_item_actor : public iuse_actor
             AS_CANT_YET         // Skill too low
         };
 
-        enum repair_type : int {
+        enum repair_type : std::uint8_t {
             RT_NOTHING = 0,
             RT_REPAIR = 1,          // Just repairing damage
             RT_REFIT = 2,           // Refitting

--- a/src/iuse_software_kitten.h
+++ b/src/iuse_software_kitten.h
@@ -41,7 +41,7 @@ class robot_finds_kitten
         cata::mdarray<int, point, rfkCOLS, rfkLINES> rfkscreen;
         int nummessages = 0;
 
-        enum class ui_state : int {
+        enum class ui_state : std::uint8_t {
             instructions,
             main,
             invalid_input,

--- a/src/iuse_software_minesweeper.h
+++ b/src/iuse_software_minesweeper.h
@@ -20,7 +20,7 @@ class minesweeper_game
         std::map<int, std::map<int, int> > mLevel;
         static constexpr int bomb = -1;
 
-        enum reveal {
+        enum reveal : std::uint8_t {
             unknown,
             flag,
             seen

--- a/src/jmapgen_flags.h
+++ b/src/jmapgen_flags.h
@@ -2,7 +2,7 @@
 #ifndef CATA_SRC_JMAPGEN_FLAGS_H
 #define CATA_SRC_JMAPGEN_FLAGS_H
 
-enum class jmapgen_flags {
+enum class jmapgen_flags : std::uint8_t {
     allow_terrain_under_other_data,
     dismantle_all_before_placing_terrain,
     erase_all_before_placing_terrain,

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -562,7 +562,7 @@ size_t TextJsonArray::size() const
 {
     return positions.size();
 }
-bool TextJsonArray::empty()
+bool TextJsonArray::empty() const
 {
     return positions.empty();
 }

--- a/src/json.h
+++ b/src/json.h
@@ -756,7 +756,7 @@ class JsonOut
         void set_need_separator() {
             need_separator = true;
         }
-        std::ostream *get_stream() {
+        std::ostream *get_stream() const {
             return stream;
         }
         int tell();
@@ -1263,7 +1263,7 @@ class TextJsonArray
 
         bool has_more() const; // true iff more elements may be retrieved with next_*
         size_t size() const;
-        bool empty();
+        bool empty() const;
         std::string str(); // copy array json as string
         [[noreturn]] void throw_error( const std::string &err ) const;
         [[noreturn]] void throw_error( int idx, const std::string &err ) const;

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -50,7 +50,7 @@ constexpr inline int LIGHT_RANGE( float b )
                              LIGHT_TRANSPARENCY_OPEN_AIR ) );
 }
 
-enum class lit_level : int {
+enum class lit_level : std::uint8_t {
     DARK = 0,
     LOW, // Hard to see
     BRIGHT_ONLY, // bright but indistinct

--- a/src/line.h
+++ b/src/line.h
@@ -82,7 +82,7 @@ struct enum_traits<direction> {
 namespace std
 {
 template <> struct hash<direction> {
-    std::size_t operator()( const direction &d ) const {
+    std::size_t operator()( const direction &d ) const noexcept {
         return static_cast<std::size_t>( d );
     }
 };

--- a/src/list.h
+++ b/src/list.h
@@ -180,7 +180,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
                 nodes = std::move( source.nodes );
                 free_list_head = std::move( source.free_list_head );
                 beyond_end = std::move( source.beyond_end );
-                number_of_elements = source.number_of_elements;
+                number_of_elements = std::move( source.number_of_elements );
                 source.nodes = nullptr;
                 source.beyond_end = nullptr;
                 return *this;
@@ -764,7 +764,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
                     return node_pointer == rh.node_pointer;
                 }
 
-                inline LIST_FORCE_INLINE bool operator!=( const list_iterator &rh ) const noexcept {
+                inline LIST_FORCE_INLINE bool operator!=( const list_iterator rh ) const noexcept {
                     return node_pointer != rh.node_pointer;
                 }
 
@@ -1210,7 +1210,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
 
     public:
 
-        iterator insert( const iterator &it, const element_type &element ) {
+        iterator insert( const iterator it, const element_type &element ) {
             // ie. list is not empty
             if( last_endpoint != nullptr ) {
                 // No erased nodes available for reuse
@@ -1396,7 +1396,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
 
         // This is almost identical to the insert implementations above with the only changes being std::forward of element parameters
         template<typename... arguments>
-        iterator emplace( const iterator &it, arguments &&... parameters ) {
+        iterator emplace( const iterator it, arguments &&... parameters ) {
             if( last_endpoint != nullptr ) {
                 if( node_allocator_pair.number_of_erased_nodes == 0 ) {
                     if( last_endpoint == groups.last_endpoint_group->beyond_end ) {
@@ -1657,7 +1657,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
 
         // Range insert
         template <class iterator_type>
-        iterator insert( const iterator &it,
+        iterator insert( const iterator it,
                          typename plf_enable_if_c < !std::numeric_limits<iterator_type>::is_integer,
                          iterator_type >::type first, const iterator_type last ) {
             if( first == last ) {
@@ -1674,7 +1674,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
         }
 
         // Initializer-list insert
-        inline iterator insert( const iterator &it,
+        inline iterator insert( const iterator it,
                                 const std::initializer_list<element_type> &element_list ) {
             // use range insert:
             return insert( it, element_list.begin(), element_list.end() );
@@ -1697,7 +1697,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
 
         // Single erase:
         // if uninitialized/invalid iterator supplied, function could generate an exception, hence no noexcept
-        iterator erase( const const_iterator &it ) {
+        iterator erase( const const_iterator it ) {
             cata_assert( node_pointer_allocator_pair.total_number_of_elements != 0 );
             cata_assert( it.node_pointer != nullptr );
             cata_assert( it.node_pointer != end_iterator.node_pointer );

--- a/src/list.h
+++ b/src/list.h
@@ -27,14 +27,9 @@
 #define LIST_BLOCK_MIN static_cast<group_size_type>((sizeof(node) * 8 > (sizeof(*this) + sizeof(group)) * 2) ? 8 : (((sizeof(*this) + sizeof(group)) * 2) / sizeof(node)) + 1)
 #define LIST_BLOCK_MAX 2048
 
-#define LIST_CONSTEXPR
-#define LIST_NOEXCEPT_SWAP(the_allocator) noexcept
-#define LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept
-
-// TODO: Switch to these when we move to C++17
-// #define LIST_CONSTEXPR constexpr
-// #define LIST_NOEXCEPT_SWAP(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_swap::value)
-// #define LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
+#define LIST_CONSTEXPR constexpr
+#define LIST_NOEXCEPT_SWAP(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_swap::value)
+#define LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
 
 // Note: GCC creates faster code without forcing inline
 #if defined(_MSC_VER)
@@ -185,7 +180,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
                 nodes = std::move( source.nodes );
                 free_list_head = std::move( source.free_list_head );
                 beyond_end = std::move( source.beyond_end );
-                number_of_elements = std::move( source.number_of_elements );
+                number_of_elements = source.number_of_elements;
                 source.nodes = nullptr;
                 source.beyond_end = nullptr;
                 return *this;
@@ -769,7 +764,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
                     return node_pointer == rh.node_pointer;
                 }
 
-                inline LIST_FORCE_INLINE bool operator!=( const list_iterator rh ) const noexcept {
+                inline LIST_FORCE_INLINE bool operator!=( const list_iterator &rh ) const noexcept {
                     return node_pointer != rh.node_pointer;
                 }
 
@@ -1215,7 +1210,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
 
     public:
 
-        iterator insert( const iterator it, const element_type &element ) {
+        iterator insert( const iterator &it, const element_type &element ) {
             // ie. list is not empty
             if( last_endpoint != nullptr ) {
                 // No erased nodes available for reuse
@@ -1401,7 +1396,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
 
         // This is almost identical to the insert implementations above with the only changes being std::forward of element parameters
         template<typename... arguments>
-        iterator emplace( const iterator it, arguments &&... parameters ) {
+        iterator emplace( const iterator &it, arguments &&... parameters ) {
             if( last_endpoint != nullptr ) {
                 if( node_allocator_pair.number_of_erased_nodes == 0 ) {
                     if( last_endpoint == groups.last_endpoint_group->beyond_end ) {
@@ -1662,7 +1657,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
 
         // Range insert
         template <class iterator_type>
-        iterator insert( const iterator it,
+        iterator insert( const iterator &it,
                          typename plf_enable_if_c < !std::numeric_limits<iterator_type>::is_integer,
                          iterator_type >::type first, const iterator_type last ) {
             if( first == last ) {
@@ -1679,7 +1674,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
         }
 
         // Initializer-list insert
-        inline iterator insert( const iterator it,
+        inline iterator insert( const iterator &it,
                                 const std::initializer_list<element_type> &element_list ) {
             // use range insert:
             return insert( it, element_list.begin(), element_list.end() );
@@ -1702,7 +1697,7 @@ template <class element_type, class element_allocator_type = std::allocator<elem
 
         // Single erase:
         // if uninitialized/invalid iterator supplied, function could generate an exception, hence no noexcept
-        iterator erase( const const_iterator it ) {
+        iterator erase( const const_iterator &it ) {
             cata_assert( node_pointer_allocator_pair.total_number_of_elements != 0 );
             cata_assert( it.node_pointer != nullptr );
             cata_assert( it.node_pointer != end_iterator.node_pointer );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2489,7 +2489,7 @@ std::vector<spell> Character::spells_known_of_class( const trait_id &spell_class
     return ret;
 }
 
-static void refresh_favorite( uilist *menu, std::vector<spell *> known_spells )
+static void refresh_favorite( uilist *menu, const std::vector<spell *> &known_spells )
 {
     for( uilist_entry &entry : menu->entries ) {
         if( get_player_character().magic->is_favorite( known_spells[entry.retval]->id() ) ) {

--- a/src/magic.h
+++ b/src/magic.h
@@ -47,7 +47,7 @@ class event;
 }  // namespace cata
 template <typename E> struct enum_traits;
 
-enum class spell_flag : int {
+enum class spell_flag : std::uint8_t {
     PERMANENT, // items or creatures spawned with this spell do not disappear and die as normal
     PERMANENT_ALL_LEVELS, // items spawned with this spell do not disappear even if the spell is not max level
     PERCENTAGE_DAMAGE, //the spell deals damage based on the targets current hp.
@@ -98,7 +98,7 @@ enum class spell_flag : int {
     LAST
 };
 
-enum class magic_energy_type : int {
+enum class magic_energy_type : std::uint8_t {
     hp,
     mana,
     stamina,
@@ -107,7 +107,7 @@ enum class magic_energy_type : int {
     last
 };
 
-enum class spell_target : int {
+enum class spell_target : std::uint8_t {
     ally,
     hostile,
     self,
@@ -118,7 +118,7 @@ enum class spell_target : int {
     num_spell_targets
 };
 
-enum class spell_shape : int {
+enum class spell_shape : std::uint8_t {
     // circular blast area
     blast,
     // hits anything in a line from the caster to the target with a width

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -28,7 +28,7 @@ namespace enchant_vals
 {
 // the different types of values that can be modified by enchantments
 // either the item directly or the Character, whichever is more appropriate
-enum class mod : int {
+enum class mod : std::uint8_t {
     //tracker for artifact carrying penalties
     ARTIFACT_RESONANCE,
     // effects for the Character
@@ -148,14 +148,14 @@ enum class mod : int {
 class enchantment
 {
     public:
-        enum has {
+        enum has : std::uint8_t {
             WIELD,
             WORN,
             HELD,
             NUM_HAS
         };
         // the condition at which the enchantment is giving passive effects
-        enum condition {
+        enum condition : std::uint8_t {
             ALWAYS,
             ACTIVE, // the item, mutation, etc. is active
             INACTIVE, // the item, mutation, etc. is inactive

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -59,7 +59,7 @@
 static const mod_id MOD_INFORMATION_dda( "dda" );
 static const mod_id MOD_INFORMATION_dda_tutorial( "dda_tutorial" );
 
-enum class main_menu_opts : int {
+enum class main_menu_opts : std::uint8_t {
     MOTD = 0,
     NEWCHAR,
     LOADCHAR,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2885,7 +2885,7 @@ void map::drop_furniture( const tripoint_bub_ms &p )
         return;
     }
 
-    enum support_state {
+    enum support_state : std::uint8_t {
         SS_NO_SUPPORT = 0,
         SS_BAD_SUPPORT, // TODO: Implement bad, shaky support
         SS_GOOD_SUPPORT,

--- a/src/map.h
+++ b/src/map.h
@@ -2894,7 +2894,7 @@ class tinymap : private map
         using map::set_abs_sub;
         using map::setsubmap;
         using map::get_nonant;
-        int get_my_MAPSIZE() {
+        int get_my_MAPSIZE() const {
             return my_MAPSIZE;
         }
 };

--- a/src/map.h
+++ b/src/map.h
@@ -78,7 +78,7 @@ struct trap;
 template<typename Tripoint>
 class tripoint_range;
 
-enum class special_item_type : int;
+enum class special_item_type : std::uint8_t;
 class npc_template;
 class tileray;
 class vpart_reference;
@@ -95,7 +95,7 @@ struct wrapped_vehicle {
 using VehicleList = std::vector<wrapped_vehicle>;
 class map;
 
-enum class ter_furn_flag : int;
+enum class ter_furn_flag : std::uint8_t;
 struct pathfinding_cache;
 struct pathfinding_settings;
 template<typename T>
@@ -2425,7 +2425,7 @@ class map
         void process_items_in_vehicle( vehicle &cur_veh, submap &current_submap );
 
         /** Enum used by functors in `function_over` to control execution. */
-        enum iteration_state {
+        enum iteration_state : std::uint8_t {
             ITER_CONTINUE = 0,  // Keep iterating
             ITER_SKIP_SUBMAP,   // Skip the rest of this submap
             ITER_SKIP_ZLEVEL,   // Skip the rest of this z-level

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -23,7 +23,7 @@ struct tripoint;
 template<typename T> class generic_factory;
 template<typename T> struct enum_traits;
 
-enum class map_extra_method : int {
+enum class map_extra_method : std::uint8_t {
     null = 0,
     map_extra_function,
     mapgen,

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -119,7 +119,7 @@ void map::create_burnproducts( const tripoint &p, const item &fuel, const units:
 void map::create_burnproducts( const tripoint_bub_ms &p, const item &fuel,
                                const units::mass &burned_mass )
 {
-    const std::map<material_id, int> all_mats = fuel.made_of();
+    const std::map<material_id, int> &all_mats = fuel.made_of();
     if( all_mats.empty() ) {
         return;
     }

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -226,7 +226,7 @@ struct plant_data {
  * To add a new ter_bitflag, add below and in mapdata.cpp
  * Order does not matter.
  */
-enum class ter_furn_flag : int {
+enum class ter_furn_flag : std::uint8_t {
     TFLAG_TRANSPARENT,
     TFLAG_TRANSLUCENT,
     TFLAG_FLAMMABLE,

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3017,7 +3017,7 @@ class jmapgen_furniture : public jmapgen_piece_with_has_vehicle_collision
 class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
 {
     private:
-        enum apply_action {
+        enum apply_action : std::uint8_t {
             act_unknown, act_ignore, act_dismantle, act_erase
         };
     public:

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -5344,7 +5344,7 @@ static ret_val<void> apply_mapgen_in_phases(
     const jmapgen_objects &objects, const tripoint_rel_ms &offset, const std::string &context,
     bool verify = false )
 {
-    const ret_val<void> has_vehicle_collision = objects.has_vehicle_collision( md, offset );
+    ret_val<void> has_vehicle_collision = objects.has_vehicle_collision( md, offset );
     if( verify &&  !has_vehicle_collision.success() ) {
 
         return has_vehicle_collision;
@@ -5363,7 +5363,7 @@ static ret_val<void> apply_mapgen_in_phases(
             if( elem.phase() != phase ) {
                 break;
             }
-            const ret_val<void> has_vehicle_collision = elem.has_vehicle_collision( md, offset );
+            has_vehicle_collision = elem.has_vehicle_collision( md, offset );
             if( verify && !has_vehicle_collision.success() ) {
                 return has_vehicle_collision;
             }
@@ -8060,7 +8060,7 @@ mapgen_update_func add_mapgen_update_func( const JsonObject &jo, bool &defer )
         };
         return null_function;
     }
-    const auto update_function = [json_data]( const tripoint_abs_omt & omt_pos, mission * miss ) {
+    auto update_function = [json_data]( const tripoint_abs_omt & omt_pos, mission * miss ) {
         json_data.update_map( omt_pos, {}, tripoint_rel_ms::zero, miss );
     };
     defer = mapgen_defer::defer;

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -105,7 +105,7 @@ struct jmapgen_int {
 
 /** Mapgen pieces will be applied in order of phases.  The phases are as
  * follows: */
-enum class mapgen_phase {
+enum class mapgen_phase : std::uint8_t {
     removal,
     terrain,
     furniture,
@@ -127,7 +127,7 @@ inline bool operator<( const mapgen_phase l, const mapgen_phase r )
     return static_cast<int>( l ) < static_cast<int>( r );
 }
 
-enum jmapgen_setmap_op {
+enum jmapgen_setmap_op : std::uint8_t {
     JMAPGEN_SETMAP_OPTYPE_POINT = 0,
     JMAPGEN_SETMAP_TER,
     JMAPGEN_SETMAP_FURN,
@@ -633,7 +633,7 @@ void calculate_mapgen_weights(); // throws
 void check_mapgen_definitions();
 
 /// move to building_generation
-enum room_type {
+enum room_type : std::uint8_t {
     room_null,
     room_closet,
     room_lobby,

--- a/src/mapgen_parameter.h
+++ b/src/mapgen_parameter.h
@@ -9,7 +9,7 @@ struct mapgen_parameters;
 template <typename Id> class mapgen_value;
 class mapgendata;
 
-enum class mapgen_parameter_scope {
+enum class mapgen_parameter_scope : std::uint8_t {
     // Should be ordered from most general to most specific
     overmap_special,
     omt,

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -20,7 +20,7 @@ struct regional_settings;
 
 namespace om_direction
 {
-enum class type : int;
+enum class type : std::int8_t;
 } // namespace om_direction
 
 struct mapgen_arguments {

--- a/src/mapgenformat.cpp
+++ b/src/mapgenformat.cpp
@@ -41,7 +41,7 @@ void formatted_set_simple( map *m, const point &start, const char *cstr,
 
 template<typename ID>
 format_effect<ID>::format_effect( const std::string &chars, std::vector<ID> dets )
-    : characters( chars ), determiners( dets )
+    : characters( chars ), determiners( std::move( dets ) )
 {
     characters.erase( std::remove_if( characters.begin(), characters.end(), isspace ),
                       characters.end() );

--- a/src/material.h
+++ b/src/material.h
@@ -25,7 +25,7 @@ using material_list = std::vector<material_type>;
 using material_id_list = std::vector<material_id>;
 
 // values for how breathable a material is
-enum class breathability_rating : int {
+enum class breathability_rating : std::uint8_t {
     IMPERMEABLE = 0,
     POOR,
     AVERAGE,

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -109,7 +109,7 @@ constexpr std::optional<pass_op> get_ass_op( std::string_view token )
 }
 
 struct parse_state {
-    enum class expect : int {
+    enum class expect : std::uint8_t {
         oper = 0,
         operand,
         lparen,  // operand alias used for functions
@@ -340,7 +340,7 @@ class math_exp::math_exp_impl
         std::stack<op_ctxt> ops;
         std::stack<thingie> output;
         struct arity_t {
-            enum class type_t {
+            enum class type_t : std::uint8_t {
                 func = 0,
                 parens,
                 array,

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -561,7 +561,7 @@ diag_assign_dbl_f degradation_ass( char scope, std::vector<diag_value> const & /
 diag_assign_dbl_f spellcasting_adjustment_ass( char scope, std::vector<diag_value> const &params,
         diag_kwargs const &kwargs )
 {
-    enum spell_scope {
+    enum spell_scope : std::uint8_t {
         scope_all,
         scope_mod,
         scope_school,
@@ -729,7 +729,7 @@ diag_eval_dbl_f mod_order_eval( char /* scope */, std::vector<diag_value> const 
     };
 }
 
-enum class character_filter : int {
+enum class character_filter : std::uint8_t {
     allies = 0,
     not_allies,
     hostile,
@@ -847,7 +847,7 @@ bool mon_check_group( Creature const &critter, mongroup_id const &id )
     return MonsterGroupManager::IsMonsterInGroup( id, critter.as_monster()->type->id );
 }
 
-enum class mon_filter : int {
+enum class mon_filter : std::uint8_t {
     enemies = 0,
     friends,
     both,

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -19,7 +19,7 @@
 #include "type_id.h"
 
 struct binary_op {
-    enum class associativity {
+    enum class associativity : std::uint8_t {
         right = 0,
         left,
     };
@@ -50,7 +50,7 @@ constexpr bool operator>( binary_op const &lhs, binary_op const &rhs )
     return lhs.precedence > rhs.precedence ||
            ( lhs.precedence == rhs.precedence && lhs.assoc == binary_op::associativity::left );
 }
-enum class paren {
+enum class paren : std::uint8_t {
     left_sq = 0,
     right_sq,
     left,

--- a/src/math_parser_type.h
+++ b/src/math_parser_type.h
@@ -7,7 +7,7 @@
 
 #include "string_formatter.h"
 
-enum class math_type_t : int {
+enum class math_type_t : std::uint8_t {
     ret = 0,
     compare,
     assign,

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -30,7 +30,7 @@ static const trait_id trait_TROGLO( "TROGLO" );
 static const trait_id trait_TROGLO2( "TROGLO2" );
 static const trait_id trait_TROGLO3( "TROGLO3" );
 
-enum class medical_tab_mode {
+enum class medical_tab_mode : std::uint8_t {
     TAB_SUMMARY
 };
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1807,7 +1807,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
             new_.y = b.y();
         }
 
-        const tripoint_bub_ms &dest{ new_.x, new_.y, b.z()};
+        const tripoint_bub_ms dest{ new_.x, new_.y, b.z()};
         if( g->is_empty( dest ) ) {
             t.setpos( dest );
         }

--- a/src/mission.h
+++ b/src/mission.h
@@ -35,14 +35,14 @@ class npc;
 class overmapbuffer;
 template<typename T> struct enum_traits;
 
-enum npc_mission : int;
+enum npc_mission : std::uint8_t;
 
 namespace debug_menu
 {
 class mission_debug;
 } // namespace debug_menu
 
-enum mission_origin {
+enum mission_origin : std::uint8_t {
     ORIGIN_NULL = 0,
     ORIGIN_GAME_START, // Given when the game starts
     ORIGIN_OPENER_NPC, // NPC comes up to you when the game starts
@@ -57,7 +57,7 @@ struct enum_traits<mission_origin> {
     static constexpr mission_origin last = mission_origin::NUM_ORIGIN;
 };
 
-enum mission_goal {
+enum mission_goal : std::uint8_t {
     MGOAL_NULL = 0,
     MGOAL_GO_TO,             // Reach a certain overmap tile
     MGOAL_GO_TO_TYPE,        // Instead of a point, go to an oter_type_id map tile like "hospital_entrance"
@@ -274,7 +274,7 @@ struct mission_type {
 class mission
 {
     public:
-        enum class mission_status : int {
+        enum class mission_status : std::uint8_t {
             yet_to_start,
             in_progress,
             success,

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -34,7 +34,7 @@ using comp_list = std::vector<npc_ptr>;
 //  but this selection is done directly as part of the finalization of the mission, rather than provided
 //  as a goal at the outset, and so only counts partially.
 //
-enum mission_kind : int {
+enum mission_kind : std::uint8_t {
     No_Mission,  //  Null value
 
     //  Jobs assigned to companions for external parties

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -21,7 +21,7 @@
 #include "cata_imgui.h"
 #include "imgui/imgui.h"
 
-enum class mission_ui_tab_enum : int {
+enum class mission_ui_tab_enum : std::uint8_t {
     ACTIVE = 0,
     COMPLETED,
     FAILED,

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -64,9 +64,9 @@ class mission_ui_impl : public cataimgui::window
         }
 
     private:
-        void draw_mission_names( std::vector<mission *> missions, int &selected_mission,
+        void draw_mission_names( const std::vector<mission *> &missions, int &selected_mission,
                                  bool &need_adjust ) const;
-        void draw_selected_description( std::vector<mission *> missions, int &selected_mission );
+        void draw_selected_description( const std::vector<mission *> &missions, int &selected_mission );
 
         mission_ui_tab_enum selected_tab = mission_ui_tab_enum::ACTIVE;
         mission_ui_tab_enum switch_tab = mission_ui_tab_enum::num_tabs;
@@ -237,8 +237,8 @@ void mission_ui_impl::draw_controls()
     cataimgui::set_scroll( s );
 }
 
-void mission_ui_impl::draw_mission_names( std::vector<mission *> missions, int &selected_mission,
-        bool &need_adjust ) const
+void mission_ui_impl::draw_mission_names( const std::vector<mission *> &missions,
+        int &selected_mission, bool &need_adjust ) const
 {
     const int num_missions = missions.size();
 
@@ -267,7 +267,7 @@ void mission_ui_impl::draw_mission_names( std::vector<mission *> missions, int &
     }
 }
 
-void mission_ui_impl::draw_selected_description( std::vector<mission *> missions,
+void mission_ui_impl::draw_selected_description( const std::vector<mission *> &missions,
         int &selected_mission )
 {
     mission *miss = missions[selected_mission];

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -180,7 +180,7 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
     tripoint_abs_omt target_pos = tripoint_abs_omt::invalid;
 
     if( params.target_var.has_value() ) {
-        return project_to<coords::omt>( get_tripoint_from_var( params.target_var.value(), d, false ) );
+        return project_to<coords::omt>( get_tripoint_from_var( params.target_var, d, false ) );
     }
 
     omt_find_params find_params;

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -108,7 +108,7 @@ static const mission_type_id mission_MISSION_RECOVER_PRIEST_DIARY( "MISSION_RECO
 static const mission_type_id mission_MISSION_RECRUIT_TRACKER( "MISSION_RECRUIT_TRACKER" );
 static const mission_type_id mission_MISSION_RESCUE_DOG( "MISSION_RESCUE_DOG" );
 
-enum legacy_mission_type_id {
+enum legacy_mission_type_id : std::uint8_t {
     MISSION_NULL,
     MISSION_GET_ANTIBIOTICS,
     MISSION_GET_SOFTWARE,

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -3656,7 +3656,7 @@ bool mattack::riotbot( monster *z )
             return true;
         }
 
-        enum {ur_arrest, ur_resist, ur_trick};
+        enum : std::uint8_t {ur_arrest, ur_resist, ur_trick};
 
         // Arrest!
         uilist amenu;

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -608,7 +608,7 @@ bool Character::can_mount( const monster &critter ) const
 
 bool monexamine::pet_menu( monster &z )
 {
-    enum choices {
+    enum choices : std::uint8_t {
         swap_pos = 0,
         push_monster,
         lead,
@@ -962,7 +962,7 @@ bool monexamine::pay_bot( monster &z )
 
 bool monexamine::mfriend_menu( monster &z )
 {
-    enum choices {
+    enum choices : std::uint8_t {
         swap_pos = 0,
         push_monster,
         rename,

--- a/src/monfaction.h
+++ b/src/monfaction.h
@@ -17,7 +17,7 @@ class monfaction;
 template <typename E> struct enum_traits;
 template <typename T> class generic_factory;
 
-enum mf_attitude {
+enum mf_attitude : std::uint8_t {
     MFA_BY_MOOD = 0,    // Hostile if angry
     MFA_NEUTRAL,        // Neutral even when angry
     MFA_FRIENDLY,       // Friendly

--- a/src/monster.h
+++ b/src/monster.h
@@ -42,7 +42,7 @@ struct dealt_projectile_attack;
 struct pathfinding_settings;
 struct trap;
 
-enum class mon_trigger : int;
+enum class mon_trigger : std::uint8_t;
 
 class mon_special_attack
 {
@@ -54,7 +54,7 @@ class mon_special_attack
         // deserialize inline in monster::load due to backwards/forwards compatibility concerns
 };
 
-enum monster_attitude {
+enum monster_attitude : std::uint8_t {
     MATT_NULL = 0,
     MATT_FRIEND,
     MATT_FPASSIVE,
@@ -65,14 +65,14 @@ enum monster_attitude {
     NUM_MONSTER_ATTITUDES
 };
 
-enum monster_effect_cache_fields {
+enum monster_effect_cache_fields : std::uint8_t {
     MOVEMENT_IMPAIRED = 0,
     FLEEING,
     VISION_IMPAIRED,
     NUM_MEFF
 };
 
-enum monster_horde_attraction {
+enum monster_horde_attraction : std::uint8_t {
     MHA_NULL = 0,
     MHA_ALWAYS,
     MHA_LARGE,

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -539,13 +539,13 @@ void player_morale::display( int focus_eq, int pain_penalty, int sleepiness_pena
     class morale_line
     {
         public:
-            enum class number_format : int {
+            enum class number_format : std::uint8_t {
                 normal,
                 signed_or_dash,
                 percent,
             };
 
-            enum class line_color : int {
+            enum class line_color : std::uint8_t {
                 normal,
                 green_gray_red,
                 red_gray_green,

--- a/src/move_mode.h
+++ b/src/move_mode.h
@@ -16,14 +16,14 @@ class JsonObject;
 template<typename T>
 class generic_factory;
 
-enum class steed_type : int {
+enum class steed_type : std::uint8_t {
     NONE,
     ANIMAL,
     MECH,
     NUM
 };
 
-enum class move_mode_type : int {
+enum class move_mode_type : std::uint8_t {
     PRONE,
     CROUCHING,
     WALKING,

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -42,7 +42,7 @@ class JsonObject;
 
 // These are triggers which may affect the monster's anger or morale.
 // They are handled in monster::check_triggers(), in monster.cpp
-enum class mon_trigger : int {
+enum class mon_trigger : std::uint8_t {
     STALK,              // Increases when following the player
     HOSTILE_WEAK,       // Hurt hostile player/npc/monster seen
     HOSTILE_CLOSE,      // Hostile creature within a few tiles
@@ -237,7 +237,7 @@ struct pet_food_data {
     void deserialize( const JsonObject &data );
 };
 
-enum class mdeath_type {
+enum class mdeath_type : std::uint8_t {
     NORMAL,
     SPLATTER,
     BROKEN,

--- a/src/music.h
+++ b/src/music.h
@@ -7,7 +7,7 @@
 
 namespace music
 {
-enum music_id {
+enum music_id : std::uint8_t {
     mp3,
     instrument,
     sound,

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -32,7 +32,7 @@ class item;
 class nc_color;
 struct dream;
 
-enum game_message_type : int;
+enum game_message_type : std::uint8_t;
 
 template <typename E> struct enum_traits;
 
@@ -566,7 +566,7 @@ bool b_is_higher_trait_of_a( const trait_id &trait_a, const trait_id &trait_b );
 bool are_opposite_traits( const trait_id &trait_a, const trait_id &trait_b );
 bool are_same_type_traits( const trait_id &trait_a, const trait_id &trait_b );
 bool contains_trait( std::vector<string_id<mutation_branch>> traits, const trait_id &trait );
-enum class mutagen_technique : int {
+enum class mutagen_technique : std::uint8_t {
     consumed_mutagen,
     injected_mutagen,
     consumed_purifier,

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -19,13 +19,13 @@
 #include "string_formatter.h"
 #include "translations.h"
 #include "ui_manager.h"
-enum class mutation_menu_mode {
+enum class mutation_menu_mode : std::uint8_t {
     activating,
     examining,
     reassigning,
     hiding
 };
-enum class mutation_tab_mode {
+enum class mutation_tab_mode : std::uint8_t {
     active,
     passive,
     none

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4172,7 +4172,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                 wprintz( w_traits, c_light_red, _( "None!" ) );
             } else {
                 for( size_t i = 0; i < current_traits.size(); i++ ) {
-                    const trait_and_var current_trait = current_traits[i];
+                    const trait_and_var &current_trait = current_traits[i];
                     trim_and_print( w_traits, point( 0, i + 1 ), getmaxx( w_traits ) - 1,
                                     current_trait.trait->get_display_color(), current_trait.name() );
                 }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3770,7 +3770,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
 
 namespace char_creation
 {
-enum description_selector {
+enum description_selector : std::uint8_t {
     NAME,
     GENDER,
     OUTFIT,

--- a/src/npc.h
+++ b/src/npc.h
@@ -74,7 +74,7 @@ struct mission_type;
 struct overmap_location;
 struct pathfinding_settings;
 
-enum game_message_type : int;
+enum game_message_type : std::uint8_t;
 class gun_mode;
 
 using bionic_id = string_id<bionic_data>;
@@ -197,9 +197,9 @@ struct npc_companion_mission {
 std::string npc_class_name( const npc_class_id & );
 std::string npc_class_name_str( const npc_class_id & );
 
-enum npc_action : int;
+enum npc_action : std::uint8_t;
 
-enum npc_need {
+enum npc_need : std::uint8_t {
     need_none,
     need_ammo, need_weapon, need_gun,
     need_food, need_drink, need_safety,
@@ -207,7 +207,7 @@ enum npc_need {
 };
 
 // TODO: Turn the personality struct into a vector/map?
-enum npc_personality_type : int {
+enum npc_personality_type : std::uint8_t {
     NPE_AGGRESSION,
     NPE_BRAVERY,
     NPE_COLLECTOR,

--- a/src/npc.h
+++ b/src/npc.h
@@ -105,7 +105,7 @@ void parse_tags( std::string &phrase, const_talker const &u, const_talker const 
  */
 
 // Attitude is how we feel about the player, what we do around them
-enum npc_attitude : int {
+enum npc_attitude : std::uint8_t {
     NPCATT_NULL = 0, // Don't care/ignoring player The places this is assigned is on shelter NPC generation, and when you order a NPC to stay in a location, and after talking to a NPC that wanted to talk to you.
     NPCATT_TALK,  // Move to and talk to player
     NPCATT_LEGACY_1,
@@ -133,7 +133,7 @@ std::string npc_attitude_id( npc_attitude );
 std::string npc_attitude_name( npc_attitude );
 
 // Attitudes are grouped by overall behavior towards player
-enum class attitude_group : int {
+enum class attitude_group : std::uint8_t {
     neutral = 0, // Doesn't particularly mind the player
     hostile, // Not necessarily attacking, but also mugging, exploiting etc.
     fearful, // Run
@@ -171,7 +171,7 @@ class job_data
         void deserialize( const JsonValue &jv );
 };
 
-enum npc_mission : int {
+enum npc_mission : std::uint8_t {
     NPC_MISSION_NULL = 0, // Nothing in particular
     NPC_MISSION_LEGACY_1,
     NPC_MISSION_SHELTER, // Stay in shelter, introduce player to game
@@ -232,7 +232,7 @@ struct npc_personality {
     void deserialize( const JsonObject &data );
 };
 
-enum class combat_engagement : int {
+enum class combat_engagement : std::uint8_t {
     NONE = 0,
     CLOSE,
     WEAK,
@@ -252,14 +252,14 @@ const std::unordered_map<std::string, combat_engagement> combat_engagement_strs 
     }
 };
 
-enum class combat_skills : int {
+enum class combat_skills : std::uint8_t {
     ALL = 0,
     NO_GENERAL,
     WEAPONS_ONLY,
     WEAPONS_ONLY_NO_THROW
 };
 
-enum class aim_rule : int {
+enum class aim_rule : std::uint8_t {
     // Aim some
     WHEN_CONVENIENT = 0,
     // No concern for ammo efficiency
@@ -589,7 +589,7 @@ struct npc_need_goal_cache {
 // DO NOT USE! This is old, use strings as talk topic instead, e.g. "TALK_AGREE_FOLLOW" instead of
 // TALK_AGREE_FOLLOW. There is also convert_talk_topic which can convert the enumeration values to
 // the new string values (used to load old saves).
-enum talk_topic_enum {
+enum talk_topic_enum : std::uint8_t {
     TALK_NONE = 0, // Used to go back to last subject
     TALK_DONE, // Used to end the conversation
     TALK_GUARD, // End conversation, nothing to be said
@@ -1487,7 +1487,7 @@ class npc_template
         translation name_unique;
         translation name_suffix;
         translation temp_suffix;
-        enum class gender : int {
+        enum class gender : std::uint8_t {
             random,
             male,
             female

--- a/src/npc_favor.h
+++ b/src/npc_favor.h
@@ -7,7 +7,7 @@
 class JsonObject;
 class JsonOut;
 
-enum npc_favor_type {
+enum npc_favor_type : std::uint8_t {
     FAVOR_NULL,
     FAVOR_GENERAL, // We owe you... a favor?
     FAVOR_CASH, // We owe cash (or goods of equivalent value)

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -165,7 +165,7 @@ static constexpr int NPC_THIRST_COMPLAIN = 80;  // "Very thirsty"
 static constexpr int NPC_HUNGER_CONSUME  = 80;  // 50% of what's needed to refuse training.
 static constexpr int NPC_HUNGER_COMPLAIN = 160; // The level at which we refuse to do some tasks.
 
-enum npc_action : int {
+enum npc_action : std::uint8_t {
     npc_undecided = 0,
     npc_pause,
     npc_reload, npc_sleep,

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -585,7 +585,7 @@ int npc_trading::cash_to_favor( const npc &, int cash )
     return roll_remainder( scaled_mission_val );
 }
 
-enum npc_chat_menu {
+enum npc_chat_menu : std::uint8_t {
     NPC_CHAT_DONE,
     NPC_CHAT_TALK,
     NPC_CHAT_YELL,

--- a/src/npctalk_rules.cpp
+++ b/src/npctalk_rules.cpp
@@ -315,8 +315,9 @@ void follower_rules_ui_impl::checkbox( int rule_number, const T &this_rule,
 }
 
 template<typename T>
-void follower_rules_ui_impl::radio_group( const std::string header_id, const char *title, T *rule,
-        std::map<T, std::string> &values, input_event &assigned_hotkey, const input_event &pressed_key )
+void follower_rules_ui_impl::radio_group( const std::string &header_id, const char *title,
+        T *rule, std::map<T, std::string> &values, input_event &assigned_hotkey,
+        const input_event &pressed_key )
 {
     ImGui::Separator();
     ImGui::NewLine();

--- a/src/npctalk_rules.h
+++ b/src/npctalk_rules.h
@@ -62,7 +62,7 @@ class follower_rules_ui_impl : public cataimgui::window
 
         // makes one radio button per option in the map
         template<typename T>
-        void radio_group( std::string header_id, const char *title, T *rule,
+        void radio_group( const std::string &header_id, const char *title, T *rule,
                           std::map<T, std::string> &values, input_event &assigned_hotkey, const input_event &pressed_key );
 
         // Prepares for a rule option with multiple valid selections. Advances and wraps through

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -53,7 +53,7 @@ inline const overmap_land_use_code_id land_use_code_wetland_saltwater( "wetland_
 namespace om_direction
 {
 /** Basic enum for directions. */
-enum class type : int {
+enum class type : std::int8_t {
     invalid = -1,
     none,
     north = none,
@@ -177,7 +177,7 @@ struct overmap_static_spawns : public overmap_spawns {
 };
 
 //terrain flags enum! this is for tracking the indices of each flag.
-enum class oter_flags : int {
+enum class oter_flags : std::uint8_t {
     known_down = 0,
     known_up,
     no_rotate,    // this tile doesn't have four rotated versions (north, east, south, west)
@@ -234,7 +234,7 @@ struct enum_traits<oter_flags> {
     static constexpr oter_flags last = oter_flags::num_oter_flags;
 };
 
-enum class oter_travel_cost_type : int {
+enum class oter_travel_cost_type : std::uint8_t {
     other,
     impassable,
     road,
@@ -628,7 +628,7 @@ struct overmap_special_placement_constraints {
     numeric_interval<int> occurrences;
 };
 
-enum class overmap_special_subtype {
+enum class overmap_special_subtype : std::uint8_t {
     fixed,
     mutable_,
     last

--- a/src/options.h
+++ b/src/options.h
@@ -62,7 +62,7 @@ class options_manager
         void addOptionToPage( const std::string &name, const std::string &page );
 
     public:
-        enum copt_hide_t {
+        enum copt_hide_t : std::uint8_t {
             /** Don't hide this option */
             COPT_NO_HIDE,
             /** Hide this option in SDL build */
@@ -141,7 +141,7 @@ class options_manager
                 bool hasPrerequisite() const;
                 bool checkPrerequisite() const;
 
-                enum COPT_VALUE_TYPE {
+                enum COPT_VALUE_TYPE : std::uint8_t {
                     CVT_UNKNOWN = 0,
                     CVT_BOOL = 1,
                     CVT_STRING = 2,
@@ -301,7 +301,7 @@ class options_manager
         };
 
         /** Page item type. */
-        enum class ItemType {
+        enum class ItemType : std::uint8_t {
             BlankLine,
             GroupHeader,
             Option,

--- a/src/output.h
+++ b/src/output.h
@@ -461,7 +461,7 @@ inline bool query_yn( const char *const msg, Args &&... args )
     return query_yn( string_format( msg, std::forward<Args>( args )... ) );
 }
 
-enum class query_ynq_result {
+enum class query_ynq_result : std::uint8_t {
     quit, no, yes
 };
 query_ynq_result query_ynq( const std::string &text );
@@ -504,7 +504,7 @@ std::vector<std::string> get_hotkeys( std::string_view s );
  *
  */
 /*@{*/
-enum PopupFlags {
+enum PopupFlags : std::uint8_t {
     PF_NONE        = 0,
     PF_GET_KEY     = 1 << 0,
     PF_ON_TOP      = 1 << 2,
@@ -597,7 +597,7 @@ input_event draw_item_info( int iLeft, int iWidth, int iTop, int iHeight, item_i
 input_event draw_item_info( const std::function<catacurses::window()> &init_window,
                             item_info_data &data );
 
-enum class item_filter_type : int {
+enum class item_filter_type : std::uint8_t {
     FIRST = 1, // used for indexing into tables
     FILTER = 1,
     LOW_PRIORITY = 2,
@@ -669,7 +669,7 @@ std::pair<std::string, nc_color> get_light_level( float light );
 
 std::pair<std::string, nc_color> rad_badge_color( int rad );
 
-enum class enumeration_conjunction : int {
+enum class enumeration_conjunction : std::uint8_t {
     none,
     and_,
     or_,
@@ -1055,7 +1055,7 @@ class multiline_list
  * when the mouse is over the window (tiles only) and a click-and-drag scrollbar
  * (technically works in curses, but is smoother in tiles).
  **/
-enum scrolling_key_scheme : int {
+enum scrolling_key_scheme : std::uint8_t {
     no_scheme,
     angle_bracket_scroll,
     arrow_scroll,

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2333,7 +2333,7 @@ class joins_tracker
         }
 
         struct compare_iterators {
-            bool operator()( iterator l, iterator r ) {
+            bool operator()( iterator l, iterator r ) const {
                 return l->where < r->where;
             }
         };

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1688,7 +1688,7 @@ struct mutable_overmap_join {
     }
 };
 
-enum class join_type {
+enum class join_type : std::uint8_t {
     mandatory,
     available,
     last
@@ -2085,7 +2085,7 @@ class joins_tracker
 #endif
         }
 
-        enum class join_status {
+        enum class join_status : std::uint8_t {
             disallowed, // Conflicts with existing join, and at least one was mandatory
             matched_available, // Matches an existing non-mandatory join
             matched_non_available, // Matches an existing mandatory join

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -160,7 +160,7 @@ class overmap_special_batch
             std::vector<overmap_special_placement>::iterator pos ) {
             return placements.erase( pos );
         }
-        bool empty() {
+        bool empty() const {
             return placements.empty();
         }
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -64,7 +64,7 @@ struct om_vehicle {
     std::string name;
 };
 
-enum class radio_type : int {
+enum class radio_type : std::uint8_t {
     MESSAGE_BROADCAST,
     WEATHER_RADIO
 };

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -22,7 +22,7 @@ class overmap_connection
                 friend overmap_connection;
 
             public:
-                enum class flag : int { orthogonal };
+                enum class flag : std::uint8_t { orthogonal };
 
                 string_id<oter_type_t> terrain;
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -361,10 +361,10 @@ class map_notes_callback : public uilist_callback
         std::tuple<catacurses::window *, catacurses::window *, catacurses::window *> preview_windows;
         ui_adaptor ui;
 
-        point_abs_omt point_selected() {
+        point_abs_omt point_selected() const {
             return _notes[_selected].first;
         }
-        tripoint_abs_omt note_location() {
+        tripoint_abs_omt note_location() const {
             return tripoint_abs_omt( point_selected(), _z );
         }
     public:

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1251,7 +1251,7 @@ tripoint_abs_omt overmapbuffer::find_random(
     return find_random( origin, params );
 }
 
-shared_ptr_fast<npc> overmapbuffer::find_npc( character_id id )
+shared_ptr_fast<npc> overmapbuffer::find_npc( character_id id ) const
 {
     for( auto &it : overmaps ) {
         if( auto p = it.second->find_npc( id ) ) {
@@ -1276,7 +1276,7 @@ shared_ptr_fast<npc> overmapbuffer::find_npc_by_unique_id( const std::string &un
     return get( loc ).find_npc_by_unique_id( unique_id );
 }
 
-std::optional<basecamp *> overmapbuffer::find_camp( const point_abs_omt &p )
+std::optional<basecamp *> overmapbuffer::find_camp( const point_abs_omt &p ) const
 {
     for( auto &it : overmaps ) {
         const point_abs_omt p2( p );
@@ -1455,7 +1455,7 @@ std::vector<camp_reference> overmapbuffer::get_camps_near( const tripoint_abs_sm
     return result;
 }
 
-std::vector<shared_ptr_fast<npc>> overmapbuffer::get_overmap_npcs()
+std::vector<shared_ptr_fast<npc>> overmapbuffer::get_overmap_npcs() const
 {
     std::vector<shared_ptr_fast<npc>> result;
     for( auto &om : overmaps ) {

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -25,7 +25,7 @@
 
 class basecamp;
 class character_id;
-enum class cube_direction : int;
+enum class cube_direction : std::uint8_t;
 enum class om_vision_level : int8_t;
 class map_extra;
 class monster;

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -265,7 +265,7 @@ class overmapbuffer
          */
         void add_camp( const basecamp &camp );
 
-        std::optional<basecamp *> find_camp( const point_abs_omt &p );
+        std::optional<basecamp *> find_camp( const point_abs_omt &p ) const;
         /**
          * Get all npcs in a area with given radius around given central point.
          * All z-levels are considered.
@@ -300,13 +300,13 @@ class overmapbuffer
          * Returns NULL if the npc could not be found.
          * Searches all loaded overmaps.
          */
-        shared_ptr_fast<npc> find_npc( character_id id );
+        shared_ptr_fast<npc> find_npc( character_id id ) const;
         void foreach_npc( const std::function<void( npc & )> &callback );
         shared_ptr_fast<npc> find_npc_by_unique_id( const std::string &unique_id );
         /**
          * Get all NPCs active on the overmap
          */
-        std::vector<shared_ptr_fast<npc>> get_overmap_npcs();
+        std::vector<shared_ptr_fast<npc>> get_overmap_npcs() const;
         /**
          * Find npc by id and if found, erase it from the npc list
          * and return it ( or return nullptr if not found ).

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -562,7 +562,7 @@ void panel_manager::deserialize( const JsonArray &ja )
             for( auto it2 = layout.begin() + std::distance( layout.begin(), it ); it2 != layout.end(); ++it2 ) {
                 if( it2->get_id() == id ) {
                     if( it->get_id() != id ) {
-                        window_panel panel = *it2;
+                        const window_panel &panel = *it2;
                         layout.erase( it2 );
                         it = layout.insert( it, panel );
                     }

--- a/src/panels.h
+++ b/src/panels.h
@@ -21,9 +21,9 @@ class Character;
 class Creature;
 class mood_face;
 struct point;
-enum class cardinal_direction;
+enum class cardinal_direction : std::uint8_t;
 
-enum face_type : int {
+enum face_type : std::uint8_t {
     face_human = 0,
     face_bird,
     face_bear,

--- a/src/past_games_info.h
+++ b/src/past_games_info.h
@@ -21,7 +21,7 @@ class past_game_info
     public:
         explicit past_game_info( const JsonObject &jo );
 
-        stats_tracker &stats() {
+        stats_tracker &stats() const {
             return *stats_;
         }
 

--- a/src/path_info.h
+++ b/src/path_info.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-enum class holiday : int;
+enum class holiday : std::uint8_t;
 
 const std::string SAVE_MASTER( "master.gsav" );
 const std::string SAVE_ARTIFACTS( "artifacts.gsav" );

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -64,7 +64,7 @@ struct pickup_count {
     int count = 0;
 };
 
-enum pickup_answer : int {
+enum pickup_answer : std::int8_t {
     CANCEL = -1,
     WIELD,
     SPILL,

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -37,7 +37,7 @@ bool do_pickup( std::vector<item_location> &targets, std::vector<int> &quantitie
                 bool autopickup, bool &stash_successful, Pickup::pick_info &info );
 bool query_thief();
 
-enum from_where : int {
+enum from_where : std::uint8_t {
     from_cargo = 0,
     from_ground,
     prompt

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -12,12 +12,12 @@
 
 class pixel_minimap_projector;
 
-enum class pixel_minimap_type : int {
+enum class pixel_minimap_type : std::uint8_t {
     ortho,
     iso
 };
 
-enum class pixel_minimap_mode : int {
+enum class pixel_minimap_mode : std::uint8_t {
     solid,
     squares,
     dots

--- a/src/player_difficulty.h
+++ b/src/player_difficulty.h
@@ -7,7 +7,7 @@
 // The point after which stats cost double
 constexpr int HIGH_STAT = 12;
 
-enum class pool_type {
+enum class pool_type : std::uint8_t {
     FREEFORM = 0,
     ONE_POOL,
     MULTI_POOL,

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -273,7 +273,7 @@ static bool is_cqb_skill( const skill_id &id )
 
 namespace
 {
-enum class player_display_tab : int {
+enum class player_display_tab : std::uint8_t {
     stats,
     encumbrance,
     speed,

--- a/src/pocket_type.h
+++ b/src/pocket_type.h
@@ -4,7 +4,7 @@
 
 template <typename E> struct enum_traits;
 
-enum class pocket_type : int {
+enum class pocket_type : std::uint8_t {
     CONTAINER,
     MAGAZINE,
     MAGAZINE_WELL, //holds magazines

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -27,7 +27,7 @@ template<typename T>
 class generic_factory;
 class Character;
 
-enum class proficiency_bonus_type : int {
+enum class proficiency_bonus_type : std::uint8_t {
     strength,
     dexterity,
     intelligence,

--- a/src/proficiency_ui.cpp
+++ b/src/proficiency_ui.cpp
@@ -69,7 +69,7 @@ std::vector<display_prof_deps *> &prof_window::get_current_set()
 
 void prof_window::filter()
 {
-    enum class _prof_filter_prefix {
+    enum class _prof_filter_prefix : std::uint8_t {
         LEARNED,
         UNLEARNED,
         AS_PROGRESS,

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -201,7 +201,7 @@ class target_ui
     public:
         /* None of the public members (except ammo and range) should be modified during execution */
 
-        enum class TargetMode : int {
+        enum class TargetMode : std::uint8_t {
             Fire,
             Throw,
             ThrowBlind,
@@ -237,7 +237,7 @@ class target_ui
         // Relevant activity
         aim_activity_actor *activity = nullptr;
 
-        enum class ExitCode : int {
+        enum class ExitCode : std::uint8_t {
             Abort,
             Fire,
             Timeout,
@@ -253,7 +253,7 @@ class target_ui
         int get_sight_dispersion() const;
 
     private:
-        enum class Status : int {
+        enum class Status : std::uint8_t {
             Good, // All UI elements are enabled
             BadTarget, // Bad 'dst' selected; forbid aiming/firing
             OutOfAmmo, // Selected gun mode is out of ammo; forbid moving cursor,aiming and firing

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -26,13 +26,13 @@ class JsonObject;
 class item;
 template <typename E> struct enum_traits;
 
-enum class recipe_filter_flags : int {
+enum class recipe_filter_flags : std::uint8_t {
     none = 0,
     no_rotten = 1,
     no_favorite = 2,
 };
 
-enum class recipe_time_flag : int {
+enum class recipe_time_flag : std::uint8_t {
     none = 0,
     ignore_proficiencies = 1,
 };

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -196,7 +196,7 @@ static std::unordered_set<layer_level> filtered_layers;
 
 template<typename Unit>
 static Unit can_contain_filter( std::string_view hint, std::string_view txt, Unit max,
-                                std::vector<std::pair<std::string, Unit>> units )
+                                const std::vector<std::pair<std::string, Unit>> &units )
 {
     auto const error = [hint, txt]( char const *, size_t /* offset */ ) {
         throw math::runtime_error( _( string_format( hint, txt ) ) );

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -140,7 +140,7 @@ class recipe_subset
         /** Returns all recipes which could use component */
         const std::set<const recipe *> &of_component( const itype_id &id ) const;
 
-        enum class search_type : int {
+        enum class search_type : std::uint8_t {
             name,
             exclude_name,
             skill,

--- a/src/relic.h
+++ b/src/relic.h
@@ -99,7 +99,7 @@ class relic_procgen_data
             void deserialize( const JsonObject &jo );
         };
 
-        enum type {
+        enum type : std::uint8_t {
             passive_enchantment_add,
             passive_enchantment_mult,
             hit_you,
@@ -138,14 +138,14 @@ class relic_procgen_data
         void deserialize( const JsonObject &jobj );
 };
 
-enum class relic_recharge_has : int {
+enum class relic_recharge_has : std::uint8_t {
     WIELD,
     WORN,
     HELD,
     NUM
 };
 
-enum class relic_recharge_type : int {
+enum class relic_recharge_type : std::uint8_t {
     NONE,
     PERIODIC,
     LUNAR,

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -167,7 +167,7 @@ struct quality_requirement {
     }
 };
 
-enum class requirement_display_flags : int {
+enum class requirement_display_flags : std::uint8_t {
     none = 0,
     no_unavailable = 1,
 };

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -51,7 +51,7 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
     int content_height = 0;
     const int num_columns = 6;
 
-    enum Columns : int {
+    enum Columns : std::uint8_t {
         COLUMN_RULE,
         COLUMN_ATTITUDE,
         COLUMN_PROXIMITY,

--- a/src/safemode_ui.h
+++ b/src/safemode_ui.h
@@ -17,18 +17,18 @@ class JsonOut;
 class safemode
 {
     private:
-        enum Tabs : int {
+        enum Tabs : std::uint8_t {
             GLOBAL_TAB,
             CHARACTER_TAB,
             MAX_TAB
         };
 
-        enum class Categories : int {
+        enum class Categories : std::uint8_t {
             HOSTILE_SPOTTED,
             SOUND
         };
 
-        enum class MovementModes : int {
+        enum class MovementModes : std::uint8_t {
             WALKING,
             DRIVING,
             BOTH

--- a/src/scent_block.h
+++ b/src/scent_block.h
@@ -13,7 +13,7 @@ struct scent_block {
     template<typename T>
     using data_block = std::array < std::array < T, SEEY + 2 >, SEEX + 2 >;
 
-    enum class data_mode : int {
+    enum class data_mode : std::uint8_t {
         NONE = 0,
         SET = 1,
         MAX = 2

--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -26,7 +26,7 @@
 #include "ui.h"
 #include "ui_manager.h"
 
-enum class scores_ui_tab : int {
+enum class scores_ui_tab : std::uint8_t {
     achievements = 0,
     conducts,
     scores,

--- a/src/shadowcasting.h
+++ b/src/shadowcasting.h
@@ -21,7 +21,7 @@ struct tripoint;
 // player is looking at is lit.
 // For non-opaque tiles direction doesn't matter so we just use the single
 // default_ value.
-enum class quadrant : int {
+enum class quadrant : std::uint8_t {
     NE,
     SE,
     SW,
@@ -29,7 +29,7 @@ enum class quadrant : int {
     default_ = NE
 };
 
-enum class vertical_direction {
+enum class vertical_direction : std::uint8_t {
     UP,
     DOWN,
     BOTH

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -90,7 +90,7 @@ Skill::Skill( const skill_id &ident, const translation &name, const translation 
 }
 
 std::vector<const Skill *> Skill::get_skills_sorted_by(
-    std::function<bool ( const Skill &, const Skill & )> pred )
+    const std::function<bool ( const Skill &, const Skill & )> &pred )
 {
     std::vector<const Skill *> result;
     result.reserve( skills.size() );

--- a/src/skill.h
+++ b/src/skill.h
@@ -59,7 +59,7 @@ class Skill
         static void reset();
 
         static std::vector<const Skill *> get_skills_sorted_by(
-            std::function<bool ( const Skill &, const Skill & )> pred );
+            const std::function<bool ( const Skill &, const Skill & )> &pred );
 
         Skill();
         Skill( const skill_id &ident, const translation &name, const translation &description,

--- a/src/sleep.h
+++ b/src/sleep.h
@@ -32,7 +32,7 @@ struct comfort_data {
     static const int COMFORT_COMFORTABLE = 5;
     static const int COMFORT_VERY_COMFORTABLE = 10;
 
-    enum class category {
+    enum class category : std::uint8_t {
         terrain,
         furniture,
         trap,

--- a/src/smart_controller_ui.h
+++ b/src/smart_controller_ui.h
@@ -17,7 +17,7 @@ struct smart_controller_settings {
     smart_controller_settings( bool &enabled, int &battery_lo, int &battery_hi );
 };
 
-enum smart_controller_ui_selection {
+enum smart_controller_ui_selection : std::uint8_t {
     enabled,
     lo_and_hi_slider,
     manual,

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -20,7 +20,7 @@ template <typename E> struct enum_traits;
 
 namespace sounds
 {
-enum class sound_t : int {
+enum class sound_t : std::uint8_t {
     background = 0,
     weather,
     sensory, // Sonar etc. Ensures this sound will usually get a visual marker so the player can see it.
@@ -94,7 +94,7 @@ struct enum_traits<sounds::sound_t> {
 namespace sfx
 {
 //Channel assignments:
-enum class channel : int {
+enum class channel : std::int8_t {
     any = -1,                   //Finds the first available channel
     daytime_outdoors_env = 0,
     nighttime_outdoors_env,
@@ -130,7 +130,7 @@ enum class channel : int {
 };
 
 //Group Assignments:
-enum class group : int {
+enum class group : std::uint8_t {
     weather = 1,    //SFX related to weather
     time_of_day,    //SFX related to time of day
     context_themes, //SFX related to context themes

--- a/src/stats_tracker.h
+++ b/src/stats_tracker.h
@@ -26,7 +26,7 @@ namespace cata
 struct range_hash;
 }  // namespace cata
 
-enum class monotonically : int;
+enum class monotonically : std::uint8_t;
 class score;
 class stats_tracker;
 

--- a/src/string_id_utils.h
+++ b/src/string_id_utils.h
@@ -37,7 +37,7 @@ std::vector<std::pair<K, V>> sorted_lex( Col col )
 template<typename Col,
          typename El = std::decay_t<decltype( *std::declval<const Col &>().begin() )>,
          std::enable_if_t<std::is_same_v<El, string_id<typename El::value_type>>, int> = 0>
-std::vector<El> sorted_lex( Col col )
+std::vector<El> sorted_lex( const Col &col )
 {
     std::vector<El> ret;
     ret.insert( ret.begin(), col.begin(), col.end() );

--- a/src/subbodypart.h
+++ b/src/subbodypart.h
@@ -27,7 +27,7 @@ struct body_part_type;
 using sub_bodypart_str_id = string_id<sub_body_part_type>;
 using sub_bodypart_id = int_id<sub_body_part_type>;
 
-enum class side : int {
+enum class side : std::uint8_t {
     BOTH,
     LEFT,
     RIGHT,

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -757,7 +757,7 @@ void suffer::in_sunlight( Character &you )
     }
 }
 
-std::map<bodypart_id, float> Character::bodypart_exposure()
+std::map<bodypart_id, float> Character::bodypart_exposure() const
 {
     std::map<bodypart_id, float> bp_exposure;
     // May need to iterate over all body parts several times, so make a copy

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -815,7 +815,7 @@ void suffer::from_sunburn( Character &you, bool severe )
     // TODO: Could factor bodypart_exposure out of Character too
     std::map<bodypart_id, float> bp_exposure = you.bodypart_exposure();
 
-    enum Sunburn { None, Focus_Loss, Pain, Damage };
+    enum Sunburn : std::uint8_t { None, Focus_Loss, Pain, Damage };
 
     auto heavy_sunburn = [severe, &you]( bodypart_id bp ) {
         if( severe ) {

--- a/src/talker.h
+++ b/src/talker.h
@@ -23,11 +23,11 @@ class recipe;
 struct tripoint;
 class vehicle;
 struct mutation_variant;
-enum class get_body_part_flags;
+enum class get_body_part_flags : std::uint8_t;
 
 namespace npc_factions
 {
-enum class relationship : int;
+enum class relationship : std::uint8_t;
 } // namespace npc_factions
 
 using bodytype_id = std::string;

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -25,7 +25,7 @@ struct mutation_variant;
 
 namespace npc_factions
 {
-enum class relationship : int;
+enum class relationship : std::uint8_t;
 } // namespace npc_factions
 
 /*

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -312,7 +312,7 @@ int talker_npc_const::value( const item &it ) const
     return me_npc->value( it );
 }
 
-enum consumption_result {
+enum consumption_result : std::uint8_t {
     REFUSED = 0,
     CONSUMED_SOME, // Consumption didn't fail, but don't delete the item
     CONSUMED_ALL   // Consumption succeeded, delete the item

--- a/src/test_data.h
+++ b/src/test_data.h
@@ -22,7 +22,7 @@ struct efficiency_data {
     void deserialize( const JsonObject &jo );
 };
 
-enum class spawn_type : int {
+enum class spawn_type : std::uint8_t {
     none = 0,
     item_group,
     recipe,

--- a/src/text_style_check.h
+++ b/src/text_style_check.h
@@ -7,18 +7,18 @@
 #include <functional>
 #include <string>
 
-enum class text_style_fix : int {
+enum class text_style_fix : std::uint8_t {
     removal,
     insertion,
     replacement
 };
 
-enum class fix_end_of_string_spaces : int {
+enum class fix_end_of_string_spaces : std::uint8_t {
     no,
     yes
 };
 
-enum class escape_unicode : int {
+enum class escape_unicode : std::uint8_t {
     no,
     yes
 };

--- a/src/timed_event.h
+++ b/src/timed_event.h
@@ -8,7 +8,7 @@
 #include "coords_fwd.h"
 #include "submap.h"
 
-enum class timed_event_type : int {
+enum class timed_event_type : std::uint8_t {
     NONE,
     HELP,
     WANTED,

--- a/src/trade_ui.h
+++ b/src/trade_ui.h
@@ -82,7 +82,7 @@ class trade_ui
             select_t items_trader;
         };
 
-        enum class event { TRADECANCEL = 0, TRADEOK = 1, SWITCH = 2, NEVENTS = 3 };
+        enum class event : std::uint8_t { TRADECANCEL = 0, TRADEOK = 1, SWITCH = 2, NEVENTS = 3 };
 
         trade_ui( party_t &you, npc &trader, currency_t cost = 0, std::string title = _( "Trade" ) );
 

--- a/src/translation_document.h
+++ b/src/translation_document.h
@@ -21,7 +21,7 @@ class InvalidTranslationDocumentException : public std::exception
         const char *what() const noexcept override;
 };
 
-enum class Endianness {
+enum class Endianness : std::uint8_t {
     BigEndian,
     LittleEndian
 };

--- a/src/translation_manager.cpp
+++ b/src/translation_manager.cpp
@@ -8,7 +8,7 @@ TranslationManager &TranslationManager::GetInstance()
     return singleton;
 }
 
-std::unordered_set<std::string> TranslationManager::GetAvailableLanguages()
+std::unordered_set<std::string> TranslationManager::GetAvailableLanguages() const
 {
     return impl->GetAvailableLanguages();
 }

--- a/src/translation_manager.h
+++ b/src/translation_manager.h
@@ -20,7 +20,7 @@ class TranslationManager
         TranslationManager( const TranslationManager & ) = delete;
         TranslationManager( TranslationManager && ) = delete;
         static TranslationManager &GetInstance();
-        std::unordered_set<std::string> GetAvailableLanguages();
+        std::unordered_set<std::string> GetAvailableLanguages() const;
         void SetLanguage( const std::string &language_code );
         std::string GetCurrentLanguage() const;
         void LoadDocuments( const std::vector<std::string> &files );

--- a/src/translation_plural_evaluator.cpp
+++ b/src/translation_plural_evaluator.cpp
@@ -19,7 +19,7 @@ using ExprNode = TranslationPluralRulesEvaluator::ExprNode;
 namespace std
 {
 template<> struct hash<ExprTokenType> {
-    std::size_t operator()( const ExprTokenType &token ) const {
+    std::size_t operator()( const ExprTokenType &token ) const noexcept {
         return static_cast<std::size_t>( token );
     }
 };

--- a/src/translation_plural_evaluator.h
+++ b/src/translation_plural_evaluator.h
@@ -48,7 +48,7 @@ class TranslationPluralRulesEvaluator
                 explicit EvaluationError( const std::string &message ) : Error( message ) {}
         };
 
-        enum class ExprTokenType : int {
+        enum class ExprTokenType : std::uint8_t {
             Variable,
             Constant,
             Plus,

--- a/src/ui_extended_description.h
+++ b/src/ui_extended_description.h
@@ -8,7 +8,7 @@
 #include "imgui/imgui.h"
 #include "output.h"
 
-enum class description_target : int {
+enum class description_target : std::uint8_t {
     creature = 0,
     furniture,
     terrain,

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -242,7 +242,7 @@ class ui_adaptor
         // modified before, during, or after drawing, so they do not necessarily
         // indicate what the current cursor position would be, and therefore
         // should not be made public or have a public getter.
-        enum class cursor {
+        enum class cursor : std::uint8_t {
             last, custom, disabled
         };
         cursor cursor_type = cursor::last;

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -108,7 +108,7 @@ class uistatedata
 {
         /**** this will set a default value on startup, however to save, see below ****/
     private:
-        enum side { left = 0, right = 1, NUM_PANES = 2 };
+        enum side : std::uint8_t { left = 0, right = 1, NUM_PANES = 2 };
     public:
         int ags_pay_gas_selected_pump = 0;
 

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -27,7 +27,7 @@ class vpart_info;
 struct requirement_data;
 
 /** Represents possible return values from the cant_do function. */
-enum class task_reason : int {
+enum class task_reason : std::int8_t {
     UNKNOWN_TASK = -1, //No such task
     CAN_DO, //Task can be done
     INVALID_TARGET, //No valid target i.e. can't "change tire" if no tire present

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -54,7 +54,7 @@ const std::vector<vpart_info> &get_all();
 
 // bitmask backing store of -certain- vpart_info.flags, ones that
 // won't be going away, are involved in core functionality, and are checked frequently
-enum vpart_bitflags : int {
+enum vpart_bitflags : std::uint8_t {
     VPFLAG_ARMOR,
     VPFLAG_APPLIANCE,
     VPFLAG_ARCADE,

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4379,7 +4379,7 @@ double vehicle::coeff_air_drag() const
                   p.info().has_flag( "OPENABLE" ) );
     };
 
-    const auto d_protrusion = [&]( std::vector<int> parts_at ) {
+    const auto d_protrusion = [&]( const std::vector<int> &parts_at ) {
         if( parts_at.size() > 1 ) {
             return false;
         } else {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2496,7 +2496,7 @@ bool vehicle::split_vehicles( map &here,
         if( split_parts.empty() ) {
             continue;
         }
-        std::vector<point_rel_ms> split_mounts = new_mounts[ i ];
+        const std::vector<point_rel_ms> &split_mounts = new_mounts[ i ];
         did_split = true;
 
         vehicle *new_vehicle = nullptr;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1834,7 +1834,7 @@ class vehicle
          */
         bool check_heli_descend( Character &p ) const;
         bool check_heli_ascend( Character &p ) const;
-        bool check_is_heli_landed();
+        bool check_is_heli_landed() const;
         /**
          * Player is driving the vehicle
          * @param trn is turn direction
@@ -2044,7 +2044,7 @@ class vehicle
         void unlock( int part_index );
         // returns whether the door can be locked with an attached DOOR_LOCKING part.
         bool part_has_lock( int part_index ) const;
-        bool can_close( int part_index, Character &who );
+        bool can_close( int part_index, Character &who ) const;
 
         // @returns true if vehicle only has foldable parts
         bool is_foldable() const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -60,8 +60,8 @@ struct itype;
 struct uilist_entry;
 template <typename E> struct enum_traits;
 
-enum vpart_bitflags : int;
-enum class ter_furn_flag : int;
+enum vpart_bitflags : std::uint8_t;
+enum class ter_furn_flag : std::uint8_t;
 template<typename feature_type>
 class vehicle_part_with_feature_range;
 
@@ -97,7 +97,7 @@ constexpr int SCATTER_DISTANCE = 3;
 //adjust this to balance collision damage
 constexpr int k_mvel = 200;
 
-enum class part_status_flag : int {
+enum class part_status_flag : std::uint8_t {
     any = 0,
     working = 1 << 0,
     available = 1 << 1,
@@ -109,7 +109,7 @@ struct enum_traits<part_status_flag> {
     static constexpr bool is_flag_enum = true;
 };
 
-enum veh_coll_type : int {
+enum veh_coll_type : std::uint8_t {
     veh_coll_nothing,  // 0 - nothing,
     veh_coll_body,     // 1 - monster/player/npc
     veh_coll_veh,      // 2 - vehicle
@@ -184,7 +184,7 @@ class vehicle_stack : public item_stack
         units::volume max_volume() const override;
 };
 
-enum towing_point_side : int {
+enum towing_point_side : std::uint8_t {
     TOW_FRONT,
     TOW_SIDE,
     TOW_BACK,
@@ -669,7 +669,7 @@ class turret_data
         bool can_reload() const;
         bool can_unload() const;
 
-        enum class status : int {
+        enum class status : std::uint8_t {
             invalid,
             no_ammo,
             no_power,
@@ -703,7 +703,7 @@ struct label : public point_rel_ms {
     void serialize( JsonOut &json ) const;
 };
 
-enum class autodrive_result : int {
+enum class autodrive_result : std::uint8_t {
     // the driver successfully performed course correction or simply did nothing
     // in order to keep going forward
     ok,

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -360,7 +360,7 @@ struct auto_navigation_data {
     Tripoint adjust_z( const Tripoint &p ) const;
 };
 
-enum class collision_check_result : int {
+enum class collision_check_result : std::uint8_t {
     ok,
     no_visibility,
     close_obstacle,

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -371,7 +371,7 @@ class vehicle::autodrive_controller
 {
     public:
         explicit autodrive_controller( const vehicle &driven_veh, const Character &driver );
-        const Character &get_driver() {
+        const Character &get_driver() const {
             return driver;
         }
         const auto_navigation_data &get_data() {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1347,7 +1347,7 @@ void vehicle::selfdrive( const int trn, const int acceleration )
     }
 }
 
-bool vehicle::check_is_heli_landed()
+bool vehicle::check_is_heli_landed() const
 {
     // @TODO - when there are chasms that extend below z-level 0 - perhaps the heli
     // will be able to descend into them but for now, assume z-level-0 == the ground.

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1247,7 +1247,7 @@ void vehicle::lock( int part_index )
     }
 }
 
-bool vehicle::can_close( int part_index, Character &who )
+bool vehicle::can_close( int part_index, Character &who ) const
 {
     creature_tracker &creatures = get_creature_tracker();
     part_index = get_non_fake_part( part_index );

--- a/src/visitable.h
+++ b/src/visitable.h
@@ -13,7 +13,7 @@
 class item;
 class Character;
 
-enum class VisitResponse : int {
+enum class VisitResponse : std::uint8_t {
     ABORT, // Stop processing after this node
     NEXT,  // Descend vertically to any child nodes and then horizontally to next sibling
     SKIP   // Skip any child nodes and move directly to the next sibling

--- a/src/vitamin.h
+++ b/src/vitamin.h
@@ -18,7 +18,7 @@
 class JsonObject;
 template <typename T> struct enum_traits;
 
-enum class vitamin_type : int {
+enum class vitamin_type : std::uint8_t {
     VITAMIN,
     TOXIN,
     DRUG,

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -21,7 +21,7 @@ class vehicle_stack;
 class vpart_info;
 struct vehicle_part;
 
-enum vpart_bitflags : int;
+enum vpart_bitflags : std::uint8_t;
 class vpart_reference;
 struct point;
 struct tripoint;

--- a/src/vpart_range.h
+++ b/src/vpart_range.h
@@ -13,7 +13,7 @@
 #include "vehicle.h"
 #include "vpart_position.h"
 
-enum class part_status_flag : int;
+enum class part_status_flag : std::uint8_t;
 
 /**
  * Exposes (multiple) parts of one vehicle as @ref vpart_reference.

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -23,7 +23,7 @@ class JsonValue;
 
 // Information about an attack on a weak point.
 struct weakpoint_attack {
-    enum class attack_type : int {
+    enum class attack_type : std::uint8_t {
         NONE, // Unusual damage instances, such as falls, spells, and effects.
         MELEE_BASH, // Melee bludgeoning attacks
         MELEE_CUT, // Melee slashing attacks

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -26,7 +26,7 @@ class generic_factory;
 const weather_type_id WEATHER_NULL( "null" );
 const weather_type_id WEATHER_CLEAR( "clear" );
 
-enum class precip_class : int {
+enum class precip_class : std::uint8_t {
     none,
     very_light,
     light,
@@ -38,7 +38,7 @@ struct enum_traits<precip_class> {
     static constexpr precip_class last = precip_class::last;
 };
 
-enum weather_sound_category : int {
+enum weather_sound_category : std::uint8_t {
     silent,
     drizzle,
     rainy,

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1827,7 +1827,7 @@ std::string widget::layout( const avatar &ava, unsigned int max_width, int label
             // Total widget width w/o padding
             const int total_widget_width = std::accumulate( wgts.begin(), wgts.end(), 0,
             [child_width]( int sum, const widget_id & wid ) {
-                widget cur_child = wid.obj();
+                const widget &cur_child = wid.obj();
                 return sum + ( cur_child._style == "layout" &&
                                cur_child._width > 0 ? cur_child._width : child_width );
             } );

--- a/src/widget.h
+++ b/src/widget.h
@@ -15,7 +15,7 @@
 
 // These are the supported data variables for widgets, defined as enum widget_var.
 // widget_var names may be given as the "var" field in widget JSON.
-enum class widget_var : int {
+enum class widget_var : std::uint8_t {
     focus,          // Current focus, integer
     move,           // Current move counter, integer
     move_remainder, // Current remaining moves, integer
@@ -99,7 +99,7 @@ struct enum_traits<widget_var> {
 
 // This is deliberately separate from "direction".
 // The values correspond to the indexed directions returned from avatar::get_mon_visible
-enum class cardinal_direction : int {
+enum class cardinal_direction : std::uint8_t {
     NORTH = 0,
     NORTHEAST = 1,
     EAST = 2,
@@ -120,7 +120,7 @@ struct enum_traits<cardinal_direction> {
 };
 
 // Used when determining bodypart status indicators in sidebar widgets.
-enum class bodypart_status : int {
+enum class bodypart_status : std::uint8_t {
     BITTEN,
     INFECTED,
     BROKEN,
@@ -137,7 +137,7 @@ struct enum_traits<bodypart_status> {
 };
 
 // Determines how text and labels are aligned for widgets
-enum class widget_alignment : int {
+enum class widget_alignment : std::uint8_t {
     LEFT,
     CENTER,
     RIGHT,

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -2089,7 +2089,7 @@ void load_external_option( const JsonObject &jo )
     options_manager::update_options_cache();
 }
 
-mod_manager &worldfactory::get_mod_manager()
+mod_manager &worldfactory::get_mod_manager() const
 {
     return *mman;
 }
@@ -2104,7 +2104,7 @@ WORLD *worldfactory::get_world( const std::string &name )
     return iter->second.get();
 }
 
-std::string worldfactory::get_world_name( const size_t index )
+std::string worldfactory::get_world_name( const size_t index ) const
 {
     size_t i = 0;
     for( const auto &elem : all_worlds ) {
@@ -2116,7 +2116,7 @@ std::string worldfactory::get_world_name( const size_t index )
     return "";
 }
 
-size_t worldfactory::get_world_index( const std::string &name )
+size_t worldfactory::get_world_index( const std::string &name ) const
 {
     size_t i = 0;
     for( const auto &elem : all_worlds ) {

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -104,9 +104,9 @@ class worldfactory
         /// Returns the *existing* world of given name.
         WORLD *get_world( const std::string &name );
         /// Returns the *existing* world's name from its index in the world list.
-        std::string get_world_name( size_t index );
+        std::string get_world_name( size_t index ) const;
         /// Returns the *existing* world's index in the world list from its name.
-        size_t get_world_index( const std::string &name );
+        size_t get_world_index( const std::string &name ) const;
         bool has_world( const std::string &name ) const;
 
         void set_active_world( WORLD *world );
@@ -124,7 +124,7 @@ class worldfactory
 
         void save_last_world_info() const;
 
-        mod_manager &get_mod_manager();
+        mod_manager &get_mod_manager() const;
 
         void remove_world( const std::string &worldname );
         bool valid_worldname( const std::string &name, bool automated = false ) const;

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -15,7 +15,7 @@
 #include "pimpl.h"
 #include "type_id.h"
 
-enum class special_game_type;
+enum class special_game_type : std::uint8_t;
 
 class JsonArray;
 class JsonObject;


### PR DESCRIPTION
#### Summary
Infrastructure "Apply Clang-Tidy and VS static analysis suggestions."

#### Purpose of change
Improve code readability and performance. On my machine this reduced mean time per `do_turn` from 135 microseconds to 131.5, around a 2.5% speedup.

#### Describe the solution
Apply changes. There are a lot of changes but they're grouped by commit and nearly all changes are trivial. 

#### Describe alternatives you've considered

None.

#### Testing

The game compiles and tests run.

#### Additional context
