### PR TITLE
Don't try to GENERATE typed coordinates

### DIFF
--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -29,11 +29,10 @@ TEST_CASE( "map_coordinate_conversion_functions" )
         here.vertical_shift( 0 );
     } );
 
-    tripoint test_point =
-        GENERATE( tripoint::zero, tripoint::south,
-                  tripoint::east, tripoint::above,
-                  tripoint::below );
-    tripoint_bub_ms test_bub( test_point );
+    tripoint_bub_ms test_point = tripoint_bub_ms::zero +
+                                 GENERATE( tripoint_rel_ms::zero, tripoint_rel_ms::south,
+                                           tripoint_rel_ms::east, tripoint_rel_ms::above,
+                                           tripoint_rel_ms::below );
     int z = GENERATE( 0, 1, -1, OVERMAP_HEIGHT, -OVERMAP_DEPTH );
 
     // Make sure we're not in the 'easy' case where abs_sub is zero
@@ -53,18 +52,18 @@ TEST_CASE( "map_coordinate_conversion_functions" )
 
     point_abs_ms map_origin_ms = project_to<coords::ms>( here.get_abs_sub().xy() );
 
-    tripoint_abs_ms test_abs = map_origin_ms + rebase_rel( test_bub );
+    tripoint_abs_ms test_abs = map_origin_ms + rebase_rel( test_point );
 
     if( test_abs.z() > OVERMAP_HEIGHT || test_abs.z() < -OVERMAP_DEPTH ) {
         return;
     }
 
-    CAPTURE( test_bub );
+    CAPTURE( test_point );
     CAPTURE( test_abs );
 
     // Verify round-tripping
     CHECK( here.getglobal( here.bub_from_abs( test_abs ) ) == test_abs );
-    CHECK( here.bub_from_abs( here.getglobal( test_bub ) ) == test_bub );
+    CHECK( here.bub_from_abs( here.getglobal( test_point ) ) == test_point );
 }
 
 TEST_CASE( "destroy_grabbed_furniture" )

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -29,10 +29,10 @@ TEST_CASE( "map_coordinate_conversion_functions" )
         here.vertical_shift( 0 );
     } );
 
-    tripoint_bub_ms test_point =
-        GENERATE( tripoint_bub_ms::zero, tripoint_bub_ms::zero + tripoint::south,
-                  tripoint_bub_ms::zero + tripoint::east, tripoint_bub_ms::zero + tripoint::above,
-                  tripoint_bub_ms::zero + tripoint::below );
+    tripoint test_point =
+        GENERATE( tripoint::zero, tripoint::south,
+                  tripoint::east, tripoint::above,
+                  tripoint::below );
     tripoint_bub_ms test_bub( test_point );
     int z = GENERATE( 0, 1, -1, OVERMAP_HEIGHT, -OVERMAP_DEPTH );
 
@@ -53,7 +53,7 @@ TEST_CASE( "map_coordinate_conversion_functions" )
 
     point_abs_ms map_origin_ms = project_to<coords::ms>( here.get_abs_sub().xy() );
 
-    tripoint_abs_ms test_abs = map_origin_ms + rebase_rel( test_point );
+    tripoint_abs_ms test_abs = map_origin_ms + rebase_rel( test_bub );
 
     if( test_abs.z() > OVERMAP_HEIGHT || test_abs.z() < -OVERMAP_DEPTH ) {
         return;
@@ -64,7 +64,7 @@ TEST_CASE( "map_coordinate_conversion_functions" )
 
     // Verify round-tripping
     CHECK( here.getglobal( here.bub_from_abs( test_abs ) ) == test_abs );
-    CHECK( here.bub_from_abs( here.getglobal( test_point ) ) == test_point );
+    CHECK( here.bub_from_abs( here.getglobal( test_bub ) ) == test_bub );
 }
 
 TEST_CASE( "destroy_grabbed_furniture" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Address ASAN failures to deal with #79106 test code changes. This is an alternative to #79132 that attempts to deal with the failing code rather than a total reversion of #79106. Thus, (at least) one of the two PRs should be scrapped when a decision is made.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Revert the GENERATE usage that seems to blow up in the ASAN tests and adjust the rest of the test to use test_bub instead of test_point.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Try to see if GENERATE likes tripoint_rel_ms better, but I think a reversion and not bothering about it is easier, and figuring out exactly why GENERATE + ASAN gets upset might not be worth the trouble (and delay, if that approach fails).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Has to be done by github, as I don't have the means to perform the failing test locally.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
