### PR TITLE
[XE] Change book required for vampire best friend quest

### DIFF
--- a/data/mods/Xedra_Evolved/npc/npc_vampiresacrifice_chat.json
+++ b/data/mods/Xedra_Evolved/npc/npc_vampiresacrifice_chat.json
@@ -298,11 +298,11 @@
   {
     "id": "mission_best_friend_bookhunt3",
     "type": "mission_definition",
-    "name": { "str": "Help me find my favorite book.  All Things Weird." },
-    "description": "Could you help me find my favorite book?  It's All Things Weird, by Felicity Powell.  It gives a great sense of humor to the end of the world!",
+    "name": { "str": "Help me find my favorite book.  Cat's Cradle." },
+    "description": "Could you help me find my favorite book?  It's Cat's Cradle, by Kurt Vonnegut.  It's an interesting take on an alternate cataclysmic scenario.",
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 2,
-    "item": "book_fict_soft_docu_AWT",
+    "item": "book_fict_soft_satire_cats",
     "origins": [ "ORIGIN_SECONDARY" ],
     "value": 0,
     "dialogue": {


### PR DESCRIPTION
#### Summary
Mods "[XE] Change a vampire book hunt target to bring all the options into parity"

#### Purpose of change
 Two of the books for the XE vampire book hunt quest are lootable while the third one is only attainable via a godco quest from Felicity Powell. The change to the third quest brings it in line with the other two, making all three books lootable instead of locking one behind other quests.

#### Describe the solution
Changed the applicable JSON entries to a new lootable book similar to the other two book hunt quests.

#### Describe alternatives you've considered
Alternatively we could simply change the advice line for the third quest to reflect that the book is only attainable by doing a quest for Felicity Powell however that leaves the one quest significantly more difficult to complete.

#### Testing
The chosen book is lootable and can be used to complete the quest.

#### Additional context

