### PR TITLE
load all of the user’s chosen font files as fallbacks for ImGui to use

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -366,8 +366,7 @@ static void AddGlyphRangesMisc( UNUSED ImFontGlyphRangesBuilder *b )
 }
 
 
-// Load the first font that exists in typefaces, falling back to unifont
-// if none of them exist.
+// Load all fonts that exist in typefaces list
 // - typefaces is a list of paths.
 static void load_font( ImGuiIO &io, const std::vector<font_config> &typefaces,
                        const ImWchar *ranges )
@@ -375,21 +374,23 @@ static void load_font( ImGuiIO &io, const std::vector<font_config> &typefaces,
     std::vector<font_config> io_typefaces{ typefaces };
     ensure_unifont_loaded( io_typefaces );
 
+    ImFontConfig config = ImFontConfig();
+
+    bool first = true;
     auto it = std::begin( io_typefaces );
     for( ; it != std::end( io_typefaces ); ++it ) {
         if( !file_exist( it->path ) ) {
             debugmsg( "Font file '%s' does not exist.", it->path );
+        } else {
+            config.MergeMode = !first;
+            config.FontBuilderFlags = it->imgui_config();
+            io.Fonts->AddFontFromFileTTF( it->path.c_str(), fontheight, &config, ranges );
+            first = false;
         }
-        break;
     }
-    if( it == std::end( io_typefaces ) ) {
+    if( first ) {
         debugmsg( "No fonts were found in the fontdata file." );
     }
-
-    ImFontConfig config = ImFontConfig();
-    config.FontBuilderFlags = it->imgui_config();
-
-    io.Fonts->AddFontFromFileTTF( it->path.c_str(), fontheight, &config, ranges );
 }
 
 static void check_font( const ImFont *font )

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -380,7 +380,7 @@ static void load_font( ImGuiIO &io, const std::vector<font_config> &typefaces,
     auto it = std::begin( io_typefaces );
     for( ; it != std::end( io_typefaces ); ++it ) {
         if( !file_exist( it->path ) ) {
-            debugmsg( "Font file '%s' does not exist.", it->path );
+            printf( "Font file '%s' does not exist.\n", it->path.c_str() );
         } else {
             config.MergeMode = !first;
             config.FontBuilderFlags = it->imgui_config();


### PR DESCRIPTION
#### Summary
Interface "load all of the user’s chosen font files as fallbacks for ImGui to use"

#### Purpose of change
This allows imgui to pull any glyphs missing from the user’s first choice of font from the others in the list.

#### Testing
Set the game locale to Chinese or Japanese. Add an appropriate font to the `gui_font` list in `fonts.json`. Use the ImGui style editor to verify that there are glyphs loaded for both CJK characters and the usual Latin characters.

#### Additional context
I had to wait until ocornut/imgui#8081 was fixed before I could implement this. Now that it’s been fixed and we’ve caught up to a version of ImGui that includes the fix there’s no reason to avoid it.