### PR TITLE
sundry typification

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -346,7 +346,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg,
 
     static emit_id muzzle_smoke( "emit_smaller_smoke_plume" );
     if( proj_effects.count( ammo_effect_MUZZLE_SMOKE ) ) {
-        here.emit_field( trajectory.front().raw(), muzzle_smoke );
+        here.emit_field( trajectory.front(), muzzle_smoke );
     }
 
     if( !no_overshoot && range < extend_to_range ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1545,7 +1545,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                         // Add scent type to the overlay_strings list for every visible tile when
                         // displaying scent
                         if( g->display_overlay_state( ACTION_DISPLAY_SCENT_TYPE ) && !invisible[0] ) {
-                            const scenttype_id scent_type = get_scent().get_type( pos.raw() );
+                            const scenttype_id scent_type = get_scent().get_type( pos );
                             if( !scent_type.is_empty() ) {
                                 here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ) + half_tile,
                                                                     formatted_text( scent_type.c_str(),

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7149,7 +7149,7 @@ bool Character::invoke_item( item *used, const std::string &method, const tripoi
     }
 
     std::optional<int> charges_used = actually_used->type->invoke( this, *actually_used,
-                                      pt.raw(), method );
+                                      pt, method );
     if( !charges_used.has_value() ) {
         set_moves( pre_obtain_moves );
         return false;

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -258,7 +258,7 @@ bool Character::try_remove_grab( bool attacking )
                                pd[index]->get_name(), sturdiness, chance );
                 // the item is ripped off your character
                 if( sturdiness < chance ) {
-                    pd[index]->spill_contents( adjacent_tile().raw() );
+                    pd[index]->spill_contents( adjacent_tile() );
                     add_msg_player_or_npc( m_bad,
                                            _( "As you struggle to escape the grab something comes loose and falls to the ground!" ),
                                            _( "As <npcname> struggles to escape the grab something comes loose and falls to the ground!" ) );

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1093,7 +1093,7 @@ static bool eat( item &food, Character &you, bool force )
     int charges_used = 0;
     if( food.type->has_use() ) {
         if( !food.type->can_use( "PETFOOD" ) ) {
-            charges_used = food.type->invoke( &you, food, you.pos() ).value_or( 0 );
+            charges_used = food.type->invoke( &you, food, you.pos_bub() ).value_or( 0 );
             if( charges_used <= 0 ) {
                 return false;
             }
@@ -1878,7 +1878,7 @@ static bool consume_med( item &target, Character &you )
 
     int amount_used = 1;
     if( target.type->has_use() ) {
-        amount_used = target.type->invoke( &you, target, you.pos() ).value_or( 0 );
+        amount_used = target.type->invoke( &you, target, you.pos_bub() ).value_or( 0 );
         if( amount_used <= 0 ) {
             return false;
         }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -215,11 +215,6 @@ tripoint_bub_ms Creature::pos_bub() const
     return get_map().bub_from_abs( location );
 }
 
-void Creature::setpos( const tripoint &p, bool check_gravity/* = true*/ )
-{
-    Creature::setpos( tripoint_bub_ms( p ), check_gravity );
-}
-
 void Creature::setpos( const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
 {
     const tripoint_abs_ms old_loc = get_location();

--- a/src/creature.h
+++ b/src/creature.h
@@ -319,8 +319,6 @@ class Creature : public viewer
             return get_location().z();
         }
         virtual void gravity_check();
-        // TODO: Get rid of untyped overload
-        void setpos( const tripoint &p, bool check_gravity = true );
         void setpos( const tripoint_bub_ms &p, bool check_gravity = true );
 
         /** Checks if the creature fits confortably into a given tile. */

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -633,10 +633,10 @@ bool do_turn()
     scent_map &scent = get_scent();
     // No-scent debug mutation has to be processed here or else it takes time to start working
     if( !u.has_flag( STATIC( json_character_flag( "NO_SCENT" ) ) ) ) {
-        scent.set( u.pos(), u.scent, u.get_type_of_scent() );
+        scent.set( u.pos_bub(), u.scent, u.get_type_of_scent() );
         overmap_buffer.set_scent( u.global_omt_location(),  u.scent );
     }
-    scent.update( u.pos(), m );
+    scent.update( u.pos_bub(), m );
 
     // We need floor cache before checking falling 'n stuff
     m.build_floor_caches();

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5415,7 +5415,7 @@ drop_locations basecamp::get_equipment( tinymap *target_bay, const tripoint_omt_
     inventory_multiselector inv_s( *pc, preset, msg,
                                    make_raw_stats, /*allow_select_contained =*/ true );
 
-    inv_s.add_remote_map_items( target_bay, target.raw() );
+    inv_s.add_remote_map_items( target_bay, target );
     inv_s.set_title( title );
     inv_s.set_hint( _( "To select items, type a number before selecting." ) );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11265,7 +11265,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
         ( !get_option<bool>( "AUTO_PICKUP_SAFEMODE" ) ||
           !u.get_mon_visible().has_dangerous_creature_in_proximity ) &&
         ( m.has_items( u.pos_bub() ) || get_option<bool>( "AUTO_PICKUP_ADJACENT" ) ) ) {
-        Pickup::autopickup( u.pos() );
+        Pickup::autopickup( u.pos_bub() );
     }
 
     // If the new tile is a boardable part, board it
@@ -12902,7 +12902,7 @@ point_rel_sm game::update_map( int &x, int &y, bool z_level_changed )
 
     if( shift == point_rel_sm::zero ) {
         // adjust player position
-        u.setpos( tripoint( x, y, m.get_abs_sub().z() ) );
+        u.setpos( tripoint_bub_ms( x, y, m.get_abs_sub().z() ) );
         if( z_level_changed ) {
             // Update what parts of the world map we can see
             // We may be able to see farther now that the z-level has changed.
@@ -12940,12 +12940,12 @@ point_rel_sm game::update_map( int &x, int &y, bool z_level_changed )
         }
     }
 
-    scent.shift( shift_ms.raw() );
+    scent.shift( shift_ms );
 
     // Also ensure the player is on current z-level
     // m.get_abs_sub().z should later be removed, when there is no longer such a thing
     // as "current z-level"
-    u.setpos( tripoint( x, y, m.get_abs_sub().z() ) );
+    u.setpos( tripoint_bub_ms( x, y, m.get_abs_sub().z() ) );
 
     // Only do the loading after all coordinates have been shifted.
 
@@ -13192,7 +13192,7 @@ void game::display_scent()
             return;
         }
         shared_ptr_fast<game::draw_callback_t> scent_cb = make_shared_fast<game::draw_callback_t>( [&]() {
-            scent.draw( w_terrain, div * 2, u.pos_bub().raw() + u.view_offset.raw() );
+            scent.draw( w_terrain, div * 2, u.pos_bub() + u.view_offset );
         } );
         g->add_draw_callback( scent_cb );
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2206,16 +2206,31 @@ drop_locations game_menus::inv::multidrop( Character &you )
 drop_locations game_menus::inv::pickup( const std::optional<tripoint> &target,
                                         const std::vector<drop_location> &selection )
 {
+    std::optional<tripoint_bub_ms> tmp;
+    if( target.has_value() ) {
+        tmp = tripoint_bub_ms( target.value() );
+    }
+    return game_menus::inv::pickup( tmp, selection );
+}
+
+drop_locations game_menus::inv::pickup( const std::optional<tripoint_bub_ms> &target,
+                                        const std::vector<drop_location> &selection )
+{
     avatar &you = get_avatar();
     pickup_inventory_preset preset( you, /*skip_wield_check=*/true, /*ignore_liquidcont=*/true );
     preset.save_state = &pickup_ui_default_state;
 
-    pickup_selector pick_s( you, preset, _( "ITEMS TO PICK UP" ), target );
+    std::optional<tripoint> tmp;
+    if( target.has_value() ) {
+        tmp = target.value().raw();
+    }
+
+    pickup_selector pick_s( you, preset, _( "ITEMS TO PICK UP" ), tmp );
 
     // Add items from the selected tile, or from current and all surrounding tiles
     if( target ) {
-        pick_s.add_vehicle_items( *target );
-        pick_s.add_map_items( *target );
+        pick_s.add_vehicle_items( tripoint_bub_ms( *target ) );
+        pick_s.add_map_items( tripoint_bub_ms( *target ) );
     } else {
         pick_s.add_nearby_items();
     }
@@ -2235,16 +2250,6 @@ drop_locations game_menus::inv::pickup( const std::optional<tripoint> &target,
     }
 
     return pick_s.execute();
-}
-
-drop_locations game_menus::inv::pickup( const std::optional<tripoint_bub_ms> &target,
-                                        const std::vector<drop_location> &selection )
-{
-    std::optional<tripoint> tmp;
-    if( target.has_value() ) {
-        tmp = target.value().raw();
-    }
-    return game_menus::inv::pickup( tmp, selection );
 }
 
 class smokable_selector_preset : public inventory_selector_preset
@@ -2412,8 +2417,8 @@ void game_menus::inv::compare( const std::optional<tripoint> &offset )
     inv_s.set_hint( _( "Select two items to compare them." ) );
 
     if( offset ) {
-        inv_s.add_map_items( you.pos() + *offset );
-        inv_s.add_vehicle_items( you.pos() + *offset );
+        inv_s.add_map_items( you.pos_bub() + *offset );
+        inv_s.add_vehicle_items( you.pos_bub() + *offset );
     } else {
         inv_s.add_nearby_items();
     }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -870,7 +870,7 @@ static void haul()
             break;
         case 2: {
             inventory_haul_selector selector( player_character );
-            selector.add_map_items( player_character.pos() );
+            selector.add_map_items( player_character.pos_bub() );
             selector.apply_selection( player_character.haul_list );
             selector.set_title( _( "Select items to haul" ) );
             selector.set_hint( _( "To select x items, type a number before selecting." ) );

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -617,10 +617,10 @@ class inventory_selector
         void add_contained_ebooks( item_location &container );
         void add_character_items( Character &character );
         void add_character_ebooks( Character &character );
-        void add_map_items( const tripoint &target );
-        void add_vehicle_items( const tripoint &target );
+        void add_map_items( const tripoint_bub_ms &target );
+        void add_vehicle_items( const tripoint_bub_ms &target );
         void add_nearby_items( int radius = 1 );
-        void add_remote_map_items( tinymap *remote_map, const tripoint &target );
+        void add_remote_map_items( tinymap *remote_map, const tripoint_omt_ms &target );
         void add_basecamp_items( const basecamp &camp );
         /** Remove all items */
         void clear_items();
@@ -686,7 +686,7 @@ class inventory_selector
         input_context ctxt;
 
         const item_category *naturalize_category( const item_category &category,
-                const tripoint &pos );
+                const tripoint_bub_ms &pos );
 
         inventory_entry *add_entry( inventory_column &target_column,
                                     std::vector<item_location> &&locations,
@@ -798,7 +798,7 @@ class inventory_selector
         void draw_footer( const catacurses::window &w ) const;
         void draw_columns( const catacurses::window &w );
         void draw_frame( const catacurses::window &w ) const;
-        void _add_map_items( tripoint const &target, item_category const &cat, item_stack &items,
+        void _add_map_items( tripoint_bub_ms const &target, item_category const &cat, item_stack &items,
                              std::function<item_location( item & )> const &floc );
 
     public:

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -712,7 +712,7 @@ item &item::activate()
 
 bool item::activate_thrown( const tripoint_bub_ms &pos )
 {
-    return type->invoke( nullptr, *this, pos.raw() ).value_or( 0 );
+    return type->invoke( nullptr, *this, pos ).value_or( 0 );
 }
 
 units::energy item::mod_energy( const units::energy &qty )
@@ -10547,7 +10547,7 @@ bool item::spill_contents( const tripoint_bub_ms &pos )
         is_container_empty() ) {
         return true;
     }
-    return contents.spill_contents( pos.raw() );
+    return contents.spill_contents( pos );
 }
 
 bool item::spill_open_pockets( Character &guy, const item *avoid )
@@ -10557,7 +10557,7 @@ bool item::spill_open_pockets( Character &guy, const item *avoid )
 
 void item::overflow( const tripoint_bub_ms &pos, const item_location &loc )
 {
-    contents.overflow( pos.raw(), loc );
+    contents.overflow( pos, loc );
 }
 
 book_proficiency_bonuses item::get_book_proficiency_bonuses() const
@@ -11269,7 +11269,7 @@ int item::ammo_consume( int qty, const tripoint_bub_ms &pos, Character *carrier 
 
     // Consume charges loaded in the item or its magazines
     if( is_magazine() || uses_magazine() ) {
-        qty -= contents.ammo_consume( qty, pos.raw() );
+        qty -= contents.ammo_consume( qty, pos );
         if( ammo_capacity( ammo_battery ) == 0 && carrier != nullptr ) {
             carrier->invalidate_weight_carried_cache();
         }
@@ -13598,7 +13598,7 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms 
         if( type->revert_to ) {
             convert( *type->revert_to, carrier );
         } else {
-            type->invoke( carrier, *this, pos.raw(), "transform" );
+            type->invoke( carrier, *this, pos, "transform" );
         }
         if( typeId() == itype_joint_lit && carrier != nullptr ) {
             carrier->add_effect( effect_weed_high, 1_minutes ); // one last puff
@@ -13618,7 +13618,7 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms 
                                             type_name() );
                 convert( *type->revert_to, carrier );
             } else {
-                type->invoke( carrier, *this, pos.raw(), "transform" );
+                type->invoke( carrier, *this, pos, "transform" );
             }
             active = false;
             return false;
@@ -13743,7 +13743,7 @@ bool item::process_extinguish( map &here, Character *carrier, const tripoint_bub
     if( type->revert_to ) {
         convert( *type->revert_to, carrier );
     } else {
-        type->invoke( carrier, *this, pos.raw(), "transform" );
+        type->invoke( carrier, *this, pos, "transform" );
     }
     active = false;
     // Item remains
@@ -14427,7 +14427,7 @@ bool item::process_tool( Character *carrier, const tripoint_bub_ms &pos )
         }
     }
 
-    type->tick( carrier, *this, pos.raw() );
+    type->tick( carrier, *this, pos );
     return false;
 }
 
@@ -14491,7 +14491,7 @@ bool item::process( map &here, Character *carrier, const tripoint_bub_ms &pos, f
 {
     process_relic( carrier, pos );
     if( recursive ) {
-        contents.process( here, carrier, pos.raw(), type->insulation_factor * insulation, flag,
+        contents.process( here, carrier, pos, type->insulation_factor * insulation, flag,
                           spoil_multiplier_parent, watertight_container );
     }
     return process_internal( here, carrier, pos, insulation, flag, spoil_multiplier_parent,
@@ -14501,7 +14501,7 @@ bool item::process( map &here, Character *carrier, const tripoint_bub_ms &pos, f
 bool item::leak( map &here, Character *carrier, const tripoint_bub_ms &pos, item_pocket *pocke )
 {
     if( is_container() ) {
-        contents.leak( here, carrier, pos.raw(), pocke );
+        contents.leak( here, carrier, pos, pocke );
         return false;
     } else if( this->made_of( phase_id::LIQUID ) && !this->is_frozen_liquid() ) {
         if( pocke ) {

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1218,7 +1218,7 @@ void item_contents::on_pickup( Character &guy, item *avoid )
     }
 }
 
-bool item_contents::spill_contents( const tripoint &pos )
+bool item_contents::spill_contents( const tripoint_bub_ms &pos )
 {
     bool spilled = false;
     for( item_pocket &pocket : contents ) {
@@ -1229,7 +1229,7 @@ bool item_contents::spill_contents( const tripoint &pos )
     return spilled;
 }
 
-void item_contents::overflow( const tripoint &pos, const item_location &loc )
+void item_contents::overflow( const tripoint_bub_ms &pos, const item_location &loc )
 {
     for( item_pocket &pocket : contents ) {
         pocket.overflow( pos, loc );
@@ -1244,11 +1244,6 @@ void item_contents::heat_up()
         }
         pocket.heat_up();
     }
-}
-
-int item_contents::ammo_consume( int qty, const tripoint &pos, float fuel_efficiency )
-{
-    return item_contents::ammo_consume( qty, tripoint_bub_ms( pos ), fuel_efficiency );
 }
 
 int item_contents::ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel_efficiency )
@@ -2507,7 +2502,8 @@ void item_contents::remove_internal( const std::function<bool( item & )> &filter
     }
 }
 
-void item_contents::process( map &here, Character *carrier, const tripoint &pos, float insulation,
+void item_contents::process( map &here, Character *carrier, const tripoint_bub_ms &pos,
+                             float insulation,
                              temperature_flag flag, float spoil_multiplier_parent, bool watertight_container )
 {
     for( item_pocket &pocket : contents ) {
@@ -2518,7 +2514,8 @@ void item_contents::process( map &here, Character *carrier, const tripoint &pos,
     }
 }
 
-void item_contents::leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke )
+void item_contents::leak( map &here, Character *carrier, const tripoint_bub_ms &pos,
+                          item_pocket *pocke )
 {
     for( item_pocket &pocket : contents ) {
         if( pocket.is_type( pocket_type::CONTAINER ) ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -292,9 +292,9 @@ class item_contents
 
         item_pocket *contained_where( const item &contained );
         void on_pickup( Character &guy, item *avoid = nullptr );
-        bool spill_contents( const tripoint &pos );
+        bool spill_contents( const tripoint_bub_ms &pos );
         // spill items that don't fit in the container
-        void overflow( const tripoint &pos, const item_location &loc );
+        void overflow( const tripoint_bub_ms &pos, const item_location &loc );
         void clear_items();
         // clears all items from magazine type pockets
         void clear_magazines();
@@ -313,8 +313,6 @@ class item_contents
         // heats up the contents if they have temperature
         void heat_up();
         // returns amount of ammo consumed
-        // TODO: Get rid of untyped overload.
-        int ammo_consume( int qty, const tripoint &pos, float fuel_efficiency = -1.0 );
         int ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel_efficiency = -1.0 );
         item *magazine_current();
         std::set<ammotype> ammo_types() const;
@@ -354,11 +352,12 @@ class item_contents
          * Is part of the recursive call of item::process. see that function for additional comments
          * NOTE: this destroys the items that get processed
          */
-        void process( map &here, Character *carrier, const tripoint &pos, float insulation = 1,
+        void process( map &here, Character *carrier, const tripoint_bub_ms &pos, float insulation = 1,
                       temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f,
                       bool watertight_container = false );
 
-        void leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke = nullptr );
+        void leak( map &here, Character *carrier, const tripoint_bub_ms &pos,
+                   item_pocket *pocke = nullptr );
 
         bool item_has_uses_recursive() const;
         bool stacks_with( const item_contents &rhs, int depth = 0, int maxdepth = 2 ) const;

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -233,7 +233,7 @@ class item_location::impl::item_on_map : public item_location::impl
         std::string describe( const Character *ch ) const override {
             std::string res = get_map().name( cur.pos() );
             if( ch ) {
-                res += std::string( " " ) += direction_suffix( ch->pos(), cur.pos().raw() );
+                res += std::string( " " ) += direction_suffix( ch->pos_bub(), cur.pos() );
             }
             return res;
         }
@@ -352,7 +352,7 @@ class item_location::impl::item_on_person : public item_location::impl
             if( !ensure_who_unpacked() ) {
                 return tripoint::zero;
             }
-            return who->pos();
+            return who->pos_bub().raw();
         }
 
         Character *carrier() const override {
@@ -508,7 +508,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
                 debugmsg( "item in vehicle part without cargo storage" );
             }
             if( ch ) {
-                res += " " + direction_suffix( ch->pos_bub().raw(), part_pos.pos_bub().raw() );
+                res += " " + direction_suffix( ch->pos_bub(), part_pos.pos_bub() );
             }
             return res;
         }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -785,7 +785,7 @@ void item_pocket::casings_handle( const std::function<bool( item & )> &func )
 void item_pocket::handle_liquid_or_spill( Character &guy, const item *avoid )
 {
     if( guy.is_npc() ) {
-        spill_contents( guy.pos() );
+        spill_contents( guy.pos_bub() );
         return;
     }
 
@@ -887,11 +887,10 @@ std::string item_pocket::translated_sealed_prefix() const
     }
 }
 
-bool item_pocket::detonate( const tripoint &pos, std::vector<item> &drops )
+bool item_pocket::detonate( const tripoint_bub_ms &pos, std::vector<item> &drops )
 {
-    const tripoint_bub_ms p{pos}; // TODO: Remove when operation typified.
-    const auto new_end = std::remove_if( contents.begin(), contents.end(), [&p, &drops]( item & it ) {
-        return it.detonate( p, drops );
+    const auto new_end = std::remove_if( contents.begin(), contents.end(), [&pos, &drops]( item & it ) {
+        return it.detonate( pos, drops );
     } );
     if( new_end != contents.end() ) {
         contents.erase( new_end, contents.end() );
@@ -1780,7 +1779,7 @@ static void move_to_parent_pocket_recursive( const tripoint &pos, item &it,
     here.add_item_or_charges( pos, it );
 }
 
-void item_pocket::overflow( const tripoint &pos, const item_location &loc )
+void item_pocket::overflow( const tripoint_bub_ms &pos, const item_location &loc )
 {
     if( is_type( pocket_type::MOD ) || is_type( pocket_type::CORPSE ) ||
         is_type( pocket_type::EBOOK ) || is_type( pocket_type::CABLE ) ) {
@@ -1797,7 +1796,7 @@ void item_pocket::overflow( const tripoint &pos, const item_location &loc )
             item_location content_loc( loc, &it );
             content_loc.overflow();
         } else {
-            it.overflow( tripoint_bub_ms( pos ) );
+            it.overflow( pos );
         }
     }
 
@@ -1812,7 +1811,7 @@ void item_pocket::overflow( const tripoint &pos, const item_location &loc )
             if( !is_type( pocket_type::MIGRATION ) && can_contain( *iter, true ).success() ) {
                 ++iter;
             } else {
-                move_to_parent_pocket_recursive( pos, *iter, loc, carrier );
+                move_to_parent_pocket_recursive( pos.raw(), *iter, loc, carrier );
                 iter = contents.erase( iter );
             }
             continue;
@@ -1827,7 +1826,7 @@ void item_pocket::overflow( const tripoint &pos, const item_location &loc )
         if( cont_copy_type.first->second ) {
             ++iter;
         } else {
-            move_to_parent_pocket_recursive( pos, *iter, loc, carrier );
+            move_to_parent_pocket_recursive( pos.raw(), *iter, loc, carrier );
             iter = contents.erase( iter );
         }
     }
@@ -1854,7 +1853,7 @@ void item_pocket::overflow( const tripoint &pos, const item_location &loc )
             if( overflow_count > 0 ) {
                 ammo.charges -= overflow_count;
                 item dropped_ammo( ammo.typeId(), ammo.birthday(), overflow_count );
-                move_to_parent_pocket_recursive( pos, *iter, loc, carrier );
+                move_to_parent_pocket_recursive( pos.raw(), *iter, loc, carrier );
                 total_qty -= overflow_count;
             }
             if( ammo.count() == 0 ) {
@@ -1873,7 +1872,7 @@ void item_pocket::overflow( const tripoint &pos, const item_location &loc )
             return left.volume() > right.volume();
         } );
         while( remaining_volume() < 0_ml && !contents.empty() ) {
-            move_to_parent_pocket_recursive( pos, contents.front(), loc, carrier );
+            move_to_parent_pocket_recursive( pos.raw(), contents.front(), loc, carrier );
             contents.pop_front();
         }
     }
@@ -1882,7 +1881,7 @@ void item_pocket::overflow( const tripoint &pos, const item_location &loc )
             return left.weight() > right.weight();
         } );
         while( remaining_weight() < 0_gram && !contents.empty() ) {
-            move_to_parent_pocket_recursive( pos, contents.front(), loc, carrier );
+            move_to_parent_pocket_recursive( pos.raw(), contents.front(), loc, carrier );
             contents.pop_front();
         }
     }
@@ -1904,7 +1903,7 @@ void item_pocket::on_contents_changed()
     restack();
 }
 
-bool item_pocket::spill_contents( const tripoint &pos )
+bool item_pocket::spill_contents( const tripoint_bub_ms &pos )
 {
     if( is_type( pocket_type::EBOOK ) || is_type( pocket_type::CORPSE ) ||
         is_type( pocket_type::CABLE ) ) {
@@ -1959,16 +1958,16 @@ void item_pocket::remove_items_if( const std::function<bool( item & )> &filter )
     on_contents_changed();
 }
 
-void item_pocket::process( map &here, Character *carrier, const tripoint &pos, float insulation,
+void item_pocket::process( map &here, Character *carrier, const tripoint_bub_ms &pos,
+                           float insulation,
                            temperature_flag flag, float spoil_multiplier_parent, bool watertight_container )
 {
-    const tripoint_bub_ms p{ pos }; // TODO: Get rid of this when operation typified.
     for( auto iter = contents.begin(); iter != contents.end(); ) {
-        if( iter->process( here, carrier, p, insulation, flag,
+        if( iter->process( here, carrier, pos, insulation, flag,
                            // spoil multipliers on pockets are not additive or multiplicative, they choose the best
                            std::min( spoil_multiplier_parent, spoil_multiplier() ),
                            watertight_container || can_contain_liquid( false ) ) ) {
-            iter->spill_contents( p );
+            iter->spill_contents( pos );
             iter = contents.erase( iter );
         } else {
             ++iter;
@@ -1976,13 +1975,12 @@ void item_pocket::process( map &here, Character *carrier, const tripoint &pos, f
     }
 }
 
-void item_pocket::leak( map &here, Character *carrier, const tripoint &pos,
+void item_pocket::leak( map &here, Character *carrier, const tripoint_bub_ms &pos,
                         item_pocket *pocke )
 {
-    const tripoint_bub_ms p{pos}; // TODO: Get rid of this once the operation gets typified.
     std::vector<item *> erases;
     for( auto iter = contents.begin(); iter != contents.end(); ) {
-        if( iter->leak( here, carrier, p, this ) ) {
+        if( iter->leak( here, carrier, pos, this ) ) {
             if( watertight() ) {
                 ++iter;
                 continue;
@@ -1997,8 +1995,8 @@ void item_pocket::leak( map &here, Character *carrier, const tripoint &pos,
                 pocke->add( *it );
             } else {
                 iter->unset_flag( flag_FROM_FROZEN_LIQUID );
-                iter->on_drop( p );
-                here.add_item_or_charges( p, *iter );
+                iter->on_drop( pos );
+                here.add_item_or_charges( pos, *iter );
                 if( carrier != nullptr ) {
                     carrier->invalidate_weight_carried_cache();
                     carrier->add_msg_if_player( _( "Liquid leaked out from the %s and dripped onto the ground!" ),

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -13,6 +13,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "coords_fwd.h"
 #include "enums.h"
 #include "flat_set.h"
 #include "pocket_type.h"
@@ -277,7 +278,7 @@ class item_pocket
         bool sealed() const;
 
         std::string translated_sealed_prefix() const;
-        bool detonate( const tripoint &p, std::vector<item> &drops );
+        bool detonate( const tripoint_bub_ms &p, std::vector<item> &drops );
 
         void remove_all_ammo( Character &guy );
         void remove_all_mods( Character &guy );
@@ -288,8 +289,8 @@ class item_pocket
         std::optional<item> remove_item( const item &it );
         std::optional<item> remove_item( const item_location &it );
         // spills any contents that can't fit into the pocket, largest items first
-        void overflow( const tripoint &pos, const item_location &loc );
-        bool spill_contents( const tripoint &pos );
+        void overflow( const tripoint_bub_ms &pos, const item_location &loc );
+        bool spill_contents( const tripoint_bub_ms &pos );
         void on_pickup( Character &guy, item *avoid = nullptr );
         void on_contents_changed();
         void handle_liquid_or_spill( Character &guy, const item *avoid = nullptr );
@@ -302,11 +303,12 @@ class item_pocket
          * Is part of the recursive call of item::process. see that function for additional comments
          * NOTE: this destroys the items that get processed
          */
-        void process( map &here, Character *carrier, const tripoint &pos, float insulation = 1,
+        void process( map &here, Character *carrier, const tripoint_bub_ms &pos, float insulation = 1,
                       temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f,
                       bool watertight_container = false );
 
-        void leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke = nullptr );
+        void leak( map &here, Character *carrier, const tripoint_bub_ms &pos,
+                   item_pocket *pocke = nullptr );
 
         pocket_type saved_type() const {
             return _saved_type;

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -182,18 +182,17 @@ const use_function *itype::get_use( const std::string &iuse_name ) const
     return iter != use_methods.end() ? &iter->second : nullptr;
 }
 
-int itype::tick( Character *p, item &it, const tripoint &pos ) const
+int itype::tick( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
-    const tripoint_bub_ms position{pos}; // TODO: Get rid of this when operation typified
     int charges_to_use = 0;
     for( const auto &method : tick_action ) {
-        charges_to_use += method.second.call( p, it, position ).value_or( 0 );
+        charges_to_use += method.second.call( p, it, pos ).value_or( 0 );
     }
 
     return charges_to_use;
 }
 
-std::optional<int> itype::invoke( Character *p, item &it, const tripoint &pos ) const
+std::optional<int> itype::invoke( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
     if( !has_use() ) {
         return 0;
@@ -205,10 +204,9 @@ std::optional<int> itype::invoke( Character *p, item &it, const tripoint &pos ) 
     }
 }
 
-std::optional<int> itype::invoke( Character *p, item &it, const tripoint &pos,
+std::optional<int> itype::invoke( Character *p, item &it, const tripoint_bub_ms &pos,
                                   const std::string &iuse_name ) const
 {
-    const tripoint_bub_ms position{ pos }; // TODO: Get rid of this when operation typified.
     const use_function *use = get_use( iuse_name );
     if( use == nullptr ) {
         debugmsg( "Tried to invoke %s on a %s, which doesn't have this use_function",
@@ -216,7 +214,7 @@ std::optional<int> itype::invoke( Character *p, item &it, const tripoint &pos,
         return 0;
     }
     if( p ) {
-        const auto ret = use->can_call( *p, it, position );
+        const auto ret = use->can_call( *p, it, pos );
 
         if( !ret.success() ) {
             p->add_msg_if_player( m_info, ret.str() );
@@ -224,7 +222,7 @@ std::optional<int> itype::invoke( Character *p, item &it, const tripoint &pos,
         }
     }
 
-    return use->call( p, it, position );
+    return use->call( p, it, pos );
 }
 
 std::string gun_type_type::name() const

--- a/src/itype.h
+++ b/src/itype.h
@@ -1582,10 +1582,10 @@ struct itype {
 
         // Here "invoke" means "actively use". "Tick" means "active item working"
         std::optional<int> invoke( Character *p, item &it,
-                                   const tripoint &pos ) const; // Picks first method or returns 0
-        std::optional<int> invoke( Character *p, item &it, const tripoint &pos,
+                                   const tripoint_bub_ms &pos ) const; // Picks first method or returns 0
+        std::optional<int> invoke( Character *p, item &it, const tripoint_bub_ms &pos,
                                    const std::string &iuse_name ) const;
-        int tick( Character *p, item &it, const tripoint &pos ) const;
+        int tick( Character *p, item &it, const tripoint_bub_ms &pos ) const;
 
         virtual ~itype() = default;
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7192,7 +7192,7 @@ static void sendRadioSignal( Character &p, const flag_id &signal )
                     sounds::sound( p.pos_bub(), 6, sounds::sound_t::alarm, _( "beep" ), true, "misc", "beep" );
                     // Invoke to transform a radio-modded explosive into its active form
                     if( itm->has_flag( flag_RADIO_INVOKE_PROC ) ) {
-                        itm->type->invoke( &p, *itm, loc.raw() );
+                        itm->type->invoke( &p, *itm, loc );
                         item_location itm_loc = item_location( map_cursor( loc ), itm );
                         here.update_lum( itm_loc, true );
                     }

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -755,7 +755,8 @@ std::vector<point_omt_ms> squares_in_direction( const point_omt_ms &p1, const po
     result.reserve( tmp.size() );
 
     for( const point_bub_ms &point : tmp ) {
-        result.emplace_back( point_omt_ms( point.raw() ) );
+        const point_omt_ms work_around = point_omt_ms( point.raw() );
+        result.emplace_back( work_around );
     }
 
     return result;

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -673,7 +673,7 @@ std::string direction_arrow( const direction dir )
     return arrow;
 }
 
-std::string direction_suffix( const tripoint &p, const tripoint &q )
+std::string direction_suffix( const tripoint_bub_ms &p, const tripoint_bub_ms &q )
 {
     int dist = square_dist( p, q );
     if( dist <= 0 ) {
@@ -687,36 +687,37 @@ std::string direction_suffix( const tripoint &p, const tripoint &q )
 // Sub-sub-cardinals are direction && abs(x) > abs(y) or vice versa.
 // Result is adjacent cardinal and sub-cardinals, plus the nearest other cardinal.
 // e.g. if the direction is NNE, also include E.
-std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &to )
+std::vector<tripoint_bub_ms> squares_closer_to( const tripoint_bub_ms &from,
+        const tripoint_bub_ms &to )
 {
-    std::vector<tripoint> adjacent_closer_squares;
+    std::vector<tripoint_bub_ms> adjacent_closer_squares;
     adjacent_closer_squares.reserve( 5 );
-    const tripoint d( -from + to );
-    const point a( std::abs( d.x ), std::abs( d.y ) );
-    if( d.z != 0 ) {
-        adjacent_closer_squares.push_back( from + tripoint( sgn( d.x ), sgn( d.y ), sgn( d.z ) ) );
+    const tripoint_rel_ms d( to - from );
+    const point a( std::abs( d.x() ), std::abs( d.y() ) );
+    if( d.z() != 0 ) {
+        adjacent_closer_squares.push_back( from + tripoint( sgn( d.x() ), sgn( d.y() ), sgn( d.z() ) ) );
     }
     if( a.x > a.y ) {
         // X dominant.
-        adjacent_closer_squares.push_back( from + point( sgn( d.x ), 0 ) );
-        adjacent_closer_squares.push_back( from + point( sgn( d.x ), 1 ) );
-        adjacent_closer_squares.push_back( from + point( sgn( d.x ), -1 ) );
-        if( d.y != 0 ) {
-            adjacent_closer_squares.push_back( from + point( 0, sgn( d.y ) ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x() ), 0 ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x() ), 1 ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x() ), -1 ) );
+        if( d.y() != 0 ) {
+            adjacent_closer_squares.push_back( from + point( 0, sgn( d.y() ) ) );
         }
     } else if( a.x < a.y ) {
         // Y dominant.
-        adjacent_closer_squares.push_back( from + point( 0, sgn( d.y ) ) );
-        adjacent_closer_squares.push_back( from + point( 1, sgn( d.y ) ) );
-        adjacent_closer_squares.push_back( from + point( -1, sgn( d.y ) ) );
-        if( d.x != 0 ) {
-            adjacent_closer_squares.push_back( from + point( sgn( d.x ), 0 ) );
+        adjacent_closer_squares.push_back( from + point( 0, sgn( d.y() ) ) );
+        adjacent_closer_squares.push_back( from + point( 1, sgn( d.y() ) ) );
+        adjacent_closer_squares.push_back( from + point( -1, sgn( d.y() ) ) );
+        if( d.x() != 0 ) {
+            adjacent_closer_squares.push_back( from + point( sgn( d.x() ), 0 ) );
         }
-    } else if( d.x != 0 ) {
+    } else if( d.x() != 0 ) {
         // Pure diagonal.
-        adjacent_closer_squares.push_back( from + point( sgn( d.x ), sgn( d.y ) ) );
-        adjacent_closer_squares.push_back( from + point( sgn( d.x ), 0 ) );
-        adjacent_closer_squares.push_back( from + point( 0, sgn( d.y ) ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x() ), sgn( d.y() ) ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x() ), 0 ) );
+        adjacent_closer_squares.push_back( from + point( 0, sgn( d.y() ) ) );
     }
 
     return adjacent_closer_squares;
@@ -724,27 +725,40 @@ std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &t
 
 // Returns a vector of the adjacent square in the direction of the target,
 // and the two squares flanking it.
-std::vector<point> squares_in_direction( const point &p1, const point &p2 )
+std::vector<point_bub_ms> squares_in_direction( const point_bub_ms &p1, const point_bub_ms &p2 )
 {
     int junk = 0;
-    point center_square = line_to( p1, p2, junk )[0];
-    std::vector<point> adjacent_squares;
+    point_bub_ms center_square = line_to( p1, p2, junk )[0];
+    std::vector<point_bub_ms> adjacent_squares;
     adjacent_squares.reserve( 3 );
     adjacent_squares.push_back( center_square );
-    if( p1.x == center_square.x ) {
+    if( p1.x() == center_square.x() ) {
         // Horizontally adjacent.
-        adjacent_squares.emplace_back( p1.x + 1, center_square.y );
-        adjacent_squares.emplace_back( p1.x - 1, center_square.y );
-    } else if( p1.y == center_square.y ) {
+        adjacent_squares.emplace_back( p1.x() + 1, center_square.y() );
+        adjacent_squares.emplace_back( p1.x() - 1, center_square.y() );
+    } else if( p1.y() == center_square.y() ) {
         // Vertically adjacent.
-        adjacent_squares.emplace_back( center_square.x, p1.y + 1 );
-        adjacent_squares.emplace_back( center_square.x, p1.y - 1 );
+        adjacent_squares.emplace_back( center_square.x(), p1.y() + 1 );
+        adjacent_squares.emplace_back( center_square.x(), p1.y() - 1 );
     } else {
         // Diagonally adjacent.
-        adjacent_squares.emplace_back( p1.x, center_square.y );
-        adjacent_squares.emplace_back( center_square.x, p1.y );
+        adjacent_squares.emplace_back( p1.x(), center_square.y() );
+        adjacent_squares.emplace_back( center_square.x(), p1.y() );
     }
     return adjacent_squares;
+}
+
+std::vector<point_omt_ms> squares_in_direction( const point_omt_ms &p1, const point_omt_ms &p2 )
+{
+    const std::vector<point_bub_ms> tmp = squares_in_direction( rebase_bub( p1 ), rebase_bub( p2 ) );
+    std::vector<point_omt_ms> result;
+    result.reserve( tmp.size() );
+
+    for( const point_bub_ms &point : tmp ) {
+        result.emplace_back( point_omt_ms( point.raw() ) );
+    }
+
+    return result;
 }
 
 rl_vec2d rl_vec3d::xy() const
@@ -975,4 +989,36 @@ units::angle coord_to_angle( const tripoint &a, const tripoint &b )
         rad += 2_pi_radians;
     }
     return rad;
+}
+
+FastDistanceApproximation trig_dist_fast( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 )
+{
+    return FastDistanceApproximation(
+               ( loc1.x() - loc2.x() ) * ( loc1.x() - loc2.x() ) +
+               ( loc1.y() - loc2.y() ) * ( loc1.y() - loc2.y() ) +
+               ( loc1.z() - loc2.z() ) * ( loc1.z() - loc2.z() ) );
+}
+
+FastDistanceApproximation square_dist_fast( const tripoint_bub_ms &loc1,
+        const tripoint_bub_ms &loc2 )
+{
+    const tripoint_rel_ms d = ( loc1 - loc2 ).abs();
+    return FastDistanceApproximation( std::max( { d.x(), d.y(), d.z() } ) );
+}
+
+FastDistanceApproximation rl_dist_fast( const point_bub_ms &a, const point_bub_ms &b )
+{
+    return rl_dist_fast( tripoint_bub_ms( a, 0 ), tripoint_bub_ms( b, 0 ) );
+}
+
+float trig_dist( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 )
+{
+    return std::sqrt( static_cast<double>( ( loc1.x() - loc2.x() ) * ( loc1.x() - loc2.x() ) ) +
+                      ( ( loc1.y() - loc2.y() ) * ( loc1.y() - loc2.y() ) ) +
+                      ( ( loc1.z() - loc2.z() ) * ( loc1.z() - loc2.z() ) ) );
+}
+
+float trig_dist( const point_bub_ms &loc1, const point_bub_ms &loc2 )
+{
+    return trig_dist( tripoint_bub_ms( loc1, 0 ), tripoint_bub_ms( loc2, 0 ) );
 }

--- a/src/line.h
+++ b/src/line.h
@@ -8,7 +8,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "coordinates.h"
+#include "coords_fwd.h"
 #include "point.h"
 #include "units.h"
 
@@ -136,7 +136,7 @@ std::string direction_name_short( direction dir );
 std::string direction_arrow( direction dir );
 
 /* Get suffix describing vector from p to q (e.g. 1NW, 2SE) or empty string if p == q */
-std::string direction_suffix( const tripoint &p, const tripoint &q );
+std::string direction_suffix( const tripoint_bub_ms &p, const tripoint_bub_ms &q );
 
 /**
  * The actual Bresenham algorithm in 2D and 3D, everything else should call these
@@ -165,10 +165,12 @@ inline float trig_dist( const tripoint &loc1, const tripoint &loc2 )
                       ( ( loc1.y - loc2.y ) * ( loc1.y - loc2.y ) ) +
                       ( ( loc1.z - loc2.z ) * ( loc1.z - loc2.z ) ) );
 }
+float trig_dist( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 );
 inline float trig_dist( const point &loc1, const point &loc2 )
 {
     return trig_dist( tripoint( loc1, 0 ), tripoint( loc2, 0 ) );
 }
+float trig_dist( const point_bub_ms &loc1, const point_bub_ms &loc2 );
 
 // Roguelike distance; maximum of dX and dY
 inline int square_dist( const tripoint &loc1, const tripoint &loc2 )
@@ -227,29 +229,19 @@ struct FastDistanceApproximation {
         }
 };
 
-inline FastDistanceApproximation trig_dist_fast( const tripoint &loc1, const tripoint &loc2 )
-{
-    return FastDistanceApproximation(
-               ( loc1.x - loc2.x ) * ( loc1.x - loc2.x ) +
-               ( loc1.y - loc2.y ) * ( loc1.y - loc2.y ) +
-               ( loc1.z - loc2.z ) * ( loc1.z - loc2.z ) );
-}
-inline FastDistanceApproximation square_dist_fast( const tripoint &loc1, const tripoint &loc2 )
-{
-    const tripoint d = ( loc1 - loc2 ).abs();
-    return FastDistanceApproximation( std::max( { d.x, d.y, d.z } ) );
-}
-inline FastDistanceApproximation rl_dist_fast( const tripoint &loc1, const tripoint &loc2 )
+FastDistanceApproximation trig_dist_fast( const tripoint_bub_ms &loc1,
+        const tripoint_bub_ms &loc2 );
+FastDistanceApproximation square_dist_fast( const tripoint_bub_ms &loc1,
+        const tripoint_bub_ms &loc2 );
+inline FastDistanceApproximation rl_dist_fast( const tripoint_bub_ms &loc1,
+        const tripoint_bub_ms &loc2 )
 {
     if( trigdist ) {
         return trig_dist_fast( loc1, loc2 );
     }
     return square_dist_fast( loc1, loc2 );
 }
-inline FastDistanceApproximation rl_dist_fast( const point &a, const point &b )
-{
-    return rl_dist_fast( tripoint( a, 0 ), tripoint( b, 0 ) );
-}
+FastDistanceApproximation rl_dist_fast( const point_bub_ms &a, const point_bub_ms &b );
 
 float rl_dist_exact( const tripoint &loc1, const tripoint &loc2 );
 // Sum of distance in both axes
@@ -269,10 +261,12 @@ float get_normalized_angle( const point &start, const point &end );
 std::vector<tripoint> continue_line( const std::vector<tripoint> &line, int distance );
 std::vector<tripoint_bub_ms> continue_line( const std::vector<tripoint_bub_ms> &line,
         int distance );
-std::vector<point> squares_in_direction( const point &p1, const point &p2 );
+std::vector<point_bub_ms> squares_in_direction( const point_bub_ms &p1, const point_bub_ms &p2 );
+std::vector<point_omt_ms> squares_in_direction( const point_omt_ms &p1, const point_omt_ms &p2 );
 // Returns a vector of squares adjacent to @from that are closer to @to than @from is.
 // Currently limited to the same z-level as @from.
-std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &to );
+std::vector<tripoint_bub_ms> squares_closer_to( const tripoint_bub_ms &from,
+        const tripoint_bub_ms &to );
 void calc_ray_end( units::angle, int range, const tripoint &p, tripoint &out );
 template<typename Point, coords::origin Origin, coords::scale Scale>
 void calc_ray_end( units::angle angle, int range,

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1707,7 +1707,7 @@ void spell_effect::emit( const spell &sp, Creature &caster, const tripoint_bub_m
 {
     const std::set<tripoint_bub_ms> area = spell_effect_area( sp, target, caster );
     for( const tripoint_bub_ms &aoe : area ) {
-        get_map().emit_field( aoe.raw(), emit_id( sp.effect_data() ) );
+        get_map().emit_field( aoe, emit_id( sp.effect_data() ) );
     }
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1596,7 +1596,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const bool 
                 z_change = psgp.z() - part_pos.z();
             }
 
-            psg->setpos( psgp.raw() );
+            psg->setpos( psgp );
             r.moved = true;
         }
     }
@@ -10471,7 +10471,7 @@ bool map::try_fall( const tripoint_bub_ms &p, Creature *c ) const
         }
 
         if( valid.empty() ) {
-            critter->setpos( c->pos() );
+            critter->setpos( c->pos_bub() );
             add_msg( m_bad, _( "You fall down under %s!" ), critter->disp_name() );
         } else {
             critter->setpos( random_entry( valid ) );

--- a/src/map.h
+++ b/src/map.h
@@ -371,12 +371,16 @@ class map
                 int );
 
         //FIXME some field processor use private methods
-        friend void field_processor_fd_fire( const tripoint &, field_entry &, field_proc_data & );
-        friend void field_processor_spread_gas( const tripoint &, field_entry &, field_proc_data & );
-        friend void field_processor_wandering_field( const tripoint &, field_entry &, field_proc_data & );
-        friend void field_processor_fd_fire_vent( const tripoint &, field_entry &, field_proc_data & );
-        friend void field_processor_fd_flame_burst( const tripoint &, field_entry &, field_proc_data & );
-        friend void field_processor_fd_incendiary( const tripoint &, field_entry &, field_proc_data & );
+        friend void field_processor_fd_fire( const tripoint_bub_ms &, field_entry &, field_proc_data & );
+        friend void field_processor_spread_gas( const tripoint_bub_ms &, field_entry &, field_proc_data & );
+        friend void field_processor_wandering_field( const tripoint_bub_ms &, field_entry &,
+                field_proc_data & );
+        friend void field_processor_fd_fire_vent( const tripoint_bub_ms &, field_entry &,
+                field_proc_data & );
+        friend void field_processor_fd_flame_burst( const tripoint_bub_ms &, field_entry &,
+                field_proc_data & );
+        friend void field_processor_fd_incendiary( const tripoint_bub_ms &, field_entry &,
+                field_proc_data & );
 
         // for testing
         friend void clear_fields( int zlevel );
@@ -474,9 +478,6 @@ class map
                                         const visibility_variables &cache ) const;
 
         // See field.cpp
-        // TODO: Get rid of untyped overload.
-        std::tuple<maptile, maptile, maptile> get_wind_blockers( const int &winddirection,
-                const tripoint &pos );
         std::tuple<maptile, maptile, maptile> get_wind_blockers( const int &winddirection,
                 const tripoint_bub_ms &pos );
 
@@ -561,22 +562,12 @@ class map
         // TODO: Get rid of untyped overload.
         maptile maptile_at_internal( const tripoint &p );
         maptile maptile_at_internal( const tripoint_bub_ms &p );
-        // TODO: Get rid of untyped overload.
-        std::pair<tripoint, maptile> maptile_has_bounds( const tripoint &p, bool bounds_checked );
         std::pair<tripoint_bub_ms, maptile> maptile_has_bounds( const tripoint_bub_ms &p,
                 bool bounds_checked );
-        // TODO: Get rid of untyped overload.
-        std::array<std::pair<tripoint, maptile>, 8> get_neighbors( const tripoint &p );
         std::array<std::pair<tripoint_bub_ms, maptile>, 8> get_neighbors( const tripoint_bub_ms &p );
-        // TODO: Get rid of untyped overload.
-        void spread_gas( field_entry &cur, const tripoint &p, int percent_spread,
-                         const time_duration &outdoor_age_speedup, scent_block &sblk,
-                         const oter_id &om_ter );
         void spread_gas( field_entry &cur, const tripoint_bub_ms &p, int percent_spread,
                          const time_duration &outdoor_age_speedup, scent_block &sblk,
                          const oter_id &om_ter );
-        // TODO: get rid of untyped overload.
-        void create_hot_air( const tripoint &p, int intensity );
         void create_hot_air( const tripoint_bub_ms &p, int intensity );
         bool gas_can_spread_to( field_entry &cur, const maptile &dst );
         void gas_spread_to( field_entry &cur, maptile &dst, const tripoint_bub_ms &p );
@@ -1716,8 +1707,6 @@ class map
         void maybe_trigger_prox_trap( const tripoint_bub_ms &pos, Creature &c, bool may_avoid ) const;
 
         // Spawns byproducts from items destroyed in fire.
-        // TODO: Get rid of untyped overload.
-        void create_burnproducts( const tripoint &p, const item &fuel, const units::mass &burned_mass );
         void create_burnproducts( const tripoint_bub_ms &p, const item &fuel,
                                   const units::mass &burned_mass );
         // See fields.cpp
@@ -1888,8 +1877,6 @@ class map
          * @param src Id of object producing the emission
          * @param mul Multiplies the chance and possibly qty (if `chance*mul > 100`) of the emission
          */
-        // TODO: Get rid of untyped overload.
-        void emit_field( const tripoint &pos, const emit_id &src, float mul = 1.0f );
         void emit_field( const tripoint_bub_ms &pos, const emit_id &src, float mul = 1.0f );
 
         // Scent propagation helpers

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -749,8 +749,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             line_furn( &m, furn_str_id::NULL_ID(), point( 10, 7 ), point( 10, 8 ) );
 
             //Spill sand from damaged sandbags
-            std::vector<point> sandbag_positions = squares_in_direction( point( 10, 7 ), point( 11, 8 ) );
-            for( point &i : sandbag_positions ) {
+            std::vector<point_omt_ms> sandbag_positions = squares_in_direction( point_omt_ms( 10, 7 ),
+                    point_omt_ms( 11, 8 ) );
+            for( point_omt_ms &i : sandbag_positions ) {
                 m.spawn_item( { i, abs_sub.z }, itype_bag_canvas, rng( 5, 13 ) );
                 m.spawn_item( { i, abs_sub.z }, itype_material_sand, rng( 3, 8 ) );
             }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -111,11 +111,6 @@ static const trait_id trait_THRESH_SPIDER( "THRESH_SPIDER" );
 
 using namespace map_field_processing;
 
-void map::create_burnproducts( const tripoint &p, const item &fuel, const units::mass &burned_mass )
-{
-    map::create_burnproducts( tripoint_bub_ms( p ), fuel, burned_mass );
-}
-
 void map::create_burnproducts( const tripoint_bub_ms &p, const item &fuel,
                                const units::mass &burned_mass )
 {
@@ -205,16 +200,6 @@ static int ter_furn_movecost( const ter_t &ter, const furn_t &furn )
 }
 
 // Wrapper to allow skipping bound checks except at the edges of the map
-std::pair<tripoint, maptile> map::maptile_has_bounds( const tripoint &p, const bool bounds_checked )
-{
-    if( bounds_checked ) {
-        // We know that the point is in bounds
-        return {p, maptile_at_internal( p )};
-    }
-
-    return {p, maptile_at( p )};
-}
-
 std::pair<tripoint_bub_ms, maptile> map::maptile_has_bounds( const tripoint_bub_ms &p,
         const bool bounds_checked )
 {
@@ -224,27 +209,6 @@ std::pair<tripoint_bub_ms, maptile> map::maptile_has_bounds( const tripoint_bub_
     }
 
     return { p, maptile_at( p ) };
-}
-
-std::array<std::pair<tripoint, maptile>, 8> map::get_neighbors( const tripoint &p )
-{
-    // Find out which edges are in the bubble
-    // Where possible, do just one bounds check for all the neighbors
-    const bool west = p.x > 0;
-    const bool north = p.y > 0;
-    const bool east = p.x < SEEX * my_MAPSIZE - 1;
-    const bool south = p.y < SEEY * my_MAPSIZE - 1;
-    return std::array< std::pair<tripoint, maptile>, 8 > { {
-            maptile_has_bounds( p + eight_horizontal_neighbors[0], west &&north ),
-            maptile_has_bounds( p + eight_horizontal_neighbors[1], north ),
-            maptile_has_bounds( p + eight_horizontal_neighbors[2], east &&north ),
-            maptile_has_bounds( p + eight_horizontal_neighbors[3], west ),
-            maptile_has_bounds( p + eight_horizontal_neighbors[4], east ),
-            maptile_has_bounds( p + eight_horizontal_neighbors[5], west &&south ),
-            maptile_has_bounds( p + eight_horizontal_neighbors[6], south ),
-            maptile_has_bounds( p + eight_horizontal_neighbors[7], east &&south ),
-        }
-    };
 }
 
 std::array<std::pair<tripoint_bub_ms, maptile>, 8> map::get_neighbors( const tripoint_bub_ms &p )
@@ -307,16 +271,9 @@ void map::gas_spread_to( field_entry &cur, maptile &dst, const tripoint_bub_ms &
     }
 }
 
-void map::spread_gas( field_entry &cur, const tripoint &p, int percent_spread,
-                      const time_duration &outdoor_age_speedup, scent_block &sblk, const oter_id &om_ter )
-{
-    map::spread_gas( cur, tripoint_bub_ms( p ), percent_spread, outdoor_age_speedup, sblk, om_ter );
-}
-
 void map::spread_gas( field_entry &cur, const tripoint_bub_ms &p, int percent_spread,
                       const time_duration &outdoor_age_speedup, scent_block &sblk, const oter_id &om_ter )
 {
-    // TODO: fix point types
     const bool sheltered = g->is_sheltered( p );
     weather_manager &weather = get_weather();
     const int winddirection = weather.winddirection;
@@ -413,11 +370,6 @@ void map::spread_gas( field_entry &cur, const tripoint_bub_ms &p, int percent_sp
 /*
 Helper function that encapsulates the logic involved in creating hot air.
 */
-void map::create_hot_air( const tripoint &p, int intensity )
-{
-    map::create_hot_air( tripoint_bub_ms( p ), intensity );
-}
-
 void map::create_hot_air( const tripoint_bub_ms &p, int intensity )
 {
     field_type_id hot_air;
@@ -471,7 +423,7 @@ void map::process_fields_in_submap( submap *const current_submap,
     const oter_id &om_ter = overmap_buffer.ter( coords::project_to<coords::omt>(
                                 abs_sub + rebase_rel( submap ) ) );
     Character &player_character = get_player_character();
-    scent_block sblk( submap.raw(), get_scent() );
+    scent_block sblk( submap, get_scent() );
 
     // Initialize the map tile wrapper
     maptile map_tile( current_submap, point_sm_ms::zero );
@@ -532,7 +484,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                 }
 
                 for( const FieldProcessorPtr &proc : pd.cur_fd_type->get_processors() ) {
-                    proc( p.raw(), cur, pd );
+                    proc( p, cur, pd );
                 }
 
                 cur.do_decay();
@@ -546,7 +498,7 @@ void map::process_fields_in_submap( submap *const current_submap,
     sblk.commit_modifications();
 }
 
-static void field_processor_upgrade_intensity( const tripoint &, field_entry &cur,
+static void field_processor_upgrade_intensity( const tripoint_bub_ms &, field_entry &cur,
         field_proc_data & )
 {
     // Upgrade field intensity
@@ -559,7 +511,7 @@ static void field_processor_upgrade_intensity( const tripoint &, field_entry &cu
     }
 }
 
-static void field_processor_underwater_dissipation( const tripoint &, field_entry &cur,
+static void field_processor_underwater_dissipation( const tripoint_bub_ms &, field_entry &cur,
         field_proc_data &pd )
 {
     // Dissipate faster in water
@@ -568,16 +520,17 @@ static void field_processor_underwater_dissipation( const tripoint &, field_entr
     }
 }
 
-static void field_processor_fd_acid( const tripoint &p, field_entry &cur, field_proc_data &pd )
+static void field_processor_fd_acid( const tripoint_bub_ms &p, field_entry &cur,
+                                     field_proc_data &pd )
 {
     //cur_fd_type_id == fd_acid
-    if( p.z <= -OVERMAP_DEPTH ) {
+    if( p.z() <= -OVERMAP_DEPTH ) {
         return;
     }
 
     // Try to fall by a z-level
-    tripoint_bub_ms dst{ p.x, p.y, p.z - 1 };
-    if( pd.here.valid_move( p, dst.raw(), true, true ) ) {
+    tripoint_bub_ms dst = p + tripoint::below;
+    if( pd.here.valid_move( p, dst, true, true ) ) {
         field_entry *acid_there = pd.here.get_field( dst, fd_acid );
         if( !acid_there ) {
             pd.here.add_field( dst, fd_acid, cur.get_field_intensity(), cur.get_field_age() );
@@ -601,7 +554,7 @@ static void field_processor_fd_acid( const tripoint &p, field_entry &cur, field_
     // TODO: Allow spreading to the sides if age < 0 && intensity == 3
 }
 
-static void field_processor_fd_extinguisher( const tripoint &p, field_entry &cur,
+static void field_processor_fd_extinguisher( const tripoint_bub_ms &p, field_entry &cur,
         field_proc_data &pd )
 {
     //  if( cur_fd_type_id == fd_extinguisher )
@@ -613,48 +566,50 @@ static void field_processor_fd_extinguisher( const tripoint &p, field_entry &cur
     }
 }
 
-static void field_processor_apply_slime( const tripoint &p, field_entry &cur, field_proc_data &pd )
+static void field_processor_apply_slime( const tripoint_bub_ms &p, field_entry &cur,
+        field_proc_data &pd )
 {
     // if( cur_fd_type.apply_slime_factor > 0 )
     pd.sblk.apply_slime( p, cur.get_field_intensity() * pd.cur_fd_type->apply_slime_factor );
 }
 
 // Spread gaseous fields
-void field_processor_spread_gas( const tripoint &p, field_entry &cur, field_proc_data &pd )
+void field_processor_spread_gas( const tripoint_bub_ms &p, field_entry &cur, field_proc_data &pd )
 {
     // if( cur.gas_can_spread() )
     pd.here.spread_gas( cur, p, pd.cur_fd_type->percent_spread, pd.cur_fd_type->outdoor_age_speedup,
                         pd.sblk, pd.om_ter );
 }
 
-static void field_processor_fd_fungal_haze( const tripoint &p, field_entry &cur,
+static void field_processor_fd_fungal_haze( const tripoint_bub_ms &p, field_entry &cur,
         field_proc_data &/*pd*/ )
 {
     // if( cur_fd_type_id == fd_fungal_haze ) {
     if( one_in( 10 - 2 * cur.get_field_intensity() ) ) {
         // Haze'd terrain
-        fungal_effects().spread_fungus( tripoint_bub_ms( p ) );
+        fungal_effects().spread_fungus( p );
     }
 }
 
 // Process npc complaints moved to player_in_field
 
-static void field_processor_extra_radiation( const tripoint &p, field_entry &cur,
+static void field_processor_extra_radiation( const tripoint_bub_ms &p, field_entry &cur,
         field_proc_data &pd )
 {
     // Apply radiation
     const field_intensity_level &ilevel = cur.get_intensity_level();
     if( ilevel.extra_radiation_max > 0 ) {
         int extra_radiation = rng( ilevel.extra_radiation_min, ilevel.extra_radiation_max );
-        pd.here.adjust_radiation( tripoint_bub_ms( p ), extra_radiation );
+        pd.here.adjust_radiation( p, extra_radiation );
     }
 }
 
-void field_processor_wandering_field( const tripoint &p, field_entry &cur, field_proc_data &pd )
+void field_processor_wandering_field( const tripoint_bub_ms &p, field_entry &cur,
+                                      field_proc_data &pd )
 {
     // Apply wandering fields from vents
     const field_type_id wandering_field_type_id = pd.cur_fd_type->wandering_field;
-    for( const tripoint_bub_ms &pnt : points_in_radius( tripoint_bub_ms( p ),
+    for( const tripoint_bub_ms &pnt : points_in_radius( p,
             cur.get_field_intensity() - 1 ) ) {
         field &wandering_field = pd.here.get_field( pnt );
         field_entry *tmpfld = wandering_field.find_field( wandering_field_type_id );
@@ -666,7 +621,7 @@ void field_processor_wandering_field( const tripoint &p, field_entry &cur, field
     }
 }
 
-void field_processor_fd_fire_vent( const tripoint &p, field_entry &cur, field_proc_data &pd )
+void field_processor_fd_fire_vent( const tripoint_bub_ms &p, field_entry &cur, field_proc_data &pd )
 {
     if( cur.get_field_intensity() > 1 ) {
         if( one_in( 3 ) ) {
@@ -680,7 +635,8 @@ void field_processor_fd_fire_vent( const tripoint &p, field_entry &cur, field_pr
 }
 
 //TODO extract common logic from this and field_processor_fd_fire_vent
-void field_processor_fd_flame_burst( const tripoint &p, field_entry &cur, field_proc_data &pd )
+void field_processor_fd_flame_burst( const tripoint_bub_ms &p, field_entry &cur,
+                                     field_proc_data &pd )
 {
     if( cur.get_field_intensity() > 1 ) {
         cur.set_field_intensity( cur.get_field_intensity() - 1 );
@@ -691,7 +647,7 @@ void field_processor_fd_flame_burst( const tripoint &p, field_entry &cur, field_
     }
 }
 
-static void field_processor_fd_electricity( const tripoint &p, field_entry &cur,
+static void field_processor_fd_electricity( const tripoint_bub_ms &p, field_entry &cur,
         field_proc_data &pd )
 {
     // Higher chance of spreading for intense fields
@@ -702,12 +658,12 @@ static void field_processor_fd_electricity( const tripoint &p, field_entry &cur,
 
     const int spread_intensity_cap = 3 + std::max( ( current_intensity - 3 ) / 2, 0 );
 
-    std::vector<tripoint> grounded_tiles;
-    std::vector<tripoint> tiles_with_creatures;
-    std::vector<tripoint> other_tiles;
+    std::vector<tripoint_bub_ms> grounded_tiles;
+    std::vector<tripoint_bub_ms> tiles_with_creatures;
+    std::vector<tripoint_bub_ms> other_tiles;
 
     bool valid_candidates = false;
-    for( const tripoint_bub_ms &dst : points_in_radius( tripoint_bub_ms( p ), 1 ) ) {
+    for( const tripoint_bub_ms &dst : points_in_radius( p, 1 ) ) {
         if( !pd.here.inbounds( dst ) ) {
             continue;
         }
@@ -720,12 +676,12 @@ static void field_processor_fd_electricity( const tripoint &p, field_entry &cur,
         }
 
         if( pd.here.impassable( dst ) ) {
-            grounded_tiles.push_back( dst.raw() );
+            grounded_tiles.push_back( dst );
         } else {
             if( get_creature_tracker().creature_at( dst ) ) {
-                tiles_with_creatures.push_back( dst.raw() );
+                tiles_with_creatures.push_back( dst );
             } else {
-                other_tiles.push_back( dst.raw() );
+                other_tiles.push_back( dst );
             }
         }
         valid_candidates = true;
@@ -740,7 +696,7 @@ static void field_processor_fd_electricity( const tripoint &p, field_entry &cur,
     int creature_weight = here_impassable ? 5 : 6;
     int other_weight = here_impassable ? 0 : 1;
 
-    std::vector<tripoint> *target_vector = nullptr;
+    std::vector<tripoint_bub_ms> *target_vector = nullptr;
     while( current_intensity > 0 ) {
 
         if( here_impassable && one_in( 3 ) ) {
@@ -777,7 +733,7 @@ static void field_processor_fd_electricity( const tripoint &p, field_entry &cur,
 
         int vector_index = rng( 0, target_vector->size() - 1 );
         auto target_it = target_vector->begin() + vector_index;
-        tripoint_bub_ms target_point = tripoint_bub_ms( *target_it );
+        tripoint_bub_ms target_point = *target_it;
 
         const field_type_str_id &field_type = pd.here.get_applicable_electricity_field(
                 target_point );
@@ -802,7 +758,7 @@ static void field_processor_fd_electricity( const tripoint &p, field_entry &cur,
     }
 }
 
-static void field_processor_monster_spawn( const tripoint &p, field_entry &cur,
+static void field_processor_monster_spawn( const tripoint_bub_ms &p, field_entry &cur,
         field_proc_data &pd )
 {
     const field_intensity_level &int_level = cur.get_intensity_level();
@@ -816,12 +772,12 @@ static void field_processor_monster_spawn( const tripoint &p, field_entry &cur,
                 if( !mgr.name ) {
                     continue;
                 }
-                if( const std::optional<tripoint> spawn_point =
+                if( const std::optional<tripoint_bub_ms> spawn_point =
                         random_point( points_in_radius( p, int_level.monster_spawn_radius ),
-                [&pd]( const tripoint & n ) {
+                [&pd]( const tripoint_bub_ms & n ) {
                 return pd.here.passable( n );
                 } ) ) {
-                    const tripoint_bub_ms pt = tripoint_bub_ms( spawn_point.value() );
+                    const tripoint_bub_ms pt = spawn_point.value();
                     pd.here.add_spawn( mgr, pt );
                 }
             }
@@ -829,7 +785,8 @@ static void field_processor_monster_spawn( const tripoint &p, field_entry &cur,
     }
 }
 
-static void field_processor_fd_push_items( const tripoint &p, field_entry &, field_proc_data &pd )
+static void field_processor_fd_push_items( const tripoint_bub_ms &p, field_entry &,
+        field_proc_data &pd )
 {
     map_stack items = pd.here.i_at( p );
     creature_tracker &creatures = get_creature_tracker();
@@ -839,8 +796,8 @@ static void field_processor_fd_push_items( const tripoint &p, field_entry &, fie
             pushee++;
         } else {
             std::vector<tripoint_bub_ms> valid;
-            for( const tripoint_bub_ms &dst : points_in_radius( tripoint_bub_ms( p ), 1 ) ) {
-                if( dst.raw() != p && pd.here.get_field( dst, fd_push_items ) ) {
+            for( const tripoint_bub_ms &dst : points_in_radius( p, 1 ) ) {
+                if( dst != p && pd.here.get_field( dst, fd_push_items ) ) {
                     valid.push_back( dst );
                 }
             }
@@ -876,7 +833,7 @@ static void field_processor_fd_push_items( const tripoint &p, field_entry &, fie
     }
 }
 
-static void field_processor_fd_shock_vent( const tripoint &p, field_entry &cur,
+static void field_processor_fd_shock_vent( const tripoint_bub_ms &p, field_entry &cur,
         field_proc_data &pd )
 {
     if( cur.get_field_intensity() > 1 ) {
@@ -887,27 +844,27 @@ static void field_processor_fd_shock_vent( const tripoint &p, field_entry &cur,
         cur.set_field_intensity( 3 );
         int num_bolts = rng( 3, 6 );
         for( int i = 0; i < num_bolts; i++ ) {
-            point dir;
-            while( dir == point::zero ) {
+            point_rel_ms dir;
+            while( dir == point_rel_ms::zero ) {
                 dir = { rng( -1, 1 ), rng( -1, 1 ) };
             }
             int dist = rng( 4, 12 );
-            point bolt = p.xy();
+            point_bub_ms bolt = p.xy();
             for( int n = 0; n < dist; n++ ) {
                 bolt += dir;
-                pd.here.add_field( tripoint_bub_ms( bolt.x, bolt.y, p.z ), fd_electricity, rng( 2, 3 ) );
+                pd.here.add_field( tripoint_bub_ms( bolt, p.z() ), fd_electricity, rng( 2, 3 ) );
                 if( one_in( 4 ) ) {
-                    if( dir.x == 0 ) {
-                        dir.x = rng( 0, 1 ) * 2 - 1;
+                    if( dir.x() == 0 ) {
+                        dir.x() = rng( 0, 1 ) * 2 - 1;
                     } else {
-                        dir.x = 0;
+                        dir.x() = 0;
                     }
                 }
                 if( one_in( 4 ) ) {
-                    if( dir.y == 0 ) {
-                        dir.y = rng( 0, 1 ) * 2 - 1;
+                    if( dir.y() == 0 ) {
+                        dir.y() = rng( 0, 1 ) * 2 - 1;
                     } else {
-                        dir.y = 0;
+                        dir.y() = 0;
                     }
                 }
             }
@@ -915,7 +872,8 @@ static void field_processor_fd_shock_vent( const tripoint &p, field_entry &cur,
     }
 }
 
-static void field_processor_fd_acid_vent( const tripoint &p, field_entry &cur, field_proc_data &pd )
+static void field_processor_fd_acid_vent( const tripoint_bub_ms &p, field_entry &cur,
+        field_proc_data &pd )
 {
     if( cur.get_field_intensity() > 1 ) {
         if( cur.get_field_age() >= 1_minutes ) {
@@ -924,10 +882,10 @@ static void field_processor_fd_acid_vent( const tripoint &p, field_entry &cur, f
         }
     } else {
         cur.set_field_intensity( 3 );
-        for( const tripoint_bub_ms &t : points_in_radius( tripoint_bub_ms( p ), 5 ) ) {
+        for( const tripoint_bub_ms &t : points_in_radius( p, 5 ) ) {
             const field_entry *acid = pd.here.get_field( t, fd_acid );
             if( acid && acid->get_field_intensity() == 0 ) {
-                int new_intensity = 3 - rl_dist( p, t.raw() ) / 2 + ( one_in( 3 ) ? 1 : 0 );
+                int new_intensity = 3 - rl_dist( p, t ) / 2 + ( one_in( 3 ) ? 1 : 0 );
                 if( new_intensity > 3 ) {
                     new_intensity = 3;
                 }
@@ -939,10 +897,11 @@ static void field_processor_fd_acid_vent( const tripoint &p, field_entry &cur, f
     }
 }
 
-void field_processor_fd_incendiary( const tripoint &p, field_entry &cur, field_proc_data &pd )
+void field_processor_fd_incendiary( const tripoint_bub_ms &p, field_entry &cur,
+                                    field_proc_data &pd )
 {
     // Needed for variable scope
-    tripoint_bub_ms dst( tripoint_bub_ms( p ) + point( rng( -1, 1 ), rng( -1, 1 ) ) );
+    tripoint_bub_ms dst( p + point( rng( -1, 1 ), rng( -1, 1 ) ) );
 
     if( pd.here.has_flag( ter_furn_flag::TFLAG_FLAMMABLE, dst ) ||
         pd.here.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH, dst ) ||
@@ -958,14 +917,15 @@ void field_processor_fd_incendiary( const tripoint &p, field_entry &cur, field_p
     pd.here.create_hot_air( p, cur.get_field_intensity() );
 }
 
-static void field_processor_make_rubble( const tripoint &p, field_entry &, field_proc_data &pd )
+static void field_processor_make_rubble( const tripoint_bub_ms &p, field_entry &,
+        field_proc_data &pd )
 {
     // if( cur_fd_type.legacy_make_rubble )
     // Legacy Stuff
     pd.here.make_rubble( p );
 }
 
-static void field_processor_fd_fungicidal_gas( const tripoint &p, field_entry &cur,
+static void field_processor_fd_fungicidal_gas( const tripoint_bub_ms &p, field_entry &cur,
         field_proc_data &pd )
 {
     // Check the terrain and replace it accordingly to simulate the fungus dieing off
@@ -980,9 +940,8 @@ static void field_processor_fd_fungicidal_gas( const tripoint &p, field_entry &c
     }
 }
 
-void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_data &pd )
+void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_proc_data &pd )
 {
-    const tripoint_bub_ms pos{ p }; // TODO: Remove when operation typified
     const field_type_id fd_fire = ::fd_fire;
     map &here = pd.here;
     maptile &map_tile = pd.map_tile;
@@ -990,10 +949,10 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
 
     cur.set_field_age( std::max( -24_hours, cur.get_field_age() ) );
     // Entire objects for ter/frn for flags
-    bool sheltered = g->is_sheltered( pos );
+    bool sheltered = g->is_sheltered( p );
     weather_manager &weather = get_weather();
     int winddirection = weather.winddirection;
-    int windpower = get_local_windpower( weather.windspeed, om_ter, get_map().getglobal( pos ),
+    int windpower = get_local_windpower( weather.windspeed, om_ter, get_map().getglobal( p ),
                                          winddirection,
                                          sheltered );
     const ter_t &ter = map_tile.get_ter_t();
@@ -1016,14 +975,14 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
     // The huge indent below should probably be somehow moved away from here
     // without forcing the function to use i_at( p ) for fires without items
     if( !is_sealed && map_tile.get_item_count() > 0 ) {
-        map_stack items_here = here.i_at( pos );
+        map_stack items_here = here.i_at( p );
         std::vector<item> new_content;
         for( auto it = items_here.begin(); it != items_here.end(); ) {
             if( it->will_explode_in_fire() ) {
                 // We need to make a copy because the iterator validity is not predictable
                 item copy = *it;
                 it = items_here.erase( it );
-                if( copy.detonate( pos, new_content ) ) {
+                if( copy.detonate( p, new_content ) ) {
                     // Need to restart, iterators may not be valid
                     it = items_here.begin();
                 }
@@ -1047,7 +1006,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             // which we can not use, so only call `weight` when it's still an existing item.
             const units::mass new_weight = destroyed ? 0_gram : fuel->weight( false );
             if( old_weight != new_weight ) {
-                here.create_burnproducts( pos, *fuel, old_weight - new_weight );
+                here.create_burnproducts( p, *fuel, old_weight - new_weight );
             }
 
             if( destroyed ) {
@@ -1068,14 +1027,14 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             }
         }
 
-        here.spawn_items( pos, new_content );
+        here.spawn_items( p, new_content );
         smoke = roll_remainder( frd.smoke_produced );
         time_added = 1_turns * roll_remainder( frd.fuel_produced );
     }
 
     int part;
     // Get the part of the vehicle in the fire (_internal skips the boundary check)
-    vehicle *veh = here.veh_at_internal( pos, part );
+    vehicle *veh = here.veh_at_internal( p, part );
     if( veh != nullptr ) {
         veh->damage( here, part, cur.get_field_intensity() * 10, damage_heat, true );
         // Damage the vehicle in the fire.
@@ -1094,7 +1053,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
-                here.bash( pos, 999, false, true, true );
+                here.bash( p, 999, false, true, true );
             }
 
         } else if( ter_furn_has_flag( ter, frn, ter_furn_flag::TFLAG_FLAMMABLE_HARD ) &&
@@ -1105,7 +1064,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
-                here.bash( pos, 999, false, true, true );
+                here.bash( p, 999, false, true, true );
             }
 
         } else if( ter.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {
@@ -1115,8 +1074,8 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
-                here.bash( pos, 999, false, true, true );
-                here.spawn_item( pos, "ash", 1, rng( 10, 1000 ) );
+                here.bash( p, 999, false, true, true );
+                here.spawn_item( p, "ash", 1, rng( 10, 1000 ) );
             }
 
         } else if( frn.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {
@@ -1126,14 +1085,14 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
-                here.furn_set( pos, furn_f_ash );
-                here.add_item_or_charges( pos, item( "ash" ) );
+                here.furn_set( p, furn_f_ash );
+                here.add_item_or_charges( p, item( "ash" ) );
             }
 
-        } else if( ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) && pos.z() > -OVERMAP_DEPTH ) {
+        } else if( ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) && p.z() > -OVERMAP_DEPTH ) {
             // We're hanging in the air - let's fall down
-            tripoint_bub_ms dst{ pos.x(), pos.y(), pos.z() - 1};
-            if( here.valid_move( pos, dst, true, true ) ) {
+            tripoint_bub_ms dst = p + tripoint::below;
+            if( here.valid_move( p, dst, true, true ) ) {
                 maptile dst_tile = here.maptile_at_internal( dst );
                 field_entry *fire_there = dst_tile.find_field( fd_fire );
                 if( !fire_there ) {
@@ -1172,9 +1131,9 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
 
     // Below we will access our nearest 8 neighbors, so let's cache them now
     // This should probably be done more globally, because large fires will re-do it a lot
-    auto neighs = here.get_neighbors( pos );
+    auto neighs = here.get_neighbors( p );
     // Get the neighbours that are allowed due to wind direction
-    auto maptiles = here.get_wind_blockers( winddirection, pos );
+    auto maptiles = here.get_wind_blockers( winddirection, p );
     maptile remove_tile = std::get<0>( maptiles );
     maptile remove_tile2 = std::get<1>( maptiles );
     maptile remove_tile3 = std::get<2>( maptiles );
@@ -1299,8 +1258,8 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
     // Allow raging fires (and only raging fires) to spread up
     // Spreading down is achieved by wrecking the walls/floor and then falling
     if( ( cur.get_field_intensity() == 3 ||
-          here.ter( pos ).obj().has_flag( ter_furn_flag::TFLAG_TREE ) ) && p.z < OVERMAP_HEIGHT ) {
-        const tripoint_bub_ms dst_p = pos + tripoint::above;
+          here.ter( p ).obj().has_flag( ter_furn_flag::TFLAG_TREE ) ) && p.z() < OVERMAP_HEIGHT ) {
+        const tripoint_bub_ms dst_p = p + tripoint::above;
         // Let it burn through the floor
         maptile dst = here.maptile_at_internal( dst_p );
         const ter_t &dst_ter = dst.get_ter_t();
@@ -1422,7 +1381,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
                                       one_in( 5 ) ) ) ||
                     nearwebfld ||
                     ( one_in( 5 ) && dst.get_item_count() > 0 &&
-                      here.flammable_items_at( pos + eight_horizontal_neighbors[i] ) )
+                      here.flammable_items_at( p + eight_horizontal_neighbors[i] ) )
                 ) ) {
                 // Nearby open flammable ground? Set it on fire.
                 // Make the new fire quite weak, so that it doesn't start jumping around instantly
@@ -1440,9 +1399,9 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
     if( !ter_furn_has_flag( ter, frn, ter_furn_flag::TFLAG_SUPPRESS_SMOKE ) &&
         rng( 0, 100 - windpower ) <= smoke &&
         rng( 3, 35 ) < cur.get_field_intensity() * 10 ) {
-        bool smoke_up = pos.z() < OVERMAP_HEIGHT;
+        bool smoke_up = p.z() < OVERMAP_HEIGHT;
         if( smoke_up ) {
-            tripoint_bub_ms up{pos + tripoint::above};
+            tripoint_bub_ms up{p + tripoint::above};
             if( here.has_flag_ter( ter_furn_flag::TFLAG_NO_FLOOR, up ) ) {
                 here.add_field( up, fd_smoke, rng( 1, cur.get_field_intensity() ), 0_turns, false );
             } else {
@@ -1453,7 +1412,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
 
         if( !smoke_up ) {
             // Create thicker smoke
-            here.add_field( pos, fd_smoke, cur.get_field_intensity(), 0_turns, false );
+            here.add_field( p, fd_smoke, cur.get_field_intensity(), 0_turns, false );
         }
     }
 
@@ -1461,11 +1420,11 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
     // Don't produce too much of it if we have a lot fires nearby, they produce
     // radiant heat which does what hot air would do anyway
     if( adjacent_fires < 5 && rng( 0, 4 - adjacent_fires ) ) {
-        here.create_hot_air( pos, cur.get_field_intensity() );
+        here.create_hot_air( p, cur.get_field_intensity() );
     }
 }
 
-static void field_processor_fd_last_known( const tripoint &p, field_entry &cur,
+static void field_processor_fd_last_known( const tripoint_bub_ms &p, field_entry &cur,
         field_proc_data &pd )
 {
     ( void )pd;
@@ -2118,12 +2077,6 @@ void map::monster_in_field( monster &z )
 }
 
 std::tuple<maptile, maptile, maptile> map::get_wind_blockers( const int &winddirection,
-        const tripoint &pos )
-{
-    return map::get_wind_blockers( winddirection, tripoint_bub_ms( pos ) );
-}
-
-std::tuple<maptile, maptile, maptile> map::get_wind_blockers( const int &winddirection,
         const tripoint_bub_ms &pos )
 {
     static const std::array<std::pair<int, std::tuple< point_rel_ms, point_rel_ms, point_rel_ms >>, 9>
@@ -2156,11 +2109,6 @@ std::tuple<maptile, maptile, maptile> map::get_wind_blockers( const int &winddir
     const maptile remove_tile2 = maptile_at( removepoint2 );
     const maptile remove_tile3 = maptile_at( removepoint3 );
     return std::make_tuple( remove_tile, remove_tile2, remove_tile3 );
-}
-
-void map::emit_field( const tripoint &pos, const emit_id &src, float mul )
-{
-    map::emit_field( tripoint_bub_ms( pos ), src, mul );
 }
 
 void map::emit_field( const tripoint_bub_ms &pos, const emit_id &src, float mul )

--- a/src/map_field.h
+++ b/src/map_field.h
@@ -2,6 +2,8 @@
 #ifndef CATA_SRC_MAP_FIELD_H
 #define CATA_SRC_MAP_FIELD_H
 
+#include "coords_fwd.h"
+
 struct tripoint;
 class field_entry;
 struct field_type;
@@ -14,7 +16,8 @@ namespace map_field_processing
  * Pointer to the "field processor" - a function that will be called each alive field entry of a matching field type
  * during field processing.
  */
-using FieldProcessorPtr = void( * )( const tripoint &p, field_entry &cur, field_proc_data &pd );
+using FieldProcessorPtr = void( * )( const tripoint_bub_ms &p, field_entry &cur,
+                                     field_proc_data &pd );
 
 /**
  * Returns list of "field processors" for a given field type

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -911,7 +911,7 @@ bool melee_actor::call( monster &z ) const
                         float path_distance = rng_float( 0, 1.0 );
                         tripoint_rel_ms vector = target->pos_bub() - z.pos_bub();
                         vector = { vector.x() *path_distance, vector.y() *path_distance, vector.z() *path_distance };
-                        pd[index]->spill_contents( z.pos() + vector.raw() );
+                        pd[index]->spill_contents( z.pos_bub() + vector );
                         add_msg( m_bad, _( "As you hit the ground something comes loose and is knocked away from you!" ) );
                         popup( _( "As you hit the ground something comes loose and is knocked away from you!" ) );
                     }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -299,7 +299,7 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
     // Preserve item temporarily for component breakdown
     item temp = *shield;
 
-    shield->get_contents().spill_contents( pos() );
+    shield->get_contents().spill_contents( pos_bub() );
 
     shield.remove_item();
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1101,7 +1101,7 @@ bool mattack::resurrect( monster *z )
         if( iter != sees_and_is_empty_cache.end() ) {
             return iter->second;
         }
-        sees_and_is_empty_cache[T] = here.sees( z->pos(), T, -1 ) && g->is_empty( T );
+        sees_and_is_empty_cache[T] = here.sees( z->pos_bub().raw(), T, -1 ) && g->is_empty( T );
         return sees_and_is_empty_cache[T];
     };
     for( item_location &location : here.get_active_items_in_radius( z->pos_bub(), range,
@@ -1286,14 +1286,14 @@ bool mattack::smash( monster *z )
  *                      second = the number of empty spaces found.
  */
 template <size_t N = 1>
-std::pair < std::array < tripoint, ( 2 * N + 1 ) * ( 2 * N + 1 ) >, size_t >
-find_empty_neighbors( const tripoint &origin )
+std::pair < std::array < tripoint_bub_ms, ( 2 * N + 1 ) * ( 2 * N + 1 ) >, size_t >
+find_empty_neighbors( const tripoint_bub_ms &origin )
 {
     constexpr int r = static_cast<int>( N );
 
-    std::pair < std::array < tripoint, ( 2 * N + 1 )*( 2 * N + 1 ) >, size_t > result;
+    std::pair < std::array < tripoint_bub_ms, ( 2 * N + 1 )*( 2 * N + 1 ) >, size_t > result;
 
-    for( const tripoint &tmp : get_map().points_in_radius( origin, r ) ) {
+    for( const tripoint_bub_ms &tmp : get_map().points_in_radius( origin, r ) ) {
         if( g->is_empty( tmp ) ) {
             result.first[result.second++] = tmp;
         }
@@ -1309,10 +1309,10 @@ find_empty_neighbors( const tripoint &origin )
  * @see find_empty_neighbors
  */
 template <size_t N = 1>
-std::pair < std::array < tripoint, ( 2 * N + 1 ) * ( 2 * N + 1 ) >, size_t >
+std::pair < std::array < tripoint_bub_ms, ( 2 * N + 1 ) * ( 2 * N + 1 ) >, size_t >
 find_empty_neighbors( const Creature &c )
 {
-    return find_empty_neighbors<N>( c.pos() );
+    return find_empty_neighbors<N>( c.pos_bub() );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -300,7 +300,7 @@ bool monster::can_move_to( const tripoint_bub_ms &p ) const
 
 float monster::rate_target( Creature &c, float best, bool smart ) const
 {
-    const FastDistanceApproximation d = rl_dist_fast( pos(), c.pos() );
+    const FastDistanceApproximation d = rl_dist_fast( pos_bub(), c.pos_bub() );
     if( d <= 0 ) {
         return FLT_MAX;
     }
@@ -769,8 +769,8 @@ void monster::plan()
  * Since it incorporates the current distance metric,
  * it also scales for diagonal vs orthogonal movement.
  **/
-static float get_stagger_adjust( const tripoint &source, const tripoint &destination,
-                                 const tripoint &next_step )
+static float get_stagger_adjust( const tripoint_bub_ms &source, const tripoint_bub_ms &destination,
+                                 const tripoint_bub_ms &next_step )
 {
     // TODO: push this down into rl_dist
     const float initial_dist =
@@ -1108,7 +1108,7 @@ void monster::move()
         // This is a float and using trig_dist() because that Does the Right Thing(tm)
         // in both circular and roguelike distance modes.
         const float distance_to_target = trig_dist( pos_bub(), destination );
-        for( tripoint &candidate : squares_closer_to( pos_bub().raw(), destination.raw() ) ) {
+        for( tripoint_bub_ms &candidate : squares_closer_to( pos_bub(), destination ) ) {
             // rare scenario when monster is on the border of the map and it's goal is outside of the map
             if( !here.inbounds( candidate ) ) {
                 continue;
@@ -1119,24 +1119,24 @@ void monster::move()
             if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, candidate ) ) {
                 via_ramp = true;
                 rampPos -= 1;
-                candidate.z += 1;
+                candidate += tripoint_rel_ms::above;
             } else if( here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, candidate ) ) {
                 via_ramp = true;
                 rampPos += 1;
-                candidate.z -= 1;
+                candidate += tripoint_rel_ms::below;
             }
             const tripoint_abs_ms candidate_abs = get_map().getglobal( candidate );
 
-            if( candidate.z != posz() ) {
+            if( candidate.z() != posz() ) {
                 bool can_z_move = true;
-                if( !here.valid_move( pos(), candidate, false, true, via_ramp ) ) {
+                if( !here.valid_move( pos_bub(), candidate, false, true, via_ramp ) ) {
                     // Can't phase through floor
                     can_z_move = false;
                 }
 
                 // If we're trying to go up but can't fly, check if we can climb. If we can't, then don't
                 // This prevents non-climb/fly enemies running up walls
-                if( candidate.z > posz() && !( via_ramp || flies() ) ) {
+                if( candidate.z() > posz() && !( via_ramp || flies() ) ) {
                     if( !can_climb() || !here.has_floor_or_support( candidate ) ) {
                         if( ( !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) ||
                               !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, candidate ) ) ) {
@@ -1149,10 +1149,10 @@ void monster::move()
                 // Last chance - we can still do the z-level stair teleport bullshit that isn't removed yet
                 // TODO: Remove z-level stair bullshit teleport after aligning all stairs
                 if( !can_z_move &&
-                    posx() / ( SEEX * 2 ) == candidate.x / ( SEEX * 2 ) &&
-                    posy() / ( SEEY * 2 ) == candidate.y / ( SEEY * 2 ) ) {
-                    const tripoint upper = candidate.z > posz() ? candidate : pos();
-                    const tripoint lower = candidate.z > posz() ? pos() : candidate;
+                    posx() / ( SEEX * 2 ) == candidate.x() / ( SEEX * 2 ) &&
+                    posy() / ( SEEY * 2 ) == candidate.y() / ( SEEY * 2 ) ) {
+                    const tripoint_bub_ms upper = candidate.z() > posz() ? candidate : pos_bub();
+                    const tripoint_bub_ms lower = candidate.z() > posz() ? pos_bub() : candidate;
                     if( here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, upper ) &&
                         here.has_flag( ter_furn_flag::TFLAG_GOES_UP, lower ) ) {
                         can_z_move = true;
@@ -1223,8 +1223,8 @@ void monster::move()
                 }
             }
 
-            const float progress = distance_to_target - trig_dist( tripoint( candidate.xy(),
-                                   candidate.z + rampPos ), destination.raw() );
+            const float progress = distance_to_target - trig_dist( tripoint_bub_ms( candidate.xy(),
+                                   candidate.z() + rampPos ), destination );
             // The x2 makes the first (and most direct) path twice as likely,
             // since the chance of switching is 1/1, 1/4, 1/6, 1/8
             switch_chance += progress * 2;
@@ -1252,8 +1252,8 @@ void monster::move()
               here.open_door( *this, local_next_step, !here.is_outside( pos_bub() ) ) ) ||
             ( !pacified && bash_at( local_next_step ) ) ||
             ( !pacified && push_to( local_next_step, 0, 0 ) ) ||
-            move_to( local_next_step, false, false, get_stagger_adjust( pos(), destination.raw(),
-                     local_next_step.raw() ) );
+            move_to( local_next_step, false, false, get_stagger_adjust( pos_bub(), destination,
+                     local_next_step ) );
 
         if( !did_something ) {
             mod_moves( -get_speed() ); // If we don't do this, we'll get infinite loops.
@@ -1429,7 +1429,7 @@ tripoint_bub_ms monster::scent_move()
         return { -1, -1, INT_MIN };
     }
     scent_map &scents = get_scent();
-    bool in_range = scents.inbounds( pos() );
+    bool in_range = scents.inbounds( pos_bub() );
     if( !in_range ) {
         return { -1, -1, INT_MIN };
     }
@@ -1449,7 +1449,7 @@ tripoint_bub_ms monster::scent_move()
 
     Character &player_character = get_player_character();
     const bool fleeing = is_fleeing( player_character );
-    int scent_here = scents.get_unsafe( pos() );
+    int scent_here = scents.get_unsafe( pos_bub() );
     if( fleeing ) {
         bestsmell = scent_here;
     }
@@ -1598,26 +1598,27 @@ int monster::calc_climb_cost( const tripoint_bub_ms &f, const tripoint_bub_ms &t
  * Return points of an area extending 1 tile to either side and
  * (maxdepth) tiles behind basher.
  */
-static std::vector<tripoint> get_bashing_zone( const tripoint &bashee, const tripoint &basher,
+static std::vector<tripoint_bub_ms> get_bashing_zone( const tripoint_bub_ms &bashee,
+        const tripoint_bub_ms &basher,
         int maxdepth )
 {
-    std::vector<tripoint> direction;
+    std::vector<tripoint_bub_ms> direction;
     direction.reserve( 2 );
     direction.push_back( bashee );
     direction.push_back( basher );
     // Draw a line from the target through the attacker.
-    std::vector<tripoint> path = continue_line( direction, maxdepth );
+    std::vector<tripoint_bub_ms> path = continue_line( direction, maxdepth );
     // Remove the target.
     path.insert( path.begin(), basher );
-    std::vector<tripoint> zone;
+    std::vector<tripoint_bub_ms> zone;
     // Go ahead and reserve enough room for all the points since
     // we know how many it will be.
     zone.reserve( 3 * maxdepth );
-    tripoint previous = bashee;
-    for( const tripoint &p : path ) {
-        std::vector<point> swath = squares_in_direction( previous.xy(), p.xy() );
-        for( const point &q : swath ) {
-            zone.emplace_back( q, bashee.z );
+    tripoint_bub_ms previous = bashee;
+    for( const tripoint_bub_ms &p : path ) {
+        std::vector<point_bub_ms> swath = squares_in_direction( previous.xy(), p.xy() );
+        for( const point_bub_ms &q : swath ) {
+            zone.emplace_back( q, bashee.z() );
         }
 
         previous = p;
@@ -1694,15 +1695,15 @@ int monster::group_bash_skill( const tripoint_bub_ms &target )
 
     // pileup = more bash skill, but only help bashing mob directly in front of target
     const int max_helper_depth = 5;
-    const std::vector<tripoint> bzone = get_bashing_zone( target.raw(), pos(), max_helper_depth );
+    const std::vector<tripoint_bub_ms> bzone = get_bashing_zone( target, pos_bub(), max_helper_depth );
 
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &candidate : bzone ) {
+    for( const tripoint_bub_ms &candidate : bzone ) {
         // Drawing this line backwards excludes the target and includes the candidate.
-        std::vector<tripoint> path_to_target = line_to( target.raw(), candidate, 0, 0 );
+        std::vector<tripoint_bub_ms> path_to_target = line_to( target, candidate, 0, 0 );
         bool connected = true;
         monster *mon = nullptr;
-        for( const tripoint &in_path : path_to_target ) {
+        for( const tripoint_bub_ms &in_path : path_to_target ) {
             // If any point in the line from zombie to target is not a cooperating zombie,
             // it can't contribute.
             mon = creatures.creature_at<monster>( in_path );
@@ -1722,7 +1723,7 @@ int monster::group_bash_skill( const tripoint_bub_ms &target )
         // If we made it here, the last monster checked was the candidate.
         monster &helpermon = *mon;
         // Contribution falls off rapidly with distance from target.
-        bashskill += helpermon.bash_skill() / rl_dist( candidate, target.raw() );
+        bashskill += helpermon.bash_skill() / rl_dist( candidate, target );
     }
 
     return bashskill;
@@ -2339,8 +2340,8 @@ bool monster::will_reach( const point_bub_ms &p )
         return false;
     }
 
-    if( has_flag( mon_flag_SMELLS ) && get_scent().get( pos() ) > 0 &&
-        get_scent().get( { p, posz() } ) > get_scent().get( pos() ) ) {
+    if( has_flag( mon_flag_SMELLS ) && get_scent().get( pos_bub() ) > 0 &&
+        get_scent().get( { p, posz() } ) > get_scent().get( pos_bub() ) ) {
         return true;
     }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -374,7 +374,7 @@ tripoint_bub_ms npc::good_escape_direction( bool include_pos )
             add_msg_debug( debugmode::DF_NPC_MOVEAI,
                            "<color_light_gray>%s thinks </color><color_light_blue>%s</color><color_light_gray> is the best retreat spot they've seen so far</color><color_light_blue> rated %1.2f</color><color_light_gray>after checking %i candidates</color>",
                            name, pt.to_string_writable(), best_rating, num_points_searched );
-            candidates.emplace_back( pos() + displace_XY( pt_dir ) );
+            candidates.emplace_back( pos_bub() + displace_XY( pt_dir ) );
         } else if( cur_rating < best_rating ) {
             if( one_in( 5 ) ) {
                 add_msg_debug( debugmode::DF_NPC_MOVEAI,
@@ -382,7 +382,7 @@ tripoint_bub_ms npc::good_escape_direction( bool include_pos )
                                name, num_points_searched );
             }
             candidates.clear();
-            candidates.emplace_back( pos() + displace_XY( pt_dir ) );
+            candidates.emplace_back( pos_bub() + displace_XY( pt_dir ) );
             best_rating = cur_rating;
         }
         num_points_searched += 1;
@@ -4314,7 +4314,7 @@ void npc::activate_item( item &it )
 {
     const int oldmoves = moves;
     if( it.is_tool() || it.is_food() ) {
-        it.type->invoke( this, it, pos() );
+        it.type->invoke( this, it, pos_bub() );
     }
 
     if( moves == oldmoves ) {
@@ -4353,7 +4353,7 @@ void npc::heal_player( Character &patient )
         return;
     }
     if( !is_hallucination() ) {
-        int charges_used = used.type->invoke( this, used, patient.pos(), "heal" ).value_or( 0 );
+        int charges_used = used.type->invoke( this, used, patient.pos_bub(), "heal" ).value_or( 0 );
         consume_charges( used, charges_used );
     } else {
         pretend_heal( patient, used );
@@ -4424,7 +4424,7 @@ void npc::heal_self()
     add_msg_if_player_sees( *this, _( "%1$s starts applying a %2$s." ), disp_name(), used.tname() );
     warn_about( "heal_self", 1_turns );
 
-    int charges_used = used.type->invoke( this, used, pos(), "heal" ).value_or( 0 );
+    int charges_used = used.type->invoke( this, used, pos_bub(), "heal" ).value_or( 0 );
     if( used.is_medication() && charges_used > 0 ) {
         consume_charges( used, charges_used );
     }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6118,7 +6118,7 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
             inv_s.clear_items();
             for( const tripoint_bub_ms &pos : get_map().points_in_radius( center, max_radius ) ) {
                 if( rl_dist( center, pos ) >= min_radius ) {
-                    inv_s.add_map_items( pos.raw() );
+                    inv_s.add_map_items( pos );
                 }
             }
             if( inv_s.empty() ) {
@@ -6136,7 +6136,7 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
             inv_s.clear_items();
             for( const tripoint_bub_ms &pos : get_map().points_in_radius( center, max_radius ) ) {
                 if( rl_dist( center, pos ) >= min_radius ) {
-                    inv_s.add_map_items( pos.raw() );
+                    inv_s.add_map_items( pos );
                 }
             }
             if( inv_s.empty() ) {

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -390,7 +390,7 @@ bool Pickup::do_pickup( std::vector<item_location> &targets, std::vector<int> &q
 }
 
 // Auto pickup items at given location
-void Pickup::autopickup( const tripoint &p )
+void Pickup::autopickup( const tripoint_bub_ms &p )
 {
     map &local = get_map();
 
@@ -406,7 +406,7 @@ void Pickup::autopickup( const tripoint &p )
     }
     Character &player = get_player_character();
     // Recursively pick up adjacent items if that option is on.
-    if( get_option<bool>( "AUTO_PICKUP_ADJACENT" ) && player.pos() == p ) {
+    if( get_option<bool>( "AUTO_PICKUP_ADJACENT" ) && player.pos_bub() == p ) {
         //Autopickup adjacent
         std::array<direction, 8> adjacentDir = {
             direction::NORTH, direction::NORTHEAST, direction::EAST,
@@ -415,10 +415,9 @@ void Pickup::autopickup( const tripoint &p )
         };
         for( direction &elem : adjacentDir ) {
 
-            tripoint apos = tripoint( displace_XY( elem ), 0 );
-            apos += p;
+            tripoint_rel_ms apos = tripoint_rel_ms( point_rel_ms( displace_XY( elem ) ), 0 );
 
-            autopickup( apos );
+            autopickup( p + apos );
         }
     }
     // Bail out if this square cannot be auto-picked-up
@@ -488,7 +487,7 @@ void Pickup::pick_info::deserialize( const JsonObject &jsobj )
 void Pickup::pick_info::set_src( const item_location &src_ )
 {
     // item_location of source may become invalid after the item is moved, so save the information separately.
-    src_pos = src_.position();
+    src_pos = src_.pos_bub();
     src_container = src_.parent_item();
     src_type = src_.where();
 }

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -4,6 +4,7 @@
 
 #include <vector>
 
+#include "coords_fwd.h"
 #include "cuboid_rectangle.h"
 #include "item_location.h"
 #include "point.h"
@@ -24,7 +25,7 @@ struct pick_info {
 
     units::volume total_bulk_volume = 0_ml;
     item_location::type src_type = item_location::type::invalid;
-    tripoint src_pos;
+    tripoint_bub_ms src_pos;
     item_location src_container;
     item_location dst;
 };
@@ -44,7 +45,7 @@ enum from_where : int {
 };
 
 /** Pick up items; 'g' or ',' or via examine() */
-void autopickup( const tripoint &p );
+void autopickup( const tripoint_bub_ms &p );
 /** Determines the cost of moving an item by a character. */
 int cost_to_move_item( const Character &who, const item &it );
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -193,7 +193,7 @@ static int RAS_time( const Character &p, const item_location &loc );
 * @param ammo   Ammo used.
 * @param pos    Character position.
 */
-static void cycle_action( item &weap, const itype_id &ammo, const tripoint &pos );
+static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_ms &pos );
 static void make_gun_sound_effect( const Character &p, bool burst, item *weapon );
 
 class target_ui
@@ -1154,7 +1154,7 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         }
 
         if( !current_ammo.is_null() ) {
-            cycle_action( gun, current_ammo, pos() );
+            cycle_action( gun, current_ammo, pos_bub() );
         }
 
         if( gun_skill == skill_launcher ) {
@@ -2253,13 +2253,13 @@ int RAS_time( const Character &p, const item_location &loc )
     return time;
 }
 
-static void cycle_action( item &weap, const itype_id &ammo, const tripoint &pos )
+static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_ms &pos )
 {
     map &here = get_map();
     // eject casings and linkages in random direction avoiding walls using player position as fallback
-    std::vector<tripoint> tiles = closest_points_first( pos, 1 );
+    std::vector<tripoint_bub_ms> tiles = closest_points_first( pos, 1 );
     tiles.erase( tiles.begin() );
-    tiles.erase( std::remove_if( tiles.begin(), tiles.end(), [&]( const tripoint & e ) {
+    tiles.erase( std::remove_if( tiles.begin(), tiles.end(), [&]( const tripoint_bub_ms & e ) {
         return !here.passable( e );
     } ), tiles.end() );
     tripoint_bub_ms eject{ tiles.empty() ? pos : random_entry( tiles ) };

--- a/src/scent_block.cpp
+++ b/src/scent_block.cpp
@@ -1,9 +1,9 @@
 #include "coordinates.h"
 #include "scent_block.h"
 
-scent_block::scent_block( const tripoint &sub, scent_map &scents )
+scent_block::scent_block( const tripoint_bub_sm &sub, scent_map &scents )
 // NOLINTNEXTLINE(cata-use-named-point-constants)
-    : origin( coords::project_to<coords::ms>( tripoint_bub_sm( sub ) ).raw() + point( -1, -1 ) )
+    : origin( coords::project_to<coords::ms>( sub ) + point( -1, -1 ) )
     , scents( scents )
     , modification_count( 0 )
 {
@@ -25,14 +25,14 @@ void scent_block::commit_modifications()
                 case data_mode::NONE:
                     break;
                 case data_mode::SET: {
-                    tripoint p = origin + tripoint( x, y, 0 );
+                    tripoint_bub_ms p{ origin + tripoint( x, y, 0 ) };
                     if( scents.inbounds( p ) ) {
                         scents.set_unsafe( p, assignment[x][y].intensity );
                     }
                     break;
                 }
                 case data_mode::MAX: {
-                    tripoint p = origin + tripoint( x, y, 0 );
+                    tripoint_bub_ms p{ origin + tripoint( x, y, 0 ) };
                     if( scents.inbounds( p ) ) {
                         scents.set_unsafe( p, std::max( assignment[x][y].intensity, scents.get_unsafe( p ) ) );
                     }
@@ -46,16 +46,17 @@ void scent_block::commit_modifications()
 // We should be working entirely within the range, so don't range check here
 void scent_block::apply_gas( const tripoint_bub_ms &p, const int nintensity )
 {
-    const point ndx = index( p.raw() );
-    assignment[ndx.x][ndx.y].mode = data_mode::SET;
-    assignment[ndx.x][ndx.y].intensity = std::max( 0, assignment[ndx.x][ndx.y].intensity - nintensity );
+    const point_rel_ms ndx = index( p );
+    assignment[ndx.x()][ndx.y()].mode = data_mode::SET;
+    assignment[ndx.x()][ndx.y()].intensity = std::max( 0,
+            assignment[ndx.x()][ndx.y()].intensity - nintensity );
     ++modification_count;
 }
 
-void scent_block::apply_slime( const tripoint &p, int intensity )
+void scent_block::apply_slime( const tripoint_bub_ms &p, int intensity )
 {
-    const point ndx = index( p );
-    datum &dat = assignment[ndx.x][ndx.y];
+    const point_rel_ms ndx = index( p );
+    datum &dat = assignment[ndx.x()][ndx.y()];
     switch( dat.mode ) {
         case data_mode::NONE: {
             // we don't know what the current intensity is, so we must do a max operation

--- a/src/scent_block.h
+++ b/src/scent_block.h
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <array>
 
-#include "coords_fwd.h"
+#include "coordinates.h"
 #include "point.h"
 #include "scent_map.h"
 
@@ -25,21 +25,21 @@ struct scent_block {
     };
     data_block<datum> assignment;
 
-    tripoint origin;
+    tripoint_bub_ms origin;
     scent_map &scents;
     int modification_count;
 
-    scent_block( const tripoint &sub, scent_map &scents );
+    scent_block( const tripoint_bub_sm &sub, scent_map &scents );
 
     void commit_modifications();
 
-    point index( const tripoint &p ) const {
-        return -origin.xy() + p.xy();
+    point_rel_ms index( const tripoint_bub_ms &p ) const {
+        return p.xy() - origin.xy();
     }
 
     // We should be working entirely within the range, so don't range check here
     void apply_gas( const tripoint_bub_ms &p, int nintensity = 0 );
-    void apply_slime( const tripoint &p, int intensity );
+    void apply_slime( const tripoint_bub_ms &p, int intensity );
 };
 
 #endif // CATA_SRC_SCENT_BLOCK_H

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -68,7 +68,8 @@ void scent_map::decay()
     }
 }
 
-void scent_map::draw( const catacurses::window &win, const int div, const tripoint &center ) const
+void scent_map::draw( const catacurses::window &win, const int div,
+                      const tripoint_bub_ms &center ) const
 {
     cata_assert( div != 0 );
     const point max( getmaxx( win ), getmaxy( win ) );
@@ -80,55 +81,50 @@ void scent_map::draw( const catacurses::window &win, const int div, const tripoi
     }
 }
 
-void scent_map::shift( const point &sm_shift )
+void scent_map::shift( const point_rel_ms &sm_shift )
 {
     // Set up iteration such that we ensure data has been moved before
     // it's overwritten.
-    const int x_start = sm_shift.x >= 0 ? 0 : MAPSIZE_X - 1;
-    const int x_stop = sm_shift.x >= 0 ? MAPSIZE_X : -1;
-    const int x_step = sm_shift.x >= 0 ? 1 : -1;
-    const int y_start = sm_shift.y >= 0 ? 0 : MAPSIZE_Y - 1;
-    const int y_stop = sm_shift.y >= 0 ? MAPSIZE_Y : -1;
-    const int y_step = sm_shift.y >= 0 ? 1 : -1;
+    const int x_start = sm_shift.x() >= 0 ? 0 : MAPSIZE_X - 1;
+    const int x_stop = sm_shift.x() >= 0 ? MAPSIZE_X : -1;
+    const int x_step = sm_shift.x() >= 0 ? 1 : -1;
+    const int y_start = sm_shift.y() >= 0 ? 0 : MAPSIZE_Y - 1;
+    const int y_stop = sm_shift.y() >= 0 ? MAPSIZE_Y : -1;
+    const int y_step = sm_shift.y() >= 0 ? 1 : -1;
 
     for( int x = x_start; x != x_stop; x += x_step ) {
         for( int y = y_start; y != y_stop; y += y_step ) {
-            const point p = point( x, y ) + sm_shift;
-            grscent[x][y] = inbounds( p ) ? grscent[p.x][p.y] : 0;
+            const point_bub_ms p = point_bub_ms( x, y ) + sm_shift;
+            grscent[x][y] = inbounds( p ) ? grscent[p.x()][p.y()] : 0;
         }
     }
 }
 
-int scent_map::get( const tripoint &p ) const
+int scent_map::get( const tripoint_bub_ms &p ) const
 {
-    if( inbounds( p ) && grscent[p.x][p.y] > 0 ) {
+    if( inbounds( p ) && grscent[p.x()][p.y()] > 0 ) {
         return get_unsafe( p );
     }
     return 0;
 }
 
-int scent_map::get( const tripoint_bub_ms &p ) const
-{
-    return scent_map::get( p.raw() );
-}
-
-void scent_map::set( const tripoint &p, int value, const scenttype_id &type )
+void scent_map::set( const tripoint_bub_ms &p, int value, const scenttype_id &type )
 {
     if( inbounds( p ) ) {
         set_unsafe( p, value, type );
     }
 }
 
-void scent_map::set_unsafe( const tripoint &p, int value, const scenttype_id &type )
+void scent_map::set_unsafe( const tripoint_bub_ms &p, int value, const scenttype_id &type )
 {
-    grscent[p.x][p.y] = value;
+    grscent[p.x()][p.y()] = value;
     if( !type.is_empty() ) {
         typescent = type;
     }
 }
-int scent_map::get_unsafe( const tripoint &p ) const
+int scent_map::get_unsafe( const tripoint_bub_ms &p ) const
 {
-    return grscent[p.x][p.y] - std::abs( get_map().get_abs_sub().z() - p.z );
+    return grscent[p.x()][p.y()] - std::abs( get_map().get_abs_sub().z() - p.z() );
 }
 
 scenttype_id scent_map::get_type() const
@@ -136,47 +132,47 @@ scenttype_id scent_map::get_type() const
     return typescent;
 }
 
-scenttype_id scent_map::get_type( const tripoint &p ) const
+scenttype_id scent_map::get_type( const tripoint_bub_ms &p ) const
 {
     scenttype_id id;
-    if( inbounds( p ) && grscent[p.x][p.y] > 0 ) {
+    if( inbounds( p ) && grscent[p.x()][p.y()] > 0 ) {
         id = typescent;
     }
     return id;
 }
 
-bool scent_map::inbounds( const tripoint &p ) const
+bool scent_map::inbounds( const tripoint_bub_ms &p ) const
 {
     // HACK: This weird long check here is a hack around the fact that scentmap is 2D
     // A z-level can access scentmap if it is within SCENT_MAP_Z_REACH flying z-level move from player's z-level
     // That is, if a flying critter could move directly up or down (or stand still) and be on same z-level as player
     const int levz = get_map().get_abs_sub().z();
-    const bool scent_map_z_level_inbounds = ( p.z == levz ) ||
-                                            ( std::abs( p.z - levz ) == SCENT_MAP_Z_REACH &&
-                                                    get_map().valid_move( p, tripoint( p.xy(), levz ), false, true ) );
+    const bool scent_map_z_level_inbounds = ( p.z() == levz ) ||
+                                            ( std::abs( p.z() - levz ) == SCENT_MAP_Z_REACH &&
+                                                    get_map().valid_move( p, tripoint_bub_ms( p.xy(), levz ), false, true ) );
     if( !scent_map_z_level_inbounds ) {
         return false;
     }
     return inbounds( p.xy() );
 }
 
-bool scent_map::inbounds( const point &p ) const
+bool scent_map::inbounds( const point_bub_ms &p ) const
 {
-    static constexpr point scent_map_boundary_min{};
-    static constexpr point scent_map_boundary_max( MAPSIZE_X, MAPSIZE_Y );
+    static constexpr point_bub_ms scent_map_boundary_min{};
+    static constexpr point_bub_ms scent_map_boundary_max( MAPSIZE_X, MAPSIZE_Y );
 
-    static constexpr half_open_rectangle<point> scent_map_boundaries(
+    static constexpr half_open_rectangle<point_bub_ms> scent_map_boundaries(
         scent_map_boundary_min, scent_map_boundary_max );
 
     return scent_map_boundaries.contains( p );
 }
 
-void scent_map::update( const tripoint &center, map &m )
+void scent_map::update( const tripoint_bub_ms &center, map &m )
 {
     // Stop updating scent after X turns of the player not moving.
     // Once wind is added, need to reset this on wind shifts as well.
     if( !player_last_position || center != *player_last_position ) {
-        player_last_position.emplace( center );
+        player_last_position = center;
         player_last_moved = calendar::turn;
     } else if( player_last_moved + 1000_turns < calendar::turn ) {
         return;
@@ -195,10 +191,10 @@ void scent_map::update( const tripoint &center, map &m )
     scent_array<bool> reduces_scent;
 
     // for loop constants
-    const int scentmap_minx = center.x - SCENT_RADIUS;
-    const int scentmap_maxx = center.x + SCENT_RADIUS;
-    const int scentmap_miny = center.y - SCENT_RADIUS;
-    const int scentmap_maxy = center.y + SCENT_RADIUS;
+    const int scentmap_minx = center.x() - SCENT_RADIUS;
+    const int scentmap_maxx = center.x() + SCENT_RADIUS;
+    const int scentmap_miny = center.y() - SCENT_RADIUS;
+    const int scentmap_maxy = center.y() + SCENT_RADIUS;
 
     // decrease this to reduce gas spread. Keep it under 125 for
     // stability. This is essentially a decimal number * 1000.

--- a/src/scent_map.h
+++ b/src/scent_map.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "calendar.h"
-#include "coords_fwd.h"
+#include "coordinates.h"
 #include "enums.h" // IWYU pragma: keep
 #include "map_scale_constants.h"
 #include "point.h"
@@ -50,7 +50,7 @@ class scent_map
 
         scent_array<int> grscent;
         scenttype_id typescent;
-        std::optional<tripoint> player_last_position; // NOLINT(cata-serialize)
+        std::optional<tripoint_bub_ms> player_last_position; // NOLINT(cata-serialize)
         time_point player_last_moved = calendar::before_time_starts; // NOLINT(cata-serialize)
 
         const game &gm; // NOLINT(cata-serialize)
@@ -61,12 +61,12 @@ class scent_map
         void deserialize( const std::string &data, bool is_type = false );
         std::string serialize( bool is_type = false ) const;
 
-        void draw( const catacurses::window &win, int div, const tripoint &center ) const;
+        void draw( const catacurses::window &win, int div, const tripoint_bub_ms &center ) const;
 
-        void update( const tripoint &center, map &m );
+        void update( const tripoint_bub_ms &center, map &m );
         void reset();
         void decay();
-        void shift( const point &sm_shift );
+        void shift( const point_rel_ms &sm_shift );
 
         /**
          * Get the scent value at the given position.
@@ -74,19 +74,17 @@ class scent_map
          * The coordinate system is the same as the @ref map (`g->m`) uses.
          */
         /**@{*/
-        void set( const tripoint &p, int value, const scenttype_id &type = scenttype_id() );
-        // TODO: Get rid of untyped override
-        int get( const tripoint &p ) const;
+        void set( const tripoint_bub_ms &p, int value, const scenttype_id &type = scenttype_id() );
         int get( const tripoint_bub_ms &p ) const;
         /**@}*/
-        void set_unsafe( const tripoint &p, int value, const scenttype_id &type = scenttype_id() );
-        int get_unsafe( const tripoint &p ) const;
+        void set_unsafe( const tripoint_bub_ms &p, int value, const scenttype_id &type = scenttype_id() );
+        int get_unsafe( const tripoint_bub_ms &p ) const;
 
         scenttype_id get_type() const;
-        scenttype_id get_type( const tripoint &p ) const;
+        scenttype_id get_type( const tripoint_bub_ms &p ) const;
 
-        bool inbounds( const tripoint &p ) const;
-        bool inbounds( const point &p ) const;
+        bool inbounds( const tripoint_bub_ms &p ) const;
+        bool inbounds( const point_bub_ms &p ) const;
 };
 
 scent_map &get_scent();

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -527,14 +527,15 @@ void start_location::burn( const tripoint_abs_omt &omtstart, const size_t count,
     tinymap m;
     m.load( omtstart, false );
     m.build_outside_cache( m.get_abs_sub().z() );
-    point player_pos = get_player_character().pos().xy();
-    const point u( player_pos.x % HALF_MAPSIZE_X, player_pos.y % HALF_MAPSIZE_Y );
+    point_bub_ms player_pos = get_player_character().pos_bub().xy();
+    const point_bub_ms u( player_pos.x() % HALF_MAPSIZE_X, player_pos.y() % HALF_MAPSIZE_Y );
     std::vector<tripoint_omt_ms> valid;
     for( const tripoint_omt_ms &p : m.points_on_zlevel() ) {
         if( !( m.has_flag_ter( ter_furn_flag::TFLAG_DOOR, p ) ||
                m.has_flag_ter( ter_furn_flag::TFLAG_OPENCLOSE_INSIDE, p ) ||
                m.is_outside( p ) ||
-               ( p.x() >= u.x - rad && p.x() <= u.x + rad && p.y() >= u.y - rad && p.y() <= u.y + rad ) ) ) {
+               ( p.x() >= u.x() - rad && p.x() <= u.x() + rad && p.y() >= u.y() - rad &&
+                 p.y() <= u.y() + rad ) ) ) {
             if( m.has_flag( ter_furn_flag::TFLAG_FLAMMABLE, p ) ||
                 m.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH, p ) ) {
                 valid.push_back( p );

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -64,7 +64,7 @@ int talker_character_const::posz() const
 
 tripoint talker_character_const::pos() const
 {
-    return me_chr_const->pos();
+    return me_chr_const->pos_bub().raw();
 }
 
 tripoint_bub_ms talker_character_const::pos_bub() const

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -38,7 +38,7 @@ int talker_monster_const::posz() const
 
 tripoint talker_monster_const::pos() const
 {
-    return me_mon_const->pos();
+    return me_mon_const->pos_bub().raw();
 }
 
 tripoint_bub_ms talker_monster_const::pos_bub() const

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -374,7 +374,7 @@ static consumption_result try_consume( npc &p, item &it, std::string &reason )
             reason = p.chat_snippets().snip_consume_med.translated();
         }
         if( to_eat.type->has_use() ) {
-            amount_used = to_eat.type->invoke( &p, to_eat, p.pos() ).value_or( 0 );
+            amount_used = to_eat.type->invoke( &p, to_eat, p.pos_bub() ).value_or( 0 );
             if( amount_used <= 0 ) {
                 reason = p.chat_snippets().snip_consume_nocharge.translated();
                 return REFUSED;

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -125,8 +125,8 @@ trade_ui::trade_ui( party_t &you, npc &trader, currency_t cost, std::string titl
             zmgr.get_point_set_loot( trader.get_location(), PICKUP_RANGE, trader.get_fac_id() );
 
         for( tripoint_bub_ms const &pt : src ) {
-            _panes[_trader]->add_map_items( pt.raw() );
-            _panes[_trader]->add_vehicle_items( pt.raw() );
+            _panes[_trader]->add_map_items( pt );
+            _panes[_trader]->add_vehicle_items( pt );
         }
     } else if( !trader.is_player_ally() ) {
         _panes[_trader]->add_nearby_items( 1 );

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -401,7 +401,7 @@ class veh_menu_cb : public uilist_callback
                 player_character.view_offset = tripoint_rel_ms::zero;
             } else {
                 const tripoint &center = points[menu->selected];
-                player_character.view_offset = tripoint_rel_ms( center - player_character.pos() );
+                player_character.view_offset = tripoint_rel_ms( center - player_character.pos_bub().raw() );
                 // Remove next line if/when it's wanted/safe to shift view to other zlevels
                 player_character.view_offset.z() = 0;
             }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -211,24 +211,24 @@ void vehicle::control_doors()
 
         menu.add( _( "Open all curtains" ) )
         .hotkey_auto()
-        .location( get_player_character().pos() )
+        .location( get_player_character().pos_bub().raw() )
         .on_submit( [&open_or_close_all] { open_or_close_all( true, "CURTAIN" ); } );
 
         menu.add( _( "Open all curtains and doors" ) )
         .hotkey_auto()
-        .location( get_player_character().pos() )
+        .location( get_player_character().pos_bub().raw() )
         .on_submit( [&open_or_close_all, &lock_or_unlock_all] {
             lock_or_unlock_all( false, "LOCKABLE_DOOR" );
             open_or_close_all( true, "" );
         } );
         menu.add( _( "Close all doors" ) )
         .hotkey_auto()
-        .location( get_player_character().pos() )
+        .location( get_player_character().pos_bub().raw() )
         .on_submit( [&open_or_close_all] { open_or_close_all( false, "DOOR" ); } );
 
         menu.add( _( "Close all curtains and doors" ) )
         .hotkey_auto()
-        .location( get_player_character().pos() )
+        .location( get_player_character().pos_bub().raw() )
         .on_submit( [&open_or_close_all] { open_or_close_all( false, "" ); } );
 
         for( const vpart_reference &vp_motor : get_avail_parts( "DOOR_MOTOR" ) ) {
@@ -1560,7 +1560,7 @@ void vehicle::use_monster_capture( int part, const tripoint_bub_ms &pos )
         return;
     }
     item base = item( parts[part].get_base() );
-    base.type->invoke( &get_avatar(), base, pos.raw() );
+    base.type->invoke( &get_avatar(), base, pos );
     if( base.has_var( "contained_name" ) ) {
         parts[part].set_flag( vp_flag::animal_flag );
     } else {

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -123,7 +123,7 @@ void run_test_case( Character &u )
     u.i_add( item( "e_tool" ) );
 
     SECTION( "1-step construction activity with pre_terrain" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_door( tripoint::south );
         construction const build =
@@ -148,7 +148,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with pre_flags" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -159,7 +159,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with prereq with only pre_special" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_gravel( tripoint::south );
         construction const pre_build =
@@ -178,7 +178,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity - alternative build from same group" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -190,7 +190,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with existing partial" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -203,7 +203,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with alternative partial" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -216,7 +216,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with mismatched partial" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -230,7 +230,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "visible but unreachable construction" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         u.path_settings->bash_strength = 0;
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window = { 0, 5, 0 };
@@ -249,7 +249,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "multiple-step construction activity with fetch required" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_door( tripoint::south );
         construction const build =
@@ -259,7 +259,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "multiple-step construction activity with prereq from a different group" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_door( tripoint::south );
         construction const build =
@@ -269,7 +269,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "multiple-step construction activity with partial of a recursive prerequisite" ) {
-        u.setpos( tripoint::zero );
+        u.setpos( tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_door( tripoint::south );
         partial_con pc;

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -1438,7 +1438,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             REQUIRE( m.i_at( c.pos_bub() ).empty() );
             c.i_add_or_drop( plastic_bottle, 3 );
             THEN( "no prompt" ) {
-                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == true );
@@ -1465,7 +1465,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             c.i_add( plastic_bottle );
             c.i_add( plastic_bottle );
             THEN( "no prompt" ) {
-                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == true );
@@ -1487,7 +1487,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             REQUIRE( !m.i_at( c.pos_bub() ).begin()->empty_container() );
             THEN( "player is prompted" ) {
                 REQUIRE( c.crafting_inventory().count_item( plastic_bottle.typeId() ) == 3 );
-                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == false );
@@ -1517,7 +1517,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             c.i_add( plastic_bottle );
             REQUIRE( !( *c.worn.front().all_items_top().begin() )->empty_container() );
             THEN( "player is prompted" ) {
-                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == false );
@@ -1542,7 +1542,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             REQUIRE( m.i_at( c.pos_bub() ).size() == 6 );
             THEN( "no prompt" ) {
                 REQUIRE( c.crafting_inventory().count_item( empty_plastic_bottle.typeId() ) == 6 );
-                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == true );
@@ -1572,7 +1572,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             REQUIRE( c.worn.front().all_items_top().size() == 6 );
             THEN( "no prompt" ) {
                 REQUIRE( c.crafting_inventory().count_item( empty_plastic_bottle.typeId() ) == 6 );
-                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == true );
@@ -1597,7 +1597,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             REQUIRE( m.i_at( c.pos_bub() ).size() == 5 );
             THEN( "player is prompted" ) {
                 REQUIRE( c.crafting_inventory().count_item( empty_plastic_bottle.typeId() ) == 5 );
-                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == false );
@@ -1626,7 +1626,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             REQUIRE( c.worn.front().all_items_top().size() == 5 );
             THEN( "player is prompted" ) {
                 REQUIRE( c.crafting_inventory().count_item( empty_plastic_bottle.typeId() ) == 5 );
-                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 1, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == false );
@@ -1653,7 +1653,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             REQUIRE( m.i_at( c.pos_bub() ).empty() );
             c.i_add_or_drop( plastic_bottle, 10 );
             THEN( "no prompt" ) {
-                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == true );
@@ -1680,7 +1680,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             c.i_add( plastic_bottle );
             c.i_add( plastic_bottle );
             THEN( "no prompt" ) {
-                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == true );
@@ -1702,7 +1702,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             REQUIRE( !m.i_at( c.pos_bub() ).begin()->empty_container() );
             THEN( "player is prompted" ) {
                 REQUIRE( c.crafting_inventory().count_item( plastic_bottle.typeId() ) == 10 );
-                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == false );
@@ -1732,7 +1732,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             c.i_add( plastic_bottle );
             REQUIRE( !( *c.worn.front().all_items_top().begin() )->empty_container() );
             THEN( "player is prompted" ) {
-                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == false );
@@ -1757,7 +1757,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             REQUIRE( m.i_at( c.pos_bub() ).size() == 13 );
             THEN( "no prompt" ) {
                 REQUIRE( c.crafting_inventory().count_item( empty_plastic_bottle.typeId() ) == 13 );
-                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == true );
@@ -1794,7 +1794,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             REQUIRE( c.worn.front().all_items_top().size() == 13 );
             THEN( "no prompt" ) {
                 REQUIRE( c.crafting_inventory().count_item( empty_plastic_bottle.typeId() ) == 13 );
-                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == true );
@@ -1819,7 +1819,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             REQUIRE( m.i_at( c.pos_bub() ).size() == 10 );
             THEN( "player is prompted" ) {
                 REQUIRE( c.crafting_inventory().count_item( empty_plastic_bottle.typeId() ) == 10 );
-                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == false );
@@ -1853,7 +1853,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             REQUIRE( c.worn.front().all_items_top().size() == 10 );
             THEN( "player is prompted" ) {
                 REQUIRE( c.crafting_inventory().count_item( empty_plastic_bottle.typeId() ) == 10 );
-                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos() );
+                craft_command cmd( &*recipe_makeshift_funnel, 3, false, &c, c.pos_bub().raw() );
                 cmd.execute( true );
                 item_filter filter = recipe_makeshift_funnel->get_component_filter();
                 CHECK( cmd.continue_prompt_liquids( filter, true ) == false );
@@ -2079,7 +2079,7 @@ TEST_CASE( "tools_with_charges_as_components", "[crafting]" )
         c.i_add_or_drop( thread );
         c.i_add_or_drop( sheet_cotton, cotton_sheets_in_recipe );
         WHEN( "crafting a balaclava" ) {
-            craft_command cmd( &*recipe_balclava, 1, false, &c, c.pos() );
+            craft_command cmd( &*recipe_balclava, 1, false, &c, c.pos_bub().raw() );
             cmd.execute( true );
             item res = cmd.create_in_progress_craft();
             THEN( "craft uses the free thread instead of tool ammo as component" ) {
@@ -2116,7 +2116,7 @@ TEST_CASE( "tools_with_charges_as_components", "[crafting]" )
         c.i_add_or_drop( thread );
         c.i_add_or_drop( sheet_cotton, cotton_sheets_in_recipe );
         WHEN( "crafting a balaclava" ) {
-            craft_command cmd( &*recipe_balclava, 1, false, &c, c.pos() );
+            craft_command cmd( &*recipe_balclava, 1, false, &c, c.pos_bub().raw() );
             cmd.execute( true );
             item res = cmd.create_in_progress_craft();
             THEN( "craft uses the free thread instead of tool ammo as component" ) {

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -335,8 +335,9 @@ TEST_CASE( "EOC_transform_line", "[eoc][timed_event]" )
     overmap_buffer.insert_npc( guy );
     npc &npc = *guy;
     clear_character( npc );
-    std::optional<tripoint> const dest = random_point( get_map(), []( tripoint const & p ) {
-        return p.xy() != get_avatar().pos().xy();
+    std::optional<tripoint_bub_ms> const dest = random_point( get_map(), [](
+    tripoint_bub_ms const & p ) {
+        return p.xy() != get_avatar().pos_bub().xy();
     } );
     REQUIRE( dest.has_value() );
     npc.setpos( { dest.value().xy(), get_avatar().posz() } );

--- a/tests/firstaid_test.cpp
+++ b/tests/firstaid_test.cpp
@@ -46,7 +46,7 @@ TEST_CASE( "avatar_does_healing", "[activity][firstaid][avatar]" )
     const bodypart_id right_arm( "arm_r" );
     npc &dunsel = spawn_npc( point_bub_ms( point::east ), "test_talker" );
     set_time( calendar::turn_zero + 12_hours );
-    dunsel.pos() = dummy.pos() + point::east;
+    dunsel.pos_bub() = dummy.pos_bub() + point::east;
     dummy.set_skill_level( skill_firstaid, 10 );
     int moves = 500;
     item_location bandages = dummy.i_add( item( itype_bandages ) );
@@ -101,7 +101,7 @@ TEST_CASE( "npc_does_healing", "[activity][firstaid][npc]" )
     const bodypart_id right_arm( "arm_r" );
     npc &dunsel = spawn_npc( point_bub_ms( point::east ), "test_talker" );
     set_time( calendar::turn_zero + 12_hours );
-    dunsel.pos() = dummy.pos() + point::east;
+    dunsel.pos_bub() = dummy.pos_bub() + point::east;
     dunsel.set_skill_level( skill_firstaid, 10 );
     int moves = 500;
     item_location bandages = dunsel.i_add( item( itype_bandages ) );
@@ -111,7 +111,7 @@ TEST_CASE( "npc_does_healing", "[activity][firstaid][npc]" )
         dunsel.apply_damage( nullptr, right_arm, 20 );
         WHEN( "npc bandages self" ) {
             // See npc::heal_self()
-            bandages->type->invoke( &dunsel, *bandages, dunsel.pos(), "heal" );
+            bandages->type->invoke( &dunsel, *bandages, dunsel.pos_bub(), "heal" );
             process_activity( dunsel );
             THEN( "Check that bandage was consumed and arm is bandaged" ) {
                 CHECK( start_bandage_count - dunsel.items_with( bandages_filter ).size() == 1 );
@@ -123,7 +123,7 @@ TEST_CASE( "npc_does_healing", "[activity][firstaid][npc]" )
         dunsel.apply_damage( nullptr, right_arm, 20 );
         WHEN( "npc bandages self and is interrupted before finishing" ) {
             // See npc::heal_self()
-            bandages->type->invoke( &dunsel, *bandages, dunsel.pos(), "heal" );
+            bandages->type->invoke( &dunsel, *bandages, dunsel.pos_bub(), "heal" );
             process_activity_interrupt( dunsel, moves / 2 );
             THEN( "Check that bandage was not consumed and arm is not bandaged" ) {
                 CHECK( start_bandage_count - dunsel.items_with( bandages_filter ).size() == 0 );
@@ -135,7 +135,7 @@ TEST_CASE( "npc_does_healing", "[activity][firstaid][npc]" )
         dummy.apply_damage( nullptr, right_arm, 20 );
         WHEN( "npc bandages avatar" ) {
             // See npc::heal_player
-            bandages->type->invoke( &dunsel, *bandages, dummy.pos(), "heal" );
+            bandages->type->invoke( &dunsel, *bandages, dummy.pos_bub(), "heal" );
             process_activity( dunsel );
             THEN( "Check that bandage was consumed and avatar's arm is bandaged" ) {
                 CHECK( start_bandage_count - dunsel.items_with( bandages_filter ).size() == 1 );

--- a/tests/ground_destroy_test.cpp
+++ b/tests/ground_destroy_test.cpp
@@ -64,7 +64,7 @@ TEST_CASE( "explosion_on_ground", "[.]" )
     const tripoint_bub_ms area_center( area_dim / 2, area_dim / 2, 0 );
     item rdx_keg( rdx_keg_typeid );
     rdx_keg.charges = 0;
-    rdx_keg.type->invoke( &get_avatar(), rdx_keg, area_center.raw() );
+    rdx_keg.type->invoke( &get_avatar(), rdx_keg, area_center );
 
     // Check area to see if any t_flat_roof is present.
     for( int x = 0; x < area_dim; x++ ) {
@@ -110,7 +110,7 @@ TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
     const tripoint_bub_ms area_center( area_dim / 2, area_dim / 2, 0 );
     item rdx_keg( rdx_keg_typeid );
     rdx_keg.charges = 0;
-    rdx_keg.type->invoke( &get_avatar(), rdx_keg, area_center.raw() );
+    rdx_keg.type->invoke( &get_avatar(), rdx_keg, area_center );
 
     // Check z0 for open air
     bool found_open_air = false;

--- a/tests/item_autopickup_test.cpp
+++ b/tests/item_autopickup_test.cpp
@@ -156,7 +156,7 @@ static void add_autopickup_rules( const std::vector<unique_item *> &what, bool i
 // Simulate character moving over a tile that contains items.
 static void simulate_auto_pickup( const tripoint_bub_ms &pos, avatar &they )
 {
-    Pickup::autopickup( pos.raw() );
+    Pickup::autopickup( pos );
     process_activity( they );
 }
 

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -38,12 +38,12 @@ static const itype_id itype_medium_battery_cell( "medium_battery_cell" );
 
 static const mtype_id mon_manhack( "mon_manhack" );
 
-static monster *find_adjacent_monster( const tripoint &pos )
+static monster *find_adjacent_monster( const tripoint_bub_ms &pos )
 {
-    tripoint target = pos;
+    tripoint_bub_ms target = pos;
     creature_tracker &creatures = get_creature_tracker();
-    for( target.x = pos.x - 1; target.x <= pos.x + 1; target.x++ ) {
-        for( target.y = pos.y - 1; target.y <= pos.y + 1; target.y++ ) {
+    for( target.x() = pos.x() - 1; target.x() <= pos.x() + 1; target.x()++ ) {
+        for( target.y() = pos.y() - 1; target.y() <= pos.y() + 1; target.y()++ ) {
             if( target == pos ) {
                 continue;
             }
@@ -67,7 +67,7 @@ TEST_CASE( "manhack", "[iuse_actor][manhack]" )
 
     REQUIRE( player_character.has_item( *test_item ) );
 
-    monster *new_manhack = find_adjacent_monster( player_character.pos() );
+    monster *new_manhack = find_adjacent_monster( player_character.pos_bub() );
     REQUIRE( new_manhack == nullptr );
 
     player_character.invoke_item( &*test_item );
@@ -76,7 +76,7 @@ TEST_CASE( "manhack", "[iuse_actor][manhack]" )
         return it.typeId() == itype_bot_manhack;
     } ) );
 
-    new_manhack = find_adjacent_monster( player_character.pos() );
+    new_manhack = find_adjacent_monster( player_character.pos_bub() );
     REQUIRE( new_manhack != nullptr );
     REQUIRE( new_manhack->type->id == mon_manhack );
     g->clear_zombies();

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -764,7 +764,7 @@ TEST_CASE( "water_purification_tablet_activation", "[iuse][pur_tablets]" )
     avatar dummy;
     dummy.normalize();
     build_test_map( ter_t_grass );
-    const tripoint test_origin( 20, 20, 0 );
+    const tripoint_bub_ms test_origin( 20, 20, 0 );
     dummy.setpos( test_origin );
     // Give the player a backpack to hold the tablets
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
@@ -958,7 +958,7 @@ TEST_CASE( "water_tablet_purification_test", "[iuse][pur_tablets]" )
     avatar dummy;
     dummy.normalize();
     build_test_map( ter_t_grass );
-    const tripoint test_origin( 20, 20, 0 );
+    const tripoint_bub_ms test_origin( 20, 20, 0 );
     dummy.setpos( test_origin );
 
     SECTION( "Test purifying time" ) {

--- a/tests/line_test.cpp
+++ b/tests/line_test.cpp
@@ -317,40 +317,40 @@ TEST_CASE( "direction_name", "[line]" )
 TEST_CASE( "squares_closer_to_test", "[line]" )
 {
     // TODO: make this ordering agnostic.
-    auto actual = squares_closer_to( tripoint::zero, {10, 0, 0} );
-    std::vector<tripoint> expected = {tripoint::east, tripoint::south_east, tripoint::north_east};
+    auto actual = squares_closer_to( tripoint_bub_ms::zero, {10, 0, 0} );
+    std::vector<tripoint_bub_ms> expected = {tripoint_bub_ms::zero + tripoint::east, tripoint_bub_ms::zero + tripoint::south_east, tripoint_bub_ms::zero + tripoint::north_east};
     CHECK( actual == expected );
 
-    actual = squares_closer_to( tripoint::zero, {-10, -10, 0} );
-    expected = {tripoint::north_west, tripoint::west, tripoint::north};
+    actual = squares_closer_to( tripoint_bub_ms::zero, {-10, -10, 0} );
+    expected = { tripoint_bub_ms::zero + tripoint::north_west, tripoint_bub_ms::zero + tripoint::west, tripoint_bub_ms::zero + tripoint::north};
     CHECK( actual == expected );
 
-    actual = squares_closer_to( tripoint::zero, {10, 10, 0} );
-    expected = {tripoint::south_east, tripoint::east, tripoint::south};
+    actual = squares_closer_to( tripoint_bub_ms::zero, {10, 10, 0} );
+    expected = { tripoint_bub_ms::zero + tripoint::south_east, tripoint_bub_ms::zero + tripoint::east, tripoint_bub_ms::zero + tripoint::south};
     CHECK( actual == expected );
 
-    actual = squares_closer_to( tripoint::zero, {10, 9, 0} );
-    expected = {tripoint::east, tripoint::south_east, tripoint::north_east, tripoint::south};
+    actual = squares_closer_to( tripoint_bub_ms::zero, {10, 9, 0} );
+    expected = { tripoint_bub_ms::zero + tripoint::east, tripoint_bub_ms::zero + tripoint::south_east, tripoint_bub_ms::zero + tripoint::north_east, tripoint_bub_ms::zero + tripoint::south};
     CHECK( actual == expected );
 
-    actual = squares_closer_to( tripoint::zero, {10, 1, 0} );
-    expected = {tripoint::east, tripoint::south_east, tripoint::north_east, tripoint::south};
+    actual = squares_closer_to( tripoint_bub_ms::zero, {10, 1, 0} );
+    expected = { tripoint_bub_ms::zero + tripoint::east, tripoint_bub_ms::zero + tripoint::south_east, tripoint_bub_ms::zero + tripoint::north_east, tripoint_bub_ms::zero + tripoint::south};
     CHECK( actual == expected );
 
-    actual = squares_closer_to( {10, 9, 0}, tripoint::zero );
-    expected = {tripoint( 9, 9, 0 ), tripoint( 9, 10, 0 ), tripoint( 9, 8, 0 ), tripoint( 10, 8, 0 )};
+    actual = squares_closer_to( {10, 9, 0}, tripoint_bub_ms::zero );
+    expected = { tripoint_bub_ms( 9, 9, 0 ), tripoint_bub_ms( 9, 10, 0 ), tripoint_bub_ms( 9, 8, 0 ), tripoint_bub_ms( 10, 8, 0 )};
     CHECK( actual == expected );
 
-    actual = squares_closer_to( tripoint::zero, {-10, -9, 0} );
-    expected = {tripoint::west, tripoint::south_west, tripoint::north_west, tripoint::north};
+    actual = squares_closer_to( tripoint_bub_ms::zero, {-10, -9, 0} );
+    expected = { tripoint_bub_ms::zero + tripoint::west, tripoint_bub_ms::zero + tripoint::south_west, tripoint_bub_ms::zero + tripoint::north_west, tripoint_bub_ms::zero + tripoint::north};
     CHECK( actual == expected );
 
     actual = squares_closer_to( {10, -10, 0}, {10, 10, 0} );
-    expected = {tripoint( 10, -9, 0 ), tripoint( 11, -9, 0 ), tripoint( 9, -9, 0 )};
+    expected = {tripoint_bub_ms( 10, -9, 0 ), tripoint_bub_ms( 11, -9, 0 ), tripoint_bub_ms( 9, -9, 0 )};
     CHECK( actual == expected );
 
     actual = squares_closer_to( {10, -10, 0}, {-10, -5, 0} );
-    expected = {tripoint( 9, -10, 0 ), tripoint( 9, -9, 0 ), tripoint( 9, -11, 0 ), tripoint( 10, -9, 0 )};
+    expected = {tripoint_bub_ms( 9, -10, 0 ), tripoint_bub_ms( 9, -9, 0 ), tripoint_bub_ms( 9, -11, 0 ), tripoint_bub_ms( 10, -9, 0 )};
     CHECK( actual == expected );
 }
 

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -586,14 +586,14 @@ TEST_CASE( "spell_effect_-_summon", "[magic][spell][effect][summon]" )
     clear_map();
 
     // Avatar/spellcaster and summoned mummy locations
-    const tripoint dummy_loc = { 60, 60, 0 };
+    const tripoint_bub_ms dummy_loc = { 60, 60, 0 };
     const tripoint_bub_ms mummy_loc = { 61, 60, 0 };
 
     avatar &dummy = get_avatar();
     creature_tracker &creatures = get_creature_tracker();
     clear_character( dummy );
     dummy.setpos( dummy_loc );
-    REQUIRE( dummy.pos() == dummy_loc );
+    REQUIRE( dummy.pos_bub() == dummy_loc );
     REQUIRE( creatures.creature_at( dummy_loc ) );
     REQUIRE( g->num_creatures() == 1 );
 

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -265,7 +265,7 @@ TEST_CASE( "milk_rotting", "[active_item][map]" )
 TEST_CASE( "active_monster_drops", "[active_item][map]" )
 {
     clear_map();
-    get_avatar().setpos( tripoint::zero );
+    get_avatar().setpos( tripoint_bub_ms::zero );
     tripoint_bub_ms start_loc = get_avatar().pos_bub() + tripoint::east;
     map &here = get_map();
     restore_on_out_of_scope restore_temp(

--- a/tests/mapgen_remove_npcs_test.cpp
+++ b/tests/mapgen_remove_npcs_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE( "mapgen_remove_npcs" )
         map &here = get_map();
         clear_map();
         clear_avatar();
-        tripoint const start_loc( HALF_MAPSIZE_X + SEEX - 2, HALF_MAPSIZE_Y + SEEY - 1, 0 );
+        tripoint_bub_ms const start_loc( HALF_MAPSIZE_X + SEEX - 2, HALF_MAPSIZE_Y + SEEY - 1, 0 );
         get_avatar().setpos( start_loc );
         clear_npcs();
         set_time( calendar::turn_zero + 12_hours );

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -201,7 +201,7 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
     clear_avatar();
     you.set_dodges_left( 1 ) ;
     REQUIRE( Approx( you.get_dodge() ) == 4.0 );
-    you.setpos( target_location.raw() );
+    you.setpos( target_location );
     const tripoint_abs_ms abs_target_location = you.get_location();
     reset_caches( target_location.z(), target_location.z() );
     REQUIRE( g->natural_light_level( 0 ) > 50.0 );

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -102,7 +102,7 @@ static int can_catch_player( const std::string &monster_type, const tripoint &di
         return true;
     } );
 
-    const tripoint center{ 65, 65, 0 };
+    const tripoint_bub_ms center{ 65, 65, 0 };
     test_player.setpos( center );
     test_player.set_moves( 0 );
     // Give the player a head start.
@@ -125,7 +125,7 @@ static int can_catch_player( const std::string &monster_type, const tripoint &di
                 test_player.posy() < SEEY * static_cast<int>( MAPSIZE / 2 ) ||
                 test_player.posx() >= SEEX * ( 1 + static_cast<int>( MAPSIZE / 2 ) ) ||
                 test_player.posy() >= SEEY * ( 1 + static_cast<int>( MAPSIZE / 2 ) ) ) {
-                tripoint offset = center - test_player.pos();
+                tripoint_rel_ms offset = center - test_player.pos_bub();
                 test_player.setpos( center );
                 test_monster.setpos( test_monster.pos_bub() + offset );
                 // Verify that only the player and one monster are present.
@@ -134,7 +134,7 @@ static int can_catch_player( const std::string &monster_type, const tripoint &di
             const int move_cost = get_map().combined_movecost(
                                       test_player.pos_bub(), test_player.pos_bub() + direction_of_flight, nullptr, 0 );
             tracker.push_back( {'p', move_cost, rl_dist( test_monster.pos_bub(), test_player.pos_bub() ),
-                                test_player.pos()
+                                test_player.pos_bub().raw()
                                } );
             test_player.mod_moves( -move_cost );
         }
@@ -146,7 +146,7 @@ static int can_catch_player( const std::string &monster_type, const tripoint &di
             test_monster.move();
             tracker.push_back( {'m', moves_before - test_monster.get_moves(),
                                 rl_dist( test_monster.pos_bub(), test_player.pos_bub() ),
-                                test_monster.pos()
+                                test_monster.pos_bub().raw()
                                } );
             if( rl_dist( test_monster.pos_bub(), test_player.pos_bub() ) == 1 ) {
                 INFO( tracker );

--- a/tests/morale_test.cpp
+++ b/tests/morale_test.cpp
@@ -261,7 +261,7 @@ TEST_CASE( "player_morale_ranged_kill_of_unaware_hostile_bandit", "[player_moral
     CHECK( m.get_total_positive_value() == 0 );
     CHECK( m.get_total_negative_value() == 0 );
     CHECK( badguy.guaranteed_hostile() == true );
-    CHECK( badguy.sees( player.pos() ) == false );
+    CHECK( badguy.sees( player.pos_bub() ) == false );
     for( size_t loop = 0; loop < 1000; loop++ ) {
         player.set_body();
         arm_shooter( player, "shotgun_s" );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -133,7 +133,7 @@ static npc &prep_test( dialogue &d, bool shopkeep = false )
     player_character.name = "Alpha Avatar";
     REQUIRE_FALSE( player_character.in_vehicle );
 
-    const tripoint test_origin( 15, 15, 0 );
+    const tripoint_bub_ms test_origin( 15, 15, 0 );
     player_character.setpos( test_origin );
 
     g->faction_manager_ptr->create_if_needed();
@@ -1121,7 +1121,7 @@ TEST_CASE( "npc_compare_int", "[npc_talk]" )
     get_weather().weather_precise->humidity = 16;
     get_weather().weather_precise->pressure = 17;
     get_weather().clear_temp_cache();
-    player_character.setpos( tripoint( -1, -2, -3 ) );
+    player_character.setpos( { -1, -2, -3 } );
     player_character.set_pain( 21 );
     player_character.add_bionic( bio_power_storage );
     player_character.set_power_level( 22_mJ );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -252,7 +252,7 @@ static constexpr char setup[height][width + 1] = {
     "    #####        ",
 };
 
-static void check_npc_movement( const tripoint &origin )
+static void check_npc_movement( const tripoint_bub_ms &origin )
 {
     INFO( "Should not crash from infinite recursion" );
     creature_tracker &creatures = get_creature_tracker();
@@ -265,7 +265,7 @@ static void check_npc_movement( const tripoint &origin )
                 case 'M':
                 case 'B':
                 case 'C':
-                    tripoint p = origin + point( x, y );
+                    tripoint_bub_ms p = origin + point( x, y );
                     npc *guy = creatures.creature_at<npc>( p );
                     REQUIRE( guy != nullptr );
                     guy->move();
@@ -278,7 +278,7 @@ static void check_npc_movement( const tripoint &origin )
     for( int y = 0; y < height; ++y ) {
         for( int x = 0; x < width; ++x ) {
             if( setup[y][x] == 'A' ) {
-                tripoint p = origin + point( x, y );
+                tripoint_bub_ms p = origin + point( x, y );
                 npc *guy = creatures.creature_at<npc>( p );
                 REQUIRE( guy != nullptr );
                 CHECK( !guy->has_effect( effect_bouldering ) );
@@ -290,7 +290,7 @@ static void check_npc_movement( const tripoint &origin )
     for( int y = 0; y < height; ++y ) {
         for( int x = 0; x < width; ++x ) {
             if( setup[y][x] == 'R' ) {
-                tripoint p = origin + point( x, y );
+                tripoint_bub_ms p = origin + point( x, y );
                 npc *guy = creatures.creature_at<npc>( p );
                 REQUIRE( guy != nullptr );
                 CHECK( guy->has_effect( effect_bouldering ) );
@@ -305,7 +305,7 @@ static void check_npc_movement( const tripoint &origin )
                 case 'W':
                 case 'M':
                     CAPTURE( setup[y][x] );
-                    tripoint p = origin + point( x, y );
+                    tripoint_bub_ms p = origin + point( x, y );
                     npc *guy = creatures.creature_at<npc>( p );
                     CHECK( guy != nullptr );
                     break;
@@ -319,7 +319,7 @@ static void check_npc_movement( const tripoint &origin )
             switch( setup[y][x] ) {
                 case 'B':
                 case 'C':
-                    tripoint p = origin + point( x, y );
+                    tripoint_bub_ms p = origin + point( x, y );
                     npc *guy = creatures.creature_at<npc>( p );
                     CHECK( guy == nullptr );
                     break;
@@ -533,11 +533,11 @@ TEST_CASE( "npc-movement" )
     }
 
     SECTION( "NPCs escape dangerous terrain by pushing other NPCs" ) {
-        check_npc_movement( player_character.pos() );
+        check_npc_movement( player_character.pos_bub() );
     }
 
     SECTION( "Player in vehicle & NPCs escaping dangerous terrain" ) {
-        const tripoint origin = player_character.pos();
+        const tripoint_bub_ms origin = player_character.pos_bub();
 
         for( int y = 0; y < height; ++y ) {
             for( int x = 0; x < width; ++x ) {

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -144,7 +144,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
 
     dummy.cash = 0;
 
-    const tripoint spot( 60, 60, 0 );
+    const tripoint_bub_ms spot( 60, 60, 0 );
     dummy.setpos( spot );
     dummy.clear_values();
     dummy.magic = pimpl<known_magic>();

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -51,7 +51,8 @@ static std::ostream &operator<<( std::ostream &stream, const throw_test_pstats &
            " PER: " << pstats.per << " SKL: " << pstats.skill_lvl;
 }
 
-static void reset_player( Character &you, const throw_test_pstats &pstats, const tripoint &pos )
+static void reset_player( Character &you, const throw_test_pstats &pstats,
+                          const tripoint_bub_ms &pos )
 {
     clear_character( you );
     CHECK( !you.in_vehicle );
@@ -93,7 +94,7 @@ static void test_throwing_player_versus(
 
     max_throws = std::max( min_throws, max_throws );
     do {
-        reset_player( you, pstats, player_start.raw() );
+        reset_player( you, pstats, player_start );
         you.set_moves( 1000 );
         you.set_stamina( you.get_stamina_max() );
 
@@ -248,7 +249,7 @@ static void test_player_kills_monster(
         int num_items = 0;
         int last_range = -1;
 
-        reset_player( you, pstats, player_start.raw() );
+        reset_player( you, pstats, player_start );
 
         monster &mon = spawn_test_monster( mon_id, monster_start, false );
         mon.set_moves( 0 );

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -31,7 +31,7 @@ static void clear_game_drag( const ter_id &terrain )
     Character &player_character = get_player_character();
     // Move player somewhere safe
     CHECK( !player_character.in_vehicle );
-    player_character.setpos( tripoint::zero );
+    player_character.setpos( tripoint_bub_ms::zero );
     // Blind the player to avoid needless drawing-related overhead
     player_character.add_effect( effect_blind, 1_turns, true );
     // Make sure the ST is 8 so that muscle powered results are consistent

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -49,7 +49,7 @@ static void clear_game( const ter_id &terrain )
     Character &player_character = get_player_character();
     // Move player somewhere safe
     REQUIRE_FALSE( player_character.in_vehicle );
-    player_character.setpos( tripoint::zero );
+    player_character.setpos( tripoint_bub_ms::zero );
     // Blind the player to avoid needless drawing-related overhead
     player_character.add_effect( effect_blind, 1_turns, true );
 

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -398,7 +398,7 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
     }
     REQUIRE( fakes_tested == 4 );
 
-    tripoint prev_player_pos = you.pos();
+    tripoint_bub_ms prev_player_pos = you.pos_bub();
     // Then open them all back up.
     for( const vpart_reference &vp : veh->get_avail_parts( "OPENABLE" ) ) {
         REQUIRE( !vp.part().is_fake );

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -32,7 +32,7 @@ static void reset_player()
     Character &player_character = get_player_character();
     // Move player somewhere safe
     REQUIRE( !player_character.in_vehicle );
-    player_character.setpos( tripoint::zero );
+    player_character.setpos( tripoint_bub_ms::zero );
     // Blind the player to avoid needless drawing-related overhead
     player_character.add_effect( effect_blind, 1_turns, true );
 }

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -22,7 +22,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
     Character &player_character = get_player_character();
     for( units::angle dir = 0_degrees; dir < 360_degrees; dir += vehicles::steer_increment ) {
         CHECK( !player_character.in_vehicle );
-        const tripoint test_origin( 15, 15, 0 );
+        const tripoint_bub_ms test_origin( 15, 15, 0 );
         player_character.setpos( test_origin );
         tripoint_bub_ms vehicle_origin{ 10, 10, 0 };
         VehicleList vehs = here.get_vehicles();

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -743,7 +743,7 @@ static int test_autopilot_moving( const vproto_id &veh_id, const vpart_id &extra
     Character &player_character = get_player_character();
     // Move player somewhere safe
     REQUIRE_FALSE( player_character.in_vehicle );
-    player_character.setpos( tripoint::zero );
+    player_character.setpos( tripoint_bub_ms::zero );
 
     const tripoint_bub_ms map_starting_point( 60, 60, 0 );
     map &here = get_map();

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -1942,7 +1942,7 @@ TEST_CASE( "widgets_showing_weather_conditions", "[widget][weather]" )
         }
 
         SECTION( "cannot see weather when underground" ) {
-            ava.setpos( tripoint::below );
+            ava.setpos( tripoint_bub_ms::zero + tripoint::below );
             CHECK( weather_w.layout( ava ) == "Weather: <color_c_light_gray>Underground</color>" );
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Change usage of untyped coordinates into typed ones. This time a scattered bunch of conversions.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Find operations using untyped coordinates, change them to use typed coordinates and change their usages to do so as well.
No functional changes made.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded save, walked up ramp, jumped into car, drove through reinforced hay bales (destroyed headlight), ran over zombie corpse with inventory, ran over a couple of turkeys, smashed into stationary vehicle. Nothing odd seen (apart from the vehicle part destruction, which happens at times).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I think I've gotten rid of all usages of Creature::pos(), but haven't removed it because I'm not completely sure all usages are gone (the compiler isn't helping by generating hundreds of fake usage entries), and even more because I actually prefer the pos_bub() function name to the pos() one, and thus don't want to rename it. I'd also prefer to rename the various operations that return absolute positions to pos_abs() (with some occasional pos_omt)() sprinkled in when needed) as those names are rather clear about what kind of positions they provide.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
