### PR TITLE
[MoM] Remove muscle seizures from electrokinetic overload, make downed and stun random duration

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -538,9 +538,8 @@
     "condition": { "u_has_effect": "effect_electrokin_overload" },
     "effect": [
       { "u_message": "Your muscles suddenly seize up!", "type": "bad" },
-      { "u_add_effect": "downed", "duration": 5 },
-      { "u_add_effect": "motor_seizure", "duration": 4 },
-      { "u_add_effect": "stunned", "duration": 1 },
+      { "u_add_effect": "downed", "duration": [ 2, 8 ] },
+      { "u_add_effect": "stunned", "duration": [ 1, 4 ] },
       { "run_eocs": "EOC_ELECTRO_OVERLOAD_ZAP", "time_in_future": [ "1 minutes", "45 minutes" ] }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Remove muscle seizures from electrokinetic overload, make downed and stun random duration"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had a weird bug in my personal game and eventually tracked it down to if my character gains the muscle seizures effect, the game instantly crashes with no error. This does not happen on a fresh game with a new character, and I was ready to chalk it up to the quirks of keeping a game running since April and repeatedly updating to keep up with experimental when I noticed something: even though `motor_seizure` was only applied with a duration of 4 on the test character, it would often take them much longer to stand up. The average was around 40 turns and the highest was _73_ turns.

Well, if you suffer electrokinetic overload and it dumps you on the ground with muscle spasms for over a minute, it might as well just kill you outright because against any even moderately dangerous opponent you're going to suffer massive damage if you can't dodge for 73 turns worth of attacks. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the application of  `motor_seizure`. Replace the fixed downed and stunned duration with random ones to achieve the same effect. Now electrokinetic overload is still dangerous and creates new problems you'll have to solve, but it is no longer effectively `u_die`
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Got electrokinetic overload, stood up in a handful of turns instead of dozens. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It's definitely nice that this fixes the crash in my personal game but the end result will be more getting dumped naked back on my Sky Island because I'll no longer be able to avoid those horrible situations I put myself in due to the game crashing. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
