### PR TITLE
[Aftershock] Add human++ genemods

### DIFF
--- a/data/mods/Aftershock/mutations/human_plus.json
+++ b/data/mods/Aftershock/mutations/human_plus.json
@@ -24,7 +24,7 @@
   },
   {
     "type": "mutation",
-    "id": "AFS_HEALTH_CAPABILITY_GENEMODS",
+    "id": "AFS_HEALTH_CAPABILITY_GENEMOD",
     "name": { "str": "Genemod: Improved Health" },
     "points": 3,
     "description": "Your resistance to disease and infection, as well as your ability to recover from injuries, have been improved through genemod treatments.",
@@ -34,7 +34,7 @@
   },
   {
     "type": "mutation",
-    "id": "AFS_RECOVERY_CAPABILITY_GENEMODS",
+    "id": "AFS_RECOVERY_CAPABILITY_GENEMOD",
     "name": { "str": "Genemod: Efficient System" },
     "points": 3,
     "description": "The efficiency of your metabolic processes, from the length of your sleep cycle to losing fatigue after exercise, have been improved through genemod treatments.",
@@ -49,5 +49,14 @@
         ]
       }
     ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_BEAUTY_GENEMOD",
+    "name": { "str": "Genemod: Beauty" },
+    "points": 3,
+    "description": "Your physical appearance has been improved through genemod treatments.",
+    "enchantments": [ { "mutations": [ "BEAUTIFUL" ] } ],
+    "cancels": [ "UGLY", "DEFORMED", "DEFORMED2" ]
   }
 ]

--- a/data/mods/Aftershock/mutations/human_plus.json
+++ b/data/mods/Aftershock/mutations/human_plus.json
@@ -16,7 +16,7 @@
   {
     "type": "mutation",
     "id": "AFS_MENTAL_CAPABILITY_GENEMOD",
-    "name": { "str": "Genemod: Improved Mental Flexibilty" },
+    "name": { "str": "Genemod: Improved Mental Flexibility" },
     "points": 3,
     "cancels": [ "FORGETFUL" ],
     "description": "Your concentration and memorization abilities have been increased through genemod treatments.",

--- a/data/mods/Aftershock/mutations/human_plus.json
+++ b/data/mods/Aftershock/mutations/human_plus.json
@@ -1,0 +1,53 @@
+[
+  {
+    "type": "mutation",
+    "id": "AFS_PHYSICAL_CAPABILITY_GENEMOD",
+    "name": { "str": "Genemod: Improved Physical Capability" },
+    "points": 3,
+    "description": "Your strength, coordination, and sensory acuity have been increased through genemod treatments.",
+    "cancels": [ "MYOPIC", "HYPEROPIC", "BADHEARING" ],
+    "enchantments": [
+      {
+        "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "DEXTERITY", "add": 2 }, { "value": "PERCEPTION", "add": 2 } ]
+      }
+    ],
+    "flags": [ "IMMUNE_HEARING_DAMAGE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_MENTAL_CAPABILITY_GENEMOD",
+    "name": { "str": "Genemod: Improved Mental Flexibilty" },
+    "points": 3,
+    "cancels": [ "FORGETFUL" ],
+    "description": "Your concentration and memorization abilities have been increased through genemod treatments.",
+    "enchantments": [ { "values": [ { "value": "INTELLIGENCE", "add": 2 }, { "value": "LEARNING_FOCUS", "add": 10 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_HEALTH_CAPABILITY_GENEMODS",
+    "name": { "str": "Genemod: Improved Health" },
+    "points": 3,
+    "description": "Your resistance to disease and infection, as well as your ability to recover from injuries, have been improved through genemod treatments.",
+    "enchantments": [ { "mutations": [ "DISRESISTANT", "FASTHEALER", "INFRESIST" ] } ],
+    "cancels": [ "SLOWHEALER", "SLOWHEALER2", "SLOWHEALER3" ],
+    "flags": [ "MEND_ALL" ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_RECOVERY_CAPABILITY_GENEMODS",
+    "name": { "str": "Genemod: Efficient System" },
+    "points": 3,
+    "description": "The efficiency of your metabolic processes, from the length of your sleep cycle to losing fatigue after exercise, have been improved through genemod treatments.",
+    "cancels": [ "SLEEPY", "SLEEPY2" ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "CARDIO_MULTIPLIER", "multiply": 0.2 },
+          { "value": "REGEN_STAMINA", "multiply": 0.2 },
+          { "value": "SLEEPINESS_REGEN", "multiply": 0.2 },
+          { "value": "SLEEPINESS", "multiply": -0.2 }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/Aftershock/player/hobbies.json
+++ b/data/mods/Aftershock/player/hobbies.json
@@ -70,7 +70,7 @@
     "name": "Genemod: Improved Health",
     "description": "Much more common in the Hyperspace Era, the rich or those from Earth still have access to genemodding technology designed to make humanity better.  This is the suite of improvements to health, providing increased healing speed and resistance to disease and infection.",
     "points": 2,
-    "traits": [ "AFS_HEALTH_CAPABILITY_GENEMODS" ]
+    "traits": [ "AFS_HEALTH_CAPABILITY_GENEMOD" ]
   },
   {
     "type": "profession",
@@ -79,7 +79,16 @@
     "name": "Genemod: Efficient System",
     "description": "Much more common in the Hyperspace Era, the rich or those from Earth still have access to genemodding technology designed to make humanity better.  This is the suite of improvements to recovery, allowing a quicker sleep cycle and faster return to baseline after exertion.",
     "points": 2,
-    "traits": [ "AFS_RECOVERY_CAPABILITY_GENEMODS" ]
+    "traits": [ "AFS_RECOVERY_CAPABILITY_GENEMOD" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "afs_beauty_genemod",
+    "name": "Genemod: Beauty",
+    "description": "Much more common in the Hyperspace Era, the rich or those from Earth still have access to genemodding technology designed to make humanity better.  This is the suite of improvements to physical appearance, offering clearer skin, more striking features, increased facial symmetry, and removing signs of aging.",
+    "points": 2,
+    "traits": [ "AFS_BEAUTY_GENEMOD" ]
   },
   {
     "type": "profession",

--- a/data/mods/Aftershock/player/hobbies.json
+++ b/data/mods/Aftershock/player/hobbies.json
@@ -48,6 +48,42 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "afs_physical_stat_genemod",
+    "name": "Genemod: Physical Ability",
+    "description": "Much more common in the Hyperspace Era, the rich or those from Earth still have access to genemodding technology designed to make humanity better.  This is the suite of improvements to increase strength, coordination, and sensory ability as well as fix problems such as nearsightedness.",
+    "points": 2,
+    "traits": [ "AFS_PHYSICAL_CAPABILITY_GENEMOD" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "afs_mental_stat_genemod",
+    "name": "Genemod: Mental Acuity",
+    "description": "Much more common in the Hyperspace Era, the rich or those from Earth still have access to genemodding technology designed to make humanity better.  This is the suite of improvements to increase mental flexibility and memorization.",
+    "points": 2,
+    "traits": [ "AFS_MENTAL_CAPABILITY_GENEMOD" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "afs_health_genemod",
+    "name": "Genemod: Improved Health",
+    "description": "Much more common in the Hyperspace Era, the rich or those from Earth still have access to genemodding technology designed to make humanity better.  This is the suite of improvements to health, providing increased healing speed and resistance to disease and infection.",
+    "points": 2,
+    "traits": [ "AFS_HEALTH_CAPABILITY_GENEMODS" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "afs_efficiency_genemod",
+    "name": "Genemod: Efficient System",
+    "description": "Much more common in the Hyperspace Era, the rich or those from Earth still have access to genemodding technology designed to make humanity better.  This is the suite of improvements to recovery, allowing a quicker sleep cycle and faster return to baseline after exertion.",
+    "points": 2,
+    "traits": [ "AFS_RECOVERY_CAPABILITY_GENEMODS" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "afs_electrokinetic_hobby",
     "name": "Esper Inheritance (Spark)",
     "description": "Some long-distant member of your family received psi treatments during the Hyperspace Era and somehow it stuck in their DNA.  Always unpredictable, skipping multiple generations at a time, that inheritance has been passed down to you.  You have no training and little idea what you're doing, but you've developed a trick or two.",

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -268,7 +268,7 @@
     "description": "The exiled scion of an unfavorable seat within the Wraitheon board of directors, wealthy beyond measure even in their estrangement.  Sent to the frontier in a last-ditch effort to salvage their reputation, or more likely, to find a silent and politically convenient death.",
     "points": 8,
     "CBMs": [ "bio_batteries", "bio_power_storage_mkII", "bio_eye_enhancer", "bio_int_enhancer", "bio_memory", "bio_cable" ],
-    "traits": [ "FLIMSY3", "SLOWHEALER3" ],
+    "traits": [ "FLIMSY3", "SLOWHEALER3", "AFS_MENTAL_CAPABILITY_GENEMOD", "AFS_RECOVERY_CAPABILITY_GENEMODS" ],
     "pets": [ { "name": "afs_mon_sentinel_lx", "amount": 2 } ],
     "skills": [ { "level": 6, "name": "speech" }, { "level": 6, "name": "computer" } ],
     "items": {

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -268,7 +268,7 @@
     "description": "The exiled scion of an unfavorable seat within the Wraitheon board of directors, wealthy beyond measure even in their estrangement.  Sent to the frontier in a last-ditch effort to salvage their reputation, or more likely, to find a silent and politically convenient death.",
     "points": 8,
     "CBMs": [ "bio_batteries", "bio_power_storage_mkII", "bio_eye_enhancer", "bio_int_enhancer", "bio_memory", "bio_cable" ],
-    "traits": [ "FLIMSY3", "SLOWHEALER3", "AFS_MENTAL_CAPABILITY_GENEMOD", "AFS_RECOVERY_CAPABILITY_GENEMODS" ],
+    "traits": [ "FLIMSY3", "SLOWHEALER3", "AFS_MENTAL_CAPABILITY_GENEMOD", "AFS_RECOVERY_CAPABILITY_GENEMOD" ],
     "pets": [ { "name": "afs_mon_sentinel_lx", "amount": 2 } ],
     "skills": [ { "level": 6, "name": "speech" }, { "level": 6, "name": "computer" } ],
     "items": {

--- a/data/mods/Aftershock/scenarios.json
+++ b/data/mods/Aftershock/scenarios.json
@@ -94,7 +94,17 @@
     "allowed_locs": [ "sloc_augustmoon_docking" ],
     "professions": [ "afs_salvor", "afs_academic", "afs_holo_fighter", "afs_wraitheon_executive", "rocket_jumper", "robot_scavenger" ],
     "whitelist_hobbies": true,
-    "hobbies": [ "afs_speed_freak", "afs_armament_license", "afs_spacer", "afs_leadership", "afs_earthling" ],
+    "hobbies": [
+      "afs_speed_freak",
+      "afs_armament_license",
+      "afs_spacer",
+      "afs_leadership",
+      "afs_earthling",
+      "afs_physical_stat_genemod",
+      "afs_mental_stat_genemod",
+      "afs_health_genemod",
+      "afs_efficiency_genemod"
+    ],
     "flags": [ "LONE_START" ],
     "start_name": "Port Augustmoon"
   },

--- a/data/mods/Aftershock/scenarios.json
+++ b/data/mods/Aftershock/scenarios.json
@@ -103,7 +103,8 @@
       "afs_physical_stat_genemod",
       "afs_mental_stat_genemod",
       "afs_health_genemod",
-      "afs_efficiency_genemod"
+      "afs_efficiency_genemod",
+      "afs_beauty_genemod"
     ],
     "flags": [ "LONE_START" ],
     "start_name": "Port Augustmoon"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Aftershock] Add human++ genemods"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had this in a personal mod, talking about it with Candlebury and got the go-ahead to PR it as backgrounds.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add five gene treatments designed to make humans..._better_. 

- Genemod: Improved Physical Capability - better strength, coordination and senses, removes problems with your eyes, and prevents hearing damage.
- Genemod: Improved Mental Flexibilty - better intelligence and adds learning focus, removes Forgetful.
- Genemod: Improved Health - a container mutation containing Disease Resistant, Fast Healer, and Infection Resistant
- Genemod: Efficient System - Improved stamina regeneration, reduced sleepiness and quicker sleepiness recovery, and improved cardio. 
- Genemod: Beauty - A container mutation containing Beautiful

You can take them as starting backgrounds if your character would have had them. I gave the Wraitheon Exec Improved Mental Flexibility and Efficient System (based on their other traits, they clearly didn't care about Improved Physical Capability. They have people for that.)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Created a character, made sure the hobbies showed up, loaded into the game and checked their effects. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Mercurial would almost certainly offer these for sale, but that can be a future PR. 

I could have given these all marketing names (Genemod: Achilles, Genemod: Odysseus, Genemod: Adonis), but decided to make them easily understandable.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
