### PR TITLE
Don't place null monsters or on null positions

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9278,7 +9278,6 @@ void map::spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight, b
             // then fall back to picking a random point that is a valid location.
             if( valid_location( center ) ) {
                 place_it( center );
-                //            } else if( const std::optional<tripoint_bub_ms> pos = random_point( points, valid_location ) ) {
             } else {
                 const std::optional<tripoint_bub_ms> pos = random_point( points, valid_location );
                 if( pos.has_value() ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9263,6 +9263,9 @@ void map::spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight, b
 
             const auto place_it = [&]( const tripoint_bub_ms & p ) {
                 monster *const placed = g->place_critter_at( make_shared_fast<monster>( tmp ), p );
+                if( placed == nullptr ) {
+                    return;
+                }
                 if( !i.data.patrol_points_rel_ms.empty() ) {
                     placed->set_patrol_route( i.data.patrol_points_rel_ms );
                 }
@@ -9275,8 +9278,12 @@ void map::spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight, b
             // then fall back to picking a random point that is a valid location.
             if( valid_location( center ) ) {
                 place_it( center );
-            } else if( const std::optional<tripoint_bub_ms> pos = random_point( points, valid_location ) ) {
-                place_it( *pos );
+                //            } else if( const std::optional<tripoint_bub_ms> pos = random_point( points, valid_location ) ) {
+            } else {
+                const std::optional<tripoint_bub_ms> pos = random_point( points, valid_location );
+                if( pos.has_value() ) {
+                    place_it( *pos );
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Address symptoms of #79045, i.e. segfault when placing null monsters or monsters on null positions.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Verify an optional position is actually present before feeding it into a function as a position.
2. Verify a generated monster pointer is valid before trying to use it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not completely sure the null position is actually causing a crash, as it could be that it just feed the probably very incorrect (0, 0, 0) into the call instead. Thus, it might actually have been possible to leave this unchanged (and buggy).

Trying to understand the logic of the code/call chain and stop the causes of the failures. It would be useful to do that for someone willing to take it on. There seems to be a lot of teleportation around, and it might be that the teleportation target location determination would need adjustment to fail only rarely, or even not at all.
During the testing the trace messages were produced a lot, which indicates this is a bigger issue. I don't know what happens when the monsters aren't generated, but I could imagine the lab eventually being depopulated if the monsters disappear gradually as they try to teleport and are removed from their source but not arrive at the destination. However, I don't know it that's what's happening or if the spawn failures are new monsters.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Placement of add_msg output before the return of a null monster and as an else branch when checking if the optional position has a value, followed by a number of runs with the bug report save (the error doesn't happen every time) and noted both messages triggering.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It's disgusting to abuse `if` statements' evaluation part for declarations and assignments, so getting rid of that is a win in itself.

Noted one case of an error message about the failure to place a monster. This is probably part of the overall issue cause complex, but it was not investigated further. There didn't seem to be any visible negative consequences.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
