### PR TITLE
Add versioning to vcpkg setup

### DIFF
--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -31,7 +31,7 @@ In a `cmd.exe` shell:
 REM cd to the appropriate folder first
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
-git checkout 3b57fb2e1ff55613db14d2aaf0a30529289c7050
+git pull
 .\bootstrap-vcpkg.bat -disableMetrics
 .\vcpkg integrate install
 ```
@@ -40,10 +40,12 @@ In a Git Bash shell, the commands are almost the same except the filesystem path
 # cd to the appropriate folder first
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
-git checkout 3b57fb2e1ff55613db14d2aaf0a30529289c7050
+git pull
 ./bootstrap-vcpkg.bat -disableMetrics
 ./vcpkg.exe integrate install
 ```
+
+If during the compilation you're getting a vcpkg error along the lines of `error: no version database entry for sdl2 at 2.26.5`, that probably means that your vcpkg install is too old. Running a `git pull` in vcpkg directory should fix the issue.
 
 ## Cloning and compilation:
 

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -2,7 +2,10 @@
     "name": "cdda-vcpkg-dependencies",
     "version-string": "0.I",
     "dependencies": [
-        "sdl2",
+        {
+          "name": "sdl2",
+          "version>=": "2.26.4#0"
+        },
         {
           "name": "sdl2-image",
           "features": [ "libjpeg-turbo" ]
@@ -12,6 +15,10 @@
           "features": [ "libflac", "mpg123", "libmodplug" ]
         },
         "sdl2-ttf",
-        "pdcurses"
-    ]
+        {
+          "name": "pdcurses",
+          "version>=": "3.9#4"
+        }
+    ],
+    "builtin-baseline": "5b11232d00476c66724c81adfe5e3777a9aec38f"
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Make vcpkg manifest versioned"

#### Purpose of change

vcpkg setup sometimes breaks for people in ways that are hard to debug, and most of those seem to be resolved by checking out specific vcpkg commit. This works, and this is what our documentation says to do.
However it can still break in mysterious ways. So we can just try and narrow things down a bit by pinning the dependency packages versions. This is what this PR does.

#### Describe the solution

Add `"builtin-baseline"` and `version>=` specifiers to our vcpkg.json. [vcpkg docs for reference](https://learn.microsoft.com/en-us/vcpkg/users/versioning)

With `builtin-baseline` specified vcpkg would choose the earliest possible version that's at least at that commit.

This has been tried before, and quickly reverted in #51626, but I believe the vcpkg state today is better than back in 2021, so we can try to revisit it. Today `version>=` specifier exists, and all the packages we depend on support it `>=` (at least at the chosen `builtin-baseline`). (This was a rather recent change too - `pdcurses` switched from `version-string` to `version` in Apr 2023)

Also add a short bit into the docs on how to handle the errors - simple `git pull` in vcpkg directory should fix it. 

#### Describe alternatives you've considered


#### Testing

Tried hopping around different commits in vcpkg repo, observed the different errors thrown at me.
In the current state of the PR things either build without issue or throw a bunch of rather distinctive errors which are reliably fixed by `git pull` (or perhaps `git checkout <reasonably fresh commit>`)
![20250112-142623-devenv](https://github.com/user-attachments/assets/d587e091-5d95-4e02-b4f2-55e47462ca6e)

#### Additional context

I've only added `version>=` specifiers on the packages that were giving me trouble, and left the others untouched. Idk if I should put that on everything for uniformity sake.

The chosen `builtin-baseline` commit is from 2023-04-13, so people who have not touched vcpkg install since then would need to `git pull`

For posterity, this is the versions of the packages that would be installed (hopefully, for everyone) as reported by `cd msvc-full-features; vcpkg.exe install --dry-run`

<details>

```
* brotli:x64-windows@1.0.9#5 
* bzip2[core,tool]:x64-windows@1.0.8#4 
* freetype[brotli,bzip2,core,png,zlib]:x64-windows@2.12.1#3 
* libflac:x64-windows@1.4.2 
* libjpeg-turbo:x64-windows@2.1.5.1
* libmodplug:x64-windows@0.8.9.0#10 
* libogg:x64-windows@1.3.5#1 
* libpng:x64-windows@1.6.39#1 
* libvorbis:x64-windows@1.3.7#2 
* mpg123:x64-windows@1.31.3 
  pdcurses:x64-windows@3.9#4 
  sdl2[base,core]:x64-windows@2.26.5 
  sdl2-image[core,libjpeg-turbo]:x64-windows@2.6.3
  sdl2-mixer[core,libflac,libmodplug,mpg123]:x64-windows@2.6.3#1
  sdl2-ttf:x64-windows@2.20.2
* vcpkg-cmake:x64-windows@2022-12-22 
* vcpkg-cmake-config:x64-windows@2022-02-06#1 
* yasm[core,tools]:x64-windows@1.3.0#5 
* yasm-tool-helper:x64-windows@2020-03-11#1 
* zlib:x64-windows@1.2.13 
```
</details>