### PR TITLE
obsolete units::legacy_volume_factor

### DIFF
--- a/data/json/furniture_and_terrain/furniture-plumbing.json
+++ b/data/json/furniture_and_terrain/furniture-plumbing.json
@@ -12,7 +12,7 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MOUNTABLE", "LIQUIDCONT" ],
     "max_volume": "200 L",
     "examine_action": "keg",
-    "keg_capacity": 600,
+    "keg_capacity": "150 L",
     "bash": {
       "str_min": 12,
       "str_max": 50,
@@ -119,7 +119,7 @@
     "flags": [ "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
     "//": "keg_capacity assumed to be from model XE36S06ST45U0 water heater <https://images.thdstatic.com/catalog/pdfImages/2d/2d7ed116-1a8c-439d-b7fe-a62a0a98f806.pdf>",
     "examine_action": "keg",
-    "keg_capacity": 400,
+    "keg_capacity": "100 L",
     "deconstruct": { "items": [ { "item": "household_water_heater", "count": 1 } ] },
     "bash": {
       "str_min": 18,
@@ -153,7 +153,7 @@
     "flags": [ "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
     "//": "keg_capacity assumed to be from model XG55T06EC50UO water heater <https://images.thdstatic.com/catalog/pdfImages/7e/7e7928b1-8b4f-472a-8ee8-b48eb1e7932a.pdf>",
     "examine_action": "keg",
-    "keg_capacity": 800,
+    "keg_capacity": "200 L",
     "deconstruct": { "items": [ { "item": "household_water_heater_family", "count": 1 } ] },
     "bash": {
       "str_min": 18,

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -992,7 +992,7 @@
     "required_str": -1,
     "flags": [ "NOITEM", "SEALED", "ALLOW_FIELD_EFFECT", "TRANSPARENT", "FLAMMABLE", "CONTAINER", "LIQUIDCONT" ],
     "examine_action": "keg",
-    "keg_capacity": 500,
+    "keg_capacity": "125 L",
     "deconstruct": {
       "items": [
         { "item": "2x4", "count": 18 },
@@ -1269,7 +1269,7 @@
     "flags": [ "CONTAINER", "LIQUIDCONT", "NOITEM", "SEALED", "TRANSPARENT" ],
     "deconstruct": { "items": [ { "item": "metal_tank", "count": 5 }, { "item": "water_faucet", "count": 1 } ] },
     "examine_action": "keg",
-    "keg_capacity": 1200,
+    "keg_capacity": "300 L",
     "bash": {
       "str_min": 10,
       "str_max": 20,
@@ -1292,7 +1292,7 @@
     "flags": [ "CONTAINER", "LIQUIDCONT", "NOITEM", "SEALED" ],
     "deconstruct": { "items": [ { "item": "sheet_metal", "count": 24 }, { "item": "water_faucet", "count": 1 } ] },
     "examine_action": "keg",
-    "keg_capacity": 6000,
+    "keg_capacity": "1500 L",
     "bash": {
       "str_min": 16,
       "str_max": 32,
@@ -1445,7 +1445,7 @@
     "required_str": -1,
     "flags": [ "NOITEM", "SEALED", "ALLOW_FIELD_EFFECT", "TRANSPARENT", "FLAMMABLE", "CONTAINER", "LIQUIDCONT", "EASY_DECONSTRUCT" ],
     "examine_action": "keg",
-    "keg_capacity": 45,
+    "keg_capacity": "11250 ml",
     "deconstruct": { "items": [ { "item": "churn", "count": 1 } ] },
     "bash": {
       "str_min": 12,
@@ -1644,7 +1644,7 @@
     "required_str": -1,
     "flags": [ "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED", "EASY_DECONSTRUCT" ],
     "examine_action": "keg",
-    "keg_capacity": 6540,
+    "keg_capacity": "1635 L",
     "deconstruct": { "items": [ { "item": "432gal_drum_rubber", "count": 1 } ] },
     "bash": {
       "str_min": 90,

--- a/data/json/furniture_and_terrain/furniture_vitrified.json
+++ b/data/json/furniture_and_terrain/furniture_vitrified.json
@@ -254,7 +254,7 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MOUNTABLE", "LIQUIDCONT" ],
     "max_volume": "200 L",
     "examine_action": "keg",
-    "keg_capacity": 600,
+    "keg_capacity": "150 L",
     "bash": {
       "str_min": 12,
       "str_max": 50,

--- a/data/mods/Aftershock/items/furniture.json
+++ b/data/mods/Aftershock/items/furniture.json
@@ -13,7 +13,7 @@
     "flags": [ "NOITEM", "SEALED", "ALLOW_FIELD_EFFECT", "TRANSPARENT", "EASY_DECONSTRUCT", "CONTAINER", "LIQUIDCONT" ],
     "deconstruct": { "items": [ { "item": "atomic_butterchurn", "count": 1 } ] },
     "examine_action": "keg",
-    "keg_capacity": 45,
+    "keg_capacity": "11250 ml",
     "bash": {
       "str_min": 12,
       "str_max": 50,

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat_machinery.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat_machinery.json
@@ -60,7 +60,7 @@
     "required_str": -1,
     "flags": [ "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED" ],
     "examine_action": "keg",
-    "keg_capacity": 20,
+    "keg_capacity": "5 L",
     "bash": {
       "str_min": 18,
       "str_max": 50,

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_spaceship_machinery.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_spaceship_machinery.json
@@ -11,7 +11,7 @@
     "coverage": 50,
     "required_str": -1,
     "flags": [ "NOITEM", "BLOCKSDOOR" ],
-    "keg_capacity": 20,
+    "keg_capacity": "5 L",
     "bash": {
       "str_min": 60,
       "str_max": 120,

--- a/data/mods/Backrooms/furniture_terrain.json
+++ b/data/mods/Backrooms/furniture_terrain.json
@@ -153,7 +153,7 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "MOUNTABLE", "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED" ],
     "examine_action": "keg",
-    "keg_capacity": 75,
+    "keg_capacity": "18750 ml",
     "deconstruct": {
       "items": [
         { "item": "plastic_chunk", "count": [ 4, 10 ] },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8059,14 +8059,14 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
             }
             while( corpse.damage() < corpse.max_damage() ) {
                 // Increase damage as we keep smashing ensuring we eventually smash the target.
-                if( x_in_y( pulp_power, corpse.volume() / units::legacy_volume_factor ) ) {
+                if( x_in_y( pulp_power, corpse.volume() / 250_ml ) ) {
                     corpse.inc_damage();
                     if( corpse.damage() == corpse.max_damage() ) {
                         num_corpses++;
                     }
                 }
 
-                if( x_in_y( pulp_power, corpse.volume() / units::legacy_volume_factor ) ) {
+                if( x_in_y( pulp_power, corpse.volume() / 250_ml ) ) {
                     // Splatter some blood around
                     // Splatter a bit more randomly, so that it looks cooler
                     const int radius = mess_radius + x_in_y( pulp_power, 500 ) + x_in_y( pulp_power, 1000 );

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -43,7 +43,7 @@ bool assign( const JsonObject &jo, const std::string_view name, units::volume &v
 {
     const auto parse = [name]( const JsonObject & obj, units::volume & out ) {
         if( obj.has_int( name ) ) {
-            out = obj.get_int( name ) * units::legacy_volume_factor;
+            out = obj.get_int( name ) * 250_ml;
             return true;
         }
 

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -1252,21 +1252,6 @@ public:
 };
 
 /**
- * Reads a volume value from legacy format: JSON contains a integer which represents multiples
- * of `units::legacy_volume_factor` (250 ml).
- */
-inline bool legacy_volume_reader( const JsonObject &jo, const std::string_view member_name,
-                                  units::volume &value, bool )
-{
-    int legacy_value;
-    if( !jo.read( member_name, legacy_value ) ) {
-        return false;
-    }
-    value = legacy_value * units::legacy_volume_factor;
-    return true;
-}
-
-/**
  * Only for external use in legacy code where migrating to `class translation`
  * is impractical. For new code load with `class translation` instead.
  */

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1092,7 +1092,7 @@ avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
                 if( std::isnan( glass_fraction ) || glass_fraction > 1.f ) {
                     glass_fraction = 0.f;
                 }
-                const int vol = weapon->volume() * glass_fraction / units::legacy_volume_factor;
+                const int vol = weapon->volume() * glass_fraction / 250_ml;
                 if( glass_portion && rng( 0, vol + 3 ) < vol ) {
                     add_msg( m_bad, _( "Your %s shatters!" ), weapon->tname() );
                     weapon->spill_contents( pos_bub() );

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -388,7 +388,7 @@ static bool handle_vehicle_target( Character &player_character, item &liquid,
         return pt.is_tank() && pt.can_reload( liquid );
     };
 
-    const units::volume stack = units::legacy_volume_factor / liquid.type->stack_size;
+    const units::volume stack = 250_ml / liquid.type->stack_size;
     const std::string title = string_format( _( "Select target tank for <color_%s>%.1fL %s</color>" ),
                               get_all_colors().get_name( liquid.color() ),
                               round_up( to_liter( liquid.charges * stack ), 1 ),

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -357,7 +357,7 @@ void iexamine::cvdmachine( Character &you, const tripoint_bub_ms & )
     }
 
     // Require materials proportional to selected item volume
-    auto qty = loc->volume() / units::legacy_volume_factor;
+    auto qty = loc->volume() / 250_ml;
     qty = std::max( 1, qty );
     requirement_data reqs = *requirement_data_cvd_diamond * qty;
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6658,7 +6658,7 @@ int item::on_wield_cost( const Character &you ) const
             d /= std::max( you.get_skill_level( melee_skill() ), 1.0f );
         }
 
-        int penalty = get_var( "volume", volume() / units::legacy_volume_factor ) * d;
+        int penalty = get_var( "volume", volume() / 250_ml ) * d;
         // arbitrary no more than 7 second of penalty
         mv += std::min( penalty, 700 );
     }
@@ -7407,7 +7407,7 @@ units::volume item::collapsed_volume_delta() const
                       has_flag( flag_REMOVED_STOCK ) ) ) {
         // consider only the base size of the gun (without mods)
         int tmpvol = get_var( "volume",
-                              ( type->volume - type->gun->barrel_volume ) / units::legacy_volume_factor );
+                              ( type->volume - type->gun->barrel_volume ) / 250_ml );
         if( tmpvol <= 3 ) {
             // intentional NOP
         } else if( tmpvol <= 5 ) {
@@ -7512,7 +7512,7 @@ units::volume item::volume( bool integral, bool ignore_contents, int charges_in_
     const int local_volume = get_var( "volume", -1 );
     units::volume ret;
     if( local_volume >= 0 ) {
-        ret = local_volume * units::legacy_volume_factor;
+        ret = local_volume * 250_ml;
     } else if( integral ) {
         ret = type->integral_volume;
     } else {
@@ -12227,7 +12227,7 @@ bool item::burn( fire_data &frd )
         if( type->volume == 0_ml ) {
             charges = 0;
         } else {
-            charges -= roll_remainder( burn_added * units::legacy_volume_factor * type->stack_size /
+            charges -= roll_remainder( burn_added * 250_ml * type->stack_size /
                                        ( 3.0 * type->volume ) );
         }
 
@@ -12252,7 +12252,7 @@ bool item::burn( fire_data &frd )
 
     burnt += roll_remainder( burn_added );
 
-    const int vol = base_volume() / units::legacy_volume_factor;
+    const int vol = base_volume() / 250_ml;
     return burnt >= vol * 3;
 }
 
@@ -12289,7 +12289,7 @@ bool item::flammable( int threshold ) const
         flammability = flammability * volume_per_turn / vol;
     } else {
         // If it burns well, it provides a bonus here
-        flammability = flammability * vol / units::legacy_volume_factor;
+        flammability = flammability * vol / 250_ml;
     }
 
     return flammability > threshold;
@@ -13531,7 +13531,7 @@ bool item::process_corpse( map &here, Character *carrier, const tripoint_bub_ms 
     if( !ready_to_revive( here, pos ) ) {
         return false;
     }
-    if( rng( 0, volume() / units::legacy_volume_factor ) > burnt &&
+    if( rng( 0, volume() / 250_ml ) > burnt &&
         g->revive_corpse( pos, *this ) ) {
         if( carrier == nullptr ) {
             if( corpse->in_species( species_ROBOT ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4078,7 +4078,7 @@ void map::smash_items( const tripoint_bub_ms &p, const int power, const std::str
         }
 
         // The volume check here pretty much only influences corpses and very large items
-        const float volume_factor = std::max<float>( 40, i->volume() / units::legacy_volume_factor );
+        const float volume_factor = std::max<float>( 40, i->volume() / 250_ml );
         float damage_chance = 10.0f * power / volume_factor;
         // Example:
         // Power 40 (just below C4 epicenter) vs plank

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1236,7 +1236,7 @@ void furn_t::load( const JsonObject &jo, const std::string &src )
     int legacy_bonus_fire_warmth_feet = units::to_legacy_bodypart_temp_delta( bonus_fire_warmth_feet );
     optional( jo, was_loaded, "bonus_fire_warmth_feet", legacy_bonus_fire_warmth_feet, 300 );
     bonus_fire_warmth_feet = units::from_legacy_bodypart_temp_delta( legacy_bonus_fire_warmth_feet );
-    optional( jo, was_loaded, "keg_capacity", keg_capacity, legacy_volume_reader, 0_ml );
+    optional( jo, was_loaded, "keg_capacity", keg_capacity, volume_reader(), 0_ml );
     optional( jo, was_loaded, "max_volume", max_volume, volume_reader(), DEFAULT_TILE_VOLUME );
     optional( jo, was_loaded, "crafting_pseudo_item", crafting_pseudo_item, itype_id() );
     optional( jo, was_loaded, "deployed_item", deployed_item );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1426,7 +1426,7 @@ sfx::sound_thread::sound_thread( const tripoint_bub_ms &source, const tripoint_b
     const item_location weapon = you.get_wielded_item();
     ang_targ = get_heard_angle( target );
     weapon_skill = weapon ? weapon->melee_skill() : skill_id::NULL_ID();
-    weapon_volume = weapon ? weapon->volume() / units::legacy_volume_factor : 0;
+    weapon_volume = weapon ? weapon->volume() / 250_ml : 0;
 }
 
 // Operator overload required for thread API.

--- a/src/units.h
+++ b/src/units.h
@@ -323,10 +323,6 @@ inline constexpr double to_liter( const volume &v )
     return v.value() / 1000.0;
 }
 
-// Legacy conversions factor for old volume values.
-// Don't use in new code! Use one of the from_* functions instead.
-constexpr volume legacy_volume_factor = from_milliliter( 250 );
-
 const mass mass_min = units::mass( std::numeric_limits<units::mass::value_type>::min(),
                                    units::mass::unit_type{} );
 

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -345,7 +345,7 @@ static vehicle_part *pick_part( const std::vector<vehicle_part *> &parts,
             std::string vname = vpr->name();
             if( !vpr->ammo_current().is_null() && vpr->ammo_current() != fuel_type_battery &&
                 !vpr->get_base().empty() ) {
-                units::volume mult = units::legacy_volume_factor / item::find_type(
+                units::volume mult = 250_ml / item::find_type(
                                          vpr->ammo_current() )->stack_size;
                 double vcur = to_liter( vpr->ammo_remaining() * mult );
                 double vmax = to_liter( vpr->ammo_capacity( vpr->get_base().only_item().ammo_type() ) * mult );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1479,7 +1479,7 @@ void veh_interact::calc_overview()
             auto no_tank_details = []( const vehicle_part & pt, const catacurses::window & w, int y ) {
                 if( !pt.ammo_current().is_null() ) {
                     const itype *pt_ammo_cur = item::find_type( pt.ammo_current() );
-                    double vol_L = to_liter( pt.ammo_remaining() * units::legacy_volume_factor /
+                    double vol_L = to_liter( pt.ammo_remaining() * 250_ml /
                                              pt_ammo_cur->stack_size );
                     int offset = 1;
                     std::string fmtstring = "%s  %5.1fL";

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7926,7 +7926,7 @@ item vehicle::get_folded_item() const
 
     folded.set_var( "tracking", tracking_on ? 1 : 0 );
     folded.set_var( "weight", to_milligram( total_mass() ) );
-    folded.set_var( "volume", folded_volume / units::legacy_volume_factor );
+    folded.set_var( "volume", folded_volume / 250_ml );
     folded.set_var( "name", string_format( _( "folded %s" ), name ) );
     folded.set_var( "vehicle_name", name );
     folded.set_var( "unfolding_time", to_moves<int>( unfolding_time() ) );

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -172,7 +172,7 @@ int vehicle::print_part_list( const catacurses::window &win, int y1, const int m
                                                vp.ammo_capacity( ammo_battery ) );
                 } else if( vp.ammo_current()->stack_size > 0 ) {
                     const itype *pt_ammo_cur = item::find_type( vp.ammo_current() );
-                    auto stack = units::legacy_volume_factor / pt_ammo_cur->stack_size;
+                    auto stack = 250_ml / pt_ammo_cur->stack_size;
                     partname += string_format( _( " (%.1fL %s)" ),
                                                round_up( units::to_liter( vp.ammo_remaining() * stack ), 1 ),
                                                item::nname( vp.ammo_current() ) );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1149,7 +1149,7 @@ void vehicle::operate_scoop()
                 that_item_there->inc_damage();
                 //The scoop gets a lot louder when breaking an item.
                 sounds::sound( position, rng( 10,
-                                              that_item_there->volume() * 2 / 260_ml ),
+                                              that_item_there->volume() * 2 / 250_ml + 10 ),
                                sounds::sound_t::combat, _( "BEEEThump" ), false, "vehicle", "scoop_thump" );
             }
             //This attempts to add the item to the scoop inventory and if successful, removes it from the map.

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1149,7 +1149,7 @@ void vehicle::operate_scoop()
                 that_item_there->inc_damage();
                 //The scoop gets a lot louder when breaking an item.
                 sounds::sound( position, rng( 10,
-                                              that_item_there->volume() * 2 / units::legacy_volume_factor + 10 ),
+                                              that_item_there->volume() * 2 / 260_ml ),
                                sounds::sound_t::combat, _( "BEEEThump" ), false, "vehicle", "scoop_thump" );
             }
             //This attempts to add the item to the scoop inventory and if successful, removes it from the map.

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -99,7 +99,7 @@ static std::map<itype_id, int> set_vehicle_fuel( vehicle &v, const float veh_fue
         } else if( pt.is_tank() && !liquid_fuel.is_null() ) {
             float qty = pt.ammo_capacity( item::find_type( liquid_fuel )->ammo->type ) * veh_fuel_mult;
             qty *= std::max( item::find_type( liquid_fuel )->stack_size, 1 );
-            qty /= to_milliliter( units::legacy_volume_factor );
+            qty /= to_milliliter( 250_ml );
             pt.ammo_set( liquid_fuel, qty );
             ret[ liquid_fuel ] += qty;
         } else {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
At the dawn of times, all items had a volume as multiples of 250 ml; 8 years ago it was fixed, and as part of it `units::legacy_volume_factor` was added
I think we can obsolete it now, and just use 250 ml directly
#### Describe the solution
Replace all places units::legacy_volume_factor was used in code, and surrounding infra
Replace `keg_capacity` with proper volume reader instead of reading everything in int, that is converted to volume as `int * units::legacy_volume_factor`
#### Testing
Kegs still work, zombie do pulp as they pulped before