### PR TITLE
[Magiclysm] Add vision levels

### DIFF
--- a/data/mods/Magiclysm/worldgen/goblin_locations/goblin_encampment.json
+++ b/data/mods/Magiclysm/worldgen/goblin_locations/goblin_encampment.json
@@ -234,7 +234,8 @@
     "name": "goblin encampment",
     "sym": "#",
     "color": "red",
-    "see_cost": "full_high"
+    "see_cost": "full_high",
+    "vision_levels": "large_building"
   },
   {
     "type": "mapgen",

--- a/data/mods/Magiclysm/worldgen/goblin_locations/orc_village.json
+++ b/data/mods/Magiclysm/worldgen/goblin_locations/orc_village.json
@@ -137,6 +137,7 @@
     "sym": "G",
     "color": "green",
     "see_cost": "high",
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_HIGH" ],
+    "vision_levels": "blends_till_details"
   }
 ]

--- a/data/mods/Magiclysm/worldgen/overmap_specials.json
+++ b/data/mods/Magiclysm/worldgen/overmap_specials.json
@@ -64,7 +64,7 @@
       { "point": [ 0, 1, -4 ], "overmap": "black_dragon_lair_z-4_SW_north" },
       { "point": [ 1, 1, -4 ], "overmap": "black_dragon_lair_z-4_SE_north" }
     ],
-    "locations": [ "forest_with_swamp" ],
+    "locations": [ "swamp" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 20 ],
     "occurrences": [ 0, 1 ]

--- a/data/mods/Magiclysm/worldgen/overmap_terrain.json
+++ b/data/mods/Magiclysm/worldgen/overmap_terrain.json
@@ -21,6 +21,7 @@
     "looks_like": "s_shoppingplaza_b2",
     "see_cost": "high",
     "extras": "build",
+    "vision_levels": "city_building",
     "mondensity": 2
   },
   {
@@ -32,6 +33,7 @@
     "looks_like": "s_shoppingplaza_b6",
     "see_cost": "none",
     "extras": "build",
+    "vision_levels": "roof_or_air",
     "mondensity": 2
   },
   {

--- a/data/mods/Magiclysm/worldgen/overmap_terrain.json
+++ b/data/mods/Magiclysm/worldgen/overmap_terrain.json
@@ -9,6 +9,7 @@
     "see_cost": "high",
     "extras": "build",
     "mondensity": 2,
+    "vision_levels": "city_building",
     "flags": [ "SIDEWALK" ]
   },
   {
@@ -41,6 +42,7 @@
     "color": "green",
     "see_cost": "high",
     "extras": "build",
+    "vision_levels": "blends_till_details",
     "mondensity": 2
   },
   {
@@ -51,15 +53,17 @@
     "color": "green",
     "see_cost": "none",
     "extras": "build",
+    "vision_levels": "blends_till_outlines",
     "mondensity": 2
   },
   {
     "type": "overmap_terrain",
     "id": "demon_spider_lair",
-    "name": "Forest",
+    "name": "demon spider lair",
     "sym": "F",
     "color": "light_gray",
     "looks_like": "spider_pit",
+    "vision_levels": "unusual_structure",
     "see_cost": "spaced_high"
   },
   {
@@ -72,6 +76,7 @@
     "see_cost": "high",
     "extras": "build",
     "mondensity": 1,
+    "vision_levels": "city_building",
     "flags": [ "SIDEWALK" ]
   },
   {
@@ -83,6 +88,7 @@
     "looks_like": "s_bookstore_roof",
     "see_cost": "none",
     "extras": "build",
+    "vision_levels": "city_building",
     "mondensity": 1
   },
   {
@@ -110,11 +116,11 @@
   {
     "type": "overmap_terrain",
     "id": "black_dragon_lair_z-0_NW",
-    "name": "swamp?",
-    "sym": "F",
-    "color": "c_light_cyan",
-    "looks_like": "forest_water",
+    "name": "black dragon lair",
+    "sym": "D",
+    "color": "dark_gray",
     "see_cost": "spaced_high",
+    "vision_levels": "forested_swampy",
     "flags": [ "SOURCE_FORAGE", "RISK_EXTREME" ]
   },
   {
@@ -139,6 +145,7 @@
     "sym": "#",
     "color": "brown",
     "looks_like": "solid_earth",
+    "vision_levels": "underground_dirt",
     "see_cost": "full_high"
   },
   {
@@ -163,6 +170,7 @@
     "sym": "%",
     "color": "dark_gray",
     "looks_like": "empty_rock",
+    "vision_levels": "underground_stone",
     "see_cost": "full_high"
   },
   {
@@ -187,7 +195,8 @@
     "sym": "%",
     "color": "dark_gray",
     "looks_like": "deep_rock",
-    "see_cost": "full_high"
+    "see_cost": "full_high",
+    "vision_levels": "underground_stone"
   },
   {
     "type": "overmap_terrain",
@@ -211,7 +220,8 @@
     "sym": "%",
     "color": "dark_gray",
     "looks_like": "deep_rock",
-    "see_cost": "full_high"
+    "see_cost": "full_high",
+    "vision_levels": "underground_stone"
   },
   {
     "type": "overmap_terrain",
@@ -230,21 +240,13 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "lake_retreat_ground",
-    "name": "forest?",
-    "sym": "F",
-    "color": "c_light_green",
-    "looks_like": "forest",
-    "see_cost": "high"
-  },
-  {
-    "type": "overmap_terrain",
     "id": "ogre_mound",
     "name": "ogre lair",
     "sym": "O",
     "color": "dark_gray",
     "looks_like": "forest_water",
-    "see_cost": "high"
+    "see_cost": "high",
+    "vision_levels": "forested_swampy"
   },
   {
     "type": "overmap_terrain",
@@ -252,61 +254,78 @@
     "name": "ogre lair roof",
     "sym": "O",
     "color": "dark_gray",
-    "see_cost": "none"
+    "see_cost": "none",
+    "vision_levels": "forested_swampy"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "lake_retreat_ground",
+    "name": "lake tower",
+    "sym": "F",
+    "color": "c_light_green",
+    "looks_like": "forest",
+    "see_cost": "high",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "lake_retreat_z1",
-    "name": "forest",
+    "name": "lake tower",
     "sym": ".",
     "color": "blue",
     "looks_like": "open_air",
-    "see_cost": "all_clear"
+    "see_cost": "all_clear",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "lake_retreat_z2",
-    "name": "forest",
+    "name": "lake tower",
     "sym": ".",
     "color": "blue",
     "looks_like": "open_air",
-    "see_cost": "all_clear"
+    "see_cost": "all_clear",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "lake_retreat_z3",
-    "name": "forest",
+    "name": "lake tower",
     "sym": ".",
     "color": "blue",
     "looks_like": "open_air",
-    "see_cost": "all_clear"
+    "see_cost": "all_clear",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "lake_retreat_z4",
-    "name": "forest",
+    "name": "lake tower roof",
     "sym": ".",
     "color": "blue",
     "looks_like": "open_air",
-    "see_cost": "all_clear"
+    "see_cost": "all_clear",
+    "vision_levels": "roof_or_air"
   },
   {
     "type": "overmap_terrain",
     "id": "lake_retreat_boathouse",
-    "name": "lake shore",
+    "name": "boathouse",
     "sym": "#",
     "color": "light_blue",
     "looks_like": "lake_shore",
-    "see_cost": "none"
+    "see_cost": "none",
+    "vision_levels": "isolated_building"
   },
   {
     "type": "overmap_terrain",
     "id": "lake_retreat_boathouse_roof",
-    "name": "forest",
+    "name": "boathouse roof",
     "sym": ".",
     "color": "blue",
     "looks_like": "open_air",
-    "see_cost": "none"
+    "see_cost": "none",
+    "vision_levels": "roof_or_air"
   },
   {
     "type": "overmap_terrain",
@@ -315,52 +334,62 @@
     "sym": "W",
     "color": "light_blue",
     "name": "wizard tower",
+    "vision_levels": "isolated_tower",
     "flags": [ "SOURCE_LUXURY", "RISK_HIGH", "SIDEWALK" ]
   },
   {
     "type": "overmap_terrain",
     "id": "wizardtower1_living",
-    "copy-from": "wizardtower1_ground"
+    "copy-from": "wizardtower1_ground",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "wizardtower1_golems",
-    "copy-from": "wizardtower1_ground"
+    "copy-from": "wizardtower1_ground",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "wizardtower1_study",
-    "copy-from": "wizardtower1_ground"
+    "copy-from": "wizardtower1_ground",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "wizardtower1_roof",
-    "copy-from": "wizardtower1_ground"
+    "copy-from": "wizardtower1_ground",
+    "vision_levels": "roof_or_air"
   },
   {
     "type": "overmap_terrain",
     "id": "wizardtower2_ground",
-    "copy-from": "wizardtower1_ground"
+    "copy-from": "wizardtower1_ground",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "wizardtower2_stairs1",
-    "copy-from": "wizardtower1_ground"
+    "copy-from": "wizardtower1_ground",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "wizardtower2_stairs2",
-    "copy-from": "wizardtower1_ground"
+    "copy-from": "wizardtower1_ground",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "wizardtower2_study",
-    "copy-from": "wizardtower1_ground"
+    "copy-from": "wizardtower1_ground",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
     "id": "wizardtower2_roof",
-    "copy-from": "wizardtower1_ground"
+    "copy-from": "wizardtower1_ground",
+    "vision_levels": "roof_or_air"
   },
   {
     "type": "overmap_terrain",
@@ -390,7 +419,8 @@
     "looks_like": "campus_lecture_0_0_0",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK" ],
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
@@ -400,7 +430,8 @@
     "color": "light_blue",
     "looks_like": "campus_lecture_0_0_1",
     "mondensity": 2,
-    "see_cost": "high"
+    "see_cost": "high",
+    "vision_levels": "isolated_tower"
   },
   {
     "type": "overmap_terrain",
@@ -435,7 +466,8 @@
   {
     "type": "overmap_terrain",
     "id": "magic_academy_basement",
-    "copy-from": "magic_academy_2nd"
+    "copy-from": "magic_academy_2nd",
+    "vision_levels": "underground_dirt"
   },
   {
     "type": "overmap_terrain",
@@ -444,7 +476,8 @@
     "sym": "#",
     "color": "light_blue",
     "looks_like": "campus_lecture_0_0_3",
-    "see_cost": "none"
+    "see_cost": "none",
+    "vision_levels": "roof_or_air"
   },
   {
     "type": "overmap_terrain",
@@ -463,7 +496,8 @@
     "color": "light_green",
     "looks_like": "standing_stones",
     "see_cost": "high",
-    "mondensity": 2
+    "mondensity": 2,
+    "vision_levels": "unusual_structure"
   },
   {
     "type": "overmap_terrain",
@@ -496,6 +530,7 @@
     "sym": "*",
     "color": "blue",
     "flags": [ "NO_ROTATE" ],
+    "vision_levels": "blends_till_outlines",
     "see_cost": "low"
   },
   {
@@ -505,6 +540,7 @@
     "sym": "*",
     "color": "blue",
     "flags": [ "NO_ROTATE" ],
+    "vision_levels": "blends_till_details",
     "see_cost": "low"
   },
   {
@@ -514,6 +550,7 @@
     "sym": "O",
     "color": "dark_gray",
     "flags": [ "NO_ROTATE", "REQUIRES_PREDECESSOR" ],
+    "vision_levels": "blends_till_outlines",
     "see_cost": "medium"
   },
   {
@@ -522,7 +559,8 @@
     "name": "druid tower",
     "sym": "F",
     "color": "green",
-    "see_cost": "high"
+    "see_cost": "high",
+    "vision_levels": "unusual_structure"
   },
   {
     "type": "overmap_terrain",
@@ -540,7 +578,8 @@
     "name": "druid tower crown",
     "sym": "F",
     "color": "green",
-    "see_cost": "high"
+    "see_cost": "high",
+    "vision_levels": "unusual_structure"
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add vision levels"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Went to go add vision levels to the dragon's lair and noticed none of the buildings had them.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the following vision levels:

- Ancient Ring of Stones: blends_till_outlines
- Attunement Altar: unusual_structure
- Big Magic Meadow: blends_till_outlines
- Black Dragon Lair: forested_swampy.  I also changed the name to Black Dragon Lair since we no longer need to obfuscate the name. 
- Demon Spider Lair: unusual_structure. I changed the name to Demon Spider Lair for the same reason.
- Druid Tower: unusual_structure
- Goblin Encampment: Large Building
- Goblin Outpost: blends_till_details
- Lake Retreat: isolated_tower
- Lake Retreat Boathouse: isolated_building
- Magic Academy: isolated_tower (it's not isolated, but it is very clearly a tower
- Magic Cabin: blends_till_details
- Magic Meadow: blends_till_details
- Magic Shop: city_building
- Ogre Mound: forested_swampy
- Used Bookstore: city_building
- Wizard's Tower: isolated_tower (it's not isolated, but it is very clearly a tower

I also made black dragon lairs spawn only in swamps (I'm planning to add green dragon lairs to the forests)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Teleported around and revealed the overmap at various vision levels. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
