### PR TITLE
Fix mutation spells learned don't lose when mutation lost

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7841,11 +7841,11 @@ void Character::update_cached_mutations()
                 if( ( are_opposite_traits( iter.first, mut ) || b_is_higher_trait_of_a( iter.first, mut )
                       || are_same_type_traits( iter.first, mut ) ) && iter.second.corrupted > 0 ) {
                     --iter.second.corrupted;
-                    if( my_mutations.count( mut ) ) {
-                        --my_mutations[mut].corrupted;
+                    if( my_mutations.count( iter.first ) ) {
+                        --my_mutations[iter.first].corrupted;
                     }
                     if( iter.second.corrupted == 0 ) {
-                        mutation_effect( mut, false );
+                        mutation_effect( iter.first, false );
                         do_mutation_updates();
                     }
                 }
@@ -7860,11 +7860,11 @@ void Character::update_cached_mutations()
             if( are_opposite_traits( iter.first, mut ) || b_is_higher_trait_of_a( iter.first, mut )
                 || are_same_type_traits( iter.first, mut ) ) {
                 ++iter.second.corrupted;
-                if( my_mutations.count( mut ) ) {
-                    ++my_mutations[mut].corrupted;
+                if( my_mutations.count( iter.first ) ) {
+                    ++my_mutations[iter.first].corrupted;
                 }
                 if( iter.second.corrupted == 1 ) {
-                    mutation_loss_effect( mut );
+                    mutation_loss_effect( iter.first );
                     do_mutation_updates();
                 }
             }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10035,7 +10035,7 @@ void Character::on_mutation_gain( const trait_id &mid )
 void Character::on_mutation_loss( const trait_id &mid )
 {
     morale->on_mutation_loss( mid );
-    magic->on_mutation_loss( mid );
+    magic->on_mutation_loss( mid, *this );
     update_type_of_scent( mid, false );
     effect_on_conditions::process_reactivate( *this );
     if( is_avatar() ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -3075,16 +3075,16 @@ void known_magic::on_mutation_gain( const trait_id &mid, Character &guy )
     }
 }
 
-void known_magic::on_mutation_loss( const trait_id &mid )
+void known_magic::on_mutation_loss( const trait_id &mid, Character &guy )
 {
-    std::vector<spell_id> spells_to_forget;
-    for( const spell *sp : get_spells() ) {
-        if( sp->is_spell_class( mid ) ) {
-            spells_to_forget.emplace_back( sp->id() );
+    for( const std::pair<const spell_id, int> &sp : mid->spells_learned ) {
+        spell &temp_sp = get_spell( sp.first );
+        int new_level = temp_sp.get_level() - sp.second;
+        if( new_level > 0 ) {
+            temp_sp.set_level( guy, new_level );
+        } else {
+            forget_spell( sp.first );
         }
-    }
-    for( const spell_id &sp_id : spells_to_forget ) {
-        forget_spell( sp_id );
     }
 }
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -751,7 +751,7 @@ class known_magic
         void evaluate_opens_spellbook_data();
 
         void on_mutation_gain( const trait_id &mid, Character &guy );
-        void on_mutation_loss( const trait_id &mid );
+        void on_mutation_loss( const trait_id &mid, Character &guy );
 
         // data written by EoC
         double caster_level_adjustment; // NOLINT(cata-serialize)


### PR DESCRIPTION
#### Summary
Bugfixes "Fix mutation spells learned don't lose when mutation lost"
#### Purpose of change
Fix #79080 
#### Describe the solution
Now, when a mutation is removed, you also lost the levels granted by `spells_learned` of it. You forgot the spell if it is not granted by any other source.
Also fix a typo that caused `mutation_effect` and `mutation_loss_effect` have some inconsistency.
#### Describe alternatives you've considered
Simply call `forget_spell`, but that would lead to inconsistency if you learned the spell yourself or have another mutation that also grants it.
#### Testing
Use this to test:
```
[
  {
    "type": "mutation",
    "id": "EGO_Soda",
    "name": "[ז] EGO Soda",
    "points": 0,
    "description": "You have bonded with Soda, for better, or for worse.",
    "starting_trait": false,
    "purifiable": false,
    "valid": false
  },
  {
    "id": "EGO_soda_success",
    "type": "SPELL",
    "name": "[ז] EGO Soda Invoke Bond",
    "description": "",
    "valid_targets": [ "self" ],
    "effect": "spawn_item",
    "effect_str": "EGO_soda_aura",
    "shape": "blast",
    "min_aoe": 0,
    "max_aoe": 0,
    "min_duration": 600,
    "max_duration": 18000,
    "duration_increment": 600,
    "base_casting_time": 0,
    "final_casting_time": 0,
    "spell_class": "EGO_Soda",
    "base_energy_cost": 0,
    "final_energy_cost": 0,
    "energy_source": "NONE",
    "difficulty": 3,
    "max_level": 30,
    "flags": [ "SILENT", "NON_MAGICAL", "NO_EXPLOSION_SFX", "NO_HANDS", "NO_LEGS" ]
  },
  {
    "id": "EGO_soda_aura",
    "type": "ARMOR",
    "name": "[ז] EGO Soda Aura",
    "description": "You feel Soda's presence in your mind, alien, twisting and writhing, yet granting you power beyond any mere mortal. While the bond is active you sense you'll be slightly harder to knock down, better at dodging, and find it easier to throw items.",
    "weight": "0 g",
    "volume": "0 ml",
    "material": [ "wind" ],
    "symbol": "0",
    "color": "white",
    "flags": [ "ZERO_WEIGHT", "NO_TAKEOFF" ],
    "relic_data": {
      "passive_effects": [
        { "id": "EGO_soda_stage_1" },
        { "id": "EGO_soda_stage_2" },
        { "id": "EGO_soda_stage_3" },
        { "id": "EGO_soda_stage_4" }
      ]
    }
  },
  {
    "type": "enchantment",
    "id": "EGO_soda_stage_1",
    "has": "WORN",
    "condition": { "math": [ "u_spell_level('EGO_soda_success') < 10" ] },
    "mutations": [ "EGO_soda_mutation_stage_1" ],
    "values": [
      { "value": "THROW_STR", "add": { "math": [ "u_spell_level('EGO_soda_success') / 2" ] } },
      { "value": "SCENT_MASK", "add": 100 },
      { "value": "DODGE_CHANCE", "add": { "math": [ "u_spell_level('EGO_soda_success') / 4" ] } },
      { "value": "KNOCKDOWN_RESIST", "add": 10 }
    ]
  },
  {
    "type": "enchantment",
    "id": "EGO_soda_stage_2",
    "has": "WORN",
    "condition": {
      "and": [ { "math": [ "u_spell_level('EGO_soda_success') >= 10" ] }, { "math": [ "u_spell_level('EGO_soda_success') < 20" ] } ]
    },
    "mutations": [ "EGO_soda_mutation_stage_2" ],
    "values": [
      { "value": "THROW_STR", "add": { "math": [ "u_spell_level('EGO_soda_success')" ] } },
      { "value": "SCENT_MASK", "add": 150 },
      { "value": "DODGE_CHANCE", "add": { "math": [ "u_spell_level('EGO_soda_success') / 3" ] } },
      { "value": "KNOCKDOWN_RESIST", "add": 20 }
    ]
  },
  {
    "type": "enchantment",
    "id": "EGO_soda_stage_3",
    "has": "WORN",
    "condition": {
      "and": [ { "math": [ "u_spell_level('EGO_soda_success') >= 20" ] }, { "math": [ "u_spell_level('EGO_soda_success') < 25" ] } ]
    },
    "mutations": [ "EGO_soda_mutation_stage_3" ],
    "values": [
      { "value": "THROW_STR", "add": { "math": [ "u_spell_level('EGO_soda_success') * 1.5" ] } },
      { "value": "SCENT_MASK", "add": 200 },
      { "value": "DODGE_CHANCE", "add": { "math": [ "u_spell_level('EGO_soda_success') / 2" ] } },
      { "value": "KNOCKDOWN_RESIST", "add": 30 }
    ]
  },
  {
    "type": "enchantment",
    "id": "EGO_soda_stage_4",
    "has": "WORN",
    "condition": { "math": [ "u_spell_level('EGO_soda_success') >= 25" ] },
    "mutations": [ "EGO_soda_mutation_stage_4" ],
    "values": [
      { "value": "THROW_STR", "add": { "math": [ "u_spell_level('EGO_soda_success') * 2" ] } },
      { "value": "SCENT_MASK", "add": 250 },
      { "value": "DODGE_CHANCE", "add": { "math": [ "u_spell_level('EGO_soda_success')" ] } },
      { "value": "KNOCKDOWN_RESIST", "add": 40 }
    ]
  },
  {
    "type": "mutation",
    "id": "EGO_soda_mutation_stage_1",
    "name": "[ז] Imperfect Soda manifestation1",
    "points": 0,
    "description": "EGO Soda mutation desc",
    "starting_trait": false,
    "purifiable": false,
    "valid": false,
    "spells_learned": [ [ "EGO_soda_summon_can_weak", 1 ] ]
  },
  {
    "type": "mutation",
    "id": "EGO_soda_mutation_stage_2",
    "name": "[ז] Imperfect Soda manifestation2",
    "points": 0,
    "description": "EGO Soda mutation desc",
    "starting_trait": false,
    "purifiable": false,
    "valid": false,
    "spells_learned": [ [ "EGO_soda_summon_can_weak", 2 ] ]
  },
  {
    "id": "EGO_soda_summon_can_weak",
    "type": "SPELL",
    "name": "[ז] Imperfect EGO Soda - Summon WellCheersBomb",
    "description": "Call forth a WellCheers can from the aether - one primed to be thrown at those who offend the might of WellCheers.",
    "valid_targets": [ "self" ],
    "effect": "spawn_item",
    "effect_str": "EGO_soda_aura",
    "shape": "blast",
    "min_range": 0,
    "max_range": 0,
    "min_aoe": 0,
    "max_aoe": 0,
    "min_duration": 200,
    "max_duration": 200,
    "base_casting_time": 80,
    "final_casting_time": 80,
    "spell_class": "EGO_Soda",
    "base_energy_cost": 200,
    "final_energy_cost": 200,
    "energy_source": "STAMINA",
    "difficulty": 0,
    "max_level": 1,
    "flags": [ "SILENT", "NO_FAIL", "NO_LEGS" ]
  },
  {
    "type": "mutation",
    "id": "EGO_soda_mutation_stage_3",
    "name": "[ז] EGO Soda manifestation3",
    "points": 0,
    "description": "EGO Soda mutation desc",
    "starting_trait": false,
    "purifiable": false,
    "valid": false,
    "spells_learned": [ [ "EGO_soda_summon_can_weak", 3 ] ]
  },
  {
    "type": "mutation",
    "id": "EGO_soda_mutation_stage_4",
    "name": "[ז] EGO Soda manifestation4",
    "points": 0,
    "description": "EGO Soda mutation desc",
    "starting_trait": false,
    "purifiable": false,
    "valid": false,
    "spells_learned": [ [ "EGO_soda_summon_can_weak", 4 ] ]
  }
]
```
![2025-01-12 095304](https://github.com/user-attachments/assets/455fbb85-d28d-427e-97dd-7ef2fce1994d)
Spell granted and forgot correctly if you only got it from the temporary mutation, and kept when you also toggled another mutation that also grants it.
#### Additional context