### PR TITLE
Move refugee center start from isolationist to its own scenario

### DIFF
--- a/data/json/mapgen/refugee_center/refugee_center.json
+++ b/data/json/mapgen/refugee_center/refugee_center.json
@@ -289,7 +289,8 @@
         { "type": "NPC_INVESTIGATE_ONLY", "faction": "lobby_beggars", "x": [ 51, 68 ], "y": [ 0, 4 ] },
         { "type": "LOOT_UNSORTED", "faction": "free_merchants", "x": [ 72, 72 ], "y": [ 0, 0 ] },
         { "type": "LOOT_CURRENCY", "faction": "free_merchants", "x": [ 71, 71 ], "y": [ 2, 2 ] },
-        { "type": "LOOT_WOOD", "faction": "free_merchants", "x": [ 71, 71 ], "y": [ 1, 1 ] }
+        { "type": "LOOT_WOOD", "faction": "free_merchants", "x": [ 71, 71 ], "y": [ 1, 1 ] },
+        { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 59, 60 ], "y": [ 10, 11 ] }
       ],
       "items": {
         "@": { "item": "bed", "chance": 80 },

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -11,6 +11,16 @@
   },
   {
     "type": "scenario",
+    "id": "refugeecenter",
+    "name": "Refugee Center",
+    "points": 0,
+    "description": "You have survived the initial wave of panic, and have made your way to a refugee center.",
+    "allowed_locs": [ "sloc_refugee_center" ],
+    "start_name": "Refugee Center",
+    "flags": [ "LONE_START" ]
+  },
+  {
+    "type": "scenario",
     "id": "friend_liam",
     "name": "Friends to the End",
     "points": -10,
@@ -143,7 +153,6 @@
     "points": 1,
     "description": "You've found a safe place away from the cities and devoid of the living dead.  Looks like you're on your own…",
     "allowed_locs": [
-      "sloc_refugee_center",
       "sloc_hermit_shack",
       "sloc_farm_survivalist",
       "sloc_cabin",

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -79,7 +79,8 @@
     "type": "start_location",
     "id": "sloc_refugee_center",
     "name": "Refugee Center",
-    "terrain": [ "evac_center_7" ]
+    "terrain": [ "evac_center_23" ],
+    "flags": [ "ALLOW_OUTSIDE" ]
   },
   {
     "type": "start_location",

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -79,7 +79,7 @@
     "type": "start_location",
     "id": "sloc_refugee_center",
     "name": "Refugee Center",
-    "terrain": [ "evac_center_23" ],
+    "terrain": [ "evac_center_18" ],
     "flags": [ "ALLOW_OUTSIDE" ]
   },
   {


### PR DESCRIPTION
#### Summary
Content "Move refugee center start from isolationist to its own scenario"

#### Purpose of change

The refugee center is a very interesting location as it opens up many of the features/content that makes this game stand out: mainly the faction system (through recruiting quest givers found at this location), the lore (by speaking to the NPCs present) and its sci-fi content (as some NPCs might tell you where NPC factions like the exodii can be found). However, it generally spawns very far away in my experience, making the trek out there feel like a daunting prospect. I wanted to alleviate this by offering a scenario to start right at the center.

#### Describe the solution

I noticed that the "Isolationist" scenario already had a Refugee center start location, but I felt it didn't make sense under that banner since starting in a room full of people is hardly Isolationist, so I moved it out to its own scenario. Additionally, I changed the terrain to spawn the player outside the entrance rather than inside a dorm because I felt it flows better if you're entering the center for the first time at the beginning of your run.

#### Describe alternatives you've considered

I considered leaving the terrain untouched so you'd start in a dorm rather than on the road. However the narrative that you're arriving at the start of the run fits better. 

I considered starting the player closer to the door- in the garden outside the door to be specific. However I kept starting behind trees or surrounded by bushes and it felt a little janky. 

#### Testing

I started 5 new games and checked if I started on the ~~road~~ path outside the front entrance each time.

#### Additional context

None.
