### PR TITLE
fixes various text input issues on ncurses

### DIFF
--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -420,6 +420,9 @@ input_event input_manager::get_input_event( const keyboard_mode /*preferred_keyb
         previously_pressed_key = 0;
         // flush any output
         catacurses::doupdate();
+        // could also just do this each time a window is created to ensure every ncurses window has this property,
+        // but this function is virtually free anyway
+        nodelay(stdscr, true);
         key = getch();
         if( key != ERR ) {
             int newch;

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -422,7 +422,7 @@ input_event input_manager::get_input_event( const keyboard_mode /*preferred_keyb
         catacurses::doupdate();
         // could also just do this each time a window is created to ensure every ncurses window has this property,
         // but this function is virtually free anyway
-        nodelay(stdscr, true);
+        nodelay( stdscr, true );
         key = getch();
         if( key != ERR ) {
             int newch;

--- a/src/third-party/imtui/imtui-impl-ncurses.cpp
+++ b/src/third-party/imtui/imtui-impl-ncurses.cpp
@@ -153,114 +153,112 @@ struct ImGuiKeyTranslation {
 // or if it is a character compatible with `ImGuiIO::addInputCharacter()`
 static ImGuiKeyTranslation ncurses_special_key_to_imgui_key( int key )
 {
-#define NK ImGuiKeyTranslation
     switch( key ) {
         case KEY_DOWN:
-            return NK( ImGuiKey_DownArrow );
+            return ImGuiKeyTranslation( ImGuiKey_DownArrow );
         case KEY_UP:
-            return NK( ImGuiKey_UpArrow );
+            return ImGuiKeyTranslation( ImGuiKey_UpArrow );
         case KEY_LEFT:
-            return NK( ImGuiKey_LeftArrow );
+            return ImGuiKeyTranslation( ImGuiKey_LeftArrow );
         case KEY_RIGHT:
-            return NK( ImGuiKey_RightArrow );
+            return ImGuiKeyTranslation( ImGuiKey_RightArrow );
         case KEY_HOME:
-            return NK( ImGuiKey_Home );
+            return ImGuiKeyTranslation( ImGuiKey_Home );
         case KEY_BACKSPACE:
-            return NK( ImGuiKey_Backspace );
+            return ImGuiKeyTranslation( ImGuiKey_Backspace );
         case KEY_F( 1 ):
-            return NK( ImGuiKey_F1 );
+            return ImGuiKeyTranslation( ImGuiKey_F1 );
         case KEY_F( 2 ):
-            return NK( ImGuiKey_F2 );
+            return ImGuiKeyTranslation( ImGuiKey_F2 );
         case KEY_F( 3 ):
-            return NK( ImGuiKey_F3 );
+            return ImGuiKeyTranslation( ImGuiKey_F3 );
         case KEY_F( 4 ):
-            return NK( ImGuiKey_F4 );
+            return ImGuiKeyTranslation( ImGuiKey_F4 );
         case KEY_F( 5 ):
-            return NK( ImGuiKey_F5 );
+            return ImGuiKeyTranslation( ImGuiKey_F5 );
         case KEY_F( 6 ):
-            return NK( ImGuiKey_F6 );
+            return ImGuiKeyTranslation( ImGuiKey_F6 );
         case KEY_F( 7 ):
-            return NK( ImGuiKey_F7 );
+            return ImGuiKeyTranslation( ImGuiKey_F7 );
         case KEY_F( 8 ):
-            return NK( ImGuiKey_F8 );
+            return ImGuiKeyTranslation( ImGuiKey_F8 );
         case KEY_F( 9 ):
-            return NK( ImGuiKey_F9 );
+            return ImGuiKeyTranslation( ImGuiKey_F9 );
         case KEY_F( 10 ):
-            return NK( ImGuiKey_F10 );
+            return ImGuiKeyTranslation( ImGuiKey_F10 );
         case KEY_F( 11 ):
-            return NK( ImGuiKey_F11 );
+            return ImGuiKeyTranslation( ImGuiKey_F11 );
         case KEY_F( 12 ):
-            return NK( ImGuiKey_F12 );
+            return ImGuiKeyTranslation( ImGuiKey_F12 );
         case KEY_F( 13 ):
-            return NK( ImGuiKey_F13 );
+            return ImGuiKeyTranslation( ImGuiKey_F13 );
         case KEY_F( 14 ):
-            return NK( ImGuiKey_F14 );
+            return ImGuiKeyTranslation( ImGuiKey_F14 );
         case KEY_F( 15 ):
-            return NK( ImGuiKey_F15 );
+            return ImGuiKeyTranslation( ImGuiKey_F15 );
         case KEY_F( 16 ):
-            return NK( ImGuiKey_F16 );
+            return ImGuiKeyTranslation( ImGuiKey_F16 );
         case KEY_F( 17 ):
-            return NK( ImGuiKey_F17 );
+            return ImGuiKeyTranslation( ImGuiKey_F17 );
         case KEY_F( 18 ):
-            return NK( ImGuiKey_F18 );
+            return ImGuiKeyTranslation( ImGuiKey_F18 );
         case KEY_F( 19 ):
-            return NK( ImGuiKey_F19 );
+            return ImGuiKeyTranslation( ImGuiKey_F19 );
         case KEY_F( 20 ):
-            return NK( ImGuiKey_F20 );
+            return ImGuiKeyTranslation( ImGuiKey_F20 );
         case KEY_F( 21 ):
-            return NK( ImGuiKey_F21 );
+            return ImGuiKeyTranslation( ImGuiKey_F21 );
         case KEY_F( 22 ):
-            return NK( ImGuiKey_F22 );
+            return ImGuiKeyTranslation( ImGuiKey_F22 );
         case KEY_F( 23 ):
-            return NK( ImGuiKey_F23 );
+            return ImGuiKeyTranslation( ImGuiKey_F23 );
         case KEY_F( 24 ):
-            return NK( ImGuiKey_F24 );
+            return ImGuiKeyTranslation( ImGuiKey_F24 );
         case KEY_DC:
-            return NK( ImGuiKey_Delete );
+            return ImGuiKeyTranslation( ImGuiKey_Delete );
         case KEY_IC:
-            return NK( ImGuiKey_Insert );
+            return ImGuiKeyTranslation( ImGuiKey_Insert );
         case KEY_NPAGE:
-            return NK( ImGuiKey_PageUp );
+            return ImGuiKeyTranslation( ImGuiKey_PageUp );
         case KEY_PPAGE:
-            return NK( ImGuiKey_PageDown );
+            return ImGuiKeyTranslation( ImGuiKey_PageDown );
         case KEY_ENTER:
-            return NK( ImGuiKey_Enter );
+            return ImGuiKeyTranslation( ImGuiKey_Enter );
         case KEY_PRINT:
-            return NK( ImGuiKey_PrintScreen );
+            return ImGuiKeyTranslation( ImGuiKey_PrintScreen );
         case KEY_A1:
-            return NK( ImGuiKey_Keypad7 );
+            return ImGuiKeyTranslation( ImGuiKey_Keypad7 );
         case KEY_A3:
-            return NK( ImGuiKey_Keypad9 );
+            return ImGuiKeyTranslation( ImGuiKey_Keypad9 );
         case KEY_B2:
-            return NK( ImGuiKey_Keypad5 );
+            return ImGuiKeyTranslation( ImGuiKey_Keypad5 );
         case KEY_C1:
-            return NK( ImGuiKey_Keypad1 );
+            return ImGuiKeyTranslation( ImGuiKey_Keypad1 );
         case KEY_C3:
-            return NK( ImGuiKey_Keypad3 );
+            return ImGuiKeyTranslation( ImGuiKey_Keypad3 );
         case KEY_END:
-            return NK( ImGuiKey_End );
+            return ImGuiKeyTranslation( ImGuiKey_End );
         case KEY_SDC:
-            return NK( ImGuiKey_Delete, true );
+            return ImGuiKeyTranslation( ImGuiKey_Delete, true );
         case KEY_SEND:
-            return NK( ImGuiKey_End, true );
+            return ImGuiKeyTranslation( ImGuiKey_End, true );
         case KEY_SHOME:
-            return NK( ImGuiKey_Home, true );
+            return ImGuiKeyTranslation( ImGuiKey_Home, true );
         case KEY_SIC:
-            return NK( ImGuiKey_Insert, true );
+            return ImGuiKeyTranslation( ImGuiKey_Insert, true );
         case KEY_SPRINT:
-            return NK( ImGuiKey_PrintScreen, true );
+            return ImGuiKeyTranslation( ImGuiKey_PrintScreen, true );
         case KEY_SLEFT:
-            return NK( ImGuiKey_LeftArrow, true );
+            return ImGuiKeyTranslation( ImGuiKey_LeftArrow, true );
         case KEY_SRIGHT:
-            return NK( ImGuiKey_RightArrow, true );
+            return ImGuiKeyTranslation( ImGuiKey_RightArrow, true );
         case KEY_SR:
-            return NK( ImGuiKey_UpArrow, true );
+            return ImGuiKeyTranslation( ImGuiKey_UpArrow, true );
         case KEY_SF:
-            return NK( ImGuiKey_DownArrow, true );
+            return ImGuiKeyTranslation( ImGuiKey_DownArrow, true );
         default:
-            return NK( ImGuiKey_None );
+            return ImGuiKeyTranslation( ImGuiKey_None );
     }
-#undef NK
 }
 
 

--- a/src/third-party/imtui/imtui-impl-ncurses.cpp
+++ b/src/third-party/imtui/imtui-impl-ncurses.cpp
@@ -40,16 +40,16 @@
 #include <thread>
 
 // SDL_Renderer data
-struct ImTui_ImplNCurses_Data
-{
-    std::vector<WINDOW*> imtui_wins;
+struct ImTui_ImplNCurses_Data {
+    std::vector<WINDOW *> imtui_wins;
 };
 
 // Backend data stored in io.BackendRendererUserData to allow support for multiple Dear ImGui contexts
 // It is STRONGLY preferred that you use docking branch with multi-viewports (== single Dear ImGui context + multiple windows) instead of multiple Dear ImGui contexts.
-static ImTui_ImplNCurses_Data* ImTui_ImplNCurses_GetBackendData()
+static ImTui_ImplNCurses_Data *ImTui_ImplNCurses_GetBackendData()
 {
-    return ImGui::GetCurrentContext() ? (ImTui_ImplNCurses_Data*)ImGui::GetIO().BackendRendererUserData : nullptr;
+    return ImGui::GetCurrentContext() ? ( ImTui_ImplNCurses_Data * )
+           ImGui::GetIO().BackendRendererUserData : nullptr;
 }
 
 namespace
@@ -104,7 +104,7 @@ void ImTui_ImplNcurses_Init( float fps_active, float fps_idle )
     if( ImGui::GetCurrentContext()->IO.BackendPlatformUserData == nullptr ) {
         ImGui::GetCurrentContext()->IO.BackendPlatformUserData = new ImTui::ImplImtui_Data();
     }
-    if(ImGui::GetIO().BackendRendererUserData == nullptr) {
+    if( ImGui::GetIO().BackendRendererUserData == nullptr ) {
         ImGui::GetIO().BackendRendererUserData = new ImTui_ImplNCurses_Data();
     }
 
@@ -131,7 +131,7 @@ void ImTui_ImplNcurses_Shutdown()
     // ref #11 : https://github.com/ggerganov/imtui/issues/11
     printf( "\033[?1003l\n" ); // Disable mouse movement events, as l = low
 
-    ImTui_ImplNCurses_Data* data = ImTui_ImplNCurses_GetBackendData();
+    ImTui_ImplNCurses_Data *data = ImTui_ImplNCurses_GetBackendData();
     if( data ) {
         delete data;
         ImGui::GetIO().BackendRendererUserData = nullptr;
@@ -142,70 +142,123 @@ void ImTui_ImplNcurses_Shutdown()
 struct ImGuiKeyTranslation {
     ImGuiKey key;
     bool shift;
-    ImGuiKeyTranslation(ImGuiKey k, bool s = false) :
-        key(k),
-        shift(s)
+    ImGuiKeyTranslation( ImGuiKey k, bool s = false ) :
+        key( k ),
+        shift( s )
     {}
 };
 
 
 // returns ImGuiKey_None if it doesn't have an ImGui_Key counterpart
 // or if it is a character compatible with `ImGuiIO::addInputCharacter()`
-static ImGuiKeyTranslation ncurses_special_key_to_imgui_key(int key) {
+static ImGuiKeyTranslation ncurses_special_key_to_imgui_key( int key )
+{
 #define NK ImGuiKeyTranslation
-    switch (key) {
-        case KEY_DOWN:      return NK(ImGuiKey_DownArrow);
-        case KEY_UP:        return NK(ImGuiKey_UpArrow);
-        case KEY_LEFT:      return NK(ImGuiKey_LeftArrow);
-        case KEY_RIGHT:     return NK(ImGuiKey_RightArrow);
-        case KEY_HOME:      return NK(ImGuiKey_Home);
-        case KEY_BACKSPACE: return NK(ImGuiKey_Backspace);
-        case KEY_F(1):      return NK(ImGuiKey_F1);
-        case KEY_F(2):      return NK(ImGuiKey_F2);
-        case KEY_F(3):      return NK(ImGuiKey_F3);
-        case KEY_F(4):      return NK(ImGuiKey_F4);
-        case KEY_F(5):      return NK(ImGuiKey_F5);
-        case KEY_F(6):      return NK(ImGuiKey_F6);
-        case KEY_F(7):      return NK(ImGuiKey_F7);
-        case KEY_F(8):      return NK(ImGuiKey_F8);
-        case KEY_F(9):      return NK(ImGuiKey_F9);
-        case KEY_F(10):     return NK(ImGuiKey_F10);
-        case KEY_F(11):     return NK(ImGuiKey_F11);
-        case KEY_F(12):     return NK(ImGuiKey_F12);
-        case KEY_F(13):     return NK(ImGuiKey_F13);
-        case KEY_F(14):     return NK(ImGuiKey_F14);
-        case KEY_F(15):     return NK(ImGuiKey_F15);
-        case KEY_F(16):     return NK(ImGuiKey_F16);
-        case KEY_F(17):     return NK(ImGuiKey_F17);
-        case KEY_F(18):     return NK(ImGuiKey_F18);
-        case KEY_F(19):     return NK(ImGuiKey_F19);
-        case KEY_F(20):     return NK(ImGuiKey_F20);
-        case KEY_F(21):     return NK(ImGuiKey_F21);
-        case KEY_F(22):     return NK(ImGuiKey_F22);
-        case KEY_F(23):     return NK(ImGuiKey_F23);
-        case KEY_F(24):     return NK(ImGuiKey_F24);
-        case KEY_DC:        return NK(ImGuiKey_Delete);
-        case KEY_IC:        return NK(ImGuiKey_Insert);
-        case KEY_NPAGE:     return NK(ImGuiKey_PageUp);
-        case KEY_PPAGE:     return NK(ImGuiKey_PageDown);
-        case KEY_ENTER:     return NK(ImGuiKey_Enter);
-        case KEY_PRINT:     return NK(ImGuiKey_PrintScreen);
-        case KEY_A1:        return NK(ImGuiKey_Keypad7);
-        case KEY_A3:        return NK(ImGuiKey_Keypad9);
-        case KEY_B2:        return NK(ImGuiKey_Keypad5);
-        case KEY_C1:        return NK(ImGuiKey_Keypad1);
-        case KEY_C3:        return NK(ImGuiKey_Keypad3);
-        case KEY_END:       return NK(ImGuiKey_End);
-        case KEY_SDC:       return NK(ImGuiKey_Delete, true);
-        case KEY_SEND:      return NK(ImGuiKey_End, true);
-        case KEY_SHOME:     return NK(ImGuiKey_Home, true);
-        case KEY_SIC:       return NK(ImGuiKey_Insert, true);
-        case KEY_SPRINT:    return NK(ImGuiKey_PrintScreen, true);
-        case KEY_SLEFT:     return NK(ImGuiKey_LeftArrow, true);
-        case KEY_SRIGHT:    return NK(ImGuiKey_RightArrow, true);
-        case KEY_SR:        return NK(ImGuiKey_UpArrow, true);
-        case KEY_SF:        return NK(ImGuiKey_DownArrow, true);
-        default:            return NK(ImGuiKey_None);
+    switch( key ) {
+        case KEY_DOWN:
+            return NK( ImGuiKey_DownArrow );
+        case KEY_UP:
+            return NK( ImGuiKey_UpArrow );
+        case KEY_LEFT:
+            return NK( ImGuiKey_LeftArrow );
+        case KEY_RIGHT:
+            return NK( ImGuiKey_RightArrow );
+        case KEY_HOME:
+            return NK( ImGuiKey_Home );
+        case KEY_BACKSPACE:
+            return NK( ImGuiKey_Backspace );
+        case KEY_F( 1 ):
+            return NK( ImGuiKey_F1 );
+        case KEY_F( 2 ):
+            return NK( ImGuiKey_F2 );
+        case KEY_F( 3 ):
+            return NK( ImGuiKey_F3 );
+        case KEY_F( 4 ):
+            return NK( ImGuiKey_F4 );
+        case KEY_F( 5 ):
+            return NK( ImGuiKey_F5 );
+        case KEY_F( 6 ):
+            return NK( ImGuiKey_F6 );
+        case KEY_F( 7 ):
+            return NK( ImGuiKey_F7 );
+        case KEY_F( 8 ):
+            return NK( ImGuiKey_F8 );
+        case KEY_F( 9 ):
+            return NK( ImGuiKey_F9 );
+        case KEY_F( 10 ):
+            return NK( ImGuiKey_F10 );
+        case KEY_F( 11 ):
+            return NK( ImGuiKey_F11 );
+        case KEY_F( 12 ):
+            return NK( ImGuiKey_F12 );
+        case KEY_F( 13 ):
+            return NK( ImGuiKey_F13 );
+        case KEY_F( 14 ):
+            return NK( ImGuiKey_F14 );
+        case KEY_F( 15 ):
+            return NK( ImGuiKey_F15 );
+        case KEY_F( 16 ):
+            return NK( ImGuiKey_F16 );
+        case KEY_F( 17 ):
+            return NK( ImGuiKey_F17 );
+        case KEY_F( 18 ):
+            return NK( ImGuiKey_F18 );
+        case KEY_F( 19 ):
+            return NK( ImGuiKey_F19 );
+        case KEY_F( 20 ):
+            return NK( ImGuiKey_F20 );
+        case KEY_F( 21 ):
+            return NK( ImGuiKey_F21 );
+        case KEY_F( 22 ):
+            return NK( ImGuiKey_F22 );
+        case KEY_F( 23 ):
+            return NK( ImGuiKey_F23 );
+        case KEY_F( 24 ):
+            return NK( ImGuiKey_F24 );
+        case KEY_DC:
+            return NK( ImGuiKey_Delete );
+        case KEY_IC:
+            return NK( ImGuiKey_Insert );
+        case KEY_NPAGE:
+            return NK( ImGuiKey_PageUp );
+        case KEY_PPAGE:
+            return NK( ImGuiKey_PageDown );
+        case KEY_ENTER:
+            return NK( ImGuiKey_Enter );
+        case KEY_PRINT:
+            return NK( ImGuiKey_PrintScreen );
+        case KEY_A1:
+            return NK( ImGuiKey_Keypad7 );
+        case KEY_A3:
+            return NK( ImGuiKey_Keypad9 );
+        case KEY_B2:
+            return NK( ImGuiKey_Keypad5 );
+        case KEY_C1:
+            return NK( ImGuiKey_Keypad1 );
+        case KEY_C3:
+            return NK( ImGuiKey_Keypad3 );
+        case KEY_END:
+            return NK( ImGuiKey_End );
+        case KEY_SDC:
+            return NK( ImGuiKey_Delete, true );
+        case KEY_SEND:
+            return NK( ImGuiKey_End, true );
+        case KEY_SHOME:
+            return NK( ImGuiKey_Home, true );
+        case KEY_SIC:
+            return NK( ImGuiKey_Insert, true );
+        case KEY_SPRINT:
+            return NK( ImGuiKey_PrintScreen, true );
+        case KEY_SLEFT:
+            return NK( ImGuiKey_LeftArrow, true );
+        case KEY_SRIGHT:
+            return NK( ImGuiKey_RightArrow, true );
+        case KEY_SR:
+            return NK( ImGuiKey_UpArrow, true );
+        case KEY_SF:
+            return NK( ImGuiKey_DownArrow, true );
+        default:
+            return NK( ImGuiKey_None );
     }
 #undef NK
 }
@@ -238,10 +291,10 @@ bool ImTui_ImplNcurses_NewFrame( std::vector<std::pair<int, ImTui::mouse_event>>
     io.KeyCtrl = false;
     io.KeyShift = false;
 
-    for (int k = (int)ImGuiKey_NamedKey_BEGIN; k < (int)ImGuiKey_NamedKey_END; k++) {
-        ImGuiKey key = (ImGuiKey)k;
+    for( int k = ( int )ImGuiKey_NamedKey_BEGIN; k < ( int )ImGuiKey_NamedKey_END; k++ ) {
+        ImGuiKey key = ( ImGuiKey )k;
         // AddKeyEvent doesn't allow alias keys
-        if (!ImGui::IsAliasKey(key) && ImGui::IsKeyDown(key)){
+        if( !ImGui::IsAliasKey( key ) && ImGui::IsKeyDown( key ) ) {
             io.AddKeyEvent( key, false );
         }
     }
@@ -276,9 +329,9 @@ bool ImTui_ImplNcurses_NewFrame( std::vector<std::pair<int, ImTui::mouse_event>>
                     io.AddInputCharactersUTF8( input );
                 }
             } else {
-                ImGuiKeyTranslation trans = ncurses_special_key_to_imgui_key(c);
-                if (trans.key == ImGuiKey_None) {
-                    io.AddInputCharacter(c);
+                ImGuiKeyTranslation trans = ncurses_special_key_to_imgui_key( c );
+                if( trans.key == ImGuiKey_None ) {
+                    io.AddInputCharacter( c );
                 } else {
                     io.AddKeyEvent( trans.key, true );
                     io.KeyShift = trans.shift;
@@ -337,60 +390,63 @@ void ImTui_ImplNcurses_UploadColorPair( short p, short f, short b )
 
 void ImTui_ImplNcurses_SetAllocedPairCount( short p )
 {
-    nColPairs = std::max(nColPairs, p) + 1;
+    nColPairs = std::max( nColPairs, p ) + 1;
 }
 
-void create_destroy_curses_windows(std::vector<WINDOW*> &windows)
+void create_destroy_curses_windows( std::vector<WINDOW *> &windows )
 {
     size_t cursesWinIdx = 0;
     int imguiWinIdx = 0;
-    for(; imguiWinIdx < GImGui->Windows.Size; imguiWinIdx++) {
-        ImGuiWindow* imwin = GImGui->Windows[imguiWinIdx];
-        if(imwin->Collapsed || !imwin->Active) {
+    for( ; imguiWinIdx < GImGui->Windows.Size; imguiWinIdx++ ) {
+        ImGuiWindow *imwin = GImGui->Windows[imguiWinIdx];
+        if( imwin->Collapsed || !imwin->Active ) {
             continue;
         }
-        if(windows.size() <= cursesWinIdx) {
-            windows.push_back(newwin(short(imwin->Size.y), short(imwin->Size.x), short(imwin->Pos.y), short(imwin->Pos.x)));
+        if( windows.size() <= cursesWinIdx ) {
+            windows.push_back( newwin( short( imwin->Size.y ), short( imwin->Size.x ), short( imwin->Pos.y ),
+                                       short( imwin->Pos.x ) ) );
         } else {
-            WINDOW* win = windows[cursesWinIdx];
-            if(getbegx( win ) != short(imwin->Pos.x) || getbegy( win ) != short(imwin->Pos.y) || getmaxx(win) != short(imwin->Size.x) || getmaxy(win) != imwin->Size.y) {
-                delwin(win);
-                windows[cursesWinIdx] = newwin(short(imwin->Size.y), short(imwin->Size.x), short(imwin->Pos.y), short(imwin->Pos.x));
+            WINDOW *win = windows[cursesWinIdx];
+            if( getbegx( win ) != short( imwin->Pos.x ) || getbegy( win ) != short( imwin->Pos.y ) ||
+                getmaxx( win ) != short( imwin->Size.x ) || getmaxy( win ) != imwin->Size.y ) {
+                delwin( win );
+                windows[cursesWinIdx] = newwin( short( imwin->Size.y ), short( imwin->Size.x ),
+                                                short( imwin->Pos.y ), short( imwin->Pos.x ) );
             }
         }
         cursesWinIdx++;
     }
-    if(cursesWinIdx < int(windows.size())) {
+    if( cursesWinIdx < int( windows.size() ) ) {
         size_t lastIndex = cursesWinIdx;
-        for(; cursesWinIdx < windows.size(); cursesWinIdx++) {
-            if(windows[cursesWinIdx] != nullptr) {
+        for( ; cursesWinIdx < windows.size(); cursesWinIdx++ ) {
+            if( windows[cursesWinIdx] != nullptr ) {
                 delwin( windows[cursesWinIdx] );
             }
         }
-        windows.erase(windows.begin() + lastIndex, windows.end());
+        windows.erase( windows.begin() + lastIndex, windows.end() );
     }
 }
 wchar_t strTmp[] = {0, 0};
 void ImTui_ImplNcurses_DrawScreen( bool active )
 {
-    ImTui::ImplImtui_Data* bd = ImTui::ImTui_Impl_GetBackendData();
-    ImTui_ImplNCurses_Data* rd = ImTui_ImplNCurses_GetBackendData();
+    ImTui::ImplImtui_Data *bd = ImTui::ImTui_Impl_GetBackendData();
+    ImTui_ImplNCurses_Data *rd = ImTui_ImplNCurses_GetBackendData();
     if( active ) {
         nActiveFrames = 10;
     }
 
-    ImTui::TScreen& g_screen = bd->Screen;
-    create_destroy_curses_windows(rd->imtui_wins);
-    ImFont* font = nullptr;
-    for(WINDOW *cursesWin : rd->imtui_wins) {
+    ImTui::TScreen &g_screen = bd->Screen;
+    create_destroy_curses_windows( rd->imtui_wins );
+    ImFont *font = nullptr;
+    for( WINDOW *cursesWin : rd->imtui_wins ) {
         int nx = g_screen.nx;
         int ny = g_screen.ny;
 
-        for( int y = getbegy(cursesWin); y <= (getbegy(cursesWin) + getmaxy(cursesWin)); ++y ) {
+        for( int y = getbegy( cursesWin ); y <= ( getbegy( cursesWin ) + getmaxy( cursesWin ) ); ++y ) {
             constexpr int no_lastp = 0x7FFFFFFF;
             int lastp = no_lastp;
-            wmove(cursesWin, y - getbegy(cursesWin), 0);
-            for( int x = getbegx(cursesWin); x <= (getbegx(cursesWin) +  getmaxx(cursesWin)); ++x ) {
+            wmove( cursesWin, y - getbegy( cursesWin ), 0 );
+            for( int x = getbegx( cursesWin ); x <= ( getbegx( cursesWin ) +  getmaxx( cursesWin ) ); ++x ) {
                 const auto cell = g_screen.data[y * nx + x];
                 const uint16_t f = cell.fg;
                 const uint16_t b = cell.bg;
@@ -408,20 +464,19 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
                 }
                 strTmp[0] = cell.ch;
                 waddwstr( cursesWin, strTmp );
-                
-                if(cell.chwidth > 1)
-                {
-                    x += (cell.chwidth - 1);
+
+                if( cell.chwidth > 1 ) {
+                    x += ( cell.chwidth - 1 );
                 }
             }
             if( lastp != no_lastp ) {
                 wattroff( cursesWin, COLOR_PAIR( colPairs[lastp].second ) );
             }
         }
-        
-        wnoutrefresh(cursesWin);
+
+        wnoutrefresh( cursesWin );
     }
-    
+
 }
 
 bool ImTui_ImplNcurses_ProcessEvent()

--- a/src/third-party/imtui/imtui-impl-ncurses.cpp
+++ b/src/third-party/imtui/imtui-impl-ncurses.cpp
@@ -115,28 +115,6 @@ void ImTui_ImplNcurses_Init( float fps_active, float fps_idle )
     g_vsync = VSync( fps_active, fps_idle );
 
     //imtui_win = newwin(LINES, COLS, 0, 0);
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_Tab, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_LeftArrow, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_RightArrow, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_UpArrow, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_DownArrow, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_PageUp, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_PageDown, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_Home, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_End, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_Insert, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_Delete, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_Backspace, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_Space, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_Enter, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_Escape, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_KeypadEnter, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_A, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_C, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_V, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_X, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_Y, true );
-    ImGui::GetIO().AddKeyEvent( ImGuiKey_Z, true );
 
     ImGui::GetIO().KeyRepeatDelay = 0.050;
     ImGui::GetIO().KeyRepeatRate = 0.050;
@@ -160,6 +138,79 @@ void ImTui_ImplNcurses_Shutdown()
     }
 }
 
+
+struct ImGuiKeyTranslation {
+    ImGuiKey key;
+    bool shift;
+    ImGuiKeyTranslation(ImGuiKey k, bool s = false) :
+        key(k),
+        shift(s)
+    {}
+};
+
+
+// returns ImGuiKey_None if it doesn't have an ImGui_Key counterpart
+// or if it is a character compatible with `ImGuiIO::addInputCharacter()`
+static ImGuiKeyTranslation ncurses_special_key_to_imgui_key(int key) {
+#define NK ImGuiKeyTranslation
+    switch (key) {
+        case KEY_DOWN:      return NK(ImGuiKey_DownArrow);
+        case KEY_UP:        return NK(ImGuiKey_UpArrow);
+        case KEY_LEFT:      return NK(ImGuiKey_LeftArrow);
+        case KEY_RIGHT:     return NK(ImGuiKey_RightArrow);
+        case KEY_HOME:      return NK(ImGuiKey_Home);
+        case KEY_BACKSPACE: return NK(ImGuiKey_Backspace);
+        case KEY_F(1):      return NK(ImGuiKey_F1);
+        case KEY_F(2):      return NK(ImGuiKey_F2);
+        case KEY_F(3):      return NK(ImGuiKey_F3);
+        case KEY_F(4):      return NK(ImGuiKey_F4);
+        case KEY_F(5):      return NK(ImGuiKey_F5);
+        case KEY_F(6):      return NK(ImGuiKey_F6);
+        case KEY_F(7):      return NK(ImGuiKey_F7);
+        case KEY_F(8):      return NK(ImGuiKey_F8);
+        case KEY_F(9):      return NK(ImGuiKey_F9);
+        case KEY_F(10):     return NK(ImGuiKey_F10);
+        case KEY_F(11):     return NK(ImGuiKey_F11);
+        case KEY_F(12):     return NK(ImGuiKey_F12);
+        case KEY_F(13):     return NK(ImGuiKey_F13);
+        case KEY_F(14):     return NK(ImGuiKey_F14);
+        case KEY_F(15):     return NK(ImGuiKey_F15);
+        case KEY_F(16):     return NK(ImGuiKey_F16);
+        case KEY_F(17):     return NK(ImGuiKey_F17);
+        case KEY_F(18):     return NK(ImGuiKey_F18);
+        case KEY_F(19):     return NK(ImGuiKey_F19);
+        case KEY_F(20):     return NK(ImGuiKey_F20);
+        case KEY_F(21):     return NK(ImGuiKey_F21);
+        case KEY_F(22):     return NK(ImGuiKey_F22);
+        case KEY_F(23):     return NK(ImGuiKey_F23);
+        case KEY_F(24):     return NK(ImGuiKey_F24);
+        case KEY_DC:        return NK(ImGuiKey_Delete);
+        case KEY_IC:        return NK(ImGuiKey_Insert);
+        case KEY_NPAGE:     return NK(ImGuiKey_PageUp);
+        case KEY_PPAGE:     return NK(ImGuiKey_PageDown);
+        case KEY_ENTER:     return NK(ImGuiKey_Enter);
+        case KEY_PRINT:     return NK(ImGuiKey_PrintScreen);
+        case KEY_A1:        return NK(ImGuiKey_Keypad7);
+        case KEY_A3:        return NK(ImGuiKey_Keypad9);
+        case KEY_B2:        return NK(ImGuiKey_Keypad5);
+        case KEY_C1:        return NK(ImGuiKey_Keypad1);
+        case KEY_C3:        return NK(ImGuiKey_Keypad3);
+        case KEY_END:       return NK(ImGuiKey_End);
+        case KEY_SDC:       return NK(ImGuiKey_Delete, true);
+        case KEY_SEND:      return NK(ImGuiKey_End, true);
+        case KEY_SHOME:     return NK(ImGuiKey_Home, true);
+        case KEY_SIC:       return NK(ImGuiKey_Insert, true);
+        case KEY_SPRINT:    return NK(ImGuiKey_PrintScreen, true);
+        case KEY_SLEFT:     return NK(ImGuiKey_LeftArrow, true);
+        case KEY_SRIGHT:    return NK(ImGuiKey_RightArrow, true);
+        case KEY_SR:        return NK(ImGuiKey_UpArrow, true);
+        case KEY_SF:        return NK(ImGuiKey_DownArrow, true);
+        default:            return NK(ImGuiKey_None);
+    }
+#undef NK
+}
+
+
 bool ImTui_ImplNcurses_NewFrame( std::vector<std::pair<int, ImTui::mouse_event>> key_events )
 {
     bool hasInput = false;
@@ -168,7 +219,10 @@ bool ImTui_ImplNcurses_NewFrame( std::vector<std::pair<int, ImTui::mouse_event>>
     int screenSizeY = 0;
 
     getmaxyx( stdscr, screenSizeY, screenSizeX );
-    ImGui::GetIO().DisplaySize = ImVec2( screenSizeX, screenSizeY );
+
+    ImGuiIO &io = ImGui::GetIO();
+
+    io.DisplaySize = ImVec2( screenSizeX, screenSizeY );
 
     static int mx = 0;
     static int my = 0;
@@ -179,10 +233,20 @@ bool ImTui_ImplNcurses_NewFrame( std::vector<std::pair<int, ImTui::mouse_event>>
 
     input[2] = 0;
 
-    ImGui::GetIO().KeyCtrl = false;
-    ImGui::GetIO().KeyShift = false;
 
-    for( auto key_event_pair : key_events ) {
+
+    io.KeyCtrl = false;
+    io.KeyShift = false;
+
+    for (int k = (int)ImGuiKey_NamedKey_BEGIN; k < (int)ImGuiKey_NamedKey_END; k++) {
+        ImGuiKey key = (ImGuiKey)k;
+        // AddKeyEvent doesn't allow alias keys
+        if (!ImGui::IsAliasKey(key) && ImGui::IsKeyDown(key)){
+            io.AddKeyEvent( key, false );
+        }
+    }
+
+    for( std::pair<int, ImTui::mouse_event> key_event_pair : key_events ) {
         int c = key_event_pair.first;
 
         if( c == KEY_MOUSE ) {
@@ -202,45 +266,23 @@ bool ImTui_ImplNcurses_NewFrame( std::vector<std::pair<int, ImTui::mouse_event>>
                 rbut = 0;
             }
             //printf("mstate = 0x%016lx\n", mstate);
-            ImGui::GetIO().KeyCtrl |= ( ( mstate & 0x0F000000 ) == 0x01000000 );
+            io.KeyCtrl |= ( ( mstate & 0x0F000000 ) == 0x01000000 );
         } else if( c != ERR ) {
             input[0] = ( c & 0x000000FF );
             input[1] = ( c & 0x0000FF00 ) >> 8;
             //printf("c = %d, c0 = %d, c1 = %d xxx\n", c, input[0], input[1]);
             if( c < 127 ) {
                 if( !ImGui::IsKeyDown( ImGuiKey_Enter ) ) {
-                    ImGui::GetIO().AddInputCharactersUTF8( input );
+                    io.AddInputCharactersUTF8( input );
                 }
-            }
-        if( c == 330 ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_Delete );
-            } else if( c == KEY_BACKSPACE || c == KEY_DC || c == 127 ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_Backspace );
-                // Shift + arrows (probably not portable :()
-            } else if( c == 393 ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_LeftArrow );
-                ImGui::GetIO().KeyShift = true;
-            } else if( c == 402 ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_RightArrow );
-                ImGui::GetIO().KeyShift = true;
-            } else if( c == 337 ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_UpArrow );
-                ImGui::GetIO().KeyShift = true;
-            } else if( c == 336 ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_DownArrow );
-                ImGui::GetIO().KeyShift = true;
-            } else if( c == KEY_BACKSPACE ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_Backspace );
-            } else if( c == KEY_LEFT ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_LeftArrow );
-            } else if( c == KEY_RIGHT ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_RightArrow );
-            } else if( c == KEY_UP ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_UpArrow );
-            } else if( c == KEY_DOWN ) {
-                ImGui::GetIO().AddInputCharacter( ImGuiKey_DownArrow );
             } else {
-                ImGui::GetIO().AddInputCharacter( c );
+                ImGuiKeyTranslation trans = ncurses_special_key_to_imgui_key(c);
+                if (trans.key == ImGuiKey_None) {
+                    io.AddInputCharacter(c);
+                } else {
+                    io.AddKeyEvent( trans.key, true );
+                    io.KeyShift = trans.shift;
+                }
             }
         }
 
@@ -252,30 +294,30 @@ bool ImTui_ImplNcurses_NewFrame( std::vector<std::pair<int, ImTui::mouse_event>>
     }
 
     if( ImGui::IsKeyDown( ImGuiKey_A ) ) {
-        ImGui::GetIO().KeyCtrl = true;
+        io.KeyCtrl = true;
     }
     if( ImGui::IsKeyDown( ImGuiKey_C ) ) {
-        ImGui::GetIO().KeyCtrl = true;
+        io.KeyCtrl = true;
     }
     if( ImGui::IsKeyDown( ImGuiKey_V ) ) {
-        ImGui::GetIO().KeyCtrl = true;
+        io.KeyCtrl = true;
     }
     if( ImGui::IsKeyDown( ImGuiKey_X ) ) {
-        ImGui::GetIO().KeyCtrl = true;
+        io.KeyCtrl = true;
     }
     if( ImGui::IsKeyDown( ImGuiKey_Y ) ) {
-        ImGui::GetIO().KeyCtrl = true;
+        io.KeyCtrl = true;
     }
     if( ImGui::IsKeyDown( ImGuiKey_Z ) ) {
-        ImGui::GetIO().KeyCtrl = true;
+        io.KeyCtrl = true;
     }
 
-    ImGui::GetIO().MousePos.x = mx;
-    ImGui::GetIO().MousePos.y = my;
-    ImGui::GetIO().MouseDown[0] = lbut;
-    ImGui::GetIO().MouseDown[1] = rbut;
+    io.MousePos.x = mx;
+    io.MousePos.y = my;
+    io.MouseDown[0] = lbut;
+    io.MouseDown[1] = rbut;
 
-    ImGui::GetIO().DeltaTime = g_vsync.delta_s();
+    io.DeltaTime = g_vsync.delta_s();
 
     return hasInput;
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixed several issues with imgui text input on ncurses"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #78879

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

It makes input non-blocking (fixes odd behavior of the keybinding menu filtering described in #78879 for example, [thanks](https://github.com/CleverRaven/Cataclysm-DDA/issues/78879#issuecomment-2577606597) for the hint @casmic!)
Also now handles special characters specially instead of pushing them through `ImGuiIO::AddInputCharacter()`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I can't think of another alternative save for some implementation details
namely input being non-blocking could potentially cause the game to do more work than it has to each frame, if that presents an issue it could make sense to just add a tiny timeout instead of using no delay at all

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I launched the game and entered the world name prompt and played around with it and it worked, then I did the same for the keybindings menu, and then I loaded a save and played around for a bit to make sure nothing was broken and there certainly don't seem to be any regressions
for reproducing it might help to see the issue this closes, it explains the issues with the old behavior

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I don't understand [these](https://github.com/JodiJodington/Cataclysm-DDA/blob/7062ba7a1e57cb8d9305dcab149c8d2405bae9ce/src/third-party/imtui/imtui-impl-ncurses.cpp#L296-L313) lines at all and don't seem to be correct at all, but they are also mirrored [upstream](https://github.com/ggerganov/imtui/blob/ec0d62d06175b369c31381e69f615cb5d337361d/src/imtui-impl-ncurses.cpp#L260-L265) so I didn't feel comfortable removing them, in general this entire file felt cargo culted but I suppose that's alright
The lines deleted [here](https://github.com/JodiJodington/Cataclysm-DDA/blob/12d57d4c22d8285320964e03eec1f9da58236c23/src/third-party/imtui/imtui-impl-ncurses.cpp#L118-L139) also don't make any sense to me and were actively creating issues (specifically it was causing the Home button to be held down which would cause issues text input), they are also not there upstream and I can only imagine it was a misunderstanding when [bumping the imgui version](https://github.com/JodiJodington/Cataclysm-DDA/commit/12d57d4c22d8285320964e03eec1f9da58236c23#diff-cd9051f5f2e994df571a2538030b7339085271a9787ecca9b76668cb43018273)  

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
