### PR TITLE
[Magiclysm] Use EoCs to allow Magiclysm fantasy species to gain mutation paths/purify themselves

### DIFF
--- a/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
+++ b/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
@@ -1,6 +1,82 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_FANTASY_SPECIES_REMOVE_THRESHOLD_GAME_START",
+    "eoc_type": "EVENT",
+    "required_event": "game_start",
+    "condition": { "u_has_any_trait": [ "ELVEN_BUILD", "DWARVEN_BUILD", "GOBLIN_BUILD", "LIZARDFOLK_BUILD", "RAVENFOLK_BUILD" ] },
+    "effect": [ { "run_eocs": "EOC_FANTASY_SPECIES_REMOVE_THRESHOLD" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FANTASY_SPECIES_REMOVE_THRESHOLD_RECURRENCE",
+    "recurrence": [ "1 days", "1 days" ],
+    "condition": { "u_has_any_trait": [ "ELVEN_BUILD", "DWARVEN_BUILD", "GOBLIN_BUILD", "LIZARDFOLK_BUILD", "RAVENFOLK_BUILD" ] },
+    "deactivate_condition": {
+      "not": { "u_has_any_trait": [ "ELVEN_BUILD", "DWARVEN_BUILD", "GOBLIN_BUILD", "LIZARDFOLK_BUILD", "RAVENFOLK_BUILD" ] }
+    },
+    "effect": [ { "run_eocs": "EOC_FANTASY_SPECIES_REMOVE_THRESHOLD" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FANTASY_SPECIES_REMOVE_THRESHOLD",
+    "effect": [
+      { "u_lose_trait": "THRESH_SPECIES_ELF" },
+      { "u_lose_trait": "THRESH_SPECIES_DWARF" },
+      { "u_lose_trait": "THRESH_SPECIES_GOBLIN" },
+      { "u_lose_trait": "THRESH_SPECIES_LIZARDFOLK" },
+      { "u_lose_trait": "THRESH_SPECIES_RAVENFOLK" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FANTASY_SPECIES_TRANSFORM_PURIFIER",
+    "recurrence": [ "10 seconds", "10 seconds" ],
+    "condition": { "u_has_any_trait": [ "ELVEN_BUILD", "DWARVEN_BUILD", "GOBLIN_BUILD", "LIZARDFOLK_BUILD", "RAVENFOLK_BUILD" ] },
+    "deactivate_condition": {
+      "not": { "u_has_any_trait": [ "ELVEN_BUILD", "DWARVEN_BUILD", "GOBLIN_BUILD", "LIZARDFOLK_BUILD", "RAVENFOLK_BUILD" ] }
+    },
+    "effect": [
+      { "math": [ "u_purifying_level", "=", "u_vitamin('mutagen_human')" ] },
+      {
+        "if": { "u_has_trait": "ELVEN_BUILD" },
+        "then": [
+          { "math": [ "u_vitamin('mutagen_human')", "-=", "u_purifying_level" ] },
+          { "math": [ "u_vitamin('mutagen_species_elf')", "+=", "u_purifying_level" ] }
+        ]
+      },
+      {
+        "if": { "u_has_trait": "DWARVEN_BUILD" },
+        "then": [
+          { "math": [ "u_vitamin('mutagen_human')", "-=", "u_purifying_level" ] },
+          { "math": [ "u_vitamin('mutagen_species_dwarf')", "+=", "u_purifying_level" ] }
+        ]
+      },
+      {
+        "if": { "u_has_trait": "GOBLIN_BUILD" },
+        "then": [
+          { "math": [ "u_vitamin('mutagen_human')", "-=", "u_purifying_level" ] },
+          { "math": [ "u_vitamin('mutagen_species_goblin')", "+=", "u_purifying_level" ] }
+        ]
+      },
+      {
+        "if": { "u_has_trait": "LIZARDFOLK_BUILD" },
+        "then": [
+          { "math": [ "u_vitamin('mutagen_human')", "-=", "u_purifying_level" ] },
+          { "math": [ "u_vitamin('mutagen_species_lizardfolk')", "+=", "u_purifying_level" ] }
+        ]
+      },
+      {
+        "if": { "u_has_trait": "RAVENFOLK_BUILD" },
+        "then": [
+          { "math": [ "u_vitamin('mutagen_human')", "-=", "u_purifying_level" ] },
+          { "math": [ "u_vitamin('mutagen_species_ravenfolk')", "+=", "u_purifying_level" ] }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_IRON_ALLERGY_WEARING_IRON_OR_STEEL",
     "eoc_type": "EVENT",
     "required_event": "character_wears_item",

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -338,7 +338,6 @@
     "description": "Like a cat, elven eyes are well-attuned to low levels of light, able to pick up even the slightest glimmer.  You have greatly-enhanced night vision.",
     "types": [ "EYES" ],
     "category": [ "SPECIES_ELF" ],
-    "threshreq": [ "THRESH_SPECIES_ELF" ],
     "enchantments": [ { "values": [ { "value": "NIGHT_VIS", "add": 5 } ] } ]
   },
   {
@@ -350,7 +349,6 @@
     "description": "Your delicate pointed ears allow you to hear all the sounds of the world.",
     "types": [ "HEARING" ],
     "category": [ "SPECIES_ELF" ],
-    "threshreq": [ "THRESH_SPECIES_ELF" ],
     "flags": [ "SAFECRACK_NO_TOOL" ],
     "enchantments": [ { "values": [ { "value": "HEARING_MULT", "multiply": 2 } ] } ]
   },
@@ -363,7 +361,6 @@
     "purifiable": false,
     "types": [ "SLEEP" ],
     "category": [ "SPECIES_ELF" ],
-    "threshreq": [ "THRESH_SPECIES_ELF" ],
     "flags": [ "SEESLEEP" ],
     "enchantments": [ { "values": [ { "value": "SLEEPINESS_REGEN", "multiply": 1 }, { "value": "SLEEPINESS", "multiply": -0.166667 } ] } ]
   },
@@ -400,12 +397,6 @@
         "values": [ { "value": "MOVE_COST", "multiply": -0.1 } ]
       }
     ]
-  },
-  {
-    "type": "mutation",
-    "id": "ELFAEYES",
-    "copy-from": "ELFAEYES",
-    "extend": { "category": [ "SPECIES_ELF" ] }
   },
   {
     "type": "mutation",
@@ -503,7 +494,6 @@
     "ugliness": 5,
     "description": "Goblins are much smaller than humans, often no more than half the height.  You have a harder time carrying things and can't eat as much, but you're better at dodging and make very little noise when you move.",
     "category": [ "SPECIES_GOBLIN" ],
-    "threshreq": [ "THRESH_SPECIES_GOBLIN" ],
     "flags": [ "TINY" ],
     "anger_relations": [ [ "WARG", -90 ] ],
     "spells_learned": [ [ "goblin_tame_warg_spell", 1 ] ],
@@ -533,7 +523,6 @@
     "valid": false,
     "flags": [ "MYOPIC_IN_LIGHT" ],
     "category": [ "SPECIES_GOBLIN" ],
-    "threshreq": [ "THRESH_SPECIES_GOBLIN" ],
     "enchantments": [
       {
         "condition": { "not": "is_day" },
@@ -608,7 +597,6 @@
     "ugliness": 0,
     "description": "Lizardfolk are taller and stronger than humans but not much thicker and are surprisingly fast for their size (+1 STR, +1 DEX).",
     "category": [ "SPECIES_LIZARDFOLK" ],
-    "threshreq": [ "THRESH_SPECIES_LIZARDFOLK" ],
     "flags": [ "LARGE" ],
     "enchantments": [
       {
@@ -648,7 +636,6 @@
     "name": { "str": "Ectothermia" },
     "points": -3,
     "description": "Your body has become permanently cold-blooded.  Your speed lowers or raises 1% for every 2 (1.1) degrees below or above 65 F (18.3 C).  All this and you need even more food to maintain your energy.",
-    "threshreq": [ "THRESH_SPECIES_LIZARDFOLK" ],
     "purifiable": false,
     "types": [ "METABOLISM" ],
     "category": [ "SPECIES_LIZARDFOLK" ],
@@ -669,7 +656,6 @@
     "points": 2,
     "purifiable": false,
     "category": [ "SPECIES_LIZARDFOLK" ],
-    "threshreq": [ "THRESH_SPECIES_LIZARDFOLK" ],
     "types": [ "PREDATION" ],
     "flags": [ "PRED2" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "COMBAT_CATCHUP", "multiply": 1.5 } ] } ]
@@ -715,7 +701,6 @@
     "description": "Your face and jaws are those of a predatory lizard, with a set of sharp teeth to go with them.  They look NASTY--as do the bite wounds they can inflict--but prevent wearing mouthgear.",
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
-    "category": [ "SPECIES_LIZARDFOLK" ],
     "restricts_gear": [ "mouth" ],
     "social_modifiers": { "intimidate": 10 },
     "integrated_armor": [ "integrated_lizardfolk_teeth" ]
@@ -744,8 +729,7 @@
     "ugliness": 1,
     "description": "Ravenfolk are about the same size as humans, though their feathers and wings obviously set them apart.",
     "//": "Bird mutation path means this mutation is just to prevent multiple species and doesn't need any modifiers.",
-    "category": [ "SPECIES_RAVENFOLK" ],
-    "threshreq": [ "THRESH_SPECIES_RAVENFOLK" ]
+    "category": [ "SPECIES_RAVENFOLK" ]
   },
   {
     "type": "mutation",
@@ -770,7 +754,6 @@
     "mixed_effect": true,
     "description": "You have a pair of large raven wings projecting from your shoulderblades.  Your body is too heavy to be able to fly, but if you're not too weighed down, you might be able to glide from a ledge or lessen the impact of a fall.",
     "category": [ "SPECIES_RAVENFOLK" ],
-    "threshreq": [ "THRESH_SPECIES_RAVENFOLK" ],
     "types": [ "WINGS" ],
     "strict_threshreq": true,
     "restricts_gear": [ "torso" ],
@@ -792,7 +775,6 @@
     "purifiable": false,
     "types": [ "TEETH", "MUZZLE" ],
     "cancels": [ "MOUTH_TENTACLES" ],
-    "threshreq": [ "THRESH_SPECIES_RAVENFOLK" ],
     "category": [ "SPECIES_RAVENFOLK" ],
     "wet_protection": [ { "part": "mouth", "ignored": 2 } ],
     "restricts_gear": [ "mouth" ],

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -168,7 +168,6 @@
     "description": "Dwarves are smaller than humans, the better to deal with confined spaces underground, but as solid as the mountains (+2 STR, -1 DEX).",
     "flags": [ "SMALL" ],
     "category": [ "SPECIES_DWARF" ],
-    "threshreq": [ "THRESH_SPECIES_DWARF" ],
     "enchantments": [
       {
         "values": [ { "value": "MOVE_COST", "multiply": 0.05 }, { "value": "STRENGTH", "add": 2 }, { "value": "DEXTERITY", "add": -1 } ]
@@ -184,7 +183,6 @@
     "starting_trait": false,
     "purifiable": false,
     "category": [ "SPECIES_DWARF" ],
-    "threshreq": [ "THRESH_SPECIES_DWARF" ],
     "enchantments": [ { "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": 0.1 } ] } ],
     "flags": [ "CRAFT_IN_DARKNESS" ]
   },
@@ -197,8 +195,7 @@
     "starting_trait": false,
     "purifiable": false,
     "enchantments": [ "THERMAL_VISION_GOOD_PASSIVE" ],
-    "category": [ "SPECIES_DWARF", "SPECIES_GOBLIN" ],
-    "threshreq": [ "THRESH_SPECIES_DWARF", "THRESH_SPECIES_GOBLIN" ]
+    "category": [ "SPECIES_DWARF", "SPECIES_GOBLIN" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Use EoCs to allow Magiclysm fantasy species to gain mutation paths/purify themselves"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I gave the Magiclysm fantasy species threshold mutations because some of the  traits they have are post-threshold, but it was never a great solution. Lizardfolk should be able to emulate their black dragon overlords, and the manatouched elven wizard seems like a natural combination. 

Fortunately, thanks to EoCs I have a solution.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Run an EoC on game start and once per day afterwards that removes the threshold mutations from each fantasy species. The game loads fine and doesn't complain if you do this.

Also, have an EoC that converts all purifier taken into the appropriate mutagen. Elven or goblin mutagen doesn't exist in the game (the vitamin is in the files but you can't find it anywhere), but now if you're a goblin and take purifier, it'll revert you to being a goblin and not a human. 

Remove the threshold requirement on almost all fantasy species traits (some are taken from existing mutation lines and this is not possible). 

This still isn't a  perfect solution since each fantasy species has more traits in their pool than they start with otherwise the tests yell at me, but it's better than the previous "no threshold for you" situation.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Started game as an goblin and a dwarf, threshold was properly removed in both cases

Started game as an elf, threshold was properly removed. Debug fully-mutated manatouched and gained all mutations. Took multiple purifiers and properly gained the "Elven reversion' effect. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
