### PR TITLE
fix fallback font rendering

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -379,8 +379,7 @@ static void load_font( ImGuiIO &io, const std::vector<font_config> &typefaces,
     for( ; it != std::end( io_typefaces ); ++it ) {
         if( !file_exist( it->path ) ) {
             debugmsg( "Font file '%s' does not exist.", it->path );
-        } else
-        {
+        } else {
             break;
         }
     }

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -379,8 +379,10 @@ static void load_font( ImGuiIO &io, const std::vector<font_config> &typefaces,
     for( ; it != std::end( io_typefaces ); ++it ) {
         if( !file_exist( it->path ) ) {
             debugmsg( "Font file '%s' does not exist.", it->path );
+        } else
+        {
+            break;
         }
-        break;
     }
     if( it == std::end( io_typefaces ) ) {
         debugmsg( "No fonts were found in the fontdata file." );


### PR DESCRIPTION
#### Summary
Bugfixes "Fallback font rendering works again"

#### Purpose of change

I accidentally broke fallback font rendering in #78830, causing #78966.

fixes #78966

#### Describe the solution

Add an else statement.

#### Describe alternatives you've considered

None.

#### Testing

Game no longer crashes with given font config file.

#### Additional context

I'm mildly surprised static analysis didn't catch this.