### PR TITLE
Fix infinite bounce

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -61,7 +61,7 @@ static const itype_id itype_glass_shard( "glass_shard" );
 
 static const json_character_flag json_flag_HARDTOHIT( "HARDTOHIT" );
 
-static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
+static void drop_or_embed_projectile( const dealt_projectile_attack &attack, projectile &proj_arg )
 {
     const projectile &proj = attack.proj;
     const item &drop_item = proj.get_drop();
@@ -139,6 +139,9 @@ static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
     }
 
     if( embed ) {
+        if( proj_arg.proj_effects.count( ammo_effect_BOUNCE ) ) {
+            proj_arg.proj_effects.erase( ammo_effect_BOUNCE );
+        }
         mon->add_item( dropped_item );
         add_msg_if_player_sees( pt, _( "The %1$s embeds in %2$s!" ),
                                 dropped_item.tname(), mon->disp_name() );
@@ -531,7 +534,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
         tp = prev_point;
     }
 
-    drop_or_embed_projectile( attack );
+    drop_or_embed_projectile( attack, proj );
 
     int dealt_damage = attack.dealt_dam.total_damage();
     apply_ammo_effects( null_source ? nullptr : origin, tp, proj.proj_effects, dealt_damage );

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -562,6 +562,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
         } );
         if( mon_ptr ) {
             Creature &z = *mon_ptr;
+            attack.targets_hit[&z].first += 0;
             add_msg( _( "The attack bounced to %s!" ), z.get_name() );
             projectile_attack( attack, proj, tp, z.pos_bub(), dispersion, origin, in_veh );
             sfx::play_variant_sound( "fire_gun", "bio_lightning_tail",

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1080,6 +1080,9 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
             hits++;
         }
         for( std::pair<Creature *const, std::pair<int, int>> &hit_entry : shot.targets_hit ) {
+            if( hit_entry.second.first == 0 ) {
+                continue;
+            }
             if( monster *const m = hit_entry.first->as_monster() ) {
                 cata::event e = cata::event::make<event_type::character_ranged_attacks_monster>( getID(), gun_id,
                                 m->type->id );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix infinite bounce"
#### Purpose of change
It turns out that #79035 made infinite bounce possible in the situation below.
![2025-01-11 144405](https://github.com/user-attachments/assets/144e89dd-26e3-4620-a235-ff63b6715f5a)
There are only two targets not yet been hit, when one of them is chosen, unintentional hit on the monsters between the main targets will turn the proj back to aim another target, making the proj bounce forever.
#### Describe the solution
Prevent it.
Also, add a check to make sure embeded proj does not bounce.
#### Describe alternatives you've considered
Limit the number of times a proj can bounce.
#### Testing
No more infinite bounce, and embeded proj does not bounce anymore.
#### Additional context
Bounced proj is using the same dispersion, should make it irrelevant, or at least introduce more rng.