### PR TITLE
Revert "typified map.h and dependents" (#79106)

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -241,7 +241,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
         get_option<bool>( "AUTO_FEATURES" ) && get_option<bool>( "AUTO_MINING" ) &&
         !m.veh_at( dest_loc ) && !you.is_underwater() && !you.has_effect( effect_stunned ) &&
         !you.has_effect( effect_psi_stunned ) && !is_riding && !you.has_effect( effect_incorporeal ) &&
-        !m.impassable_field_at( dest_loc ) && !you.has_flag( json_flag_CANNOT_MOVE ) ) {
+        !m.impassable_field_at( d.raw() ) && !you.has_flag( json_flag_CANNOT_MOVE ) ) {
         if( weapon && weapon->has_flag( flag_DIG_TOOL ) ) {
             if( weapon->type->can_use( "JACKHAMMER" ) &&
                 weapon->ammo_sufficient( &you ) ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1521,7 +1521,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                             invisible[0] = true;
                         } else {
                             if( would_apply_vision_effects( offscreen_type ) ) {
-                                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0},
+                                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos.raw(), 0},
                                         tile_render_info::vision_effect{ offscreen_type } );
                             }
                             break;
@@ -1690,7 +1690,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                                     || you.sees_with_specials( *critter ) ) ) ) {
                                 invisible[0] = true;
                             } else {
-                                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0},
+                                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos.raw(), 0},
                                         tile_render_info::vision_effect{ vis_type } );
                                 break;
                             }
@@ -1701,7 +1701,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                         invisible[1 + i] = apply_visible( np, ch2, here );
                     }
 
-                    here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0},
+                    here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos.raw(), 0},
                             tile_render_info::sprite{ ll, invisible } );
                     // Stop building draw points below when floor reached
                     if( here.dont_draw_lower_floor( pos ) ) {

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -297,7 +297,7 @@ void creature_tracker::remove_dead()
 template<typename T>
 T *creature_tracker::creature_at( const tripoint &p, bool allow_hallucination )
 {
-    return creature_at<T>( get_map().getglobal( tripoint_bub_ms( p ) ), allow_hallucination );
+    return creature_at<T>( get_map().getglobal( p ), allow_hallucination );
 }
 
 template<typename T>
@@ -423,7 +423,7 @@ void creature_tracker::flood_fill_zone( const Creature &origin )
 template<typename T>
 const T *creature_tracker::creature_at( const tripoint &p, bool allow_hallucination ) const
 {
-    return creature_at<T>( get_map().getglobal( tripoint_bub_ms( p ) ), allow_hallucination );
+    return creature_at<T>( get_map().getglobal( p ), allow_hallucination );
 }
 
 template<typename T>

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -901,7 +901,7 @@ std::optional<int> iuse::meth( Character *p, item *, const tripoint_bub_ms & )
         map &here = get_map();
         // breathe out some smoke
         for( int i = 0; i < 3; i++ ) {
-            point_rel_ms offset( rng( -2, 2 ), rng( -2, 2 ) );
+            point offset( rng( -2, 2 ), rng( -2, 2 ) );
             here.add_field( p->pos_bub() + offset, field_type_id( "fd_methsmoke" ), 2 );
         }
     } else {
@@ -8229,7 +8229,7 @@ heating_requirements heating_requirements_for_weight( const units::mass &frozen,
     return {volume, ammo, time};
 }
 
-static std::optional<std::pair<tripoint_bub_ms, itype_id>> appliance_heater_selector( Character *p )
+static std::optional<std::pair<tripoint, itype_id>> appliance_heater_selector( Character *p )
 {
     const std::optional<tripoint_bub_ms> pt = choose_adjacent_highlight( _( "Select an appliance." ),
             _( "There is no appliance nearby." ), ACTION_EXAMINE, false );
@@ -8264,7 +8264,7 @@ static std::optional<std::pair<tripoint_bub_ms, itype_id>> appliance_heater_sele
                     p->add_msg_if_player( m_info, _( "You haven't selected any heater." ) );
                     return std::nullopt;
                 } else {
-                    return std::make_pair( pt.value(), pseudo_tools[app_menu.ret] );
+                    return std::make_pair( pt.value().raw(), pseudo_tools[app_menu.ret] );
                 }
 
             }
@@ -8322,7 +8322,7 @@ heater find_heater( Character *p, item *it )
                                  1,
                                  _( "You don't have a proper heating tool.  Try selecting an appliance with a heater." ) );
         if( !loc ) {
-            std::optional<std::pair<tripoint_bub_ms, itype_id>> app = appliance_heater_selector( p );
+            std::optional<std::pair<tripoint, itype_id>> app = appliance_heater_selector( p );
             if( !app ) {
                 return {loc, true, -1, 0, vpt, pseudo_flag};
             } else {

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -672,6 +672,11 @@ void map::add_light_source( const tripoint_bub_ms &p, float luminance )
 
 // Tile light/transparency: 3D
 
+lit_level map::light_at( const tripoint &p ) const
+{
+    return map::light_at( tripoint_bub_ms( p ) );
+}
+
 lit_level map::light_at( const tripoint_bub_ms &p ) const
 {
     if( !inbounds( p ) ) {
@@ -1427,21 +1432,21 @@ void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, 
 
 void map::apply_light_ray(
     cata::mdarray<bool, point_bub_ms, LIGHTMAP_CACHE_X, LIGHTMAP_CACHE_Y> &lit,
-    const tripoint_bub_ms &s, const tripoint_bub_ms &e, float luminance )
+    const tripoint &s, const tripoint &e, float luminance )
 {
-    point a( std::abs( e.x() - s.x() ) * 2, std::abs( e.y() - s.y() ) * 2 );
-    point d( ( s.x() < e.x() ) ? 1 : -1, ( s.y() < e.y() ) ? 1 : -1 );
+    point a( std::abs( e.x - s.x ) * 2, std::abs( e.y - s.y ) * 2 );
+    point d( ( s.x < e.x ) ? 1 : -1, ( s.y < e.y ) ? 1 : -1 );
     point_bub_ms p( s.xy() );
 
     quadrant quad = quadrant_from_x_y( d.x, d.y );
 
     // TODO: Invert that z comparison when it's sane
-    if( s.z() != e.z() || ( s.x() == e.x() && s.y() == e.y() ) ) {
+    if( s.z != e.z || ( s.x == e.x && s.y == e.y ) ) {
         return;
     }
 
-    auto &lm = get_cache( s.z() ).lm;
-    auto &transparency_cache = get_cache( s.z() ).transparency_cache;
+    auto &lm = get_cache( s.z ).lm;
+    auto &transparency_cache = get_cache( s.z ).transparency_cache;
 
     float distance = 1.0f;
     float transparency = LIGHT_TRANSPARENCY_OPEN_AIR;
@@ -1480,7 +1485,7 @@ void map::apply_light_ray(
             }
 
             distance += scaling_factor;
-        } while( !( p.x() == e.x() && p.y() == e.y() ) );
+        } while( !( p.x() == e.x && p.y() == e.y ) );
     } else {
         int t = a.x - ( a.y / 2 );
         do {
@@ -1512,6 +1517,6 @@ void map::apply_light_ray(
             }
 
             distance += scaling_factor;
-        } while( !( p.x() == e.x() && p.y() == e.y() ) );
+        } while( !( p.x() == e.x && p.y() == e.y ) );
     }
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1250,7 +1250,7 @@ std::set<tripoint_bub_ms> map::get_moving_vehicle_targets( const Creature &z, in
         if( !v.v->is_moving() ) {
             continue;
         }
-        if( std::abs( v.pos.z() - zpos.z() ) > fov_3d_z_range ) {
+        if( std::abs( v.pos.z - zpos.z() ) > fov_3d_z_range ) {
             continue;
         }
         if( rl_dist( zpos, tripoint_bub_ms( v.pos ) ) > max_range + 40 ) {
@@ -1301,7 +1301,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
                     elem->sm_pos.z = cz;
                     wrapped_vehicle w;
                     w.v = elem.get();
-                    w.pos = w.v->pos_bub();
+                    w.pos = w.v->pos_bub().raw();
                     vehs.push_back( w );
                 }
             }
@@ -1314,6 +1314,11 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
 optional_vpart_position map::veh_at( const tripoint_abs_ms &p ) const
 {
     return veh_at( bub_from_abs( p ) );
+}
+
+optional_vpart_position map::veh_at( const tripoint &p ) const
+{
+    return veh_at( tripoint_bub_ms( p ) );
 }
 
 optional_vpart_position map::veh_at( const tripoint_bub_ms &p ) const
@@ -1702,6 +1707,11 @@ bool map::has_furn( const tripoint_bub_ms &p ) const
     return furn( p ) != furn_str_id::NULL_ID();
 }
 
+furn_id map::furn( const tripoint &p ) const
+{
+    return furn( tripoint_bub_ms( p ) );
+}
+
 furn_id map::furn( const tripoint_bub_ms p ) const
 {
     if( !inbounds( p ) ) {
@@ -1888,6 +1898,10 @@ std::string map::furnname( const tripoint_bub_ms &p )
  * retained for high performance comparisons, save/load, and gradual transition
  * to string terrain.id
  */
+ter_id map::ter( const tripoint p ) const
+{
+    return ter( tripoint_bub_ms( p ) );
+}
 ter_id map::ter( const tripoint_bub_ms &p ) const
 {
     if( !inbounds( p ) ) {
@@ -2629,6 +2643,11 @@ int map::climb_difficulty( const tripoint_bub_ms &p ) const
     return std::max( 0, best_difficulty - blocks_movement );
 }
 
+bool map::has_floor( const tripoint &p ) const
+{
+    return map::has_floor( tripoint_bub_ms( p ) );
+}
+
 bool map::has_floor( const tripoint_bub_ms &p ) const
 {
     if( !zlevels || p.z() < -OVERMAP_DEPTH + 1 || p.z() > OVERMAP_HEIGHT ) {
@@ -2639,6 +2658,11 @@ bool map::has_floor( const tripoint_bub_ms &p ) const
     }
     return !has_flag( ter_furn_flag::TFLAG_NO_FLOOR, p ) &&
            !has_flag( ter_furn_flag::TFLAG_NO_FLOOR_WATER, p );
+}
+
+bool map::has_floor_or_water( const tripoint &p ) const
+{
+    return map::has_floor_or_water( tripoint_bub_ms( p ) );
 }
 
 bool map::has_floor_or_water( const tripoint_bub_ms &p ) const
@@ -2671,12 +2695,22 @@ bool map::supports_above( const tripoint_bub_ms &p ) const
     return veh_at( p ).has_value();
 }
 
+bool map::has_floor_or_support( const tripoint &p ) const
+{
+    return map::has_floor_or_support( tripoint_bub_ms( p ) );
+}
+
 bool map::has_floor_or_support( const tripoint_bub_ms &p ) const
 {
     const tripoint_bub_ms below( p.xy(), p.z() - 1 );
     return !valid_move( p, below, false, true );
 }
 
+bool map::has_vehicle_floor( const tripoint &p ) const
+{
+    const tripoint_bub_ms p_bub( p );
+    return has_vehicle_floor( p_bub );
+}
 bool map::has_vehicle_floor( const tripoint_bub_ms &p ) const
 {
     return veh_at( p ).part_with_feature( "BOARDABLE", false ) ||
@@ -3040,6 +3074,11 @@ bool map::can_put_items( const tripoint_bub_ms &p ) const
 bool map::can_put_items_ter_furn( const tripoint_bub_ms &p ) const
 {
     return !has_flag( ter_furn_flag::TFLAG_NOITEM, p ) && !has_flag( ter_furn_flag::TFLAG_SEALED, p );
+}
+
+bool map::has_flag_ter( const std::string &flag, const tripoint &p ) const
+{
+    return ter( tripoint_bub_ms( p ) ).obj().has_flag( flag );
 }
 
 bool map::has_flag_ter( const std::string &flag, const tripoint_bub_ms &p ) const
@@ -5314,7 +5353,7 @@ void map::make_active( item_location &loc )
     item *target = loc.get_item();
 
     point_sm_ms l;
-    submap *const current_submap = get_submap_at( loc.pos_bub(), l );
+    submap *const current_submap = get_submap_at( loc.position(), l.raw() );
     if( current_submap == nullptr ) {
         debugmsg( "Tried to make active at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return;
@@ -6400,6 +6439,11 @@ std::optional<field_entry> map::get_impassable_field_at( const tripoint_bub_ms &
     return potential_field;
 }
 
+bool map::impassable_field_at( const tripoint &p )
+{
+    return impassable_field_at( tripoint_bub_ms( p ) );
+}
+
 bool map::impassable_field_at( const tripoint_bub_ms &p )
 {
     for( auto &pr : field_at( p ) ) {
@@ -6409,6 +6453,11 @@ bool map::impassable_field_at( const tripoint_bub_ms &p )
         }
     }
     return false;
+}
+
+std::vector<field_type_id> map::get_impassable_field_type_ids_at( const tripoint &p )
+{
+    return get_impassable_field_type_ids_at( tripoint_bub_ms( p ) );
 }
 
 std::vector<field_type_id> map::get_impassable_field_type_ids_at( const tripoint_bub_ms &p )
@@ -8968,6 +9017,11 @@ const std::vector<tripoint_bub_ms> &map::trap_locations( const trap_id &type ) c
     return traplocs[type.to_i()];
 }
 
+bool map::inbounds( const tripoint &p ) const
+{
+    return inbounds( tripoint_bub_ms( p ) );
+}
+
 bool map::inbounds( const tripoint_abs_ms &p ) const
 {
     return inbounds( bub_from_abs( p ) );
@@ -9542,6 +9596,11 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
 
 //////////
 ///// coordinate helpers
+
+tripoint_abs_ms map::getglobal( const tripoint &p ) const
+{
+    return map::getglobal( tripoint_bub_ms( p ) );
+}
 
 tripoint_abs_ms map::getglobal( const tripoint_bub_ms &p ) const
 {
@@ -10155,6 +10214,17 @@ tripoint_range<tripoint_bub_ms> map::points_in_rectangle( const tripoint_bub_ms 
     return tripoint_range<tripoint_bub_ms>( min, max );
 }
 
+tripoint_range<tripoint> map::points_in_radius( const tripoint &center, size_t radius,
+        size_t radiusz ) const
+{
+    const tripoint min( std::max<int>( 0, center.x - radius ), std::max<int>( 0, center.y - radius ),
+                        clamp<int>( center.z - radiusz, -OVERMAP_DEPTH, OVERMAP_HEIGHT ) );
+    const tripoint max( std::min<int>( SEEX * my_MAPSIZE - 1, center.x + radius ),
+                        std::min<int>( SEEX * my_MAPSIZE - 1, center.y + radius ), clamp<int>( center.z + radiusz,
+                                -OVERMAP_DEPTH, OVERMAP_HEIGHT ) );
+    return tripoint_range<tripoint>( min, max );
+}
+
 tripoint_range<tripoint_bub_ms> map::points_in_radius(
     const tripoint_bub_ms &center, size_t radius, size_t radiusz ) const
 {
@@ -10454,6 +10524,11 @@ void map::update_pathfinding_cache( int zlev ) const
     cache.dirty_points.clear();
 }
 
+void map::clip_to_bounds( tripoint &p ) const
+{
+    clip_to_bounds( p.x, p.y, p.z );
+}
+
 void map::clip_to_bounds( tripoint_bub_ms &p ) const
 {
     clip_to_bounds( p.x(), p.y(), p.z() );
@@ -10584,6 +10659,11 @@ bool map::has_haulable_items( const tripoint_bub_ms &pos )
         }
     }
     return false;
+}
+
+std::vector<item_location> map::get_haulable_items( const tripoint &pos )
+{
+    return map::get_haulable_items( tripoint_bub_ms( pos ) );
 }
 
 std::vector<item_location> map::get_haulable_items( const tripoint_bub_ms &pos )

--- a/src/map.h
+++ b/src/map.h
@@ -88,7 +88,7 @@ struct projectile;
 struct veh_collision;
 
 struct wrapped_vehicle {
-    tripoint_bub_ms pos;
+    tripoint pos;
     vehicle *v;
 };
 
@@ -308,7 +308,7 @@ struct tile_render_info {
         // accumulator for 3d tallness of sprites rendered here so far;
         int height_3d = 0;
 
-        common( const tripoint_bub_ms &pos, const int height_3d )
+        common( const tripoint &pos, const int height_3d )
             : pos( pos ), height_3d( height_3d ) {}
     };
 
@@ -779,6 +779,8 @@ class map
         *
         * @param p Tile to check for vehicle
         */
+        // TODO: fix point types (remove the first overload)
+        optional_vpart_position veh_at( const tripoint &p ) const;
         optional_vpart_position veh_at( const tripoint_abs_ms &p ) const;
         optional_vpart_position veh_at( const tripoint_bub_ms &p ) const;
         vehicle *veh_at_internal( const tripoint_bub_ms &p, int &part_num );
@@ -840,6 +842,8 @@ class map
         bool has_furn( const point_bub_ms &p ) const {
             return has_furn( tripoint_bub_ms( p, abs_sub.z() ) );
         }
+        // TODO: fix point types (remove the first overload)
+        furn_id furn( const tripoint &p ) const;
         furn_id furn( tripoint_bub_ms p ) const;
         furn_id furn( const point_bub_ms &p ) const {
             return furn( tripoint_bub_ms( p, abs_sub.z() ) );
@@ -865,6 +869,8 @@ class map
         bool can_move_furniture( const tripoint_bub_ms &pos, Character *you = nullptr ) const;
 
         // Terrain
+        // TODO: fix point types (remove the first overload)
+        ter_id ter( tripoint p ) const;
         ter_id ter( const tripoint_bub_ms &p ) const;
         ter_id ter( const point_bub_ms &p ) const {
             return ter( tripoint_bub_ms( p, abs_sub.z() ) );
@@ -920,6 +926,9 @@ class map
         }
 
         std::string tername( const tripoint_bub_ms &p ) const;
+        std::string tername( const point &p ) const {
+            return tername( tripoint_bub_ms( p.x, p.y, abs_sub.z() ) );
+        }
 
         // Check for terrain/furniture/field that provide a
         // "fire" item to be used for example when crafting or when
@@ -984,6 +993,7 @@ class map
         // True if items can be placed in this tile
         bool can_put_items_ter_furn( const tripoint_bub_ms &p ) const;
         // Checks terrain
+        bool has_flag_ter( const std::string &flag, const tripoint &p ) const;
         bool has_flag_ter( const std::string &flag, const tripoint_bub_ms &p ) const;
         bool has_flag_ter( const std::string &flag, const point_bub_ms &p ) const {
             return has_flag_ter( flag, tripoint_bub_ms( p, abs_sub.z() ) );
@@ -1244,6 +1254,15 @@ class map
 
         // FIXME: remove these overloads and require spawn_item to take an
         // itype_id
+        void spawn_item( const tripoint &p, const std::string &type_id,
+                         unsigned quantity = 1, int charges = 0,
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const std::set<flag_id> &flags = {}, const std::string &variant = "",
+                         const std::string &faction = "" ) {
+            spawn_item( tripoint_bub_ms( p ), itype_id( type_id ), quantity, charges, birthday, damlevel, flags,
+                        variant,
+                        faction );
+        }
         void spawn_item( const tripoint_bub_ms &p, const std::string &type_id,
                          unsigned quantity = 1, int charges = 0,
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
@@ -1519,6 +1538,7 @@ class map
 
         // returns the a field entry that is impassable at the given point if it exists
         std::optional<field_entry> get_impassable_field_at( const tripoint_bub_ms &p );
+        std::vector<field_type_id> get_impassable_field_type_ids_at( const tripoint &p );
         std::vector<field_type_id> get_impassable_field_type_ids_at( const tripoint_bub_ms &p );
 
         /**
@@ -1528,6 +1548,7 @@ class map
         field_entry *get_field( const tripoint_bub_ms &p, const field_type_id &type );
         const field_entry *get_field( const tripoint_bub_ms &p, const field_type_id &type ) const;
         bool dangerous_field_at( const tripoint_bub_ms &p );
+        bool impassable_field_at( const tripoint &p );
         bool impassable_field_at( const tripoint_bub_ms &p );
 
         // Check if player can move on top of it during mopping zone activity
@@ -1635,11 +1656,19 @@ class map
         // Returns true if terrain at p has NO flag ter_furn_flag::TFLAG_NO_FLOOR
         // and ter_furn_flag::TFLAG_NO_FLOOR_WATER,
         // if we're not in z-levels mode or if we're at lowest level
+        // TODO: Get rid of untyped overload
+        bool has_floor( const tripoint &p ) const;
         bool has_floor( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload
+        bool has_floor_or_water( const tripoint &p ) const;
         bool has_floor_or_water( const tripoint_bub_ms &p ) const;
         /** Does this tile support vehicles and furniture above it */
         bool supports_above( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload
+        bool has_floor_or_support( const tripoint &p ) const;
         bool has_floor_or_support( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload
+        bool has_vehicle_floor( const tripoint &p ) const;
         bool has_vehicle_floor( const tripoint_bub_ms &p ) const;
     private:
         /**
@@ -1680,9 +1709,10 @@ class map
         void place_vending( const tripoint_bub_ms &p, const item_group_id &type, bool reinforced = false,
                             bool lootable = false, bool powered = false );
         // places an NPC, if static NPCs are enabled or if force is true
+        // TODO: Get rid of untyped overload
+        character_id place_npc( const point &p, const string_id<npc_template> &type );
         character_id place_npc( const point_bub_ms &p, const string_id<npc_template> &type );
-        void apply_faction_ownership( const point_bub_ms &p1, const point_bub_ms &p2,
-                                      const faction_id &id );
+        void apply_faction_ownership( const point &p1, const point &p2, const faction_id &id );
         void add_spawn( const mtype_id &type, int count, const tripoint_bub_ms &p,
                         bool friendly = false, int faction_id = -1, int mission_id = -1,
                         const std::optional<std::string> &name = std::nullopt );
@@ -1714,6 +1744,10 @@ class map
         //                          can be overriden by VEHICLE_STATUS_AT_SPAWN EXTERNAL_OPTION
         // @param merge_wrecks      if true and vehicle overlaps another then both turn into wrecks
         //                          if false and vehicle will overlap aborts and returns nullptr
+        // TODO: Get rid of untyped overload
+        vehicle *add_vehicle( const vproto_id &type, const tripoint &p, const units::angle &dir,
+                              int init_veh_fuel = -1, int init_veh_status = -1, bool merge_wrecks = true,
+                              bool force_status = false );
         vehicle *add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, const units::angle &dir,
                               int init_veh_fuel = -1, int init_veh_status = -1, bool merge_wrecks = true,
                               bool force_status = false );
@@ -1721,6 +1755,8 @@ class map
         // Light/transparency
         float light_transparency( const tripoint_bub_ms &p ) const;
         // Assumes 0,0 is light map center
+        // TODO: Get rid of untyped overload.
+        lit_level light_at( const tripoint &p ) const;
         lit_level light_at( const tripoint_bub_ms &p ) const;
         // Raw values for tilesets
         float ambient_light_at( const tripoint_bub_ms &p ) const;
@@ -1750,6 +1786,8 @@ class map
          * Coordinates is in the system that is used by the ter/furn/i_at functions.
          * Output is in the same scale, but in global system.
          */
+        // TODO: fix point types (remove the first overload)
+        tripoint_abs_ms getglobal( const tripoint &p ) const;
         tripoint_abs_ms getglobal( const tripoint_bub_ms &p ) const;
         /**
          * Inverse of @ref getglobal
@@ -1758,6 +1796,7 @@ class map
         point_bub_ms bub_from_abs( const point_abs_ms &p ) const {
             return bub_from_abs( tripoint_abs_ms( p, abs_sub.z() ) ).xy();
         }
+        bool inbounds( const tripoint &p ) const;
         bool inbounds( const tripoint_bub_ms &p ) const;
         bool inbounds( const tripoint_abs_ms &p ) const;
         bool inbounds( const tripoint_abs_sm &p ) const {
@@ -1773,6 +1812,8 @@ class map
         }
 
         /** Clips the coordinates of p to fit the map bounds */
+        // TODO: Get rid of untyped overload.
+        void clip_to_bounds( tripoint &p ) const;
         void clip_to_bounds( tripoint_bub_ms &p ) const;
         void clip_to_bounds( int &x, int &y ) const;
         void clip_to_bounds( int &x, int &y, int &z ) const;
@@ -1975,6 +2016,12 @@ class map
             std::tie( sm, offset_p ) = project_remain<coords::sm>( p );
             return unsafe_get_submap_at( p );
         }
+        // TODO: Get rid of untyped overload
+        submap *get_submap_at( const tripoint &p, point &offset_p ) {
+            offset_p.x = p.x % SEEX;
+            offset_p.y = p.y % SEEY;
+            return get_submap_at( tripoint_bub_ms( p ) );
+        }
         submap *get_submap_at( const tripoint_bub_ms &p, point_sm_ms &offset_p ) {
             offset_p.x() = p.x() % SEEX;
             offset_p.y() = p.y() % SEEY;
@@ -1984,6 +2031,9 @@ class map
             offset_p.x() = p.x() % SEEX;
             offset_p.y() = p.y() % SEEY;
             return get_submap_at( p );
+        }
+        submap *get_submap_at( const point &p, point &offset_p ) {
+            return get_submap_at( { p, abs_sub.z() }, offset_p );
         }
         /**
          * Get submap pointer in the grid at given grid coordinates. Grid coordinates must
@@ -2057,7 +2107,7 @@ class map
         void apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, float luminance,
                               const units::angle &wideangle = 30_degrees );
         void apply_light_ray( cata::mdarray<bool, point_bub_ms, MAPSIZE_X, MAPSIZE_Y> &lit,
-                              const tripoint_bub_ms &s, const tripoint_bub_ms &e, float luminance );
+                              const tripoint &s, const tripoint &e, float luminance );
         void add_light_from_items( const tripoint_bub_ms &p, const item_stack &items );
         void add_item_light_recursive( const tripoint_bub_ms &p, const item &it );
         std::unique_ptr<vehicle> add_vehicle_to_map( std::unique_ptr<vehicle> veh, bool merge_wrecks );
@@ -2199,6 +2249,9 @@ class map
         // Clips the area to map bounds
         tripoint_range<tripoint_bub_ms> points_in_rectangle(
             const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const;
+        // TODO: fix point types (remove the first overload)
+        tripoint_range<tripoint> points_in_radius(
+            const tripoint &center, size_t radius, size_t radiusz = 0 ) const;
         tripoint_range<tripoint_bub_ms> points_in_radius(
             const tripoint_bub_ms &center, size_t radius, size_t radiusz = 0 ) const;
 
@@ -2234,6 +2287,8 @@ class map
         bool dont_draw_lower_floor( const tripoint_bub_ms &p ) const;
 
         bool has_haulable_items( const tripoint_bub_ms &pos );
+        // TODO: Get rid of untyped overload
+        std::vector<item_location> get_haulable_items( const tripoint &pos );
         std::vector<item_location> get_haulable_items( const tripoint_bub_ms &pos );
 
 #if defined(TILES)
@@ -2310,8 +2365,16 @@ class tinymap : private map
         }
 
         using map::translate;
+        // TODO: Get rid of untyped overload.
+        ter_id ter( const tripoint &p ) const {
+            return map::ter( tripoint_bub_ms( p ) );
+        }
         ter_id ter( const tripoint_omt_ms &p ) const {
             return map::ter( rebase_bub( p ) );
+        }
+        // TODO: Get rid of untyped overload.
+        bool ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
+            return map::ter_set( tripoint_bub_ms( p ), new_terrain, avoid_creatures );
         }
         bool ter_set( const tripoint_omt_ms &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
             return map::ter_set( rebase_bub( p ), new_terrain, avoid_creatures );
@@ -2330,8 +2393,16 @@ class tinymap : private map
         furn_id furn( const point_omt_ms &p ) const {
             return map::furn( rebase_bub( p ) );
         }
+        // TODO: Get rid of untyped overload.
+        furn_id furn( const tripoint &p ) const {
+            return map::furn( tripoint_bub_ms( p ) );
+        }
         furn_id furn( const tripoint_omt_ms &p ) const {
             return map::furn( rebase_bub( p ) );
+        }
+        // TODO: Get rid of untyped overload.
+        bool has_furn( const tripoint &p ) const {
+            return map::has_furn( tripoint_bub_ms( p ) );
         }
         bool has_furn( const tripoint_omt_ms &p ) const {
             return map::has_furn( rebase_bub( p ) );
@@ -2341,6 +2412,11 @@ class tinymap : private map
         }
         void set( const tripoint_omt_ms &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
             map::set( rebase_bub( p ), new_terrain, new_furniture );
+        }
+        // TODO: Get rid of untyped overload.
+        bool furn_set( const tripoint &p, const furn_id &new_furniture, bool furn_reset = false,
+                       bool avoid_creatures = false ) {
+            return map::furn_set( tripoint_bub_ms( p ), new_furniture, furn_reset, avoid_creatures );
         }
         bool furn_set( const tripoint_omt_ms &p, const furn_id &new_furniture, bool furn_reset = false,
                        bool avoid_creatures = false ) {
@@ -2372,8 +2448,22 @@ class tinymap : private map
             const tripoint_omt_ms &from, const tripoint_omt_ms &to ) const;
         tripoint_range<tripoint_omt_ms> points_in_radius(
             const tripoint_omt_ms &center, size_t radius, size_t radiusz = 0 ) const;
+        // TODO: Get rid of untyped overload.
+        map_stack i_at( const tripoint &p ) {
+            return map::i_at( tripoint_bub_ms( p ) );
+        }
         map_stack i_at( const tripoint_omt_ms &p ) {
             return map::i_at( rebase_bub( p ) );
+        }
+        // TODO: Get rid of untyped overload.
+        void spawn_item( const tripoint &p, const itype_id &type_id,
+                         unsigned quantity = 1, int charges = 0,
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const std::set<flag_id> &flags = {}, const std::string &variant = "",
+                         const std::string &faction = "" ) {
+            map::spawn_item( tripoint_bub_ms( p ), type_id, quantity, charges, birthday, damlevel, flags,
+                             variant,
+                             faction );
         }
         void spawn_item( const tripoint_omt_ms &p, const itype_id &type_id,
                          unsigned quantity = 1, int charges = 0,
@@ -2421,6 +2511,10 @@ class tinymap : private map
         }
         void i_rem( const tripoint_omt_ms &p, item *it ) {
             map::i_rem( rebase_bub( p ), it );
+        }
+        // TODO: Get rid of untyped overload.
+        void i_clear( const tripoint &p ) {
+            return map::i_clear( tripoint_bub_ms( p ) );
         }
         void i_clear( const tripoint_omt_ms &p ) {
             return map::i_clear( rebase_bub( p ) );
@@ -2480,6 +2574,10 @@ class tinymap : private map
         tripoint_omt_ms omt_from_abs( const tripoint_abs_ms &p ) const {
             return rebase_omt( map::bub_from_abs( p ) );
         };
+        // TODO: Get rid of untyped overload.
+        bool is_outside( const tripoint &p ) const {
+            return map::is_outside( tripoint_bub_ms( p ) );
+        }
         bool is_outside( const tripoint_omt_ms &p ) const {
             return map::is_outside( rebase_bub( p ) );
         }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -387,7 +387,7 @@ static bool mx_helicopter( map &m, const tripoint_abs_sm &abs_sub )
         wreckage_pos = { clamp( c.x() + offset.x(), min.x(), x_max ), clamp( c.y() + offset.y(), min.y(), y_max ), abs_sub.z()};
     }
 
-    vehicle *wreckage = m.add_vehicle( crashed_hull, wreckage_pos, dir1, rng( 1, 33 ), 1 );
+    vehicle *wreckage = m.add_vehicle( crashed_hull, wreckage_pos.raw(), dir1, rng( 1, 33 ), 1 );
 
     const auto controls_at = []( vehicle * wreckage, const tripoint_bub_ms & pos ) {
         return !wreckage->get_parts_at( pos, "CONTROLS", part_status_flag::any ).empty() ||

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -899,20 +899,20 @@ void reset_mapgens()
 
 size_t mapgen_function_json_base::calc_index( const point &p ) const
 {
-    if( p.x >= mapgensize.x() ) {
+    if( p.x >= mapgensize.x ) {
         debugmsg( "invalid value %zu for x in calc_index", p.x );
     }
-    if( p.y >= mapgensize.y() ) {
+    if( p.y >= mapgensize.y ) {
         debugmsg( "invalid value %zu for y in calc_index", p.y );
     }
-    return p.y * mapgensize.y() + p.x;
+    return p.y * mapgensize.y + p.x;
 }
 
 static bool common_check_bounds( const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
-                                 const point_rel_ms &mapgensize, const JsonObject &jso )
+                                 const point &mapgensize, const JsonObject &jso )
 {
-    half_open_rectangle<point_rel_ms> bounds( point_rel_ms::zero, mapgensize );
-    if( !bounds.contains( point_rel_ms( x.val, y.val ) ) ) {
+    half_open_rectangle<point> bounds( point::zero, mapgensize );
+    if( !bounds.contains( point( x.val, y.val ) ) ) {
         return false;
     }
 
@@ -928,11 +928,11 @@ static bool common_check_bounds( const jmapgen_int &x, const jmapgen_int &y, con
         jso.throw_error( "z maximum has to be identical to z minimum" );
     }
 
-    if( x.valmax > mapgensize.x() - 1 ) {
+    if( x.valmax > mapgensize.x - 1 ) {
         jso.throw_error_at( "x", "coordinate range cannot cross grid boundaries" );
     }
 
-    if( y.valmax > mapgensize.y() - 1 ) {
+    if( y.valmax > mapgensize.y - 1 ) {
         jso.throw_error_at( "y", "coordinate range cannot cross grid boundaries" );
     }
 
@@ -975,11 +975,11 @@ mapgen_function_json::mapgen_function_json( const JsonObject &jsobj,
     , rotation( 0 )
     , fallback_predecessor_mapgen_( oter_str_id::NULL_ID() )
 {
-    m_offset.x() = grid_offset.x * mapgensize.x();
-    m_offset.y() = grid_offset.y * mapgensize.y();
+    m_offset.x() = grid_offset.x * mapgensize.x;
+    m_offset.y() = grid_offset.y * mapgensize.y;
     m_offset.z() = 0;
-    total_size.x() = grid_total.x * mapgensize.x();
-    total_size.y() = grid_total.y * mapgensize.y();
+    total_size.x = grid_total.x * mapgensize.x;
+    total_size.y = grid_total.y * mapgensize.y;
     objects = jmapgen_objects( m_offset, mapgensize, total_size );
 }
 
@@ -2068,7 +2068,7 @@ class jmapgen_faction : public jmapgen_piece
                 return;
             }
             // TODO: Make apply_faction_ownership 3D aware.
-            dat.m.apply_faction_ownership( point_bub_ms( x.val, y.val ), point_bub_ms( x.valmax, y.valmax ),
+            dat.m.apply_faction_ownership( point( x.val, y.val ), point( x.valmax, y.valmax ),
                                            chosen_id );
         }
 
@@ -3935,14 +3935,14 @@ class jmapgen_nested : public jmapgen_piece
 
             // Check whether any of the nests can attempt to place stuff out of
             // bounds
-            std::unordered_map<point_rel_ms, nested_mapgen_id> nest_placement_coords;
+            std::unordered_map<point, nested_mapgen_id> nest_placement_coords;
             auto add_coords_from = [&]( const mapgen_value<nested_mapgen_id> &nest_id_val ) {
                 for( const nested_mapgen_id &nest_id :
                      nest_id_val.all_possible_results( parameters ) ) {
                     if( nest_id.is_null() ) {
                         continue;
                     }
-                    for( const point_rel_ms &p : nest_id->all_placement_coords() ) {
+                    for( const point &p : nest_id->all_placement_coords() ) {
                         nest_placement_coords.emplace( p, nest_id );
                     }
                 }
@@ -3958,13 +3958,13 @@ class jmapgen_nested : public jmapgen_piece
             nested_mapgen_id offending_nest_x;
             nested_mapgen_id offending_nest_y;
 
-            for( const std::pair<const point_rel_ms, nested_mapgen_id> &p : nest_placement_coords ) {
-                if( p.first.x() > max_relative.x ) {
-                    max_relative.x = p.first.x();
+            for( const std::pair<const point, nested_mapgen_id> &p : nest_placement_coords ) {
+                if( p.first.x > max_relative.x ) {
+                    max_relative.x = p.first.x;
                     offending_nest_x = p.second;
                 }
-                if( p.first.y() > max_relative.y ) {
-                    max_relative.y = p.first.y();
+                if( p.first.y > max_relative.y ) {
+                    max_relative.y = p.first.y;
                     offending_nest_y = p.second;
                 }
             }
@@ -4022,8 +4022,8 @@ class jmapgen_nested : public jmapgen_piece
         }
 };
 
-jmapgen_objects::jmapgen_objects( const tripoint_rel_ms &offset, const point_rel_ms &mapsize,
-                                  const point_rel_ms &tot_size )
+jmapgen_objects::jmapgen_objects( const tripoint_rel_ms &offset, const point &mapsize,
+                                  const point &tot_size )
     : m_offset( offset )
     , mapgensize( mapsize )
     , total_size( tot_size )
@@ -4543,8 +4543,8 @@ bool mapgen_function_json_nested::setup_internal( const JsonObject &jo )
     // Mandatory - nested mapgen must be explicitly sized
     if( jo.has_array( "mapgensize" ) ) {
         JsonArray jarr = jo.get_array( "mapgensize" );
-        mapgensize = point_rel_ms( jarr.get_int( 0 ), jarr.get_int( 1 ) );
-        if( mapgensize.x() == 0 || mapgensize.x() != mapgensize.y() ) {
+        mapgensize = point( jarr.get_int( 0 ), jarr.get_int( 1 ) );
+        if( mapgensize.x == 0 || mapgensize.x != mapgensize.y ) {
             // Non-square sizes not implemented yet
             jo.throw_error( "\"mapgensize\" must be an array of two identical, positive numbers" );
         }
@@ -4645,21 +4645,21 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
     // mandatory: mapgensize rows of mapgensize character lines, each of which must have a
     // matching key in "terrain", unless fill_ter is set
     // "rows:" [ "aaaajustlikeinmapgen.cpp", "this.must!be!exactly.24!", "and_must_match_terrain_", .... ]
-    point_rel_ms expected_dim = mapgensize + m_offset.xy();
-    cata_assert( expected_dim.x() >= 0 );
-    cata_assert( expected_dim.y() >= 0 );
-    const std::string default_row( expected_dim.x(), ' ' );
+    point expected_dim = mapgensize + m_offset.xy().raw();
+    cata_assert( expected_dim.x >= 0 );
+    cata_assert( expected_dim.y >= 0 );
+    const std::string default_row( expected_dim.x, ' ' );
     const bool default_rows = !jo.has_array( "rows" );
     if( !default_rows ) {
         parray = jo.get_array( "rows" );
-        if( static_cast<int>( parray.size() ) < expected_dim.y() ) {
+        if( static_cast<int>( parray.size() ) < expected_dim.y ) {
             parray.throw_error( string_format( "format: rows: must have at least %d rows, not %d",
-                                               expected_dim.y(), parray.size() ) );
+                                               expected_dim.y, parray.size() ) );
         }
-        if( static_cast<int>( parray.size() ) != total_size.y() ) {
+        if( static_cast<int>( parray.size() ) != total_size.y ) {
             parray.throw_error(
                 string_format( "format: rows: must have %d rows, not %d; check mapgensize if applicable",
-                               total_size.y(), parray.size() ) );
+                               total_size.y, parray.size() ) );
         }
     }
 
@@ -4674,25 +4674,25 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
 
     parameters = palette.get_parameters();
 
-    for( int c = m_offset.y(); c < expected_dim.y(); c++ ) {
+    for( int c = m_offset.y(); c < expected_dim.y; c++ ) {
         const std::string row = default_rows ? default_row : parray.get_string( c );
         static std::vector<std::string_view> row_keys;
         row_keys.clear();
-        row_keys.reserve( total_size.x() );
+        row_keys.reserve( total_size.x );
         utf8_display_split_into( row, row_keys );
-        if( row_keys.size() < static_cast<size_t>( expected_dim.x() ) ) {
+        if( row_keys.size() < static_cast<size_t>( expected_dim.x ) ) {
             cata_assert( !default_rows );
             parray.throw_error(
                 string_format( "format: row %d must have at least %d columns, not %d",
-                               c + 1, expected_dim.x(), row_keys.size() ) );
+                               c + 1, expected_dim.x, row_keys.size() ) );
         }
-        if( row_keys.size() != static_cast<size_t>( total_size.x() ) ) {
+        if( row_keys.size() != static_cast<size_t>( total_size.x ) ) {
             cata_assert( !default_rows );
             parray.throw_error(
                 string_format( "format: row %d must have %d columns, not %d; check mapgensize if applicable",
-                               c + 1, total_size.x(), row_keys.size() ) );
+                               c + 1, total_size.x, row_keys.size() ) );
         }
-        for( int i = m_offset.x(); i < expected_dim.x(); i++ ) {
+        for( int i = m_offset.x(); i < expected_dim.x; i++ ) {
             const tripoint_rel_ms p = tripoint_rel_ms( i, c, 0 ) - m_offset;
             const map_key key{ std::string( row_keys[i] ) };
             const auto iter_ter = keys_with_terrain.find( key );
@@ -4864,15 +4864,14 @@ void mapgen_function_json_base::check_common() const
     objects.check( context_, parameters );
 }
 
-void mapgen_function_json_base::add_placement_coords_to( std::unordered_set<point_rel_ms> &result )
-const
+void mapgen_function_json_base::add_placement_coords_to( std::unordered_set<point> &result ) const
 {
     objects.add_placement_coords_to( result );
 }
 
-std::unordered_set<point_rel_ms> nested_mapgen::all_placement_coords() const
+std::unordered_set<point> nested_mapgen::all_placement_coords() const
 {
-    std::unordered_set<point_rel_ms> result;
+    std::unordered_set<point> result;
     for( const weighted_object<int, std::shared_ptr<mapgen_function_json_nested>> &o : funcs_ ) {
         o.obj->add_placement_coords_to( result );
     }
@@ -4912,7 +4911,7 @@ void jmapgen_objects::merge_parameters_into( mapgen_parameters &params,
     }
 }
 
-void jmapgen_objects::add_placement_coords_to( std::unordered_set<point_rel_ms> &result ) const
+void jmapgen_objects::add_placement_coords_to( std::unordered_set<point> &result ) const
 {
     for( const jmapgen_obj &obj : objects ) {
         const jmapgen_place &where = obj.first;
@@ -5188,11 +5187,11 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_TRAP: {
-                const point_rel_ms c( x_get(), y_get() );
+                const point c( x_get(), y_get() );
                 const int cx2 = x2_get();
                 const int cy2 = y2_get();
-                for( int tx = c.x(); tx <= cx2; tx++ ) {
-                    for( int ty = c.y(); ty <= cy2; ty++ ) {
+                for( int tx = c.x; tx <= cx2; tx++ ) {
+                    for( int ty = c.y; ty <= cy2; ty++ ) {
                         // TODO: the trap_id should be stored separately and not be wrapped in an jmapgen_int
                         mtrap_set( &m, tripoint_bub_ms( tx, ty, z_level ), trap_id( val.get() ),
                                    dat.has_flag( jmapgen_flags::avoid_creatures ) );
@@ -5201,11 +5200,11 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_TRAP_REMOVE: {
-                const point_rel_ms c( x_get(), y_get() );
+                const point c( x_get(), y_get() );
                 const int cx2 = x2_get();
                 const int cy2 = y2_get();
-                for( int tx = c.x(); tx <= cx2; tx++ ) {
-                    for( int ty = c.y(); ty <= cy2; ty++ ) {
+                for( int tx = c.x; tx <= cx2; tx++ ) {
+                    for( int ty = c.y; ty <= cy2; ty++ ) {
                         // TODO: the trap_id should be stored separately and not be wrapped in an jmapgen_int
                         mremove_trap( &m, tripoint_bub_ms( tx, ty, z_level ), trap_id( val.get() ).id() );
                     }
@@ -5213,11 +5212,11 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_CREATURE_REMOVE: {
-                const point_rel_ms c( x_get(), y_get() );
+                const point c( x_get(), y_get() );
                 const int cx2 = x2_get();
                 const int cy2 = y2_get();
-                for( int tx = c.x(); tx <= cx2; tx++ ) {
-                    for( int ty = c.y(); ty <= cy2; ty++ ) {
+                for( int tx = c.x; tx <= cx2; tx++ ) {
+                    for( int ty = c.y; ty <= cy2; ty++ ) {
                         Creature *tmp_critter = get_creature_tracker().creature_at( tripoint_abs_ms( m.getglobal(
                                                     tripoint_bub_ms( tx,
                                                             ty, z_level ) ) ), true );
@@ -5229,33 +5228,33 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_ITEM_REMOVE: {
-                const point_rel_ms c( x_get(), y_get() );
+                const point c( x_get(), y_get() );
                 const int cx2 = x2_get();
                 const int cy2 = y2_get();
-                for( int tx = c.x(); tx <= cx2; tx++ ) {
-                    for( int ty = c.y(); ty <= cy2; ty++ ) {
+                for( int tx = c.x; tx <= cx2; tx++ ) {
+                    for( int ty = c.y; ty <= cy2; ty++ ) {
                         m.i_clear( tripoint_bub_ms( tx, ty, z_level ) );
                     }
                 }
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_FIELD_REMOVE: {
-                const point_rel_ms c( x_get(), y_get() );
+                const point c( x_get(), y_get() );
                 const int cx2 = x2_get();
                 const int cy2 = y2_get();
-                for( int tx = c.x(); tx <= cx2; tx++ ) {
-                    for( int ty = c.y(); ty <= cy2; ty++ ) {
+                for( int tx = c.x; tx <= cx2; tx++ ) {
+                    for( int ty = c.y; ty <= cy2; ty++ ) {
                         mremove_fields( &m, tripoint_bub_ms( tx, ty, z_level ) );
                     }
                 }
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_RADIATION: {
-                const point_rel_ms c2( x_get(), y_get() );
+                const point c2( x_get(), y_get() );
                 const int cx2 = x2_get();
                 const int cy2 = y2_get();
-                for( int tx = c2.x(); tx <= cx2; tx++ ) {
-                    for( int ty = c2.y(); ty <= cy2; ty++ ) {
+                for( int tx = c2.x; tx <= cx2; tx++ ) {
+                    for( int ty = c2.y; ty <= cy2; ty++ ) {
                         m.set_radiation( tripoint_bub_ms( tx, ty, z_level ), static_cast<int>( val.get() ) );
                     }
                 }
@@ -6688,6 +6687,11 @@ void map::place_vending( const tripoint_bub_ms &p, const item_group_id &type, bo
     }
 }
 
+character_id map::place_npc( const point &p, const string_id<npc_template> &type )
+{
+    return map::place_npc( point_bub_ms( p ), type );
+}
+
 character_id map::place_npc( const point_bub_ms &p, const string_id<npc_template> &type )
 {
     shared_ptr_fast<npc> temp = make_shared_fast<npc>();
@@ -6699,13 +6703,12 @@ character_id map::place_npc( const point_bub_ms &p, const string_id<npc_template
     return temp->getID();
 }
 
-void map::apply_faction_ownership( const point_bub_ms &p1, const point_bub_ms &p2,
-                                   const faction_id &id )
+void map::apply_faction_ownership( const point &p1, const point &p2, const faction_id &id )
 {
-    for( const tripoint_bub_ms &p : points_in_rectangle( tripoint_bub_ms( p1, abs_sub.z() ),
-            tripoint_bub_ms( p2,
+    for( const tripoint_bub_ms &p : points_in_rectangle( tripoint_bub_ms( p1.x, p1.y, abs_sub.z() ),
+            tripoint_bub_ms( p2.x, p2.y,
                              abs_sub.z() ) ) ) {
-        map_stack items = i_at( p.xy() );
+        map_stack items = i_at( point_bub_ms( p.xy() ) );
         for( item &elem : items ) {
             elem.set_owner( id );
         }
@@ -6865,6 +6868,14 @@ void map::add_spawn(
     }
     place_on_submap->spawns.emplace_back( type, count, offset, faction_id, mission_id, friendly, name,
                                           data );
+}
+
+vehicle *map::add_vehicle( const vproto_id &type, const tripoint &p, const units::angle &dir,
+                           const int veh_fuel, const int veh_status, const bool merge_wrecks,
+                           const bool force_status/* = false*/ )
+{
+    return map::add_vehicle( type, tripoint_bub_ms( p ), dir, veh_fuel, veh_status, merge_wrecks,
+                             force_status );
 }
 
 vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, const units::angle &dir,
@@ -7168,17 +7179,17 @@ void map::rotate( int turns )
             std::swap( *pz, *pse );
             std::swap( *pe, *ps );
         } else {
-            point_rel_sm p;
+            point p;
             submap tmp;
 
             std::swap( *pse, tmp );
 
             for( int k = 0; k < 4; ++k ) {
                 p = p.rotate( turns, { 2, 2 } );
-                point_rel_sm tmpp = point_rel_sm::south_east - p;
-                submap *psep = get_submap_at_grid( tripoint_rel_sm( tmpp, z_level ) );
+                point tmpp = point::south_east - p;
+                submap *psep = get_submap_at_grid( tripoint_rel_sm( tmpp.x, tmpp.y, z_level ) );
                 if( psep == nullptr ) {
-                    debugmsg( "Tried to rotate map at (%d,%d) but the submap is not loaded", tmpp.x(), tmpp.y() );
+                    debugmsg( "Tried to rotate map at (%d,%d) but the submap is not loaded", tmpp.x, tmpp.y );
                     continue;
                 }
                 std::swap( *psep, tmp );
@@ -7188,17 +7199,17 @@ void map::rotate( int turns )
         // Then rotate them and recalculate vehicle positions.
         for( int j = 0; j < 2; ++j ) {
             for( int i = 0; i < 2; ++i ) {
-                point_rel_sm p( i, j );
-                submap *sm = get_submap_at_grid( tripoint_rel_sm( p, z_level ) );
+                point p( i, j );
+                submap *sm = get_submap_at_grid( tripoint_rel_sm( p.x, p.y, z_level ) );
                 if( sm == nullptr ) {
-                    debugmsg( "Tried to rotate map at (%d,%d) but the submap is not loaded", p.x(), p.y() );
+                    debugmsg( "Tried to rotate map at (%d,%d) but the submap is not loaded", p.x, p.y );
                     continue;
                 }
 
                 sm->rotate( turns );
 
                 for( auto &veh : sm->vehicles ) {
-                    veh->sm_pos = tripoint( p.raw(), z_level );
+                    veh->sm_pos = tripoint( p, z_level );
                 }
 
                 update_vehicle_list( sm, z_level );

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -398,8 +398,7 @@ class mapgen_palette
 
 struct jmapgen_objects {
 
-        jmapgen_objects( const tripoint_rel_ms &offset, const point_rel_ms &mapsize,
-                         const point_rel_ms &tot_size );
+        jmapgen_objects( const tripoint_rel_ms &offset, const point &mapsize, const point &tot_size );
 
         bool check_bounds( const jmapgen_place &place, const JsonObject &jso );
 
@@ -426,7 +425,7 @@ struct jmapgen_objects {
 
         void merge_parameters_into( mapgen_parameters &, const std::string &outer_context ) const;
 
-        void add_placement_coords_to( std::unordered_set<point_rel_ms> & ) const;
+        void add_placement_coords_to( std::unordered_set<point> & ) const;
 
         void apply( const mapgendata &dat, mapgen_phase, const std::string &context ) const;
         void apply( const mapgendata &dat, mapgen_phase, const tripoint_rel_ms &offset,
@@ -445,8 +444,8 @@ struct jmapgen_objects {
         using jmapgen_obj = std::pair<jmapgen_place, shared_ptr_fast<const jmapgen_piece> >;
         std::vector<jmapgen_obj> objects;
         tripoint_rel_ms m_offset;
-        point_rel_ms mapgensize;
-        point_rel_ms total_size;
+        point mapgensize;
+        point total_size;
 };
 
 class mapgen_function_json_base
@@ -459,7 +458,7 @@ class mapgen_function_json_base
         size_t calc_index( const point &p ) const;
         ret_val<void> has_vehicle_collision( const mapgendata &dat, const tripoint_rel_ms &offset ) const;
 
-        void add_placement_coords_to( std::unordered_set<point_rel_ms> & ) const;
+        void add_placement_coords_to( std::unordered_set<point> & ) const;
 
         const mapgen_parameters &get_parameters() const {
             return parameters;
@@ -487,9 +486,9 @@ class mapgen_function_json_base
         enum_bitset<jmapgen_flags> flags_;
         bool is_ready;
 
-        point_rel_ms mapgensize;
+        point mapgensize;
         tripoint_rel_ms m_offset;
-        point_rel_ms total_size;
+        point total_size;
         std::vector<jmapgen_setmap> setmap_points;
 
         jmapgen_objects objects;
@@ -575,7 +574,7 @@ class nested_mapgen
         void add( const std::shared_ptr<mapgen_function_json_nested> &p, int weight );
         // Returns a set containing every relative coordinate of a point that
         // might have something placed by this mapgen
-        std::unordered_set<point_rel_ms> all_placement_coords() const;
+        std::unordered_set<point> all_placement_coords() const;
     private:
         weighted_int_list<std::shared_ptr<mapgen_function_json_nested>> funcs_;
 };

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -28,9 +28,9 @@
 #include "vpart_position.h"
 
 // Turns two indexed to a 2D array into an index to equivalent 1D array
-static constexpr int flat_index( const point_bub_ms &p )
+static constexpr int flat_index( const point &p )
 {
-    return ( p.x() * MAPSIZE_Y ) + p.y();
+    return ( p.x * MAPSIZE_Y ) + p.y;
 }
 
 // Flattened 2D array representing a single z-level worth of pathfinding data
@@ -40,7 +40,7 @@ struct path_data_layer {
     std::bitset< MAPSIZE_X *MAPSIZE_Y > open;
     std::array< int, MAPSIZE_X *MAPSIZE_Y > score;
     std::array< int, MAPSIZE_X *MAPSIZE_Y > gscore;
-    std::array< tripoint_bub_ms, MAPSIZE_X *MAPSIZE_Y > parent;
+    std::array< tripoint, MAPSIZE_X *MAPSIZE_Y > parent;
 
     void reset() {
         closed.reset();
@@ -50,7 +50,7 @@ struct path_data_layer {
 
 struct pathfinder {
     using queue_type =
-        std::priority_queue< std::pair<int, tripoint_bub_ms>, std::vector< std::pair<int, tripoint_bub_ms> >, pair_greater_cmp_first >;
+        std::priority_queue< std::pair<int, tripoint>, std::vector< std::pair<int, tripoint> >, pair_greater_cmp_first >;
     queue_type open;
     std::array< std::unique_ptr< path_data_layer >, OVERMAP_LAYERS > path_data;
 
@@ -77,15 +77,14 @@ struct pathfinder {
         return open.empty();
     }
 
-    tripoint_bub_ms get_next() {
+    tripoint get_next() {
         const auto pt = open.top();
         open.pop();
         return pt.second;
     }
 
-    void add_point( const int gscore, const int score, const tripoint_bub_ms &from,
-                    const tripoint_bub_ms &to ) {
-        path_data_layer &layer = get_layer( to.z() );
+    void add_point( const int gscore, const int score, const tripoint &from, const tripoint &to ) {
+        path_data_layer &layer = get_layer( to.z );
         const int index = flat_index( to.xy() );
         if( layer.closed[index] ) {
             return;
@@ -101,14 +100,14 @@ struct pathfinder {
         open.emplace( score, to );
     }
 
-    void close_point( const tripoint_bub_ms &p ) {
-        path_data_layer &layer = get_layer( p.z() );
+    void close_point( const tripoint &p ) {
+        path_data_layer &layer = get_layer( p.z );
         const int index = flat_index( p.xy() );
         layer.closed[index] = true;
     }
 
-    void unclose_point( const tripoint_bub_ms &p ) {
-        path_data_layer &layer = get_layer( p.z() );
+    void unclose_point( const tripoint &p ) {
+        path_data_layer &layer = get_layer( p.z );
         const int index = flat_index( p.xy() );
         layer.closed[index] = false;
     }
@@ -119,14 +118,14 @@ static pathfinder pf;
 // Modifies `t` to point to a tile with `flag` in a 1-submap radius of `t`'s original value,
 // searching nearest points first (starting with `t` itself).
 // return false if it could not find a suitable point
-static bool vertical_move_destination( const map &m, ter_furn_flag flag, tripoint_bub_ms &t )
+static bool vertical_move_destination( const map &m, ter_furn_flag flag, tripoint &t )
 {
-    const pathfinding_cache &pf_cache = m.get_pathfinding_cache_ref( t.z() );
-    for( const point_bub_ms &p : closest_points_first( t.xy(), SEEX ) ) {
-        if( pf_cache.special[p.x()][p.y()] & ( PathfindingFlag::GoesDown | PathfindingFlag::GoesUp ) ) {
-            const tripoint_bub_ms t2( p, t.z() );
+    const pathfinding_cache &pf_cache = m.get_pathfinding_cache_ref( t.z );
+    for( const point &p : closest_points_first( t.xy(), SEEX ) ) {
+        if( pf_cache.special[p.x][p.y] & ( PathfindingFlag::GoesDown | PathfindingFlag::GoesUp ) ) {
+            const tripoint_bub_ms t2( p.x, p.y, t.z );
             if( m.has_flag( flag, t2 ) ) {
-                t = t2;
+                t = t2.raw();
                 return true;
             }
         }
@@ -423,14 +422,14 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
 
     pf.reset( min.z(), max.z() );
 
-    pf.add_point( 0, 0, f, f );
+    pf.add_point( 0, 0, f.raw(), f.raw() );
 
     bool done = false;
 
     do {
         tripoint_bub_ms cur( pf.get_next() );
 
-        const int parent_index = flat_index( cur.xy() );
+        const int parent_index = flat_index( cur.xy().raw() );
         path_data_layer &layer = pf.get_layer( cur.z() );
         if( layer.closed[parent_index] ) {
             continue;
@@ -458,7 +457,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
         constexpr std::array<int, 8> y_offset{ {  0,  0, -1,  1, -1,  1, -1, 1 } };
         for( size_t i = 0; i < 8; i++ ) {
             const tripoint_bub_ms p( cur.x() + x_offset[i], cur.y() + y_offset[i], cur.z() );
-            const int index = flat_index( p.xy() );
+            const int index = flat_index( p.xy().raw() );
 
             // TODO: Remove this and instead have sentinels at the edges
             if( p.x() < min.x() || p.x() >= max.x() || p.y() < min.y() || p.y() >= max.y() ) {
@@ -505,7 +504,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                             // From cur, not p, because we won't be walking on air
                             pf.add_point( layer.gscore[parent_index] + 10,
                                           layer.score[parent_index] + 10 + 2 * rl_dist( below, t ),
-                                          cur, below );
+                                          cur.raw(), below.raw() );
                         }
 
                         // Close p, because we won't be walking on it
@@ -515,7 +514,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                 }
             }
 
-            pf.add_point( newg, newg + 2 * rl_dist( p, t ), cur, p );
+            pf.add_point( newg, newg + 2 * rl_dist( p, t ), cur.raw(), p.raw() );
         }
 
         // TODO: We should be able to go up ramps even if we can't climb stairs.
@@ -536,14 +535,14 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                 continue;
             }
             tripoint_bub_ms dest( opt_dest.value() );
-            if( vertical_move_destination( *this, ter_furn_flag::TFLAG_GOES_UP, dest ) ) {
+            if( vertical_move_destination( *this, ter_furn_flag::TFLAG_GOES_UP, dest.raw() ) ) {
                 if( !inbounds( dest ) ) {
                     continue;
                 }
                 path_data_layer &layer = pf.get_layer( dest.z() );
                 pf.add_point( layer.gscore[parent_index] + 2,
                               layer.score[parent_index] + 2 * rl_dist( dest, t ),
-                              cur, dest );
+                              cur.raw(), dest.raw() );
             }
         }
         if( settings.allow_climb_stairs && cur.z() < max.z() &&
@@ -554,14 +553,14 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                 continue;
             }
             tripoint_bub_ms dest( opt_dest.value() );
-            if( vertical_move_destination( *this, ter_furn_flag::TFLAG_GOES_DOWN, dest ) ) {
+            if( vertical_move_destination( *this, ter_furn_flag::TFLAG_GOES_DOWN, dest.raw() ) ) {
                 if( !inbounds( dest ) ) {
                     continue;
                 }
                 path_data_layer &layer = pf.get_layer( dest.z() );
                 pf.add_point( layer.gscore[parent_index] + 2,
                               layer.score[parent_index] + 2 * rl_dist( dest, t ),
-                              cur, dest );
+                              cur.raw(), dest.raw() );
             }
         }
         if( cur.z() < max.z() && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP ) &&
@@ -574,7 +573,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
                               layer.score[parent_index] + 4 + 2 * rl_dist( above, t ),
-                              cur, above );
+                              cur.raw(), above.raw() );
             }
         }
         if( cur.z() < max.z() && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_UP ) &&
@@ -587,7 +586,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
                               layer.score[parent_index] + 4 + 2 * rl_dist( above, t ),
-                              cur, above );
+                              cur.raw(), above.raw() );
             }
         }
         if( cur.z() > min.z() && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN ) &&
@@ -600,7 +599,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
                               layer.score[parent_index] + 4 + 2 * rl_dist( below, t ),
-                              cur, below );
+                              cur.raw(), below.raw() );
             }
         }
 
@@ -611,7 +610,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
         tripoint_bub_ms cur = t;
         // Just to limit max distance, in case something weird happens
         for( int fdist = max_length; fdist != 0; fdist-- ) {
-            const int cur_index = flat_index( cur.xy() );
+            const int cur_index = flat_index( cur.raw().xy() );
             const path_data_layer &layer = pf.get_layer( cur.z() );
             const tripoint_bub_ms &par = tripoint_bub_ms( layer.parent[cur_index] );
             if( cur == f ) {

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -83,7 +83,7 @@ SDL_Texture_Ptr create_cache_texture( const SDL_Renderer_Ptr &renderer, int tile
                           tile_height );
 }
 
-SDL_Color get_map_color_at( const tripoint_bub_ms &p )
+SDL_Color get_map_color_at( const tripoint &p )
 {
     const map &here = get_map();
     if( const optional_vpart_position vp = here.veh_at( p ) ) {
@@ -226,12 +226,11 @@ void pixel_minimap::set_settings( const pixel_minimap_settings &settings )
     reset();
 }
 
-void pixel_minimap::prepare_cache_for_updates( const tripoint_bub_ms &center )
+void pixel_minimap::prepare_cache_for_updates( const tripoint &center )
 {
-    const tripoint_abs_sm new_center_sm = get_map().get_abs_sub() + rebase_rel(
-            coords::project_to<coords::sm>
-            ( center ) );
-    const tripoint_rel_sm center_sm_diff = cached_center_sm - new_center_sm;
+    const tripoint_abs_sm new_center_sm = get_map().get_abs_sub() + coords::project_to<coords::sm>
+                                          ( tripoint_bub_ms( center ) ).raw();
+    const tripoint_rel_sm center_sm_diff = tripoint_abs_sm( cached_center_sm ) - new_center_sm;
 
     //invalidate the cache if the game shifted more than one submap in the last update, or if z-level changed.
     if( std::abs( center_sm_diff.x() ) > 1 ||
@@ -244,7 +243,7 @@ void pixel_minimap::prepare_cache_for_updates( const tripoint_bub_ms &center )
         }
     }
 
-    cached_center_sm = new_center_sm;
+    cached_center_sm = new_center_sm.raw();
 }
 
 //deletes the mapping of unused submap caches from the main map
@@ -301,21 +300,22 @@ void pixel_minimap::flush_cache_updates()
     }
 }
 
-void pixel_minimap::update_cache_at( const tripoint_bub_sm &sm_pos )
+void pixel_minimap::update_cache_at( const tripoint &sm_pos )
 {
     const map &here = get_map();
-    const level_cache &access_cache = here.access_cache( sm_pos.z() );
+    const level_cache &access_cache = here.access_cache( sm_pos.z );
     const bool nv_goggle = get_player_character().get_vision_modes()[NV_GOGGLES];
 
-    submap_cache &cache_item = get_cache_at( here.get_abs_sub() + rebase_rel( sm_pos ) );
-    const tripoint_bub_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
+    // TODO: fix point types
+    submap_cache &cache_item = get_cache_at( here.get_abs_sub().raw() + sm_pos );
+    const tripoint_bub_ms ms_pos = coords::project_to<coords::ms>( tripoint_bub_sm( sm_pos ) );
 
     cache_item.touched = true;
 
     for( int y = 0; y < SEEY; ++y ) {
         for( int x = 0; x < SEEX; ++x ) {
-            const tripoint_bub_ms p = ms_pos + tripoint{x, y, 0};
-            const lit_level lighting = access_cache.visibility_cache[p.x()][p.y()];
+            const tripoint p = ms_pos.raw() + tripoint{x, y, 0};
+            const lit_level lighting = access_cache.visibility_cache[p.x][p.y];
 
             SDL_Color color;
 
@@ -349,7 +349,7 @@ void pixel_minimap::update_cache_at( const tripoint_bub_sm &sm_pos )
     }
 }
 
-pixel_minimap::submap_cache &pixel_minimap::get_cache_at( const tripoint_abs_sm &abs_sm_pos )
+pixel_minimap::submap_cache &pixel_minimap::get_cache_at( const tripoint &abs_sm_pos )
 {
     auto it = cache.find( abs_sm_pos );
 
@@ -360,13 +360,13 @@ pixel_minimap::submap_cache &pixel_minimap::get_cache_at( const tripoint_abs_sm 
     return it->second;
 }
 
-void pixel_minimap::process_cache( const tripoint_bub_ms &center )
+void pixel_minimap::process_cache( const tripoint &center )
 {
     prepare_cache_for_updates( center );
 
     for( int y = 0; y < MAPSIZE; ++y ) {
         for( int x = 0; x < MAPSIZE; ++x ) {
-            update_cache_at( { x, y, center.z()} );
+            update_cache_at( { x, y, center.z } );
         }
     }
 
@@ -436,7 +436,7 @@ void pixel_minimap::reset()
     tex_pool.reset();
 }
 
-void pixel_minimap::render( const tripoint_bub_ms &center )
+void pixel_minimap::render( const tripoint &center )
 {
     SetRenderTarget( renderer, main_tex );
     SetRenderDrawColor( renderer, pixel_minimap_r, pixel_minimap_g, pixel_minimap_b, pixel_minimap_a );
@@ -451,48 +451,48 @@ void pixel_minimap::render( const tripoint_bub_ms &center )
     RenderCopy( renderer, main_tex, &main_tex_clip_rect, &screen_clip_rect );
 }
 
-void pixel_minimap::render_cache( const tripoint_bub_ms &center )
+void pixel_minimap::render_cache( const tripoint &center )
 {
-    const tripoint_abs_sm sm_center = get_map().get_abs_sub() + rebase_rel(
-                                          coords::project_to<coords::sm>
-                                          ( center ) );
+    // TODO: fix point types
+    const tripoint_abs_sm sm_center = get_map().get_abs_sub() + coords::project_to<coords::sm>
+                                      ( tripoint_bub_ms( center ) ).raw();
     const tripoint_rel_sm sm_offset {
         total_tiles_count.x / SEEX / 2,
         total_tiles_count.y / SEEY / 2, 0
     };
 
-    point_rel_ms ms_offset;
+    point ms_offset;
     tripoint_bub_sm quotient;
     point_sm_ms remainder;
-    std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( center );
+    std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( tripoint_bub_ms( center ) );
 
-    point_sm_ms ms_base_offset = point_sm_ms( ( total_tiles_count.x / 2 ) % SEEX,
-                                 ( total_tiles_count.y / 2 ) % SEEY );
-    ms_offset = ms_base_offset - remainder;
+    point ms_base_offset = point( ( total_tiles_count.x / 2 ) % SEEX,
+                                  ( total_tiles_count.y / 2 ) % SEEY );
+    ms_offset = ms_base_offset - remainder.raw();
 
     for( const auto &elem : cache ) {
         if( !elem.second.touched ) {
             continue;   // What you gonna do with all that junk?
         }
 
-        const tripoint_rel_sm rel_pos = elem.first - sm_center;
+        const tripoint rel_pos = elem.first - sm_center.raw();
 
-        if( std::abs( rel_pos.x() ) > sm_offset.x() + 1 ||
-            std::abs( rel_pos.y() ) > sm_offset.y() + 1 ||
-            rel_pos.z() != 0 ) {
+        if( std::abs( rel_pos.x ) > sm_offset.x() + 1 ||
+            std::abs( rel_pos.y ) > sm_offset.y() + 1 ||
+            rel_pos.z != 0 ) {
             continue;
         }
 
         const tripoint_rel_sm sm_pos = tripoint_rel_sm( rel_pos ) + sm_offset;
-        const tripoint_rel_ms ms_pos = coords::project_to<coords::ms>( sm_pos ) + ms_offset;
+        const tripoint ms_pos = coords::project_to<coords::ms>( sm_pos ).raw() + ms_offset;
 
-        const SDL_Rect chunk_rect = projector->get_chunk_rect( ms_pos.xy().raw(), {SEEX, SEEY} );
+        const SDL_Rect chunk_rect = projector->get_chunk_rect( ms_pos.xy(), { SEEX, SEEY } );
 
         RenderCopy( renderer, elem.second.chunk_tex, nullptr, &chunk_rect );
     }
 }
 
-void pixel_minimap::render_critters( const tripoint_bub_ms &center )
+void pixel_minimap::render_critters( const tripoint &center )
 {
     //handles the enemy faction red highlights
     //this value should be divisible by 200
@@ -510,10 +510,9 @@ void pixel_minimap::render_critters( const tripoint_bub_ms &center )
     }
 
     const map &m = get_map();
-    const level_cache &access_cache = m.access_cache( center.z() );
+    const level_cache &access_cache = m.access_cache( center.z );
 
-    const point_rel_ms start( center.x() - total_tiles_count.x / 2,
-                              center.y() - total_tiles_count.y / 2 );
+    const point start( center.x - total_tiles_count.x / 2, center.y - total_tiles_count.y / 2 );
     const point beacon_size = {
         std::max<int>( projector->get_tile_size().x *settings.beacon_size / 2, 2 ),
         std::max<int>( projector->get_tile_size().y *settings.beacon_size / 2, 2 )
@@ -522,7 +521,7 @@ void pixel_minimap::render_critters( const tripoint_bub_ms &center )
     creature_tracker &creatures = get_creature_tracker();
     for( int y = 0; y < total_tiles_count.y; y++ ) {
         for( int x = 0; x < total_tiles_count.x; x++ ) {
-            const tripoint_bub_ms p = start + tripoint_bub_ms( x, y, center.z() );
+            const tripoint_bub_ms p = start + tripoint_bub_ms( x, y, center.z );
             if( !m.inbounds( p ) ) {
                 // p might be out-of-bounds when peeking at submap boundary. Example: center=(64,59,-5), start=(4,-1) -> p=(4,-1,-5)
                 continue;
@@ -560,8 +559,8 @@ void pixel_minimap::draw( const SDL_Rect &screen_rect, const tripoint_bub_ms &ce
     }
 
     set_screen_rect( screen_rect );
-    process_cache( center );
-    render( center );
+    process_cache( center.raw() );
+    render( center.raw() );
 }
 
 void pixel_minimap::draw_beacon( const SDL_Rect &rect, const SDL_Color &color )

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -5,7 +5,7 @@
 #include <map>
 #include <memory>
 
-#include "coordinates.h"
+#include "coords_fwd.h"
 #include "point.h"
 #include "sdl_wrappers.h"
 #include "sdl_geometry.h"
@@ -46,23 +46,23 @@ class pixel_minimap
     private:
         struct submap_cache;
 
-        submap_cache &get_cache_at( const tripoint_abs_sm &abs_sm_pos );
+        submap_cache &get_cache_at( const tripoint &abs_sm_pos );
 
         void set_screen_rect( const SDL_Rect &screen_rect );
         void reset();
 
         void draw_beacon( const SDL_Rect &rect, const SDL_Color &color );
 
-        void process_cache( const tripoint_bub_ms &center );
+        void process_cache( const tripoint &center );
 
         void flush_cache_updates();
-        void update_cache_at( const tripoint_bub_sm &pos );
-        void prepare_cache_for_updates( const tripoint_bub_ms &center );
+        void update_cache_at( const tripoint &pos );
+        void prepare_cache_for_updates( const tripoint &center );
         void clear_unused_cache();
 
-        void render( const tripoint_bub_ms &center );
-        void render_cache( const tripoint_bub_ms &center );
-        void render_critters( const tripoint_bub_ms &center );
+        void render( const tripoint &center );
+        void render_cache( const tripoint &center );
+        void render_critters( const tripoint &center );
 
         std::unique_ptr<pixel_minimap_projector> create_projector( const SDL_Rect &max_screen_rect ) const;
 
@@ -75,7 +75,7 @@ class pixel_minimap
         point pixel_size;
 
         //track the previous viewing area to determine if the minimap cache needs to be cleared
-        tripoint_abs_sm cached_center_sm;
+        tripoint cached_center_sm;
 
         SDL_Rect screen_rect;
         SDL_Rect main_tex_clip_rect;
@@ -89,7 +89,7 @@ class pixel_minimap
         class shared_texture_pool;
         std::unique_ptr<shared_texture_pool> tex_pool;
 
-        std::map<tripoint_abs_sm, submap_cache> cache;
+        std::map<tripoint, submap_cache> cache;
 };
 
 #endif // CATA_SRC_PIXEL_MINIMAP_H

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -218,11 +218,10 @@ static void deserialize( weak_ptr_fast<monster> &obj, const JsonObject &data )
     //    }
 }
 
-static tripoint_bub_ms read_legacy_creature_pos( const JsonObject &data )
+static tripoint read_legacy_creature_pos( const JsonObject &data )
 {
-    tripoint_bub_ms pos;
-    if( !data.read( "posx", pos.x() ) || !data.read( "posy", pos.y() ) ||
-        !data.read( "posz", pos.z() ) ) {
+    tripoint pos;
+    if( !data.read( "posx", pos.x ) || !data.read( "posy", pos.y ) || !data.read( "posz", pos.z ) ) {
         debugmsg( R"(Bad Creature JSON: neither "location" nor "posx", "posy", "posz" found)" );
     }
     return pos;
@@ -2060,15 +2059,15 @@ void npc::load( const JsonObject &data )
     if( !data.has_member( "location" ) ) {
         point submap_coords;
         data.read( "submap_coords", submap_coords );
-        const tripoint_bub_ms pos = read_legacy_creature_pos( data );
+        const tripoint pos = read_legacy_creature_pos( data );
         set_location( tripoint_abs_ms( project_to<coords::ms>( point_abs_sm( submap_coords ) ),
-                                       0 ) + tripoint( pos.x() % SEEX, pos.y() % SEEY, pos.z() ) );
-        std::optional<tripoint_bub_ms> opt;
+                                       0 ) + tripoint( pos.x % SEEX, pos.y % SEEY, pos.z ) );
+        std::optional<tripoint> opt;
         if( data.read( "last_player_seen_pos", opt ) && opt ) {
-            last_player_seen_pos = get_location() + ( *opt - pos );
+            last_player_seen_pos = get_location() + *opt - pos;
         }
         if( data.read( "pulp_location", opt ) && opt ) {
-            pulp_location = get_location() + ( *opt - pos );
+            pulp_location = get_location() + *opt - pos;
         }
         tripoint tmp;
         if( data.read( "guardx", tmp.x ) && data.read( "guardy", tmp.y ) && data.read( "guardz", tmp.z ) &&
@@ -2435,10 +2434,10 @@ void monster::load( const JsonObject &data )
     // TEMPORARY until 0.G
     if( !data.has_member( "location" ) ) {
         set_location( get_map().getglobal( read_legacy_creature_pos( data ) ) );
-        tripoint_bub_ms wand;
-        data.read( "wandx", wand.x() );
-        data.read( "wandy", wand.y() );
-        data.read( "wandz", wand.z() );
+        tripoint wand;
+        data.read( "wandx", wand.x );
+        data.read( "wandy", wand.y );
+        data.read( "wandz", wand.z );
         wander_pos = get_map().getglobal( wand );
         tripoint destination;
         data.read( "destination", destination );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -617,7 +617,7 @@ void veh_app_interact::populate_app_actions()
 
     /*************** Get part-specific actions ***************/
     veh_menu menu( veh, "IF YOU SEE THIS IT IS A BUG" );
-    veh->build_interact_menu( menu, veh->mount_to_tripoint( a_point ), false );
+    veh->build_interact_menu( menu, veh->mount_to_tripoint( a_point ).raw(), false );
     const std::vector<veh_menu_item> items = menu.get_items();
     for( size_t i = 0; i < items.size(); i++ ) {
         const veh_menu_item &it = items[i];

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2160,7 +2160,8 @@ class vehicle
 
         void build_electronics_menu( veh_menu &menu );
         void build_bike_rack_menu( veh_menu &menu, int part );
-        void build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, bool with_pickup );
+        // TODO: Make it typed. One call uses bubble coordinates, the other untyped veh_app_interact::a_point
+        void build_interact_menu( veh_menu &menu, const tripoint &p, bool with_pickup );
         void interact_with( const tripoint_bub_ms &p, bool with_pickup = false );
 
         std::string disp_name() const;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1825,7 +1825,7 @@ bool vehicle::use_vehicle_tool( vehicle &veh, const tripoint_bub_ms &vp_pos,
     return true;
 }
 
-void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, bool with_pickup )
+void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_pickup )
 {
     const optional_vpart_position ovp = get_map().veh_at( p );
     if( !ovp ) {
@@ -2448,6 +2448,6 @@ void vehicle::interact_with( const tripoint_bub_ms &p, bool with_pickup )
     veh_menu menu( *this, _( "Select an action" ) );
     do {
         menu.reset();
-        build_interact_menu( menu, p, with_pickup );
+        build_interact_menu( menu, p.raw(), with_pickup );
     } while( menu.query() );
 }

--- a/tests/degradation_test.cpp
+++ b/tests/degradation_test.cpp
@@ -268,7 +268,7 @@ TEST_CASE( "Repairing_degraded_items", "[item][degradation]" )
     // Setup map
     clear_map();
     set_time_to_day();
-    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos ) ) > 2 );
+    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos.raw() ) ) > 2 );
 
     GIVEN( "Item with normal degradation" ) {
         Character &u = get_player_character();
@@ -663,7 +663,7 @@ TEST_CASE( "refit_item_inside_spillable_container", "[item][repair][container]" 
     clear_avatar();
     clear_map();
     set_time_to_day();
-    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos ) ) > 2 );
+    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos.raw() ) ) > 2 );
 
     Character &u = get_player_character();
     u.set_skill_level( skill_tailor, 10 );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -29,10 +29,8 @@ TEST_CASE( "map_coordinate_conversion_functions" )
         here.vertical_shift( 0 );
     } );
 
-    tripoint_bub_ms test_point =
-        GENERATE( tripoint_bub_ms::zero, tripoint_bub_ms::zero + tripoint::south,
-                  tripoint_bub_ms::zero + tripoint::east, tripoint_bub_ms::zero + tripoint::above,
-                  tripoint_bub_ms::zero + tripoint::below );
+    tripoint test_point =
+        GENERATE( tripoint::zero, tripoint::south, tripoint::east, tripoint::above, tripoint::below );
     tripoint_bub_ms test_bub( test_point );
     int z = GENERATE( 0, 1, -1, OVERMAP_HEIGHT, -OVERMAP_DEPTH );
 
@@ -53,7 +51,7 @@ TEST_CASE( "map_coordinate_conversion_functions" )
 
     point_abs_ms map_origin_ms = project_to<coords::ms>( here.get_abs_sub().xy() );
 
-    tripoint_abs_ms test_abs = map_origin_ms + rebase_rel( test_point );
+    tripoint_abs_ms test_abs = map_origin_ms + test_point;
 
     if( test_abs.z() > OVERMAP_HEIGHT || test_abs.z() < -OVERMAP_DEPTH ) {
         return;
@@ -64,7 +62,7 @@ TEST_CASE( "map_coordinate_conversion_functions" )
 
     // Verify round-tripping
     CHECK( here.getglobal( here.bub_from_abs( test_abs ) ) == test_abs );
-    CHECK( here.bub_from_abs( here.getglobal( test_point ) ) == test_point );
+    CHECK( here.bub_from_abs( here.getglobal( test_point ) ).raw() == test_point );
 }
 
 TEST_CASE( "destroy_grabbed_furniture" )

--- a/tests/mapgen_remove_npcs_test.cpp
+++ b/tests/mapgen_remove_npcs_test.cpp
@@ -19,7 +19,7 @@ static const update_mapgen_id update_mapgen_test_update_remove_npc( "test_update
 namespace
 {
 
-void check_creature( tripoint_bub_ms const &loc, string_id<npc_template> const &id, bool state )
+void check_creature( tripoint const &loc, string_id<npc_template> const &id, bool state )
 {
     Creature *critter = get_creature_tracker().creature_at( loc, true );
     if( state ) {
@@ -30,7 +30,7 @@ void check_creature( tripoint_bub_ms const &loc, string_id<npc_template> const &
     }
 }
 
-void place_npc_and_check( map &m, tripoint_bub_ms const &loc, update_mapgen_id const &id,
+void place_npc_and_check( map &m, tripoint const &loc, update_mapgen_id const &id,
                           string_id<npc_template> const &nid )
 {
     check_creature( loc, nid, false );
@@ -40,7 +40,7 @@ void place_npc_and_check( map &m, tripoint_bub_ms const &loc, update_mapgen_id c
     g->mon_info_update();
 }
 
-void remove_npc_and_check( map &m, tripoint_bub_ms const &loc, update_mapgen_id const &id,
+void remove_npc_and_check( map &m, tripoint const &loc, update_mapgen_id const &id,
                            string_id<npc_template> const &nid )
 {
     check_creature( loc, nid, true );
@@ -74,16 +74,16 @@ TEST_CASE( "mapgen_remove_npcs" )
         tripoint_bub_ms const loc2 = here.bub_from_abs( project_to<coords::ms>( omt2 ) );
         tripoint_bub_ms const loc3 = loc2 + tripoint::east;
         REQUIRE( get_map().inbounds( loc ) );
-        place_npc_and_check( here, loc, update_mapgen_test_update_place_npc,
+        place_npc_and_check( here, loc.raw(), update_mapgen_test_update_place_npc,
                              npc_template_test_npc_trader );
         REQUIRE( overmap_buffer.get_npcs_near_omt( omt, 0 ).size() == 1 );
-        place_npc_and_check( here, loc2, update_mapgen_test_update_place_npc,
+        place_npc_and_check( here, loc2.raw(), update_mapgen_test_update_place_npc,
                              npc_template_test_npc_trader );
         REQUIRE( overmap_buffer.get_npcs_near_omt( omt2, 0 ).size() == 1 );
         REQUIRE( get_avatar().sees( loc, true ) );
 
         WHEN( "removing NPC" ) {
-            remove_npc_and_check( here, loc, update_mapgen_test_update_remove_npc,
+            remove_npc_and_check( here, loc.raw(), update_mapgen_test_update_remove_npc,
                                   npc_template_test_npc_trader );
             THEN( "NPC of same class on different submap not affected" ) {
                 REQUIRE( overmap_buffer.get_npcs_near_omt( omt, 0 ).empty() );
@@ -91,13 +91,13 @@ TEST_CASE( "mapgen_remove_npcs" )
             }
 
             THEN( "NPC of different class on same submap not affected" ) {
-                place_npc_and_check( here, loc3, update_mapgen_test_update_place_npc_thug,
+                place_npc_and_check( here, loc3.raw(), update_mapgen_test_update_place_npc_thug,
                                      npc_template_thug );
                 REQUIRE( overmap_buffer.get_npcs_near_omt( omt2, 0 ).size() == 2 );
-                remove_npc_and_check( here, loc2, update_mapgen_test_update_remove_npc,
+                remove_npc_and_check( here, loc2.raw(), update_mapgen_test_update_remove_npc,
                                       npc_template_test_npc_trader );
                 REQUIRE( overmap_buffer.get_npcs_near_omt( omt2, 0 ).size() == 1 );
-                check_creature( loc3, npc_template_thug, true );
+                check_creature( loc3.raw(), npc_template_thug, true );
             }
         }
     }

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -240,7 +240,7 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
     for( int i = 0; i < water_charges; i++ ) {
         CAPTURE( i, veh.fuel_left( itype_water_clean ) );
         menu.reset();
-        veh.build_interact_menu( menu, faucet->pos_bub(), false );
+        veh.build_interact_menu( menu, faucet->pos_bub().raw(), false );
         const std::vector<veh_menu_item> items = menu.get_items();
         const bool stomach_should_be_full = i == water_charges - 1;
         const auto drink_item_it = std::find_if( items.begin(), items.end(),


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

#79106 seems to have introduced ASan failure. See failed runs 
- in the PR itself https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12734142857/job/35491383881
- my, unrelated code: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12737041610/job/35502236262
- my, different unrelated code: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12737253216/job/35499182096
- not mine, json only change  https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12739638961/job/35503637305

The timing is suspicious (the failures started happening rouhgly after #79106 got merged), and the errors have `map_test.cpp` in them, which is vaguely related to what #79106  was doing.

The error itself is rather cryptic and I don't think this helps, but I'll add it here for posterity:
<details>

```
=================================================================
(~[slow] ~[.],starting_items)=> ==7357==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffdd8770030 at pc 0x000002580c27 bp 0x7ffdd876fef0 sp 0x7ffdd876f6b8
(~[slow] ~[.],starting_items)=> READ of size 12 at 0x7ffdd8770030 thread T0
(~[slow] ~[.],starting_items)=>     #0 0x2580c26 in __asan_memcpy (/home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/cata_test+0x2580c26)
(~[slow] ~[.],starting_items)=>     #1 0x33c6f94 in ____C_A_T_C_H____T_E_S_T____0() /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/../tests/map_test.cpp:33:9
(~[slow] ~[.],starting_items)=>     #2 0x3d0d33a in Catch::TestCase::invoke() const /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/./catch/catch.hpp:14137:15
(~[slow] ~[.],starting_items)=>     #3 0x3d0d33a in Catch::RunContext::invokeActiveTestCase() /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/./catch/catch.hpp:12997:27
(~[slow] ~[.],starting_items)=>     #4 0x3d09441 in Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/./catch/catch.hpp:12970:17
(~[slow] ~[.],starting_items)=>     #5 0x3d0791c in Catch::RunContext::runTest(Catch::TestCase const&) /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/./catch/catch.hpp:12731:13
(~[slow] ~[.],starting_items)=>     #6 0x3d14fd6 in Catch::(anonymous namespace)::TestGroup::execute() /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/./catch/catch.hpp:13324:45
(~[slow] ~[.],starting_items)=>     #7 0x3d14fd6 in Catch::Session::runInternal() /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/./catch/catch.hpp:13530:39
(~[slow] ~[.],starting_items)=>     #8 0x3d135c9 in Catch::Session::run() /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/./catch/catch.hpp:13486:24
(~[slow] ~[.],starting_items)=>     #9 0x3d4cd48 in main /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/../tests/test_main.cpp:420:26
(~[slow] ~[.],starting_items)=>     #10 0x7f1ed2829d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
(~[slow] ~[.],starting_items)=>     #11 0x7f1ed2829e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f)
(~[slow] ~[.],starting_items)=>     #12 0x25069b4 in _start (/home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/cata_test+0x25069b4)
(~[slow] ~[.],starting_items)=> 
(~[slow] ~[.],starting_items)=> Address 0x7ffdd8770030 is located in stack of thread T0 at offset 304 in frame
(~[slow] ~[.],starting_items)=>     #0 0x33c670f in ____C_A_T_C_H____T_E_S_T____0() /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/../tests/map_test.cpp:25
(~[slow] ~[.],starting_items)=> 
(~[slow] ~[.],starting_items)=>   This frame has 74 object(s):
(~[slow] ~[.],starting_items)=>     [32, 48) 'agg.tmp.i533'
(~[slow] ~[.],starting_items)=>     [64, 80) 'agg.tmp.i523'
(~[slow] ~[.],starting_items)=>     [96, 112) 'agg.tmp.i'
(~[slow] ~[.],starting_items)=>     [128, 132) 'ref.tmp.i.i457' (line 37)
(~[slow] ~[.],starting_items)=>     [144, 148) 'ref.tmp2.i.i' (line 37)
(~[slow] ~[.],starting_items)=>     [160, 164) 'ref.tmp3.i.i' (line 37)
(~[slow] ~[.],starting_items)=>     [176, 180) 'ref.tmp4.i.i458' (line 37)
(~[slow] ~[.],starting_items)=>     [192, 200) 'ref.tmp.i459'
(~[slow] ~[.],starting_items)=>     [224, 264) 'ref.tmp3.i460'
(~[slow] ~[.],starting_items)=>     [304, 316) 'ref.tmp.i.i' (line 33) <== Memory access at offset 304 is inside this variable
(~[slow] ~[.],starting_items)=>     [336, 348) 'ref.tmp4.i.i' (line 33)
(~[slow] ~[.],starting_items)=>     [368, 380) 'ref.tmp10.i.i' (line 33)
(~[slow] ~[.],starting_items)=>     [400, 412) 'ref.tmp16.i.i' (line 33)
(~[slow] ~[.],starting_items)=>     [432, 440) 'ref.tmp.i'
(~[slow] ~[.],starting_items)=>     [464, 504) 'ref.tmp3.i'
(~[slow] ~[.],starting_items)=>     [544, 576) 'restore_vertical_shift' (line 28)
(~[slow] ~[.],starting_items)=>     [608, 640) 'ref.tmp' (line 28)
(~[slow] ~[.],starting_items)=>     [672, 684) 'test_point' (line 32)
(~[slow] ~[.],starting_items)=>     [704, 720) 'agg.tmp'
(~[slow] ~[.],starting_items)=>     [736, 752) 'ref.tmp2' (line 33)
(~[slow] ~[.],starting_items)=>     [768, 780) 'test_bub' (line 36)
(~[slow] ~[.],starting_items)=>     [800, 804) 'z' (line 37)
(~[slow] ~[.],starting_items)=>     [816, 832) 'agg.tmp7'
(~[slow] ~[.],starting_items)=>     [848, 864) 'ref.tmp8' (line 37)
(~[slow] ~[.],starting_items)=>     [880, 920) 'capturer4' (line 48)
(~[slow] ~[.],starting_items)=>     [960, 976) 'agg.tmp38'
(~[slow] ~[.],starting_items)=>     [992, 1008) 'ref.tmp39' (line 48)
(~[slow] ~[.],starting_items)=>     [1024, 1040) 'agg.tmp40'
(~[slow] ~[.],starting_items)=>     [1056, 1068) 'ref.tmp43' (line 48)
(~[slow] ~[.],starting_items)=>     [1088, 1160) 'catchAssertionHandler' (line 50)
(~[slow] ~[.],starting_items)=>     [1200, 1216) 'ref.tmp52' (line 50)
(~[slow] ~[.],starting_items)=>     [1232, 1248) 'ref.tmp54' (line 50)
(~[slow] ~[.],starting_items)=>     [1264, 1280) 'agg.tmp55'
(~[slow] ~[.],starting_items)=>     [1296, 1344) 'ref.tmp58' (line 50)
(~[slow] ~[.],starting_items)=>     [1376, 1388) 'ref.tmp61' (line 50)
(~[slow] ~[.],starting_items)=>     [1408, 1412) 'ref.tmp74' (line 50)
(~[slow] ~[.],starting_items)=>     [1424, 1496) 'catchAssertionHandler93' (line 51)
(~[slow] ~[.],starting_items)=>     [1536, 1552) 'ref.tmp94' (line 51)
(~[slow] ~[.],starting_items)=>     [1568, 1584) 'ref.tmp96' (line 51)
(~[slow] ~[.],starting_items)=>     [1600, 1616) 'agg.tmp97'
(~[slow] ~[.],starting_items)=>     [1632, 1680) 'ref.tmp102' (line 51)
(~[slow] ~[.],starting_items)=>     [1712, 1724) 'ref.tmp105' (line 51)
(~[slow] ~[.],starting_items)=>     [1744, 1748) 'ref.tmp118' (line 51)
(~[slow] ~[.],starting_items)=>     [1760, 1832) 'catchAssertionHandler144' (line 52)
(~[slow] ~[.],starting_items)=>     [1872, 1888) 'ref.tmp145' (line 52)
(~[slow] ~[.],starting_items)=>     [1904, 1920) 'ref.tmp147' (line 52)
(~[slow] ~[.],starting_items)=>     [1936, 1952) 'agg.tmp148'
(~[slow] ~[.],starting_items)=>     [1968, 2016) 'ref.tmp153' (line 52)
(~[slow] ~[.],starting_items)=>     [2048, 2060) 'ref.tmp156' (line 52)
(~[slow] ~[.],starting_items)=>     [2080, 2092) 'test_abs' (line 56)
(~[slow] ~[.],starting_items)=>     [2112, 2152) 'capturer5' (line 62)
(~[slow] ~[.],starting_items)=>     [2192, 2208) 'agg.tmp239'
(~[slow] ~[.],starting_items)=>     [2224, 2240) 'ref.tmp240' (line 62)
(~[slow] ~[.],starting_items)=>     [2256, 2272) 'agg.tmp241'
(~[slow] ~[.],starting_items)=>     [2288, 2328) 'capturer6' (line 63)
(~[slow] ~[.],starting_items)=>     [2368, 2384) 'agg.tmp247'
(~[slow] ~[.],starting_items)=>     [2400, 2416) 'ref.tmp248' (line 63)
(~[slow] ~[.],starting_items)=>     [2432, 2448) 'agg.tmp249'
(~[slow] ~[.],starting_items)=>     [2464, 2536) 'catchAssertionHandler256' (line 66)
(~[slow] ~[.],starting_items)=>     [2576, 2592) 'ref.tmp257' (line 66)
(~[slow] ~[.],starting_items)=>     [2608, 2624) 'ref.tmp259' (line 66)
(~[slow] ~[.],starting_items)=>     [2640, 2656) 'agg.tmp260'
(~[slow] ~[.],starting_items)=>     [2672, 2720) 'ref.tmp265' (line 66)
(~[slow] ~[.],starting_items)=>     [2752, 2760) 'ref.tmp266' (line 66)
(~[slow] ~[.],starting_items)=>     [2784, 2796) 'ref.tmp268' (line 66)
(~[slow] ~[.],starting_items)=>     [2816, 2828) 'ref.tmp269' (line 66)
(~[slow] ~[.],starting_items)=>     [2848, 2920) 'catchAssertionHandler310' (line 67)
(~[slow] ~[.],starting_items)=>     [2960, 2976) 'ref.tmp311' (line 67)
(~[slow] ~[.],starting_items)=>     [2992, 3008) 'ref.tmp313' (line 67)
(~[slow] ~[.],starting_items)=>     [3024, 3040) 'agg.tmp314'
(~[slow] ~[.],starting_items)=>     [3056, 3104) 'ref.tmp319' (line 67)
(~[slow] ~[.],starting_items)=>     [3136, 3144) 'ref.tmp320' (line 67)
(~[slow] ~[.],starting_items)=>     [3168, 3180) 'ref.tmp322' (line 67)
(~[slow] ~[.],starting_items)=>     [3200, 3212) 'ref.tmp323' (line 67)
(~[slow] ~[.],starting_items)=> HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
(~[slow] ~[.],starting_items)=>       (longjmp and C++ exceptions *are* supported)
(~[slow] ~[.],starting_items)=> SUMMARY: AddressSanitizer: stack-use-after-scope (/home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/cata_test+0x2580c26) in __asan_memcpy
(~[slow] ~[.],starting_items)=> Shadow bytes around the buggy address:
(~[slow] ~[.],starting_items)=>   0x10003b0e5fb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
(~[slow] ~[.],starting_items)=>   0x10003b0e5fc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
(~[slow] ~[.],starting_items)=>   0x10003b0e5fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
(~[slow] ~[.],starting_items)=>   0x10003b0e5fe0: f1 f1 f1 f1 f8 f8 f2 f2 f8 f8 f2 f2 f8 f8 f2 f2
(~[slow] ~[.],starting_items)=>   0x10003b0e5ff0: f8 f2 f8 f2 f8 f2 f8 f2 f8 f2 f2 f2 f8 f8 f8 f8
(~[slow] ~[.],starting_items)=> =>0x10003b0e6000: f8 f2 f2 f2 f2 f2[f8]f8 f2 f2 f8 f8 f2 f2 f8 f8
(~[slow] ~[.],starting_items)=>   0x10003b0e6010: f2 f2 f8 f8 f2 f2 f8 f2 f2 f2 f8 f8 f8 f8 f8 f2
(~[slow] ~[.],starting_items)=>   0x10003b0e6020: f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2 f8 f8 f8 f8
(~[slow] ~[.],starting_items)=>   0x10003b0e6030: f2 f2 f2 f2 00 04 f2 f2 00 00 f2 f2 00 00 f2 f2
(~[slow] ~[.],starting_items)=>   0x10003b0e6040: f8 f8 f2 f2 f8 f2 00 00 f2 f2 f8 f8 f2 f2 f8 f8
(~[slow] ~[.],starting_items)=>   0x10003b0e6050: f8 f8 f8 f2 f2 f2 f2 f2 00 00 f2 f2 f8 f8 f2 f2
(~[slow] ~[.],starting_items)=> Shadow byte legend (one shadow byte represents 8 application bytes):
(~[slow] ~[.],starting_items)=>   Addressable:           00
(~[slow] ~[.],starting_items)=>   Partially addressable: 01 02 03 04 05 06 07 
(~[slow] ~[.],starting_items)=>   Heap left redzone:       fa
(~[slow] ~[.],starting_items)=>   Freed heap region:       fd
(~[slow] ~[.],starting_items)=>   Stack left redzone:      f1
(~[slow] ~[.],starting_items)=>   Stack mid redzone:       f2
(~[slow] ~[.],starting_items)=>   Stack right redzone:     f3
(~[slow] ~[.],starting_items)=>   Stack after return:      f5
(~[slow] ~[.],starting_items)=>   Stack use after scope:   f8
(~[slow] ~[.],starting_items)=>   Global redzone:          f9
(~[slow] ~[.],starting_items)=>   Global init order:       f6
(~[slow] ~[.],starting_items)=>   Poisoned by user:        f7
(~[slow] ~[.],starting_items)=>   Container overflow:      fc
(~[slow] ~[.],starting_items)=>   Array cookie:            ac
(~[slow] ~[.],starting_items)=>   Intra object redzone:    bb
(~[slow] ~[.],starting_items)=>   ASan internal:           fe
(~[slow] ~[.],starting_items)=>   Left alloca redzone:     ca
(~[slow] ~[.],starting_items)=>   Right alloca redzone:    cb
(~[slow] ~[.],starting_items)=>   Shadow gap:              cc
(~[slow] ~[.],starting_items)=> ==7357==ABORTING
```

</details>

I don't think I am able to debug this, but I do believe it's valuable to revert it first in order to get CI back to mostly-green, and then reapply later when we better understand what's going on and how to fix.

#### Describe the solution
Click the Revert button on github.

#### Describe alternatives you've considered
- Try to actively fix the error, and suffer CI wrath in the meanwhile. This might mean introducing *more* breakages that get masked by already-failing CI, which is not an improvement IMO.
- Try to revert partially instead of wholesale. I feel this is not any easier tbh...

#### Testing
None.
Hopefully CI will pass.

#### Additional context
