### PR TITLE
Docs: standardize comments in item*.h somewhat

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -295,14 +295,14 @@ class item : public visitable
         item &ammo_unset();
 
         /**
-        * Sets item damage constrained by [@ref degradation and @ref max_damage]
-        */
+         * Set item damage constrained by [@ref degradation and @ref max_damage].
+         */
         void set_damage( int qty );
 
         /**
-        * Sets item's degradation constrained by [0 and @ref max_damage]
-        * If item damage is lower it is raised up to @ref degradation
-        */
+         * Set item degradation constrained by [0 and @ref max_damage].
+         * If item damage is lower it is raised up to @ref degradation.
+         */
         void set_degradation( int qty );
 
         /**
@@ -458,32 +458,32 @@ class item : public visitable
         std::string info( bool showtext, std::vector<iteminfo> &iteminfo ) const;
 
         /**
-        * Return all the information about the item and its type, and dump to vector.
-        *
-        * This includes the different
-        * properties of the @ref itype (if they are visible to the player). The returned string
-        * is already translated and can be *very* long.
-        * @param showtext If true, shows the item description, otherwise only the properties item type.
-        * @param iteminfo The properties (encapsulated into @ref iteminfo) are added to this vector,
-        * the vector can be used to compare them to properties of another item.
-        * @param batch The batch crafting number to multiply data by
-        */
+         * Return all the information about the item and its type, and dump to vector.
+         *
+         * This includes the different
+         * properties of the @ref itype (if they are visible to the player). The returned string
+         * is already translated and can be *very* long.
+         * @param showtext If true, shows the item description, otherwise only the properties item type.
+         * @param iteminfo The properties (encapsulated into @ref iteminfo) are added to this vector,
+         * the vector can be used to compare them to properties of another item.
+         * @param batch The batch crafting number to multiply data by
+         */
         std::string info( bool showtext, std::vector<iteminfo> &iteminfo, int batch ) const;
 
         /**
-        * Return all the information about the item and its type, and dump to vector.
-        *
-        * This includes the different
-        * properties of the @ref itype (if they are visible to the player). The returned string
-        * is already translated and can be *very* long.
-        * @param parts controls which parts of the iteminfo to return.
-        * @param info The properties (encapsulated into @ref iteminfo) are added to this vector,
-        * the vector can be used to compare them to properties of another item.
-        * @param batch The batch crafting number to multiply data by
-        */
+         * Return all the information about the item and its type, and dump to vector.
+         *
+         * This includes the different
+         * properties of the @ref itype (if they are visible to the player). The returned string
+         * is already translated and can be *very* long.
+         * @param parts controls which parts of the iteminfo to return.
+         * @param info The properties (encapsulated into @ref iteminfo) are added to this vector,
+         * the vector can be used to compare them to properties of another item.
+         * @param batch The batch crafting number to multiply data by
+         */
         std::string info( std::vector<iteminfo> &info, const iteminfo_query *parts = nullptr,
                           int batch = 1 ) const;
-        /* type specific helper functions for info() that should probably be in itype() */
+        /** Type specific helper functions for info() that should probably be in itype(). */
         void basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                          bool debug ) const;
         void debug_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
@@ -671,10 +671,10 @@ class item : public visitable
         bool merge_charges( const item &rhs );
 
         /**
-        * Total weight of an item accounting for all contained/integrated items
-        * @param include_contents if true include weight of contained items
-        * @param integral if true return effective weight if this item was integrated into another
-        */
+         * Total weight of an item accounting for all contained/integrated items.
+         * @param include_contents if true include weight of contained items.
+         * @param integral if true return effective weight if this item was integrated into another.
+         */
         units::mass weight( bool include_contents = true, bool integral = false ) const;
 
         /**
@@ -733,17 +733,17 @@ class item : public visitable
         damage_instance base_damage_thrown() const;
 
         /**
-        * Calculate the item's effective damage per second past armor when wielded by a
+         * Calculate the item's effective damage per second past armor when wielded by a
          * character against a monster.
          */
         double effective_dps( const Character &guy, Creature &mon ) const;
         /**
          * calculate effective dps against a stock set of monsters.  by default, assume g->u
          * is wielding
-        * for_display - include monsters intended for display purposes
+         * for_display - include monsters intended for display purposes
          * for_calc - include monsters intended for evaluation purposes
          * for_display and for_calc are inclusive
-               */
+         */
         std::map<std::string, double> dps( bool for_display, bool for_calc, const Character &guy ) const;
         std::map<std::string, double> dps( bool for_display, bool for_calc ) const;
         /** return the average dps of the weapon against evaluation monsters */
@@ -758,9 +758,9 @@ class item : public visitable
         bool is_melee( const damage_type_id &dt ) const;
 
         /**
-         *  Is this item an effective melee weapon for any damage type?
-         *  @see item::is_gun()
-         *  @note an item can be both a gun and melee weapon concurrently
+         * Is this item an effective melee weapon for any damage type?
+         * @see item::is_gun().
+         * @note an item can be both a gun and melee weapon concurrently.
          */
         bool is_melee() const;
 
@@ -787,7 +787,7 @@ class item : public visitable
 
         /**
          * Sets time until activation for an item that will self-activate in the future.
-         **/
+         */
         void set_countdown( int num_turns );
 
         /**
@@ -835,19 +835,21 @@ class item : public visitable
         /** Permits filthy components, should only be used as a helper in creating filters */
         bool allow_crafting_component() const;
 
-        // seal the item's pockets. used for crafting and spawning items.
+        /** Seal the item's pockets. Used for crafting and spawning items. */
         bool seal();
 
         bool all_pockets_sealed() const;
         bool any_pockets_sealed() const;
-        /** Whether this is container. Note that container does not necessarily means it's
-         * suitable for liquids. */
+        /**
+         * Whether this is a container. Note that container does not necessarily means it's
+         * suitable for liquids.
+         */
         bool is_container() const;
         /** Whether it is a container, and if it is has some restrictions */
         bool is_container_with_restriction() const;
         /** Whether it is a container with only one pocket, and if it is has some restrictions */
         bool is_single_container_with_restriction() const;
-        // whether the contents has a pocket with the associated type
+        /** Whether contents has a pocket with @param pk_type type. */
         bool has_pocket_type( pocket_type pk_type ) const;
         bool has_any_with( const std::function<bool( const item & )> &filter,
                            pocket_type pk_type ) const;
@@ -857,7 +859,7 @@ class item : public visitable
 
         bool container_type_pockets_empty() const;
 
-        // gets all pockets contained in this item
+        /** Get all pockets contained in this item. */
         std::vector<const item_pocket *> get_all_contained_pockets() const;
         std::vector<item_pocket *> get_all_contained_pockets();
         std::vector<const item_pocket *> get_all_standard_pockets() const;
@@ -870,8 +872,11 @@ class item : public visitable
          * NOTE: This assumes that there is always one and only one pocket where ammo goes (mag or mag well)
          */
         void update_modified_pockets();
-        // for pocket update stuff, which pocket is @contained in?
-        // returns a nullptr if the item is not contained, and prints a debug message
+        /**
+         * For pocket update stuff.
+         * @return which pocket @contained is in.
+         * return a nullptr if the item is not contained, and print a debug message.
+         */
         item_pocket *contained_where( const item &contained );
         const item_pocket *contained_where( const item &contained ) const;
         /** Whether this is a container which can be used to store liquids. */
@@ -939,7 +944,7 @@ class item : public visitable
         units::mass get_total_holster_weight() const;
         units::mass get_used_holster_weight() const;
 
-        // recursive function that checks pockets for remaining free space
+        /** Recursive function checking pockets for remaining free space. */
         units::volume check_for_free_space() const;
         units::volume get_selected_stack_volume( const std::map<const item *, int> &without ) const;
         bool has_unrestricted_pockets() const;
@@ -947,20 +952,23 @@ class item : public visitable
         units::volume get_nested_content_volume_recursive( const std::map<const item *, int> &without )
         const;
 
-        // returns the abstract 'size' of the pocket
-        // used for attaching to molle items
+        /**
+         * Return the abstract 'size' of the pocket.
+         * Used for attaching to molle items.
+         */
         int get_pocket_size() const;
 
         /**
          * Returns true if the item can be attached with PALS straps
          */
         bool can_attach_as_pocket() const;
-
-        // what will the move cost be of taking @it out of this container?
-        // should only be used from item_location if possible, to account for
-        // player inventory handling penalties from traits
+        /**
+         * @return the move cost of taking @it out of this container.
+         * Should only be used from item_location if possible, to account for
+         * player inventory handling penalties from traits.
+         */
         int obtain_cost( const item &it ) const;
-        // what will the move cost be of storing @it into this container? (CONTAINER pocket type)
+        /** @return the move cost of storing @it into a CONTAINER pocket of this container. */
         int insert_cost( const item &it ) const;
 
         /**
@@ -983,9 +991,9 @@ class item : public visitable
         void clear_automatic_whitelist();
 
         /**
-        * True if item and its contents have any uses.
-        * @param contents_only Set to true to ignore the item itself and check only its contents.
-        */
+         * True if item and its contents have any uses.
+         * @param contents_only Set to true to ignore the item itself and check only its contents.
+         */
         bool item_has_uses_recursive( bool contents_only = false ) const;
 
         /*@{*/
@@ -1248,9 +1256,9 @@ class item : public visitable
          */
         int made_of( const material_id &mat_ident ) const;
         /**
-        * Check we can repair with this material (e.g. matches at least one
-        * in our set.)
-        */
+         * Check we can repair with this material (e.g. matches at least one
+         * in our set.)
+         */
         bool can_repair_with( const material_id &mat_ident ) const;
         /**
          * Are we solid, liquid, gas, plasma?
@@ -1274,16 +1282,16 @@ class item : public visitable
         bool flammable( int threshold = 0 ) const;
 
         /**
-        * Helper function to retrieve any applicable resistance bonuses from item mods.
-        * @param dmg_type Damage type
-        * @return Amount of additional modded resistance
-        */
+         * Helper function to retrieve any applicable resistance bonuses from item mods.
+         * @param dmg_type Damage type.
+         * @return Amount of additional modded resistance.
+         */
         float get_clothing_mod_val_for_damage_type( const damage_type_id &dmg_type ) const;
 
         /**
-        * Helper function to check whether a damage_type can damage items for forward-declared
-        * damage_type.
-        */
+         * Helper function to check whether a damage_type can damage items for forward-declared
+         * damage_type.
+         */
         bool damage_type_can_damage_items( const damage_type_id &dmg_type ) const;
 
         /**
@@ -1360,30 +1368,30 @@ class item : public visitable
         /** How much degradation has the item accumulated? */
         int degradation() const;
 
-        // Sets a random degradation within [0, damage), used when spawning the item
+        /** Set a random degradation within [0, damage). Used when spawning the item. */
         void rand_degradation();
 
-        // @see itype::damage_level()
+        /** @see itype::damage_level(). */
         int damage_level( bool precise = false ) const;
 
-        // modifies melee weapon damage to account for item's damage
+        /** Modifiy melee weapon damage to account for item's damage. */
         float damage_adjusted_melee_weapon_damage( float value ) const;
-        // modifies gun damage to account for item's damage
+        /** Modifiy gun damage to account for item's damage. */
         float damage_adjusted_gun_damage( float value ) const;
-        // modifies armor resist to account for item's damage
+        /** Modifiy armor resist to account for item's damage. */
         float damage_adjusted_armor_resist( float value ) const;
 
-        // @return 0 if item is count_by_charges() or 4000 ( value of itype::damage_max_ )
+        /** @return 0 if item is count_by_charges() or 4000 ( value of itype::damage_max_ ). */
         int max_damage() const;
 
         /**
-        * Returns how many damage levels can be repaired on this item
-        * Example: item with  100 damage returns 1 (  100 -> 0 )
-        * Example: item with 2100 damage returns 3 ( 2100 -> 1100 -> 100 -> 0 )
-        */
+         * Return how many damage levels can be repaired on this item.
+         * Example: item with  100 damage returns 1 (  100 -> 0 ).
+         * Example: item with 2100 damage returns 3 ( 2100 -> 1100 -> 100 -> 0 ).
+         */
         int repairable_levels() const;
 
-        // @return 1 for undamaged items or remaining hp divided by max hp in range [0, 1)
+        /** @return 1 for undamaged items or remaining hp divided by max hp in range [0, 1). */
         float get_relative_health() const;
 
         /**
@@ -1422,7 +1430,7 @@ class item : public visitable
          */
         armor_status damage_armor_transforms( damage_unit &du, double enchant_multiplier = 1 ) const;
 
-        // @return colorize()-ed damage indicator as string, e.g. "<color_green>++</color>"
+        /** @return colorize()-ed damage indicator as string, e.g. "<color_green>++</color>". */
         std::string damage_indicator() const;
 
         /**
@@ -1594,14 +1602,14 @@ class item : public visitable
                          bool loose_message = false, tripoint_bub_ms cable_position = tripoint_bub_ms::zero );
 
         /**
-        * @brief Exchange power between an item's batteries and the vehicle/appliance it's linked to.
-        * @brief A positive link().charge_rate will charge the item at the expense of the vehicle,
-        * while a negative link().charge_rate will charge the vehicle at the expense of the item.
-        *
-        * @param linked_veh The vehicle the item is connected to.
-        * @param turns_elapsed The number of turns the link has spent outside the reality bubble. Default 1.
-        * @return The amount of power given or taken to be displayed; ignores turns_elapsed and inefficiency.
-        */
+         * @brief Exchange power between an item's batteries and the vehicle/appliance it's linked to.
+         * @brief A positive link().charge_rate will charge the item at the expense of the vehicle,
+         * while a negative link().charge_rate will charge the vehicle at the expense of the item.
+         *
+         * @param linked_veh The vehicle the item is connected to.
+         * @param turns_elapsed The number of turns the link has spent outside the reality bubble. Default 1.
+         * @return The amount of power given or taken to be displayed; ignores turns_elapsed and inefficiency.
+         */
         int charge_linked_batteries( vehicle &linked_veh, int turns_elapsed = 1 );
 
         /**
@@ -1673,13 +1681,13 @@ class item : public visitable
 
         bool has_temperature() const;
 
-        /** Returns true if the item is A: is SOLID and if it B: is of type LIQUID */
+        /** Returns true if the item is SOLID and of type LIQUID. */
         bool is_frozen_liquid() const;
 
         /** Returns empty string if the book teach no skill */
         std::string get_book_skill() const;
 
-        //** Returns specific heat of the item (J/g K) */
+        /** Returns specific heat of the item (J/g K). */
         float get_specific_heat_liquid() const;
         float get_specific_heat_solid() const;
 
@@ -1693,7 +1701,7 @@ class item : public visitable
         /** How resistant clothes made of this material are to wind (0-100) */
         int wind_resist() const;
 
-        /** What faults can potentially occur with this item? */
+        /** Return faults that can potentially occur with this item. */
         std::set<fault_id> faults_potential() const;
 
         bool can_have_fault_type( const std::string &fault_type ) const;
@@ -1770,9 +1778,9 @@ class item : public visitable
         bool can_reload_with( const item &ammo, bool now ) const;
 
         /**
-          * Returns true if it doesn't have flag NO_UNLOAD,
-          * and any of the contents are not frozen or not empty if it's liquid
-          */
+         * Return true if this doesn't have flag NO_UNLOAD, is not empty, is not sealed, is open,
+         * and none contents are frozen.
+         */
         bool can_unload() const;
 
         /**
@@ -1780,7 +1788,8 @@ class item : public visitable
          */
         bool contains_no_solids() const;
 
-        bool is_dangerous() const; // Is it an active grenade or something similar that will hurt us?
+        /** Is it an active grenade or something similar that will hurt us? */
+        bool is_dangerous() const;
 
         /** Is item derived from a zombie? */
         bool is_tainted() const;
@@ -1790,13 +1799,13 @@ class item : public visitable
          */
         bool is_soft() const;
 
-        // is any bit of the armor rigid
+        /** Is any bit of the armor rigid? */
         bool is_rigid() const;
-        // is any bit of the armor comfortable
+        /** Is any bit of the armor comfortable? */
         bool is_comfortable() const;
         template <typename T>
         bool is_bp_rigid( const T &bp ) const;
-        // check if rigid and that it only cares about the layer it is on
+        /** Check if rigid and that it only cares about the layer it is on. */
         template <typename T>
         bool is_bp_rigid_selective( const T &bp ) const;
         template <typename T>
@@ -1809,8 +1818,10 @@ class item : public visitable
         void set_snippet( const snippet_id &id );
 
         bool operator<( const item &other ) const;
-        /** List of all @ref components in printable form, empty if this item has
-         * no components */
+        /**
+         * List of all @ref components in printable form, empty if this item has
+         * no components.
+         */
         std::string components_to_string() const;
 
         /** Creates a hash from the itype_ids of this item's @ref components. */
@@ -1819,14 +1830,14 @@ class item : public visitable
         /** return the unique identifier of the items underlying type */
         itype_id typeId() const;
 
-        /** Checks is item affect fall */
+        /** Check if item affect fall. */
         bool affects_fall() const;
 
-        //flat damage reduction (increase if negative) on fall (some logic may apply)
+        /** Flat damage reduction (increase if negative) on fall (some logic may apply). */
         int fall_damage_reduction() const;
         /**
-          * if the item will spill if placed into a container
-          */
+         * Will the item spill if placed into a container?
+         */
         bool will_spill() const;
         bool will_spill_if_unsealed() const;
         /**
@@ -1843,12 +1854,13 @@ class item : public visitable
          */
         bool spill_contents( const tripoint_bub_ms &pos );
         bool spill_open_pockets( Character &guy, const item *avoid = nullptr );
-        // spill items that don't fit in the container
+        /** Spill items that don't fit in the container. */
         void overflow( const tripoint_bub_ms &pos, const item_location &loc = item_location::nowhere );
 
-        /** Checks if item is a holster and currently capable of storing obj
-         *  @param obj object that we want to holster
-         *  @param ignore only check item is compatible and ignore any existing contents
+        /**
+         * Check if item is a holster and currently capable of storing obj.
+         * @param obj object that we want to holster.
+         * @param ignore only check item is compatible and ignore any existing contents.
          */
         bool can_holster( const item &obj, bool ignore = false ) const;
 
@@ -2001,7 +2013,7 @@ class item : public visitable
          * Checks whether item itself has given flag (doesn't check item type or gunmods).
          * Essentially get_flags().count(f).
          * Works faster than `has_flag`
-        */
+         */
         bool has_own_flag( const flag_id &f ) const;
 
         /** returns read-only set of flags of this item (not including flags from item type or gunmods) */
@@ -2029,10 +2041,10 @@ class item : public visitable
         void unset_flags();
         /*@}*/
 
-        /**Does this item have the specified vitamin*/
+        /** Does this item have the specified vitamin? */
         bool has_vitamin( const vitamin_id &vitamin ) const;
 
-        /**Does this item have the specified fault*/
+        /** Does this item have the specified fault? */
         bool has_fault( const fault_id &fault ) const;
 
         /** Does this item part have a fault with this flag */
@@ -2049,9 +2061,9 @@ class item : public visitable
         /*@{*/
         bool has_property( const std::string &prop ) const;
         /**
-          * Get typed property for item.
-          * Return same type as the passed default value, or string where no default provided
-          */
+         * Get typed property for item.
+         * Return same type as the passed default value, or string where no default provided.
+         */
         std::string get_property_string( const std::string &prop, const std::string &def = "" ) const;
         int64_t get_property_int64_t( const std::string &prop, int64_t def = 0 ) const;
         /*@}*/
@@ -2115,7 +2127,7 @@ class item : public visitable
          * Whether this item (when worn) covers the given sub body part.
          */
         bool covers( const sub_bodypart_id &bp, bool check_ablative_armor = true ) const;
-        // do both items overlap a bodypart at all? returns the side that conflicts via rhs
+        /** Do both items overlap a bodypart at all? Return the side that conflicts via rhs. */
         std::optional<side> covers_overlaps( const item &rhs ) const;
         /**
          * Bitset of all covered body parts.
@@ -2128,16 +2140,16 @@ class item : public visitable
          */
         body_part_set get_covered_body_parts() const;
         /**
-        * Bitset of all covered body parts, from a specific side.
-        *
-        * If the bit is set, the body part is covered by this
-        * item (when worn). The index of the bit should be a body part, for example:
-        * @code if( some_armor.get_covered_body_parts().test( bp_head ) ) { ... } @endcode
-        * For testing only a single body part, use @ref covers instead. This function allows you
-        * to get the whole covering data in one call.
-        *
-        * @param s Specifies the side. Will be ignored for non-sided items.
-        */
+         * Bitset of all covered body parts, from a specific side.
+         *
+         * If the bit is set, the body part is covered by this
+         * item (when worn). The index of the bit should be a body part, for example:
+         * @code if( some_armor.get_covered_body_parts().test( bp_head ) ) { ... } @endcode
+         * For testing only a single body part, use @ref covers instead. This function allows you
+         * to get the whole covering data in one call.
+         *
+         * @param s Specifies the side. Will be ignored for non-sided items.
+         */
         body_part_set get_covered_body_parts( side s ) const;
 
         /**
@@ -2156,16 +2168,16 @@ class item : public visitable
         bool has_sublocations() const;
 
         /**
-          * Returns true if item is armor and can be worn on different sides of the body
-          */
+         * Return true if item is armor and can be worn on different sides of the body.
+         */
         bool is_sided() const;
         /**
          *  Returns side item currently worn on. Returns BOTH if item is not sided or no side currently set
          */
         side get_side() const;
         /**
-          * Change the side on which the item is worn. Returns false if the item is not sided
-          */
+         * Change the side on which the item is worn. Return false if the item is not sided.
+         */
         bool set_side( side s );
 
         /**
@@ -2207,9 +2219,9 @@ class item : public visitable
          */
         float get_thickness( const bodypart_id &bp ) const;
         /**
-        * Returns the average thickness value for the specified sub-bodypart, or 0 for non-armor. Thickness
-        * is a relative value that affects the items resistance against bash / cutting / bullet damage.
-        */
+         * Returns the average thickness value for the specified sub-bodypart, or 0 for non-armor. Thickness
+         * is a relative value that affects the items resistance against bash / cutting / bullet damage.
+         */
         float get_thickness( const sub_bodypart_id &bp ) const;
         /**
          * Returns clothing layer for item.
@@ -2327,8 +2339,8 @@ class item : public visitable
          */
         bool is_worn_only_with( const item &it ) const;
         /**
-        * Returns true wether this item is worn or not
-        */
+         * Return true if this item is worn by the player.
+         */
         bool is_worn_by_player() const;
 
         /**
@@ -2376,8 +2388,8 @@ class item : public visitable
          */
         std::set<recipe_id> get_saved_recipes() const;
         /**
-        * Sets recipes stored on the item (laptops, smartphones, sd cards etc)
-        */
+         * Set recipes stored on the item (laptops, smartphones, sd cards etc).
+         */
         void set_saved_recipes( const std::set<recipe_id> &recipes );
         /**
          * Enumerates recipes available from this book and the skill level required to use them.
@@ -2446,7 +2458,7 @@ class item : public visitable
 
         void clear_itype_variant();
 
-        // Description of the item provided by the variant, or an empty string
+        /** Description of the item provided by the variant, or an empty string. */
         std::string variant_description() const;
 
         /**
@@ -2455,7 +2467,7 @@ class item : public visitable
          */
         int shots_remaining( const Character *carrier ) const;
 
-        // Does this use electrical energy, or is it fueled by something else?
+        /** Return true if this uses electrical or a different kind of energy. */
         bool uses_energy() const;
         /**
          * Energy available from battery/UPS/bionics
@@ -2496,28 +2508,30 @@ class item : public visitable
 
         /** Quantity of ammunition consumed per usage of tool or with each shot of gun */
         int ammo_required() const;
-        // gets the first ammo in all magazine pockets
-        // does not support multiple magazine pockets!
+        /**
+         * Return the first ammo found iterating all magazine pockets. Null if none found.
+         * Does not support multiple magazine pockets!
+         */
         item &first_ammo();
-        // gets the first ammo in all magazine pockets
-        // does not support multiple magazine pockets!
         const item &first_ammo() const;
-        // spills liquid and other contents from the container. contents may remain
-        // in the container if the player cancels spilling. removing liquid from
-        // a magazine requires unload logic.
+        /**
+         * Spill liquid and other contents from the container. Contents may remain
+         * in the container if the player cancels spilling. Removing liquid from
+         * a magazine requires unload logic.
+         */
         void handle_liquid_or_spill( Character &guy, const item *avoid = nullptr );
 
         /**
-         * Check if sufficient ammo is loaded for given number of uses.
-         * Check if there is enough ammo loaded in a tool for the given number of uses
+         * Check if sufficient ammo is loaded for given number of uses
          * or given number of gun shots.
-         * If carrier is provides then UPS and bionic may be also used as ammo
+         * UPS and bionic may be also used as ammo if carrier provides it.
+         *
          * Using this function for this check is preferred
          * because we expect to add support for items consuming multiple ammo types in
          * the future.  Users of this function will not need to be refactored when this
          * happens.
          *
-         * @param carrier who holds the item. Needed for UPS/bionic
+         * @param carrier holder of the item, used for getting UPS and bionic power
          * @param qty Number of uses
          * @returns true if ammo sufficient for number of uses is loaded, false otherwise
          */
@@ -2557,43 +2571,54 @@ class item : public visitable
          */
         int activation_consume( int qty, const tripoint_bub_ms &pos, Character *carrier );
 
-        // Returns whether the item has ammo in it, either directly or via a selected magazine, which
-        // contrasts with ammo_data(), which just returns the magazine data if a magazine is selected,
-        // regardless of whether that magazine is empty or not.
+        /**
+         * Return whether the item has ammo in it, either directly or via a selected magazine, which
+         * contrasts with ammo_data(), which just returns the magazine data if a magazine is selected,
+         * regardless of whether that magazine is empty.
+         */
         bool has_ammo() const;
-        // Cheaper way to just check if ammo_data exists if the data is to be just discarded afterwards.
+        /** A cheaper way to check if ammo_data exists. Useful when the data would be discarded afterwards. */
         bool has_ammo_data() const;
         /** Specific ammo data, returns nullptr if item is neither ammo nor loaded with any */
         const itype *ammo_data() const;
         /** Specific ammo type, returns "null" if item is neither ammo nor loaded with any */
         itype_id ammo_current() const;
-        /** Get currently loaded ammo, if any.
-         * @return item reference or null item if not loaded. */
+        /**
+         * Get currently loaded ammo, if any.
+         * @return item reference or null item if not loaded.
+         */
         const item &loaded_ammo() const;
-        /** Ammo type of an ammo item
-         *  @return ammotype of ammo item or a null id if the item is not ammo */
+        /**
+         * @return ammotype of ammo item or a null id if the item is not ammo.
+         */
         ammotype ammo_type() const;
 
-        /** Ammo types (@ref ammunition_type) the item magazine pocket can contain.
-         *  @param conversion whether to include the effect of any flags or mods which convert the type
-         *  @return empty set if item does not have a magazine for a specific ammo type */
+        /**
+         * Ammo types (@ref ammunition_type) the item magazine pocket can contain.
+         * @param conversion whether to include the effect of any flags or mods which convert the type.
+         * @return empty set if item does not have a magazine for a specific ammo type.
+         */
         std::set<ammotype> ammo_types( bool conversion = true ) const;
-        /** Default ammo for the item magazine pocket, if item has ammo_types().
-         *  @param conversion whether to include the effect of any flags or mods which convert the type
-         *  @return itype_id::NULL_ID() if item does have a magazine for a specific ammo type */
+        /**
+         * Default ammo for the item magazine pocket, if item has ammo_types().
+         * @param conversion whether to include the effect of any flags or mods which convert the type.
+         * @return itype_id::NULL_ID() if item does have a magazine for a specific ammo type.
+         */
         itype_id ammo_default( bool conversion = true ) const;
-        // format a string with all the ammo that this mag can use
+        /** Format a string with all the ammo that this mag can use. */
         std::string print_ammo( ammotype at, const item *gun = nullptr ) const;
 
-        /** Get default ammo for the first ammotype common to an item and its current magazine or "NULL" if none exists
-         * @param conversion whether to include the effect of any flags or mods which convert the type
-         * @return itype_id of default ammo for the first ammotype common to an item and its current magazine or "NULL" if none exists */
+        /**
+         * Get default ammo for the first ammotype common to an item and its current magazine or "NULL" if none exists.
+         * @param conversion whether to include the effect of any flags or mods which convert the type.
+         * @return itype_id of said ammo or "NULL" if none exists.
+         */
         itype_id common_ammo_default( bool conversion = true ) const;
 
         /** Get ammo effects for item optionally inclusive of any resulting from the loaded ammo */
         std::set<ammo_effect_str_id> ammo_effects( bool with_ammo = true ) const;
 
-        /* Get the name to be used when sorting this item by ammo type */
+        /** Get the name to be used when sorting this item by ammo type. */
         std::string ammo_sort_name() const;
 
         /** How many spent casings are contained within this item? */
@@ -2608,20 +2633,24 @@ class item : public visitable
         /** Does item have magazine well */
         bool uses_magazine() const;
 
-        /** Get the default magazine type (if any) for the current effective ammo type
-         *  @param conversion whether to include the effect of any flags or mods which convert item's ammo type
-         *  @return magazine type or "null" if item has integral magazine or no magazines for current ammo type */
+        /**
+         * Get the default magazine type (if any) for the current effective ammo type.
+         * @param conversion whether to include the effect of any flags or mods which convert item's ammo type.
+         * @return magazine type or "null" if item has integral magazine or no magazines for current ammo type.
+         */
         itype_id magazine_default( bool conversion = false ) const;
 
-        /** Get compatible magazines (if any) for this item
-         *  @return magazine compatibility which is always empty if item has integral magazine
-         *  @see item::magazine_integral
+        /**
+         * Get compatible magazines (if any) for this item.
+         * @return magazine compatibility which is always empty if item has integral magazine.
+         * @see item::magazine_integral.
          */
         std::set<itype_id> magazine_compatible() const;
 
-        /** Currently loaded magazine (if any)
-         *  @return current magazine or nullptr if either no magazine loaded or item has integral magazine
-         *  @see item::magazine_integral
+        /**
+         * Get currently loaded magazine (if any).
+         * @return current magazine or nullptr if either no magazine loaded or item has integral magazine.
+         * @see item::magazine_integral.
          */
         item *magazine_current();
         const item *magazine_current() const;
@@ -2644,8 +2673,8 @@ class item : public visitable
         /** Get first attached gunmod with flag or nullptr if no such mod or item is not a gun */
         item *gunmod_find_by_flag( const flag_id &flag );
 
-        /*
-         * Checks if mod can be applied to this item considering any current state (jammed, loaded etc.)
+        /**
+         * Check if a mod can be applied to this item considering any current state (jammed, loaded etc.).
          * @param msg message describing reason for any incompatibility
          */
         ret_val<void> is_gunmod_compatible( const item &mod ) const;
@@ -2700,10 +2729,10 @@ class item : public visitable
         int gun_range( bool with_ammo = true ) const;
 
         /**
-         *  Get effective recoil considering handling, loaded ammo and effects of attached gunmods
-         *  @param p player stats such as STR can alter effective recoil
-         *  @param bipod whether any bipods should be considered
-         *  @return effective recoil (per shot) or zero if gun uses ammo and none is loaded
+         * Get effective recoil considering handling, loaded ammo and effects of attached gunmods.
+         * @param p player stats such as STR can alter effective recoil.
+         * @param bipod whether any bipods should be considered.
+         * @return effective recoil (per shot) or zero if gun uses ammo and none is loaded.
          */
         int gun_recoil( const Character &p, bool bipod = false, bool ideal_strength = false ) const;
 
@@ -2714,7 +2743,7 @@ class item : public visitable
         damage_instance gun_damage( bool with_ammo = true, bool shot = false ) const;
         damage_instance gun_damage( itype_id ammo ) const;
         /**
-        * The base weight of gun which takes receiver into account
+         * The base weight of a gun plus mod integral weight.
          */
         units::mass gun_base_weight() const;
         /**
@@ -2726,8 +2755,8 @@ class item : public visitable
          */
         int gun_dispersion( bool with_ammo = true, bool with_scaling = true ) const;
         /**
-        * Summed shot spread from mods. Returns 0 on non-gun items.
-        */
+         * Summed shot spread from mods. Return 0 on non-gun items.
+         */
         float gun_shot_spread_multiplier() const;
         /**
          * The skill used to operate the gun. Can be "null" if this is not a gun.
@@ -2753,11 +2782,6 @@ class item : public visitable
          */
         int get_reload_time() const;
         /*@}*/
-
-        /**
-         * @name Vehicle parts
-         *
-         *@{*/
 
         /**
          * @name Bionics / CBMs
@@ -2786,7 +2810,7 @@ class item : public visitable
 
         /**
          * Returns name of deceased being if it had any or empty string if not
-         **/
+         */
         std::string get_corpse_name() const;
         /**
          * Returns the translated item name for the item with given id.
@@ -2817,12 +2841,13 @@ class item : public visitable
         static bool type_is_defined( const itype_id &id );
 
         /**
-        * Returns true if item has "item_label" itemvar
-        */
+         * Return true if item has "item_label" itemvar.
+         */
         bool has_label() const;
         /**
-        * Returns label from "item_label" itemvar and quantity
-        */
+         * Return label from "item_label" itemvar and quantity, if it has a label.
+         * Use type_name method with passed parameters otherwise.
+         */
         std::string label( unsigned int quantity = 0, bool use_variant = true,
                            bool use_cond_name = true, bool use_corpse = true ) const;
 
@@ -2831,12 +2856,13 @@ class item : public visitable
         /** Puts the skill in context of the item */
         skill_id contextualize_skill( const skill_id &id ) const;
 
-        /* Remove a monster from this item and spawn it.
+        /**
+         * Remove a monster from this item and spawn it.
          * See @game::place_critter for meaning of @p target and @p pos.
          * @return Whether the monster has been spawned (may fail if no space available).
          */
         bool release_monster( const tripoint_bub_ms &target, int radius = 0 );
-        /* add the monster at target to this item, despawning it */
+        /** Add the monster at target to this item, despawning it. */
         int contain_monster( const tripoint_bub_ms &target );
 
         time_duration age() const;
@@ -2968,8 +2994,9 @@ class item : public visitable
         std::list<item *> all_items_top();
         /** returns a list of pointers to all top-level items */
         std::list<const item *> all_items_top( pocket_type pk_type ) const;
-        /** returns a list of pointers to all top-level items
-         *  if unloading is true it ignores items in pockets that are flagged to not unload
+        /**
+         * Return a list of pointers to all top-level items.
+         * If unloading is true ignore items in pockets flagged not to be unloaded.
          */
         std::list<item *> all_items_top( pocket_type pk_type, bool unloading = false );
 
@@ -3011,10 +3038,10 @@ class item : public visitable
 
         void clear_items();
         bool empty() const;
-        // ignores all pockets except CONTAINER pockets to check if this contents is empty.
+        /** Check if contents is empty. Checking only CONTAINER pockets. */
         bool empty_container() const;
 
-        // gets the item contained IFF one item is contained (CONTAINER pocket), otherwise a null item reference
+        /** Get the item contained IFF one item is contained in CONTAINER pocket, otherwise a null item reference. */
         item &only_item();
         const item &only_item() const;
         item *get_item_with( const std::function<bool( const item & )> &filter );
@@ -3068,7 +3095,7 @@ class item : public visitable
          */
         void calc_temp( const units::temperature &temp, float insulation, const time_duration &time_delta );
 
-        /** Calculates item specific energy (J/g) from temperature*/
+        /** Calculate item specific energy (J/g) from temperature. */
         units::specific_energy get_specific_energy_from_temperature( const units::temperature
                 &new_temperature )
         const;
@@ -3084,8 +3111,8 @@ class item : public visitable
 
         void update_inherited_flags();
         /**
-        * Update prefix_tags_cache and suffix_tags_cache
-        */
+         * Update prefix_tags_cache and suffix_tags_cache.
+         */
         void update_prefix_suffix_flags();
         void update_prefix_suffix_flags( const flag_id &flag );
 
@@ -3138,7 +3165,8 @@ class item : public visitable
 
     private:
         item_contents contents;
-        /** `true` if item has any of the flags that require processing in item::process_internal.
+        /**
+         * `true` if item has any of the flags that require processing in item::process_internal.
          * This flag is reset to `true` if item tags are changed.
          */
         bool requires_tags_processing = true;
@@ -3152,16 +3180,18 @@ class item : public visitable
         std::string corpse_name;       // Name of the late lamented
         cata::heap<std::set<matec_id>> techniques; // item specific techniques
 
-        // Select a random variant from the possibilities
-        // Intended to be called when no explicit variant is set
+        /**
+         * Select a random variant from the possibilities.
+         * Intended to be called when no explicit variant is set.
+         */
         void select_itype_variant();
 
         bool can_have_itype_variant() const;
 
-        // Does this have a variant with this id?
+        /** Does this have a variant with this id? */
         bool possible_itype_variant( const std::string &test ) const;
 
-        // If the item has a gun variant, this points to it
+        /** If the item has a gun variant, this points to it. */
         const itype_variant_data *_itype_variant = nullptr;
 
         /**
@@ -3217,9 +3247,11 @@ class item : public visitable
         harvest_drop_type_id dropped_from =
             harvest_drop_type_id::NULL_ID(); // The drop type this item spawned from
 
-        // Set when the item / its content changes. Used for worn item with
-        // encumbrance depending on their content.
-        // This not part serialized or compared on purpose!
+        /**
+         * Set when the item / its content changes. Used for worn item with
+         * encumbrance depending on their content.
+         * This part is not serialized or compared on purpose!
+         */
         bool encumbrance_update_ = false;
 
         item_contents &get_contents() {
@@ -3248,9 +3280,9 @@ class item : public visitable
          * PNULL.
          */
         phase_id current_phase = static_cast<phase_id>( 0 );
-        // The faction that owns this item.
+        /** The faction that owns this item. */
         mutable faction_id owner = faction_id::NULL_ID();
-        // The faction that previously owned this item
+        /** The faction that previously owned this item. */
         mutable faction_id old_owner = faction_id::NULL_ID();
         int damage_ = 0;
         int degradation_ = 0;
@@ -3264,7 +3296,7 @@ class item : public visitable
         };
         mutable cat_cache cached_category;
 
-        // additional encumbrance this specific item has
+        /** Additional encumbrance this item, not itype, has. */
         units::volume additional_encumbrance = 0_ml;
 
     public:

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -39,14 +39,13 @@ class item_contents
 {
     public:
         item_contents() = default;
-        // used for loading itype
+        /** Used for loading itype. */
         explicit item_contents( const std::vector<pocket_data> &pockets );
 
         /**
-          * returns an item_location and pointer to the best pocket that can contain the item @it
-          * checks all items contained in every pocket
-          * only checks CONTAINER pocket type
-          */
+         * Return an item_location and a pointer to the best pocket that can contain the item @it.
+         * Check all items contained in every pocket of CONTAINER pocket type.
+         */
         std::pair<item_location, item_pocket *> best_pocket( const item &it, item_location &this_loc,
                 const item *avoid = nullptr, bool allow_sealed = false, bool ignore_settings = false,
                 bool nested = false, bool ignore_rigidity = false );
@@ -95,19 +94,19 @@ class item_contents
          */
         bool can_reload_with( const item &ammo, bool now ) const;
 
-        // Returns true if contents are empty (ignoring item mods, since they aren't contents)
+        /** Return true if contents are empty (ignoring item mods, since they aren't contents). */
         bool empty() const;
-        // Returns true if contents are empty of everything including mods
+        /** Return true if contents are empty of everything including mods. */
         bool empty_with_no_mods() const;
-        // ignores all pockets except CONTAINER pockets to check if this contents is empty.
+        /** Check if contents is empty. Checking only CONTAINER pockets. */
         bool empty_container() const;
-        // checks if CONTAINER pockets are all full
+        /** Check if CONTAINER pockets are all full. */
         bool full( bool allow_bucket ) const;
-        // Checks if MAGAZINE pockets are all full
+        /** Check if MAGAZINE pockets are all full. */
         bool is_magazine_full() const;
-        // are any CONTAINER pockets bigger on the inside than the container's volume?
+        /** Are any CONTAINER pockets bigger on the inside than the container's volume? */
         bool bigger_on_the_inside( const units::volume &container_volume ) const;
-        // number of pockets
+        /** Number of pockets. */
         size_t size() const;
 
         /** returns a list of pointers to all top-level items from pockets that match the predicate */
@@ -141,7 +140,7 @@ class item_contents
         std::vector<item *> gunmods();
         /** gets all gunmods in the item */
         std::vector<const item *> gunmods() const;
-        // checks the pockets if this speedloader is compatible
+        /** Check this speedloader is compatible with pockets. */
         bool allows_speedloader( const itype_id &speedloader_id ) const;
 
         std::vector<const item *> mods() const;
@@ -159,7 +158,10 @@ class item_contents
         // all magazines compatible with any pockets.
         // this only checks MAGAZINE_WELL
         std::set<itype_id> magazine_compatible() const;
-        // returns the default magazine; assumes only one MAGAZINE_WELL. returns NULL_ID if not a magazine well or no compatible magazines.
+        /**
+         * Return the default magazine of the first MAGAZINE_WELL pocket.
+         * Return NULL_ID if no pockets are a MAGAZINE_WELL.
+         */
         itype_id magazine_default() const;
         /**
          * This function is to aid migration to using nested containers.
@@ -173,16 +175,16 @@ class item_contents
         units::mass item_weight_modifier() const;
         units::length item_length_modifier() const;
 
-        // gets the total weight capacity of all pockets
+        /** Get the total weight capacity of all pockets. */
         units::mass total_container_weight_capacity( bool unrestricted_pockets_only = false ) const;
 
         /**
-          * gets the total volume available to be used.
-          * does not guarantee that an item of that size can be inserted.
-          */
+         * Get the total volume available to be used.
+         * Does not guarantee that an item of that size can be inserted.
+         */
         units::volume total_container_capacity( bool unrestricted_pockets_only = false ) const;
 
-        // Gets the total volume of every is_standard_type container
+        /** Get the total volume of every is_standard_type container. */
         units::volume total_standard_capacity( bool unrestricted_pockets_only = false ) const;
 
         units::volume remaining_container_capacity( bool unrestricted_pockets_only = false ) const;
@@ -193,7 +195,7 @@ class item_contents
         units::volume get_nested_content_volume_recursive( const std::map<const item *, int> &without )
         const;
 
-        // get all holsters
+        /** Get all holsters. */
         int get_used_holsters() const;
         int get_total_holsters() const;
         units::volume get_total_holster_volume() const;
@@ -201,7 +203,7 @@ class item_contents
         units::mass get_total_holster_weight() const;
         units::mass get_used_holster_weight() const;
 
-        // gets all CONTAINER pockets contained in this item
+        /** Get all CONTAINER/standard/ablative pockets in this item. */
         std::vector<const item_pocket *> get_all_contained_pockets() const;
         std::vector<item_pocket *> get_all_contained_pockets();
         std::vector<const item_pocket *> get_all_standard_pockets() const;
@@ -213,17 +215,19 @@ class item_contents
         std::vector<item_pocket *>
         get_pockets( std::function<bool( item_pocket const & )> const &filter );
 
-        // called when adding an item as pockets
-        // to a molle item
+        /**
+         * Called when adding an item as pockets to a molle item.
+         */
         void add_pocket( const item &pocket );
 
-        // called when removing a molle pocket
-        // needs the index of the pocket in both
-        // related vectors
-        // returns the item that was attached
+        /*
+         * Called when removing a molle pocket.
+         * @param index of the pocket in both related vectors.
+         * @return the item that was attached.
+         */
         item remove_pocket( int index );
 
-        // retrieves the pocket in contents corresponding to the added pocket item
+        /** Retrieve the pocket in contents corresponding to the added pocket item. */
         const item_pocket *get_added_pocket( int index ) const;
 
         std::vector<const item *> get_added_pockets() const;
@@ -235,15 +239,17 @@ class item_contents
         units::mass get_additional_weight() const;
         units::volume get_additional_volume() const;
 
-        // Gets all CONTAINER/MAGAZINE/MAGAZINE WELL pockets in this item
+        /** Get all CONTAINER/MAGAZINE/MAGAZINE WELL pockets in this item. */
         std::vector<const item_pocket *> get_all_reloadable_pockets() const;
 
-        // gets the number of charges of liquid that can fit into the rest of the space
+        /** Get the number of charges of liquid that can fit into the rest of the space. */
         int remaining_capacity_for_liquid( const item &liquid ) const;
 
-        /** If contents should contribute to encumbrance, returns a value
+        /**
+         * If contents should contribute to encumbrance, return a value
          * between 0 and 1 indicating the position between minimum and maximum
-         * contribution it's currently making.  Otherwise, return 0 */
+         * contribution it's currently making. Otherwise, return 0.
+         */
         float relative_encumbrance() const;
         /** True if every pocket is rigid or we have no pockets */
         bool all_pockets_rigid() const;
@@ -253,11 +259,13 @@ class item_contents
         /** returns the best quality of the id that's contained in the item in CONTAINER pockets */
         int best_quality( const quality_id &id ) const;
 
-        // what will the move cost be of taking @it out of this container?
-        // should only be used from item_location if possible, to account for
-        // player inventory handling penalties from traits
+        /**
+         * @return the move cost of taking @it out of this container.
+         * Should only be used from item_location if possible, to account for
+         * player inventory handling penalties from traits.
+         */
         int obtain_cost( const item &it ) const;
-        // what will the move cost be of storing @it into this container? (CONTAINER pocket type)
+        /** @return the move cost of storing @it into this container's CONTAINER pocket. */
         int insert_cost( const item &it ) const;
 
         /**
@@ -293,10 +301,10 @@ class item_contents
         item_pocket *contained_where( const item &contained );
         void on_pickup( Character &guy, item *avoid = nullptr );
         bool spill_contents( const tripoint_bub_ms &pos );
-        // spill items that don't fit in the container
+        /** Spill items that don't fit in the container. */
         void overflow( const tripoint_bub_ms &pos, const item_location &loc );
         void clear_items();
-        // clears all items from magazine type pockets
+        /** Clear all items from magazine type pockets. */
         void clear_magazines();
         void clear_pockets_if( const std::function<bool( item_pocket const & )> &filter );
         void update_open_pockets();
@@ -306,34 +314,36 @@ class item_contents
          */
         void set_item_defaults();
 
-        // returns true if any pocket was sealed
+        /** Return true if any pocket was sealed. */
         bool seal_all_pockets();
         bool all_pockets_sealed() const;
         bool any_pockets_sealed() const;
-        // heats up the contents if they have temperature
+        /** Heat the contents if it has temperature. */
         void heat_up();
-        // returns amount of ammo consumed
+        /** Return the amount of ammo consumed. */
         int ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel_efficiency = -1.0 );
         item *magazine_current();
         std::set<ammotype> ammo_types() const;
         int ammo_capacity( const ammotype &ammo ) const;
-        // gets the first ammo in all magazine pockets
-        // does not support multiple magazine pockets!
+        /**
+         * Return the first ammo found when iterating all magazine pockets. Null if none found.
+         * Does not support multiple magazine pockets!
+         */
         item &first_ammo();
-        // gets the first ammo in all magazine pockets
-        // does not support multiple magazine pockets!
         const item &first_ammo() const;
-        // spills liquid and other contents from the container. contents may remain
-        // in the container if the player cancels spilling. removing liquid from
-        // a magazine requires unload logic.
+        /**
+         * Spill liquid and other contents from the container. Contents may remain
+         * in the container if the player cancels spilling. Removing liquid from
+         * a magazine requires unload logic.
+         */
         void handle_liquid_or_spill( Character &guy, const item *avoid = nullptr );
-        // returns true if any of the pockets will spill if placed into a pocket
+        /** Return true if any of the pockets will spill if placed into a pocket. */
         bool will_spill() const;
         bool will_spill_if_unsealed() const;
         bool spill_open_pockets( Character &guy, const item *avoid = nullptr );
         void casings_handle( const std::function<bool( item & )> &func );
 
-        // gets the item contained IFF one item is contained (CONTAINER pocket), otherwise a null item reference
+        /** Get the item contained IFF one item is contained in a CONTAINER pocket, otherwise a null item reference. */
         item &only_item();
         item &first_item();
         const item &only_item() const;
@@ -342,7 +352,7 @@ class item_contents
         const item *get_item_with( const std::function<bool( const item & )> &filter ) const;
         void remove_items_if( const std::function<bool( item & )> &filter );
 
-        // whether the contents has a pocket with the associated type
+        /** Whether contents has a pocket with @param pk_type type. */
         bool has_pocket_type( pocket_type pk_type ) const;
         bool has_unrestricted_pockets() const;
         bool has_any_with( const std::function<bool( const item & )> &filter,
@@ -362,9 +372,9 @@ class item_contents
         bool item_has_uses_recursive() const;
         bool stacks_with( const item_contents &rhs, int depth = 0, int maxdepth = 2 ) const;
         bool same_contents( const item_contents &rhs ) const;
-        // can this item be used as a funnel?
+        /** Can this item be used as a funnel? */
         bool is_funnel_container( units::volume &bigger_than ) const;
-        // the container has restrictions
+        /** Any pocket has restrictions. */
         bool is_restricted_container() const;
         bool is_single_restricted_container() const;
         /**
@@ -378,7 +388,7 @@ class item_contents
 
         void info( std::vector<iteminfo> &info, const iteminfo_query *parts ) const;
 
-        // reads the items in the MOD pocket first
+        /** Read the items in the MOD pocket only. */
         void read_mods( const item_contents &read_input );
         void combine( const item_contents &read_input, bool convert = false, bool into_bottom = false,
                       bool restack_charges = true, bool ignore_contents = false );
@@ -386,9 +396,10 @@ class item_contents
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &data );
     private:
-        // finds the pocket the item will fit in, given the pocket type.
-        // this will be where the algorithm picks the best pocket in the contents
-        // returns nullptr if none is found
+        /**
+         * Find the best pocket of type pk_type the item will fit in.
+         * @return nullptr if none is found.
+         */
         ret_val<item_pocket *> find_pocket_for( const item &it,
                                                 pocket_type pk_type = pocket_type::CONTAINER );
 
@@ -397,12 +408,12 @@ class item_contents
 
         std::list<item_pocket> contents;
 
-        // pockets that have been custom added
+        /** Pockets that have been custom added. */
         std::vector<item> additional_pockets;
         // TODO make this work with non torso items
         units::volume additional_pockets_volume = 0_ml; // NOLINT(cata-serialize)
 
-        // an abstraction for how many 'spaces' of this item have been used attaching additional pockets
+        /** An abstraction for how many 'spaces' of this item have been used attaching additional pockets. */
         int additional_pockets_space_used = 0; // NOLINT(cata-serialize)
 
         struct item_contents_helper;

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -173,6 +173,7 @@ class item_pocket
         const item &back() const;
         item &front();
         const item &front() const;
+        /** Number of items in this pocket. */
         size_t size() const;
         void pop_back();
 


### PR DESCRIPTION
#### Summary
Infrastructure "Standardize docs"


#### Purpose of change

Reading src/item.h, there are some inconsistencies in docs, which are annoying when reading. So I removed most of them.

Related files have exact copy of some comments, so I changed those too.

#### Describe the solution

 - Replace // with /** */, fix weird spacing.
 - If I was already fixing a comment, I made it a proper sentence with punctuation. Then I also changed returns -> return; gets-> get etc.
 - Some comments were weirdly worded or wrong, so I changed them.
   - I sometimes had to look at the implementation.

Notable changes include answering a question (previous doc) by writing what the method does:
 - From `// Does this use electrical energy, or is it fueled by something else?`
 - To `/** Return true if this uses electrical or a different kind of energy. */`
 - From `// what will the move cost be of storing @it into this container? (CONTAINER pocket type)`
 - To `/** @return the move cost of storing @it into this container's CONTAINER pocket. */`


#### Describe alternatives you've considered

 - Not doing this.
 - Change all returns -> return.
    - I tried to minimize the amount of comments I touched. And the ammount of changes.

#### Testing

Docs cannot be tested.

#### Additional context
