### PR TITLE
Reset seed in sections even when no explicit seed given

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -224,7 +224,12 @@ struct CataListener : Catch::TestEventListenerBase {
     void sectionStarting( Catch::SectionInfo const &sectionInfo ) override {
         TestEventListenerBase::sectionStarting( sectionInfo );
         // Initialize the cata RNG with the Catch seed for reproducible tests
-        rng_set_engine_seed( m_config->rngSeed() );
+        const unsigned int seed = m_config->rngSeed();
+        if( seed ) {
+            rng_set_engine_seed( seed );
+        } else {
+            rng_set_engine_seed( rng_get_first_seed() );
+        }
         // Clear the message log so on test failures we see only messages from
         // during that test
         Messages::clear_messages();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #78980

#### Describe the solution

As the title says, behavior there was different when no seed was given, so fix that.

#### Describe alternatives you've considered



#### Testing

Ran the test from the issue without giving a seed. Then reran with the seed printed in the first run. Did that twice for good measure. Results were the same.

#### Additional context

Shortened output:
```
Cataclysm-DDA> .\Cataclysm-test-vcpkg-static-Release-x64.exe random_generator

Filters: random_generator

21:58:20.495 INFO : 1
21:58:20.495 INFO : 1
21:58:20.495 INFO : 0
21:58:20.496 INFO : 1
21:58:20.496 INFO : 1
21:58:20.496 INFO : 1
21:58:20.497 INFO : 1
21:58:20.497 INFO : 1
21:58:20.497 INFO : 0
21:58:20.497 INFO : 1

21:58:20.499 INFO : Default randomness seeded to: 3321968024

Cataclysm-DDA> .\Cataclysm-test-vcpkg-static-Release-x64.exe random_generator --rng-seed 3321968024

Filters: random_generator

21:58:46.645 INFO : 1
21:58:46.646 INFO : 1
21:58:46.646 INFO : 0
21:58:46.646 INFO : 1
21:58:46.647 INFO : 1
21:58:46.647 INFO : 1
21:58:46.647 INFO : 1
21:58:46.647 INFO : 1
21:58:46.648 INFO : 0
21:58:46.648 INFO : 1

21:58:46.649 INFO : Randomness seeded to: 3321968024

Cataclysm-DDA> .\Cataclysm-test-vcpkg-static-Release-x64.exe random_generator

Filters: random_generator

22:03:39.922 INFO : 1
22:03:39.922 INFO : 1
22:03:39.922 INFO : 1
22:03:39.923 INFO : 0
22:03:39.923 INFO : 0
22:03:39.923 INFO : 1
22:03:39.924 INFO : 1
22:03:39.924 INFO : 1
22:03:39.924 INFO : 1
22:03:39.924 INFO : 1

22:03:39.926 INFO : Default randomness seeded to: 408498724

Cataclysm-DDA> .\Cataclysm-test-vcpkg-static-Release-x64.exe random_generator --rng-seed 408498724

Filters: random_generator

22:04:04.403 INFO : 1
22:04:04.403 INFO : 1
22:04:04.403 INFO : 1
22:04:04.404 INFO : 0
22:04:04.404 INFO : 0
22:04:04.404 INFO : 1
22:04:04.404 INFO : 1
22:04:04.404 INFO : 1
22:04:04.405 INFO : 1
22:04:04.405 INFO : 1

22:04:04.406 INFO : Randomness seeded to: 408498724
```