### PR TITLE
[MoM] Add electronoetic batteries

### DIFF
--- a/data/mods/MindOverMatter/itemgroups/matrix_technology_labs.json
+++ b/data/mods/MindOverMatter/itemgroups/matrix_technology_labs.json
@@ -72,8 +72,34 @@
     "subtype": "distribution",
     "id": "dist_shield_belts",
     "items": [
-      { "item": "psionic_shield_belt_broken", "prob": 3, "charges": [ 0, 15 ] },
-      { "item": "psionic_shield_belt", "prob": 1, "charges": [ 0, 90 ] }
+      {
+        "item": "medium_battery_electronoetic_refined",
+        "ammo-item": "battery",
+        "charges": [ 100, 448 ],
+        "container-item": "psionic_shield_belt",
+        "prob": 1
+      },
+      {
+        "item": "medium_battery_electronoetic_refined",
+        "ammo-item": "battery",
+        "charges": [ 100, 448 ],
+        "container-item": "psionic_shield_belt_broken",
+        "prob": 6
+      },
+      {
+        "item": "medium_battery_electronoetic",
+        "ammo-item": "battery",
+        "charges": [ 20, 168 ],
+        "container-item": "psionic_shield_belt",
+        "prob": 4
+      },
+      {
+        "item": "medium_battery_electronoetic",
+        "ammo-item": "battery",
+        "charges": [ 20, 168 ],
+        "container-item": "psionic_shield_belt_broken",
+        "prob": 14
+      }
     ]
   },
   {
@@ -81,8 +107,34 @@
     "subtype": "distribution",
     "id": "dist_fire_shield_belts",
     "items": [
-      { "item": "psionic_fire_shield_belt_broken", "prob": 3, "charges": [ 0, 15 ] },
-      { "item": "psionic_fire_shield_belt", "prob": 1, "charges": [ 0, 300 ] }
+      {
+        "item": "medium_battery_electronoetic_refined",
+        "ammo-item": "battery",
+        "charges": [ 100, 448 ],
+        "container-item": "psionic_fire_shield_belt",
+        "prob": 1
+      },
+      {
+        "item": "medium_battery_electronoetic_refined",
+        "ammo-item": "battery",
+        "charges": [ 100, 448 ],
+        "container-item": "psionic_fire_shield_belt_broken",
+        "prob": 6
+      },
+      {
+        "item": "medium_battery_electronoetic",
+        "ammo-item": "battery",
+        "charges": [ 20, 168 ],
+        "container-item": "psionic_fire_shield_belt",
+        "prob": 4
+      },
+      {
+        "item": "medium_battery_electronoetic",
+        "ammo-item": "battery",
+        "charges": [ 20, 168 ],
+        "container-item": "psionic_fire_shield_belt_broken",
+        "prob": 14
+      }
     ]
   },
   {
@@ -107,7 +159,27 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "collection_mindsight_and_note",
-    "items": [ { "item": "psionic_mindsight_glasses", "prob": 100 }, { "item": "lab_file_QD944_P_item", "prob": 100 } ]
+    "items": [
+      {
+        "distribution": [
+          {
+            "item": "light_battery_electronoetic",
+            "ammo-item": "battery",
+            "charges": [ 20, 48 ],
+            "container-item": "psionic_mindsight_glasses",
+            "prob": 80
+          },
+          {
+            "item": "light_battery_electronoetic_refined",
+            "ammo-item": "battery",
+            "charges": [ 60, 128 ],
+            "container-item": "psionic_mindsight_glasses",
+            "prob": 20
+          }
+        ]
+      },
+      { "item": "lab_file_QD944_P_item", "prob": 100 }
+    ]
   },
   {
     "type": "item_group",

--- a/data/mods/MindOverMatter/itemgroups/matrix_technology_labs.json
+++ b/data/mods/MindOverMatter/itemgroups/matrix_technology_labs.json
@@ -41,6 +41,7 @@
       { "item": "chem_sulphuric_acid", "prob": 20, "container-item": "bottle_glass" },
       { "item": "chem_muriatic_acid", "prob": 15, "container-item": "bottle_glass" },
       { "item": "chem_nitric_acid", "prob": 15, "container-item": "bottle_glass" },
+      { "group": "dist_electronoetic_batteries", "prob": 25 },
       { "item": "denat_alcohol", "prob": 10, "charges": [ 250, -1 ] },
       { "item": "methed_alcohol", "prob": 10, "charges": [ 250, -1 ] },
       { "item": "mortar_pestle", "prob": 20 },
@@ -188,6 +189,19 @@
     "items": [ { "item": "psionic_transporter_remote", "prob": 5 }, { "item": "psionic_transporter_beacon", "prob": 1 } ]
   },
   {
+    "id": "dist_electronoetic_batteries",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [
+      { "item": "light_battery_electronoetic", "charges": 48, "prob": 160, "count": [ 1, 4 ] },
+      { "item": "light_battery_electronoetic_refined", "charges": 128, "prob": 16, "count": [ 1, 2 ] },
+      { "item": "medium_battery_electronoetic", "charges": 168, "prob": 80, "count": [ 1, 4 ] },
+      { "item": "medium_battery_electronoetic_refined", "charges": 448, "prob": 8, "count": [ 1, 2 ] },
+      { "item": "heavy_battery_electronoetic", "charges": 777, "prob": 20, "count": [ 1, 2 ] },
+      { "item": "heavy_battery_electronoetic_refined", "charges": 2072, "prob": 2 }
+    ]
+  },
+  {
     "type": "item_group",
     "subtype": "distribution",
     "id": "psi_lab_no_recipes",
@@ -229,6 +243,7 @@
       { "item": "chem_sulphuric_acid", "prob": 20, "container-item": "bottle_glass" },
       { "item": "chem_muriatic_acid", "prob": 15, "container-item": "bottle_glass" },
       { "item": "chem_nitric_acid", "prob": 15, "container-item": "bottle_glass" },
+      { "group": "dist_electronoetic_batteries", "prob": 25 },
       { "item": "denat_alcohol", "prob": 10, "charges": [ 250, -1 ] },
       { "item": "methed_alcohol", "prob": 10, "charges": [ 250, -1 ] },
       { "item": "mortar_pestle", "prob": 20 },
@@ -267,10 +282,10 @@
     "type": "item_group",
     "subtype": "distribution",
     "items": [
-      { "group": "collection_mindsight_and_note", "prob": 1 },
-      { "item": "psionic_telepathic_dampener", "prob": 1 },
-      { "item": "schematics_telepathic_focusing_tool", "prob": 1 },
-      { "item": "telepathic_focusing_tool", "prob": 1 }
+      { "group": "collection_mindsight_and_note", "prob": 4 },
+      { "item": "psionic_telepathic_dampener", "prob": 4 },
+      { "item": "schematics_telepathic_focusing_tool", "prob": 4 },
+      { "item": "telepathic_focusing_tool", "prob": 4 }
     ]
   }
 ]

--- a/data/mods/MindOverMatter/items/armor/belt.json
+++ b/data/mods/MindOverMatter/items/armor/belt.json
@@ -49,7 +49,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "shield belt (active)", "str_pl": "shield belts (active)" },
     "copy-from": "psionic_shield_belt",
-    "power_draw": "200 W",
+    "power_draw": "150 W",
     "revert_to": "psionic_shield_belt",
     "use_action": [
       {
@@ -128,7 +128,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "suppression belt (active)", "str_pl": "suppression belts (active)" },
     "copy-from": "psionic_fire_shield_belt",
-    "power_draw": "80 W",
+    "power_draw": "50 W",
     "revert_to": "psionic_fire_shield_belt",
     "use_action": [
       {

--- a/data/mods/MindOverMatter/items/armor/belt.json
+++ b/data/mods/MindOverMatter/items/armor/belt.json
@@ -13,14 +13,8 @@
     "looks_like": "leather_belt",
     "color": "yellow",
     "material_thickness": 1.5,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM" ],
-        "default_magazine": "medium_battery_electronoetic"
-      }
-    ],
+    "ammo": [ "battery" ],
+    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "NO_REPAIR", "COMBAT_TOGGLEABLE" ],
     "use_action": [
       {
         "type": "transform",
@@ -33,7 +27,14 @@
         "menu_text": "Flip the switch"
       }
     ],
-    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "NO_REPAIR", "COMBAT_TOGGLEABLE" ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_cell"
+      }
+    ],
     "armor": [
       {
         "encumbrance": 2,
@@ -42,7 +43,24 @@
         "specifically_covers": [ "torso_waist" ],
         "volume_encumber_modifier": 0.35
       }
-    ]
+    ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ACTIVE",
+          "name": "Active Shield Belt",
+          "description": "The air around you has a faint shimmer.",
+          "ench_effects": [ { "effect": "effect_shield_belt_telekin_protection", "intensity": 1 } ],
+          "incoming_damage_mod": [
+            { "type": "bash", "add": -8 },
+            { "type": "stab", "add": -20 },
+            { "type": "cut", "add": -15 },
+            { "type": "bullet", "add": -40 }
+          ]
+        }
+      ]
+    }
   },
   {
     "id": "psionic_shield_belt_on",
@@ -93,6 +111,7 @@
     "looks_like": "leather_belt",
     "color": "red",
     "material_thickness": 1.5,
+    "ammo": [ "battery" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -122,7 +141,20 @@
         "specifically_covers": [ "torso_waist" ],
         "volume_encumber_modifier": 0.35
       }
-    ]
+    ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ACTIVE",
+          "name": "Active Suppresion Belt",
+          "description": "The air around you feels cool.",
+          "incoming_damage_mod": [ { "type": "heat", "multiply": -1 } ],
+          "values": [ { "value": "CLIMATE_CONTROL_CHILL", "add": 1000 } ],
+          "ench_effects": [ { "effect": "effect_suppression_belt_fire_protection", "intensity": 1 } ]
+        }
+      ]
+    }
   },
   {
     "id": "psionic_fire_shield_belt_on",

--- a/data/mods/MindOverMatter/items/armor/belt.json
+++ b/data/mods/MindOverMatter/items/armor/belt.json
@@ -13,7 +13,14 @@
     "looks_like": "leather_belt",
     "color": "yellow",
     "material_thickness": 1.5,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "psionic_charge_power": 90 } } ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_electronoetic"
+      }
+    ],
     "use_action": [
       {
         "type": "transform",
@@ -26,7 +33,7 @@
         "menu_text": "Flip the switch"
       }
     ],
-    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "NO_REPAIR", "COMBAT_TOGGLEABLE", "NO_UNLOAD" ],
+    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "NO_REPAIR", "COMBAT_TOGGLEABLE" ],
     "armor": [
       {
         "encumbrance": 2,
@@ -35,31 +42,14 @@
         "specifically_covers": [ "torso_waist" ],
         "volume_encumber_modifier": 0.35
       }
-    ],
-    "relic_data": {
-      "passive_effects": [
-        {
-          "has": "WORN",
-          "condition": "ACTIVE",
-          "ench_effects": [ { "effect": "effect_shield_belt_telekin_protection", "intensity": 1 } ],
-          "incoming_damage_mod": [
-            { "type": "bash", "add": -8 },
-            { "type": "stab", "add": -20 },
-            { "type": "cut", "add": -15 },
-            { "type": "bullet", "add": -40 }
-          ]
-        }
-      ],
-      "charge_info": { "recharge_type": "periodic", "time": "60 s", "regenerate_ammo": true }
-    },
-    "//": "Recharge time is 60 seconds due to bug #48019, making it actually 30 seconds. Reduce to 30 seconds if that ever gets fixed."
+    ]
   },
   {
     "id": "psionic_shield_belt_on",
     "type": "TOOL_ARMOR",
     "name": { "str": "shield belt (active)", "str_pl": "shield belts (active)" },
     "copy-from": "psionic_shield_belt",
-    "turns_per_charge": 1,
+    "power_draw": "200 W",
     "revert_to": "psionic_shield_belt",
     "use_action": [
       {
@@ -86,8 +76,7 @@
         "need_worn": true,
         "menu_text": "Flip the switch"
       }
-    ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "psionic_charge_power": 90 } } ]
+    ]
   },
   {
     "id": "psionic_fire_shield_belt",
@@ -103,7 +92,14 @@
     "looks_like": "leather_belt",
     "color": "red",
     "material_thickness": 1.5,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "psionic_charge_power": 300 } } ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_electronoetic"
+      }
+    ],
     "use_action": [
       {
         "type": "transform",
@@ -116,7 +112,7 @@
         "menu_text": "Flip the switch"
       }
     ],
-    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "NO_REPAIR", "COMBAT_TOGGLEABLE", "NO_UNLOAD" ],
+    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "NO_REPAIR", "COMBAT_TOGGLEABLE" ],
     "armor": [
       {
         "encumbrance": 2,
@@ -125,27 +121,14 @@
         "specifically_covers": [ "torso_waist" ],
         "volume_encumber_modifier": 0.35
       }
-    ],
-    "relic_data": {
-      "passive_effects": [
-        {
-          "has": "WORN",
-          "condition": "ACTIVE",
-          "incoming_damage_mod": [ { "type": "heat", "multiply": -1 } ],
-          "values": [ { "value": "CLIMATE_CONTROL_CHILL", "add": 1000 } ],
-          "ench_effects": [ { "effect": "effect_suppression_belt_fire_protection", "intensity": 1 } ]
-        }
-      ],
-      "charge_info": { "recharge_type": "periodic", "time": "30 s", "regenerate_ammo": true }
-    },
-    "//": "Recharge time is 30 seconds due to bug #48019, making it actually 15 seconds. Reduce to 15 seconds if that ever gets fixed."
+    ]
   },
   {
     "id": "psionic_fire_shield_belt_on",
     "type": "TOOL_ARMOR",
     "name": { "str": "suppression belt (active)", "str_pl": "suppression belts (active)" },
     "copy-from": "psionic_fire_shield_belt",
-    "turns_per_charge": 1,
+    "power_draw": "80 W",
     "revert_to": "psionic_fire_shield_belt",
     "use_action": [
       {
@@ -173,6 +156,13 @@
         "menu_text": "Flip the switch"
       }
     ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "psionic_charge_power": 300 } } ]
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_electronoetic"
+      }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/items/armor/belt.json
+++ b/data/mods/MindOverMatter/items/armor/belt.json
@@ -7,7 +7,7 @@
     "weight": "350 g",
     "volume": "500 ml",
     "price": "100 USD",
-    "price_postapoc": "5 USD",
+    "price_postapoc": "50 USD",
     "material": [ "nylon", "steel", "nether_crystal" ],
     "symbol": "[",
     "looks_like": "leather_belt",
@@ -68,6 +68,7 @@
     "name": { "str": "shield belt" },
     "copy-from": "psionic_shield_belt",
     "description": "A simple synthetic fabric belt with a box to the right of the belt loop.  The box has a toggleable switch and a stylized shield with Ψ and the XEDRA logo inside it.  It also has a large crack across it and rattles when moved.",
+    "price_postapoc": "5 USD",
     "use_action": [
       {
         "type": "transform",
@@ -86,7 +87,7 @@
     "weight": "350 g",
     "volume": "500 ml",
     "price": "100 USD",
-    "price_postapoc": "5 USD",
+    "price_postapoc": "50 USD",
     "material": [ "nylon", "steel", "nether_crystal" ],
     "symbol": "[",
     "looks_like": "leather_belt",
@@ -147,6 +148,7 @@
     "copy-from": "psionic_fire_shield_belt",
     "name": { "str": "suppression belt" },
     "description": "A simple synthetic fabric belt with a box to the right of the belt loop.  The box has a toggleable switch and a stylized flame with a large circle and line superimposed over it and a Ψ behind the XEDRA logo inside it.  It also has a large crack across it and rattles when moved.",
+    "price_postapoc": "5 USD",
     "use_action": [
       {
         "type": "transform",

--- a/data/mods/MindOverMatter/items/armor/head.json
+++ b/data/mods/MindOverMatter/items/armor/head.json
@@ -66,7 +66,7 @@
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
-        "default_magazine": "light_plus_battery_cell"
+        "default_magazine": "light_battery_electronoetic"
       }
     ],
     "armor": [ { "encumbrance": 4, "coverage": 100, "covers": [ "eyes" ] } ],

--- a/data/mods/MindOverMatter/items/batteries.json
+++ b/data/mods/MindOverMatter/items/batteries.json
@@ -1,0 +1,111 @@
+[
+  {
+    "id": "light_battery_electronoetic",
+    "type": "MAGAZINE",
+    "category": "tool_magazine",
+    "name": { "str": "light electronoetic battery", "str_pl": "light electronoetic batteries" },
+    "description": "A light battery but with the casing devoid of branding or symbols other than a plus and minus on opposite ends.  It's surprisingly heavy.",
+    "ascii_picture": "light_battery_cell",
+    "weight": "20 g",
+    "volume": "8 ml",
+    "longest_side": "50 mm",
+    "price": "31 cent",
+    "price_postapoc": "2 USD",
+    "material": [
+      { "type": "budget_steel", "portion": 90 },
+      { "type": "nether_crystal", "portion": 9 },
+      { "type": "plastic", "portion": 1 }
+    ],
+    "symbol": "=",
+    "color": "cyan",
+    "ammo_type": [ "battery" ],
+    "//": "Capacity 3x normal",
+    "capacity": 48,
+    "looks_like": "battery",
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_LIGHT" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 48 } } ]
+  },
+  {
+    "id": "light_battery_electronoetic_refined",
+    "copy-from": "light_battery_electronoetic",
+    "type": "MAGAZINE",
+    "category": "tool_magazine",
+    "name": { "str": "light refined electronoetic battery", "str_pl": "light refined electronoetic batteries" },
+    "//": "Capacity 8x normal",
+    "capacity": 128,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 128 } } ]
+  },
+  {
+    "id": "medium_battery_electronoetic",
+    "type": "MAGAZINE",
+    "category": "tool_magazine",
+    "name": { "str": "medium electronoetic battery", "str_pl": "medium electronoetic batteries" },
+    "description": "A medium battery but with the casing devoid of branding or symbols other than a plus and minus on opposite ends.  It's surprisingly heavy.",
+    "ascii_picture": "medium_battery_cell",
+    "weight": "100 g",
+    "volume": "17 ml",
+    "longest_side": "65 mm",
+    "price": "101 cent",
+    "price_postapoc": "5 USD",
+    "material": [
+      { "type": "budget_steel", "portion": 90 },
+      { "type": "nether_crystal", "portion": 9 },
+      { "type": "plastic", "portion": 1 }
+    ],
+    "symbol": "=",
+    "color": "cyan",
+    "ammo_type": [ "battery" ],
+    "looks_like": "battery",
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_MEDIUM" ],
+    "//": "Capacity 3x normal",
+    "capacity": 168,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 168 } } ]
+  },
+  {
+    "id": "medium_battery_electronoetic_refined",
+    "copy-from": "medium_battery_electronoetic",
+    "type": "MAGAZINE",
+    "category": "tool_magazine",
+    "name": { "str": "medium refined electronoetic battery", "str_pl": "medium refined electronoetic batteries" },
+    "//": "Capacity 8x normal",
+    "capacity": 448,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 448 } } ]
+  },
+  {
+    "id": "heavy_battery_electronoeti",
+    "type": "MAGAZINE",
+    "category": "tool_magazine",
+    "name": { "str": "electronoetic tool battery", "str_pl": "electronoetic tool batteries" },
+    "description": "A battery cell, compatible with all kinds of industrial-grade equipment and portable tools, but with the casing devoid of branding or symbols other than a plus and minus on opposite ends.  It's surprisingly heavy.",
+    "ascii_picture": "heavy_battery_cell",
+    "weight": "400 g",
+    "volume": "382 ml",
+    "longest_side": "113 mm",
+    "//2": "113 * 75 * 62 mm",
+    "price": "22 USD",
+    "price_postapoc": "35 cent",
+    "material": [
+      { "type": "budget_steel", "portion": 90 },
+      { "type": "nether_crystal", "portion": 9 },
+      { "type": "plastic", "portion": 1 }
+    ],
+    "symbol": "=",
+    "color": "yellow",
+    "ammo_type": [ "battery" ],
+    "//": "Capacity 3x normal",
+    "capacity": 777,
+    "looks_like": "battery",
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_HEAVY" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 777 } } ]
+  },
+  {
+    "id": "heavy_battery_electronoetic_refined",
+    "copy-from": "medium_battery_electronoetic",
+    "type": "MAGAZINE",
+    "category": "tool_magazine",
+    "name": { "str": "refined electronoetic tool battery", "str_pl": "refined electronoetic tool batteries" },
+    "//": "Capacity 8x normal",
+    "capacity": 2072,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 2072 } } ]
+  }
+]

--- a/data/mods/MindOverMatter/items/batteries.json
+++ b/data/mods/MindOverMatter/items/batteries.json
@@ -72,7 +72,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 448 } } ]
   },
   {
-    "id": "heavy_battery_electronoeti",
+    "id": "heavy_battery_electronoetic",
     "type": "MAGAZINE",
     "category": "tool_magazine",
     "name": { "str": "electronoetic tool battery", "str_pl": "electronoetic tool batteries" },

--- a/data/mods/MindOverMatter/items/batteries.json
+++ b/data/mods/MindOverMatter/items/batteries.json
@@ -90,7 +90,7 @@
       { "type": "plastic", "portion": 1 }
     ],
     "symbol": "=",
-    "color": "yellow",
+    "color": "cyan",
     "ammo_type": [ "battery" ],
     "//": "Capacity 3x normal",
     "capacity": 777,

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -1739,6 +1739,7 @@ electrolyzer
 electrolyzers
 electromagnetics
 electromancy
+electronoetic
 electroreceptors
 elephantry
 Elish


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add electronoetic batteries"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

More dense energy storage for batteries is something people have been working on for a while and definitely something that Project PHAVIAN would have devoted effort towards, and the existence of Electrokinesis means they could have succeeded. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add electronoetic light, medium, and tool batteries and refined versions of the same. The base version has 3x more dense energy storage (roughly the existing difference between nickel cadmium and lithium ion batteries), and the refined version has 8x more dense energy storage.

Change the shield belt and suppression belt so they come with electronoetic batteries in them. Due to the way relic_data works this will not affect existing belts, so your belts are safe.

Hopefully eventually I can make these rechargeable through special machines, but at the moment `RECHARGEABLE` is a true/false flag, so they're not rechargeable at the moment. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a bunch of psi division captains, picked up the shield belts, and turned them on and off.

Checked itemgroups for batteries. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
