### PR TITLE
Fix NPC rules window scaling for small terminal sizes

### DIFF
--- a/src/npctalk_rules.h
+++ b/src/npctalk_rules.h
@@ -48,8 +48,12 @@ class follower_rules_ui_impl : public cataimgui::window
         bool setup_button( int &button_num, std::string &label, bool should_color );
         bool setup_table_button( int &button_num, std::string &label, bool should_color );
 
-        size_t window_width = str_width_to_pixels( TERMX ) / 2;
-        size_t window_height = str_height_to_pixels( TERMY ) / 2;
+        float window_width = std::clamp( float( str_width_to_pixels( EVEN_MINIMUM_TERM_WIDTH ) ),
+                                         ImGui::GetMainViewport()->Size.x / 2,
+                                         ImGui::GetMainViewport()->Size.x );
+        float window_height = std::clamp( float( str_height_to_pixels( EVEN_MINIMUM_TERM_HEIGHT ) ),
+                                          ImGui::GetMainViewport()->Size.y / 2,
+                                          ImGui::GetMainViewport()->Size.y );
 
         // makes a checkbox for the rule
         template<typename T>


### PR DESCRIPTION
#### Summary
`SUMMARY: Interface "Fix NPC rules window scaling for small terminal sizes"`

#### Purpose of change

Set a minimum width and height for the NPC rules window so information does not become unreadable at small terminal sizes.

#### Describe the solution

Set the window to not go below the minimum terminal sizes of 80x24. Otherwise, it'll retain its current behavior.

#### Describe alternatives you've considered

No alternatives were considered.

#### Testing

Game compiles and loads
Open the NPC rules window at maximum and minimum terminal size
Click some buttons and checkboxes inside the window

#### Additional context
Before, tested on build caafa67. Terminal size 80x24
![Screenshot 2025-01-05 094601](https://github.com/user-attachments/assets/8fe848cd-f676-4e3d-954d-dbab952bcc29)

After
![Screenshot 2025-01-05 094350](https://github.com/user-attachments/assets/17be932b-a591-45f4-9586-416ece654f85)

Max terminal size (well, it's 240x66)
![Screenshot 2025-01-05 094336](https://github.com/user-attachments/assets/68a3b5ee-9426-4472-94b9-c34bb5996b23)

A random size
![Screenshot 2025-01-05 094432](https://github.com/user-attachments/assets/3e072414-a721-454a-8c7a-e914f3138971)
