### PR TITLE
[Aftershock] Replace combination lock safes with electronically locked safes.

### DIFF
--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
@@ -449,5 +449,100 @@
         { "item": "steel_chunk", "count": [ 0, 1 ] }
       ]
     }
+  },
+  {
+    "type": "furniture",
+    "id": "f_e_safe_c",
+    "name": "safe",
+    "looks_like": "f_safe_c",
+    "description": "A small, heavy, and near-unbreachable metal box with an electronic lock.  This one isn't actually locked, just closed.",
+    "symbol": "X",
+    "color": "light_gray",
+    "move_cost_mod": -1,
+    "coverage": 30,
+    "required_str": 14,
+    "max_volume": "250 L",
+    "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "PLACE_ITEM", "MOUNTABLE" ],
+    "open": "f_e_safe_o",
+    "examine_action": "open_safe",
+    "bash": {
+      "str_min": 40,
+      "str_max": 200,
+      "sound": "screeching metal!",
+      "sound_fail": "whump!",
+      "items": [
+        { "item": "steel_chunk", "count": [ 1, 5 ] },
+        { "item": "scrap", "count": [ 1, 5 ] },
+        { "item": "rock", "count": [ 1, 2 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_e_safe_l",
+    "name": "safe",
+    "looks_like": "f_e_safe_c",
+    "symbol": "X",
+    "description": "A small, heavy, and near-unbreachable metal box with an electronic lock.  With a hacking tool and the right skills you might be able to crack it.",
+    "color": "light_gray",
+    "move_cost_mod": -1,
+    "coverage": 30,
+    "required_str": 14,
+    "max_volume": "250 L",
+    "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "PLACE_ITEM", "MOUNTABLE" ],
+    "oxytorch": { "result": "f_e_safe_o", "duration": "14 seconds" },
+    "examine_action": {
+      "type": "effect_on_condition",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_unlock_afs_e_safe",
+          "effect": [
+            { "math": [ "_t_delay = time('1 h')" ] },
+            {
+              "run_eocs": "EOC_start_lock_hack",
+              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": "13", "t_radius": "1" },
+              "alpha_talker": "avatar"
+            }
+          ]
+        }
+      ]
+    },
+    "bash": {
+      "str_min": 40,
+      "str_max": 200,
+      "sound": "screeching metal!",
+      "sound_fail": "whump!",
+      "items": [
+        { "item": "steel_chunk", "count": [ 1, 5 ] },
+        { "item": "scrap", "count": [ 1, 5 ] },
+        { "item": "rock", "count": [ 1, 2 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_e_safe_o",
+    "name": "open safe",
+    "looks_like": "f_safe_o",
+    "description": "A small, heavy, and near-unbreachable metal box with an electronic lock, albeit significantly less secure with the door open.",
+    "symbol": "O",
+    "color": "light_gray",
+    "move_cost_mod": -1,
+    "coverage": 30,
+    "required_str": 14,
+    "max_volume": "250 L",
+    "flags": [ "TRANSPARENT", "CONTAINER", "PLACE_ITEM", "MOUNTABLE" ],
+    "close": "f_e_safe_c",
+    "bash": {
+      "str_min": 40,
+      "str_max": 200,
+      "sound": "screeching metal!",
+      "sound_fail": "whump!",
+      "items": [
+        { "item": "steel_chunk", "count": [ 1, 5 ] },
+        { "item": "scrap", "count": [ 1, 5 ] },
+        { "item": "rock", "count": [ 1, 2 ] }
+      ]
+    }
   }
 ]

--- a/data/mods/Aftershock/maps/mapgen/exosuit_garage.json
+++ b/data/mods/Aftershock/maps/mapgen/exosuit_garage.json
@@ -118,7 +118,7 @@
         "â": "f_rack",
         "ä": "f_rack",
         "é": "f_sealed_intermodal_crate",
-        "ë": "f_safe_l",
+        "ë": "f_e_safe_l",
         "ê": "f_rack",
         "í": "f_locker"
       },
@@ -176,7 +176,7 @@
         "ä": "f_rack",
         "é": "f_intermodal_crate_open",
         "ê": "f_rack",
-        "ë": "f_safe_o",
+        "ë": "f_e_safe_o",
         "í": "f_locker"
       }
     }

--- a/data/mods/Aftershock/maps/mapgen/general_store.json
+++ b/data/mods/Aftershock/maps/mapgen/general_store.json
@@ -44,7 +44,7 @@
         "ë": "f_rack",
         "í": "f_rack",
         "s": "f_stool",
-        "2": "f_safe_l",
+        "2": "f_e_safe_l",
         "3": "f_intermodal_crate_open",
         "4": "f_sealed_intermodal_crate"
       },

--- a/data/mods/Aftershock/maps/mapgen/habitat_blocks/habitat_block_1.json
+++ b/data/mods/Aftershock/maps/mapgen/habitat_blocks/habitat_block_1.json
@@ -368,7 +368,7 @@
       ],
       "palettes": [ "afs_habitat_residential_furnishing" ],
       "terrain": { ";": "t_linoleum_white_olight_inactive" },
-      "furniture": { "$": "f_safe_l", "á": "f_rack", "â": "f_rack" },
+      "furniture": { "$": "f_e_safe_l", "á": "f_rack", "â": "f_rack" },
       "items": {
         "$": { "item": "afs_cash_safe" },
         "á": { "item": "afs_old_food_storage", "chance": 40, "repeat": [ 1, 3 ] },
@@ -452,7 +452,7 @@
       ],
       "palettes": [ "afs_habitat_residential_furnishing" ],
       "terrain": { ";": "t_linoleum_white_olight_inactive", "1": "t_afs_door_metal_elocked" },
-      "furniture": { "$": "f_safe_l", "á": "f_rack", "â": "f_reinforced_displaycase" },
+      "furniture": { "$": "f_e_safe_l", "á": "f_rack", "â": "f_reinforced_displaycase" },
       "items": {
         "$": { "item": "afs_cash_safe" },
         "á": { "item": "afs_tools_robot_maintenance", "chance": 40, "repeat": [ 1, 2 ] },
@@ -500,7 +500,7 @@
         "ä": "f_reinforced_displaycase",
         "é": "f_rack",
         "ê": "f_rack",
-        "$": "f_safe_l"
+        "$": "f_e_safe_l"
       },
       "items": {
         "á": { "item": "afs_any_ballistic_ammo", "chance": 60, "repeat": [ 3, 6 ] },
@@ -546,7 +546,7 @@
       ],
       "palettes": [ "afs_habitat_residential_furnishing" ],
       "terrain": { "/": "t_wall_prefab_metal", ":": "t_door_c", ";": "t_linoleum_white_olight_inactive" },
-      "furniture": { "1": "f_clothing_rail", "2": "f_mannequin", "$": "f_safe_l" },
+      "furniture": { "1": "f_clothing_rail", "2": "f_mannequin", "$": "f_e_safe_l" },
       "items": {
         "r": { "item": "afs_colonist_outfit", "chance": 60, "repeat": [ 1, 2 ] },
         "m": { "item": "afs_colonist_outfit" },
@@ -588,7 +588,7 @@
       ],
       "palettes": [ "afs_habitat_residential_furnishing" ],
       "terrain": { ";": "t_linoleum_white_olight_inactive" },
-      "furniture": { "á": "f_rack", "$": "f_safe_l" },
+      "furniture": { "á": "f_rack", "$": "f_e_safe_l" },
       "items": { "á": { "item": "afs_tools_structural_repair", "chance": 60, "repeat": [ 1, 3 ] }, "$": { "item": "afs_cash_safe" } }
     }
   },
@@ -626,7 +626,7 @@
       ],
       "palettes": [ "afs_habitat_residential_furnishing" ],
       "terrain": { "/": "t_wall_prefab_metal", ";": "t_linoleum_white_olight_inactive", "1": "t_afs_door_metal_elocked" },
-      "furniture": { "$": "f_safe_l", "á": "f_rack", "â": "f_rack" },
+      "furniture": { "$": "f_e_safe_l", "á": "f_rack", "â": "f_rack" },
       "items": {
         "á": { "item": "softdrugs", "chance": 80, "repeat": [ 2, 6 ] },
         "â": { "item": "drugs_rare", "chance": 80, "repeat": [ 1, 4 ] },

--- a/data/mods/Aftershock/maps/mapgen/map_palletes.json
+++ b/data/mods/Aftershock/maps/mapgen/map_palletes.json
@@ -51,7 +51,7 @@
       "?": "f_sofa",
       "t": "f_table",
       "^": "f_indoor_plant",
-      "x": "f_safe_l"
+      "x": "f_e_safe_l"
     },
     "toilets": { ";": {  } },
     "items": { "d": { "item": "office", "chance": 70 } }

--- a/data/mods/Aftershock/maps/mapgen_pallete/afs_formless_ruins.json
+++ b/data/mods/Aftershock/maps/mapgen_pallete/afs_formless_ruins.json
@@ -23,7 +23,7 @@
       "<": "t_stairs_up"
     },
     "furniture": {
-      "$": "f_safe_l",
+      "$": "f_e_safe_l",
       "A": "f_neuralnet_inserter",
       "0": "f_cryo_pod",
       "&": "f_toilet",

--- a/data/mods/Aftershock/maps/mapgen_pallete/afs_generic_building.json
+++ b/data/mods/Aftershock/maps/mapgen_pallete/afs_generic_building.json
@@ -28,7 +28,7 @@
       "~": "t_sidewalk"
     },
     "furniture": {
-      "$": "f_safe_l",
+      "$": "f_e_safe_l",
       "A": "f_neuralnet_inserter",
       "0": "f_cryo_pod",
       "&": "f_toilet",

--- a/data/mods/Aftershock/maps/mapgen_pallete/arcology.json
+++ b/data/mods/Aftershock/maps/mapgen_pallete/arcology.json
@@ -28,7 +28,7 @@
       "<": "t_stairs_up"
     },
     "furniture": {
-      "$": "f_safe_l",
+      "$": "f_e_safe_l",
       "A": "f_neuralnet_inserter",
       "0": "f_cryo_pod",
       "&": "f_toilet",
@@ -69,7 +69,7 @@
       "<": "t_stairs_up"
     },
     "furniture": {
-      "$": "f_safe_l",
+      "$": "f_e_safe_l",
       "A": "f_neuralnet_inserter",
       "0": "f_cryo_pod",
       "&": "f_toilet",

--- a/data/mods/Aftershock/maps/mapgen_pallete/augmentation_clinic.json
+++ b/data/mods/Aftershock/maps/mapgen_pallete/augmentation_clinic.json
@@ -23,7 +23,7 @@
       "~": "t_sidewalk"
     },
     "furniture": {
-      "$": "f_safe_l",
+      "$": "f_e_safe_l",
       "A": "f_neuralnet_inserter",
       "0": "f_cryo_pod",
       "&": "f_toilet",

--- a/data/mods/Aftershock/ter_fur_transform.json
+++ b/data/mods/Aftershock/ter_fur_transform.json
@@ -15,6 +15,12 @@
         "valid_furniture": [ "f_reinforced_displaycase" ],
         "message": "A panel of reinforced glass receeds into the case.",
         "message_good": true
+      },
+      {
+        "result": "f_e_safe_c",
+        "valid_furniture": [ "f_e_safe_l" ],
+        "message": "The safe's display chimes happily as the locking mechanism releases.",
+        "message_good": true
       }
     ],
     "terrain": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Aftershock] Replace combination lock safes with electronically locked ones."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
It's a bit weird that in the far flung sci-fi future people are still using combination lock safes everywhere. It would be more theme fitting if they had electronic locks that could be hacked.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Introduce a new safe furniture that has an electronic lock and uses the aftershock hacking EOC system. It's difficulty is a fair bit higher than everything hackable in the mod so far. So you'll need a character with pretty high computers skill to crack them. Or an oxy-torch to cut them open.

Replace all instances of safes, locked, closed, or open with the the electronic variant. (Within the confines of Aftershock.)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There is technically a gun-safe that already has an electronic lock. I opted against using this since it's difficulty is not customizable and it's hardcoded to always say "Hack Gun Safe". Which isn't ideal for anything that isn't a gun safe.

I considered making a less secure version for more mundane applications. But for now all safes are really hard to crack be they money safes, or bionic safes.

I copied the stats of I believe the standard furniture safe directly. I could have adjusted them but I think they were fine as they were.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I spawned and cracked open a bunch of safes. Verifying the functionality worked and was about at the level of difficulty I felt would be appropriate.

I also verified the structures are now spawning the new safes.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
