### PR TITLE
Prevent segfault when search gives no hits

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2537,7 +2537,7 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
 
         //Draw options
         calcStartPos( iStartPos, cur_id, iContentHeight, profs_length );
-        const int end_pos = iStartPos + std::min( iContentHeight, profs_length );
+        const int end_pos = iStartPos + std::min( { iContentHeight, profs_length, sorted_profs.size() } );
         std::string cur_prof_notes;
         for( int i = iStartPos; i < end_pos; i++ ) {
             nc_color col;
@@ -2892,7 +2892,7 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
 
         //Draw options
         calcStartPos( iStartPos, cur_id, iContentHeight, hobbies_length );
-        const int end_pos = iStartPos + std::min( iContentHeight, hobbies_length );
+        const int end_pos = iStartPos + std::min( { iContentHeight, hobbies_length, sorted_hobbies.size() } );
         std::string cur_hob_notes;
         for( int i = iStartPos; i < end_pos; i++ ) {
             nc_color col;
@@ -3606,7 +3606,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
 
         //Draw options
         calcStartPos( iStartPos, cur_id, iContentHeight, scens_length );
-        const int end_pos = iStartPos + std::min( iContentHeight, scens_length );
+        const int end_pos = iStartPos + std::min( { iContentHeight, scens_length, sorted_scens.size() } );
         std::string current_scenario_notes;
         for( int i = iStartPos; i < end_pos; i++ ) {
             nc_color col;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent segfault when search gives no hits"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents segfault when searches during character creation gives no hits.

To reproduce the issue being fixed:
1. Create custom character
2. Tab to "Scenario"
3. Press `/` to search, enter something that gives no hits, such as `99`
4. Segfault

Similar segfault also happens for "Profession" and "Background" tab.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<details>
<summary>Stacktrace of segfault being fixed</summary>

```
Thread 1 "cataclysm-tiles" received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
warning: 44     ./nptl/pthread_kill.c: No such file or directory
(gdb) bt
 #0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
 #1  0x00007ffff778acef in __pthread_kill_internal (threadid=<optimized out>, signo=6) at ./nptl/pthread_kill.c:78
 #2  0x00007ffff7736c42 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
 #3  0x00007ffff771f4f0 in __GI_abort () at ./stdlib/abort.c:79
 #4  0x00007ffff7ad4f9e in std::__glibcxx_assert_fail(char const*, int, char const*, char const*) () from /lib/x86_64-linux-gnu/libstdc++.so.6
 #5  0x0000555556536759 in std::vector<string_id<profession>, std::allocator<string_id<profession> > >::operator[] (this=<optimized out>, __n=<optimized out>) at /usr/include/c++/14/bits/stl_vector.h:1130
 #6  std::vector<string_id<profession>, std::allocator<string_id<profession> > >::operator[] (this=<optimized out>, __n=<optimized out>) at /usr/include/c++/14/bits/stl_vector.h:1128
 #7  0x000055555653609b in operator() (__closure=0x555558499bd0, ui=...) at src/newcharacter.cpp:2544
 #8  0x00005555569d5a09 in ui_adaptor::redraw_invalidated () at src/ui_manager.cpp:448
 #9  0x00005555569d5ac7 in ui_adaptor::redraw () at src/ui_manager.cpp:353
 #10 0x00005555569d5aee in ui_manager::redraw () at src/ui_manager.cpp:516
 #11 0x00005555567242cd in query_popup::query_once (this=this@entry=0x7fffffff6890) at src/popup.cpp:295
 #12 0x0000555556724b9f in query_popup::query (this=this@entry=0x7fffffff6890) at src/popup.cpp:405
 #13 0x000055555664b8ff in popup (text="Nothing found.", flags=flags@entry=PF_NONE) at src/output.cpp:993
 #14 0x0000555555aadb73 in popup<>(char const*) (mes=mes@entry=0x555556b4cd0a "Nothing found.") at src/output.h:529
 #15 0x0000555556529731 in filter_entries<string_id<profession>, <unnamed struct> >(avatar &, int &, std::vector<string_id<profession>, std::allocator<string_id<profession> > > &, std::vector<string_id<profession>, std::allocator<string_id<profession> > > &, std::string, struct {...}, string_id<profession>) (u=...,  cur_id=@0x7fffffff6ba4: 0, old_entries=std::vector of length 0, capacity 185, new_entries=std::vector of length 185, capacity 185 = {...}, filterstring="999", sorter=..., chosen_entry=...) at src/newcharacter.cpp:2415
 #16 0x0000555556531f9b in set_profession (tabs=..., u=..., pool=<optimized out>) at src/newcharacter.cpp:2598
 #17 avatar::create (this=this@entry=0x5555583e4150, type=type@entry=character_type::CUSTOM, tempname="") at src/newcharacter.cpp:837
 #18 0x0000555556242bc0 in main_menu::new_character_tab (this=this@entry=0x7fffffffd9f0) at src/main_menu.cpp:1028
 #19 0x0000555556245326 in main_menu::opening_screen (this=this@entry=0x7fffffffd9f0) at src/main_menu.cpp:884
 #20 0x00005555557feb01 in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:857

(gdb) frame 7
 #7  0x000055555653609b in operator() (__closure=0x55557a911460, ui=...) at src/newcharacter.cpp:2544
2544                if( u.prof != &sorted_profs[i].obj() ) {

(gdb) print i
$1 = 0

(gdb) print sorted_profs
$2 = std::vector of length 0, capacity 185

(gdb) print iStartPos
$3 = (int &) @0x7fffffff6bc0: 0

(gdb) print end_pos
$4 = 59

(gdb) print profs_length
$5 = (size_t &) @0x7fffffff6c08: 185

(gdb) print iContentHeight
$6 = (size_t &) @0x7fffffff6be0: 59
```
</details>

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Steps above no longer causes segfault, but instead shows popup "no hits"
* Can still search for Scenarios, Professions and Backgrounds as expected

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
