### PR TITLE
exodii leave

### DIFF
--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1302,5 +1302,23 @@
       { "u_message": "The veiled butterfly's wings move in odd ways and a strange glow envelops you!", "type": "bad" },
       { "math": [ "u_val('rad')", "+=", "20" ] }
     ]
+  },
+  {
+    "id": "exodii_self_detonate",
+    "type": "SPELL",
+    "name": { "str": "Exodii Self Detonate", "//~": "NO_I18N" },
+    "description": { "str": "Nothing to see here.", "//~": "NO_I18N" },
+    "valid_targets": [ "hostile", "ally", "ground" ],
+    "flags": [ "SPLIT_DAMAGE" ],
+    "effect": "attack",
+    "shape": "cone",
+    "min_damage": 300,
+    "max_damage": 300,
+    "damage_type": "cut",
+    "min_range": 60,
+    "max_range": 60,
+    "min_aoe": 1200,
+    "max_aoe": 1200,
+    "extra_effects": [ { "id": "boomer_claymore_suicide", "hit_self": true } ]
   }
 ]

--- a/data/json/monsters/cyborgs.json
+++ b/data/json/monsters/cyborgs.json
@@ -121,6 +121,7 @@
     "path_settings": { "max_dist": 30, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": { "subtype": "collection", "groups": [ [ "robots", 80 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
+    "upgrades": { "age_grow": 1440, "into": "mon_exodii_phasing" },
     "flags": [
       "SEES",
       "HEARS",
@@ -186,6 +187,7 @@
         "no_ammo_sound": "a chk!"
       }
     ],
+    "upgrades": { "age_grow": 1440, "into": "mon_exodii_phasing" },
     "death_drops": { "subtype": "collection", "groups": [ [ "robots", 80 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
     "flags": [
@@ -200,6 +202,23 @@
       "HIT_AND_RUN"
     ],
     "armor": { "bash": 42, "cut": 48, "acid": 12, "heat": 8, "bullet": 35 }
+  },
+  {
+    "id": "mon_exodii_phasing",
+    "type": "MONSTER",
+    "name": { "str": "phasing quadruped" },
+    "description": "This enormous quadrupedal robot seems to be cobbled together from parts, most of them unfamiliar to you.  It is rattling and beeping.",
+    "copy-from": "mon_exodii_quad",
+    "special_attacks": [
+      {
+        "type": "spell",
+        "spell_data": { "id": "exodii_self_detonate", "hit_self": true },
+        "cooldown": 2,
+        "monster_message": "The Exodii quadruped is rattling and blaring some kind of alarm."
+      }
+    ],
+    "death_drops": {  },
+    "death_function": { "corpse_type": "NO_CORPSE" }
   },
   {
     "id": "mon_zomborg",


### PR DESCRIPTION
#### Summary
Content "exodii leave"

#### Purpose of change

Implement lore

#### Describe the solution

Every exodii crawler and quad spawns with four year timer. After four years, they change into a "phasing quadruped" and cast a self detonate spell (spell not yet written)

TODO: a warning greeting from Rubik not to sleep in the castle starting after three and a half game years have passed. 

#### Describe alternatives you've considered

Wait for someone to build something better

#### Testing

WIP

#### Additional context

Four years is arbitrary, inspired by Star Trek's four year mission