### PR TITLE
Check validity of plant data on load

### DIFF
--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1321,6 +1321,13 @@ void furn_t::check() const
                       e.str().c_str() );
         }
     }
+    if( plant && !plant->transform.is_valid() ) {
+        debugmsg( "Invalid furniture %s for plant transform in furn %s", plant->transform.c_str(),
+                  id.c_str() );
+    }
+    if( plant && !plant->base.is_valid() ) {
+        debugmsg( "Invalid furniture %s for plant base in furn %s", plant->base.c_str(), id.c_str() );
+    }
 }
 
 int activity_byproduct::roll() const


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The loss of seed in #78939 was due to loading a bad definition. They took a mod from experimental and loaded it on 0.H. It didn't throw any errors, but it had an invalid furniture transform defined. We should have caught that on loading, we didn't.

#### Describe the solution
Check on loading to make sure the furniture ID is valid. Throw a debugmsg if it's not.

#### Describe alternatives you've considered
Making this error fatal (i.e. being unable to load the game)

#### Testing
![image](https://github.com/user-attachments/assets/ca96a11f-c551-4586-96e4-6dda270016b0)


#### Additional context

