### PR TITLE
Focus the default selection in query popups

### DIFF
--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -55,6 +55,7 @@ class query_popup_impl : public cataimgui::window
 
 void query_popup_impl::draw_controls()
 {
+    ImGui::SetNavCursorVisible( true );
     mouse_selected_option = -1;
 
     for( const std::string &line : parent->folded_msg ) {
@@ -74,7 +75,7 @@ void query_popup_impl::draw_controls()
             }
             if( keyboard_selected_option != last_keyboard_selected_option &&
                 keyboard_selected_option == short( ind ) && ImGui::IsWindowFocused() ) {
-                ImGui::SetKeyboardFocusHere( -1 );
+                ImGui::SetItemDefaultFocus();
             }
             current_line = parent->buttons[ind].pos.y;
         }


### PR DESCRIPTION
#### Summary
Interface "Focus the default selection in query popups"

#### Purpose of change

* Fixes #78317 

#### Describe the solution

Two-line change

#### Describe alternatives you've considered

Let someone else do it

#### Testing

It's a bit fraudulent because the very first popup you'd ever see would be only half-highlighted (until you change the selection)
![20250112-195814-cataclysm-tiles](https://github.com/user-attachments/assets/3ad2cf25-5be1-4fd2-be80-4e6dba7f0edf)
but everything going forward is full working
![20250112-200338-cataclysm-tiles](https://github.com/user-attachments/assets/ae4a3822-3d8b-4953-91f3-3f91bbccda03)

#### Additional context

I'm yelling into the void here, but I find it really frustrating that there was so much hubbub about game being absolutely unplayable due to this bug (see the comments and the linked issues on #78317) and yet nobody bothered actually go look into it. Literally a two line change (or one-line change if you don't do `SetNavCursorVisible` which is kinda turbo optional, turns out)...