### PR TITLE
[MoM] Proficiency reshuffling, some crafts require that you are a psion

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_crafting.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_crafting.json
@@ -63,6 +63,6 @@
         }
       ]
     },
-    "effect": [ { "math": [ "u_proficiency('prof_psionic_minimum_requirements', 'format': 'permille', 'direct': true) += 1000" ] } ]
+    "effect": [ { "math": [ "u_proficiency('prof_psionic_minimum_requirements', 'format': 'percent', 'direct': true) += 100" ] } ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_crafting.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_crafting.json
@@ -28,6 +28,50 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_MOM_GRANT_GROUNDING_MEDITATION_TO_PSIONS",
+    "recurrence": 1,
+    "condition": {
+      "and": [
+        {
+          "u_has_any_trait": [
+            "BIOKINETIC",
+            "CLAIRSENTIENT",
+            "ELECTROKINETIC",
+            "PHOTOKINETIC",
+            "PYROKINETIC",
+            "TELEKINETIC",
+            "TELEPATH",
+            "TELEPORTER",
+            "VITAKINETIC"
+          ]
+        },
+        { "math": [ "u_skill('metaphysics') >= 4" ] }
+      ]
+    },
+    "deactivate_condition": {
+      "or": [
+        { "u_know_recipe": "psi_centering_meditation_drain_reduce" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "BIOKINETIC",
+              "CLAIRSENTIENT",
+              "ELECTROKINETIC",
+              "PHOTOKINETIC",
+              "PYROKINETIC",
+              "TELEKINETIC",
+              "TELEPATH",
+              "TELEPORTER",
+              "VITAKINETIC"
+            ]
+          }
+        }
+      ]
+    },
+    "effect": [ { "u_learn_recipe": "psi_centering_meditation_drain_reduce" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_MOM_GAME_ONGOING_GRANT_CRAFTING_PROFICIENICES",
     "recurrence": 1,
     "condition": {

--- a/data/mods/MindOverMatter/effectoncondition/eoc_crafting.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_crafting.json
@@ -25,5 +25,44 @@
     "id": "EOC_PSI_PRACTICE_FOCUS_MOD_4",
     "condition": { "math": [ "u_val('focus') >= 30" ] },
     "effect": [ { "math": [ "u_val('focus')", "-=", "5" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_GAME_ONGOING_GRANT_CRAFTING_PROFICIENICES",
+    "recurrence": 1,
+    "condition": {
+      "u_has_any_trait": [
+        "BIOKINETIC",
+        "CLAIRSENTIENT",
+        "ELECTROKINETIC",
+        "PHOTOKINETIC",
+        "PYROKINETIC",
+        "TELEKINETIC",
+        "TELEPATH",
+        "TELEPORTER",
+        "VITAKINETIC"
+      ]
+    },
+    "deactivate_condition": {
+      "or": [
+        { "u_has_proficiency": "prof_psionic_minimum_requirements" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "BIOKINETIC",
+              "CLAIRSENTIENT",
+              "ELECTROKINETIC",
+              "PHOTOKINETIC",
+              "PYROKINETIC",
+              "TELEKINETIC",
+              "TELEPATH",
+              "TELEPORTER",
+              "VITAKINETIC"
+            ]
+          }
+        }
+      ]
+    },
+    "effect": [ { "math": [ "u_proficiency('prof_psionic_minimum_requirements', 'format': 'permille', 'direct': true) += 1000" ] } ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_game_initialization.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_game_initialization.json
@@ -164,6 +164,6 @@
         "VITAKINETIC"
       ]
     },
-    "effect": [ { "math": [ "u_proficiency('prof_psionic_minimum_requirements', 'format': 'percent') += 100" ] } ]
+    "effect": [ { "math": [ "u_proficiency('prof_psionic_minimum_requirements', 'format': 'permille') += 1000" ] } ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_game_initialization.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_game_initialization.json
@@ -145,25 +145,5 @@
       { "math": [ "global_tier_three_power_learning_time_low = 345600" ] },
       { "math": [ "global_tier_three_power_learning_time_high = 604800" ] }
     ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_MOM_GAME_BEGIN_GRANT_CRAFTING_PROFICIENICES",
-    "eoc_type": "EVENT",
-    "required_event": "game_begin",
-    "condition": {
-      "u_has_any_trait": [
-        "BIOKINETIC",
-        "CLAIRSENTIENT",
-        "ELECTROKINETIC",
-        "PHOTOKINETIC",
-        "PYROKINETIC",
-        "TELEKINETIC",
-        "TELEPATH",
-        "TELEPORTER",
-        "VITAKINETIC"
-      ]
-    },
-    "effect": [ { "math": [ "u_proficiency('prof_psionic_minimum_requirements', 'format': 'permille', 'direct': true) += 1000" ] } ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_game_initialization.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_game_initialization.json
@@ -164,6 +164,6 @@
         "VITAKINETIC"
       ]
     },
-    "effect": [ { "math": [ "u_proficiency('prof_psionic_minimum_requirements', 'format': 'permille') += 1000" ] } ]
+    "effect": [ { "math": [ "u_proficiency('prof_psionic_minimum_requirements', 'format': 'permille', 'direct': true) += 1000" ] } ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_game_initialization.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_game_initialization.json
@@ -145,5 +145,25 @@
       { "math": [ "global_tier_three_power_learning_time_low = 345600" ] },
       { "math": [ "global_tier_three_power_learning_time_high = 604800" ] }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_GAME_BEGIN_GRANT_CRAFTING_PROFICIENICES",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "condition": {
+      "u_has_any_trait": [
+        "BIOKINETIC",
+        "CLAIRSENTIENT",
+        "ELECTROKINETIC",
+        "PHOTOKINETIC",
+        "PYROKINETIC",
+        "TELEKINETIC",
+        "TELEPATH",
+        "TELEPORTER",
+        "VITAKINETIC"
+      ]
+    },
+    "effect": [ { "math": [ "u_proficiency('prof_psionic_minimum_requirements', 'format': 'percent') += 100" ] } ]
   }
 ]

--- a/data/mods/MindOverMatter/recipes/armor.json
+++ b/data/mods/MindOverMatter/recipes/armor.json
@@ -12,6 +12,7 @@
     "book_learn": [ [ "schematics_anchoring_crown", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
       { "proficiency": "prof_psionic_basic", "required": true },
       { "proficiency": "prof_psionic_containment", "required": false },
       { "proficiency": "prof_psionic_warping", "required": false }
@@ -41,6 +42,7 @@
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
       { "proficiency": "prof_psionic_basic", "required": true },
       { "proficiency": "prof_psionic_containment", "required": false },
       { "proficiency": "prof_psionic_warping", "required": false }

--- a/data/mods/MindOverMatter/recipes/batteries.json
+++ b/data/mods/MindOverMatter/recipes/batteries.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "medium_storage_battery",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "electronics",
+    "skills_required": [ "fabrication", 2 ],
+    "difficulty": 3,
+    "time": "40 m",
+    "book_learn": [ [ "manual_electronics", 2 ], [ "mag_electronics", 2 ], [ "manual_mechanics", 3 ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "proficiencies": [
+      { "proficiency": "prof_elec_soldering" },
+      { "proficiency": "prof_elec_circuits" },
+      { "proficiency": "prof_elec_semiconductors" },
+      { "proficiency": "prof_matrix_technology_beginner" }
+    ],
+    "components": [ [ [ "small_storage_battery", 10 ] ], [ [ "e_scrap", 4 ] ], [ [ "scrap", 8 ] ], [ [ "cable", 5 ] ] ]
+  }
+]

--- a/data/mods/MindOverMatter/recipes/chemistry.json
+++ b/data/mods/MindOverMatter/recipes/chemistry.json
@@ -11,8 +11,8 @@
     "batch_time_factors": [ 80, 4 ],
     "book_learn": [ [ "schematics_reactant_liquid_base", 5 ] ],
     "proficiencies": [
-      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_intro_chemistry", "required": false },
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "serum_production_standard", 25 ] ],
     "components": [

--- a/data/mods/MindOverMatter/recipes/chemistry.json
+++ b/data/mods/MindOverMatter/recipes/chemistry.json
@@ -10,7 +10,10 @@
     "time": "55 m",
     "batch_time_factors": [ 80, 4 ],
     "book_learn": [ [ "schematics_reactant_liquid_base", 5 ] ],
-    "proficiencies": [ { "proficiency": "prof_psionic_basic", "required": false } ],
+    "proficiencies": [
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
+      { "proficiency": "prof_psionic_basic", "required": false }
+    ],
     "using": [ [ "serum_production_standard", 25 ] ],
     "components": [
       [ [ "ether", 100 ] ],
@@ -36,8 +39,7 @@
     "tools": [ [ [ "microscope", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
-      { "proficiency": "prof_inorganic_chemistry", "required": false },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
     "components": [ [ [ "matrix_crystal_biokin_dust", 3 ] ] ],
@@ -71,8 +73,7 @@
     "tools": [ [ [ "microscope", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
-      { "proficiency": "prof_inorganic_chemistry", "required": false },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
     "components": [ [ [ "matrix_crystal_clair_dust", 3 ] ] ],
@@ -106,8 +107,7 @@
     "tools": [ [ [ "microscope", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
-      { "proficiency": "prof_inorganic_chemistry", "required": false },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
     "components": [ [ [ "matrix_crystal_electrokin_dust", 3 ] ] ],
@@ -141,8 +141,7 @@
     "tools": [ [ [ "microscope", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
-      { "proficiency": "prof_inorganic_chemistry", "required": false },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
     "components": [ [ [ "matrix_crystal_photokin_dust", 3 ] ] ],
@@ -176,8 +175,7 @@
     "tools": [ [ [ "microscope", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
-      { "proficiency": "prof_inorganic_chemistry", "required": false },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
     "components": [ [ [ "matrix_crystal_pyrokin_dust", 3 ] ] ],
@@ -211,8 +209,7 @@
     "tools": [ [ [ "microscope", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
-      { "proficiency": "prof_inorganic_chemistry", "required": false },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
     "components": [ [ [ "matrix_crystal_telekin_dust", 3 ] ] ],
@@ -246,8 +243,7 @@
     "tools": [ [ [ "microscope", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
-      { "proficiency": "prof_inorganic_chemistry", "required": false },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
     "components": [ [ [ "matrix_crystal_telepath_dust", 3 ] ] ],
@@ -281,8 +277,7 @@
     "tools": [ [ [ "microscope", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
-      { "proficiency": "prof_inorganic_chemistry", "required": false },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
     "components": [ [ [ "matrix_crystal_teleport_dust", 3 ] ] ],
@@ -316,8 +311,7 @@
     "tools": [ [ [ "microscope", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
-      { "proficiency": "prof_inorganic_chemistry", "required": false },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
     "components": [ [ [ "matrix_crystal_vitakin_dust", 3 ] ] ],
@@ -351,8 +345,7 @@
     "tools": [ [ [ "microscope", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
-      { "proficiency": "prof_inorganic_chemistry", "required": false },
-      { "proficiency": "prof_psionic_basic", "required": false }
+      { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
     "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
     "components": [ [ [ "matrix_crystal_drained_dust", 3 ] ] ],

--- a/data/mods/MindOverMatter/recipes/medical.json
+++ b/data/mods/MindOverMatter/recipes/medical.json
@@ -15,6 +15,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_intro_biology", "required": false },
       { "proficiency": "prof_pharmaceutical", "required": false },
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
       { "proficiency": "prof_psionic_basic", "required": true },
       { "proficiency": "prof_psionic_containment", "required": false },
       { "proficiency": "prof_psionic_morphic", "required": false }
@@ -43,6 +44,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_intro_biology", "required": false },
       { "proficiency": "prof_pharmaceutical", "required": false },
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
       { "proficiency": "prof_psionic_basic", "required": true },
       { "proficiency": "prof_psionic_containment", "required": true },
       { "proficiency": "prof_psionic_morphic", "required": false }
@@ -73,6 +75,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_intro_biology", "required": false },
       { "proficiency": "prof_pharmaceutical", "required": false },
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
       { "proficiency": "prof_psionic_basic", "required": true },
       { "proficiency": "prof_psionic_containment", "required": false },
       { "proficiency": "prof_psionic_warping", "required": false }

--- a/data/mods/MindOverMatter/recipes/nether_attunement.json
+++ b/data/mods/MindOverMatter/recipes/nether_attunement.json
@@ -44,6 +44,7 @@
     "time": "1 h",
     "book_learn": [ [ "phavian_report_psionic_drain", 5 ] ],
     "proficiencies": [
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
       { "proficiency": "prof_psionic_basic", "required": true },
       { "proficiency": "prof_psionic_containment", "required": false }
     ],

--- a/data/mods/MindOverMatter/recipes/nether_attunement.json
+++ b/data/mods/MindOverMatter/recipes/nether_attunement.json
@@ -9,7 +9,7 @@
     "subcategory": "CSC_PSIONIC_OTHER",
     "difficulty": 4,
     "time": "15 m",
-    "autolearn": true,
+    "proficiencies": [ { "proficiency": "prof_psionic_minimum_requirements", "required": true } ],
     "skill_used": "metaphysics",
     "flags": [ "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
     "result_eocs": [

--- a/data/mods/MindOverMatter/recipes/proficiencies.json
+++ b/data/mods/MindOverMatter/recipes/proficiencies.json
@@ -233,7 +233,7 @@
     "id": "prof_matrix_technology_beginner",
     "category": "prof_matrix_technology",
     "name": { "str": "Principles of Matrix Technology" },
-    "//": "This should not be used in any recipe that requires ",
+    "//": "This should not be used in any recipe that requires actual psionics to create",
     "description": "You know the basics of creating items using matrix crystals that don't require you to personally to use psi in the crafting process.",
     "can_learn": true,
     "default_time_multiplier": 2,

--- a/data/mods/MindOverMatter/recipes/proficiencies.json
+++ b/data/mods/MindOverMatter/recipes/proficiencies.json
@@ -153,6 +153,14 @@
   },
   {
     "type": "proficiency",
+    "id": "prof_psionic_minimum_requirements",
+    "category": "prof_psionic",
+    "name": { "str": "Psionic Crafting" },
+    "description": "You are capable of using psi and can craft things that require active psionic channeling.",
+    "can_learn": false
+  },
+  {
+    "type": "proficiency",
     "id": "prof_psionic_basic",
     "category": "prof_psionic",
     "name": { "str": "Psionic Channeling" },
@@ -160,7 +168,8 @@
     "can_learn": true,
     "default_time_multiplier": 2,
     "default_skill_penalty": 0.3,
-    "time_to_learn": "12 h"
+    "time_to_learn": "12 h",
+    "required_proficiencies": [ "prof_psionic_minimum_requirements" ]
   },
   {
     "type": "proficiency",
@@ -171,7 +180,8 @@
     "can_learn": true,
     "default_time_multiplier": 1.2,
     "default_skill_penalty": 0.4,
-    "time_to_learn": "20 h"
+    "time_to_learn": "20 h",
+    "required_proficiencies": [ "prof_psionic_minimum_requirements" ]
   },
   {
     "type": "proficiency",
@@ -208,5 +218,23 @@
     "default_skill_penalty": 0.4,
     "time_to_learn": "18 h",
     "required_proficiencies": [ "prof_psionic_basic", "prof_psionic_containment" ]
+  },
+  {
+    "type": "proficiency_category",
+    "id": "prof_matrix_technology",
+    "name": "Matrix Technology",
+    "description": "Proficiencies that help with making materials whose capabilities or functions are possible due to the existence of psionics, but which do not require its use in their creation."
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_matrix_technology_beginner",
+    "category": "prof_matrix_technology",
+    "name": { "str": "Principles of Matrix Technology" },
+    "//": "This should not be used in any recipe that requires ",
+    "description": "You know the basics of creating items using matrix crystals that don't require you to personally to use psi in the crafting process.",
+    "can_learn": true,
+    "default_time_multiplier": 2,
+    "default_skill_penalty": 0.3,
+    "time_to_learn": "8 h"
   }
 ]

--- a/data/mods/MindOverMatter/recipes/proficiencies.json
+++ b/data/mods/MindOverMatter/recipes/proficiencies.json
@@ -157,7 +157,10 @@
     "category": "prof_psionic",
     "name": { "str": "Psionic Crafting" },
     "description": "You are capable of using psi and can craft things that require active psionic channeling.",
-    "can_learn": false
+    "can_learn": false,
+    "teachable": false,
+    "default_time_multiplier": 1,
+    "time_to_learn": "1 h"
   },
   {
     "type": "proficiency",

--- a/data/mods/MindOverMatter/recipes/proficiencies.json
+++ b/data/mods/MindOverMatter/recipes/proficiencies.json
@@ -156,7 +156,7 @@
     "id": "prof_psionic_minimum_requirements",
     "category": "prof_psionic",
     "name": { "str": "Psionic Crafting" },
-    "description": "You are capable of using psi and can craft things that require active psionic channeling.",
+    "description": "You are capable of using psi and can undertake crafts that require active psionic channeling.",
     "can_learn": false,
     "teachable": false,
     "default_time_multiplier": 1,

--- a/data/mods/MindOverMatter/recipes/proficiencies.json
+++ b/data/mods/MindOverMatter/recipes/proficiencies.json
@@ -155,7 +155,7 @@
     "type": "proficiency",
     "id": "prof_psionic_minimum_requirements",
     "category": "prof_psionic",
-    "name": { "str": "Psionic Crafting" },
+    "name": { "str": "Noetic Crafting" },
     "description": "You are capable of using psi and can undertake crafts that require active psionic channeling.",
     "can_learn": false,
     "teachable": false,

--- a/data/mods/MindOverMatter/recipes/psionics_practice.json
+++ b/data/mods/MindOverMatter/recipes/psionics_practice.json
@@ -70,8 +70,7 @@
     "proficiencies": [ { "proficiency": "prof_psionic_basic", "time_multiplier": 1, "skill_penalty": 0 } ],
     "time": "1 h",
     "qualities": [ { "id": "MATRIX_CHANNEL", "level": 1 } ],
-    "components": [ [ [ "matrix_shard", 1 ], [ "matrix_crystal_drained", 1 ] ] ],
-    "byproducts": [ [ "matrix_crystal_drained_dust", 10 ] ],
+    "tools": [ [ [ "matrix_shard", -1 ], [ "matrix_crystal_drained", -1 ] ] ],
     "book_learn": [ [ "manual_psionics_advan", 3 ], [ "schematics_matrix_channeling", 3 ], [ "schematics_matrix_aligning", 3 ] ]
   },
   {
@@ -86,7 +85,10 @@
     "practice_data": { "min_difficulty": 4, "max_difficulty": 4, "skill_limit": 4 },
     "proficiencies": [ { "proficiency": "prof_psionic_ritual", "time_multiplier": 1, "skill_penalty": 0 } ],
     "time": "1 h",
-    "book_learn": [ [ "manual_psionic_ritual", 4 ] ]
+    "qualities": [ { "id": "MATRIX_CHANNEL", "level": 1 } ],
+    "tools": [ [ [ "matrix_shard", 1 ], [ "matrix_crystal_drained", 1 ] ] ],
+    "book_learn": [ [ "manual_psionic_ritual", 4 ] ],
+    "flags": [ "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ]
   },
   {
     "id": "prac_concentration_basic",

--- a/data/mods/MindOverMatter/recipes/research.json
+++ b/data/mods/MindOverMatter/recipes/research.json
@@ -63,6 +63,7 @@
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_intro_biology", "required": false },
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
       { "proficiency": "prof_psionic_basic", "required": true },
       { "proficiency": "prof_psionic_ritual", "required": false }
     ],
@@ -131,6 +132,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_intro_biology", "required": false },
       { "proficiency": "prof_pharmaceutical", "required": false },
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
       { "proficiency": "prof_psionic_basic", "required": true },
       { "proficiency": "prof_psionic_ritual", "required": false }
     ],

--- a/data/mods/MindOverMatter/recipes/rituals.json
+++ b/data/mods/MindOverMatter/recipes/rituals.json
@@ -14,7 +14,8 @@
     "tools": [ [ [ "telepathic_focusing_tool", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_psionic_basic", "required": true },
-      { "proficiency": "prof_psionic_ritual", "required": true }
+      { "proficiency": "prof_psionic_ritual", "required": true },
+      { "proficiency": "prof_psionic_containment", "required": false }
     ],
     "flags": [ "SECRET", "BLIND_EASY" ],
     "result_eocs": [ "EOC_TELEPATHIC_MENTAL_ENGINEERING_SELECTOR" ]
@@ -33,7 +34,8 @@
     "book_learn": [ [ "phavian_psionic_martial_power_book", 5 ] ],
     "proficiencies": [
       { "proficiency": "prof_psionic_basic", "required": true },
-      { "proficiency": "prof_psionic_ritual", "required": false }
+      { "proficiency": "prof_psionic_ritual", "required": false },
+      { "proficiency": "prof_psionic_containment", "required": false }
     ],
     "flags": [ "SECRET", "BLIND_HARD" ],
     "result_eocs": [

--- a/data/mods/MindOverMatter/recipes/tools.json
+++ b/data/mods/MindOverMatter/recipes/tools.json
@@ -12,7 +12,7 @@
     "book_learn": [ [ "schematics_matrix_channeling", 3 ] ],
     "qualities": [ { "id": "HAMMER_FINE", "level": 1 }, { "id": "FINE_GRIND", "level": 1 }, { "id": "VISE", "level": 1 } ],
     "tools": [ [ [ "angle_grinder", 50 ] ] ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_psionic_basic", "required": false } ],
+    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_matrix_technology_beginner", "required": false } ],
     "using": [ [ "soldering_standard", 15 ], [ "steel_tiny", 5 ] ],
     "components": [ [ [ "matrix_crystal_drained", 1 ] ] ],
     "flags": [ "SECRET" ]
@@ -37,7 +37,7 @@
     "tools": [ [ [ "swage", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_psionic_basic", "required": false },
+      { "proficiency": "prof_matrix_technology_beginner", "required": false },
       { "proficiency": "prof_fine_metalsmithing", "required": false }
     ],
     "using": [ [ "soldering_standard", 15 ], [ "steel_tiny", 5 ] ],
@@ -68,7 +68,9 @@
     "tools": [ [ [ "swage", -1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_psionic_basic", "required": false },
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
+      { "proficiency": "prof_psionic_basic", "required": true },
+      { "proficiency": "prof_psionic_ritual", "required": false },
       { "proficiency": "prof_fine_metalsmithing", "required": false }
     ],
     "using": [ [ "soldering_standard", 15 ], [ "steel_tiny", 15 ] ],
@@ -87,6 +89,7 @@
     "reversible": true,
     "decomp_learn": 0,
     "qualities": [ { "id": "MATRIX_CHANNEL", "level": 1 } ],
+    "proficiencies": [ { "proficiency": "prof_matrix_technology_beginner" } ],
     "book_learn": [ [ "schematics_everglow_lamp", 1 ] ],
     "components": [
       [ [ "amplifier", 1 ] ],
@@ -117,7 +120,7 @@
     "reversible": true,
     "decomp_learn": 1,
     "book_learn": [ [ "schematics_everglow_lamp", 2 ] ],
-    "proficiencies": [ { "proficiency": "prof_plasticworking" }, { "proficiency": "prof_psionic_basic" } ],
+    "proficiencies": [ { "proficiency": "prof_plasticworking" }, { "proficiency": "prof_matrix_technology_beginner" } ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "MATRIX_CHANNEL", "level": 1 } ],
     "components": [
       [ [ "plastic_chunk", 2 ] ],

--- a/data/mods/MindOverMatter/recipes/travel.json
+++ b/data/mods/MindOverMatter/recipes/travel.json
@@ -12,6 +12,7 @@
     "batch_time_factors": [ 80, 3 ],
     "book_learn": [ [ "schematics_transporters", 9 ] ],
     "proficiencies": [
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
       { "proficiency": "prof_psionic_basic", "required": true },
       { "proficiency": "prof_psionic_containment", "required": false },
       { "proficiency": "prof_psionic_warping", "required": false },
@@ -55,6 +56,7 @@
     "batch_time_factors": [ 80, 3 ],
     "book_learn": [ [ "schematics_transporters", 6 ] ],
     "proficiencies": [
+      { "proficiency": "prof_psionic_minimum_requirements", "required": true },
       { "proficiency": "prof_psionic_basic", "required": true },
       { "proficiency": "prof_psionic_containment", "required": false },
       { "proficiency": "prof_psionic_warping", "required": false },

--- a/data/mods/MindOverMatter/recipes/weapons.json
+++ b/data/mods/MindOverMatter/recipes/weapons.json
@@ -12,10 +12,7 @@
     "reversible": false,
     "autolearn": false,
     "book_learn": [ [ "schematics_grenade_inferno", 5 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_psionic_basic", "required": false },
-      { "proficiency": "prof_psionic_containment", "required": false }
-    ],
+    "proficiencies": [ { "proficiency": "prof_matrix_technology_beginner", "required": false } ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "MATRIX_CHANNEL", "level": 1 } ],
     "using": [ [ "volatile_explosive", 20, "LIST" ], [ "explosives_casting_standard", 1 ] ],
     "components": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Proficiency reshuffling, some crafts require that you are a psion"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I've been wanting to add makeshift matrix technology, the kind of things that survivors with matrix crystals and time on their hands might be able to figure out, but I'd also like to make a distinction between matrix technology that requires that you yourself are a psion and can use psi when making the craft, and crafts that just channel psi by virtue of incorporating matrix crystals into their design. That's what this PR tries to accomplish.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a new proficiency, `Noetic Crafting`, that cannot be learned and cannot be taught, and gate currently psionic crafting proficiencies behind this one. You gain it automatically if you have any psi powers through a recurrence 1 EoC. 

Add another new proficiency, `Principles of Matrix Technology`, and remove `Psionic Channeling` and its follow-ups from recipes that do not require you to be a psion, replacing them with `Principles of Matrix Technology`

Reshuffle some recipes. I'm planning a follow-up to this PR that adds similar locking proficiencies for specific psionic paths (so you'll need to be a vitakinetic if you want to manufacture `morphic reversion serum`, for example, but can still find some in the world otherwise), but I'll do that separately.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game as a non-psion, did not gain Noetic Crafting. Debugged in the Telepath trait, immediately gained Noetic Crafting.

Loaded game as a non-psion, debugged Metaphysics 5 and the tools and materials for the Psionic Channeling practice recipe. Practiced 10 times, did not gain even 1% toward the proficiency (because it's now locked behind Noetic Crafting)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Another idea I had is that in ruined labs, perhaps you can find machines that can grant you these proficiencies temporarily, but one thing at a time.

My goal is that eventually there will be enough stuff that you can play through MoM without using any of the powers and feel like it meaningfully adds to the game. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
