### PR TITLE
put foil wrappers inside of the roll

### DIFF
--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -142,7 +142,7 @@
       { "item": "RPG_die", "prob": 10 },
       { "item": "metal_RPG_die", "prob": 1 },
       { "item": "aluminum_foil", "prob": 25 },
-      { "item": "wrapper_foil", "prob": 12, "count": [ 5, 40 ], "container-item": "wrapper_foil_roll" },
+      { "item": "wrapper_foil", "prob": 12, "count": [ 5, 40 ], "entry-wrapper": "wrapper_foil_roll" },
       { "item": "nuts_bolts", "prob": 20, "charges": [ 1, 4 ] },
       { "item": "plastic_shopping_bag", "prob": 60, "count": [ 1, 10 ] },
       {

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -278,7 +278,7 @@
     "entries": [
       { "item": "wrapper", "prob": 50 },
       { "item": "wrapper_foil", "prob": 5 },
-      { "item": "wrapper_foil", "prob": 25, "count": [ 5, 40 ], "container-item": "wrapper_foil_roll" },
+      { "item": "wrapper_foil", "prob": 25, "count": [ 5, 40 ], "entry-wrapper": "wrapper_foil_roll" },
       { "item": "bottle_glass", "prob": 70 },
       { "item": "can_drink", "prob": 60 },
       { "item": "flyer", "prob": 30 },
@@ -396,7 +396,7 @@
       [ "cup_plastic", 40 ],
       [ "wrapper", 34 ],
       [ "wrapper_foil", 3 ],
-      { "item": "wrapper_foil", "prob": 5, "count": [ 5, 40 ], "container-item": "wrapper_foil_roll" },
+      { "item": "wrapper_foil", "prob": 5, "count": [ 5, 40 ], "entry-wrapper": "wrapper_foil_roll" },
       [ "bag_plastic", 20 ],
       [ "bottle_glass", 30 ],
       [ "can_drink", 30 ],
@@ -446,7 +446,7 @@
       { "prob": 15, "group": "tea_raw_bag_plastic_33" },
       { "prob": 10, "group": "tea_green_raw_bag_plastic_33" },
       { "item": "wrapper", "prob": 75 },
-      { "item": "wrapper_foil", "prob": 5, "count": [ 5, 40 ], "container-item": "wrapper_foil_roll" },
+      { "item": "wrapper_foil", "prob": 5, "count": [ 5, 40 ], "entry-wrapper": "wrapper_foil_roll" },
       { "group": "teabag_box", "prob": 10 }
     ]
   },
@@ -544,7 +544,7 @@
     "entries": [
       { "item": "wrapper", "prob": 17 },
       { "item": "wrapper_foil", "prob": 1 },
-      { "item": "wrapper_foil", "prob": 5, "count": [ 5, 40 ], "container-item": "wrapper_foil_roll" },
+      { "item": "wrapper_foil", "prob": 5, "count": [ 5, 40 ], "entry-wrapper": "wrapper_foil_roll" },
       { "item": "bag_plastic", "prob": 15 },
       { "item": "bottle_glass", "prob": 10 },
       { "item": "can_drink", "prob": 10 },
@@ -620,7 +620,7 @@
       { "item": "cup_plastic", "prob": 50 },
       { "item": "wrapper", "prob": 50 },
       { "item": "wrapper_foil", "prob": 5 },
-      { "item": "wrapper_foil", "prob": 25, "count": [ 5, 40 ], "container-item": "wrapper_foil_roll" },
+      { "item": "wrapper_foil", "prob": 25, "count": [ 5, 40 ], "entry-wrapper": "wrapper_foil_roll" },
       { "item": "bag_plastic", "prob": 50 },
       { "item": "cotton_patchwork", "prob": 50 },
       { "item": "syringe", "prob": 5 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Aluminum foil rolls with wrappers spawned as "X rolls with 1 wrapper", not as "1 roll with X wrappers"
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Switch all `"container-item": "foil_wrapper_roll"` entries to `"entry-wrapper": "foil_wrapper_roll"`. That way, the `foil_wrapper` entries aren't spawning `"count"`-times, each in the `container-item`, but the entry spawns one `entry-wrapper` that contains `count` `foil_wrapper`s
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
First, I was going to set up a "foil_wrapper_roll_with_5_to_40" item group, but then I stumbled over `entry-wrapper` while doublechecking how to make a group in the docs 😃
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. edit the `debug_itemgroup_test` mapgen to spawn the `SUS_junk_drawer` item group
2. spawn the debug special and walk around until I find a tile with an aluminum foil wrapper
3. check the count/contents

before:
![before](https://github.com/user-attachments/assets/05b2bfda-05f7-41a3-9470-47224b342b9d)

after:
![after](https://github.com/user-attachments/assets/5bafe8d1-f3b6-4f15-8739-b3f86a71ab72)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
