### PR TITLE
whitelist roadstop overmap terrain test

### DIFF
--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -24,7 +24,11 @@
       "s_reststop_1_roof",
       "s_reststop_2_roof",
       "s_restparking_1",
-      "s_restparking_2"
+      "s_restparking_2",
+      "roadstop",
+      "roadstop_roof",
+      "roadstop_a",
+      "roadstop_a_roof"
     ]
   }
 ]


### PR DESCRIPTION


#### Summary
Bugfixes "whitelist roadstop overmap terrain test"

#### Purpose of change

Fix build

#### Describe the solution

Adds the four variants of roadstop terrains to the overmap test whitelist. They all are set to ""priority": -1" so should be routinely failing the overmap test and they are, for example https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12692962927/job/35382138605?pr=78875

#### Describe alternatives you've considered

Increase their priority, but this would make it so they could not generate next to an existing road because mapgen is built strangely for that
Remove them
Make them uniques

#### Testing

N/A

#### Additional context

Following these instructions from the test failure output:
To resolve errors about missing terrains you can either give the terrain the
([slow] ~starting_items)=> SHOULD_NOT_SPAWN flag, intended for terrains that should never spawn, for
([slow] ~starting_items)=> example test terrains or work in progress, or tweak the constraints so that
([slow] ~starting_items)=> the terrain can spawn more reliably, or add them to the whitelist at /data/
([slow] ~starting_items)=> mods/TEST_DATA/overmap_terrain_coverage_test/
([slow] ~starting_items)=> overmap_terrain_coverage_whitelist.json intended for terrains that sometimes
([slow] ~starting_items)=> spawn, but cannot be expected to spawn reliably enough for this test.
