### PR TITLE
typified map.h and dependents

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -241,7 +241,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
         get_option<bool>( "AUTO_FEATURES" ) && get_option<bool>( "AUTO_MINING" ) &&
         !m.veh_at( dest_loc ) && !you.is_underwater() && !you.has_effect( effect_stunned ) &&
         !you.has_effect( effect_psi_stunned ) && !is_riding && !you.has_effect( effect_incorporeal ) &&
-        !m.impassable_field_at( d.raw() ) && !you.has_flag( json_flag_CANNOT_MOVE ) ) {
+        !m.impassable_field_at( dest_loc ) && !you.has_flag( json_flag_CANNOT_MOVE ) ) {
         if( weapon && weapon->has_flag( flag_DIG_TOOL ) ) {
             if( weapon->type->can_use( "JACKHAMMER" ) &&
                 weapon->ammo_sufficient( &you ) ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1521,7 +1521,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                             invisible[0] = true;
                         } else {
                             if( would_apply_vision_effects( offscreen_type ) ) {
-                                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos.raw(), 0},
+                                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0},
                                         tile_render_info::vision_effect{ offscreen_type } );
                             }
                             break;
@@ -1690,7 +1690,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                                     || you.sees_with_specials( *critter ) ) ) ) {
                                 invisible[0] = true;
                             } else {
-                                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos.raw(), 0},
+                                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0},
                                         tile_render_info::vision_effect{ vis_type } );
                                 break;
                             }
@@ -1701,7 +1701,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                         invisible[1 + i] = apply_visible( np, ch2, here );
                     }
 
-                    here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos.raw(), 0},
+                    here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0},
                             tile_render_info::sprite{ ll, invisible } );
                     // Stop building draw points below when floor reached
                     if( here.dont_draw_lower_floor( pos ) ) {

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -297,7 +297,7 @@ void creature_tracker::remove_dead()
 template<typename T>
 T *creature_tracker::creature_at( const tripoint &p, bool allow_hallucination )
 {
-    return creature_at<T>( get_map().getglobal( p ), allow_hallucination );
+    return creature_at<T>( get_map().getglobal( tripoint_bub_ms( p ) ), allow_hallucination );
 }
 
 template<typename T>
@@ -423,7 +423,7 @@ void creature_tracker::flood_fill_zone( const Creature &origin )
 template<typename T>
 const T *creature_tracker::creature_at( const tripoint &p, bool allow_hallucination ) const
 {
-    return creature_at<T>( get_map().getglobal( p ), allow_hallucination );
+    return creature_at<T>( get_map().getglobal( tripoint_bub_ms( p ) ), allow_hallucination );
 }
 
 template<typename T>

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -901,7 +901,7 @@ std::optional<int> iuse::meth( Character *p, item *, const tripoint_bub_ms & )
         map &here = get_map();
         // breathe out some smoke
         for( int i = 0; i < 3; i++ ) {
-            point offset( rng( -2, 2 ), rng( -2, 2 ) );
+            point_rel_ms offset( rng( -2, 2 ), rng( -2, 2 ) );
             here.add_field( p->pos_bub() + offset, field_type_id( "fd_methsmoke" ), 2 );
         }
     } else {
@@ -8229,7 +8229,7 @@ heating_requirements heating_requirements_for_weight( const units::mass &frozen,
     return {volume, ammo, time};
 }
 
-static std::optional<std::pair<tripoint, itype_id>> appliance_heater_selector( Character *p )
+static std::optional<std::pair<tripoint_bub_ms, itype_id>> appliance_heater_selector( Character *p )
 {
     const std::optional<tripoint_bub_ms> pt = choose_adjacent_highlight( _( "Select an appliance." ),
             _( "There is no appliance nearby." ), ACTION_EXAMINE, false );
@@ -8264,7 +8264,7 @@ static std::optional<std::pair<tripoint, itype_id>> appliance_heater_selector( C
                     p->add_msg_if_player( m_info, _( "You haven't selected any heater." ) );
                     return std::nullopt;
                 } else {
-                    return std::make_pair( pt.value().raw(), pseudo_tools[app_menu.ret] );
+                    return std::make_pair( pt.value(), pseudo_tools[app_menu.ret] );
                 }
 
             }
@@ -8322,7 +8322,7 @@ heater find_heater( Character *p, item *it )
                                  1,
                                  _( "You don't have a proper heating tool.  Try selecting an appliance with a heater." ) );
         if( !loc ) {
-            std::optional<std::pair<tripoint, itype_id>> app = appliance_heater_selector( p );
+            std::optional<std::pair<tripoint_bub_ms, itype_id>> app = appliance_heater_selector( p );
             if( !app ) {
                 return {loc, true, -1, 0, vpt, pseudo_flag};
             } else {

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -672,11 +672,6 @@ void map::add_light_source( const tripoint_bub_ms &p, float luminance )
 
 // Tile light/transparency: 3D
 
-lit_level map::light_at( const tripoint &p ) const
-{
-    return map::light_at( tripoint_bub_ms( p ) );
-}
-
 lit_level map::light_at( const tripoint_bub_ms &p ) const
 {
     if( !inbounds( p ) ) {
@@ -1432,21 +1427,21 @@ void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, 
 
 void map::apply_light_ray(
     cata::mdarray<bool, point_bub_ms, LIGHTMAP_CACHE_X, LIGHTMAP_CACHE_Y> &lit,
-    const tripoint &s, const tripoint &e, float luminance )
+    const tripoint_bub_ms &s, const tripoint_bub_ms &e, float luminance )
 {
-    point a( std::abs( e.x - s.x ) * 2, std::abs( e.y - s.y ) * 2 );
-    point d( ( s.x < e.x ) ? 1 : -1, ( s.y < e.y ) ? 1 : -1 );
+    point a( std::abs( e.x() - s.x() ) * 2, std::abs( e.y() - s.y() ) * 2 );
+    point d( ( s.x() < e.x() ) ? 1 : -1, ( s.y() < e.y() ) ? 1 : -1 );
     point_bub_ms p( s.xy() );
 
     quadrant quad = quadrant_from_x_y( d.x, d.y );
 
     // TODO: Invert that z comparison when it's sane
-    if( s.z != e.z || ( s.x == e.x && s.y == e.y ) ) {
+    if( s.z() != e.z() || ( s.x() == e.x() && s.y() == e.y() ) ) {
         return;
     }
 
-    auto &lm = get_cache( s.z ).lm;
-    auto &transparency_cache = get_cache( s.z ).transparency_cache;
+    auto &lm = get_cache( s.z() ).lm;
+    auto &transparency_cache = get_cache( s.z() ).transparency_cache;
 
     float distance = 1.0f;
     float transparency = LIGHT_TRANSPARENCY_OPEN_AIR;
@@ -1485,7 +1480,7 @@ void map::apply_light_ray(
             }
 
             distance += scaling_factor;
-        } while( !( p.x() == e.x && p.y() == e.y ) );
+        } while( !( p.x() == e.x() && p.y() == e.y() ) );
     } else {
         int t = a.x - ( a.y / 2 );
         do {
@@ -1517,6 +1512,6 @@ void map::apply_light_ray(
             }
 
             distance += scaling_factor;
-        } while( !( p.x() == e.x && p.y() == e.y ) );
+        } while( !( p.x() == e.x() && p.y() == e.y() ) );
     }
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1250,7 +1250,7 @@ std::set<tripoint_bub_ms> map::get_moving_vehicle_targets( const Creature &z, in
         if( !v.v->is_moving() ) {
             continue;
         }
-        if( std::abs( v.pos.z - zpos.z() ) > fov_3d_z_range ) {
+        if( std::abs( v.pos.z() - zpos.z() ) > fov_3d_z_range ) {
             continue;
         }
         if( rl_dist( zpos, tripoint_bub_ms( v.pos ) ) > max_range + 40 ) {
@@ -1301,7 +1301,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
                     elem->sm_pos.z = cz;
                     wrapped_vehicle w;
                     w.v = elem.get();
-                    w.pos = w.v->pos_bub().raw();
+                    w.pos = w.v->pos_bub();
                     vehs.push_back( w );
                 }
             }
@@ -1314,11 +1314,6 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
 optional_vpart_position map::veh_at( const tripoint_abs_ms &p ) const
 {
     return veh_at( bub_from_abs( p ) );
-}
-
-optional_vpart_position map::veh_at( const tripoint &p ) const
-{
-    return veh_at( tripoint_bub_ms( p ) );
 }
 
 optional_vpart_position map::veh_at( const tripoint_bub_ms &p ) const
@@ -1707,11 +1702,6 @@ bool map::has_furn( const tripoint_bub_ms &p ) const
     return furn( p ) != furn_str_id::NULL_ID();
 }
 
-furn_id map::furn( const tripoint &p ) const
-{
-    return furn( tripoint_bub_ms( p ) );
-}
-
 furn_id map::furn( const tripoint_bub_ms p ) const
 {
     if( !inbounds( p ) ) {
@@ -1898,10 +1888,6 @@ std::string map::furnname( const tripoint_bub_ms &p )
  * retained for high performance comparisons, save/load, and gradual transition
  * to string terrain.id
  */
-ter_id map::ter( const tripoint p ) const
-{
-    return ter( tripoint_bub_ms( p ) );
-}
 ter_id map::ter( const tripoint_bub_ms &p ) const
 {
     if( !inbounds( p ) ) {
@@ -2643,11 +2629,6 @@ int map::climb_difficulty( const tripoint_bub_ms &p ) const
     return std::max( 0, best_difficulty - blocks_movement );
 }
 
-bool map::has_floor( const tripoint &p ) const
-{
-    return map::has_floor( tripoint_bub_ms( p ) );
-}
-
 bool map::has_floor( const tripoint_bub_ms &p ) const
 {
     if( !zlevels || p.z() < -OVERMAP_DEPTH + 1 || p.z() > OVERMAP_HEIGHT ) {
@@ -2658,11 +2639,6 @@ bool map::has_floor( const tripoint_bub_ms &p ) const
     }
     return !has_flag( ter_furn_flag::TFLAG_NO_FLOOR, p ) &&
            !has_flag( ter_furn_flag::TFLAG_NO_FLOOR_WATER, p );
-}
-
-bool map::has_floor_or_water( const tripoint &p ) const
-{
-    return map::has_floor_or_water( tripoint_bub_ms( p ) );
 }
 
 bool map::has_floor_or_water( const tripoint_bub_ms &p ) const
@@ -2695,22 +2671,12 @@ bool map::supports_above( const tripoint_bub_ms &p ) const
     return veh_at( p ).has_value();
 }
 
-bool map::has_floor_or_support( const tripoint &p ) const
-{
-    return map::has_floor_or_support( tripoint_bub_ms( p ) );
-}
-
 bool map::has_floor_or_support( const tripoint_bub_ms &p ) const
 {
     const tripoint_bub_ms below( p.xy(), p.z() - 1 );
     return !valid_move( p, below, false, true );
 }
 
-bool map::has_vehicle_floor( const tripoint &p ) const
-{
-    const tripoint_bub_ms p_bub( p );
-    return has_vehicle_floor( p_bub );
-}
 bool map::has_vehicle_floor( const tripoint_bub_ms &p ) const
 {
     return veh_at( p ).part_with_feature( "BOARDABLE", false ) ||
@@ -3074,11 +3040,6 @@ bool map::can_put_items( const tripoint_bub_ms &p ) const
 bool map::can_put_items_ter_furn( const tripoint_bub_ms &p ) const
 {
     return !has_flag( ter_furn_flag::TFLAG_NOITEM, p ) && !has_flag( ter_furn_flag::TFLAG_SEALED, p );
-}
-
-bool map::has_flag_ter( const std::string &flag, const tripoint &p ) const
-{
-    return ter( tripoint_bub_ms( p ) ).obj().has_flag( flag );
 }
 
 bool map::has_flag_ter( const std::string &flag, const tripoint_bub_ms &p ) const
@@ -5353,7 +5314,7 @@ void map::make_active( item_location &loc )
     item *target = loc.get_item();
 
     point_sm_ms l;
-    submap *const current_submap = get_submap_at( loc.position(), l.raw() );
+    submap *const current_submap = get_submap_at( loc.pos_bub(), l );
     if( current_submap == nullptr ) {
         debugmsg( "Tried to make active at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return;
@@ -6439,11 +6400,6 @@ std::optional<field_entry> map::get_impassable_field_at( const tripoint_bub_ms &
     return potential_field;
 }
 
-bool map::impassable_field_at( const tripoint &p )
-{
-    return impassable_field_at( tripoint_bub_ms( p ) );
-}
-
 bool map::impassable_field_at( const tripoint_bub_ms &p )
 {
     for( auto &pr : field_at( p ) ) {
@@ -6453,11 +6409,6 @@ bool map::impassable_field_at( const tripoint_bub_ms &p )
         }
     }
     return false;
-}
-
-std::vector<field_type_id> map::get_impassable_field_type_ids_at( const tripoint &p )
-{
-    return get_impassable_field_type_ids_at( tripoint_bub_ms( p ) );
 }
 
 std::vector<field_type_id> map::get_impassable_field_type_ids_at( const tripoint_bub_ms &p )
@@ -9045,11 +8996,6 @@ const std::vector<tripoint_bub_ms> &map::trap_locations( const trap_id &type ) c
     return traplocs[type.to_i()];
 }
 
-bool map::inbounds( const tripoint &p ) const
-{
-    return inbounds( tripoint_bub_ms( p ) );
-}
-
 bool map::inbounds( const tripoint_abs_ms &p ) const
 {
     return inbounds( bub_from_abs( p ) );
@@ -9624,11 +9570,6 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
 
 //////////
 ///// coordinate helpers
-
-tripoint_abs_ms map::getglobal( const tripoint &p ) const
-{
-    return map::getglobal( tripoint_bub_ms( p ) );
-}
 
 tripoint_abs_ms map::getglobal( const tripoint_bub_ms &p ) const
 {
@@ -10242,17 +10183,6 @@ tripoint_range<tripoint_bub_ms> map::points_in_rectangle( const tripoint_bub_ms 
     return tripoint_range<tripoint_bub_ms>( min, max );
 }
 
-tripoint_range<tripoint> map::points_in_radius( const tripoint &center, size_t radius,
-        size_t radiusz ) const
-{
-    const tripoint min( std::max<int>( 0, center.x - radius ), std::max<int>( 0, center.y - radius ),
-                        clamp<int>( center.z - radiusz, -OVERMAP_DEPTH, OVERMAP_HEIGHT ) );
-    const tripoint max( std::min<int>( SEEX * my_MAPSIZE - 1, center.x + radius ),
-                        std::min<int>( SEEX * my_MAPSIZE - 1, center.y + radius ), clamp<int>( center.z + radiusz,
-                                -OVERMAP_DEPTH, OVERMAP_HEIGHT ) );
-    return tripoint_range<tripoint>( min, max );
-}
-
 tripoint_range<tripoint_bub_ms> map::points_in_radius(
     const tripoint_bub_ms &center, size_t radius, size_t radiusz ) const
 {
@@ -10552,11 +10482,6 @@ void map::update_pathfinding_cache( int zlev ) const
     cache.dirty_points.clear();
 }
 
-void map::clip_to_bounds( tripoint &p ) const
-{
-    clip_to_bounds( p.x, p.y, p.z );
-}
-
 void map::clip_to_bounds( tripoint_bub_ms &p ) const
 {
     clip_to_bounds( p.x(), p.y(), p.z() );
@@ -10687,11 +10612,6 @@ bool map::has_haulable_items( const tripoint_bub_ms &pos )
         }
     }
     return false;
-}
-
-std::vector<item_location> map::get_haulable_items( const tripoint &pos )
-{
-    return map::get_haulable_items( tripoint_bub_ms( pos ) );
 }
 
 std::vector<item_location> map::get_haulable_items( const tripoint_bub_ms &pos )

--- a/src/map.h
+++ b/src/map.h
@@ -88,7 +88,7 @@ struct projectile;
 struct veh_collision;
 
 struct wrapped_vehicle {
-    tripoint pos;
+    tripoint_bub_ms pos;
     vehicle *v;
 };
 
@@ -308,7 +308,7 @@ struct tile_render_info {
         // accumulator for 3d tallness of sprites rendered here so far;
         int height_3d = 0;
 
-        common( const tripoint &pos, const int height_3d )
+        common( const tripoint_bub_ms &pos, const int height_3d )
             : pos( pos ), height_3d( height_3d ) {}
     };
 
@@ -779,8 +779,6 @@ class map
         *
         * @param p Tile to check for vehicle
         */
-        // TODO: fix point types (remove the first overload)
-        optional_vpart_position veh_at( const tripoint &p ) const;
         optional_vpart_position veh_at( const tripoint_abs_ms &p ) const;
         optional_vpart_position veh_at( const tripoint_bub_ms &p ) const;
         vehicle *veh_at_internal( const tripoint_bub_ms &p, int &part_num );
@@ -842,8 +840,6 @@ class map
         bool has_furn( const point_bub_ms &p ) const {
             return has_furn( tripoint_bub_ms( p, abs_sub.z() ) );
         }
-        // TODO: fix point types (remove the first overload)
-        furn_id furn( const tripoint &p ) const;
         furn_id furn( tripoint_bub_ms p ) const;
         furn_id furn( const point_bub_ms &p ) const {
             return furn( tripoint_bub_ms( p, abs_sub.z() ) );
@@ -869,8 +865,6 @@ class map
         bool can_move_furniture( const tripoint_bub_ms &pos, Character *you = nullptr ) const;
 
         // Terrain
-        // TODO: fix point types (remove the first overload)
-        ter_id ter( tripoint p ) const;
         ter_id ter( const tripoint_bub_ms &p ) const;
         ter_id ter( const point_bub_ms &p ) const {
             return ter( tripoint_bub_ms( p, abs_sub.z() ) );
@@ -926,9 +920,6 @@ class map
         }
 
         std::string tername( const tripoint_bub_ms &p ) const;
-        std::string tername( const point &p ) const {
-            return tername( tripoint_bub_ms( p.x, p.y, abs_sub.z() ) );
-        }
 
         // Check for terrain/furniture/field that provide a
         // "fire" item to be used for example when crafting or when
@@ -993,7 +984,6 @@ class map
         // True if items can be placed in this tile
         bool can_put_items_ter_furn( const tripoint_bub_ms &p ) const;
         // Checks terrain
-        bool has_flag_ter( const std::string &flag, const tripoint &p ) const;
         bool has_flag_ter( const std::string &flag, const tripoint_bub_ms &p ) const;
         bool has_flag_ter( const std::string &flag, const point_bub_ms &p ) const {
             return has_flag_ter( flag, tripoint_bub_ms( p, abs_sub.z() ) );
@@ -1254,15 +1244,6 @@ class map
 
         // FIXME: remove these overloads and require spawn_item to take an
         // itype_id
-        void spawn_item( const tripoint &p, const std::string &type_id,
-                         unsigned quantity = 1, int charges = 0,
-                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
-                         const std::set<flag_id> &flags = {}, const std::string &variant = "",
-                         const std::string &faction = "" ) {
-            spawn_item( tripoint_bub_ms( p ), itype_id( type_id ), quantity, charges, birthday, damlevel, flags,
-                        variant,
-                        faction );
-        }
         void spawn_item( const tripoint_bub_ms &p, const std::string &type_id,
                          unsigned quantity = 1, int charges = 0,
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
@@ -1538,7 +1519,6 @@ class map
 
         // returns the a field entry that is impassable at the given point if it exists
         std::optional<field_entry> get_impassable_field_at( const tripoint_bub_ms &p );
-        std::vector<field_type_id> get_impassable_field_type_ids_at( const tripoint &p );
         std::vector<field_type_id> get_impassable_field_type_ids_at( const tripoint_bub_ms &p );
 
         /**
@@ -1548,7 +1528,6 @@ class map
         field_entry *get_field( const tripoint_bub_ms &p, const field_type_id &type );
         const field_entry *get_field( const tripoint_bub_ms &p, const field_type_id &type ) const;
         bool dangerous_field_at( const tripoint_bub_ms &p );
-        bool impassable_field_at( const tripoint &p );
         bool impassable_field_at( const tripoint_bub_ms &p );
 
         // Check if player can move on top of it during mopping zone activity
@@ -1656,19 +1635,11 @@ class map
         // Returns true if terrain at p has NO flag ter_furn_flag::TFLAG_NO_FLOOR
         // and ter_furn_flag::TFLAG_NO_FLOOR_WATER,
         // if we're not in z-levels mode or if we're at lowest level
-        // TODO: Get rid of untyped overload
-        bool has_floor( const tripoint &p ) const;
         bool has_floor( const tripoint_bub_ms &p ) const;
-        // TODO: Get rid of untyped overload
-        bool has_floor_or_water( const tripoint &p ) const;
         bool has_floor_or_water( const tripoint_bub_ms &p ) const;
         /** Does this tile support vehicles and furniture above it */
         bool supports_above( const tripoint_bub_ms &p ) const;
-        // TODO: Get rid of untyped overload
-        bool has_floor_or_support( const tripoint &p ) const;
         bool has_floor_or_support( const tripoint_bub_ms &p ) const;
-        // TODO: Get rid of untyped overload
-        bool has_vehicle_floor( const tripoint &p ) const;
         bool has_vehicle_floor( const tripoint_bub_ms &p ) const;
     private:
         /**
@@ -1709,10 +1680,9 @@ class map
         void place_vending( const tripoint_bub_ms &p, const item_group_id &type, bool reinforced = false,
                             bool lootable = false, bool powered = false );
         // places an NPC, if static NPCs are enabled or if force is true
-        // TODO: Get rid of untyped overload
-        character_id place_npc( const point &p, const string_id<npc_template> &type );
         character_id place_npc( const point_bub_ms &p, const string_id<npc_template> &type );
-        void apply_faction_ownership( const point &p1, const point &p2, const faction_id &id );
+        void apply_faction_ownership( const point_bub_ms &p1, const point_bub_ms &p2,
+                                      const faction_id &id );
         void add_spawn( const mtype_id &type, int count, const tripoint_bub_ms &p,
                         bool friendly = false, int faction_id = -1, int mission_id = -1,
                         const std::optional<std::string> &name = std::nullopt );
@@ -1744,10 +1714,6 @@ class map
         //                          can be overriden by VEHICLE_STATUS_AT_SPAWN EXTERNAL_OPTION
         // @param merge_wrecks      if true and vehicle overlaps another then both turn into wrecks
         //                          if false and vehicle will overlap aborts and returns nullptr
-        // TODO: Get rid of untyped overload
-        vehicle *add_vehicle( const vproto_id &type, const tripoint &p, const units::angle &dir,
-                              int init_veh_fuel = -1, int init_veh_status = -1, bool merge_wrecks = true,
-                              bool force_status = false );
         vehicle *add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, const units::angle &dir,
                               int init_veh_fuel = -1, int init_veh_status = -1, bool merge_wrecks = true,
                               bool force_status = false );
@@ -1755,8 +1721,6 @@ class map
         // Light/transparency
         float light_transparency( const tripoint_bub_ms &p ) const;
         // Assumes 0,0 is light map center
-        // TODO: Get rid of untyped overload.
-        lit_level light_at( const tripoint &p ) const;
         lit_level light_at( const tripoint_bub_ms &p ) const;
         // Raw values for tilesets
         float ambient_light_at( const tripoint_bub_ms &p ) const;
@@ -1786,8 +1750,6 @@ class map
          * Coordinates is in the system that is used by the ter/furn/i_at functions.
          * Output is in the same scale, but in global system.
          */
-        // TODO: fix point types (remove the first overload)
-        tripoint_abs_ms getglobal( const tripoint &p ) const;
         tripoint_abs_ms getglobal( const tripoint_bub_ms &p ) const;
         /**
          * Inverse of @ref getglobal
@@ -1796,7 +1758,6 @@ class map
         point_bub_ms bub_from_abs( const point_abs_ms &p ) const {
             return bub_from_abs( tripoint_abs_ms( p, abs_sub.z() ) ).xy();
         }
-        bool inbounds( const tripoint &p ) const;
         bool inbounds( const tripoint_bub_ms &p ) const;
         bool inbounds( const tripoint_abs_ms &p ) const;
         bool inbounds( const tripoint_abs_sm &p ) const {
@@ -1812,8 +1773,6 @@ class map
         }
 
         /** Clips the coordinates of p to fit the map bounds */
-        // TODO: Get rid of untyped overload.
-        void clip_to_bounds( tripoint &p ) const;
         void clip_to_bounds( tripoint_bub_ms &p ) const;
         void clip_to_bounds( int &x, int &y ) const;
         void clip_to_bounds( int &x, int &y, int &z ) const;
@@ -2016,12 +1975,6 @@ class map
             std::tie( sm, offset_p ) = project_remain<coords::sm>( p );
             return unsafe_get_submap_at( p );
         }
-        // TODO: Get rid of untyped overload
-        submap *get_submap_at( const tripoint &p, point &offset_p ) {
-            offset_p.x = p.x % SEEX;
-            offset_p.y = p.y % SEEY;
-            return get_submap_at( tripoint_bub_ms( p ) );
-        }
         submap *get_submap_at( const tripoint_bub_ms &p, point_sm_ms &offset_p ) {
             offset_p.x() = p.x() % SEEX;
             offset_p.y() = p.y() % SEEY;
@@ -2031,9 +1984,6 @@ class map
             offset_p.x() = p.x() % SEEX;
             offset_p.y() = p.y() % SEEY;
             return get_submap_at( p );
-        }
-        submap *get_submap_at( const point &p, point &offset_p ) {
-            return get_submap_at( { p, abs_sub.z() }, offset_p );
         }
         /**
          * Get submap pointer in the grid at given grid coordinates. Grid coordinates must
@@ -2107,7 +2057,7 @@ class map
         void apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, float luminance,
                               const units::angle &wideangle = 30_degrees );
         void apply_light_ray( cata::mdarray<bool, point_bub_ms, MAPSIZE_X, MAPSIZE_Y> &lit,
-                              const tripoint &s, const tripoint &e, float luminance );
+                              const tripoint_bub_ms &s, const tripoint_bub_ms &e, float luminance );
         void add_light_from_items( const tripoint_bub_ms &p, const item_stack &items );
         void add_item_light_recursive( const tripoint_bub_ms &p, const item &it );
         std::unique_ptr<vehicle> add_vehicle_to_map( std::unique_ptr<vehicle> veh, bool merge_wrecks );
@@ -2249,9 +2199,6 @@ class map
         // Clips the area to map bounds
         tripoint_range<tripoint_bub_ms> points_in_rectangle(
             const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const;
-        // TODO: fix point types (remove the first overload)
-        tripoint_range<tripoint> points_in_radius(
-            const tripoint &center, size_t radius, size_t radiusz = 0 ) const;
         tripoint_range<tripoint_bub_ms> points_in_radius(
             const tripoint_bub_ms &center, size_t radius, size_t radiusz = 0 ) const;
 
@@ -2287,8 +2234,6 @@ class map
         bool dont_draw_lower_floor( const tripoint_bub_ms &p ) const;
 
         bool has_haulable_items( const tripoint_bub_ms &pos );
-        // TODO: Get rid of untyped overload
-        std::vector<item_location> get_haulable_items( const tripoint &pos );
         std::vector<item_location> get_haulable_items( const tripoint_bub_ms &pos );
 
 #if defined(TILES)
@@ -2365,16 +2310,8 @@ class tinymap : private map
         }
 
         using map::translate;
-        // TODO: Get rid of untyped overload.
-        ter_id ter( const tripoint &p ) const {
-            return map::ter( tripoint_bub_ms( p ) );
-        }
         ter_id ter( const tripoint_omt_ms &p ) const {
             return map::ter( rebase_bub( p ) );
-        }
-        // TODO: Get rid of untyped overload.
-        bool ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
-            return map::ter_set( tripoint_bub_ms( p ), new_terrain, avoid_creatures );
         }
         bool ter_set( const tripoint_omt_ms &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
             return map::ter_set( rebase_bub( p ), new_terrain, avoid_creatures );
@@ -2393,16 +2330,8 @@ class tinymap : private map
         furn_id furn( const point_omt_ms &p ) const {
             return map::furn( rebase_bub( p ) );
         }
-        // TODO: Get rid of untyped overload.
-        furn_id furn( const tripoint &p ) const {
-            return map::furn( tripoint_bub_ms( p ) );
-        }
         furn_id furn( const tripoint_omt_ms &p ) const {
             return map::furn( rebase_bub( p ) );
-        }
-        // TODO: Get rid of untyped overload.
-        bool has_furn( const tripoint &p ) const {
-            return map::has_furn( tripoint_bub_ms( p ) );
         }
         bool has_furn( const tripoint_omt_ms &p ) const {
             return map::has_furn( rebase_bub( p ) );
@@ -2412,11 +2341,6 @@ class tinymap : private map
         }
         void set( const tripoint_omt_ms &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
             map::set( rebase_bub( p ), new_terrain, new_furniture );
-        }
-        // TODO: Get rid of untyped overload.
-        bool furn_set( const tripoint &p, const furn_id &new_furniture, bool furn_reset = false,
-                       bool avoid_creatures = false ) {
-            return map::furn_set( tripoint_bub_ms( p ), new_furniture, furn_reset, avoid_creatures );
         }
         bool furn_set( const tripoint_omt_ms &p, const furn_id &new_furniture, bool furn_reset = false,
                        bool avoid_creatures = false ) {
@@ -2448,22 +2372,8 @@ class tinymap : private map
             const tripoint_omt_ms &from, const tripoint_omt_ms &to ) const;
         tripoint_range<tripoint_omt_ms> points_in_radius(
             const tripoint_omt_ms &center, size_t radius, size_t radiusz = 0 ) const;
-        // TODO: Get rid of untyped overload.
-        map_stack i_at( const tripoint &p ) {
-            return map::i_at( tripoint_bub_ms( p ) );
-        }
         map_stack i_at( const tripoint_omt_ms &p ) {
             return map::i_at( rebase_bub( p ) );
-        }
-        // TODO: Get rid of untyped overload.
-        void spawn_item( const tripoint &p, const itype_id &type_id,
-                         unsigned quantity = 1, int charges = 0,
-                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
-                         const std::set<flag_id> &flags = {}, const std::string &variant = "",
-                         const std::string &faction = "" ) {
-            map::spawn_item( tripoint_bub_ms( p ), type_id, quantity, charges, birthday, damlevel, flags,
-                             variant,
-                             faction );
         }
         void spawn_item( const tripoint_omt_ms &p, const itype_id &type_id,
                          unsigned quantity = 1, int charges = 0,
@@ -2511,10 +2421,6 @@ class tinymap : private map
         }
         void i_rem( const tripoint_omt_ms &p, item *it ) {
             map::i_rem( rebase_bub( p ), it );
-        }
-        // TODO: Get rid of untyped overload.
-        void i_clear( const tripoint &p ) {
-            return map::i_clear( tripoint_bub_ms( p ) );
         }
         void i_clear( const tripoint_omt_ms &p ) {
             return map::i_clear( rebase_bub( p ) );
@@ -2574,10 +2480,6 @@ class tinymap : private map
         tripoint_omt_ms omt_from_abs( const tripoint_abs_ms &p ) const {
             return rebase_omt( map::bub_from_abs( p ) );
         };
-        // TODO: Get rid of untyped overload.
-        bool is_outside( const tripoint &p ) const {
-            return map::is_outside( tripoint_bub_ms( p ) );
-        }
         bool is_outside( const tripoint_omt_ms &p ) const {
             return map::is_outside( rebase_bub( p ) );
         }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -387,7 +387,7 @@ static bool mx_helicopter( map &m, const tripoint_abs_sm &abs_sub )
         wreckage_pos = { clamp( c.x() + offset.x(), min.x(), x_max ), clamp( c.y() + offset.y(), min.y(), y_max ), abs_sub.z()};
     }
 
-    vehicle *wreckage = m.add_vehicle( crashed_hull, wreckage_pos.raw(), dir1, rng( 1, 33 ), 1 );
+    vehicle *wreckage = m.add_vehicle( crashed_hull, wreckage_pos, dir1, rng( 1, 33 ), 1 );
 
     const auto controls_at = []( vehicle * wreckage, const tripoint_bub_ms & pos ) {
         return !wreckage->get_parts_at( pos, "CONTROLS", part_status_flag::any ).empty() ||

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -398,7 +398,8 @@ class mapgen_palette
 
 struct jmapgen_objects {
 
-        jmapgen_objects( const tripoint_rel_ms &offset, const point &mapsize, const point &tot_size );
+        jmapgen_objects( const tripoint_rel_ms &offset, const point_rel_ms &mapsize,
+                         const point_rel_ms &tot_size );
 
         bool check_bounds( const jmapgen_place &place, const JsonObject &jso );
 
@@ -425,7 +426,7 @@ struct jmapgen_objects {
 
         void merge_parameters_into( mapgen_parameters &, const std::string &outer_context ) const;
 
-        void add_placement_coords_to( std::unordered_set<point> & ) const;
+        void add_placement_coords_to( std::unordered_set<point_rel_ms> & ) const;
 
         void apply( const mapgendata &dat, mapgen_phase, const std::string &context ) const;
         void apply( const mapgendata &dat, mapgen_phase, const tripoint_rel_ms &offset,
@@ -444,8 +445,8 @@ struct jmapgen_objects {
         using jmapgen_obj = std::pair<jmapgen_place, shared_ptr_fast<const jmapgen_piece> >;
         std::vector<jmapgen_obj> objects;
         tripoint_rel_ms m_offset;
-        point mapgensize;
-        point total_size;
+        point_rel_ms mapgensize;
+        point_rel_ms total_size;
 };
 
 class mapgen_function_json_base
@@ -458,7 +459,7 @@ class mapgen_function_json_base
         size_t calc_index( const point &p ) const;
         ret_val<void> has_vehicle_collision( const mapgendata &dat, const tripoint_rel_ms &offset ) const;
 
-        void add_placement_coords_to( std::unordered_set<point> & ) const;
+        void add_placement_coords_to( std::unordered_set<point_rel_ms> & ) const;
 
         const mapgen_parameters &get_parameters() const {
             return parameters;
@@ -486,9 +487,9 @@ class mapgen_function_json_base
         enum_bitset<jmapgen_flags> flags_;
         bool is_ready;
 
-        point mapgensize;
+        point_rel_ms mapgensize;
         tripoint_rel_ms m_offset;
-        point total_size;
+        point_rel_ms total_size;
         std::vector<jmapgen_setmap> setmap_points;
 
         jmapgen_objects objects;
@@ -574,7 +575,7 @@ class nested_mapgen
         void add( const std::shared_ptr<mapgen_function_json_nested> &p, int weight );
         // Returns a set containing every relative coordinate of a point that
         // might have something placed by this mapgen
-        std::unordered_set<point> all_placement_coords() const;
+        std::unordered_set<point_rel_ms> all_placement_coords() const;
     private:
         weighted_int_list<std::shared_ptr<mapgen_function_json_nested>> funcs_;
 };

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -83,7 +83,7 @@ SDL_Texture_Ptr create_cache_texture( const SDL_Renderer_Ptr &renderer, int tile
                           tile_height );
 }
 
-SDL_Color get_map_color_at( const tripoint &p )
+SDL_Color get_map_color_at( const tripoint_bub_ms &p )
 {
     const map &here = get_map();
     if( const optional_vpart_position vp = here.veh_at( p ) ) {
@@ -226,11 +226,12 @@ void pixel_minimap::set_settings( const pixel_minimap_settings &settings )
     reset();
 }
 
-void pixel_minimap::prepare_cache_for_updates( const tripoint &center )
+void pixel_minimap::prepare_cache_for_updates( const tripoint_bub_ms &center )
 {
-    const tripoint_abs_sm new_center_sm = get_map().get_abs_sub() + coords::project_to<coords::sm>
-                                          ( tripoint_bub_ms( center ) ).raw();
-    const tripoint_rel_sm center_sm_diff = tripoint_abs_sm( cached_center_sm ) - new_center_sm;
+    const tripoint_abs_sm new_center_sm = get_map().get_abs_sub() + rebase_rel(
+            coords::project_to<coords::sm>
+            ( center ) );
+    const tripoint_rel_sm center_sm_diff = cached_center_sm - new_center_sm;
 
     //invalidate the cache if the game shifted more than one submap in the last update, or if z-level changed.
     if( std::abs( center_sm_diff.x() ) > 1 ||
@@ -243,7 +244,7 @@ void pixel_minimap::prepare_cache_for_updates( const tripoint &center )
         }
     }
 
-    cached_center_sm = new_center_sm.raw();
+    cached_center_sm = new_center_sm;
 }
 
 //deletes the mapping of unused submap caches from the main map
@@ -300,22 +301,21 @@ void pixel_minimap::flush_cache_updates()
     }
 }
 
-void pixel_minimap::update_cache_at( const tripoint &sm_pos )
+void pixel_minimap::update_cache_at( const tripoint_bub_sm &sm_pos )
 {
     const map &here = get_map();
-    const level_cache &access_cache = here.access_cache( sm_pos.z );
+    const level_cache &access_cache = here.access_cache( sm_pos.z() );
     const bool nv_goggle = get_player_character().get_vision_modes()[NV_GOGGLES];
 
-    // TODO: fix point types
-    submap_cache &cache_item = get_cache_at( here.get_abs_sub().raw() + sm_pos );
-    const tripoint_bub_ms ms_pos = coords::project_to<coords::ms>( tripoint_bub_sm( sm_pos ) );
+    submap_cache &cache_item = get_cache_at( here.get_abs_sub() + rebase_rel( sm_pos ) );
+    const tripoint_bub_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
 
     cache_item.touched = true;
 
     for( int y = 0; y < SEEY; ++y ) {
         for( int x = 0; x < SEEX; ++x ) {
-            const tripoint p = ms_pos.raw() + tripoint{x, y, 0};
-            const lit_level lighting = access_cache.visibility_cache[p.x][p.y];
+            const tripoint_bub_ms p = ms_pos + tripoint{x, y, 0};
+            const lit_level lighting = access_cache.visibility_cache[p.x()][p.y()];
 
             SDL_Color color;
 
@@ -349,7 +349,7 @@ void pixel_minimap::update_cache_at( const tripoint &sm_pos )
     }
 }
 
-pixel_minimap::submap_cache &pixel_minimap::get_cache_at( const tripoint &abs_sm_pos )
+pixel_minimap::submap_cache &pixel_minimap::get_cache_at( const tripoint_abs_sm &abs_sm_pos )
 {
     auto it = cache.find( abs_sm_pos );
 
@@ -360,13 +360,13 @@ pixel_minimap::submap_cache &pixel_minimap::get_cache_at( const tripoint &abs_sm
     return it->second;
 }
 
-void pixel_minimap::process_cache( const tripoint &center )
+void pixel_minimap::process_cache( const tripoint_bub_ms &center )
 {
     prepare_cache_for_updates( center );
 
     for( int y = 0; y < MAPSIZE; ++y ) {
         for( int x = 0; x < MAPSIZE; ++x ) {
-            update_cache_at( { x, y, center.z } );
+            update_cache_at( { x, y, center.z()} );
         }
     }
 
@@ -436,7 +436,7 @@ void pixel_minimap::reset()
     tex_pool.reset();
 }
 
-void pixel_minimap::render( const tripoint &center )
+void pixel_minimap::render( const tripoint_bub_ms &center )
 {
     SetRenderTarget( renderer, main_tex );
     SetRenderDrawColor( renderer, pixel_minimap_r, pixel_minimap_g, pixel_minimap_b, pixel_minimap_a );
@@ -451,48 +451,48 @@ void pixel_minimap::render( const tripoint &center )
     RenderCopy( renderer, main_tex, &main_tex_clip_rect, &screen_clip_rect );
 }
 
-void pixel_minimap::render_cache( const tripoint &center )
+void pixel_minimap::render_cache( const tripoint_bub_ms &center )
 {
-    // TODO: fix point types
-    const tripoint_abs_sm sm_center = get_map().get_abs_sub() + coords::project_to<coords::sm>
-                                      ( tripoint_bub_ms( center ) ).raw();
+    const tripoint_abs_sm sm_center = get_map().get_abs_sub() + rebase_rel(
+                                          coords::project_to<coords::sm>
+                                          ( center ) );
     const tripoint_rel_sm sm_offset {
         total_tiles_count.x / SEEX / 2,
         total_tiles_count.y / SEEY / 2, 0
     };
 
-    point ms_offset;
+    point_rel_ms ms_offset;
     tripoint_bub_sm quotient;
     point_sm_ms remainder;
-    std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( tripoint_bub_ms( center ) );
+    std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( center );
 
-    point ms_base_offset = point( ( total_tiles_count.x / 2 ) % SEEX,
-                                  ( total_tiles_count.y / 2 ) % SEEY );
-    ms_offset = ms_base_offset - remainder.raw();
+    point_sm_ms ms_base_offset = point_sm_ms( ( total_tiles_count.x / 2 ) % SEEX,
+                                 ( total_tiles_count.y / 2 ) % SEEY );
+    ms_offset = ms_base_offset - remainder;
 
     for( const auto &elem : cache ) {
         if( !elem.second.touched ) {
             continue;   // What you gonna do with all that junk?
         }
 
-        const tripoint rel_pos = elem.first - sm_center.raw();
+        const tripoint_rel_sm rel_pos = elem.first - sm_center;
 
-        if( std::abs( rel_pos.x ) > sm_offset.x() + 1 ||
-            std::abs( rel_pos.y ) > sm_offset.y() + 1 ||
-            rel_pos.z != 0 ) {
+        if( std::abs( rel_pos.x() ) > sm_offset.x() + 1 ||
+            std::abs( rel_pos.y() ) > sm_offset.y() + 1 ||
+            rel_pos.z() != 0 ) {
             continue;
         }
 
         const tripoint_rel_sm sm_pos = tripoint_rel_sm( rel_pos ) + sm_offset;
-        const tripoint ms_pos = coords::project_to<coords::ms>( sm_pos ).raw() + ms_offset;
+        const tripoint_rel_ms ms_pos = coords::project_to<coords::ms>( sm_pos ) + ms_offset;
 
-        const SDL_Rect chunk_rect = projector->get_chunk_rect( ms_pos.xy(), { SEEX, SEEY } );
+        const SDL_Rect chunk_rect = projector->get_chunk_rect( ms_pos.xy().raw(), {SEEX, SEEY} );
 
         RenderCopy( renderer, elem.second.chunk_tex, nullptr, &chunk_rect );
     }
 }
 
-void pixel_minimap::render_critters( const tripoint &center )
+void pixel_minimap::render_critters( const tripoint_bub_ms &center )
 {
     //handles the enemy faction red highlights
     //this value should be divisible by 200
@@ -510,9 +510,10 @@ void pixel_minimap::render_critters( const tripoint &center )
     }
 
     const map &m = get_map();
-    const level_cache &access_cache = m.access_cache( center.z );
+    const level_cache &access_cache = m.access_cache( center.z() );
 
-    const point start( center.x - total_tiles_count.x / 2, center.y - total_tiles_count.y / 2 );
+    const point_rel_ms start( center.x() - total_tiles_count.x / 2,
+                              center.y() - total_tiles_count.y / 2 );
     const point beacon_size = {
         std::max<int>( projector->get_tile_size().x *settings.beacon_size / 2, 2 ),
         std::max<int>( projector->get_tile_size().y *settings.beacon_size / 2, 2 )
@@ -521,7 +522,7 @@ void pixel_minimap::render_critters( const tripoint &center )
     creature_tracker &creatures = get_creature_tracker();
     for( int y = 0; y < total_tiles_count.y; y++ ) {
         for( int x = 0; x < total_tiles_count.x; x++ ) {
-            const tripoint_bub_ms p = start + tripoint_bub_ms( x, y, center.z );
+            const tripoint_bub_ms p = start + tripoint_bub_ms( x, y, center.z() );
             if( !m.inbounds( p ) ) {
                 // p might be out-of-bounds when peeking at submap boundary. Example: center=(64,59,-5), start=(4,-1) -> p=(4,-1,-5)
                 continue;
@@ -559,8 +560,8 @@ void pixel_minimap::draw( const SDL_Rect &screen_rect, const tripoint_bub_ms &ce
     }
 
     set_screen_rect( screen_rect );
-    process_cache( center.raw() );
-    render( center.raw() );
+    process_cache( center );
+    render( center );
 }
 
 void pixel_minimap::draw_beacon( const SDL_Rect &rect, const SDL_Color &color )

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -5,7 +5,7 @@
 #include <map>
 #include <memory>
 
-#include "coords_fwd.h"
+#include "coordinates.h"
 #include "point.h"
 #include "sdl_wrappers.h"
 #include "sdl_geometry.h"
@@ -46,23 +46,23 @@ class pixel_minimap
     private:
         struct submap_cache;
 
-        submap_cache &get_cache_at( const tripoint &abs_sm_pos );
+        submap_cache &get_cache_at( const tripoint_abs_sm &abs_sm_pos );
 
         void set_screen_rect( const SDL_Rect &screen_rect );
         void reset();
 
         void draw_beacon( const SDL_Rect &rect, const SDL_Color &color );
 
-        void process_cache( const tripoint &center );
+        void process_cache( const tripoint_bub_ms &center );
 
         void flush_cache_updates();
-        void update_cache_at( const tripoint &pos );
-        void prepare_cache_for_updates( const tripoint &center );
+        void update_cache_at( const tripoint_bub_sm &pos );
+        void prepare_cache_for_updates( const tripoint_bub_ms &center );
         void clear_unused_cache();
 
-        void render( const tripoint &center );
-        void render_cache( const tripoint &center );
-        void render_critters( const tripoint &center );
+        void render( const tripoint_bub_ms &center );
+        void render_cache( const tripoint_bub_ms &center );
+        void render_critters( const tripoint_bub_ms &center );
 
         std::unique_ptr<pixel_minimap_projector> create_projector( const SDL_Rect &max_screen_rect ) const;
 
@@ -75,7 +75,7 @@ class pixel_minimap
         point pixel_size;
 
         //track the previous viewing area to determine if the minimap cache needs to be cleared
-        tripoint cached_center_sm;
+        tripoint_abs_sm cached_center_sm;
 
         SDL_Rect screen_rect;
         SDL_Rect main_tex_clip_rect;
@@ -89,7 +89,7 @@ class pixel_minimap
         class shared_texture_pool;
         std::unique_ptr<shared_texture_pool> tex_pool;
 
-        std::map<tripoint, submap_cache> cache;
+        std::map<tripoint_abs_sm, submap_cache> cache;
 };
 
 #endif // CATA_SRC_PIXEL_MINIMAP_H

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -218,10 +218,11 @@ static void deserialize( weak_ptr_fast<monster> &obj, const JsonObject &data )
     //    }
 }
 
-static tripoint read_legacy_creature_pos( const JsonObject &data )
+static tripoint_bub_ms read_legacy_creature_pos( const JsonObject &data )
 {
-    tripoint pos;
-    if( !data.read( "posx", pos.x ) || !data.read( "posy", pos.y ) || !data.read( "posz", pos.z ) ) {
+    tripoint_bub_ms pos;
+    if( !data.read( "posx", pos.x() ) || !data.read( "posy", pos.y() ) ||
+        !data.read( "posz", pos.z() ) ) {
         debugmsg( R"(Bad Creature JSON: neither "location" nor "posx", "posy", "posz" found)" );
     }
     return pos;
@@ -2059,15 +2060,15 @@ void npc::load( const JsonObject &data )
     if( !data.has_member( "location" ) ) {
         point submap_coords;
         data.read( "submap_coords", submap_coords );
-        const tripoint pos = read_legacy_creature_pos( data );
+        const tripoint_bub_ms pos = read_legacy_creature_pos( data );
         set_location( tripoint_abs_ms( project_to<coords::ms>( point_abs_sm( submap_coords ) ),
-                                       0 ) + tripoint( pos.x % SEEX, pos.y % SEEY, pos.z ) );
-        std::optional<tripoint> opt;
+                                       0 ) + tripoint( pos.x() % SEEX, pos.y() % SEEY, pos.z() ) );
+        std::optional<tripoint_bub_ms> opt;
         if( data.read( "last_player_seen_pos", opt ) && opt ) {
-            last_player_seen_pos = get_location() + *opt - pos;
+            last_player_seen_pos = get_location() + ( *opt - pos );
         }
         if( data.read( "pulp_location", opt ) && opt ) {
-            pulp_location = get_location() + *opt - pos;
+            pulp_location = get_location() + ( *opt - pos );
         }
         tripoint tmp;
         if( data.read( "guardx", tmp.x ) && data.read( "guardy", tmp.y ) && data.read( "guardz", tmp.z ) &&
@@ -2434,10 +2435,10 @@ void monster::load( const JsonObject &data )
     // TEMPORARY until 0.G
     if( !data.has_member( "location" ) ) {
         set_location( get_map().getglobal( read_legacy_creature_pos( data ) ) );
-        tripoint wand;
-        data.read( "wandx", wand.x );
-        data.read( "wandy", wand.y );
-        data.read( "wandz", wand.z );
+        tripoint_bub_ms wand;
+        data.read( "wandx", wand.x() );
+        data.read( "wandy", wand.y() );
+        data.read( "wandz", wand.z() );
         wander_pos = get_map().getglobal( wand );
         tripoint destination;
         data.read( "destination", destination );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -617,7 +617,7 @@ void veh_app_interact::populate_app_actions()
 
     /*************** Get part-specific actions ***************/
     veh_menu menu( veh, "IF YOU SEE THIS IT IS A BUG" );
-    veh->build_interact_menu( menu, veh->mount_to_tripoint( a_point ).raw(), false );
+    veh->build_interact_menu( menu, veh->mount_to_tripoint( a_point ), false );
     const std::vector<veh_menu_item> items = menu.get_items();
     for( size_t i = 0; i < items.size(); i++ ) {
         const veh_menu_item &it = items[i];

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2160,8 +2160,7 @@ class vehicle
 
         void build_electronics_menu( veh_menu &menu );
         void build_bike_rack_menu( veh_menu &menu, int part );
-        // TODO: Make it typed. One call uses bubble coordinates, the other untyped veh_app_interact::a_point
-        void build_interact_menu( veh_menu &menu, const tripoint &p, bool with_pickup );
+        void build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, bool with_pickup );
         void interact_with( const tripoint_bub_ms &p, bool with_pickup = false );
 
         std::string disp_name() const;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1825,7 +1825,7 @@ bool vehicle::use_vehicle_tool( vehicle &veh, const tripoint_bub_ms &vp_pos,
     return true;
 }
 
-void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_pickup )
+void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, bool with_pickup )
 {
     const optional_vpart_position ovp = get_map().veh_at( p );
     if( !ovp ) {
@@ -2448,6 +2448,6 @@ void vehicle::interact_with( const tripoint_bub_ms &p, bool with_pickup )
     veh_menu menu( *this, _( "Select an action" ) );
     do {
         menu.reset();
-        build_interact_menu( menu, p.raw(), with_pickup );
+        build_interact_menu( menu, p, with_pickup );
     } while( menu.query() );
 }

--- a/tests/degradation_test.cpp
+++ b/tests/degradation_test.cpp
@@ -268,7 +268,7 @@ TEST_CASE( "Repairing_degraded_items", "[item][degradation]" )
     // Setup map
     clear_map();
     set_time_to_day();
-    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos.raw() ) ) > 2 );
+    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos ) ) > 2 );
 
     GIVEN( "Item with normal degradation" ) {
         Character &u = get_player_character();
@@ -663,7 +663,7 @@ TEST_CASE( "refit_item_inside_spillable_container", "[item][repair][container]" 
     clear_avatar();
     clear_map();
     set_time_to_day();
-    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos.raw() ) ) > 2 );
+    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos ) ) > 2 );
 
     Character &u = get_player_character();
     u.set_skill_level( skill_tailor, 10 );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -29,8 +29,10 @@ TEST_CASE( "map_coordinate_conversion_functions" )
         here.vertical_shift( 0 );
     } );
 
-    tripoint test_point =
-        GENERATE( tripoint::zero, tripoint::south, tripoint::east, tripoint::above, tripoint::below );
+    tripoint_bub_ms test_point =
+        GENERATE( tripoint_bub_ms::zero, tripoint_bub_ms::zero + tripoint::south,
+                  tripoint_bub_ms::zero + tripoint::east, tripoint_bub_ms::zero + tripoint::above,
+                  tripoint_bub_ms::zero + tripoint::below );
     tripoint_bub_ms test_bub( test_point );
     int z = GENERATE( 0, 1, -1, OVERMAP_HEIGHT, -OVERMAP_DEPTH );
 
@@ -51,7 +53,7 @@ TEST_CASE( "map_coordinate_conversion_functions" )
 
     point_abs_ms map_origin_ms = project_to<coords::ms>( here.get_abs_sub().xy() );
 
-    tripoint_abs_ms test_abs = map_origin_ms + test_point;
+    tripoint_abs_ms test_abs = map_origin_ms + rebase_rel( test_point );
 
     if( test_abs.z() > OVERMAP_HEIGHT || test_abs.z() < -OVERMAP_DEPTH ) {
         return;
@@ -62,7 +64,7 @@ TEST_CASE( "map_coordinate_conversion_functions" )
 
     // Verify round-tripping
     CHECK( here.getglobal( here.bub_from_abs( test_abs ) ) == test_abs );
-    CHECK( here.bub_from_abs( here.getglobal( test_point ) ).raw() == test_point );
+    CHECK( here.bub_from_abs( here.getglobal( test_point ) ) == test_point );
 }
 
 TEST_CASE( "destroy_grabbed_furniture" )

--- a/tests/mapgen_remove_npcs_test.cpp
+++ b/tests/mapgen_remove_npcs_test.cpp
@@ -19,7 +19,7 @@ static const update_mapgen_id update_mapgen_test_update_remove_npc( "test_update
 namespace
 {
 
-void check_creature( tripoint const &loc, string_id<npc_template> const &id, bool state )
+void check_creature( tripoint_bub_ms const &loc, string_id<npc_template> const &id, bool state )
 {
     Creature *critter = get_creature_tracker().creature_at( loc, true );
     if( state ) {
@@ -30,7 +30,7 @@ void check_creature( tripoint const &loc, string_id<npc_template> const &id, boo
     }
 }
 
-void place_npc_and_check( map &m, tripoint const &loc, update_mapgen_id const &id,
+void place_npc_and_check( map &m, tripoint_bub_ms const &loc, update_mapgen_id const &id,
                           string_id<npc_template> const &nid )
 {
     check_creature( loc, nid, false );
@@ -40,7 +40,7 @@ void place_npc_and_check( map &m, tripoint const &loc, update_mapgen_id const &i
     g->mon_info_update();
 }
 
-void remove_npc_and_check( map &m, tripoint const &loc, update_mapgen_id const &id,
+void remove_npc_and_check( map &m, tripoint_bub_ms const &loc, update_mapgen_id const &id,
                            string_id<npc_template> const &nid )
 {
     check_creature( loc, nid, true );
@@ -74,16 +74,16 @@ TEST_CASE( "mapgen_remove_npcs" )
         tripoint_bub_ms const loc2 = here.bub_from_abs( project_to<coords::ms>( omt2 ) );
         tripoint_bub_ms const loc3 = loc2 + tripoint::east;
         REQUIRE( get_map().inbounds( loc ) );
-        place_npc_and_check( here, loc.raw(), update_mapgen_test_update_place_npc,
+        place_npc_and_check( here, loc, update_mapgen_test_update_place_npc,
                              npc_template_test_npc_trader );
         REQUIRE( overmap_buffer.get_npcs_near_omt( omt, 0 ).size() == 1 );
-        place_npc_and_check( here, loc2.raw(), update_mapgen_test_update_place_npc,
+        place_npc_and_check( here, loc2, update_mapgen_test_update_place_npc,
                              npc_template_test_npc_trader );
         REQUIRE( overmap_buffer.get_npcs_near_omt( omt2, 0 ).size() == 1 );
         REQUIRE( get_avatar().sees( loc, true ) );
 
         WHEN( "removing NPC" ) {
-            remove_npc_and_check( here, loc.raw(), update_mapgen_test_update_remove_npc,
+            remove_npc_and_check( here, loc, update_mapgen_test_update_remove_npc,
                                   npc_template_test_npc_trader );
             THEN( "NPC of same class on different submap not affected" ) {
                 REQUIRE( overmap_buffer.get_npcs_near_omt( omt, 0 ).empty() );
@@ -91,13 +91,13 @@ TEST_CASE( "mapgen_remove_npcs" )
             }
 
             THEN( "NPC of different class on same submap not affected" ) {
-                place_npc_and_check( here, loc3.raw(), update_mapgen_test_update_place_npc_thug,
+                place_npc_and_check( here, loc3, update_mapgen_test_update_place_npc_thug,
                                      npc_template_thug );
                 REQUIRE( overmap_buffer.get_npcs_near_omt( omt2, 0 ).size() == 2 );
-                remove_npc_and_check( here, loc2.raw(), update_mapgen_test_update_remove_npc,
+                remove_npc_and_check( here, loc2, update_mapgen_test_update_remove_npc,
                                       npc_template_test_npc_trader );
                 REQUIRE( overmap_buffer.get_npcs_near_omt( omt2, 0 ).size() == 1 );
-                check_creature( loc3.raw(), npc_template_thug, true );
+                check_creature( loc3, npc_template_thug, true );
             }
         }
     }

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -240,7 +240,7 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
     for( int i = 0; i < water_charges; i++ ) {
         CAPTURE( i, veh.fuel_left( itype_water_clean ) );
         menu.reset();
-        veh.build_interact_menu( menu, faucet->pos_bub().raw(), false );
+        veh.build_interact_menu( menu, faucet->pos_bub(), false );
         const std::vector<veh_menu_item> items = menu.get_items();
         const bool stomach_should_be_full = i == water_charges - 1;
         const auto drink_item_it = std::find_if( items.begin(), items.end(),


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Get rid of usages of untyped coordinates by replacing them with typed ones. This time finishing map.h and dealing with some dependents and some sundry stuff.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Find usages of untyped operations, convert any dependents to use the typed one instead, possibly with some recursion, and then removing the untyped operation. A fair number of operations were already unused due to previous typification efforts.

Also encountered a bug in avatar.cpp operation avatar_action.move() where the relative position passed into the operation was used to check for impassability. This was uncovered when the called untyped operation was removed and the remaining one didn't match when .raw() was removed. The conclusion was that call should have been made with the same parameter as similar operations nearby, i.e. the reference modified by the offset.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkey, smash into stationary vehicle.

The move operation change was not tested as I don't really know how to test it. It should have a limited impact, given that the bug hasn't been discovered previously. I guess impassable fields aren't that common.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
