### PR TITLE
[MoM] Allow Enhance Mobility to scale with Nether Attunement and intelligence

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -88,7 +88,7 @@ This is natural painkiller and so has natural effects (reduces speed slightly)<b
 *Duration*: 5 minutes to 15 minutes, plus 45 seconds to 120 seconds per level<br />
 *Stamina Cost*: 4500, minus 150 per level to a minimum of 2500<br />
 *Channeling Time*: 275 moves, minus 15 moves per level to a minimum of 50.<br />
-*Effects*: Reduces encumbrance on every body part, improving every 4 levels.  Other than -2 at level 0 through 3, encumbrance reduction is equal to power threshold level: -4 from levels 4 to 7, -8 from levels 8 to 11, and so on.<br />
+*Effects*: Reduces encumbrance on every body part, starting at -2 and improving by -2 every 2 levels, to a maximum of -32 at level 30.<br />
 *Prerequisites*: Overcome Pain 4,  Heightened Reflexes 6 *or* Flexibility 9, Burst of Speed 10 *or* Combat Dance 4 *or* Physical Enhancement 10.<br />
 
 ## Hammerhand (C) 

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -314,7 +314,334 @@
     "apply_message": "",
     "remove_message": "Your gear suddenly seems to weigh you down.",
     "rating": "good",
-    "max_duration": "7 days"
+    "max_duration": "7 days",
+    "enchantments": [
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "0"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "2"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_01" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "2"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "4"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_02" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "4"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "6"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_03" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "6"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "8"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_04" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "8"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "10"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_05" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "10"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "12"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_06" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "12"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "14"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_07" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "14"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "16"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_08" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "16"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "18"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_09" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "18"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "20"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_10" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "20"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "22"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_11" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "22"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "24"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_12" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "24"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "26"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_13" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "26"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "28"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_14" ]
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                ">=",
+                "28"
+              ]
+            },
+            {
+              "math": [
+                "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+                "<",
+                "30"
+              ]
+            }
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_15" ]
+      },
+      {
+        "condition": {
+          "math": [
+            "u_spell_level('biokin_enhance_mobility') * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling",
+            ">=",
+            "30"
+          ]
+        },
+        "mutations": [ "BIOKIN_ENHANCE_MOBILITY_16" ]
+      }
+    ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/mutations/temporary.json
+++ b/data/mods/MindOverMatter/mutations/temporary.json
@@ -52,6 +52,27 @@
     "player_display": false,
     "valid": false,
     "encumbrance_always": [
+      [ "head", -6 ],
+      [ "torso", -6 ],
+      [ "hand_r", -6 ],
+      [ "hand_l", -6 ],
+      [ "arm_r", -6 ],
+      [ "arm_l", -6 ],
+      [ "leg_r", -6 ],
+      [ "leg_l", -6 ]
+    ]
+  },
+  {
+    "id": "BIOKIN_ENHANCE_MOBILITY_04",
+    "type": "mutation",
+    "name": { "str": "Enhanced Mobility" },
+    "description": "Your gear isn't bothering you as much.",
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "player_display": false,
+    "valid": false,
+    "encumbrance_always": [
       [ "head", -8 ],
       [ "torso", -8 ],
       [ "hand_r", -8 ],
@@ -63,7 +84,28 @@
     ]
   },
   {
-    "id": "BIOKIN_ENHANCE_MOBILITY_04",
+    "id": "BIOKIN_ENHANCE_MOBILITY_05",
+    "type": "mutation",
+    "name": { "str": "Enhanced Mobility" },
+    "description": "Your gear isn't bothering you as much.",
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "player_display": false,
+    "valid": false,
+    "encumbrance_always": [
+      [ "head", -10 ],
+      [ "torso", -10 ],
+      [ "hand_r", -10 ],
+      [ "hand_l", -10 ],
+      [ "arm_r", -10 ],
+      [ "arm_l", -10 ],
+      [ "leg_r", -10 ],
+      [ "leg_l", -10 ]
+    ]
+  },
+  {
+    "id": "BIOKIN_ENHANCE_MOBILITY_06",
     "type": "mutation",
     "name": { "str": "Enhanced Mobility" },
     "description": "Your gear isn't bothering you as much.",
@@ -84,7 +126,28 @@
     ]
   },
   {
-    "id": "BIOKIN_ENHANCE_MOBILITY_05",
+    "id": "BIOKIN_ENHANCE_MOBILITY_07",
+    "type": "mutation",
+    "name": { "str": "Enhanced Mobility" },
+    "description": "Your gear isn't bothering you as much.",
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "player_display": false,
+    "valid": false,
+    "encumbrance_always": [
+      [ "head", -14 ],
+      [ "torso", -14 ],
+      [ "hand_r", -14 ],
+      [ "hand_l", -14 ],
+      [ "arm_r", -14 ],
+      [ "arm_l", -14 ],
+      [ "leg_r", -14 ],
+      [ "leg_l", -14 ]
+    ]
+  },
+  {
+    "id": "BIOKIN_ENHANCE_MOBILITY_08",
     "type": "mutation",
     "name": { "str": "Enhanced Mobility" },
     "description": "Your gear isn't bothering you as much.",
@@ -105,7 +168,28 @@
     ]
   },
   {
-    "id": "BIOKIN_ENHANCE_MOBILITY_06",
+    "id": "BIOKIN_ENHANCE_MOBILITY_09",
+    "type": "mutation",
+    "name": { "str": "Enhanced Mobility" },
+    "description": "Your gear isn't bothering you as much.",
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "player_display": false,
+    "valid": false,
+    "encumbrance_always": [
+      [ "head", -18 ],
+      [ "torso", -18 ],
+      [ "hand_r", -18 ],
+      [ "hand_l", -18 ],
+      [ "arm_r", -18 ],
+      [ "arm_l", -18 ],
+      [ "leg_r", -18 ],
+      [ "leg_l", -18 ]
+    ]
+  },
+  {
+    "id": "BIOKIN_ENHANCE_MOBILITY_10",
     "type": "mutation",
     "name": { "str": "Enhanced Mobility" },
     "description": "Your gear isn't bothering you as much.",
@@ -123,6 +207,132 @@
       [ "arm_l", -20 ],
       [ "leg_r", -20 ],
       [ "leg_l", -20 ]
+    ]
+  },
+  {
+    "id": "BIOKIN_ENHANCE_MOBILITY_11",
+    "type": "mutation",
+    "name": { "str": "Enhanced Mobility" },
+    "description": "Your gear isn't bothering you as much.",
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "player_display": false,
+    "valid": false,
+    "encumbrance_always": [
+      [ "head", -22 ],
+      [ "torso", -22 ],
+      [ "hand_r", -22 ],
+      [ "hand_l", -22 ],
+      [ "arm_r", -22 ],
+      [ "arm_l", -22 ],
+      [ "leg_r", -22 ],
+      [ "leg_l", -22 ]
+    ]
+  },
+  {
+    "id": "BIOKIN_ENHANCE_MOBILITY_12",
+    "type": "mutation",
+    "name": { "str": "Enhanced Mobility" },
+    "description": "Your gear isn't bothering you as much.",
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "player_display": false,
+    "valid": false,
+    "encumbrance_always": [
+      [ "head", -24 ],
+      [ "torso", -24 ],
+      [ "hand_r", -24 ],
+      [ "hand_l", -24 ],
+      [ "arm_r", -24 ],
+      [ "arm_l", -24 ],
+      [ "leg_r", -24 ],
+      [ "leg_l", -24 ]
+    ]
+  },
+  {
+    "id": "BIOKIN_ENHANCE_MOBILITY_13",
+    "type": "mutation",
+    "name": { "str": "Enhanced Mobility" },
+    "description": "Your gear isn't bothering you as much.",
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "player_display": false,
+    "valid": false,
+    "encumbrance_always": [
+      [ "head", -26 ],
+      [ "torso", -26 ],
+      [ "hand_r", -26 ],
+      [ "hand_l", -26 ],
+      [ "arm_r", -26 ],
+      [ "arm_l", -26 ],
+      [ "leg_r", -26 ],
+      [ "leg_l", -26 ]
+    ]
+  },
+  {
+    "id": "BIOKIN_ENHANCE_MOBILITY_14",
+    "type": "mutation",
+    "name": { "str": "Enhanced Mobility" },
+    "description": "Your gear isn't bothering you as much.",
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "player_display": false,
+    "valid": false,
+    "encumbrance_always": [
+      [ "head", -28 ],
+      [ "torso", -28 ],
+      [ "hand_r", -28 ],
+      [ "hand_l", -28 ],
+      [ "arm_r", -28 ],
+      [ "arm_l", -28 ],
+      [ "leg_r", -28 ],
+      [ "leg_l", -28 ]
+    ]
+  },
+  {
+    "id": "BIOKIN_ENHANCE_MOBILITY_15",
+    "type": "mutation",
+    "name": { "str": "Enhanced Mobility" },
+    "description": "Your gear isn't bothering you as much.",
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "player_display": false,
+    "valid": false,
+    "encumbrance_always": [
+      [ "head", -30 ],
+      [ "torso", -30 ],
+      [ "hand_r", -30 ],
+      [ "hand_l", -30 ],
+      [ "arm_r", -30 ],
+      [ "arm_l", -30 ],
+      [ "leg_r", -30 ],
+      [ "leg_l", -30 ]
+    ]
+  },
+  {
+    "id": "BIOKIN_ENHANCE_MOBILITY_16",
+    "type": "mutation",
+    "name": { "str": "Enhanced Mobility" },
+    "description": "Your gear isn't bothering you as much.",
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "player_display": false,
+    "valid": false,
+    "encumbrance_always": [
+      [ "head", -32 ],
+      [ "torso", -32 ],
+      [ "hand_r", -32 ],
+      [ "hand_l", -32 ],
+      [ "arm_r", -32 ],
+      [ "arm_l", -32 ],
+      [ "leg_r", -32 ],
+      [ "leg_l", -32 ]
     ]
   },
   {

--- a/data/mods/MindOverMatter/obsolete/eocs.json
+++ b/data/mods/MindOverMatter/obsolete/eocs.json
@@ -78,6 +78,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_BIOKIN_ENHANCE_MOBILITY_SWITCHER",
-    "effect": {  }
+    "effect": [  ]
   }
 ]

--- a/data/mods/MindOverMatter/obsolete/eocs.json
+++ b/data/mods/MindOverMatter/obsolete/eocs.json
@@ -74,5 +74,10 @@
         { "case": 20, "effect": { "u_add_trait": "PHOTOKIN_HIDE_UGLY_06" } }
       ]
     }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BIOKIN_ENHANCE_MOBILITY_SWITCHER",
+    "effect": {  }
   }
 ]

--- a/data/mods/MindOverMatter/powers/biokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/biokinesis_concentration_eocs.json
@@ -331,7 +331,7 @@
     "condition": { "not": { "u_has_effect": "effect_biokin_enhance_mobility" } },
     "effect": [
       { "u_message": "Your gear doesn't seem to encumber you as much.", "type": "good" },
-      { "run_eocs": [ "EOC_POWER_MAINTENANCE_PLUS_ONE", "EOC_BIOKIN_ENHANCE_MOBILITY_SWITCHER" ] },
+      { "run_eocs": [ "EOC_POWER_MAINTENANCE_PLUS_ONE" ] },
       { "u_add_effect": "effect_biokin_enhance_mobility", "duration": "PERMANENT" },
       {
         "run_eocs": "EOC_BIOKIN_ENHANCE_MOBILITY_DRAIN",
@@ -350,21 +350,6 @@
       }
     ],
     "false_effect": [ { "run_eocs": "EOC_BIOKIN_REMOVE_ENHANCE_MOBILITY" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_BIOKIN_ENHANCE_MOBILITY_SWITCHER",
-    "effect": {
-      "switch": { "math": [ "u_spell_level('biokin_enhance_mobility')" ] },
-      "cases": [
-        { "case": 0, "effect": [ { "u_add_trait": "BIOKIN_ENHANCE_MOBILITY_01" } ] },
-        { "case": 4, "effect": [ { "u_add_trait": "BIOKIN_ENHANCE_MOBILITY_02" } ] },
-        { "case": 8, "effect": [ { "u_add_trait": "BIOKIN_ENHANCE_MOBILITY_03" } ] },
-        { "case": 12, "effect": [ { "u_add_trait": "BIOKIN_ENHANCE_MOBILITY_04" } ] },
-        { "case": 16, "effect": [ { "u_add_trait": "BIOKIN_ENHANCE_MOBILITY_05" } ] },
-        { "case": 20, "effect": [ { "u_add_trait": "BIOKIN_ENHANCE_MOBILITY_06" } ] }
-      ]
-    }
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Allow Enhance Mobility to scale with Nether Attunement and intelligence"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The need to use a mutation to convey the encumbrance bonus from Enhance Mobility has previously limited its scaling potential. However, now that mutations are properly added and removed by enchantment conditions, we can add this functionality.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Update the Enhance Mobility effect with a large number of conditions that check power level, intelligence, and Nether Attunement, and grant appropriate levels of the mutation at each point. Add extra mutations to cover the other levels. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Channeled Enhance Mobility, debugged power level, Nether Attunement, and Intelligence up and down and saw the level of encumbrance change.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Have a couple other powers to do this with too, and probably some XE and Magiclysm spells.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
