### PR TITLE
[Magiclysm] Rename 'Introduction to the Divine' to 'The Limits of Magical Recovery'

### DIFF
--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -9,7 +9,7 @@
     "type": "item_group",
     "id": "religious_books",
     "copy-from": "religious_books",
-    "extend": { "items": [ [ "priest_beginner", 1 ], [ "priest_advanced", 1 ], [ "druid_spellbook", 1 ] ] }
+    "extend": { "items": [ [ "priest_advanced", 1 ], [ "druid_spellbook", 1 ] ] }
   },
   {
     "type": "item_group",
@@ -1472,7 +1472,6 @@
     "items": [
       {
         "distribution": [
-          { "item": "priest_beginner", "prob": 30 },
           { "item": "spell_scroll_light_healing", "prob": 50 },
           { "item": "spell_scroll_bio_acidicspray", "prob": 50 },
           { "item": "spell_scroll_biomancer_paralytic_dart", "prob": 50 },
@@ -1486,6 +1485,7 @@
       {
         "distribution": [
           { "item": "wizard_utility", "prob": 20 },
+          { "item": "priest_beginner", "prob": 30 },
           { "item": "spell_scroll_biomancer_slow_bleeding", "prob": 40 },
           { "item": "spell_scroll_biomancer_scalpel_fingers", "prob": 30 },
           { "item": "spell_scroll_pain_split", "prob": 50 },
@@ -1617,7 +1617,6 @@
       },
       {
         "distribution": [
-          { "item": "priest_beginner", "prob": 20 },
           { "item": "wizard_beginner", "prob": 20 },
           { "item": "spell_scroll_create_atomic_light", "prob": 50 },
           { "item": "spell_scroll_ethereal_grasp", "prob": 50 },

--- a/data/mods/Magiclysm/itemgroups/spellbooks.json
+++ b/data/mods/Magiclysm/itemgroups/spellbooks.json
@@ -271,7 +271,6 @@
     "//": "These are spellbooks that a beginner would have, or scrolls that would have this tier or one tier higher of spells.",
     "items": [
       [ "wizard_beginner", 30 ],
-      [ "priest_beginner", 30 ],
       [ "techno_idiots", 30 ],
       [ "novice_stormshaper_book", 30 ],
       [ "book_lazy_magic", 30 ],
@@ -307,6 +306,7 @@
     "type": "item_group",
     "items": [
       [ "wizard_utility", 50 ],
+      [ "priest_beginner", 30 ],
       [ "priest_advanced", 50 ],
       [ "prepper_spellbook", 30 ],
       [ "techno_fundamentals", 50 ],

--- a/data/mods/Magiclysm/items/spellbooks.json
+++ b/data/mods/Magiclysm/items/spellbooks.json
@@ -138,7 +138,7 @@
     "name": { "str": "The Limits of Magical Recovery", "str_pl": "copies of The Limits of Magical Recovery" },
     "//": "1 technomancer, 2 biomancer, 1 druid spells",
     "description": "A study of the progress of using magic to cure ailments and heal wounds throughout the ages, from the earliest simple rituals to set bones all the way through modern thaumaturgical research into cancer treatments and curing Orcus's disease.  Some of the descriptions are detailed enough to be used as spell formulae.",
-    "weight": "920 g",
+    "weight": "900 g",
     "volume": "750 ml",
     "price": "150 USD",
     "material": [ "paper" ],

--- a/data/mods/Magiclysm/items/spellbooks.json
+++ b/data/mods/Magiclysm/items/spellbooks.json
@@ -132,19 +132,20 @@
   },
   {
     "id": "priest_beginner",
+    "//2": "id for legacy reasons",
     "type": "BOOK",
     "category": "manuals",
-    "name": { "str": "Introduction to the Divine", "str_pl": "copies of Introduction to the Divine" },
-    "//": "1 technomancer, 1 biomancer, 1 classless spells",
-    "description": "This appears to mostly be a religious text, but it does have some notes on healing.",
-    "weight": "585 g",
-    "volume": "500 ml",
-    "price": "50 USD",
+    "name": { "str": "The Limits of Magical Recovery", "str_pl": "copies of The Limits of Magical Recovery" },
+    "//": "1 technomancer, 2 biomancer, 1 druid spells",
+    "description": "A study of the progress of using magic to cure ailments and heal wounds throughout the ages, from the earliest simple rituals to set bones all the way through modern thaumaturgical research into cancer treatments and curing Orcus's disease.  Some of the descriptions are detailed enough to be used as spell formulae.",
+    "weight": "920 g",
+    "volume": "750 ml",
+    "price": "150 USD",
     "material": [ "paper" ],
     "looks_like": "cookbook",
     "symbol": "?",
     "color": "light_green",
-    "use_action": { "type": "learn_spell", "spells": [ "light_healing", "blinding_flash", "bless" ] }
+    "use_action": { "type": "learn_spell", "spells": [ "light_healing", "biomancer_cure_disease_minor", "bless", "druid_healing_herb" ] }
   },
   {
     "id": "priest_advanced",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Rename 'Introduction to the Divine' to 'The Limits of Magical Recovery'"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The spellbook name `Introduction to the Divine` (and a bunch of copied priest [ in the D&D sense] professions starting with that book) are a remnant of earlier Magiclysm design involving the classic blasty Arcane vs healy Divine magic that did not make it into the final lore. As such, it should be changed. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the spellbook to `The Limits of Magical Recovery`, a book about the history of thaumaturgical treatments throughout the ages, but still detailed enough that it can be used to study spells. Add one more biomancy spell and one druid spell. Move the book up a loot tier.

(`The Paladin's Guide to Modern Spellcasting` seems to either be an ancient text or some occult weirdo writing in a deliberately archaic fashion, so it doesn't need any changing)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I plan to remove those religious professions (which already exist in vanilla, and are copied here solely so they can start with a copy of `Introduction to the Divine`) and add some more comprehensive hobbies for magic, like healing, wilderness survival, divination, etc. So if you want to be a healing priest, take the vanilla priest profession and a healing magic hobby. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
