### PR TITLE
Bump minimum supported macOS version to 10.15 (macOS Catalina)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -576,8 +576,8 @@ endif
 # OSX
 ifeq ($(NATIVE), osx)
   DEFINES += -DMACOSX
-  CXXFLAGS += -mmacosx-version-min=10.13
-  LDFLAGS += -mmacosx-version-min=10.13 -framework CoreFoundation -Wl,-headerpad_max_install_names
+  CXXFLAGS += -mmacosx-version-min=10.15
+  LDFLAGS += -mmacosx-version-min=10.15 -framework CoreFoundation -Wl,-headerpad_max_install_names
   ifeq ($(UNIVERSAL_BINARY), 1)
     CXXFLAGS += -arch x86_64 -arch arm64
     LDFLAGS += -arch x86_64 -arch arm64

--- a/doc/COMPILING/COMPILER_SUPPORT.md
+++ b/doc/COMPILING/COMPILER_SUPPORT.md
@@ -32,11 +32,9 @@ At the time of writing:
   which uses [gcc
   14.0](https://fedoraproject.org/wiki/Changes/GNUToolchainF40).
 * MSYS [offers gcc 12.2](https://packages.msys2.org/base).
-* macOS 10.13+ has 96.0% [market
-  share](https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide)[^2]
-  and that corresponds to [XCode 10.1](https://xcodereleases.com/).
-
-[^2]: [Limit reported macOS release to 10.15 series](https://bugs.webkit.org/show_bug.cgi?id=216593)
+* macOS 10.15+ (macOS Catalina) has 96.0% [market
+  share](https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide)
+  and that corresponds to [XCode 11.4](https://xcodereleases.com/).
 
 With the supported compilers we can get all the C++17 language
 features and [most but not all of the C++17 library

--- a/doc/COMPILING/COMPILER_SUPPORT.md
+++ b/doc/COMPILING/COMPILER_SUPPORT.md
@@ -33,8 +33,10 @@ At the time of writing:
   14.0](https://fedoraproject.org/wiki/Changes/GNUToolchainF40).
 * MSYS [offers gcc 12.2](https://packages.msys2.org/base).
 * macOS 10.15+ (macOS Catalina) has 96.0% [market
-  share](https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide)
+  share](https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide)[^2]
   and that corresponds to [XCode 11.4](https://xcodereleases.com/).
+
+[^2]: [macOS releases past 10.15 series can not be estimated faithfully](https://bugs.webkit.org/show_bug.cgi?id=216593)
 
 With the supported compilers we can get all the C++17 language
 features and [most but not all of the C++17 library

--- a/doc/COMPILING/COMPILER_SUPPORT.md
+++ b/doc/COMPILING/COMPILER_SUPPORT.md
@@ -6,7 +6,7 @@
 | [clang](https://clang.llvm.org)                      | [10.0](https://releases.llvm.org/10.0.0/docs/index.html) |
 | [MinGW-w64](https://www.mingw-w64.org)               | [UCRT 14.2.0](https://www.mingw-w64.org/downloads/)  |
 | [Visual Studio](https://visualstudio.microsoft.com/) | [2019](COMPILING-VS-VCPKG.md) |
-| [XCode](https://developer.apple.com/xcode)           | [10.1](https://developer.apple.com/documentation/xcode-release-notes/xcode-10_1-release-notes) <br/> [macOS 10.13](https://en.wikipedia.org/wiki/MacOS_High_Sierra) |
+| [XCode](https://developer.apple.com/xcode)           | [11.4](https://developer.apple.com/documentation/xcode-release-notes/xcode-11_4-release-notes) <br/> [macOS 10.15](https://en.wikipedia.org/wiki/MacOS_Catalina) |
 
 Our goal with compiler support is to make it as easy as possible for new
 contributors to get started with development of the game, while also using the


### PR DESCRIPTION
#### Summary
Infrastructure "Bump minimum supported macOS version to 10.15 (macOS Catalina)"

#### Purpose of change
Is a requirement for #79092 (macOS 10.13 does not have `<filesystem>` header despite supporting C++17. [[ref](https://stackoverflow.com/questions/42633477/macos-clang-c17-filesystem-header-not-found)])

At the time of writing macOS 10.13 (macOS High Sierra) has a market share of 0.92%, and macOS 10.15 is at 96.35% (ref: https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide)
![StatCounter-macos_version-ww-monthly-202312-202412](https://github.com/user-attachments/assets/3a0ef976-5c50-47e4-b21f-ca58e3ced639)
Dropping support for 10.13 does not sound unreasonable.

#### Describe the solution

Update the `-mmacosx-version-min` flag
Update the docs.

#### Describe alternatives you've considered

- Making a `<filesystem>` shim *specifically* for old macOS... 
- N/A really

#### Testing

Added a random `std::filesystem::path` usage to one of cpp files, fed it to the CI, CI didn't seem to mind ([link](https://github.com/moxian/Cataclysm-DDA/pull/5))

#### Additional context
The way we're reporting min supported xcode seems to be fraudulent, since there's no clear correspondence between mac os version (incl. `-mmacosx-version-min`) and xcode version. The xcode running on CI is version 15.2 for example, [judging by the logs](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12729495075/job/35481351906?pr=79092). Perhaps it would be better to remove that field completely so as not to confuse people?.. Idk, this is a tangent anyway...

If someone who understands Apple ecosystem could double-check my xcode selection that would be appreciated.