### PR TITLE
remove dead code

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1712,22 +1712,6 @@ void Item_factory::add_actor( std::unique_ptr<iuse_actor> ptr )
     iuse_function_list[ type ] = use_function( std::move( ptr ) );
 }
 
-void Item_factory::add_item_type( const itype &def )
-{
-    if( m_runtimes.count( def.id ) > 0 ) {
-        // Do NOT allow overwriting it, it's undefined behavior
-        debugmsg( "Tried to add runtime type %s, but it exists already", def.id.c_str() );
-        return;
-    }
-
-    auto &new_item_ptr = m_runtimes[ def.id ];
-    new_item_ptr = std::make_unique<itype>( def );
-    if( frozen ) {
-        finalize_pre( *new_item_ptr );
-        finalize_post( *new_item_ptr );
-    }
-}
-
 void Item_factory::init()
 {
     add_iuse( "ACIDBOMB_ACT", &iuse::acidbomb_act );

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -242,13 +242,6 @@ class Item_factory
         const itype *find_template( const itype_id &id ) const;
 
         /**
-         * Add a passed in itype to the collection of item types.
-         * If the item type overrides an existing type, the existing type is deleted first.
-         * @param def The new item type, must not be null.
-         */
-        void add_item_type( const itype &def );
-
-        /**
          * Check if an iuse is known to the Item_factory.
          * @param type Iuse type id.
          */


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Remove dead code.

#### Describe the solution

#### Describe alternatives you've considered

Use it to replace instances of `m_runtimes[ id ].reset( def );`, which I didn't realize at first is adding to `m_runtimes` by `reset` to `def`.

#### Testing

Should compile.

#### Additional context

 - Found in #78950.