### PR TITLE
A couple of small fixes for C++20 compliance

### DIFF
--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -102,7 +102,8 @@ moon_phase get_moon_phase( const time_point &p )
     const int num_middays = to_days<int>( p - calendar::turn_zero + 1_days / 2 );
     const time_duration nearest_midnight = num_middays * 1_days;
     const double phase_change = nearest_midnight / moon_phase_duration;
-    const int current_phase = static_cast<int>( std::round( phase_change * MOON_PHASE_MAX ) ) %
+    const int current_phase = static_cast<int>( std::round( phase_change * static_cast<int>
+                              ( MOON_PHASE_MAX ) ) ) %
                               static_cast<int>( MOON_PHASE_MAX );
     return static_cast<moon_phase>( current_phase );
 }

--- a/src/cata_path.h
+++ b/src/cata_path.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_CATA_PATH_H
 
 #include <iosfwd>
+#include <string>
 
 #include <ghc/fs_std_fwd.hpp>
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3951,7 +3951,7 @@ void mm_submap::serialize( JsonOut &jsout ) const
     const auto write_seq = [&]() {
         jsout.start_array();
         jsout.write( num_same );
-        jsout.write( last.symbol );
+        jsout.write( static_cast<int>( last.symbol ) );
         jsout.write( last.ter_id );
         jsout.write( static_cast<int>( last.ter_subtile ) );
         jsout.write( static_cast<int>( last.ter_rotation ) );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7881,8 +7881,9 @@ time_duration vehicle::folding_time() const
 {
     const vehicle_part_range vpr = get_all_parts();
     return std::accumulate( vpr.begin(), vpr.end(), time_duration(),
-    []( time_duration & acc, const vpart_reference & part ) {
-        return acc + ( part.part().removed ? time_duration() : part.info().get_folding_time() );
+    []( time_duration acc, const vpart_reference & part ) {
+        return acc + ( part.part().removed ? time_duration() :
+                       part.info().get_folding_time() );
     } );
 }
 
@@ -7890,8 +7891,9 @@ time_duration vehicle::unfolding_time() const
 {
     const vehicle_part_range vpr = get_all_parts();
     return std::accumulate( vpr.begin(), vpr.end(), time_duration(),
-    []( time_duration & acc, const vpart_reference & part ) {
-        return acc + ( part.part().removed ? time_duration() : part.info().get_unfolding_time() );
+    []( time_duration acc, const vpart_reference & part ) {
+        return acc + ( part.part().removed ? time_duration() :
+                       part.info().get_unfolding_time() );
     } );
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

I tried compiling our codebase with --std=c++-20 and it almost worked, modulo these few issues (and the `char8_t` thing which we don't talk about).
So I thought I'd upstream them, should be easy enough.

#### Describe the solution
Set c++ standard to c++20 in MSVS, add a `/Zc:char8_t-` to additional compilation options, build the thing, fix errors as you get them

#### Describe alternatives you've considered

N/A

#### Testing

Builds. Old saves load fine.

#### Additional context
N/A