### PR TITLE
Fix ClangBuildAnalyzer workflow

### DIFF
--- a/.github/workflows/CBA.yml
+++ b/.github/workflows/CBA.yml
@@ -29,11 +29,16 @@ jobs:
     - uses: ammaraskar/gcc-problem-matcher@master
     - name: make
       run: |
+        clang++ --version
         ClangBuildAnalyzer --start .
-        CLANG=clang++-14 CXXFLAGS=-ftime-trace make
+        CLANG=clang++ CXXFLAGS=-ftime-trace make
         ClangBuildAnalyzer --stop . buildAnalysis
     - name: Analyze
       run: ClangBuildAnalyzer --analyze buildAnalysis
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ClangBuildAnalyzer-analysis
+        path: buildAnalysis
     - uses: actions/upload-artifact@v4
       with:
         name: ClangBuildAnalyzer-traces


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Github is [bumping their runner versions](https://github.com/actions/runner-images/issues/10636), and so `ubuntu-latest` no longer has `clang-14` package, [breaking our CBA workflow](https://github.com/CleverRaven/Cataclysm-DDA/actions/workflows/CBA.yml).
This PR un-breaks it.

#### Describe the solution

Invoke unversioned `clang++` instead of specifically `clang++-14`. We don't much care about the specific compiler version in this case.

#### Describe alternatives you've considered

Pin the ubuntu image version instead of un-pinning clang version. I think my current approach is a bit more forward-compatible, but it also shouldn't really matter.

Drive-by change: upload the compiled "analysis" file as an artifact, and not just the individual traces. It should make it easier to parse the results locally (i.e. you would now be able to run `CBA --analyse analysis-filename` directly instead of needing to prepare `analysis-filename` first by doing something like.. uhh.. `CBA --start dirname && find dirname | xargs touch && CBA --stop dirname  analysis-filename && CBA --analyze analysis-filename` .

#### Testing

Slightly bastardized version of the PR in my fork: https://github.com/moxian/Cataclysm-DDA/pull/6

#### Additional context
N/A