### PR TITLE
Aftershock: Gameified EMP mechanics

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -491,10 +491,10 @@
   },
   {
     "type": "EXTERNAL_OPTION",
-    "name": "EMP_DISABLE_ELECTRONICS",
-    "//": "Whether EMP effects will permanently disable items.",
+    "name": "GAME_EMP",
+    "//": "EMP will disable electonics for a short period of ~60 seconds, instead of permanently.  Theres a 5% chance of items shorting out permanently.",
     "stype": "bool",
-    "value": true
+    "value": false
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/json/faults/faults_electronic.json
+++ b/data/json/faults/faults_electronic.json
@@ -61,5 +61,13 @@
       [ "soldering_standard", 5 ],
       { "qualities": [ { "id": "SCREW", "level": 1 } ], "components": [ [ [ "circuit", 1 ] ] ] }
     ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_emp_reboot",
+    "name": { "str": "rebooting" },
+    "description": "This device is rebooting after being shorted by an EMP.",
+    "item_prefix": "rebooting",
+    "flags": [ "ITEM_BROKEN" ]
   }
 ]

--- a/data/mods/Aftershock/options.json
+++ b/data/mods/Aftershock/options.json
@@ -13,9 +13,9 @@
   },
   {
     "type": "EXTERNAL_OPTION",
-    "name": "EMP_DISABLE_ELECTRONICS",
+    "name": "GAME_EMP",
     "stype": "bool",
-    "value": false
+    "value": true
   },
   {
     "type": "EXTERNAL_OPTION",


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Create an alternate EMP mechanic that disables items only temporarily."

#### Purpose of change
EMP attacks are a staple of sci-fi games, to the point that even vanilla DDA includes them, Aftershock also should also have those.  The implementation here is more fit for a game in which you carry an inventory full of high tech gadgets, instead of all of them being intermediately ruined, they are thrown offline only for a small interval,

#### Describe the solution
Items exposed to EMP attacks get a fault that self resolves in ~60 seconds. Although theres a 5% chance for items to be ruined permanently.

Mostly its intended to heavily disrupt you during combat only, with the small chance for permanent damage serving as a detterent for simply tanking EMP effects and giving a little extra value to the electronics skill (since EMP faults can be repaired).

This feature is enabled using external options.

#### Describe alternatives you've considered
EOCs? But that would be crazy complex.

#### Testing
Dropped a smartphone on the map and kept one in my inventory. Threw an EMP grenade. Both started rebooting and became usable after a short while.