### PR TITLE
[MoM] Concentrating on powers at higher Nether Attunement has a chance of backlash

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -563,7 +563,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, your head begins to throb.", "type": "bad" },
+      { "u_message": "Your head begins to throb.", "type": "bad" },
       {
         "u_add_effect": "psionic_overload",
         "duration": {
@@ -592,7 +592,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, the temperature suddenly drops!", "type": "bad" },
+      { "u_message": "The temperature suddenly drops!", "type": "bad" },
       { "u_cast_spell": { "id": "nether_attunement_cold_chill", "hit_self": true } }
     ]
   },
@@ -616,7 +616,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, you feel a strange tingling sensation.", "type": "mixed" },
+      { "u_message": "You feel a strange tingling sensation.", "type": "mixed" },
       { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(5) + 2" ] }
     ]
   },
@@ -647,11 +647,11 @@
             "condition": { "math": [ "rand(1) >= 1" ] },
             "effect": [
               { "u_add_effect": "effect_nether_attunement_health_bonus", "duration": "30 seconds" },
-              { "u_message": "As you unleash your powers, you bloom with vitality.", "type": "good" }
+              { "u_message": "You feel filled with vigor.", "type": "good" }
             ],
             "false_effect": [
               { "u_add_effect": "effect_nether_attunement_health_penalty", "duration": "30 seconds" },
-              { "u_message": "As you unleash your powers, you are struck with malaise.", "type": "bad" }
+              { "u_message": "You feel drained of vitality.", "type": "bad" }
             ]
           }
         ]
@@ -678,7 +678,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, blood drips from your nose.", "type": "bad" },
+      { "u_message": "Blood drips from your nose.", "type": "bad" },
       { "u_add_effect": "bleed", "intensity": 1, "target_part": "head", "duration": "5 minutes" },
       { "math": [ "u_hp('head')", "-=", "1" ] }
     ]
@@ -703,7 +703,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, they take more out of you than you expected.", "type": "bad" },
+      { "u_message": "You feel a sudden wave of fatigue.", "type": "bad" },
       { "math": [ "u_val('stamina')", "-=", "rng(3000,9000)" ] }
     ]
   },
@@ -727,7 +727,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, you feel tired.", "type": "bad" },
+      { "u_message": "You feel a sudden wave of exhaustion.", "type": "bad" },
       { "math": [ "u_val('sleepiness')", "+=", "rng(30,90)" ] }
     ]
   },
@@ -756,10 +756,7 @@
           "id": "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT_2",
           "condition": { "not": { "u_has_proficiency": "effect_nether_attunement_attenuation" } },
           "effect": [
-            {
-              "u_message": "As you unleash your powers, you feel a strange tingling sensation that does not go away.",
-              "type": "mixed"
-            },
+            { "u_message": "You feel a strange tingling sensation that does not go away.", "type": "mixed" },
             {
               "u_add_effect": "effect_nether_attunement_raiser",
               "duration": {
@@ -791,7 +788,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, you feel a stabbing pain!", "type": "good" },
+      { "u_message": "You feel a stabbing pain!", "type": "good" },
       { "math": [ "u_pain()", "+=", "rand(7) + 3" ] },
       {
         "u_add_effect": "effect_nether_attunement_feedback",
@@ -821,7 +818,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, you feel a surge of strength!", "type": "good" },
+      { "u_message": "You feel a surge of strength!", "type": "good" },
       {
         "u_add_effect": "effect_nether_attunement_power_surge",
         "duration": { "math": [ "u_vitamin('vitamin_psionic_drain') * rng(1,10)" ] }
@@ -848,7 +845,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, your skin feels tight!", "type": "bad" },
+      { "u_message": "Your skin feels tight!", "type": "bad" },
       {
         "u_add_effect": "effect_psi_teleport_lock",
         "duration": {
@@ -877,7 +874,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, your muscles tremble and weaken.", "type": "bad" },
+      { "u_message": "Your muscles tremble and weaken.", "type": "bad" },
       {
         "u_add_effect": "effect_biokin_overload",
         "duration": {
@@ -911,7 +908,7 @@
           "id": "EOC_NETHER_EFFECT_CHECK_ATTENUATION_2",
           "condition": { "not": { "u_has_proficiency": "effect_nether_attunement_raiser" } },
           "effect": [
-            { "u_message": "As you unleash your powers, the flow of energy slows to a trickle!", "type": "bad" },
+            { "u_message": "The flow of Netherum energy slows to a trickle!", "type": "bad" },
             {
               "u_add_effect": "effect_nether_attunement_attenuation",
               "duration": {
@@ -943,7 +940,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, you gasp and your breath gives out.", "type": "bad" },
+      { "u_message": "You gasp and your breath gives out.", "type": "bad" },
       {
         "u_add_effect": "effect_psi_reduced_breathing",
         "duration": {
@@ -972,7 +969,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, you begin to feel a sudden sense of dread and paranoia!", "type": "bad" },
+      { "u_message": "You begin to feel a sudden sense of dread and paranoia!", "type": "bad" },
       {
         "u_add_effect": "hallu",
         "duration": {
@@ -1001,7 +998,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, a soundless explosion hurls you off your feet.", "type": "bad" },
+      { "u_message": "A soundless explosion hurls you off your feet.", "type": "bad" },
       { "u_cast_spell": { "id": "nether_attunement_everyone_downed", "hit_self": true } }
     ]
   },
@@ -1025,10 +1022,7 @@
       ]
     },
     "effect": [
-      {
-        "u_message": "As you unleash your powers, the flow of Nether energy you are channeling is suddenly cut off!",
-        "type": "bad"
-      },
+      { "u_message": "The flow of Nether energy is suddenly cut off!", "type": "bad" },
       {
         "u_add_effect": "effect_psi_null_unbound",
         "duration": {
@@ -1058,7 +1052,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, crackling energy erupts all around you!", "type": "bad" },
+      { "u_message": "Crackling energy erupts all around you!", "type": "bad" },
       { "u_cast_spell": { "id": "nether_attunement_nether_lightning", "hit_self": false } }
     ]
   },
@@ -1084,7 +1078,7 @@
     },
     "effect": [
       { "u_add_effect": "tindrift", "duration": "1 day" },
-      { "u_message": "As you unleash your powers, you feel a horrible sensation of watching eyes.", "type": "bad" }
+      { "u_message": "You feel a horrible sensation of watching eyes.", "type": "bad" }
     ]
   },
   {
@@ -1108,7 +1102,7 @@
     },
     "effect": [
       { "run_eocs": "EOC_NETHER_ATTUNEMENT_MUTATION_GAINER" },
-      { "u_message": "As you unleash your powers, feel an internal wrenching sensation.", "type": "bad" }
+      { "u_message": "You feel an internal wrenching sensation.", "type": "bad" }
     ]
   },
   {
@@ -1133,7 +1127,7 @@
     },
     "effect": [
       { "u_set_field": "fd_fatigue", "radius": 0, "intensity": 3, "hit_player": false },
-      { "u_message": "As you unleash your powers, the air around you twists and warps in on itself.", "type": "bad" }
+      { "u_message": "The air around you twists and warps in on itself.", "type": "bad" }
     ]
   },
   {

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -698,7 +698,10 @@
         { "x_in_y_chance": { "x": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] }, "y": 2500 } }
       ]
     },
-    "effect": { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" }
+    "effect": [
+      { "u_message": "Your concentration waves for just a moment.", "type": "bad" },
+      { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -699,7 +699,7 @@
       ]
     },
     "effect": [
-      { "u_message": "Your concentration waves for just a moment.", "type": "bad" },
+      { "u_message": "Your concentration wavers for just a moment.", "type": "bad" },
       { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" }
     ]
   },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -618,7 +618,8 @@
       },
       {
         "math": [ "u_skill_exp('metaphysics', 'format': 'raw')", "+=", "(15 * u_latest_channeled_power_difficulty)" ]
-      }
+      },
+      { "run_eocs": "EOC_CONCENTRATION_CHECK_FOR_NETHER_ATTUNEMENT_BACKLASH" }
     ],
     "false_effect": [
       {

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -694,7 +694,7 @@
     "id": "EOC_CONCENTRATION_CHECK_FOR_NETHER_ATTUNEMENT_BACKLASH",
     "condition": {
       "and": [
-        { "math": [ "u_vitamin('vitamin_maintained_powers') >= 15" ] },
+        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 15" ] },
         { "x_in_y_chance": { "x": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] }, "y": 2500 } }
       ]
     },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -627,6 +627,7 @@
           "EOC_CONCENTRATION_IN_NETHER_AREAS_ATTUNEMENT",
           "EOC_NETHER_ATTUNEMENT_FEEDBACK_CHECK_CONCENTRATION",
           "EOC_CONCENTRATION_SUCCESS_REDUCE_FOCUS",
+          "EOC_CONCENTRATION_CHECK_FOR_NETHER_ATTUNEMENT_BACKLASH",
           "EOC_CONCENTRATION_VS_LIMIT_CALCULATIONS"
         ]
       },
@@ -686,6 +687,17 @@
     "id": "EOC_CONCENTRATION_FAILURE_REDUCE_FOCUS",
     "condition": { "and": [ { "math": [ "u_vitamin('vitamin_maintained_powers') > 0" ] }, { "math": [ "u_val('focus') >= 20" ] } ] },
     "effect": [ { "math": [ "u_val('focus')", "-=", "5" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CONCENTRATION_CHECK_FOR_NETHER_ATTUNEMENT_BACKLASH",
+    "condition": {
+      "and": [
+        { "math": [ "u_vitamin('vitamin_maintained_powers') >= 15" ] },
+        { "x_in_y_chance": { "x": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] }, "y": 2500 } }
+      ]
+    },
+    "effect": { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" }
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Concentrating on powers at higher Nether Attunement has a chance of backlash"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Play with fire and you get burned.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

When a concentration check is made, there's a chance for Nether Attunement backlash.  This is much lower than the chance on channeling a power (the maximum chance during the concentration check is 10% odds if you're at maximum Nether Attunement [equation is Nether Attunement vitamin / 2500], and then it still has to do the normal Nether Attunement backlash check to see if anything actually happens), but very importantly, it's not zero. 

When you hit those odds and it checks for backlash, you get a `Your concentration wavers for just a moment` message. This doesn't mean that you _will_ experience backlash, just that you could have.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Set odds to [vitamin] in 250 and turned on Levitation for extremely frequent concentration checks. You can get backlash.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I too am guilty of saying "Metabolic Hyperefficiency at Nether Attunement 12 in my base? Sleeping one day a week sounds great!"
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
