### PR TITLE
Refactor `ammo_effect_BOUNCE`

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -56,7 +56,7 @@
   {
     "id": "BOUNCE",
     "type": "ammo_effect",
-    "//": "Inflicts target with `bounced` effect and rebounds to a nearby target without this effect. Hardcoded"
+    "//": "Projectile with this effect will rebound to a nearby target after hitting the oringinal target. Will not choose targets already hit by this projectile. Hardcoded"
   },
   {
     "id": "BURST",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -302,12 +302,6 @@
   },
   {
     "type": "effect_type",
-    "id": "bounced",
-    "name": [ { "str": "Bounced", "//~": "NO_I18N" } ],
-    "desc": [ { "str": "AI tag used for bouncing ammo targeting.  This is a bug if you have it.", "//~": "NO_I18N" } ]
-  },
-  {
-    "type": "effect_type",
     "id": "npc_value_interaction_timer_short",
     "//2": "This prevents you from building value with NPCs too quickly by just talking to them constantly."
   },

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -57,8 +57,6 @@ static const ammo_effect_str_id ammo_effect_STREAM_TINY( "STREAM_TINY" );
 static const ammo_effect_str_id ammo_effect_TANGLE( "TANGLE" );
 static const ammo_effect_str_id ammo_effect_WIDE( "WIDE" );
 
-static const efftype_id effect_bounced( "bounced" );
-
 static const itype_id itype_glass_shard( "glass_shard" );
 
 static const json_character_flag json_flag_HARDTOHIT( "HARDTOHIT" );
@@ -545,18 +543,20 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
 
     // TODO: Move this outside now that we have hit point in return values?
     if( proj.proj_effects.count( ammo_effect_BOUNCE ) ) {
-        // Add effect so the shooter is not targeted itself.
-        if( origin && !origin->has_effect( effect_bounced ) ) {
-            origin->add_effect( effect_bounced, 1_turns );
-        }
         Creature *mon_ptr = g->get_creature_if( [&]( const Creature & z ) {
+            if( &z == origin ) {
+                return false;
+            }
             // search for creatures in radius 4 around impact site
             if( rl_dist( z.pos_bub(), tp ) <= 4 &&
                 here.sees( z.pos_bub(), tp, -1 ) ) {
                 // don't hit targets that have already been hit
-                if( !z.has_effect( effect_bounced ) ) {
-                    return true;
+                for( auto it : attack.targets_hit ) {
+                    if( &z == it.first ) {
+                        return false;
+                    }
                 }
+                return true;
             }
             return false;
         } );

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -219,9 +219,9 @@ projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersi
 }
 
 void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_arg,
-        const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
-        const dispersion_sources &dispersion, Creature *origin, const vehicle *in_veh,
-        const weakpoint_attack &wp_attack, bool first )
+                        const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
+                        const dispersion_sources &dispersion, Creature *origin, const vehicle *in_veh,
+                        const weakpoint_attack &wp_attack, bool first )
 {
     const bool do_animation = first && get_option<bool>( "ANIMATION_PROJECTILES" );
 

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -220,7 +220,7 @@ projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersi
     return aim;
 }
 
-dealt_projectile_attack projectile_attack( const projectile &proj_arg,
+void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_arg,
         const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
         const dispersion_sources &dispersion, Creature *origin, const vehicle *in_veh,
         const weakpoint_attack &wp_attack, bool first )
@@ -258,14 +258,16 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg,
 
     // TODO: move to-hit roll back in here
 
-    dealt_projectile_attack attack {
-        proj_arg, nullptr, dealt_damage_instance(), source, aim.missed_by
-    };
+    attack.proj = proj_arg;
+    attack.hit_critter = nullptr;
+    attack.dealt_dam = dealt_damage_instance();
+    attack.end_point = source;
+    attack.missed_by = aim.missed_by;
 
     // No suicidal shots
     if( source == target_arg ) {
         debugmsg( "Projectile_attack targeted own square." );
-        return attack;
+        return;
     }
 
     projectile &proj = attack.proj;
@@ -561,12 +563,9 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg,
         if( mon_ptr ) {
             Creature &z = *mon_ptr;
             add_msg( _( "The attack bounced to %s!" ), z.get_name() );
-            z.add_effect( effect_bounced, 1_turns );
-            projectile_attack( proj, tp, z.pos_bub(), dispersion, origin, in_veh );
+            projectile_attack( attack, proj, tp, z.pos_bub(), dispersion, origin, in_veh );
             sfx::play_variant_sound( "fire_gun", "bio_lightning_tail",
                                      sfx::get_heard_volume( z.pos_bub() ), sfx::get_heard_angle( z.pos_bub() ) );
         }
     }
-
-    return attack;
 }

--- a/src/ballistics.h
+++ b/src/ballistics.h
@@ -40,10 +40,10 @@ projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersi
  *  dispersion.
  *  Returns the rolled dispersion of the shot and the actually hit point.
  */
-void projectile_attack( dealt_projectile_attack &shot, const projectile &proj_arg,
+void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_arg,
                         const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
                         const dispersion_sources &dispersion, Creature *origin = nullptr, const vehicle *in_veh = nullptr,
-                        const weakpoint_attack &attack = weakpoint_attack(), bool first = true );
+                        const weakpoint_attack &wp_attack = weakpoint_attack(), bool first = true );
 
 /* Used for selecting which part to target in a projectile attack
  * Primarily a template for ease of testing, but can be reused!

--- a/src/ballistics.h
+++ b/src/ballistics.h
@@ -40,7 +40,7 @@ projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersi
  *  dispersion.
  *  Returns the rolled dispersion of the shot and the actually hit point.
  */
-dealt_projectile_attack projectile_attack( const projectile &proj_arg,
+void projectile_attack( dealt_projectile_attack &shot, const projectile &proj_arg,
         const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
         const dispersion_sources &dispersion, Creature *origin = nullptr, const vehicle *in_veh = nullptr,
         const weakpoint_attack &attack = weakpoint_attack(), bool first = true );

--- a/src/ballistics.h
+++ b/src/ballistics.h
@@ -41,9 +41,9 @@ projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersi
  *  Returns the rolled dispersion of the shot and the actually hit point.
  */
 void projectile_attack( dealt_projectile_attack &shot, const projectile &proj_arg,
-        const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
-        const dispersion_sources &dispersion, Creature *origin = nullptr, const vehicle *in_veh = nullptr,
-        const weakpoint_attack &attack = weakpoint_attack(), bool first = true );
+                        const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
+                        const dispersion_sources &dispersion, Creature *origin = nullptr, const vehicle *in_veh = nullptr,
+                        const weakpoint_attack &attack = weakpoint_attack(), bool first = true );
 
 /* Used for selecting which part to target in a projectile attack
  * Primarily a template for ease of testing, but can be reused!

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1026,8 +1026,8 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             proj.range = rl_dist( pr.second, pos_bub() ) - 1;
             proj.proj_effects = {{ ammo_effect_NO_ITEM_DAMAGE, ammo_effect_DRAW_AS_LINE, ammo_effect_NO_DAMAGE_SCALING, ammo_effect_JET }};
 
-            dealt_projectile_attack dealt = projectile_attack(
-                                                proj, pr.second, pos_bub(), dispersion_sources{ 0 }, this );
+            dealt_projectile_attack dealt;
+            projectile_attack( dealt, proj, pr.second, pos_bub(), dispersion_sources{ 0 }, this );
             here.add_item_or_charges( dealt.end_point, pr.first );
         }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1376,14 +1376,20 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
 
     proj.apply_effects_damage( *this, source, dealt_dam, goodhit < accuracy_critical );
 
+    int total_dam = dealt_dam.total_damage();
+
     if( print_messages ) {
-        messaging_projectile_attack( source, hit_selection, dealt_dam.total_damage() );
+        messaging_projectile_attack( source, hit_selection, total_dam );
     }
 
     check_dead_state();
     attack.hit_critter = this;
     attack.missed_by = goodhit;
     attack.headshot = hit_selection.is_headshot;
+    attack.targets_hit[this].first++;
+    if( total_dam > 0 ) {
+        attack.targets_hit[this].second += total_dam;
+    }
 }
 
 dealt_damage_instance Creature::deal_damage( Creature *source, bodypart_id bp,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -80,7 +80,6 @@ struct mutation_branch;
 static const ammo_effect_str_id ammo_effect_APPLY_SAP( "APPLY_SAP" );
 static const ammo_effect_str_id ammo_effect_BEANBAG( "BEANBAG" );
 static const ammo_effect_str_id ammo_effect_BLINDS_EYES( "BLINDS_EYES" );
-static const ammo_effect_str_id ammo_effect_BOUNCE( "BOUNCE" );
 static const ammo_effect_str_id ammo_effect_FOAMCRETE( "FOAMCRETE" );
 static const ammo_effect_str_id ammo_effect_IGNITE( "IGNITE" );
 static const ammo_effect_str_id ammo_effect_INCENDIARY( "INCENDIARY" );
@@ -101,7 +100,6 @@ static const damage_type_id damage_heat( "heat" );
 
 static const efftype_id effect_all_fours( "all_fours" );
 static const efftype_id effect_blind( "blind" );
-static const efftype_id effect_bounced( "bounced" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_eff_mind_seeing_bonus_10( "eff_mind_seeing_bonus_10" );
 static const efftype_id effect_eff_mind_seeing_bonus_20( "eff_mind_seeing_bonus_20" );
@@ -972,13 +970,6 @@ double Creature::accuracy_projectile_attack( dealt_projectile_attack &attack ) c
     return attack.missed_by + std::max( 0.0, std::min( 1.0, dodge_rescaled ) );
 }
 
-void projectile::apply_effects_nodamage( Creature &target, Creature *source ) const
-{
-    if( proj_effects.count( ammo_effect_BOUNCE ) ) {
-        target.add_effect( effect_source( source ), effect_bounced, 1_turns );
-    }
-}
-
 void projectile::apply_effects_damage( Creature &target, Creature *source,
                                        const dealt_damage_instance &dealt_dam, bool critical ) const
 {
@@ -1338,8 +1329,6 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
         print_proj_avoid_msg( source, player_view );
         return;
     }
-
-    proj.apply_effects_nodamage( *this, source );
 
     // Create a copy that records whether the attack is a crit.
     weakpoint_attack wp_attack_copy = wp_attack;

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -279,8 +279,9 @@ static bool sting_shoot( monster *z, Creature *target, damage_instance &dam, flo
     proj.impact.add( dam );
     proj.proj_effects.insert( ammo_effect_NO_OVERSHOOT );
 
-    dealt_projectile_attack atk = projectile_attack( proj, z->pos_bub(), target->pos_bub(),
-                                  dispersion_sources{ 500 }, z );
+    dealt_projectile_attack atk;
+    projectile_attack( atk, proj, z->pos_bub(), target->pos_bub(),
+                       dispersion_sources{ 500 }, z );
     if( atk.dealt_dam.total_damage() > 0 ) {
         target->add_msg_if_player( m_bad, _( "The %s shoots a dart into you!" ), z->name() );
         // whether this function returns true determines whether it applies a status effect like paralysis or mutation
@@ -733,8 +734,9 @@ bool mattack::acid( monster *z )
     proj.impact.add_damage( damage_acid, 5 );
     proj.range = 10;
     proj.proj_effects.insert( ammo_effect_NO_OVERSHOOT );
-    dealt_projectile_attack dealt = projectile_attack( proj, z->pos_bub(), target->pos_bub(),
-                                    dispersion_sources{ 5400 }, z );
+    dealt_projectile_attack dealt;
+    projectile_attack( dealt, proj, z->pos_bub(), target->pos_bub(),
+                       dispersion_sources{ 5400 }, z );
     const tripoint_bub_ms &hitp = tripoint_bub_ms( dealt.end_point );
     const Creature *hit_critter = dealt.hit_critter;
     if( hit_critter == nullptr && here.hit_with_acid( hitp ) ) {
@@ -958,8 +960,9 @@ bool mattack::pull_metal_weapon( monster *z )
                     proj.range = rl_dist( foe->pos_bub(), z->pos_bub() ) - 1;
                     proj.proj_effects = { { ammo_effect_NO_ITEM_DAMAGE, ammo_effect_DRAW_AS_LINE, ammo_effect_NO_DAMAGE_SCALING, ammo_effect_JET } };
 
-                    dealt_projectile_attack dealt = projectile_attack( proj, foe->pos_bub(), z->pos_bub(),
-                                                    dispersion_sources{ 0 }, z );
+                    dealt_projectile_attack dealt;
+                    projectile_attack( dealt, proj, foe->pos_bub(), z->pos_bub(),
+                                       dispersion_sources{ 0 }, z );
                     get_map().add_item( dealt.end_point, pulled_weapon );
                     target->add_msg_player_or_npc( m_type, _( "The %s is pulled away from your hands!" ),
                                                    _( "The %s is pulled away from <npcname>'s hands!" ), pulled_weapon.tname() );
@@ -1555,7 +1558,8 @@ bool mattack::spit_sap( monster *z )
     proj.range = 12;
     proj.proj_effects.insert( ammo_effect_APPLY_SAP );
     proj.impact.add_damage( damage_acid, rng( 5, 10 ) );
-    projectile_attack( proj, z->pos_bub(), target->pos_bub(), dispersion_sources{ 150 }, z );
+    dealt_projectile_attack atk;
+    projectile_attack( atk, proj, z->pos_bub(), target->pos_bub(), dispersion_sources{ 150 }, z );
 
     return true;
 }

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -134,9 +134,10 @@ void mdefense::acidsplash( monster &m, Creature *const source,
     prj.proj_effects.insert( ammo_effect_DRAW_AS_LINE );
     prj.proj_effects.insert( ammo_effect_NO_DAMAGE_SCALING );
     prj.impact.add_damage( damage_acid, rng( 1, 3 ) );
+    dealt_projectile_attack atk;
     for( size_t i = 0; i < num_drops; i++ ) {
         const tripoint_bub_ms &target = random_entry( pts );
-        projectile_attack( prj, m.pos_bub(), target, dispersion_sources{ 1200 }, &m );
+        projectile_attack( atk, prj, m.pos_bub(), target, dispersion_sources{ 1200 }, &m );
     }
 
     if( get_player_view().sees( m.pos_bub() ) ) {

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -72,7 +72,8 @@ struct dealt_projectile_attack {
     double missed_by; // Accuracy of dealt attack
     bool headshot = false; // Headshot or not;
     bool shrapnel = false; // True if the projectile is generated from an explosive
-    std::map<Creature *, std::pair<int, int>> targets_hit; // Critters that hit by the projectile or null
+    // Critters that hit by the projectile or null
+    std::map<Creature *, std::pair<int, int>> targets_hit;
 };
 
 void apply_ammo_effects( Creature *source, const tripoint_bub_ms &p,

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -50,8 +50,6 @@ struct projectile {
         void apply_effects_damage( Creature &target, Creature *source,
                                    const dealt_damage_instance &dealt_dam,
                                    bool critical ) const;
-        // pplies proj_effects to a creature that was hit but not damaged
-        void apply_effects_nodamage( Creature &target, Creature *source ) const;
 
         projectile();
         projectile( const projectile & );

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -74,6 +74,7 @@ struct dealt_projectile_attack {
     double missed_by; // Accuracy of dealt attack
     bool headshot = false; // Headshot or not;
     bool shrapnel = false; // True if the projectile is generated from an explosive
+    std::map<Creature *, std::pair<int, int>> targets_hit; // Critters that hit by the projectile or null
 };
 
 void apply_ammo_effects( Creature *source, const tripoint_bub_ms &p,

--- a/tests/archery_damage_test.cpp
+++ b/tests/archery_damage_test.cpp
@@ -83,9 +83,11 @@ static void test_archery_balance( const std::string &weapon_type, const std::str
     test_projectile.impact = weapon.gun_damage();
     test_projectile.proj_effects = weapon.ammo_effects();
     test_projectile.critical_multiplier = weapon.ammo_data()->ammo->critical_multiplier;
+    std::map<Creature *, std::pair<int, int>> targets_hit;
 
     dealt_projectile_attack attack {
-        test_projectile, nullptr, dealt_damage_instance(), tripoint_bub_ms::zero, accuracy_critical * 0.75
+        test_projectile, nullptr, dealt_damage_instance(), tripoint_bub_ms::zero, accuracy_critical * 0.75,
+        false, false, targets_hit
     };
     if( !killable.empty() ) {
         test_projectile_attack( killable, true, attack, weapon_type, headshot );

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -140,8 +140,9 @@ static float get_avg_bullet_dmg( const std::string &clothing_id )
         dude->setpos( dude_pos );
         dude->wear_item( cloth, false );
         dude->add_effect( effect_sleep, 1_hours );
-        dealt_projectile_attack atk = projectile_attack( proj, badguy_pos, dude_pos, dispersion_sources(),
-                                      &*badguy );
+        dealt_projectile_attack atk;
+        projectile_attack( atk, proj, badguy_pos, dude_pos, dispersion_sources(),
+                           &*badguy );
         dude->deal_projectile_attack( &*badguy, atk, false );
         if( atk.missed_by < 1.0 ) {
             num_hits++;

--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -36,9 +36,8 @@ static tripoint_bub_ms projectile_end_point( const std::vector<tripoint_bub_ms> 
 
     dealt_projectile_attack attack;
 
-    attack = projectile_attack( test_proj, range[0], range[2], dispersion_sources(),
-                                &get_player_character(),
-                                nullptr );
+    projectile_attack( attack, test_proj, range[0], range[2], dispersion_sources(),
+                       &get_player_character(), nullptr );
 
     return attack.end_point;
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Refactor `ammo_effect_BOUNCE`"
#### Purpose of change
`ammo_effect_BOUNCE` is used in Chain Lightning CBM and gravity arrow. Using `effect_bounced` to mark targets that have already been hit, you must wait one turn before firing another shot, otherwise it will not work properly, which seems silly to me.
#### Describe the solution
Add `targets_hit` and relevant infrastructures, to record targets that have already been hit by this proj, but don't prevent new shot to function.
Also use it to replace codes in `fire_gun` etc, now damages done by BOUNCE can be recorded correctly.
#### Describe alternatives you've considered
Move BOUNCE check out of `projectile_attack`?
#### Testing
Keep firing Chain Lightning CBM, the proj will bounce and stop correctly, PC and targets that have already been hit will not be targeted.
![2025-01-09 234857](https://github.com/user-attachments/assets/4e4dad98-0fea-4120-88ea-c10f8765fb3d)
![2025-01-09 234912](https://github.com/user-attachments/assets/6683ee61-de94-4b54-955f-70b38adc92c9)
#### Additional context
