### PR TITLE
Viktor hand for mana touched redux

### DIFF
--- a/data/mods/Magiclysm/Spells/manatouched.json
+++ b/data/mods/Magiclysm/Spells/manatouched.json
@@ -57,7 +57,7 @@
     "energy_source": "MANA",
     "base_energy_cost": "1000",
     "damage_type": "nether",
-    "max_level":0,
+    "max_level": 0,
     "min_damage": 80,
     "max_damage": 80,
     "min_range": 15,

--- a/data/mods/Magiclysm/Spells/manatouched.json
+++ b/data/mods/Magiclysm/Spells/manatouched.json
@@ -65,6 +65,6 @@
     "min_bash_scaling": 2,
     "max_bash_scaling": 2,
     "base_casting_time": 200,
-    "flags": [ "IGNORES_WALLS", "NO_FAIL"]
+    "flags": [ "IGNORES_WALLS", "NO_FAIL" ]
   }
 ]

--- a/data/mods/Magiclysm/Spells/manatouched.json
+++ b/data/mods/Magiclysm/Spells/manatouched.json
@@ -45,5 +45,26 @@
     "sound_description": "a zing",
     "flags": [ "CHANNELING_SPELL", "RANDOM_DAMAGE", "RANDOM_TARGET", "SOMATIC", "NO_LEGS", "MUST_HAVE_CLASS_TO_LEARN" ],
     "extra_effects": [ { "id": "magic_missile" }, { "id": "magic_missile" }, { "id": "magic_missile" }, { "id": "magic_missile" } ]
+  },
+  {
+    "id": "viktorhand_manatouched_deathray",
+    "type": "SPELL",
+    "name": "Death Ray",
+    "effect": "attack",
+    "shape": "line",
+    "description": "An orb of mana concentrates within your grasping appendage before rupturing in a line to ravage your enemies.",
+    "valid_targets": [ "hostile", "ground" ],
+    "energy_source": "MANA",
+    "base_energy_cost": "1000",
+    "damage_type": "nether",
+    "max_level":0,
+    "min_damage": 80,
+    "max_damage": 80,
+    "min_range": 15,
+    "max_range": 15,
+    "min_bash_scaling": 2,
+    "max_bash_scaling": 2,
+    "base_casting_time": 200,
+    "flags": [ "IGNORES_WALLS", "NO_FAIL"]
   }
 ]

--- a/data/mods/Magiclysm/items/integrated.json
+++ b/data/mods/Magiclysm/items/integrated.json
@@ -5,9 +5,9 @@
     "name": { "str_sp": "grasping appendage" },
     "description": "Your photophore, contaminated by extreme mana exposure, has mutated into a magical limb capable of magically suspending objects midair and using that same magic to project a concussive beam of force.",
     "material": [ { "type": "arcane_skin" }, { "type": "flesh" } ],
-    "techniques": ["VIKTORHAND_MANATOUCHED_BLAST"],
     "color": "blue",
     "symbol": "/",
+    "techniques": ["VIKTORHAND_MANATOUCHED_BLAST"],
     "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT", "PROVIDES_TECHNIQUES"],
     "pocket_data": [
       {

--- a/data/mods/Magiclysm/items/integrated.json
+++ b/data/mods/Magiclysm/items/integrated.json
@@ -7,8 +7,8 @@
     "material": [ { "type": "arcane_skin" }, { "type": "flesh" } ],
     "color": "blue",
     "symbol": "/",
-    "techniques": ["VIKTORHAND_MANATOUCHED_BLAST"],
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT", "PROVIDES_TECHNIQUES"],
+    "techniques": [ "VIKTORHAND_MANATOUCHED_BLAST" ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT", "PROVIDES_TECHNIQUES" ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",

--- a/data/mods/Magiclysm/items/integrated.json
+++ b/data/mods/Magiclysm/items/integrated.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "vitkorhand_manatouched_item",
+    "type": "TOOL",
+    "name": { "str_sp": "grasping appendage" },
+    "description": "Your photophore, contaminated by extreme mana exposure, has mutated into a magical limb capable of magically suspending objects midair and using that same magic to project a concussive beam of force.",
+    "material": [ { "type": "arcane_skin" }, { "type": "flesh" } ],
+    "techniques": ["VIKTORHAND_MANATOUCHED_BLAST"],
+    "color": "blue",
+    "symbol": "/",
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT", "PROVIDES_TECHNIQUES"],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "holster": true,
+        "max_contains_volume": "10000  L",
+        "max_contains_weight": "1000 kg",
+        "max_item_length": "3000 cm",
+        "moves": 5,
+        "weight_multiplier": 0.0,
+        "volume_multiplier": 0.0,
+        "volume_encumber_modifier": 0
+      }
+    ]
+  },
+  {
     "id": "integrated_goblin_teeth",
     "copy-from": "integrated_fangs",
     "type": "ARMOR",

--- a/data/mods/Magiclysm/techniques.json
+++ b/data/mods/Magiclysm/techniques.json
@@ -27,7 +27,7 @@
     "weighting": 5,
     "eocs": [
       {
-        "id": "tec_VITKORHAND_MANATOUCHED_BLAST",
+       "id": "tec_VITKORHAND_MANATOUCHED_BLAST",
         "effect": [
           { "math": [ "_damagetracker = u_val('mana')/500 + u_skill('spellcraft')" ] },
           {

--- a/data/mods/Magiclysm/techniques.json
+++ b/data/mods/Magiclysm/techniques.json
@@ -19,19 +19,28 @@
     "type": "technique",
     "id": "VIKTORHAND_MANATOUCHED_BLAST",
     "name": "magichand manablast",
-    "//": "supposed to simulate a chaser attack.",
+    "//": "supposed to simulate a chaser attack. You attack, and then your mana-hand pitches in another blast.",
     "melee_allowed": true,
     "unarmed_allowed": true,
     "reach_ok": true,
     "crit_ok": true,
-    "messages": [ "Your appendage blasts $s", "<npcname> blasts $s!" ],
     "weighting": 5,
-    "flat_bonuses": [
-      { "stat": "damage", "type": "bash", "scaling-stat": "int", "scale": 0.75 },
-      { "stat": "damage", "type": "nether", "scaling-stat": "spellcraft", "scale": 1 },
-      { "stat": "damage", "type": "bash", "scaling-stat": "per", "scale": 0.5 },
-      { "stat": "damage", "type": "pure", "scaling-stat": "u_val('mana')", "scale": 0.001 }
+    "eocs": [
+      {
+        "id": "tec_VITKORHAND_MANATOUCHED_BLAST",
+        "effect": [
+          { "math": [ "damagetracker1 = u_val('mana')/500" ] },
+          { "math": [ "damagetracker2 = u_skill('spellcraft')" ] },
+          { "math": [ "_damagetracker3 = damagetracker1 + damagetracker2" ] },
+          {
+            "u_message": "Your appendage blasts the <npc_name> for <context_val:damagetracker3> damage!",
+            "type": "good"
+          },
+          { "npc_message": "<npc_name>'s appendage blasts the %s!", "type": "good" },
+          { "npc_deal_damage": "pure", "amount": { "math": [ "(u_val('mana')/500)+u_skill('spellcraft')" ] } }
+        ]
+      }
     ],
-    "attack_vectors": ["vector_null"]
+    "attack_vectors": [ "vector_wrist" ]
   }
 ]

--- a/data/mods/Magiclysm/techniques.json
+++ b/data/mods/Magiclysm/techniques.json
@@ -29,11 +29,9 @@
       {
         "id": "tec_VITKORHAND_MANATOUCHED_BLAST",
         "effect": [
-          { "math": [ "damagetracker1 = u_val('mana')/500" ] },
-          { "math": [ "damagetracker2 = u_skill('spellcraft')" ] },
-          { "math": [ "_damagetracker3 = damagetracker1 + damagetracker2" ] },
+          { "math": [ "_damagetracker = u_val('mana')/500 + u_skill('spellcraft')" ] },
           {
-            "u_message": "Your appendage blasts the <npc_name> for <context_val:damagetracker3> damage!",
+            "u_message": "Your appendage blasts the <npc_name> for <context_val:damagetracker> damage!",
             "type": "good"
           },
           { "npc_message": "<npc_name>'s appendage blasts the %s!", "type": "good" },

--- a/data/mods/Magiclysm/techniques.json
+++ b/data/mods/Magiclysm/techniques.json
@@ -14,5 +14,24 @@
     ],
     "description": "Cut damage multiply by 2, crit only",
     "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "VIKTORHAND_MANATOUCHED_BLAST",
+    "name": "magichand manablast",
+    "//": "supposed to simulate a chaser attack.",
+    "melee_allowed": true,
+    "unarmed_allowed": true,
+    "reach_ok": true,
+    "crit_ok": true,
+    "messages": [ "Your appendage blasts $s", "<npcname> blasts $s!" ],
+    "weighting": 5,
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "int", "scale": 0.75 },
+      { "stat": "damage", "type": "nether", "scaling-stat": "spellcraft", "scale": 1 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "per", "scale": 0.5 },
+      { "stat": "damage", "type": "pure", "scaling-stat": "u_val('mana')", "scale": 0.001 }
+    ],
+    "attack_vectors": ["vector_null"]
   }
 ]

--- a/data/mods/Magiclysm/traits/manatouched.json
+++ b/data/mods/Magiclysm/traits/manatouched.json
@@ -136,7 +136,8 @@
     "type": "mutation",
     "id": "BIOLUM0",
     "copy-from": "BIOLUM0",
-    "extend": { "category": [ "MANATOUCHED" ] }
+    "extend": { "category": [ "MANATOUCHED" ] },
+    "changes_to": ["VIKTORHAND_MANATOUCHED"]
   },
   {
     "type": "mutation",
@@ -324,5 +325,17 @@
     "copy-from": "MORE_PAIN",
     "valid": true,
     "extend": { "category": [ "MANATOUCHED", "SPECIES_ELF" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "VIKTORHAND_MANATOUCHED",
+    "name": "Grasping Appendage",
+    "//": "give me a better name and that'll be the name",
+    "points": 8,
+    "description": "Your photophore, contaminated by extreme mana pollution, has mutated into a manipulator capable of magically suspending objects midair and using that same magic to project a concussive beam of force, both from range and in melee.",
+    "integrated_armor": ["vitkorhand_manatouched_item"],
+    "spells_learned": [["viktorhand_manatouched_deathray", 0]],
+    "category": ["MANATOUCHED"],
+    "threshreq": ["THRESH_MANA"]
   }
 ]

--- a/data/mods/Magiclysm/traits/manatouched.json
+++ b/data/mods/Magiclysm/traits/manatouched.json
@@ -137,7 +137,7 @@
     "id": "BIOLUM0",
     "copy-from": "BIOLUM0",
     "extend": { "category": [ "MANATOUCHED" ] },
-    "changes_to": ["VIKTORHAND_MANATOUCHED"]
+    "changes_to": [ "VIKTORHAND_MANATOUCHED" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Magiclysm/traits/manatouched.json
+++ b/data/mods/Magiclysm/traits/manatouched.json
@@ -333,9 +333,9 @@
     "//": "give me a better name and that'll be the name",
     "points": 8,
     "description": "Your photophore, contaminated by extreme mana pollution, has mutated into a manipulator capable of magically suspending objects midair and using that same magic to project a concussive beam of force, both from range and in melee.",
-    "integrated_armor": ["vitkorhand_manatouched_item"],
-    "spells_learned": [["viktorhand_manatouched_deathray", 0]],
-    "category": ["MANATOUCHED"],
-    "threshreq": ["THRESH_MANA"]
+    "integrated_armor": [ "vitkorhand_manatouched_item" ],
+    "spells_learned": [ [ "viktorhand_manatouched_deathray", 0 ] ],
+    "category": [ "MANATOUCHED" ],
+    "threshreq": [ "THRESH_MANA" ]
   }
 ]


### PR DESCRIPTION

#### Summary
Mods "Gives mages another reason to use Manatouched."

#### Purpose of change

Slime's kinda _**the**_ mutation line for mages in Magiclysm, even moreso than the _manatouched_ line. Higher int means higher mana AND focus, which means more mana regen & more spell EXP. I want to make a few additions to Manatouched to make it worth taking over Slime, first of which'll be this magical appendage.

#### Describe the solution

Adds a magical limb mutation - evolves from Reflex Photophore - that can lift anything in a field of magic that it projects.

A spell & technique comes alongside the limb - Death Ray, a line blast that does 80 damage to enemies & structures, and a blast that scales off of mana amount & spellcraft level.

#### Describe alternatives you've considered

keep the embodiment of mana jealous of slime mutants

#### Testing
Loaded up a game, gave myself Debug Mana mutation & tested the damage. Gave myself 10 spellcraft & tested the damage. Spawned an industrial trash can, it's being suspended in the field no problem.

#### Additional context
I'm probably going to add some more mana-focused mutations later. 

Redo of #78946. This was opened 'cause of a branch conflict that I couldn't see in Git. The previous PR has been closed.