### PR TITLE
Fix vehicle_split_section test by only destroying the vehicle and not the terrain

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4627,6 +4627,24 @@ void map::destroy_furn( const tripoint_bub_ms &p, const bool silent )
     }
 }
 
+void map::destroy_vehicle( const tripoint_bub_ms &p, const bool silent )
+{
+    if( !veh_at( p ) ) {
+        return;
+    }
+
+    // Break if it takes more than 25 destructions to remove to prevent infinite loops
+    // Example: A bashes to B, B bashes to A leads to A->B->A->...
+    int count = 0;
+    bash_params bsh{
+        999, silent, true, false, static_cast<float>( rng_float( 0, 1.0f ) ), false, false, false, false
+    };
+    while( count <= 25 && veh_at( p ) ) {
+        bash_vehicle( p, bsh );
+        count++;
+    }
+}
+
 void map::batter( const tripoint_bub_ms &p, int power, int tries, const bool silent )
 {
     int count = 0;

--- a/src/map.h
+++ b/src/map.h
@@ -1326,6 +1326,8 @@ class map
         void destroy( const tripoint_bub_ms &p, bool silent = false );
         /** Keeps bashing a square until there is no more furniture */
         void destroy_furn( const tripoint_bub_ms &, bool silent = false );
+        /** Keeps bashing a square until there is no more vehicle part */
+        void destroy_vehicle( const tripoint_bub_ms &, bool silent = false );
         void crush( const tripoint_bub_ms &p );
         void shoot( const tripoint_bub_ms &p, projectile &proj, bool hit_items );
         /** Checks if a square should collapse, returns the X for the one_in(X) collapse chance */

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -33,7 +33,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
         REQUIRE( veh_ptr != nullptr );
         std::set<tripoint_bub_ms> original_points = veh_ptr->get_points( true );
 
-        here.destroy( vehicle_origin );
+        here.destroy_vehicle( vehicle_origin );
         veh_ptr->part_removal_cleanup();
         REQUIRE( veh_ptr->get_parts_at( vehicle_origin, "", part_status_flag::available ).empty() );
         vehs = here.get_vehicles();
@@ -73,7 +73,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
         vehicle_origin = { 20, 20, 0 };
         veh_ptr = here.add_vehicle( vehicle_prototype_circle_split_test, vehicle_origin, dir, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        here.destroy( vehicle_origin );
+        here.destroy_vehicle( vehicle_origin );
         veh_ptr->part_removal_cleanup();
         REQUIRE( veh_ptr->get_parts_at( vehicle_origin, "", part_status_flag::available ).empty() );
         vehs = here.get_vehicles();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

More stable CI.

#### Describe the solution

The test was producing a lot of false positives due to destroying terrain under the vehicle, which sometimes could cause collapses that apparently destroyed more vehicle parts. Destroying terrain or anything other than vehicles is irrelevant for the test, so only destroy vehicles.

#### Describe alternatives you've considered



#### Testing

Run tests with `--rng-seed 1735408622 vehicle_split_section`. Note that without this change there was also the curious case that it only failed every second run. Somehow there were additional rng events happening in the runs that passed which ultimately resulted in different rng rolls for the terrain destruction/collapse, but I didn't manage to get to the source of that.

#### Additional context

