### PR TITLE
Man Of The Nineteenth Hour becomes hostile if significantly harmed.

### DIFF
--- a/data/mods/Xedra_Evolved/monsters/cryptids.json
+++ b/data/mods/Xedra_Evolved/monsters/cryptids.json
@@ -10,6 +10,7 @@
     "volume": "62500 ml",
     "weight": "81500 g",
     "hp": 150,
+    "anger_triggers": [ "HURT" ],
     "speed": 40,
     "material": [ "flesh" ],
     "symbol": "@",


### PR DESCRIPTION
#### Summary
Features "Allows Man of The Nineteenth Hour to defend himself if harmed outside of his active period."

#### Purpose of change

The Man Of The Nineteenth hour was only hostile - _**only**_ hostile between the hours of 19:00 and 05:00. You could blast him with a shotgun and he'd have no issue - this PR gives him the "hurt" anger trigger.

#### Describe the solution

Gives him the HURT anger trigger.

#### Describe alternatives you've considered

Keep him docile regardless of circumstance outside of his active period.

#### Testing

Load game, spawn him in, hit him twice with a Dreamforged Lucerne Hammer, he's now hostile. 

#### Additional context