### PR TITLE
Extended description window shows potential deconstruction and bash yields

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2059,41 +2059,21 @@ void construct::do_turn_deconstruct( const tripoint_bub_ms &p, Character &who )
         get_option<bool>( "QUERY_DECONSTRUCT" ) ) {
         bool cancel_construction = false;
 
-        auto deconstruct_items = []( const item_group_id & drop_group ) {
-            std::string ret;
-            const Item_spawn_data *spawn_data = item_group::spawn_data_from_group( drop_group );
-            if( spawn_data == nullptr ) {
-                return ret;
-            }
-            const std::map<const itype *, std::pair<int, int>> deconstruct_items =
-                        spawn_data->every_item_min_max();
-            for( const auto &deconstruct_item : deconstruct_items ) {
-                const int &min = deconstruct_item.second.first;
-                const int &max = deconstruct_item.second.second;
-                if( min != max ) {
-                    ret += string_format( "- %d-%d %s\n", min, max, deconstruct_item.first->nname( max ) );
-                } else {
-                    ret += string_format( "- %d %s\n", max, deconstruct_item.first->nname( max ) );
-                }
-            }
-            return ret;
-        };
         auto deconstruction_will_practice_skill = [&who]( auto & skill ) {
             return who.get_skill_level( skill.id ) >= skill.min &&
                    who.get_skill_level( skill.id ) < skill.max;
         };
 
-        auto deconstruct_query = [&who, &cancel_construction, &deconstruction_will_practice_skill,
-              &deconstruct_items]( map_common_deconstruct_info & deconstruct, std::string & name ) {
-            if( !!deconstruct.skill &&
-                deconstruction_will_practice_skill( deconstruct.skill.value() ) ) {
+        auto deconstruct_query = [&who, &cancel_construction, &deconstruction_will_practice_skill]
+        ( map_common_deconstruct_info & deconstruct, std::string & name ) {
+            if( !!deconstruct.skill && deconstruction_will_practice_skill( deconstruct.skill.value() ) ) {
                 cancel_construction = !who.query_yn(
                                           _( "Deconstructing the %s will yield:\n%s\nYou feel you might also learn something about %s.\nReally deconstruct?" ),
-                                          name, deconstruct_items( deconstruct.drop_group ), deconstruct.skill->id.obj().name() );
+                                          name, item_group::potential_items( deconstruct.drop_group ), deconstruct.skill->id.obj().name() );
             } else {
                 cancel_construction = !who.query_yn(
                                           _( "Deconstructing the %s will yield:\n%s\nReally deconstruct?" ),
-                                          name, deconstruct_items( deconstruct.drop_group ) );
+                                          name, item_group::potential_items( deconstruct.drop_group ) );
             }
         };
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2059,38 +2059,20 @@ void construct::do_turn_deconstruct( const tripoint_bub_ms &p, Character &who )
         get_option<bool>( "QUERY_DECONSTRUCT" ) ) {
         bool cancel_construction = false;
 
-        auto deconstruction_will_practice_skill = [&who]( auto & skill ) {
-            return who.get_skill_level( skill.id ) >= skill.min &&
-                   who.get_skill_level( skill.id ) < skill.max;
-        };
-
-        auto deconstruct_query = [&who, &cancel_construction, &deconstruction_will_practice_skill]
-        ( map_common_deconstruct_info & deconstruct, std::string & name ) {
-            if( !!deconstruct.skill && deconstruction_will_practice_skill( deconstruct.skill.value() ) ) {
-                cancel_construction = !who.query_yn(
-                                          _( "Deconstructing the %s will yield:\n%s\nYou feel you might also learn something about %s.\nReally deconstruct?" ),
-                                          name, item_group::potential_items( deconstruct.drop_group ), deconstruct.skill->id.obj().name() );
-            } else {
-                cancel_construction = !who.query_yn(
-                                          _( "Deconstructing the %s will yield:\n%s\nReally deconstruct?" ),
-                                          name, item_group::potential_items( deconstruct.drop_group ) );
-            }
+        auto deconstruct_query = [&]( const std::string & info ) {
+            cancel_construction = !who.query_yn( string_format( _( "%s\nConfirm deconstruct?" ), info ) );
         };
 
         std::string tname;
         if( here.has_furn( p ) ) {
             const furn_t &f = here.furn( p ).obj();
             if( f.deconstruct ) {
-                map_furn_deconstruct_info deconstruct = f.deconstruct.value();
-                tname = f.name();
-                deconstruct_query( deconstruct, tname );
+                deconstruct_query( f.deconstruct->potential_deconstruct_items( f.name() ) );
             }
         } else {
             const ter_t &t = here.ter( p ).obj();
             if( t.deconstruct ) {
-                map_ter_deconstruct_info deconstruct = t.deconstruct.value();
-                tname = t.name();
-                deconstruct_query( deconstruct, tname );
+                deconstruct_query( t.deconstruct->potential_deconstruct_items( t.name() ) );
             }
         }
         if( cancel_construction ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7654,6 +7654,7 @@ look_around_result game::look_around(
         ui = std::make_unique<ui_adaptor>();
         ui->on_screen_resize( [&]( ui_adaptor & ui ) {
             int panel_width = panel_manager::get_manager().get_current_layout().panels().begin()->get_width();
+            //FIXME: w_pixel_minimap is only reducing the height by one?
             int height = pixel_minimap_option ? TERMY - getmaxy( w_pixel_minimap ) : TERMY;
 
             // If particularly small, base height on panel width irrespective of other elements.
@@ -7749,25 +7750,30 @@ look_around_result game::look_around(
                 std::string mon_name_text = string_format( _( "%s - %s" ),
                                             ctxt.get_desc( "CHANGE_MONSTER_NAME" ),
                                             ctxt.get_action_name( "CHANGE_MONSTER_NAME" ) );
-                mvwprintz( w_info, point( 1, getmaxy( w_info ) - 2 ), c_red, mon_name_text );
+                mvwprintz( w_info, point( 1, getmaxy( w_info ) - 4 ), c_red, mon_name_text );
             }
+
+            std::string extended_description_text = string_format( _( "%s - %s" ),
+                                                    ctxt.get_desc( "EXTENDED_DESCRIPTION" ),
+                                                    ctxt.get_action_name( "EXTENDED_DESCRIPTION" ) );
+            mvwprintz( w_info, point( 1, getmaxy( w_info ) - 3 ), c_light_green, extended_description_text );
 
             std::string fast_scroll_text = string_format( _( "%s - %s" ),
                                            ctxt.get_desc( "TOGGLE_FAST_SCROLL" ),
                                            ctxt.get_action_name( "TOGGLE_FAST_SCROLL" ) );
-            mvwprintz( w_info, point( 1, getmaxy( w_info ) - 1 ), fast_scroll ? c_light_green : c_green,
+            mvwprintz( w_info, point( 1, getmaxy( w_info ) - 2 ), fast_scroll ? c_light_green : c_green,
                        fast_scroll_text );
 
             if( !ctxt.keys_bound_to( "toggle_pixel_minimap" ).empty() ) {
                 std::string pixel_minimap_text = string_format( _( "%s - %s" ),
                                                  ctxt.get_desc( "toggle_pixel_minimap" ),
                                                  ctxt.get_action_name( "toggle_pixel_minimap" ) );
-                right_print( w_info, getmaxy( w_info ) - 1, 1, pixel_minimap_option ? c_light_green : c_green,
+                right_print( w_info, getmaxy( w_info ) - 2, 1, pixel_minimap_option ? c_light_green : c_green,
                              pixel_minimap_text );
             }
 
             int first_line = 1;
-            const int last_line = getmaxy( w_info ) - 2;
+            const int last_line = getmaxy( w_info ) - 4;
             pre_print_all_tile_info( lp, w_info, first_line, last_line, cache );
 
             wnoutrefresh( w_info );

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -956,6 +956,26 @@ std::map<const itype *, std::pair<int, int>> Item_group::every_item_min_max() co
     return result;
 }
 
+std::string item_group::potential_items( const item_group_id &group_id )
+{
+    std::string ret;
+    const Item_spawn_data *spawn_data = spawn_data_from_group( group_id );
+    if( spawn_data ) {
+        const std::map<const itype *, std::pair<int, int>> items_min_max =
+                    spawn_data->every_item_min_max();
+        for( const auto &item_min_max : items_min_max ) {
+            const int &min = item_min_max.second.first;
+            const int &max = item_min_max.second.second;
+            if( min != max ) {
+                ret += string_format( "- %d-%d %s\n", min, max, item_min_max.first->nname( max ) );
+            } else {
+                ret += string_format( "- %d %s\n", max, item_min_max.first->nname( max ) );
+            }
+        }
+    }
+    return ret;
+}
+
 item_group::ItemList item_group::items_from( const item_group_id &group_id,
         const time_point &birthday, spawn_flags flags )
 {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -967,9 +967,10 @@ std::string item_group::potential_items( const item_group_id &group_id )
             const int &min = item_min_max.second.first;
             const int &max = item_min_max.second.second;
             if( min != max ) {
-                ret += string_format( "- %d-%d %s\n", min, max, item_min_max.first->nname( max ) );
+                ret += string_format( "- <color_cyan>%d-%d %s</color>\n", min, max,
+                                      item_min_max.first->nname( max ) );
             } else {
-                ret += string_format( "- %d %s\n", max, item_min_max.first->nname( max ) );
+                ret += string_format( "- <color_cyan>%d %s</color>\n", max, item_min_max.first->nname( max ) );
             }
         }
     }

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -46,6 +46,8 @@ item item_from( const item_group_id &group_id, const time_point &birthday );
  * Same as above but with implicit birthday at turn 0.
  */
 item item_from( const item_group_id &group_id );
+// Return a formatted list of min-max items an item group can spawn
+std::string potential_items( const item_group_id &group_id );
 
 using ItemList = std::vector<item>;
 /**

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -383,6 +383,13 @@ void map_fd_bash_info::load( const JsonObject &jo, const bool was_loaded,
     optional( jo, was_loaded, "msg_success", field_bash_msg_success );
 }
 
+std::string map_common_bash_info::potential_bash_items( const std::string
+        &ter_furn_name ) const
+{
+    //TODO: Add a descriptive indicator of vaguely how hard it is to bash?
+    return string_format( _( "Bashing the %s would yield:\n%s" ),
+                          ter_furn_name, item_group::potential_items( drop_group ) );
+}
 
 void map_common_deconstruct_info::load( const JsonObject &jo, const bool was_loaded,
                                         const std::string &context )
@@ -651,6 +658,10 @@ std::vector<std::string> ter_t::extended_description() const
         ret.emplace_back( deconstruct->potential_deconstruct_items( name() ) );
     }
 
+    if( is_smashable() ) {
+        ret.emplace_back( bash->potential_bash_items( name() ) );
+    }
+
     return ret;
 }
 
@@ -683,6 +694,10 @@ std::vector<std::string> furn_t::extended_description() const
 
     if( deconstruct ) {
         ret.emplace_back( deconstruct->potential_deconstruct_items( name() ) );
+    }
+
+    if( is_smashable() ) {
+        ret.emplace_back( bash->potential_bash_items( name() ) );
     }
 
     return ret;
@@ -761,7 +776,6 @@ std::vector<std::string> map_data_common_t::extended_description() const
             add( text );
         }
     };
-    add_if( is_smashable(), _( "Smashable." ) );
     add_if( has_flag( ter_furn_flag::TFLAG_DIGGABLE ), _( "Diggable." ) );
     add_if( has_flag( ter_furn_flag::TFLAG_PLOWABLE ), _( "Plowable." ) );
     add_if( has_flag( ter_furn_flag::TFLAG_ROUGH ), _( "Rough." ) );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -428,7 +428,7 @@ std::string map_common_deconstruct_info::potential_deconstruct_items( const std:
                                who.get_skill_level( skill->id ) < skill->max;
     if( will_practice_skill ) {
         return string_format(
-                   _( "Deconstructing the %s would yield:\n%s\nYou feel you might also learn something about %s." ),
+                   _( "Deconstructing the %s would yield:\n%s\nYou feel you might also learn something about <color_cyan>%s</color>." ),
                    ter_furn_name, item_group::potential_items( drop_group ), skill->id.obj().name() );
     } else {
         return string_format( _( "Deconstructing the %s would yield:\n%s" ),
@@ -655,10 +655,12 @@ std::vector<std::string> ter_t::extended_description() const
     ret.insert( ret.end(), tmp.begin(), tmp.end() );
 
     if( deconstruct ) {
+        ret.emplace_back( "--" );
         ret.emplace_back( deconstruct->potential_deconstruct_items( name() ) );
     }
 
     if( is_smashable() ) {
+        ret.emplace_back( "--" );
         ret.emplace_back( bash->potential_bash_items( name() ) );
     }
 
@@ -693,10 +695,12 @@ std::vector<std::string> furn_t::extended_description() const
     }
 
     if( deconstruct ) {
+        ret.emplace_back( "--" );
         ret.emplace_back( deconstruct->potential_deconstruct_items( name() ) );
     }
 
     if( is_smashable() ) {
+        ret.emplace_back( "--" );
         ret.emplace_back( bash->potential_bash_items( name() ) );
     }
 
@@ -785,7 +789,9 @@ std::vector<std::string> map_data_common_t::extended_description() const
     add_if( has_flag( ter_furn_flag::TFLAG_EASY_DECONSTRUCT ), _( "Simple." ) );
     add_if( has_flag( ter_furn_flag::TFLAG_MOUNTABLE ), _( "Mountable." ) );
     add_if( is_flammable(), _( "Flammable." ) );
-    tmp.emplace_back( result );
+    if( !result.empty() ) {
+        tmp.emplace_back( result );
+    }
 
     std::vector<std::string> ret;
     ret.reserve( tmp.size() );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -629,6 +629,16 @@ std::vector<std::string> ter_t::extended_description() const
     std::vector<std::string> tmp = map_data_common_t::extended_description();
     ret.insert( ret.end(), tmp.begin(), tmp.end() );
 
+    if( deconstruct ) {
+        const std::string &deconlist = item_group::potential_items( deconstruct->drop_group );
+        if( !deconlist.empty() ) {
+            ret.emplace_back( _( "You could deconstruct it to get some of the following items:" ) );
+            ret.emplace_back( deconlist );
+        } else {
+            ret.emplace_back( _( "It can be deconstructed, but won't yield any resources." ) );
+        }
+    }
+
     return ret;
 }
 
@@ -656,6 +666,16 @@ std::vector<std::string> furn_t::extended_description() const
             // \n character is skipped
             ret.emplace_back( quality_string.substr( 0, strpos ) );
             quality_string.erase( 0, strpos + 1 );
+        }
+    }
+
+    if( deconstruct ) {
+        const std::string &deconlist = item_group::potential_items( deconstruct->drop_group );
+        if( !deconlist.empty() ) {
+            ret.emplace_back( _( "You could deconstruct it to get some of the following items:" ) );
+            ret.emplace_back( deconlist );
+        } else {
+            ret.emplace_back( _( "It can be deconstructed, but won't yield any resources." ) );
         }
     }
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -62,6 +62,7 @@ struct map_common_bash_info { //TODO: Half of this shouldn't be common
         std::vector<furn_str_id> tent_centers;
         void load( const JsonObject &jo, bool was_loaded, const std::string &context );
         void check( const std::string &id ) const;
+        std::string potential_bash_items( const std::string &ter_furn_name ) const;
     public:
         virtual ~map_common_bash_info() = default;
 };

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -103,6 +103,7 @@ struct map_common_deconstruct_info {
         virtual void check( const std::string &id ) const;
     public:
         virtual ~map_common_deconstruct_info() = default;
+        std::string potential_deconstruct_items( const std::string &ter_furn_name ) const;
 };
 struct map_ter_deconstruct_info : map_common_deconstruct_info {
     ter_str_id ter_set = ter_str_id::NULL_ID();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Extended description window (x->e) shows potential deconstruction and bash yields"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I were annoyed when I made #74440 that it only let you see the potential deconstruction yields if you had the tools on hand, a peep on reddit pointed out BN sticks similar info in the extended description window that I always forget exists
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Shimmies the code from #74440 around so it's reusable
Adds potential bash and deconstruction yields to the extended description window (`x` -> `e`)
Adds the extended description bind text to the look around menu so peeps might actually stumble upon it
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Also displaying the post_ter/furn?
Indicating how hard something is to bash?
Considered making non guaranteed drops (`0-X`) a "worse" colour eg green/yellow and yellow/light red but peeps in Discord thought that'd just lead to confusion
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked the deconstruct prompt still works as intended
Checked the deconstruction + bash yields show as appropriate in the extended description

Example of a furniture with deconstruction + bash yields
![image](https://github.com/user-attachments/assets/5a0dd02e-d715-4607-b145-023e120d9ead)

Example of a terrain with no deconstruction/bash yields
![image](https://github.com/user-attachments/assets/7ef88f8f-9d5e-4826-b22b-a2b6c1afdaed)

Look around binds (in the rare instance they'd all be displayed simultaneously)
![image](https://github.com/user-attachments/assets/21896f42-7da4-4cc5-9eba-7091ed2c0839)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
