### PR TITLE
typified a-f

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -590,12 +590,7 @@ action_id get_movement_action_from_delta( const tripoint_rel_ms &d, const iso_ro
     return ACTION_NULL;
 }
 
-point get_delta_from_movement_action( const action_id act, const iso_rotate rot )
-{
-    return get_delta_from_movement_action_rel_ms( act, rot ).raw();
-}
-
-point_rel_ms get_delta_from_movement_action_rel_ms( const action_id act, const iso_rotate rot )
+point_rel_ms get_delta_from_movement_action( const action_id act, const iso_rotate rot )
 {
     const bool iso_mode = rot == iso_rotate::yes && g->is_tileset_isometric();
     switch( act ) {
@@ -1112,17 +1107,7 @@ action_id handle_main_menu()
     }
 }
 
-std::optional<tripoint> choose_direction( const std::string &message, const bool allow_vertical )
-{
-    std::optional<tripoint_rel_ms> ret = choose_direction_rel_ms( message, allow_vertical );
-    if( ret.has_value() ) {
-        return ret->raw();
-    } else {
-        return std::nullopt;
-    }
-}
-
-std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &message,
+std::optional<tripoint_rel_ms> choose_direction( const std::string &message,
         const bool allow_vertical, const bool allow_mouse, const int timeout,
         const std::function<std::pair<bool, std::optional<tripoint_rel_ms>>(
             const input_context &ctxt, const std::string &action )> &action_cb )
@@ -1193,33 +1178,10 @@ std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &messa
     return std::nullopt;
 }
 
-std::optional<tripoint> choose_adjacent( const std::string &message, const bool allow_vertical )
-{
-    const std::optional<tripoint_bub_ms> temp = choose_adjacent( get_player_character().pos_bub(),
-            message, allow_vertical );
-    std::optional<tripoint> result;
-    if( temp.has_value() ) {
-        result = temp.value().raw();
-    }
-    return result;
-}
-
-std::optional<tripoint_bub_ms> choose_adjacent_bub( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent( const std::string &message,
         const bool allow_vertical )
 {
     return choose_adjacent( get_player_character().pos_bub(), message, allow_vertical );
-}
-
-std::optional<tripoint> choose_adjacent( const tripoint &pos, const std::string &message,
-        bool allow_vertical )
-{
-    const std::optional<tripoint_bub_ms> dir = choose_adjacent(
-                tripoint_bub_ms( pos ), message, allow_vertical );
-    if( dir.has_value() ) {
-        return dir->raw();
-    } else {
-        return std::nullopt;
-    }
 }
 
 std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
@@ -1227,7 +1189,7 @@ std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
         const std::function<std::pair<bool, std::optional<tripoint_bub_ms>>(
             const input_context &ctxt, const std::string &action )> &action_cb )
 {
-    const std::optional<tripoint_rel_ms> dir = choose_direction_rel_ms(
+    const std::optional<tripoint_rel_ms> dir = choose_direction(
                 message, allow_vertical, /*allow_mouse=*/true, timeout,
     [&]( const input_context & ctxt, const std::string & action ) {
         if( action == "SELECT" ) {

--- a/src/action.h
+++ b/src/action.h
@@ -476,12 +476,7 @@ bool can_action_change_worldstate( action_id act );
  *            exits with the return value set to the tripoint, or std::nullopt
  *            if the tripoint is not a valid adjacent location.
  */
-// TODO: Get rid of untyped overload and rename _bub when the profile is free.
-std::optional<tripoint> choose_adjacent( const std::string &message, bool allow_vertical = false );
-std::optional<tripoint_bub_ms> choose_adjacent_bub( const std::string &message,
-        bool allow_vertical = false );
-// TODO: Get rid of untyped overload.
-std::optional<tripoint> choose_adjacent( const tripoint &pos, const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent( const std::string &message,
         bool allow_vertical = false );
 std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
         const std::string &message, bool allow_vertical = false, int timeout = 50,
@@ -509,10 +504,7 @@ std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
  *            exits with the return value set to the tripoint, or std::nullopt
  *            if the tripoint is not a valid direction.
  */
-// TODO: Get rid of untyped version and typed name extension.
-std::optional<tripoint> choose_direction( const std::string &message,
-        bool allow_vertical = false );
-std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &message,
+std::optional<tripoint_rel_ms> choose_direction( const std::string &message,
         bool allow_vertical = false, bool allow_mouse = false, int timeout = 50,
         const std::function<std::pair<bool, std::optional<tripoint_rel_ms>>(
             const input_context &ctxt, const std::string &action )> &action_cb = nullptr );
@@ -597,9 +589,7 @@ enum class iso_rotate : int {
 action_id get_movement_action_from_delta( const tripoint_rel_ms &d, iso_rotate rot );
 
 // Helper function to convert movement action to coordinate delta point
-// TODO: Remove untyped overload and rename typed version.
-point get_delta_from_movement_action( action_id act, iso_rotate rot );
-point_rel_ms get_delta_from_movement_action_rel_ms( action_id act, iso_rotate rot );
+point_rel_ms get_delta_from_movement_action( action_id act, iso_rotate rot );
 
 /**
  * Show the action menu

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6558,7 +6558,7 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
     if( !who.is_npc() &&
         ( who.backlog.empty() || who.backlog.front().id() != ACT_MULTIPLE_CHOP_TREES ) ) {
         while( true ) {
-            if( const std::optional<tripoint_rel_ms> dir = choose_direction_rel_ms(
+            if( const std::optional<tripoint_rel_ms> dir = choose_direction(
                         _( "Select a direction for the tree to fall in." ) ) ) {
                 direction = *dir;
                 break;
@@ -6832,7 +6832,6 @@ void forage_activity_actor::finish( player_activity &act, Character &who )
     bool next_to_bush = false;
     map &here = get_map();
     for( const tripoint_bub_ms &pnt : here.points_in_radius( who.pos_bub(), 1 ) ) {
-        // TODO: fix point types
         if( here.getglobal( pnt ) == act.placement ) {
             next_to_bush = true;
             break;
@@ -7349,7 +7348,6 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
         }
     }
     if( stage == DO ) {
-        // TODO: fix point types
         const tripoint_abs_ms src( placement );
         const tripoint_bub_ms src_loc = here.bub_from_abs( src );
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3602,7 +3602,6 @@ void activity_handlers::fertilize_plot_do_turn( player_activity *act, Character 
 
     const auto reject_tile = [&]( const tripoint_bub_ms & tile ) {
         check_fertilizer();
-        // TODO: fix point types
         ret_val<void> can_fert = iexamine::can_fertilize( *you, tile, fertilizer );
         return !can_fert.success();
     };
@@ -3610,7 +3609,6 @@ void activity_handlers::fertilize_plot_do_turn( player_activity *act, Character 
     const auto fertilize = [&]( Character & you, const tripoint_bub_ms & tile ) {
         check_fertilizer();
         if( have_fertilizer() ) {
-            // TODO: fix point types
             iexamine::fertilize_plant( you, tile, fertilizer );
             if( !have_fertilizer() ) {
                 add_msg( m_info, _( "You have run out of %s." ), item::nname( fertilizer ) );
@@ -3716,7 +3714,6 @@ void activity_handlers::pull_creature_finish( player_activity *act, Character *y
     if( you->is_avatar() ) {
         you->as_avatar()->longpull( act->name );
     } else {
-        // TODO: fix point types
         you->longpull( act->name, get_map().bub_from_abs( act->placement ) );
     }
     act->set_to_null();

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1057,7 +1057,6 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
         }
         if( act == ACT_VEHICLE_DECONSTRUCTION ) {
             // find out if there is a vehicle part here we can remove.
-            // TODO: fix point types
             std::vector<vehicle_part *> parts =
                 veh->get_parts_at( src_loc, "", part_status_flag::any );
             for( vehicle_part *part_elem : parts ) {
@@ -1081,7 +1080,6 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                     continue;
                 }
                 item base( vpinfo.base_item );
-                // TODO: fix point types
                 const units::mass max_lift = you.best_nearby_lifting_assist( src_loc );
                 const bool use_aid = max_lift >= base.weight();
                 const bool use_str = you.can_lift( base );
@@ -1103,7 +1101,6 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             }
         } else if( act == ACT_VEHICLE_REPAIR ) {
             // find out if there is a vehicle part here we can repair.
-            // TODO: fix point types
             std::vector<vehicle_part *> parts = veh->get_parts_at( src_loc, "", part_status_flag::any );
             for( vehicle_part *part_elem : parts ) {
                 const vpart_info &vpinfo = part_elem->info();
@@ -1126,7 +1123,6 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                     continue;
                 }
                 const requirement_data &reqs = vpinfo.repair_requirements();
-                // TODO: fix point types
                 const inventory &inv =
                     you.crafting_inventory( src_loc, PICKUP_RANGE - 1, false );
                 const bool can_make = reqs.can_make_with_inventory( inv, is_crafting_component );
@@ -1301,7 +1297,6 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             }
             nearest_src_loc = route.back();
         }
-        // TODO: fix point types
         const inventory pre_inv = you.crafting_inventory( nearest_src_loc, PICKUP_RANGE );
         if( !zones.empty() ) {
             const blueprint_options &options = dynamic_cast<const blueprint_options &>
@@ -1404,7 +1399,6 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
         return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
     } else if( act == ACT_MULTIPLE_DIS ) {
         // Is there anything to be disassembled?
-        // TODO: fix point types
         const inventory &inv = you.crafting_inventory( src_loc, PICKUP_RANGE, false );
         requirement_data req;
         for( item &i : here.i_at( src_loc ) ) {
@@ -1521,8 +1515,7 @@ static std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> requirements_map(
              you.get_location(), distance, you.is_npc(), _fac_id( you ) ) ) {
         // if there is a loot zone that's already near the work spot, we don't want it to be added twice.
         if( std::find( already_there_spots.begin(), already_there_spots.end(),
-                       // TODO: fix point types
-                       tripoint_bub_ms( elem ) ) != already_there_spots.end() ) {
+                       elem ) != already_there_spots.end() ) {
             // construction tasks don't need the loot spot *and* the already_there/combined spots both added.
             // but a farming task will need to go and fetch the tool no matter if its near the work spot.
             // whereas the construction will automatically use what's nearby anyway.
@@ -1811,8 +1804,7 @@ static bool construction_activity( Character &you, const zone_data * /*zone*/,
         }
     }
     pc.components = used;
-    // TODO: fix point types
-    here.partial_con_set( tripoint_bub_ms( src_loc ), pc );
+    here.partial_con_set( src_loc, pc );
     for( const std::vector<tool_comp> &it : built_chosen.requirements->get_tools() ) {
         you.consume_tools( it );
     }

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -249,7 +249,7 @@ void advanced_inventory_pane::add_items_from_area( advanced_inv_area &square,
                 square.i_stacked( square.get_vehicle_stack() ) :
                 square.i_stacked( m.i_at( square.pos ) );
 
-        map_cursor loc_cursor( tripoint_bub_ms( square.pos ) );
+        map_cursor loc_cursor( square.pos );
         for( size_t x = 0; x < stacks.size(); ++x ) {
             std::vector<item_location> locs;
             locs.reserve( stacks[x].size() );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1209,11 +1209,6 @@ bool avatar::is_obeying( const Character &p ) const
     return guy.is_obeying( *this );
 }
 
-bool avatar::cant_see( const tripoint &p ) const
-{
-    return cant_see( tripoint_bub_ms( p ) );
-}
-
 bool avatar::cant_see( const tripoint_bub_ms &p ) const
 {
 

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -286,8 +286,6 @@ class avatar : public Character
         std::string preferred_aiming_mode;
 
         // checks if the point is blocked based on characters current aiming state
-        // TODO Remove untyped overload
-        bool cant_see( const tripoint &p ) const;
         bool cant_see( const tripoint_bub_ms &p ) const;
 
         // rebuilds the full aim cache for the character if it is dirty

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -70,7 +70,7 @@ static void drop_or_embed_projectile( const dealt_projectile_attack &attack, pro
         return;
     }
 
-    const tripoint_bub_ms &pt = tripoint_bub_ms( attack.end_point );
+    const tripoint_bub_ms &pt = attack.end_point;
 
     if( effects.count( ammo_effect_SHATTER_SELF ) ) {
         // Drop the contents, not the thrown item

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -928,7 +928,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         add_msg_activate();
         add_msg_if_player( m_info, _( "You can now run faster, assisted by joint servomotors." ) );
     } else if( bio.id == bio_lighter ) {
-        const std::optional<tripoint_bub_ms> pnt = choose_adjacent_bub( _( "Start a fire where?" ) );
+        const std::optional<tripoint_bub_ms> pnt = choose_adjacent( _( "Start a fire where?" ) );
         if( pnt && here.is_flammable( *pnt ) && !here.get_field( *pnt, fd_fire ) ) {
             add_msg_activate();
             here.add_field( *pnt, fd_fire, 1 );
@@ -954,7 +954,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             set_rad( 0 );
         }
     } else if( bio.id == bio_emp ) {
-        if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent_bub(
+        if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent(
                     _( "Create an EMP where?" ) ) ) {
             add_msg_activate();
             explosion_handler::emp_blast( *pnt );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1911,7 +1911,7 @@ void Character::dismount()
         add_msg_debug( debugmode::DF_CHARACTER, "dismount called when not riding" );
         return;
     }
-    if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent_bub( _( "Dismount where?" ) ) ) {
+    if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent( _( "Dismount where?" ) ) ) {
         if( !g->is_empty( *pnt ) ) {
             add_msg( m_warning, _( "You cannot dismount there!" ) );
             return;
@@ -10709,17 +10709,17 @@ void Character::echo_pulse()
 bool Character::knows_trap( const tripoint_bub_ms &pos ) const
 {
     const tripoint_abs_ms p = get_map().getglobal( pos );
-    return known_traps.count( p.raw() ) > 0;
+    return known_traps.count( p ) > 0;
 }
 
 void Character::add_known_trap( const tripoint_bub_ms &pos, const trap &t )
 {
     const tripoint_abs_ms p = get_map().getglobal( pos );
     if( t.is_null() ) {
-        known_traps.erase( p.raw() );
+        known_traps.erase( p );
     } else {
         // TODO: known_traps should map to a trap_str_id
-        known_traps[p.raw()] = t.id.str();
+        known_traps[p] = t.id.str();
     }
 }
 
@@ -11367,11 +11367,6 @@ Creature::Attitude Character::attitude_to( const Creature &other ) const
 npc_attitude Character::get_attitude() const
 {
     return NPCATT_NULL;
-}
-
-bool Character::sees( const tripoint &t, bool, int ) const
-{
-    return sees( tripoint_bub_ms( t ) );
 }
 
 bool Character::sees( const tripoint_bub_ms &t, bool, int ) const

--- a/src/character.h
+++ b/src/character.h
@@ -3770,14 +3770,13 @@ class Character : public Creature, public visitable
         // Returns a multiplier indicating the keenness of a player's hearing.
         float hearing_ability() const;
 
-        using trap_map = std::map<tripoint, std::string>;
+        using trap_map = std::map<tripoint_abs_ms, std::string>;
         // Use @ref trap::can_see to check whether a character knows about a
         // specific trap - it will consider visible and known traps.
         bool knows_trap( const tripoint_bub_ms &pos ) const;
         void add_known_trap( const tripoint_bub_ms &pos, const trap &t );
 
         // see Creature::sees
-        bool sees( const tripoint &t, bool is_avatar = false, int range_mod = 0 ) const override;
         bool sees( const tripoint_bub_ms &t, bool is_avatar = false, int range_mod = 0 ) const override;
         // see Creature::sees
         bool sees( const Creature &critter ) const override;

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1756,9 +1756,9 @@ conditional_t::func f_query_tile( const JsonObject &jo, std::string_view member,
                 }
             } else if( type == "around" ) {
                 if( !message.empty() ) {
-                    loc = choose_adjacent_bub( message );
+                    loc = choose_adjacent( message );
                 } else {
-                    loc = choose_adjacent_bub( _( "Choose direction" ) );
+                    loc = choose_adjacent( _( "Choose direction" ) );
                 }
             } else {
                 debugmsg( string_format( "Invalid selection type: %s", type ) );

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -424,7 +424,6 @@ static shared_ptr_fast<game::draw_callback_t> construction_preview_callback(
     return make_shared_fast<game::draw_callback_t>( [&]() {
         map &here = get_map();
         // Draw construction result preview on valid squares
-        // TODO: fix point types
         for( const auto &elem : valid ) {
             const tripoint_bub_ms &loc = elem.first;
             const construction &con = *elem.second;
@@ -2084,10 +2083,8 @@ void construct::do_turn_deconstruct( const tripoint_bub_ms &p, Character &who )
 
 void construct::do_turn_shovel( const tripoint_bub_ms &p, Character &who )
 {
-    // TODO: fix point types
     sfx::play_activity_sound( "tool", "shovel", sfx::get_heard_volume( p ) );
     if( calendar::once_every( 1_minutes ) ) {
-        // TODO: fix point types
         //~ Sound of a shovel digging a pit at work!
         sounds::sound( p, 10, sounds::sound_t::activity, _( "hsh!" ) );
     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -766,17 +766,17 @@ static item_location set_item_inventory( Character &p, item &newit )
  * Helper for @ref set_item_map_or_vehicle
  * This is needed to still get a valid item_location if overflow occurs
  */
-static item_location set_item_map( const tripoint &loc, item &newit )
+static item_location set_item_map( const tripoint_bub_ms &loc, item &newit )
 {
     // Includes loc
-    for( const tripoint_bub_ms &tile : closest_points_first( tripoint_bub_ms( loc ), 2 ) ) {
+    for( const tripoint_bub_ms &tile : closest_points_first( loc, 2 ) ) {
         // Pass false to disallow overflow, null_item_reference indicates failure.
         item *it_on_map = &get_map().add_item_or_charges( tile, newit, false );
         if( it_on_map != &null_item_reference() ) {
-            return item_location( map_cursor( tripoint_bub_ms( tile ) ), it_on_map );
+            return item_location( map_cursor( tile ), it_on_map );
         }
     }
-    debugmsg( "Could not place %s on map near (%d, %d, %d)", newit.tname(), loc.x, loc.y, loc.z );
+    debugmsg( "Could not place %s on map near (%d, %d, %d)", newit.tname(), loc.x(), loc.y(), loc.z() );
     return item_location();
 }
 
@@ -807,7 +807,7 @@ static item_location set_item_map_or_vehicle( const Character &p, const tripoint
                       "Not enough space on the %1$s. <npcname> drops the %2$s on the ground." ),
             vp->part().name(), newit.tname() );
 
-        return set_item_map( loc.raw(), newit );
+        return set_item_map( loc, newit );
 
     } else {
         if( here.has_furn( loc ) ) {
@@ -823,7 +823,7 @@ static item_location set_item_map_or_vehicle( const Character &p, const tripoint
                 pgettext( "item", "<npcname> puts the %s on the ground." ),
                 newit.tname() );
         }
-        return set_item_map( loc.raw(), newit );
+        return set_item_map( loc, newit );
     }
 }
 
@@ -2926,7 +2926,6 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
             item act_item = newit;
 
             if( act_item.has_temperature() ) {
-                // TODO: fix point types
                 act_item.set_item_temperature( get_weather().get_temperature( loc ) );
             }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -203,11 +203,6 @@ Creature &Creature::operator=( Creature && ) noexcept = default;
 
 Creature::~Creature() = default;
 
-tripoint Creature::pos() const
-{
-    return Creature::pos_bub().raw();
-}
-
 tripoint_bub_ms Creature::pos_bub() const
 {
     return get_map().bub_from_abs( location );
@@ -613,11 +608,6 @@ bool Creature::sees( const Creature &critter ) const
         }
     }
     return visible( ch );
-}
-
-bool Creature::sees( const tripoint &t, bool is_avatar, int range_mod ) const
-{
-    return Creature::sees( tripoint_bub_ms( t ), is_avatar, range_mod );
 }
 
 bool Creature::sees( const tripoint_bub_ms &t, bool is_avatar, int range_mod ) const

--- a/src/creature.h
+++ b/src/creature.h
@@ -307,7 +307,6 @@ class Creature : public viewer
         /** Sets a Creature's fake boolean. */
         virtual void set_fake( bool fake_value );
         // TODO: fix point types (remove pos() and rename pos_bub() to be the new pos())
-        tripoint pos() const;
         tripoint_bub_ms pos_bub() const;
         inline int posx() const {
             return pos_bub().x();
@@ -393,8 +392,6 @@ class Creature : public viewer
          */
         /*@{*/
         bool sees( const Creature &critter ) const override;
-        // TODO: Get rid of untyped overload.
-        bool sees( const tripoint &t, bool is_avatar = false, int range_mod = 0 ) const override;
         bool sees( const tripoint_bub_ms &t, bool is_avatar = false, int range_mod = 0 ) const override;
         /*@}*/
 

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -295,12 +295,6 @@ void creature_tracker::remove_dead()
 }
 
 template<typename T>
-T *creature_tracker::creature_at( const tripoint &p, bool allow_hallucination )
-{
-    return creature_at<T>( get_map().getglobal( tripoint_bub_ms( p ) ), allow_hallucination );
-}
-
-template<typename T>
 T *creature_tracker::creature_at( const tripoint_bub_ms &p, bool allow_hallucination )
 {
     return creature_at<T>( get_map().getglobal( p ), allow_hallucination );
@@ -421,12 +415,6 @@ void creature_tracker::flood_fill_zone( const Creature &origin )
 }
 
 template<typename T>
-const T *creature_tracker::creature_at( const tripoint &p, bool allow_hallucination ) const
-{
-    return creature_at<T>( get_map().getglobal( tripoint_bub_ms( p ) ), allow_hallucination );
-}
-
-template<typename T>
 const T *creature_tracker::creature_at( const tripoint_bub_ms &p, bool allow_hallucination ) const
 {
     return creature_at<T>( get_map().getglobal( p ), allow_hallucination );
@@ -438,39 +426,29 @@ const T *creature_tracker::creature_at( const tripoint_abs_ms &p, bool allow_hal
     return const_cast<creature_tracker *>( this )->creature_at<T>( p, allow_hallucination );
 }
 
-template const monster *creature_tracker::creature_at<monster>( const tripoint &, bool ) const;
 template const monster *creature_tracker::creature_at<monster>( const tripoint_bub_ms &,
         bool ) const;
 template const monster *creature_tracker::creature_at<monster>( const tripoint_abs_ms &,
         bool ) const;
-template monster *creature_tracker::creature_at<monster>( const tripoint &, bool );
 template monster *creature_tracker::creature_at<monster>( const tripoint_bub_ms &, bool );
 template monster *creature_tracker::creature_at<monster>( const tripoint_abs_ms &, bool );
-template const npc *creature_tracker::creature_at<npc>( const tripoint &, bool ) const;
 template const npc *creature_tracker::creature_at<npc>( const tripoint_bub_ms &, bool ) const;
 template const npc *creature_tracker::creature_at<npc>( const tripoint_abs_ms &, bool ) const;
-template npc *creature_tracker::creature_at<npc>( const tripoint &, bool );
 template npc *creature_tracker::creature_at<npc>( const tripoint_bub_ms &, bool );
 template npc *creature_tracker::creature_at<npc>( const tripoint_abs_ms &, bool );
-template const avatar *creature_tracker::creature_at<avatar>( const tripoint &, bool ) const;
 template const avatar *creature_tracker::creature_at<avatar>( const tripoint_bub_ms &, bool ) const;
 template const avatar *creature_tracker::creature_at<avatar>( const tripoint_abs_ms &, bool ) const;
-template avatar *creature_tracker::creature_at<avatar>( const tripoint &, bool );
 template avatar *creature_tracker::creature_at<avatar>( const tripoint_bub_ms &, bool );
 template avatar *creature_tracker::creature_at<avatar>( const tripoint_abs_ms &, bool );
-template const Character *creature_tracker::creature_at<Character>( const tripoint &, bool ) const;
 template const Character *creature_tracker::creature_at<Character>( const tripoint_bub_ms &,
         bool ) const;
 template const Character *creature_tracker::creature_at<Character>( const tripoint_abs_ms &,
         bool ) const;
-template Character *creature_tracker::creature_at<Character>( const tripoint &, bool );
 template Character *creature_tracker::creature_at<Character>( const tripoint_bub_ms &, bool );
 template Character *creature_tracker::creature_at<Character>( const tripoint_abs_ms &, bool );
-template const Creature *creature_tracker::creature_at<Creature>( const tripoint &, bool ) const;
 template const Creature *creature_tracker::creature_at<Creature>( const tripoint_bub_ms &,
         bool ) const;
 template const Creature *creature_tracker::creature_at<Creature>( const tripoint_abs_ms &,
         bool ) const;
-template Creature *creature_tracker::creature_at<Creature>( const tripoint &, bool );
 template Creature *creature_tracker::creature_at<Creature>( const tripoint_bub_ms &, bool );
 template Creature *creature_tracker::creature_at<Creature>( const tripoint_abs_ms &, bool );

--- a/src/creature_tracker.h
+++ b/src/creature_tracker.h
@@ -110,16 +110,10 @@ class creature_tracker
          * but it's not of the requested type, returns nullptr.
          * @param allow_hallucination Whether to return monsters that are actually hallucinations.
          */
-        // TODO: fix point types (remove the first overload)
-        template<typename T = Creature>
-        T * creature_at( const tripoint &p, bool allow_hallucination = false );
         template<typename T = Creature>
         T * creature_at( const tripoint_bub_ms &p, bool allow_hallucination = false );
         template<typename T = Creature>
         T * creature_at( const tripoint_abs_ms &p, bool allow_hallucination = false );
-        // TODO: fix point types (remove the first overload)
-        template<typename T = Creature>
-        const T * creature_at( const tripoint &p, bool allow_hallucination = false ) const;
         template<typename T = Creature>
         const T * creature_at( const tripoint_bub_ms &p, bool allow_hallucination = false ) const;
         template<typename T = Creature>

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1807,11 +1807,12 @@ static void teleport_overmap( bool specific_coordinates = false )
         coord.z = coord_ints.size() >= 3 ? coord_ints[2] : 0;
         where = tripoint_abs_omt( OMAPX * coord.x, OMAPY * coord.y, coord.z );
     } else {
-        const std::optional<tripoint> dir_ = choose_direction( _( "Where is the desired overmap?" ) );
+        const std::optional<tripoint_rel_ms> dir_ = choose_direction(
+                    _( "Where is the desired overmap?" ) );
         if( !dir_ ) {
             return;
         }
-        const tripoint offset = tripoint( OMAPX * dir_->x, OMAPY * dir_->y, dir_->z );
+        const tripoint offset = tripoint( OMAPX * dir_->x(), OMAPY * dir_->y(), dir_->z() );
         where = player_character.global_omt_location() + offset;
     }
     g->place_player_overmap( where );

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -123,7 +123,7 @@ void wishitem( Character *you = nullptr );
 void wishitem( Character *you, const tripoint_bub_ms & );
 // Shows a menu to debug item groups. Spawns items if test is false, otherwise displays would be spawned items.
 void wishitemgroup( bool test );
-void wishmonster( const std::optional<tripoint> &p );
+void wishmonster( const std::optional<tripoint_bub_ms> &p );
 void wishmonstergroup( tripoint_abs_omt &loc );
 void wishmonstergroup_mon_selection( mongroup &group );
 void wishmutate( Character *you );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -2070,8 +2070,8 @@ void editmap::mapgen_retarget()
 
         ui_manager::redraw();
         action = ctxt.handle_input( get_option<int>( "BLINK_SPEED" ) );
-        if( const std::optional<tripoint> vec = ctxt.get_direction( action ) ) {
-            point_rel_ms vec_ms = coords::project_to<coords::ms>( point_rel_omt( vec->xy() ) );
+        if( const std::optional<tripoint_rel_omt> vec = ctxt.get_direction_rel_omt( action ) ) {
+            point_rel_ms vec_ms = coords::project_to<coords::ms>( vec->xy() );
             tripoint_bub_ms ptarget = target + vec_ms;
             if( get_map().inbounds( ptarget ) &&
                 get_map().inbounds( ptarget + point( SEEX, SEEY ) ) ) {

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -896,8 +896,7 @@ void resonance_cascade( const tripoint_bub_ms &p )
                                     break;
                             }
                             if( !one_in( 3 ) ) {
-                                // TODO: fix point types
-                                here.add_field( tripoint_bub_ms{ k, l, p.z()}, type, 3 );
+                                here.add_field( { k, l, p.z()}, type, 3 );
                             }
                         }
                     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5816,7 +5816,7 @@ void game::control_vehicle()
             add_msg( _( "No vehicle controls found." ) );
             return;
         } else if( num_valid_controls > 1 ) {
-            const std::optional<tripoint_bub_ms> temp = choose_adjacent_bub( _( "Control vehicle where?" ) );
+            const std::optional<tripoint_bub_ms> temp = choose_adjacent( _( "Control vehicle where?" ) );
             if( !vehicle_position ) {
                 return;
             } else {
@@ -6329,7 +6329,7 @@ void game::pickup( const tripoint_bub_ms &p )
 //represents carefully peeking around a corner, hence the large move cost.
 void game::peek()
 {
-    const std::optional<tripoint_rel_ms> p = choose_direction_rel_ms( _( "Peek where?" ), true );
+    const std::optional<tripoint_rel_ms> p = choose_direction( _( "Peek where?" ), true );
     if( !p ) {
         return;
     }
@@ -7914,7 +7914,8 @@ look_around_result game::look_around(
             action = ctxt.handle_input();
         }
         if( ( action == "LEVEL_UP" || action == "LEVEL_DOWN" || action == "MOUSE_MOVE" ||
-              ctxt.get_direction( action ) ) && ( ( select_zone && has_first_point ) || is_moving_zone ) ) {
+              ctxt.get_direction_rel_ms( action ) ) && ( ( select_zone && has_first_point ) ||
+                      is_moving_zone ) ) {
             blink = true; // Always draw blink symbols when moving cursor
         } else if( action == "TIMEOUT" ) {
             blink = !blink;
@@ -9384,7 +9385,7 @@ void game::insert_item()
 
 void game::unload_container()
 {
-    if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent_bub( _( "Unload where?" ) ) ) {
+    if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent( _( "Unload where?" ) ) ) {
         u.drop( game_menus::inv::unload_container(), *pnt );
     }
 }

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -282,7 +282,7 @@ static bool get_liquid_target( item &liquid, const item *const source, const int
 
         const std::string liqstr = string_format( _( "Pour %s where?" ), liquid_name );
 
-        const std::optional<tripoint_bub_ms> target_pos_ = choose_adjacent_bub( liqstr );
+        const std::optional<tripoint_bub_ms> target_pos_ = choose_adjacent( liqstr );
         if( !target_pos_ ) {
             return;
         }

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -548,38 +548,6 @@ static void rotate_direction_cw( int &dx, int &dy )
     dy = dir_num / 3 - 1;
 }
 
-std::optional<tripoint> input_context::get_direction( const std::string &action ) const
-{
-    static const auto noop = static_cast<tripoint( * )( tripoint )>( []( tripoint p ) {
-        return p;
-    } );
-    static const auto rotate = static_cast<tripoint( * )( tripoint )>( []( tripoint p ) {
-        rotate_direction_cw( p.x, p.y );
-        return p;
-    } );
-    const auto transform = iso_mode && g->is_tileset_isometric() ? rotate : noop;
-
-    if( action == "UP" ) {
-        return transform( tripoint::north );
-    } else if( action == "DOWN" ) {
-        return transform( tripoint::south );
-    } else if( action == "LEFT" ) {
-        return transform( tripoint::west );
-    } else if( action == "RIGHT" ) {
-        return transform( tripoint::east );
-    } else if( action == "LEFTUP" ) {
-        return transform( tripoint::north_west );
-    } else if( action == "RIGHTUP" ) {
-        return transform( tripoint::north_east );
-    } else if( action == "LEFTDOWN" ) {
-        return transform( tripoint::south_west );
-    } else if( action == "RIGHTDOWN" ) {
-        return transform( tripoint::south_east );
-    } else {
-        return std::nullopt;
-    }
-}
-
 std::optional<tripoint_rel_ms> input_context::get_direction_rel_ms( const std::string &action )
 const
 {

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -297,8 +297,6 @@ class input_context
          * the delta vector associated with it. Otherwise returns an empty value.
          * The returned vector will always have a z component of 0.
          */
-        // TODO: Get rid of untyped version and change name of the typed one.
-        std::optional<tripoint> get_direction( const std::string &action ) const;
         std::optional<tripoint_rel_ms> get_direction_rel_ms( const std::string &action ) const;
         std::optional<tripoint_rel_omt> get_direction_rel_omt( const std::string &action ) const;
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1572,7 +1572,7 @@ std::optional<int> iuse::petfood( Character *p, item *it, const tripoint_bub_ms 
         return std::nullopt;
     }
 
-    const std::optional<tripoint_bub_ms> pnt = choose_adjacent_bub( string_format(
+    const std::optional<tripoint_bub_ms> pnt = choose_adjacent( string_format(
                 _( "Tame which animal with %s?" ),
                 it->tname() ) );
     if( !pnt ) {
@@ -1822,7 +1822,7 @@ std::optional<int> iuse::fish_trap( Character *p, item *it, const tripoint_bub_m
         return std::nullopt;
     }
 
-    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Put fish trap where?" ) );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Put fish trap where?" ) );
     if( !pnt_ ) {
         return std::nullopt;
     }
@@ -1942,7 +1942,7 @@ std::optional<int> iuse::extinguisher( Character *p, item *it, const tripoint_bu
     }
     // If anyone other than the player wants to use one of these,
     // they're going to need to figure out how to aim it.
-    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent_bub( _( "Spray where?" ) );
+    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent( _( "Spray where?" ) );
     if( !dest_ ) {
         return std::nullopt;
     }
@@ -2319,7 +2319,7 @@ std::optional<int> iuse::mace( Character *p, item *it, const tripoint_bub_ms & )
     }
     // If anyone other than the player wants to use one of these,
     // they're going to need to figure out how to aim it.
-    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent_bub( _( "Spray where?" ) );
+    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent( _( "Spray where?" ) );
     if( !dest_ ) {
         return std::nullopt;
     }
@@ -2893,7 +2893,7 @@ std::optional<int> iuse::makemound( Character *p, item *it, const tripoint_bub_m
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Till soil where?" ) );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Till soil where?" ) );
     if( !pnt_ ) {
         return std::nullopt;
     }
@@ -3087,7 +3087,7 @@ static std::optional<int> dig_tool( Character *p, item *it, const tripoint_bub_m
 
     tripoint_bub_ms pnt( pos );
     if( pos == p->pos_bub() ) {
-        const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( prompt );
+        const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( prompt );
         if( !pnt_ ) {
             return std::nullopt;
         }
@@ -3680,7 +3680,7 @@ std::optional<int> iuse::tazer( Character *p, item *it, const tripoint_bub_ms &p
 
     tripoint_bub_ms pnt = pos;
     if( pos == p->pos_bub() ) {
-        const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Shock where?" ) );
+        const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Shock where?" ) );
         if( !pnt_ ) {
             return std::nullopt;
         }
@@ -4925,7 +4925,7 @@ std::optional<int> iuse::mop( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint_bub_ms & )
 {
-    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent_bub( _( "Spray where?" ) );
+    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent( _( "Spray where?" ) );
     if( !dest_ ) {
         return std::nullopt;
     }
@@ -7024,7 +7024,7 @@ std::optional<int> iuse::afs_translocator( Character *p, item *it, const tripoin
         return std::nullopt;
     }
 
-    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent_bub( _( "Create buoy where?" ) );
+    const std::optional<tripoint_bub_ms> dest_ = choose_adjacent( _( "Create buoy where?" ) );
     if( !dest_ ) {
         return std::nullopt;
     }
@@ -8045,7 +8045,7 @@ std::optional<int> iuse::directional_hologram( Character *p, item *it, const tri
                               it->tname() );
         return std::nullopt;
     }
-    const std::optional<tripoint_bub_ms> posp = choose_adjacent_bub(
+    const std::optional<tripoint_bub_ms> posp = choose_adjacent(
                 _( "Choose hologram direction." ) );
     if( !posp ) {
         return std::nullopt;
@@ -8143,7 +8143,7 @@ std::optional<int> iuse::capture_monster_act( Character *p, item *it, const trip
             return std::nullopt;
         } else {
             const std::string query = string_format( _( "Place the %s where?" ), contained_name );
-            const std::optional<tripoint_bub_ms> pos_ = choose_adjacent_bub( query );
+            const std::optional<tripoint_bub_ms> pos_ = choose_adjacent( query );
             if( !pos_ ) {
                 return std::nullopt;
             }
@@ -9368,7 +9368,7 @@ std::optional<int> iuse::binder_manage_recipe( Character *p, item *binder,
 
 std::optional<int> iuse::voltmeter( Character *p, item *, const tripoint_bub_ms & )
 {
-    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Check voltage where?" ) );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Check voltage where?" ) );
     if( !pnt_ ) {
         return std::nullopt;
     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -962,7 +962,7 @@ std::optional<int> place_monster_iuse::use( Character *p, item &it, const tripoi
         }
     } else {
         const std::string query = string_format( _( "Place the %s where?" ), newmon.name() );
-        const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( query );
+        const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( query );
         if( !pnt_ ) {
             return std::nullopt;
         }
@@ -1042,7 +1042,7 @@ std::optional<int> place_npc_iuse::use( Character *p, item &, const tripoint_bub
     map &here = get_map();
     const tripoint_range<tripoint_bub_ms> target_range = place_randomly ?
             points_in_radius( p->pos_bub(), radius ) :
-            points_in_radius( choose_adjacent_bub( _( "Place NPC where?" ) ).value_or( p->pos_bub() ), 0 );
+            points_in_radius( choose_adjacent( _( "Place NPC where?" ) ).value_or( p->pos_bub() ), 0 );
 
     const std::optional<tripoint_bub_ms> target_pos =
     random_point( target_range, [&here]( const tripoint_bub_ms & t ) {
@@ -1123,7 +1123,7 @@ static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
     }
     tripoint_bub_ms pnt( pos );
     if( pos == p->pos_bub() ) {
-        if( const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Deploy where?" ) ) ) {
+        if( const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Deploy where?" ) ) ) {
             pnt = *pnt_;
         } else {
             return ret_val<tripoint_bub_ms>::make_failure( pos );
@@ -1338,7 +1338,7 @@ bool firestarter_actor::prep_firestarter_use( const Character &p, tripoint_bub_m
 {
     // checks for fuel are handled by use and the activity, not here
     if( pos == p.pos_bub() ) {
-        if( const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_bub( _( "Light where?" ) ) ) {
+        if( const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Light where?" ) ) ) {
             pos = *pnt_;
         } else {
             return false;
@@ -1980,7 +1980,7 @@ std::optional<int> inscribe_actor::use( Character *p, item &it, const tripoint_b
     }
 
     if( choice == 0 ) {
-        const std::optional<tripoint_bub_ms> dest_ = choose_adjacent_bub( _( "Write where?" ) );
+        const std::optional<tripoint_bub_ms> dest_ = choose_adjacent( _( "Write where?" ) );
         if( !dest_ ) {
             return std::nullopt;
         }
@@ -3982,7 +3982,7 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    const std::optional<tripoint_bub_ms> pos_ = choose_adjacent_bub( string_format(
+    const std::optional<tripoint_bub_ms> pos_ = choose_adjacent( string_format(
                 _( "Place %s where?" ),
                 it.tname() ) );
     if( !pos_ ) {
@@ -5287,7 +5287,7 @@ std::optional<int> deploy_tent_actor::use( Character *p, item &it, const tripoin
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    const std::optional<tripoint_rel_ms> dir = choose_direction_rel_ms( string_format(
+    const std::optional<tripoint_rel_ms> dir = choose_direction( string_format(
                 _( "Put up the %s where (%dx%d clear area)?" ), it.tname(), diam, diam ) );
     if( !dir ) {
         return std::nullopt;

--- a/src/iuse_software_lightson.cpp
+++ b/src/iuse_software_lightson.cpp
@@ -191,9 +191,9 @@ int lightson_game::start_game()
         }
         ui_manager::redraw();
         std::string action = ctxt.handle_input();
-        if( const std::optional<tripoint> vec = ctxt.get_direction( action ) ) {
-            position.y = clamp( position.y + vec->y, 0, level_size.y - 1 );
-            position.x = clamp( position.x + vec->x, 0, level_size.x - 1 );
+        if( const std::optional<tripoint_rel_ms> vec = ctxt.get_direction_rel_ms( action ) ) {
+            position.y = clamp( position.y + vec->y(), 0, level_size.y - 1 );
+            position.x = clamp( position.x + vec->x(), 0, level_size.x - 1 );
         } else if( action == "TOGGLE_SPACE" || action == "TOGGLE_5" ) {
             toggle_lights();
             win = check_win();

--- a/src/iuse_software_minesweeper.cpp
+++ b/src/iuse_software_minesweeper.cpp
@@ -308,8 +308,8 @@ int minesweeper_game::start_game()
             action = ctxt.handle_input();
         }
 
-        if( const std::optional<tripoint> vec = ctxt.get_direction( action ) ) {
-            const point new_( vec->xy() + point( iPlayerX, iPlayerY ) );
+        if( const std::optional<tripoint_rel_ms> vec = ctxt.get_direction_rel_ms( action ) ) {
+            const point new_( vec->xy().raw() + point( iPlayerX, iPlayerY ) );
             if( new_.x >= 0 && new_.x < level.x && new_.y >= 0 && new_.y < level.y ) {
                 iPlayerX = new_.x;
                 iPlayerY = new_.y;

--- a/src/iuse_software_sokoban.cpp
+++ b/src/iuse_software_sokoban.cpp
@@ -303,9 +303,9 @@ int sokoban_game::start_game()
         }
 
         bMoved = false;
-        if( const std::optional<tripoint> vec = ctxt.get_direction( action ) ) {
-            iDirX = vec->x;
-            iDirY = vec->y;
+        if( const std::optional<tripoint_rel_ms> vec = ctxt.get_direction_rel_ms( action ) ) {
+            iDirX = vec->x();
+            iDirY = vec->y();
             bMoved = true;
         } else if( action == "QUIT" ) {
             return iScore;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2976,9 +2976,9 @@ bool target_ui::handle_cursor_movement( const std::string &action, bool &skip_re
                 set_view_offset( you->view_offset + edge_scroll );
             }
         }
-    } else if( const std::optional<tripoint> delta = ctxt.get_direction( action ) ) {
+    } else if( const std::optional<tripoint_rel_ms> delta = ctxt.get_direction_rel_ms( action ) ) {
         // Shift view/cursor with directional keys
-        shift_view_or_cursor( *delta );
+        shift_view_or_cursor( delta->raw() );
     } else if( action == "SELECT" &&
                ( mouse_pos = ctxt.get_coordinates( g->w_terrain, g->ter_view_p.raw().xy() ) ) ) {
         // Set pos by clicking with mouse

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1462,9 +1462,9 @@ void Character::store( JsonOut &json ) const
     json.start_array();
     for( const auto &elem : known_traps ) {
         json.start_object();
-        json.member( "x", elem.first.x );
-        json.member( "y", elem.first.y );
-        json.member( "z", elem.first.z );
+        json.member( "x", elem.first.x() );
+        json.member( "y", elem.first.y() );
+        json.member( "z", elem.first.z() );
         json.member( "trap", elem.second );
         json.end_object();
     }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -512,8 +512,8 @@ void veh_interact::do_main_loop()
         const int description_scroll_lines = catacurses::getmaxy( w_parts ) - 4;
         const std::string action = main_context.handle_input();
         msg.reset();
-        if( const std::optional<tripoint> vec = main_context.get_direction( action ) ) {
-            move_cursor( point_rel_ms( vec->xy() ) );
+        if( const std::optional<tripoint_rel_ms> vec = main_context.get_direction_rel_ms( action ) ) {
+            move_cursor( vec->xy() );
         } else if( action == "QUIT" ) {
             finish = true;
         } else if( action == "INSTALL" ) {

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -208,7 +208,7 @@ bool veh_shape::handle_cursor_movement( const std::string &action )
     if( action == "MOUSE_MOVE" || action == "TIMEOUT" ) {
         tripoint_rel_ms edge_scroll = g->mouse_edge_scrolling_terrain( ctxt );
         set_cursor_pos( get_cursor_pos() + edge_scroll );
-    } else if( const std::optional<tripoint> delta = ctxt.get_direction( action ) ) {
+    } else if( const std::optional<tripoint_rel_ms> delta = ctxt.get_direction_rel_ms( action ) ) {
         set_cursor_pos( get_cursor_pos() + *delta ); // move cursor with directional keys
     } else if( action == "zoom_in" ) {
         g->zoom_in();

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -10,8 +10,6 @@ class Creature;
 class viewer
 {
     public:
-        // TODO: fix point types (remove the first overload)
-        virtual bool sees( const tripoint &target, bool is_avatar = false, int range_mod = 0 ) const = 0;
         virtual bool sees( const tripoint_bub_ms &target, bool is_avatar = false,
                            int range_mod = 0 ) const = 0;
         virtual bool sees( const Creature &target ) const = 0;

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -803,7 +803,7 @@ void debug_menu::wishmonstergroup_mon_selection( mongroup &group )
     }
 }
 
-void debug_menu::wishmonster( const std::optional<tripoint> &p )
+void debug_menu::wishmonster( const std::optional<tripoint_bub_ms> &p )
 {
     std::vector<const mtype *> mtypes;
 
@@ -816,7 +816,7 @@ void debug_menu::wishmonster( const std::optional<tripoint> &p )
         wmenu.query();
         if( wmenu.ret >= 0 ) {
             const mtype_id &mon_type = mtypes[ wmenu.ret ]->id;
-            if( std::optional<tripoint_bub_ms> spawn = p ? tripoint_bub_ms( p.value() ) : g->look_around() ) {
+            if( std::optional<tripoint_bub_ms> spawn = p ? p.value() : g->look_around() ) {
                 int num_spawned = 0;
                 for( const tripoint_bub_ms &destination : closest_points_first( *spawn, cb.group ) ) {
                     monster *const mon = g->place_critter_at( mon_type, destination );

--- a/tests/effect_test.cpp
+++ b/tests/effect_test.cpp
@@ -768,7 +768,7 @@ static void test_deadliness( const effect &applied, const int expected_dead, con
     int alive = 0;
     for( int i = 0; i < 10; ++i ) {
         for( int j = 0; j < 10; ++j ) {
-            tripoint cursor( i + 20, j + 20, 0 );
+            tripoint_bub_ms cursor( i + 20, j + 20, 0 );
 
             alive += creatures.creature_at<Creature>( cursor ) != nullptr;
         }

--- a/tests/enchantments_test.cpp
+++ b/tests/enchantments_test.cpp
@@ -252,9 +252,9 @@ TEST_CASE( "Enchantment_ATTACK_SPEED_test", "[magic][enchantments]" )
     clear_map();
     Character &guy = get_player_character();
     clear_avatar();
-    g->place_critter_at( pseudo_debug_mon, tripoint_bub_ms( tripoint::south ) );
+    g->place_critter_at( pseudo_debug_mon, tripoint_bub_ms::zero + tripoint::south );
     creature_tracker &creatures = get_creature_tracker();
-    Creature &mon = *creatures.creature_at<Creature>( tripoint::south );
+    Creature &mon = *creatures.creature_at<Creature>( tripoint_bub_ms::zero + tripoint::south );
     int moves_spent_on_attacks = 0;
 
 
@@ -311,9 +311,9 @@ TEST_CASE( "Enchantment_MELEE_STAMINA_CONSUMPTION_test", "[magic][enchantments]"
     clear_map();
     Character &guy = get_player_character();
     clear_avatar();
-    g->place_critter_at( pseudo_debug_mon, tripoint_bub_ms( tripoint::south ) );
+    g->place_critter_at( pseudo_debug_mon, tripoint_bub_ms::zero + tripoint::south );
     creature_tracker &creatures = get_creature_tracker();
-    Creature &mon = *creatures.creature_at<Creature>( tripoint::south );
+    Creature &mon = *creatures.creature_at<Creature>( tripoint_bub_ms::zero + tripoint::south );
     int stamina_init = 0;
     int stamina_current = 0;
     int stamina_spent = 0;
@@ -380,9 +380,9 @@ TEST_CASE( "Enchantment_MELEE_TO_HIT_test", "[magic][enchantments]" )
     clear_map();
     Character &guy = get_player_character();
     clear_avatar();
-    g->place_critter_at( pseudo_debug_mon, tripoint_bub_ms( tripoint::south ) );
+    g->place_critter_at( pseudo_debug_mon, tripoint_bub_ms::zero + tripoint::south );
     creature_tracker &creatures = get_creature_tracker();
-    Creature &mon = *creatures.creature_at<Creature>( tripoint::south );
+    Creature &mon = *creatures.creature_at<Creature>( tripoint_bub_ms::zero + tripoint::south );
     double hit_rate = 0;
 
     INFO( "Character attacks with +100 to hit enchantment" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Replace usage of untyped coordinates with typed ones. This time files named a-f (primarily).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replace usage of untyped coordinate operations with corresponding typed ones, creating the typed ones if needed, and removal of orphaned untyped operations. Go through implementations to switch to typed coordinates.
There should be no functional changes.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run into but fail to run over turkey, get killed when running into stationary vehicle. Nothing odd seen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The UI stuff remains untyped. The coordinates should probably be in a screen specific coordinate system that doesn't exist currently.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
