### PR TITLE
Give Chimera Natural Stance

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -301,7 +301,7 @@
     "condition": {
       "and": [
         { "u_has_flag": "QUADRUPED_CROUCH" },
-        { "u_has_any_trait": [ "THRESH_RABBIT", "THRESH_BEAST", "THRESH_LUPINE", "THRESH_FELINE" ] },
+        { "u_has_any_trait": [ "THRESH_RABBIT", "THRESH_BEAST", "THRESH_LUPINE", "THRESH_FELINE", "THRESH_CHIMERA" ] },
         { "u_has_flag": "QUADRUPED_RUN" },
         { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "run" } ] },
         { "not": "u_can_drop_weapon" }
@@ -317,7 +317,7 @@
     "condition": {
       "and": [
         { "u_has_flag": "QUADRUPED_CROUCH" },
-        { "u_has_any_trait": [ "THRESH_RABBIT", "THRESH_BEAST", "THRESH_LUPINE", "THRESH_FELINE" ] },
+        { "u_has_any_trait": [ "THRESH_RABBIT", "THRESH_BEAST", "THRESH_LUPINE", "THRESH_FELINE", "THRESH_CHIMERA" ] },
         { "not": { "u_has_flag": "QUADRUPED_RUN" } },
         { "u_has_move_mode": "crouch" },
         { "not": "u_can_drop_weapon" }


### PR DESCRIPTION
#### Summary
Features "Adds Natural Stance enchantment to Chimera"

#### Purpose of change

As per #72994, Chimera category can act as a wildcard for any animal-based category. In my opinion, they should be able to benefit from Natural Stance as - if they want to - they can attempt to mutate the traits necessary, but as Natural Stance enchantment doesn't extend to Chimera, they cannot benefit from aforementioned traits.

#### Describe the solution

Allows Natural Stance to extend to the Chimera threshold.


#### Describe alternatives you've considered

Don't. This is an equally valid solution, but I'd be disappointed if I didn't have access to Natural Stance.

#### Testing

It works!

#### Additional context

I'm going to try and finish up Worm Girl's #72082, KittyTac's #61071, change up Quills a little and then finish up my Demon Spider mutation line for Magiclysm. 