### PR TITLE
[WIP] Extra world difficulty settings for vehicle and fuel availability, and zombie revivification

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13512,7 +13512,7 @@ bool item::process_corpse( map &here, Character *carrier, const tripoint_bub_ms 
         return false;
     }
 
-    if( corpse->has_flag( mon_flag_DORMANT ) ) {
+    if( corpse->has_flag( mon_flag_DORMANT ) && get_option<bool>( "ZOMBIE_REVIVIFICATION_DORMANT" ) ) {
         //if dormant, ensure trap still exists.
         const trap *trap_here = &here.tr_at( pos );
         if( trap_here->is_null() ) {
@@ -13532,7 +13532,10 @@ bool item::process_corpse( map &here, Character *carrier, const tripoint_bub_ms 
         set_var( "zombie_form", mon_human->zombify_into.c_str() );
     }
 
-    if( !ready_to_revive( here, pos ) ) {
+    const bool revivification_over_time_enabled = get_option<bool>( "ZOMBIE_REVIVIFICATION_OVER_TIME" )
+            || ( has_var( "zombie_form" ) && get_option<bool>( "ZOMBIE_REVIVIFICATION_HUMAN_ZOMBIFICATION" ) );
+
+    if( !revivification_over_time_enabled || !ready_to_revive( here, pos ) ) {
         return false;
     }
     if( rng( 0, volume() / 250_ml ) > burnt &&

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1539,7 +1539,8 @@ void spell_effect::revive( const spell &sp, Creature &caster, const tripoint_bub
     for( const tripoint_bub_ms &aoe : area ) {
         for( item &corpse : here.i_at( aoe ) ) {
             const mtype *mt = corpse.get_mtype();
-            if( !( corpse.is_corpse() && corpse.can_revive() && corpse.active &&
+            if( !( get_option<bool>( "ZOMBIE_REVIVIFICATION_SPELLS" ) && corpse.is_corpse() &&
+                   corpse.can_revive() && corpse.active &&
                    mt->has_flag( mon_flag_REVIVES ) && !mt->has_flag( mon_flag_DORMANT ) && mt->in_species( spec ) &&
                    !mt->has_flag( mon_flag_NO_NECRO ) ) ) {
                 continue;
@@ -1562,7 +1563,8 @@ void spell_effect::revive_dormant( const spell &sp, Creature &caster,
     for( const tripoint_bub_ms &aoe : area ) {
         for( item &corpse : here.i_at( aoe ) ) {
             const mtype *mt = corpse.get_mtype();
-            if( !( corpse.is_corpse() && corpse.can_revive() && corpse.active &&
+            if( !( get_option<bool>( "ZOMBIE_REVIVIFICATION_DORMANT" ) && corpse.is_corpse() &&
+                   corpse.can_revive() && corpse.active &&
                    mt->has_flag( mon_flag_REVIVES ) && mt->has_flag( mon_flag_DORMANT ) && mt->in_species( spec ) ) ) {
                 continue;
             }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2280,7 +2280,9 @@ class jmapgen_gaspump : public jmapgen_piece_with_has_vehicle_collision
             int charges = amount.get() * 100;
             dat.m.furn_set( r, furn_str_id::NULL_ID() );
             if( charges == 0 ) {
-                charges = rng( 10000, 50000 );
+                int option_fuel_modifier = get_option<int>( "DIFFICULTY_FUEL_AVAILABILITY" );
+                charges = normal_roll( 30000 * option_fuel_modifier,
+                                       10000 + 100 * option_fuel_modifier ) * option_fuel_modifier;
             }
             itype_id chosen_fuel = fuel.get( dat );
             if( chosen_fuel.is_null() ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2827,6 +2827,45 @@ void options_manager::add_options_world_default()
              to_translation( "If true, spawn zombies at shelters.  Makes the starting game a lot harder." ),
              false
            );
+
+        add( "DIFFICULTY_FUEL_AVAILABILITY", page_id, to_translation( "Fuel availability" ),
+             to_translation( "Determines the percentage of fuel, relative to the default values, that will be found in vehicles, gas stations and containers. Also affects vehicle battery charge." ),
+             0, 100, 100
+           );
+
+        add( "DIFFICULTY_VEHICLE_DAMAGE_CHANCE", page_id,
+             to_translation( "Chance of vehicles being damaged" ),
+             to_translation( "Increases the chances of vehicles being damaged.  A value of 0 will spawn vehicles with their default mapgen damage values.  A positive number will add a chance for the whole vehicle or some specific parts being destroyed." ),
+             0, 100, 0
+           );
+
+        add( "DIFFICULTY_VEHICLE_TURRET_CHANCE", page_id,
+             to_translation( "Chance of finding working vehicle turrets" ),
+             to_translation( "Determines the chance of turrets found in vehicles not being destroyed." ),
+             0, 100, 20
+           );
+
+        add( "ZOMBIE_REVIVIFICATION_OVER_TIME", page_id,
+             to_translation( "Zombie revivification over time" ),
+             to_translation( "Determines if zombies can revive over time if corpses are not pulped." ),
+             true
+           );
+
+        add( "ZOMBIE_REVIVIFICATION_SPELLS", page_id,
+             to_translation( "Zombie revivification through spells" ),
+             to_translation( "Determines if zombies can be revived through spells if corpses are not pulped.  This doesn't prevent necromancer zombies from reviving other zombies." ),
+             true
+           );
+
+        add( "ZOMBIE_REVIVIFICATION_DORMANT", page_id, to_translation( "Dormant zombie revivification" ),
+             to_translation( "Determines if dormant zombies can wake up when triggered." ),
+             true
+           );
+
+        add( "ZOMBIE_REVIVIFICATION_HUMAN_ZOMBIFICATION", page_id, to_translation( "Human zombification" ),
+             to_translation( "Determines if humans can revive as zombies after death.  This setting can be force-disabled by mods." ),
+             true
+           );
     } );
 
     add_empty_line();


### PR DESCRIPTION
#### Summary
Features "Extra world difficulty settings for vehicle and fuel availability, zombie revivification and "

#### Purpose of change
Some very useful and popular settings were implemented in the NoHope mod but lack granularity or flexibility. This PR aims to make some of those settings available as world settings providing extra customization.

#### Describe the solution
This PR will include the following world settings:
* Toggle zombification of human corpses.
* Toggle reanimation of zombie corpses over time.
* Toggle reanimation of zombies through spells.
* Toggle reanimation of dormant zombies (traps).
* Tweak fuel availability (percentage over default values). This also affects vehicle batteries and gas pumps. TODO: Apply setting to fuel containers.
* Increase chance of vehicles being destroyed. This also increases the chance of solar panels being destroyed, even in lightly damaged vehicles.
* Set the chance of turret weapons in vehicles being destroyed.

#### Describe alternatives you've considered
Playing NoHope whenever I feel the early game is not punishing enough.

#### Testing
Pending.

#### Additional context
TBD.
