### PR TITLE
Mutating a mutation that conflicts with an installed bionic causes damage

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4066,6 +4066,46 @@
   },
   {
     "type": "effect_type",
+    "id": "mutation_internal_damage",
+    "max_intensity": 3,
+    "name": [ "Botched Mutation", "Botched Mutation", "Destroyed Bionic" ],
+    "desc": [ "Your changing body did not cope well with your bionics." ],
+    "apply_message": [
+      [ "Your twisting flesh strains against the bionics invading your body.", "bad" ],
+      [ "Your twisting flesh strains against the bionics invading your body.", "bad" ],
+      [ "Your twisting flesh strains against the bionics invading your body.", "bad" ]
+    ],
+    "apply_memorial_log": "Had a mutation botched due to their installed bionics.",
+    "int_decay_tick": 25200,
+    "int_decay_remove": true,
+    "show_intensity": false,
+    "main_parts_only": true,
+    "//": "Internal bleeding",
+    "vitamins": [
+      { "vitamin": "redcells", "rate": [ [ -2, -5 ], [ -2, -5 ], [ -4, -8 ] ], "tick": [ "30s", "30s", "15s" ] },
+      { "vitamin": "blood", "rate": [ [ -2, -5 ], [ -2, -5 ], [ -4, -8 ] ], "tick": [ "30s", "30s", "15s" ] }
+    ],
+    "base_mods": {
+      "pain_min": [ 1 ],
+      "pain_max": [ 2 ],
+      "pain_chance": [ 24 ],
+      "pain_tick": [ 36 ],
+      "hurt_max": [ 1 ],
+      "hurt_chance": [ 24 ],
+      "hurt_tick": [ 40 ]
+    },
+    "scaling_mods": {
+      "pain_min": [ 1 ],
+      "pain_max": [ 4 ],
+      "pain_chance": [ -8 ],
+      "pain_tick": [ -15 ],
+      "hurt_max": [ 0 ],
+      "hurt_chance": [ -8 ],
+      "hurt_tick": [ 40 ]
+    }
+  },
+  {
+    "type": "effect_type",
     "id": "anemia",
     "name": [ "Early Iron Deficiency", "Iron Deficiency", "Acute Iron Deficiency" ],
     "desc": [

--- a/src/character.h
+++ b/src/character.h
@@ -1375,6 +1375,8 @@ class Character : public Creature, public visitable
          *  Defaults to true
          */
         bool purifiable( const trait_id &flag ) const;
+        /** Returns true if a conflict has destroyed a bionic */
+        bool handle_bio_mut_conflict( const bionic_id &bio, const trait_id &mut );
         /** Returns a dream's description selected randomly from the player's highest mutation category */
         std::string get_category_dream( const mutation_category_id &cat, int strength ) const;
         /** Returns true if the player has the entered trait in cached_mutations */


### PR DESCRIPTION
#### Summary
Balance "Mutating with an installed bionic that conflicts results in damage"

#### Purpose of change
Old todo from https://github.com/CleverRaven/Cataclysm-DDA/pull/47822

#### Describe the solution
Allow attempting mutations when you have a bionic that conflicts with it.

When attempting to mutate a trait that conflicts with an installed bionic, roll to destroy the bionic. If the bionic is destroyed, allow the mutation and give the severe version of the botched mutation effect to the player, causing them pain, blood loss, and damage to the parts on which the bionic is installed.

If the bionic is not destroyed, block the mutation and give a less severe version of the effect, with similar consequences.

#### Testing
Install squeaky ankles and alloy plating, take 1 cephalopod primer and 1 mutagen catalyst, wait 20 hours.