### PR TITLE
makes lit candle more distinct

### DIFF
--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -114,7 +114,7 @@
     "id": "candle_lit",
     "type": "TOOL",
     "copy-from": "candle",
-    "name": { "str": "candle" },
+    "name": { "str": "burning candle" },
     "description": "A thick wax candle.  It doesn't provide very much light, but it can burn for quite a long time.  This candle is lit.",
     "turns_per_charge": 1260,
     "use_action": [
@@ -1115,7 +1115,7 @@
     "id": "candle_small_lit",
     "type": "TOOL",
     "copy-from": "candle_small",
-    "name": { "str": "small candle" },
+    "name": { "str": "burning small candle" },
     "description": "A thin wax candle.  It doesn't provide very much light and will burn relatively quickly.  This candle is lit.",
     "turns_per_charge": 63,
     "use_action": [


### PR DESCRIPTION


#### Summary
None

#### Purpose of change

I was playing as a character that can draw magic circles to do magic, and i noticed the tool requirement to draw more magic circles needing `candle`. It's not obvious to me that it meant lit candle and it took me awhile to figure it out until someone in the devcord pointed out that it asks for the lit candles. 

So that's why imma rename the lit candles to be more distinct.

#### Describe the solution

`candle` -> `burning candle` and `small candle` -> `burning small candle`

#### Describe alternatives you've considered

Code the spell menu so it can say that it specifically says the needed candle is the lit ones, but renaming the item is easier.

#### Testing

![Screenshot_20250112_220442](https://github.com/user-attachments/assets/a891ce21-c197-4c22-91d0-2865df557e77)
![Screenshot_20250112_220428](https://github.com/user-attachments/assets/84963fc3-e92a-4b06-b703-dd46b820c71f)
![Screenshot_20250112_220631](https://github.com/user-attachments/assets/399bf37f-b5a1-435f-a153-8e97965523ca)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
