### PR TITLE
Rename map:: get_global->get_abs, bub_from_abs->get_bub, omt_from_abs->get_omt

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -892,7 +892,7 @@ static hack_type get_hack_type( const tripoint_bub_ms &examp )
 
 void hacking_activity_actor::finish( player_activity &act, Character &who )
 {
-    tripoint_bub_ms examp = get_map().bub_from_abs( act.placement );
+    tripoint_bub_ms examp = get_map().get_bub( act.placement );
     hack_type type = get_hack_type( examp );
     switch( hack_attempt( who, tool ) ) {
         case hack_result::UNABLE:
@@ -1270,7 +1270,7 @@ void hotwire_car_activity_actor::do_turn( player_activity &act, Character &who )
 {
     map &here = get_map();
     if( calendar::once_every( 1_minutes ) ) {
-        bool lost = !here.veh_at( here.bub_from_abs( target ) ).has_value();
+        bool lost = !here.veh_at( here.get_bub( target ) ).has_value();
         if( lost ) {
             act.set_to_null();
             debugmsg( "Lost ACT_HOTWIRE_CAR target vehicle" );
@@ -1286,7 +1286,7 @@ void hotwire_car_activity_actor::finish( player_activity &act, Character &who )
     act.set_to_null();
 
     map &here = get_map();
-    const optional_vpart_position vp = here.veh_at( here.bub_from_abs( target ) );
+    const optional_vpart_position vp = here.veh_at( here.get_bub( target ) );
     if( !vp ) {
         debugmsg( "Lost ACT_HOTWIRE_CAR target vehicle" );
         return;
@@ -2804,7 +2804,7 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
     }
 
     map &here = get_map();
-    const tripoint_bub_ms target = here.bub_from_abs( this->target );
+    const tripoint_bub_ms target = here.get_bub( this->target );
     const ter_id &ter_type = here.ter( target );
     const furn_id &furn_type = here.furn( target );
     optional_vpart_position const veh = here.veh_at( target );
@@ -5024,7 +5024,7 @@ void milk_activity_actor::do_turn( player_activity &act, Character &who )
         return;
     }
     map &here = get_map();
-    const tripoint_bub_ms source_pos = here.bub_from_abs( tripoint_abs_ms( monster_coords.at( 0 ) ) );
+    const tripoint_bub_ms source_pos = here.get_bub( tripoint_abs_ms( monster_coords.at( 0 ) ) );
     monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         // We might end up here if the creature dies while being milked
@@ -5041,7 +5041,7 @@ void milk_activity_actor::finish( player_activity &act, Character &who )
         return;
     }
     map &here = get_map();
-    const tripoint_bub_ms source_pos = here.bub_from_abs( tripoint_abs_ms( monster_coords.at( 0 ) ) );
+    const tripoint_bub_ms source_pos = here.get_bub( tripoint_abs_ms( monster_coords.at( 0 ) ) );
     monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         debugmsg( "could not find source creature for liquid transfer" );
@@ -6397,10 +6397,10 @@ static void chop_single_do_turn( player_activity &act )
 {
     const map &here = get_map();
     sfx::play_activity_sound( "tool", "axe",
-                              sfx::get_heard_volume( here.bub_from_abs( act.placement ) ) );
+                              sfx::get_heard_volume( here.get_bub( act.placement ) ) );
     if( calendar::once_every( 1_minutes ) ) {
         //~ Sound of a wood chopping tool at work!
-        sounds::sound( here.bub_from_abs( act.placement ), 15, sounds::sound_t::activity, _( "CHK!" ) );
+        sounds::sound( here.get_bub( act.placement ), 15, sounds::sound_t::activity, _( "CHK!" ) );
     }
 }
 
@@ -6418,7 +6418,7 @@ void chop_logs_activity_actor::do_turn( player_activity &act, Character & )
 void chop_logs_activity_actor::finish( player_activity &act, Character &who )
 {
     map &here = get_map();
-    const tripoint_bub_ms &pos = here.bub_from_abs( act.placement );
+    const tripoint_bub_ms &pos = here.get_bub( act.placement );
     int log_quan;
     int stick_quan;
     int splint_quan;
@@ -6502,12 +6502,12 @@ void chop_planks_activity_actor::finish( player_activity &act, Character &who )
 
     map &here = get_map();
     if( planks > 0 ) {
-        here.spawn_item( here.bub_from_abs( act.placement ), itype_2x4, planks, 0, calendar::turn );
+        here.spawn_item( here.get_bub( act.placement ), itype_2x4, planks, 0, calendar::turn );
         who.add_msg_if_player( m_good, n_gettext( "You produce %d plank.", "You produce %d planks.",
                                planks ), planks );
     }
     if( scraps > 0 ) {
-        here.spawn_item( here.bub_from_abs( act.placement ), itype_splinter, scraps, 0, calendar::turn );
+        here.spawn_item( here.get_bub( act.placement ), itype_splinter, scraps, 0, calendar::turn );
         who.add_msg_if_player( m_good, n_gettext( "You produce %d splinter.", "You produce %d splinters.",
                                scraps ), scraps );
     }
@@ -6552,7 +6552,7 @@ void chop_tree_activity_actor::do_turn( player_activity &act, Character & )
 void chop_tree_activity_actor::finish( player_activity &act, Character &who )
 {
     map &here = get_map();
-    const tripoint_bub_ms &pos = here.bub_from_abs( act.placement );
+    const tripoint_bub_ms &pos = here.get_bub( act.placement );
 
     tripoint_rel_ms direction;
     if( !who.is_npc() &&
@@ -6612,7 +6612,7 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
     // sound of falling tree
     here.collapse_at( pos, false, true, false );
     sfx::play_variant_sound( "misc", "timber",
-                             sfx::get_heard_volume( here.bub_from_abs( act.placement ) ) );
+                             sfx::get_heard_volume( here.get_bub( act.placement ) ) );
     get_event_bus().send<event_type::cuts_tree>( who.getID() );
     act.set_to_null();
     activity_handlers::resume_for_multi_activities( who );
@@ -6650,7 +6650,7 @@ void churn_activity_actor::finish( player_activity &act, Character &who )
 {
     map &here = get_map();
     who.add_msg_if_player( _( "You finish churning up the earth here." ) );
-    here.ter_set( here.bub_from_abs( act.placement ), ter_t_dirtmound );
+    here.ter_set( here.get_bub( act.placement ), ter_t_dirtmound );
     // Go back to what we were doing before
     // could be player zone activity, or could be NPC multi-farming
     act.set_to_null();
@@ -6688,7 +6688,7 @@ void clear_rubble_activity_actor::start( player_activity &act, Character & )
 void clear_rubble_activity_actor::finish( player_activity &act, Character &who )
 {
     map &here = get_map();
-    const tripoint_bub_ms &pos = here.bub_from_abs( act.placement );
+    const tripoint_bub_ms &pos = here.get_bub( act.placement );
     who.add_msg_if_player( m_info, _( "You clear up the %s." ), here.furnname( pos ) );
     here.furn_set( pos, furn_str_id::NULL_ID() );
 
@@ -6832,7 +6832,7 @@ void forage_activity_actor::finish( player_activity &act, Character &who )
     bool next_to_bush = false;
     map &here = get_map();
     for( const tripoint_bub_ms &pnt : here.points_in_radius( who.pos_bub(), 1 ) ) {
-        if( here.getglobal( pnt ) == act.placement ) {
+        if( here.get_abs( pnt ) == act.placement ) {
             next_to_bush = true;
             break;
         }
@@ -6870,7 +6870,7 @@ void forage_activity_actor::finish( player_activity &act, Character &who )
             debugmsg( "Invalid season" );
     }
 
-    const tripoint_bub_ms bush_pos = here.bub_from_abs( act.placement );
+    const tripoint_bub_ms bush_pos = here.get_bub( act.placement );
     here.ter_set( bush_pos, next_ter );
 
     // Survival gives a bigger boost, and Perception is leveled a bit.
@@ -7110,7 +7110,7 @@ void mop_activity_actor::finish( player_activity &act, Character &who )
     const bool will_mop = one_in( who.is_blind() ? 1 : 3 );
     if( will_mop ) {
         map &here = get_map();
-        here.mop_spills( here.bub_from_abs( act.placement ) );
+        here.mop_spills( here.get_bub( act.placement ) );
     }
     activity_handlers::resume_for_multi_activities( who );
 }
@@ -7264,7 +7264,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
             placement = src;
             coord_set.erase( src );
 
-            const tripoint_bub_ms &src_loc = here.bub_from_abs( src );
+            const tripoint_bub_ms &src_loc = here.get_bub( src );
             if( !here.inbounds( src_loc ) ) {
                 if( !here.inbounds( you.pos_bub() ) ) {
                     // p is implicitly an NPC that has been moved off the map, so reset the activity
@@ -7349,7 +7349,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
     }
     if( stage == DO ) {
         const tripoint_abs_ms src( placement );
-        const tripoint_bub_ms src_loc = here.bub_from_abs( src );
+        const tripoint_bub_ms src_loc = here.get_bub( src );
 
         bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_loc ) <= 1;
         // before we move any item, check if player is at or
@@ -8035,7 +8035,7 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
 
     int moves = 0;
     for( auto pos_iter = placement.cbegin(); pos_iter != placement.end();/*left - out*/ ) {
-        const tripoint_bub_ms &pos = here.bub_from_abs( *pos_iter );
+        const tripoint_bub_ms &pos = here.get_bub( *pos_iter );
         map_stack corpse_pile = here.i_at( pos );
         for( item &corpse : corpse_pile ) {
             if( !corpse.is_corpse() || !corpse.can_revive() ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1605,7 +1605,7 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
         // 1. Gather the source item.
         vehicle *source_veh = nullptr;
         map &here = get_map();
-        const tripoint_bub_ms source_pos = here.bub_from_abs( act_ref.coords.at( 0 ) );
+        const tripoint_bub_ms source_pos = here.get_bub( act_ref.coords.at( 0 ) );
         map_stack source_stack = here.i_at( source_pos );
         map_stack::iterator on_ground;
         monster *source_mon = nullptr;
@@ -1661,7 +1661,7 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
         size_t part;
         switch( static_cast<liquid_target_type>( act_ref.values.at( 2 ) ) ) {
             case liquid_target_type::VEHICLE: {
-                const optional_vpart_position vp = here.veh_at( here.bub_from_abs( act_ref.coords.at( 1 ) ) );
+                const optional_vpart_position vp = here.veh_at( here.get_bub( act_ref.coords.at( 1 ) ) );
                 if( act_ref.values.size() > 4 && vp ) {
                     const vpart_reference vpr( vp->vehicle(), act_ref.values[4] );
                     veh = &vp->vehicle();
@@ -1686,10 +1686,10 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
                 you->pour_into( act_ref.targets.at( 0 ), liquid, true );
                 break;
             case liquid_target_type::MAP:
-                if( iexamine::has_keg( here.bub_from_abs( act_ref.coords.at( 1 ) ) ) ) {
-                    iexamine::pour_into_keg( here.bub_from_abs( act_ref.coords.at( 1 ) ), liquid );
+                if( iexamine::has_keg( here.get_bub( act_ref.coords.at( 1 ) ) ) ) {
+                    iexamine::pour_into_keg( here.get_bub( act_ref.coords.at( 1 ) ), liquid );
                 } else {
-                    here.add_item_or_charges( here.bub_from_abs( act_ref.coords.at( 1 ) ), liquid );
+                    here.add_item_or_charges( here.get_bub( act_ref.coords.at( 1 ) ), liquid );
                     you->add_msg_if_player( _( "You pour %1$s onto the ground." ), liquid.tname() );
                     liquid.charges = 0;
                 }
@@ -1856,7 +1856,7 @@ void activity_handlers::game_do_turn( player_activity *act, Character *you )
 
 void activity_handlers::pickaxe_do_turn( player_activity *act, Character * )
 {
-    const tripoint_bub_ms &pos = get_map().bub_from_abs( act->placement );
+    const tripoint_bub_ms &pos = get_map().get_bub( act->placement );
     sfx::play_activity_sound( "tool", "pickaxe", sfx::get_heard_volume( pos ) );
     // each turn is too much
     if( calendar::once_every( 1_minutes ) ) {
@@ -1868,7 +1868,7 @@ void activity_handlers::pickaxe_do_turn( player_activity *act, Character * )
 void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
 {
     map &here = get_map();
-    const tripoint_bub_ms pos( here.bub_from_abs( act->placement ) );
+    const tripoint_bub_ms pos( here.get_bub( act->placement ) );
     // Invalidate the activity early to prevent a query from mod_pain()
     act->set_to_null();
     if( you->is_avatar() ) {
@@ -1928,14 +1928,14 @@ void activity_handlers::start_fire_finish( player_activity *act, Character *you 
 
     you->practice( skill_survival, act->index, 5 );
 
-    firestarter_actor::resolve_firestarter_use( you, get_map().bub_from_abs( act->placement ) );
+    firestarter_actor::resolve_firestarter_use( you, get_map().get_bub( act->placement ) );
     act->set_to_null();
 }
 
 void activity_handlers::start_fire_do_turn( player_activity *act, Character *you )
 {
     map &here = get_map();
-    tripoint_bub_ms where = here.bub_from_abs( act->placement );
+    tripoint_bub_ms where = here.get_bub( act->placement );
     if( !here.is_flammable( where ) ) {
         try_fuel_fire( *act, *you, true );
         if( !here.is_flammable( where ) ) {
@@ -2142,7 +2142,7 @@ void activity_handlers::vehicle_finish( player_activity *act, Character *you )
 {
     map &here = get_map();
     //Grab this now, in case the vehicle gets shifted
-    const optional_vpart_position vp = here.veh_at( here.bub_from_abs( tripoint_abs_ms( act->values[0],
+    const optional_vpart_position vp = here.veh_at( here.get_bub( tripoint_abs_ms( act->values[0],
                                        act->values[1],
                                        you->posz() ) ) );
     veh_interact::complete_vehicle( *you );
@@ -2397,7 +2397,7 @@ struct weldrig_hack {
         }
 
         const map &here = get_map();
-        const optional_vpart_position vp = here.veh_at( here.bub_from_abs( act.coords[0] ) );
+        const optional_vpart_position vp = here.veh_at( here.get_bub( act.coords[0] ) );
         if( !vp ) {
             return false;
         }
@@ -2886,7 +2886,7 @@ void activity_handlers::travel_do_turn( player_activity *act, Character *you )
             waypoint = clamp( cur_omt_mid, project_bounds<coords::ms>( next_omt ) );
         }
         map &here = get_map();
-        tripoint_bub_ms centre_sub = here.bub_from_abs( waypoint );
+        tripoint_bub_ms centre_sub = here.get_bub( waypoint );
         if( !here.passable( centre_sub ) ) {
             tripoint_range<tripoint_bub_ms> candidates = here.points_in_radius( centre_sub, 2 );
             for( const tripoint_bub_ms &elem : candidates ) {
@@ -3300,7 +3300,7 @@ void activity_handlers::operation_finish( player_activity *act, Character *you )
 void activity_handlers::plant_seed_finish( player_activity *act, Character *you )
 {
     map &here = get_map();
-    tripoint_bub_ms examp = here.bub_from_abs( act->placement );
+    tripoint_bub_ms examp = here.get_bub( act->placement );
     const itype_id seed_id( act->str_values[0] );
     std::list<item> used_seed;
     if( item::count_by_charges( seed_id ) ) {
@@ -3334,7 +3334,7 @@ void activity_handlers::plant_seed_finish( player_activity *act, Character *you 
 void activity_handlers::build_do_turn( player_activity *act, Character *you )
 {
     map &here = get_map();
-    partial_con *pc = here.partial_con_at( here.bub_from_abs( act->placement ) );
+    partial_con *pc = here.partial_con_at( here.get_bub( act->placement ) );
     // Maybe the player and the NPC are working on the same construction at the same time
     if( !pc ) {
         if( you->is_npc() ) {
@@ -3375,7 +3375,7 @@ void activity_handlers::build_do_turn( player_activity *act, Character *you )
     const double current_progress = old_counter * base_total_moves / 10000000.0 +
                                     delta_progress;
     you->set_moves( 0 );
-    pc->id->do_turn_special( here.bub_from_abs( act->placement ), *you );
+    pc->id->do_turn_special( here.get_bub( act->placement ), *you );
     // Current progress as a percent of base_total_moves to 2 decimal places
     pc->counter = std::round( current_progress / base_total_moves * 10000000.0 );
     pc->counter = std::min( pc->counter, 10000000 );
@@ -3485,9 +3485,9 @@ void activity_handlers::jackhammer_do_turn( player_activity *act, Character * )
 {
     map &here = get_map();
     sfx::play_activity_sound( "tool", "jackhammer",
-                              sfx::get_heard_volume( here.bub_from_abs( act->placement ) ) );
+                              sfx::get_heard_volume( here.get_bub( act->placement ) ) );
     if( calendar::once_every( 1_minutes ) ) {
-        sounds::sound( here.bub_from_abs( act->placement ), 15, sounds::sound_t::destructive_activity,
+        sounds::sound( here.get_bub( act->placement ), 15, sounds::sound_t::destructive_activity,
                        //~ Sound of a jackhammer at work!
                        _( "TATATATATATATAT!" ) );
     }
@@ -3496,7 +3496,7 @@ void activity_handlers::jackhammer_do_turn( player_activity *act, Character * )
 void activity_handlers::jackhammer_finish( player_activity *act, Character *you )
 {
     map &here = get_map();
-    const tripoint_bub_ms &pos = here.bub_from_abs( act->placement );
+    const tripoint_bub_ms &pos = here.get_bub( act->placement );
 
     here.destroy( pos, true );
 
@@ -3525,7 +3525,7 @@ static void cleanup_tiles( std::unordered_set<tripoint_abs_ms> &tiles, fn &clean
     while( it != tiles.end() ) {
         auto current = it++;
 
-        const tripoint_bub_ms &tile_loc = here.bub_from_abs( *current );
+        const tripoint_bub_ms &tile_loc = here.get_bub( *current );
 
         if( cleanup( tile_loc ) ) {
             tiles.erase( current );
@@ -3551,7 +3551,7 @@ static void perform_zone_activity_turn(
         get_sorted_tiles_by_distance( abspos, unsorted_tiles );
 
     for( const tripoint_abs_ms &tile : tiles ) {
-        const tripoint_bub_ms &tile_loc = here.bub_from_abs( tile );
+        const tripoint_bub_ms &tile_loc = here.get_bub( tile );
 
         std::vector<tripoint_bub_ms> route =
             here.route( you->pos_bub(), tile_loc, you->get_pathfinding_settings(),
@@ -3714,7 +3714,7 @@ void activity_handlers::pull_creature_finish( player_activity *act, Character *y
     if( you->is_avatar() ) {
         you->as_avatar()->longpull( act->name );
     } else {
-        you->longpull( act->name, get_map().bub_from_abs( act->placement ) );
+        you->longpull( act->name, get_map().get_bub( act->placement ) );
     }
     act->set_to_null();
 }
@@ -3830,7 +3830,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, Character *yo
 
     // choose target for spell before continuing
     const std::optional<tripoint_bub_ms> target = act->coords.empty() ? spell_being_cast.select_target(
-                you ) : get_map().bub_from_abs( act->coords.front() );
+                you ) : get_map().get_bub( act->coords.front() );
     if( target ) {
         // npcs check for target viability
         if( !you->is_npc() || spell_being_cast.is_valid_target( *you, *target ) ) {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -250,12 +250,12 @@ bool avatar::should_show_map_memory() const
 
 bool avatar::save_map_memory()
 {
-    return player_map_memory->save( get_map().getglobal( pos_bub() ) );
+    return player_map_memory->save( get_map().get_abs( pos_bub() ) );
 }
 
 void avatar::load_map_memory()
 {
-    player_map_memory->load( get_map().getglobal( pos_bub() ) );
+    player_map_memory->load( get_map().get_abs( pos_bub() ) );
 }
 
 void avatar::prepare_map_memory_region( const tripoint_abs_ms &p1, const tripoint_abs_ms &p2 )
@@ -690,14 +690,14 @@ void avatar::grab( object_type grab_type_new, const tripoint_rel_ms &grab_point_
             if( const optional_vpart_position ovp = m.veh_at( pos_bub() + gpoint ) ) {
                 for( const tripoint_bub_ms &target : ovp->vehicle().get_points() ) {
                     if( erase ) {
-                        memorize_clear_decoration( m.getglobal( target ), /* prefix = */ "vp_" );
+                        memorize_clear_decoration( m.get_abs( target ), /* prefix = */ "vp_" );
                     }
                     m.memory_cache_dec_set_dirty( target, true );
                 }
             }
         } else if( gtype != object_type::NONE ) {
             if( erase ) {
-                memorize_clear_decoration( m.getglobal( pos_bub() + gpoint ) );
+                memorize_clear_decoration( m.get_abs( pos_bub() + gpoint ) );
             }
             m.memory_cache_dec_set_dirty( pos_bub() + gpoint, true );
         }
@@ -1231,7 +1231,7 @@ void avatar::rebuild_aim_cache() const
 
     double pi = 2 * acos( 0.0 );
 
-    const tripoint_bub_ms local_last_target = get_map().bub_from_abs(
+    const tripoint_bub_ms local_last_target = get_map().get_bub(
                 last_target_pos.value() );
 
     float base_angle = atan2f( local_last_target.y() - posy(),

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -655,7 +655,7 @@ void avatar_action::swim( map &m, avatar &you, const tripoint_bub_ms &p )
             return;
         }
     }
-    tripoint_abs_ms old_abs_pos = m.getglobal( you.pos_bub() );
+    tripoint_abs_ms old_abs_pos = m.get_abs( you.pos_bub() );
     you.setpos( p );
     g->update_map( you );
 

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -722,7 +722,7 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
     }
     // NPC camps may never have had bb_pos registered
     validate_bb_pos( project_to<coords::ms>( omt_pos ) );
-    tripoint_bub_ms src_loc = here.bub_from_abs( bb_pos ) + point::north;
+    tripoint_bub_ms src_loc = here.get_bub( bb_pos ) + point::north;
     std::vector<tripoint_abs_ms> possible_liquid_dumps;
     if( mgr.has_near( zone_type_CAMP_STORAGE, abspos, MAX_VIEW_DISTANCE ) ) {
         const std::vector<const zone_data *> zones = mgr.get_near_zones( zone_type_CAMP_STORAGE, abspos,
@@ -737,21 +737,21 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
                 }
             }
             set_storage_tiles( src_set );
-            src_loc = here.bub_from_abs( zones.front()->get_center_point() );
+            src_loc = here.get_bub( zones.front()->get_center_point() );
         }
         map &here = get_map();
         for( const zone_data *zone : zones ) {
             if( zone->get_type() == zone_type_CAMP_STORAGE ) {
                 for( const tripoint_abs_ms &p : tripoint_range<tripoint_abs_ms>(
                          zone->get_start_point(), zone->get_end_point() ) ) {
-                    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_LIQUIDCONT, here.bub_from_abs( p ) ) ) {
+                    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_LIQUIDCONT, here.get_bub( p ) ) ) {
                         possible_liquid_dumps.emplace_back( p );
                     }
                 }
             }
         }
     }
-    set_dumping_spot( here.getglobal( src_loc ) );
+    set_dumping_spot( here.get_abs( src_loc ) );
     set_liquid_dumping_spot( possible_liquid_dumps );
 
 }
@@ -783,7 +783,7 @@ void basecamp::form_crafting_inventory( map &target_map )
     // find available fuel
 
     for( const tripoint_abs_ms &abs_ms_pt : src_set ) {
-        const tripoint_bub_ms &pt = target_map.bub_from_abs( abs_ms_pt );
+        const tripoint_bub_ms &pt = target_map.get_bub( abs_ms_pt );
         if( target_map.accessible_items( pt ) ) {
             for( const item &i : target_map.i_at( pt ) ) {
                 for( basecamp_fuel &bcp_f : fuels ) {
@@ -1042,7 +1042,7 @@ void basecamp_action_components::consume_components()
     std::vector<tripoint_bub_ms> src;
     src.reserve( base_.src_set.size() );
     for( const tripoint_abs_ms &p : base_.src_set ) {
-        src.emplace_back( target_map.bub_from_abs( p ) );
+        src.emplace_back( target_map.get_bub( p ) );
     }
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
         std::list<item> empty_consumed = player_character.consume_items( target_map, sel, batch_size_,

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1041,7 +1041,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
                 player_character );
         if( target.has_value() ) {
             add_msg_activate();
-            assign_activity( lockpick_activity_actor::use_bionic( here.getglobal( *target ) ) );
+            assign_activity( lockpick_activity_actor::use_bionic( here.get_abs( *target ) ) );
             if( close_bionics_ui ) {
                 *close_bionics_ui = true;
             }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1421,8 +1421,8 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     here.prev_o = o;
 
     you.prepare_map_memory_region(
-        here.getglobal( tripoint_bub_ms( min_mm_reg.x, min_mm_reg.y, center.z() ) ),
-        here.getglobal( tripoint_bub_ms( max_mm_reg.x, max_mm_reg.y, center.z() ) )
+        here.get_abs( tripoint_bub_ms( min_mm_reg.x, min_mm_reg.y, center.z() ) ),
+        here.get_abs( tripoint_bub_ms( max_mm_reg.x, max_mm_reg.y, center.z() ) )
     );
 
     //set up a default tile for the edges outside the render area
@@ -1500,7 +1500,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                 for( int zlevel = center.z(); zlevel >= draw_min_z; zlevel -- ) {
                     // todo: conversion slightly simplified, a couple of calls already use pos as tripoint_bub_ms
                     const tripoint_bub_ms pos( point_bub_ms( temp.value() ), zlevel );
-                    const tripoint_abs_ms pos_global = here.getglobal( pos );
+                    const tripoint_abs_ms pos_global = here.get_abs( pos );
                     const int &x = pos.x();
                     const int &y = pos.y();
                     const bool is_center_z = zlevel == center.z();
@@ -1880,7 +1880,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
             //bypass cache check in case we learn something new about the terrain's connections
             draw_terrain( p, lighting, height_3d, invisible, true );
             if( here.memory_cache_dec_is_dirty( p ) ) {
-                you.memorize_clear_decoration( here.getglobal( p ), "" );
+                you.memorize_clear_decoration( here.get_abs( p ), "" );
                 draw_furniture( p, lighting, height_3d, invisible, true );
                 draw_trap( p, lighting, height_3d, invisible, true );
                 draw_part_con( p, lighting, height_3d, invisible, true );
@@ -2830,7 +2830,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         case TILE_CATEGORY::FIELD:
         case TILE_CATEGORY::LIGHTING:
             // stationary map tiles, seed based on map coordinates
-            seed = simple_point_hash( here.getglobal( pos ).raw().xy() );
+            seed = simple_point_hash( here.get_abs( pos ).raw().xy() );
             break;
         case TILE_CATEGORY::VEHICLE_PART:
             // vehicle parts, seed based on coordinates within the vehicle
@@ -2862,7 +2862,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             if( fid.is_valid() ) {
                 const furn_t &f = fid.obj();
                 if( !f.is_movable() ) {
-                    seed = simple_point_hash( here.getglobal( pos ).raw().xy() );
+                    seed = simple_point_hash( here.get_abs( pos ).raw().xy() );
                 }
             }
         }
@@ -2878,7 +2878,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             if( found_id == "graffiti" ) {
                 seed = std::hash<std::string> {}( here.graffiti_at( pos ) );
             } else if( string_starts_with( found_id, "graffiti" ) ) {
-                seed = simple_point_hash( here.getglobal( pos ).raw().xy() );
+                seed = simple_point_hash( here.get_abs( pos ).raw().xy() );
             }
             break;
         case TILE_CATEGORY::ITEM:
@@ -3347,7 +3347,7 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
             // do something to get other terrain orientation values
         }
         if( here.memory_cache_ter_is_dirty( p ) ) {
-            get_avatar().memorize_terrain( here.getglobal( p ), tname, subtile, rotation );
+            get_avatar().memorize_terrain( here.get_abs( p ), tname, subtile, rotation );
         }
         // draw the actual terrain if there's no override
         if( !neighborhood_overridden ) {
@@ -3387,7 +3387,7 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
-        const memorized_tile &mt = get_terrain_memory_at( here.getglobal( p ) );
+        const memorized_tile &mt = get_terrain_memory_at( here.get_abs( p ) );
         if( !mt.get_ter_id().empty() ) {
             return memorize_only
                    ? false
@@ -3438,7 +3438,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
         if( !( you.get_grab_type() == object_type::FURNITURE
                && p == you.pos_bub() + you.grab_point )
             && here.memory_cache_dec_is_dirty( p ) ) {
-            you.memorize_decoration( here.getglobal( p ), fname, subtile, rotation );
+            you.memorize_decoration( here.get_abs( p ), fname, subtile, rotation );
         }
         // draw the actual furniture if there's no override
         if( !neighborhood_overridden ) {
@@ -3488,7 +3488,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
-        const memorized_tile &mt = get_furniture_memory_at( here.getglobal( p ) );
+        const memorized_tile &mt = get_furniture_memory_at( here.get_abs( p ) );
         if( !mt.get_dec_id().empty() ) {
             return memorize_only
                    ? false
@@ -3531,7 +3531,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
         get_tile_values( tr.loadid.to_i(), neighborhood, subtile, rotation, 0 );
         const std::string trname = tr.loadid.id().str();
         if( here.memory_cache_dec_is_dirty( p ) ) {
-            you.memorize_decoration( here.getglobal( p ), trname, subtile, rotation );
+            you.memorize_decoration( here.get_abs( p ), trname, subtile, rotation );
         }
         // draw the actual trap if there's no override
         if( !neighborhood_overridden ) {
@@ -3574,7 +3574,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
-        const memorized_tile &mt = get_trap_memory_at( here.getglobal( p ) );
+        const memorized_tile &mt = get_trap_memory_at( here.get_abs( p ) );
         if( !mt.get_dec_id().empty() ) {
             return memorize_only
                    ? false
@@ -3595,7 +3595,7 @@ bool cata_tiles::draw_part_con( const tripoint_bub_ms &p, const lit_level ll, in
         avatar &you = get_avatar();
         std::string const &trname = tr_unfinished_construction.str();
         if( here.memory_cache_dec_is_dirty( p ) ) {
-            you.memorize_decoration( here.getglobal( p ), trname, 0, 0 );
+            you.memorize_decoration( here.get_abs( p ), trname, 0, 0 );
         }
         return memorize_only
                ? false
@@ -3938,7 +3938,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
                 && !( you.get_grab_type() == object_type::VEHICLE
                       && veh.get_points().count( ( you.pos_bub() + you.grab_point ) ) )
                 && here.memory_cache_dec_is_dirty( p ) ) {
-                you.memorize_decoration( here.getglobal( p ), vd.get_tileset_id(), subtile, rotation );
+                you.memorize_decoration( here.get_abs( p ), vd.get_tileset_id(), subtile, rotation );
             }
             if( !overridden ) {
                 int height_3d_temp = height_3d;
@@ -3984,7 +3984,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
         }
     } else if( !roof && invisible[0] ) {
         // try drawing memory if invisible and not overridden
-        const memorized_tile &t = get_vpart_memory_at( here.getglobal( p ) );
+        const memorized_tile &t = get_vpart_memory_at( here.get_abs( p ) );
         std::string_view tid = t.get_dec_id();
         if( !tid.empty() ) {
             int height_3d_temp = height_3d;
@@ -4261,7 +4261,7 @@ bool cata_tiles::draw_zone_mark( const tripoint_bub_ms &p, lit_level ll, int &he
     }
 
     const zone_manager &mgr = zone_manager::get_manager();
-    const tripoint_abs_ms abs = get_map().getglobal( p );
+    const tripoint_abs_ms abs = get_map().get_abs( p );
     const zone_data *zone = mgr.get_bottom_zone( abs );
 
     if( zone && zone->has_options() ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1619,8 +1619,8 @@ bool Character::check_outbounds_activity( const player_activity &act, bool check
 {
     map &here = get_map();
     if( ( act.placement != tripoint_abs_ms() && act.placement != player_activity::invalid_place &&
-          !here.inbounds( here.bub_from_abs( act.placement ) ) ) || ( !act.coords.empty() &&
-                  !here.inbounds( here.bub_from_abs( act.coords.back() ) ) ) ) {
+          !here.inbounds( here.get_bub( act.placement ) ) ) || ( !act.coords.empty() &&
+                  !here.inbounds( here.get_bub( act.coords.back() ) ) ) ) {
         if( is_npc() && !check_only ) {
             // stash activity for when reloaded.
             stashed_outbounds_activity = act;
@@ -10714,13 +10714,13 @@ void Character::echo_pulse()
 
 bool Character::knows_trap( const tripoint_bub_ms &pos ) const
 {
-    const tripoint_abs_ms p = get_map().getglobal( pos );
+    const tripoint_abs_ms p = get_map().get_abs( pos );
     return known_traps.count( p ) > 0;
 }
 
 void Character::add_known_trap( const tripoint_bub_ms &pos, const trap &t )
 {
-    const tripoint_abs_ms p = get_map().getglobal( pos );
+    const tripoint_abs_ms p = get_map().get_abs( pos );
     if( t.is_null() ) {
         known_traps.erase( p );
     } else {
@@ -11137,7 +11137,7 @@ void Character::process_effects()
     }
 
     // Being stuck in tight spaces sucks. TODO: could be expanded to apply to non-vehicle conditions.
-    if( will_be_cramped_in_vehicle_tile( get_map().getglobal( pos_bub() ) ) ) {
+    if( will_be_cramped_in_vehicle_tile( get_map().get_abs( pos_bub() ) ) ) {
         if( is_npc() && !has_effect( effect_narcosis ) ) {
             npc &as_npc = dynamic_cast<npc &>( *this );
             as_npc.complain_about( "cramped_vehicle", 30_minutes, "<cramped_vehicle>", false );
@@ -11411,7 +11411,7 @@ void Character::set_destination( const std::vector<tripoint_bub_ms> &route,
 {
     auto_move_route = route;
     set_destination_activity( new_destination_activity );
-    destination_point.emplace( get_map().getglobal( route.back() ) );
+    destination_point.emplace( get_map().get_abs( route.back() ) );
 }
 
 void Character::clear_destination()
@@ -11449,7 +11449,7 @@ bool Character::has_destination() const
 bool Character::has_destination_activity() const
 {
     return !get_destination_activity().is_null() && destination_point &&
-           pos_bub() == get_map().bub_from_abs( *destination_point );
+           pos_bub() == get_map().get_bub( *destination_point );
 }
 
 void Character::start_destination_activity()

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1549,12 +1549,12 @@ void _rotate_zone( map &target_map, zone_data &zone, int turns )
         point_bub_ms z_l_end = z_end.xy().rotate( turns, dim );
         tripoint_abs_ms first =
             target_map.get_abs( tripoint_bub_ms( std::min( z_l_start.x(), z_l_end.x() ),
-                                  std::min( z_l_start.y(), z_l_end.y() ),
-                                  z_start.z() ) );
+                                std::min( z_l_start.y(), z_l_end.y() ),
+                                z_start.z() ) );
         tripoint_abs_ms second =
             target_map.get_abs( tripoint_bub_ms( std::max( z_l_start.x(), z_l_end.x() ),
-                                  std::max( z_l_start.y(), z_l_end.y() ),
-                                  z_end.z() ) );
+                                std::max( z_l_start.y(), z_l_end.y() ),
+                                z_end.z() ) );
         zone.set_position( std::make_pair( first, second ), false, true, false, true );
     }
 }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -307,10 +307,10 @@ plot_options::query_seed_result plot_options::query_seed()
     zone_manager &mgr = zone_manager::get_manager();
     map &here = get_map();
     const std::unordered_set<tripoint_abs_ms> zone_src_set =
-        mgr.get_near( zone_type_LOOT_SEEDS, here.getglobal( player_character.pos_bub() ),
+        mgr.get_near( zone_type_LOOT_SEEDS, here.get_abs( player_character.pos_bub() ),
                       MAX_VIEW_DISTANCE );
     for( const tripoint_abs_ms &elem : zone_src_set ) {
-        tripoint_bub_ms elem_loc = here.bub_from_abs( elem );
+        tripoint_bub_ms elem_loc = here.get_bub( elem );
         for( item &it : here.i_at( elem_loc ) ) {
             if( it.is_seed() ) {
                 seed_inv.push_back( &it );
@@ -1003,7 +1003,7 @@ std::unordered_set<tripoint_bub_ms> zone_manager::get_point_set_loot( const trip
         if( fac == z_fac && type.str().substr( 0, 4 ) == "LOOT" ) {
             for( tripoint_abs_ms point : cache.second ) {
                 if( square_dist( where, point ) <= radius ) {
-                    res.emplace( here.bub_from_abs( point ) );
+                    res.emplace( here.get_bub( point ) );
                 }
             }
         }
@@ -1014,7 +1014,7 @@ std::unordered_set<tripoint_bub_ms> zone_manager::get_point_set_loot( const trip
         if( fac == z_fac && type.str().substr( 0, 4 ) == "LOOT" ) {
             for( tripoint_abs_ms point : cache.second ) {
                 if( square_dist( where, point ) <= radius ) {
-                    res.emplace( here.bub_from_abs( point ) );
+                    res.emplace( here.get_bub( point ) );
                 }
             }
         }
@@ -1025,7 +1025,7 @@ std::unordered_set<tripoint_bub_ms> zone_manager::get_point_set_loot( const trip
             zone_type_id type = zone_data::unhash_type( cache.first );
             if( type == zone_type_NO_NPC_PICKUP ) {
                 for( tripoint_abs_ms point : cache.second ) {
-                    res.erase( here.bub_from_abs( point ) );
+                    res.erase( here.get_bub( point ) );
                 }
             }
         }
@@ -1436,7 +1436,7 @@ void zone_manager::add( const std::string &name, const zone_type_id &type, const
     map &here = pmap == nullptr ? get_map() : *pmap;
     zone_data new_zone = zone_data( name, type, fac, invert, enabled, start, end, options );
     // only non personal zones can be vehicle zones
-    optional_vpart_position const vp = here.veh_at( here.bub_from_abs( start ) );
+    optional_vpart_position const vp = here.veh_at( here.get_bub( start ) );
     if( vp && vp->vehicle().get_owner() == fac && vp.cargo() ) {
         // TODO:Allow for loot zones on vehicles to be larger than 1x1
         if( start == end &&
@@ -1536,8 +1536,8 @@ void _rotate_zone( map &target_map, zone_data &zone, int turns )
     const point dim( SEEX * 2, SEEY * 2 );
     const tripoint_bub_ms a_start( 0, 0, target_map.get_abs_sub().z() );
     const tripoint_bub_ms a_end( SEEX * 2 - 1, SEEY * 2 - 1, a_start.z() );
-    const tripoint_bub_ms z_start = target_map.bub_from_abs( zone.get_start_point() );
-    const tripoint_bub_ms z_end = target_map.bub_from_abs( zone.get_end_point() );
+    const tripoint_bub_ms z_start = target_map.get_bub( zone.get_start_point() );
+    const tripoint_bub_ms z_end = target_map.get_bub( zone.get_end_point() );
     const inclusive_cuboid<tripoint_bub_ms> boundary( a_start, a_end );
     if( boundary.contains( z_start ) && boundary.contains( z_end ) ) {
         // don't rotate centered squares
@@ -1548,11 +1548,11 @@ void _rotate_zone( map &target_map, zone_data &zone, int turns )
         point_bub_ms z_l_start = z_start.xy().rotate( turns, dim );
         point_bub_ms z_l_end = z_end.xy().rotate( turns, dim );
         tripoint_abs_ms first =
-            target_map.getglobal( tripoint_bub_ms( std::min( z_l_start.x(), z_l_end.x() ),
+            target_map.get_abs( tripoint_bub_ms( std::min( z_l_start.x(), z_l_end.x() ),
                                   std::min( z_l_start.y(), z_l_end.y() ),
                                   z_start.z() ) );
         tripoint_abs_ms second =
-            target_map.getglobal( tripoint_bub_ms( std::max( z_l_start.x(), z_l_end.x() ),
+            target_map.get_abs( tripoint_bub_ms( std::max( z_l_start.x(), z_l_end.x() ),
                                   std::max( z_l_start.y(), z_l_end.y() ),
                                   z_end.z() ) );
         zone.set_position( std::make_pair( first, second ), false, true, false, true );
@@ -1851,7 +1851,7 @@ void zone_manager::revert_vzones()
     map &here = get_map();
     for( zone_data zone : removed_vzones ) {
         //Code is copied from add() to avoid yn query
-        const tripoint_bub_ms pos = here.bub_from_abs( zone.get_start_point() );
+        const tripoint_bub_ms pos = here.get_bub( zone.get_start_point() );
         if( const std::optional<vpart_reference> vp = here.veh_at( pos ).cargo() ) {
             zone.set_is_vehicle( true );
             vp->vehicle().loot_zones.emplace( vp->mount_pos(), zone );

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -318,8 +318,8 @@ static void remove_submap_turrets()
     map &here = get_map();
     for( monster &critter : g->all_monsters() ) {
         // Check 1) same overmap coords, 2) turret, 3) hostile
-        if( coords::project_to<coords::omt>( here.getglobal( critter.pos_bub() ) ) ==
-            coords::project_to<coords::omt>( here.getglobal(
+        if( coords::project_to<coords::omt>( here.get_abs( critter.pos_bub() ) ) ==
+            coords::project_to<coords::omt>( here.get_abs(
                     player_character.pos_bub() ) ) &&
             critter.has_flag( mon_flag_CONSOLE_DESPAWN ) &&
             critter.attitude_to( player_character ) == Creature::Attitude::HOSTILE ) {

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -396,7 +396,7 @@ tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const_dialog
                   d.get_callstack() );
         return tripoint_abs_ms::invalid;
     }
-    return get_map().getglobal( d.const_actor( is_npc )->pos_bub() );
+    return get_map().get_abs( d.const_actor( is_npc )->pos_bub() );
 }
 
 template<class T>
@@ -1691,8 +1691,8 @@ conditional_t::func f_line_of_sight( const JsonObject &jo, std::string_view memb
         with_fields = jo.get_bool( "with_fields" );
     }
     return [range, loc_var_1, loc_var_2, with_fields]( const_dialogue const & d ) {
-        tripoint_bub_ms loc_1 = get_map().bub_from_abs( get_tripoint_from_var( loc_var_1, d, false ) );
-        tripoint_bub_ms loc_2 = get_map().bub_from_abs( get_tripoint_from_var( loc_var_2, d, false ) );
+        tripoint_bub_ms loc_1 = get_map().get_bub( get_tripoint_from_var( loc_var_1, d, false ) );
+        tripoint_bub_ms loc_2 = get_map().get_bub( get_tripoint_from_var( loc_var_2, d, false ) );
 
         return get_map().sees( loc_1, loc_2, range.evaluate( d ), with_fields );
     };
@@ -1766,7 +1766,7 @@ conditional_t::func f_query_tile( const JsonObject &jo, std::string_view member,
 
         }
         if( loc.has_value() ) {
-            tripoint_abs_ms pos_global = get_map().getglobal( *loc );
+            tripoint_abs_ms pos_global = get_map().get_abs( *loc );
             write_var_value( target_var.type, target_var.name, d,
                              pos_global.to_string() );
         }
@@ -1804,7 +1804,7 @@ conditional_t::func f_map_ter_furn_with_flag( const JsonObject &jo, std::string_
         terrain = false;
     }
     return [terrain, furn_type, loc_var]( const_dialogue const & d ) {
-        tripoint_bub_ms loc = get_map().bub_from_abs( get_tripoint_from_var( loc_var, d, false ) );
+        tripoint_bub_ms loc = get_map().get_bub( get_tripoint_from_var( loc_var, d, false ) );
         if( terrain ) {
             return get_map().ter( loc )->has_flag( furn_type.evaluate( d ) );
         } else {
@@ -1819,7 +1819,7 @@ conditional_t::func f_map_ter_furn_id( const JsonObject &jo, std::string_view me
     var_info loc_var = read_var_info( jo.get_object( "loc" ) );
 
     return [member, furn_type, loc_var]( const_dialogue const & d ) {
-        tripoint_bub_ms loc = get_map().bub_from_abs( get_tripoint_from_var( loc_var, d, false ) );
+        tripoint_bub_ms loc = get_map().get_bub( get_tripoint_from_var( loc_var, d, false ) );
         if( member == "map_terrain_id" ) {
             return get_map().ter( loc ) == ter_id( furn_type.evaluate( d ) );
         } else if( member == "map_furniture_id" ) {
@@ -2148,7 +2148,7 @@ conditional_t::func f_can_see_location( const JsonObject &jo, std::string_view m
     str_or_var target = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, target]( const_dialogue const & d ) {
         tripoint_abs_ms target_pos = tripoint_abs_ms( tripoint::from_string( target.evaluate( d ) ) );
-        return d.const_actor( is_npc )->can_see_location( get_map().bub_from_abs( target_pos ) );
+        return d.const_actor( is_npc )->can_see_location( get_map().get_bub( target_pos ) );
     };
 }
 
@@ -2205,7 +2205,7 @@ static std::function<T( const_dialogue const & )> get_get_str_( const JsonObject
         str_or_var target = get_str_or_var( jo.get_member( "target" ), "target" );
         bool use_beta_talker = mutator == "npc_loc_relative";
         return [target, use_beta_talker, ret_func]( const_dialogue const & d ) {
-            tripoint_abs_ms char_pos = get_map().getglobal( d.const_actor( use_beta_talker )->pos_bub() );
+            tripoint_abs_ms char_pos = get_map().get_abs( d.const_actor( use_beta_talker )->pos_bub() );
             tripoint_abs_ms target_pos = char_pos + tripoint::from_string( target.evaluate( d ) );
             return ret_func( target_pos.to_string() );
         };

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1315,7 +1315,7 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
     player_character.invalidate_crafting_inventory();
     player_character.invalidate_weight_carried_cache();
     player_character.assign_activity( ACT_BUILD );
-    player_character.activity.placement = here.getglobal( pnt );
+    player_character.activity.placement = here.get_abs( pnt );
 }
 
 void complete_construction( Character *you )
@@ -1325,7 +1325,7 @@ void complete_construction( Character *you )
         return;
     }
     map &here = get_map();
-    const tripoint_bub_ms terp = here.bub_from_abs( you->activity.placement );
+    const tripoint_bub_ms terp = here.get_bub( you->activity.placement );
     partial_con *pc = here.partial_con_at( terp );
     if( !pc ) {
         debugmsg( "No partial construction found at activity placement in complete_construction()" );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -205,7 +205,7 @@ Creature::~Creature() = default;
 
 tripoint_bub_ms Creature::pos_bub() const
 {
-    return get_map().bub_from_abs( location );
+    return get_map().get_bub( location );
 }
 
 void Creature::setpos( const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
@@ -231,7 +231,7 @@ bool Creature::will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) con
     vehicle &veh = vp_there->vehicle();
 
     std::vector<vehicle_part *> cargo_parts;
-    cargo_parts = veh.get_parts_at( here.bub_from_abs( loc ), "CARGO", part_status_flag::any );
+    cargo_parts = veh.get_parts_at( here.get_bub( loc ), "CARGO", part_status_flag::any );
 
     units::volume capacity = 0_ml;
     units::volume free_cargo = 0_ml;
@@ -246,7 +246,7 @@ bool Creature::will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) con
     }
     if( capacity > 0_ml ) {
         // First, we'll try to squeeze in. Open-topped vehicle parts have more room to step over cargo.
-        if( !veh.enclosed_at( here.bub_from_abs( loc ) ) ) {
+        if( !veh.enclosed_at( here.get_bub( loc ) ) ) {
             free_cargo *= 1.2;
         }
         const creature_size size = get_size();
@@ -293,7 +293,7 @@ void Creature::move_to( const tripoint_abs_ms &loc )
 
 void Creature::set_pos_only( const tripoint_bub_ms &p )
 {
-    location = get_map().getglobal( p );
+    location = get_map().get_abs( p );
 }
 
 void Creature::set_location( const tripoint_abs_ms &loc )

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -297,7 +297,7 @@ void creature_tracker::remove_dead()
 template<typename T>
 T *creature_tracker::creature_at( const tripoint_bub_ms &p, bool allow_hallucination )
 {
-    return creature_at<T>( get_map().getglobal( p ), allow_hallucination );
+    return creature_at<T>( get_map().get_abs( p ), allow_hallucination );
 }
 
 template<typename T>
@@ -417,7 +417,7 @@ void creature_tracker::flood_fill_zone( const Creature &origin )
 template<typename T>
 const T *creature_tracker::creature_at( const tripoint_bub_ms &p, bool allow_hallucination ) const
 {
-    return creature_at<T>( get_map().getglobal( p ), allow_hallucination );
+    return creature_at<T>( get_map().get_abs( p ), allow_hallucination );
 }
 
 template<typename T>

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -543,7 +543,7 @@ static void normalize_body( Character &u )
 static tripoint_abs_ms player_picks_tile()
 {
     std::optional<tripoint_bub_ms> newpos = g->look_around();
-    return newpos ? get_map().getglobal( *newpos ) : get_player_character().get_location();
+    return newpos ? get_map().get_abs( *newpos ) : get_player_character().get_location();
 }
 
 static void monster_ammo_edit( monster &mon )
@@ -841,7 +841,7 @@ static void monster_edit_menu()
         }
         case D_TELE: {
             if( tripoint_abs_ms newpos = player_picks_tile(); newpos != get_avatar().get_location() ) {
-                critter->setpos( get_map().bub_from_abs( newpos ) );
+                critter->setpos( get_map().get_bub( newpos ) );
             }
             break;
         }
@@ -1856,13 +1856,13 @@ static void spawn_nested_mapgen()
         }
 
         map &here = get_map();
-        const tripoint_abs_ms abs_ms( here.getglobal( *where ) );
+        const tripoint_abs_ms abs_ms( here.get_abs( *where ) );
         const tripoint_abs_omt abs_omt = project_to<coords::omt>( abs_ms );
         const tripoint_abs_sm abs_sub = project_to<coords::sm>( abs_ms );
 
         map target_map;
         target_map.load( abs_sub, true );
-        const tripoint_bub_ms local_ms = target_map.bub_from_abs( abs_ms );
+        const tripoint_bub_ms local_ms = target_map.get_bub( abs_ms );
         mapgendata md( abs_omt, target_map, 0.0f, calendar::turn, nullptr );
         const auto &ptr = nested_mapgens[nest_ids[nest_choice]].funcs().pick();
         if( ptr == nullptr ) {

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -500,7 +500,7 @@ void editmap::uber_draw_ter( const catacurses::window &w, map *m )
                     monster *mon = dynamic_cast<monster *>( critter );
                     if( mon != nullptr && mon->has_dest() ) {
                         for( auto &location : line_to( mon->get_location(), mon->get_dest() ) ) {
-                            hilights["mplan"].points[m->bub_from_abs( location )] = 1;
+                            hilights["mplan"].points[m->get_bub( location )] = 1;
                         }
                     }
                 }
@@ -2129,13 +2129,13 @@ void editmap::edit_mapgen()
     map &here = get_map();
 
     do {
-        tc.fromabs( here.getglobal( { target.xy(), here.abs_sub.z() } ).xy().raw() );
-        point_bub_ms omt_lpos = here.bub_from_abs( point_abs_ms( tc.begin_om_pos() ) );
+        tc.fromabs( here.get_abs( { target.xy(), here.abs_sub.z() } ).xy().raw() );
+        point_bub_ms omt_lpos = here.get_bub( point_abs_ms( tc.begin_om_pos() ) );
         tripoint_bub_ms om_ltarget = omt_lpos + tripoint( -1 + SEEX, -1 + SEEY, target.z() );
 
         if( target.x() != om_ltarget.x() || target.y() != om_ltarget.y() ) {
             target = om_ltarget;
-            tc.fromabs( here.getglobal( { target.xy(), here.abs_sub.z() } ).xy().raw() );
+            tc.fromabs( here.get_abs( { target.xy(), here.abs_sub.z() } ).xy().raw() );
         }
         target_list.clear();
         for( int x = target.x() - SEEX + 1; x < target.x() + SEEX + 1; x++ ) {

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -282,10 +282,10 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
 
     // Draw the explosion, but only if the explosion center is within the reality bubble
     map &bubble_map = get_map();
-    if( bubble_map.inbounds( m->getglobal( p ) ) ) {
+    if( bubble_map.inbounds( m->get_abs( p ) ) ) {
         std::map<tripoint_bub_ms, nc_color> explosion_colors;
         for( const tripoint_bub_ms &pt : closed ) {
-            const tripoint_bub_ms bubble_pos( bubble_map.bub_from_abs( m->getglobal( pt ) ) );
+            const tripoint_bub_ms bubble_pos( bubble_map.get_bub( m->get_abs( pt ) ) );
 
             if( !bubble_map.inbounds( bubble_pos ) ) {
                 continue;
@@ -337,7 +337,7 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
         }
 
         // Translate to reality bubble coordinates to work with the creature tracker.
-        const tripoint_bub_ms bubble_pos( bubble_map.bub_from_abs( m->getglobal( pt ) ) );
+        const tripoint_bub_ms bubble_pos( bubble_map.get_bub( m->get_abs( pt ) ) );
         Creature *critter = creatures.creature_at( bubble_pos, true );
         if( critter == nullptr ) {
             continue;
@@ -459,7 +459,7 @@ static std::vector<tripoint_bub_ms> shrapnel( map *m, const Creature *source,
         distrib.emplace_back( target );
         int damage = ballistic_damage( cloud.velocity, fragment_mass );
         // Translate to reality bubble coordinates to work with the creature tracker.
-        const tripoint_bub_ms bubble_pos( bubble_map.bub_from_abs( m->getglobal( target ) ) );
+        const tripoint_bub_ms bubble_pos( bubble_map.get_bub( m->get_abs( target ) ) );
         Creature *critter = creatures.creature_at( bubble_pos );
         if( damage > 0 && critter && !critter->is_dead_state() ) {
             std::poisson_distribution<> d( cloud.density );
@@ -538,14 +538,14 @@ bool explosion_processing_active()
 
 void explosion( const Creature *source, const tripoint_bub_ms &p, const explosion_data &ex )
 {
-    _explosions.emplace_back( source, get_map().getglobal( p ), ex );
+    _explosions.emplace_back( source, get_map().get_abs( p ), ex );
 }
 
 void _make_explosion( map *m, const Creature *source, const tripoint_bub_ms &p,
                       const explosion_data &ex )
 {
-    if( get_map().inbounds( m->getglobal( p ) ) ) {
-        tripoint_bub_ms bubble_pos = get_map().bub_from_abs( m->getglobal( p ) );
+    if( get_map().inbounds( m->get_abs( p ) ) ) {
+        tripoint_bub_ms bubble_pos = get_map().get_bub( m->get_abs( p ) );
         int noise = ex.power * ( ex.fire ? 2 : 10 );
         noise = ( noise > ex.max_noise ) ? ex.max_noise : noise;
 
@@ -957,7 +957,7 @@ void process_explosions()
     for( const queued_explosion &ex : explosions_copy ) {
         const int safe_range = ex.data.safe_range();
         map  *bubble_map = &get_map();
-        const tripoint_bub_ms bubble_pos( bubble_map->bub_from_abs( ex.pos ) );
+        const tripoint_bub_ms bubble_pos( bubble_map->get_bub( ex.pos ) );
 
         if( bubble_pos.x() - safe_range < 0 || bubble_pos.x() + safe_range > MAPSIZE_X ||
             bubble_pos.y() - safe_range < 0 || bubble_pos.y() + safe_range > MAPSIZE_Y ) {
@@ -970,9 +970,9 @@ void process_explosions()
             process_explosions_in_progress = true;
             m.load( origo, false, false );
             process_explosions_in_progress = false;
-            _make_explosion( &m, ex.source, m.bub_from_abs( ex.pos ), ex.data );
+            _make_explosion( &m, ex.source, m.get_bub( ex.pos ), ex.data );
         } else {
-            _make_explosion( bubble_map, ex.source, bubble_map->bub_from_abs( ex.pos ), ex.data );
+            _make_explosion( bubble_map, ex.source, bubble_map->get_bub( ex.pos ), ex.data );
         }
     }
 }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1986,7 +1986,7 @@ npc_ptr basecamp::start_mission( const mission_id &miss_id, time_duration total_
             std::vector<tripoint_bub_ms> src_set_pt;
             src_set_pt.resize( src_set.size() );
             for( const tripoint_abs_ms &p : src_set ) {
-                src_set_pt.emplace_back( target_map.bub_from_abs( p ) );
+                src_set_pt.emplace_back( target_map.get_bub( p ) );
             }
             for( item *i : equipment ) {
                 int count = i->count();
@@ -2161,7 +2161,7 @@ void basecamp::remove_camp( const tripoint_abs_omt &omt_pos ) const
     const tripoint_abs_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
     // We cannot use bb_pos here, because bb_pos may be {0,0,0} if you haven't examined the bulletin board on camp ever.
     // here.remove_submap_camp( here.getlocal( bb_pos ) );
-    here.remove_submap_camp( here.bub_from_abs( ms_pos ) );
+    here.remove_submap_camp( here.get_bub( ms_pos ) );
 }
 
 void basecamp::abandon_camp()
@@ -5923,7 +5923,7 @@ bool basecamp::distribute_food( bool player_command )
     // @FIXME: items under a vehicle cargo part will get taken even if there's no non-vehicle zone there
     // @FIXME: items in a vehicle cargo part will get taken even if the zone is on the ground underneath
     for( const tripoint_abs_ms &p_food_stock_abs : z_food ) {
-        const tripoint_bub_ms p_food_stock = here.bub_from_abs( p_food_stock_abs );
+        const tripoint_bub_ms p_food_stock = here.get_bub( p_food_stock_abs );
         map_stack items = here.i_at( p_food_stock );
         for( auto iter = items.begin(); iter != items.end(); ) {
             if( consume( *iter, nullptr ) ) {
@@ -6137,7 +6137,7 @@ void basecamp::place_results( const item &result )
 {
     map &target_bay = get_camp_map();
     form_storage_zones( target_bay, bb_pos );
-    tripoint_bub_ms new_spot = target_bay.bub_from_abs( get_dumping_spot() );
+    tripoint_bub_ms new_spot = target_bay.get_bub( get_dumping_spot() );
     // Special handling for liquids
     // find any storage-zoned LIQUIDCONT we can dump them in, set that as the item's destination instead
     if( result.made_of( phase_id::LIQUID ) ) {
@@ -6145,8 +6145,8 @@ void basecamp::place_results( const item &result )
             // No items at a potential spot? Set the destination there and stop checking.
             // We could check if the item at the tile are the same as the item we're placing, but liquids of the same typeid
             // don't always mix depending on their components...
-            if( target_bay.i_at( target_bay.bub_from_abs( potential_spot ) ).empty() ) {
-                new_spot = target_bay.bub_from_abs( potential_spot );
+            if( target_bay.i_at( target_bay.get_bub( potential_spot ) ).empty() ) {
+                new_spot = target_bay.get_bub( potential_spot );
                 break;
             }
             // We've processed the last spot and haven't found anywhere to put it, we'll end up using dumping_spot.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1219,7 +1219,7 @@ vehicle *game::place_vehicle_nearby(
             vehicle *veh = target_map.add_vehicle( id, tinymap_center, random_entry( angles ),
                                                    rng( 50, 80 ), 0, false );
             if( veh ) {
-                const tripoint_bub_ms abs_local = m.bub_from_abs( target_map.getglobal( tinymap_center ) );
+                const tripoint_bub_ms abs_local = m.get_bub( target_map.get_abs( tinymap_center ) );
                 tripoint_bub_sm quotient;
                 point_sm_ms remainder;
                 std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( abs_local );
@@ -4436,7 +4436,7 @@ std::unordered_set<tripoint_abs_ms> game::get_fishable_locations_abs( int distan
     std::unordered_set<tripoint_abs_ms> result;
     map &here = get_map();
     for( const tripoint_bub_ms pos : temp ) {
-        result.insert( here.getglobal( pos ) );
+        result.insert( here.get_abs( pos ) );
     }
 
     return result;
@@ -4506,7 +4506,7 @@ std::vector<monster *> game::get_fishable_monsters( std::unordered_set<tripoint_
     std::unordered_set<tripoint_bub_ms> temp;
 
     for( const tripoint_abs_ms pos : fishable_locations ) {
-        temp.insert( here.bub_from_abs( pos ) );
+        temp.insert( here.get_bub( pos ) );
     }
 
     return game::get_fishable_monsters( temp );
@@ -5126,7 +5126,7 @@ static bool can_place_monster( const monster &mon, const tripoint_bub_ms &p )
 
 static bool can_place_monster( const monster &mon, map *here, const tripoint_bub_ms &p )
 {
-    const tripoint_abs_ms pos = here->getglobal( p );
+    const tripoint_abs_ms pos = here->get_abs( p );
     creature_tracker &creatures = get_creature_tracker();
     if( const monster *const critter = creatures.creature_at<monster>( pos ) ) {
         // creature_tracker handles this. The hallucination monster will simply vanish
@@ -5263,7 +5263,7 @@ monster *game::place_critter_at_or_within( const shared_ptr_fast<monster> &mon, 
     if( !where ) {
         return nullptr;
     }
-    mon->spawn( here->getglobal( where.value() ) );
+    mon->spawn( here->get_abs( where.value() ) );
     if( critter_tracker->add( mon ) ) {
         mon->gravity_check();
         return mon.get();
@@ -5353,7 +5353,7 @@ bool game::spawn_hallucination( const tripoint_bub_ms &p )
         shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
         tmp->normalize();
         tmp->randomize( NC_HALLU );
-        tmp->spawn_at_precise( get_map().getglobal( p ) );
+        tmp->spawn_at_precise( get_map().get_abs( p ) );
         if( !get_creature_tracker().creature_at( p, true ) ) {
             overmap_buffer.insert_npc( tmp );
             load_npcs();
@@ -5415,7 +5415,7 @@ bool game::spawn_npc( const tripoint_bub_ms &p, const string_id<npc_template> &n
     shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
     tmp->normalize();
     tmp->load_npc_template( npc_class );
-    tmp->spawn_at_precise( get_map().getglobal( p ) );
+    tmp->spawn_at_precise( get_map().get_abs( p ) );
     if( !get_creature_tracker().creature_at( p, true ) ) {
         overmap_buffer.insert_npc( tmp );
         for( const trait_id &new_trait : traits ) {
@@ -5535,7 +5535,7 @@ bool game::is_in_sunlight( const tripoint_bub_ms &p )
 bool game::is_in_sunlight( map *here, const tripoint_bub_ms &p )
 {
     return !is_sheltered( here, p ) &&
-           incident_sun_irradiance( current_weather( here->getglobal( p ), calendar::turn ),
+           incident_sun_irradiance( current_weather( here->get_abs( p ), calendar::turn ),
                                     calendar::turn ) > irradiance::minimal;
 }
 
@@ -5634,7 +5634,7 @@ void game::save_cyborg( item *cyborg, const tripoint_bub_ms &couch_pos, Characte
         shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
         tmp->normalize();
         tmp->load_npc_template( npc_template_cyborg_rescued );
-        tmp->spawn_at_precise( get_map().getglobal( couch_pos ) );
+        tmp->spawn_at_precise( get_map().get_abs( couch_pos ) );
         overmap_buffer.insert_npc( tmp );
         tmp->hurtall( dmg_lvl * 10, nullptr );
         tmp->add_effect( effect_downed, rng( 1_turns, 4_turns ), false, 0, true );
@@ -5847,7 +5847,7 @@ void game::control_vehicle()
         // If we reached here, we gained control of a vehicle.
         // Clear the map memory for the area covered by the vehicle to eliminate ghost vehicles.
         for( const tripoint_bub_ms &target : veh->get_points() ) {
-            u.memorize_clear_decoration( m.getglobal( target ), "vp_" );
+            u.memorize_clear_decoration( m.get_abs( target ), "vp_" );
             m.memory_cache_dec_set_dirty( target, true );
         }
         veh->is_following = false;
@@ -6846,12 +6846,12 @@ void game::print_graffiti_info( const tripoint_bub_ms &lp, const catacurses::win
 
 bool game::check_zone( const zone_type_id &type, const tripoint_bub_ms &where ) const
 {
-    return zone_manager::get_manager().has( type, m.getglobal( where ) );
+    return zone_manager::get_manager().has( type, m.get_abs( where ) );
 }
 
 bool game::check_near_zone( const zone_type_id &type, const tripoint_bub_ms &where ) const
 {
-    return zone_manager::get_manager().has_near( type, m.getglobal( where ) );
+    return zone_manager::get_manager().has_near( type, m.get_abs( where ) );
 }
 
 bool game::is_zones_manager_open() const
@@ -7129,13 +7129,13 @@ void game::zones_manager()
                     true, true, false );
             if( second.position ) {
                 tripoint_abs_ms first_abs =
-                m.getglobal(
+                m.get_abs(
                     tripoint_bub_ms(
                         std::min( first.position->x(), second.position->x() ),
                         std::min( first.position->y(), second.position->y() ),
                         std::min( first.position->z(), second.position->z() ) ) );
                 tripoint_abs_ms second_abs =
-                m.getglobal(
+                m.get_abs(
                     tripoint_bub_ms(
                         std::max( first.position->x(), second.position->x() ),
                         std::max( first.position->y(), second.position->y() ),
@@ -7264,8 +7264,8 @@ void game::zones_manager()
         if( zone_cnt > 0 ) {
             blink = !blink;
             const zone_data &zone = zones[active_index].get();
-            zone_start = m.bub_from_abs( zone.get_start_point() ).raw();
-            zone_end = m.bub_from_abs( zone.get_end_point() ).raw();
+            zone_start = m.get_bub( zone.get_start_point() ).raw();
+            zone_end = m.get_bub( zone.get_end_point() ).raw();
             ctxt.set_timeout( get_option<int>( "BLINK_SPEED" ) );
         } else {
             blink = false;
@@ -7501,16 +7501,16 @@ void game::zones_manager()
                         static_popup message_pop;
                         message_pop.on_top( true );
                         message_pop.message( "%s", _( "Moving zone." ) );
-                        const tripoint_bub_ms zone_local_start_point = m.bub_from_abs( zone.get_start_point() );
-                        const tripoint_bub_ms zone_local_end_point = m.bub_from_abs( zone.get_end_point() );
+                        const tripoint_bub_ms zone_local_start_point = m.get_bub( zone.get_start_point() );
+                        const tripoint_bub_ms zone_local_end_point = m.get_bub( zone.get_end_point() );
                         // local position of the zone center, used to calculate the u.view_offset,
                         // could center the screen to the position it represents
-                        tripoint_bub_ms view_center = m.bub_from_abs( zone.get_center_point() );
+                        tripoint_bub_ms view_center = m.get_bub( zone.get_center_point() );
                         const look_around_result result_local = look_around( false, view_center,
                                                                 zone_local_start_point, false, false,
                                                                 false, true, zone_local_end_point );
                         if( result_local.position ) {
-                            const tripoint_abs_ms new_start_point = m.getglobal( *result_local.position );
+                            const tripoint_abs_ms new_start_point = m.get_abs( *result_local.position );
                             const tripoint_abs_ms new_end_point = zone.get_end_point() - zone.get_start_point() +
                                                                   new_start_point;
                             if( new_start_point == zone.get_start_point() ) {
@@ -7625,7 +7625,7 @@ void game::pre_print_all_tile_info( const tripoint_bub_ms &lp, const catacurses:
                                     const visibility_variables &cache )
 {
     // get global area info according to look_around caret position
-    tripoint_abs_omt omp( coords::project_to<coords::omt>( m.getglobal( lp ) ) );
+    tripoint_abs_omt omp( coords::project_to<coords::omt>( m.get_abs( lp ) ) );
     const oter_id &cur_ter_m = overmap_buffer.ter( omp );
     om_vision_level vision = overmap_buffer.seen( omp );
     // we only need the area name and then pass it to print_all_tile_info() function below
@@ -7926,7 +7926,7 @@ look_around_result game::look_around(
             fast_scroll = !fast_scroll;
         } else if( action == "map" ) {
             uistate.open_menu = [center]() {
-                ui::omap::look_around_map( get_map().getglobal( center ) );
+                ui::omap::look_around_map( get_map().get_abs( center ) );
             };
             break;
         } else if( action == "toggle_pixel_minimap" ) {
@@ -10693,7 +10693,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
                       const bool furniture_move )
 {
 
-    const tripoint_abs_ms dest_loc_abs = m.getglobal( dest_loc );
+    const tripoint_abs_ms dest_loc_abs = m.get_abs( dest_loc );
 
     if( m.has_flag_ter( ter_furn_flag::TFLAG_SMALL_PASSAGE, dest_loc ) ) {
         if( u.get_size() > creature_size::medium ) {
@@ -10971,7 +10971,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
     }
 
     tripoint_bub_ms oldpos = u.pos_bub();
-    tripoint_abs_ms old_abs_pos = m.getglobal( oldpos );
+    tripoint_abs_ms old_abs_pos = m.get_abs( oldpos );
 
     bool moving = dest_loc != oldpos;
 
@@ -11296,7 +11296,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
                 std::set<tripoint_abs_ms> places;
                 for( const direction &elem : adjacentDir ) {
                     if( corpse_available( u.pos_bub() + displace_XY( elem ) ) ) {
-                        places.emplace( m.getglobal( u.pos_bub() + displace_XY( elem ) ) );
+                        places.emplace( m.get_abs( u.pos_bub() + displace_XY( elem ) ) );
                     }
                 }
                 if( !places.empty() ) {
@@ -11304,7 +11304,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
                 }
             } else {
                 if( corpse_available( u.pos_bub() ) ) {
-                    u.assign_activity( pulp_activity_actor( m.getglobal( u.pos_bub() ) ) );
+                    u.assign_activity( pulp_activity_actor( m.get_abs( u.pos_bub() ) ) );
                 }
             }
         }
@@ -12535,7 +12535,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
     }
 
     const tripoint_bub_ms old_pos = u.pos_bub();
-    const tripoint_abs_ms old_abs_pos = here.getglobal( old_pos );
+    const tripoint_abs_ms old_abs_pos = here.get_abs( old_pos );
     point_rel_sm submap_shift;
     const bool z_level_changed = vertical_shift( z_after );
     if( !force ) {
@@ -12697,10 +12697,10 @@ std::optional<tripoint_bub_ms> game::find_stairs( const map &mp, int z_after,
     int best = INT_MAX;
     std::optional<tripoint_bub_ms> stairs;
     const int omtilesz = SEEX * 2 - 1;
-    const tripoint_abs_ms abs_omt_base( project_to<coords::ms>( project_to<coords::omt>( mp.getglobal(
+    const tripoint_abs_ms abs_omt_base( project_to<coords::ms>( project_to<coords::omt>( mp.get_abs(
                                             pos ) ) ) );
 
-    tripoint_bub_ms omtile_align_start( mp.bub_from_abs( tripoint_abs_ms( abs_omt_base.xy(),
+    tripoint_bub_ms omtile_align_start( mp.get_bub( tripoint_abs_ms( abs_omt_base.xy(),
                                         z_after ) ) );
     tripoint_bub_ms omtile_align_end( omtile_align_start + point( omtilesz, omtilesz ) );
 
@@ -14091,7 +14091,7 @@ namespace cata_event_dispatch
 void avatar_moves( const tripoint_abs_ms &old_abs_pos, const avatar &u, const map &m )
 {
     const tripoint_bub_ms new_pos = u.pos_bub();
-    const tripoint_abs_ms new_abs_pos = m.getglobal( new_pos );
+    const tripoint_abs_ms new_abs_pos = m.get_abs( new_pos );
     mtype_id mount_type;
     if( u.is_mounted() ) {
         mount_type = u.mounted_creature->type->id;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1035,7 +1035,7 @@ avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
     }
 
     if( should_pulp ) {
-        assign_activity( pulp_activity_actor( here.getglobal( smashp ), true ) );
+        assign_activity( pulp_activity_actor( here.get_abs( smashp ), true ) );
         return ret; // don't smash terrain if we've smashed a corpse
     }
 
@@ -1936,7 +1936,7 @@ bool Character::cast_spell( spell &sp, bool fake_spell,
         }
     }
     if( target ) {
-        spell_act.coords.emplace_back( get_map().getglobal( *target ) );
+        spell_act.coords.emplace_back( get_map().get_abs( *target ) );
     }
     assign_activity( spell_act );
     return true;

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -55,7 +55,7 @@ static void serialize_liquid_source( player_activity &act, const vehicle &veh, c
     act.values.push_back( static_cast<int>( liquid_source_type::VEHICLE ) );
     act.values.push_back( part_num );
     if( part_num != -1 ) {
-        act.coords.push_back( get_map().getglobal( veh.bub_part_pos( part_num ) ) );
+        act.coords.push_back( get_map().get_abs( veh.bub_part_pos( part_num ) ) );
     } else {
         act.coords.push_back( veh.global_square_location() );
     }
@@ -78,7 +78,7 @@ static void serialize_liquid_source( player_activity &act, const tripoint_bub_ms
         act.values.push_back( static_cast<int>( liquid_source_type::MAP_ITEM ) );
         act.values.push_back( std::distance( stack.begin(), iter ) );
     }
-    act.coords.push_back( get_map().getglobal( pos ) );
+    act.coords.push_back( get_map().get_abs( pos ) );
     act.str_values.push_back( serialize( liquid ) );
 }
 
@@ -86,7 +86,7 @@ static void serialize_liquid_target( player_activity &act, const vpart_reference
 {
     act.values.push_back( static_cast<int>( liquid_target_type::VEHICLE ) );
     act.values.push_back( 0 ); // dummy
-    act.coords.push_back( get_map().getglobal( vp.vehicle().bub_part_pos( 0 ) ) );
+    act.coords.push_back( get_map().get_abs( vp.vehicle().bub_part_pos( 0 ) ) );
     act.values.push_back( vp.part_index() ); // tank part index
 }
 
@@ -102,7 +102,7 @@ static void serialize_liquid_target( player_activity &act, const tripoint_bub_ms
 {
     act.values.push_back( static_cast<int>( liquid_target_type::MAP ) );
     act.values.push_back( 0 ); // dummy
-    act.coords.push_back( get_map().getglobal( pos ) );
+    act.coords.push_back( get_map().get_abs( pos ) );
 }
 
 namespace liquid_handler

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -848,7 +848,7 @@ void iexamine::attunement_altar( Character &you, const tripoint_bub_ms & )
 
 void iexamine::translocator( Character &, const tripoint_bub_ms &examp )
 {
-    const tripoint_abs_omt omt_loc( coords::project_to<coords::omt>( get_map().getglobal( examp ) ) );
+    const tripoint_abs_omt omt_loc( coords::project_to<coords::omt>( get_map().get_abs( examp ) ) );
     avatar &player_character = get_avatar();
     const bool activated = player_character.translocators.knows_translocator( omt_loc );
     if( !activated ) {
@@ -1476,8 +1476,8 @@ void iexamine::elevator( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
     tripoint_abs_ms const old_abs_pos = you.get_location();
-    tripoint_abs_omt const this_omt = project_to<coords::omt>( here.getglobal( examp ) );
-    tripoint_bub_ms const sm_orig = here.bub_from_abs( project_to<coords::ms>( this_omt ) );
+    tripoint_abs_omt const this_omt = project_to<coords::omt>( here.get_abs( examp ) );
+    tripoint_bub_ms const sm_orig = here.get_bub( project_to<coords::ms>( this_omt ) );
     std::vector<tripoint_bub_ms> this_elevator;
 
     for( tripoint_bub_ms const &pos : closest_points_first( examp, SEEX - 1 ) ) {
@@ -1602,7 +1602,7 @@ bool iexamine::try_start_hacking( Character &you, const tripoint_bub_ms &examp )
         item_location hacking_tool = item_location{you, &you.best_item_with_quality( qual_HACK )};
         hacking_tool->ammo_consume( hacking_tool->ammo_required(), hacking_tool.pos_bub(), &you );
         you.assign_activity( hacking_activity_actor( hacking_tool ) );
-        you.activity.placement = get_map().getglobal( examp );
+        you.activity.placement = get_map().get_abs( examp );
         return true;
     }
 }
@@ -1705,7 +1705,7 @@ void iexamine::rubble( Character &you, const tripoint_bub_ms &examp )
         return;
     }
     you.assign_activity( clear_rubble_activity_actor( moves ) );
-    you.activity.placement = here.getglobal( examp );
+    you.activity.placement = here.get_abs( examp );
 }
 
 /**
@@ -2134,7 +2134,7 @@ void iexamine::locked_object_pickable( Character &you, const tripoint_bub_ms &ex
         if( you.get_power_level() >= bio_lockpick->power_activate ) {
             you.mod_power_level( -bio_lockpick->power_activate );
             you.add_msg_if_player( m_info, _( "You activate your %s." ), bio_lockpick->name );
-            you.assign_activity( lockpick_activity_actor::use_bionic( here.getglobal( examp ) ) );
+            you.assign_activity( lockpick_activity_actor::use_bionic( here.get_abs( examp ) ) );
             return;
         } else {
             you.add_msg_if_player( m_info, _( "You don't have enough power to activate your %s." ),
@@ -2189,7 +2189,7 @@ void iexamine::bulletin_board( Character &you, const tripoint_bub_ms &examp )
 {
     g->validate_camps();
     map &here = get_map();
-    point_abs_omt omt( coords::project_to<coords::omt>( here.getglobal( examp ) ).xy() );
+    point_abs_omt omt( coords::project_to<coords::omt>( here.get_abs( examp ) ).xy() );
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( omt );
     if( bcp ) {
         basecamp *temp_camp = *bcp;
@@ -2220,7 +2220,7 @@ void iexamine::bulletin_board( Character &you, const tripoint_bub_ms &examp )
             return;
         }
 
-        temp_camp->validate_bb_pos( here.getglobal( examp ) );
+        temp_camp->validate_bb_pos( here.get_abs( examp ) );
         temp_camp->validate_assignees();
         temp_camp->validate_sort_points();
         temp_camp->scan_pseudo_items();
@@ -2772,7 +2772,7 @@ int iexamine::query_seed( const std::vector<seed_tuple> &seed_entries )
 void iexamine::plant_seed( Character &you, const tripoint_bub_ms &examp, const itype_id &seed_id )
 {
     player_activity act( ACT_PLANT_SEED, to_moves<int>( 30_seconds ) );
-    act.placement = get_map().getglobal( examp );
+    act.placement = get_map().get_abs( examp );
     act.str_values.emplace_back( seed_id );
     you.assign_activity( act );
 }
@@ -4786,7 +4786,7 @@ void iexamine::shrub_wildveggies( Character &you, const tripoint_bub_ms &examp )
     ///\EFFECT_PER randomly speeds up foraging
     move_cost /= rng( std::max( 4, you.per_cur ), 4 + you.per_cur * 2 );
     you.assign_activity( forage_activity_actor( move_cost ) );
-    you.activity.placement = here.getglobal( examp );
+    you.activity.placement = here.get_abs( examp );
     you.activity.auto_resume = true;
 }
 
@@ -4903,7 +4903,7 @@ void iexamine::part_con( Character &you, tripoint_bub_ms const &examp )
             }
         } else {
             you.assign_activity( ACT_BUILD );
-            you.activity.placement = here.getglobal( examp );
+            you.activity.placement = here.get_abs( examp );
         }
         return;
     }

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -114,7 +114,7 @@ std::vector<item_location> cardreader_examine_actor::get_cards( Character &you,
                 continue;
             }
             int dist = rl_dist( cardloc.xy(),
-                                coords::project_to<coords::omt>( get_map().getglobal( examp ) ).xy() );
+                                coords::project_to<coords::omt>( get_map().get_abs( examp ) ).xy() );
             if( dist > *omt_allowed_radius ) {
                 continue;
             }
@@ -132,7 +132,7 @@ bool cardreader_examine_actor::apply( const tripoint_bub_ms &examp ) const
 
     map &here = get_map();
     if( map_regen ) {
-        tripoint_abs_omt omt_pos( coords::project_to<coords::omt>( here.getglobal( examp ) ) );
+        tripoint_abs_omt omt_pos( coords::project_to<coords::omt>( here.get_abs( examp ) ) );
         const ret_val<void> has_colliding_vehicle = run_mapgen_update_func( mapgen_id, omt_pos, {}, nullptr,
                 false );
         if( !has_colliding_vehicle.success() ) {
@@ -180,8 +180,8 @@ void cardreader_examine_actor::call( Character &you, const tripoint_bub_ms &exam
                 break;
             }
             // Check 1) same overmap coords, 2) turret, 3) hostile
-            if( coords::project_to<coords::omt>( here.getglobal( critter.pos_bub() ) ) ==
-                coords::project_to<coords::omt>( here.getglobal( examp ) ) &&
+            if( coords::project_to<coords::omt>( here.get_abs( critter.pos_bub() ) ) ==
+                coords::project_to<coords::omt>( here.get_abs( examp ) ) &&
                 critter.has_flag( mon_flag_ID_CARD_DESPAWN ) &&
                 critter.attitude_to( you ) == Creature::Attitude::HOSTILE ) {
                 g->remove_zombie( critter );
@@ -257,7 +257,7 @@ void eoc_examine_actor::call( Character &you, const tripoint_bub_ms &examp ) con
 {
     dialogue d( get_talker_for( you ), nullptr );
     d.set_value( "this", get_map().furn( examp ).id().str() );
-    d.set_value( "pos", get_map().getglobal( examp ).to_string() );
+    d.set_value( "pos", get_map().get_abs( examp ).to_string() );
     for( const effect_on_condition_id &eoc : eocs ) {
         eoc->activate( d );
     }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -510,7 +510,7 @@ void inventory::form_from_zone( map &m, std::unordered_set<tripoint_abs_ms> &zon
     std::vector<tripoint_bub_ms> pts;
     pts.reserve( zone_pts.size() );
     for( const tripoint_abs_ms &elem : zone_pts ) {
-        pts.push_back( m.bub_from_abs( elem ) );
+        pts.push_back( m.get_bub( elem ) );
     }
     form_from_map( m, pts, pl, assign_invlet );
 }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2191,7 +2191,7 @@ void inventory_selector::add_basecamp_items( const basecamp &camp )
     std::unordered_set<tripoint_abs_ms> tiles = camp.get_storage_tiles();
     map &here = get_map();
     for( tripoint_abs_ms tile : tiles ) {
-        add_map_items( here.bub_from_abs( tile ) );
+        add_map_items( here.get_bub( tile ) );
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1518,7 +1518,7 @@ bool _stacks_location_hint( item const &lhs, item const &rhs )
     if( this_loc == that_loc ) {
         return true;
     } else if( this_loc != tripoint_abs_omt::max && that_loc != tripoint_abs_omt::max ) {
-        const tripoint_abs_omt player_loc( coords::project_to<coords::omt>( get_map().getglobal(
+        const tripoint_abs_omt player_loc( coords::project_to<coords::omt>( get_map().get_abs(
                                                get_player_character().pos_bub() ) ) );
         const int this_dist = rl_dist( player_loc, this_loc );
         const int that_dist = rl_dist( player_loc, that_loc );
@@ -13190,7 +13190,7 @@ bool item::process_temperature_rot( float insulation, const tripoint_bub_ms &pos
             // Use weather if above ground, use map temp if below
             units::temperature env_temperature;
             if( pos.z() >= 0 && flag != temperature_flag::ROOT_CELLAR ) {
-                env_temperature = wgen.get_weather_temperature( get_map().getglobal( pos ), time, seed );
+                env_temperature = wgen.get_weather_temperature( get_map().get_abs( pos ), time, seed );
             } else {
                 env_temperature = AVERAGE_ANNUAL_TEMPERATURE;
             }
@@ -13889,7 +13889,7 @@ ret_val<void> item::link_to( vehicle &veh, const point_rel_ms &mount, link_state
         link().source = bio_link ? link_state::bio_cable : link_state::no_link;
         link().target = link_type;
         link().t_veh = veh.get_safe_reference();
-        link().t_abs_pos = get_map().getglobal( link().t_veh->pos_bub() );
+        link().t_abs_pos = get_map().get_abs( link().t_veh->pos_bub() );
         link().t_mount = mount;
         link().s_bub_pos = tripoint_bub_ms::min; // Forces the item to check the length during process_link.
 
@@ -14142,7 +14142,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
         if( !length_check_needed ) {
             return false;
         }
-        link().length = rl_dist( here.getglobal( pos ), link().t_abs_pos ) +
+        link().length = rl_dist( here.get_abs( pos ), link().t_abs_pos ) +
                         link().t_mount.abs().x() + link().t_mount.abs().y();
         if( check_length() ) {
             return reset_link( true, carrier );
@@ -14195,7 +14195,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
 
     // Set the new absolute position to the vehicle's origin.
     tripoint_bub_ms t_veh_bub_pos = t_veh->pos_bub();
-    tripoint_abs_ms new_t_abs_pos = here.getglobal( t_veh_bub_pos );
+    tripoint_abs_ms new_t_abs_pos = here.get_abs( t_veh_bub_pos );
     if( link().t_abs_pos != new_t_abs_pos ) {
         link().t_abs_pos = new_t_abs_pos;
         length_check_needed = true;
@@ -14660,7 +14660,7 @@ bool item::process_internal( map &here, Character *carrier, const tripoint_bub_m
                 here.rotten_item_spawn( *this, pos );
             }
             if( is_corpse() ) {
-                here.handle_decayed_corpse( *this, here.getglobal( pos ) );
+                here.handle_decayed_corpse( *this, here.get_abs( pos ) );
             }
             return true;
         }

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -293,7 +293,7 @@ std::string location_hint( item const &it, unsigned int /* quantity */,
 {
     if( it.has_flag( json_flag_HINT_THE_LOCATION ) && it.has_var( "spawn_location_omt" ) ) {
         tripoint_abs_omt loc( it.get_var( "spawn_location_omt", tripoint_abs_omt::zero ) );
-        tripoint_abs_omt player_loc( coords::project_to<coords::omt>( get_map().getglobal(
+        tripoint_abs_omt player_loc( coords::project_to<coords::omt>( get_map().get_abs(
                                          get_avatar().pos_bub() ) ) );
         int dist = rl_dist( player_loc, loc );
         if( dist < 1 ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1759,7 +1759,7 @@ static bool good_fishing_spot( const tripoint_bub_ms &pos, Character *p )
     map &here = get_map();
     // isolated little body of water with no definite fish population
     const oter_id &cur_omt =
-        overmap_buffer.ter( coords::project_to<coords::omt>( here.getglobal( pos ) ) );
+        overmap_buffer.ter( coords::project_to<coords::omt>( here.get_abs( pos ) ) );
     std::string om_id = cur_omt.id().c_str();
     if( fishables.empty() && !here.has_flag( ter_furn_flag::TFLAG_CURRENT, pos ) &&
         // this is a ridiculous way to find a good fishing spot, but I'm just trying
@@ -2910,7 +2910,7 @@ std::optional<int> iuse::makemound( Character *p, item *it, const tripoint_bub_m
         !here.has_flag( ter_furn_flag::TFLAG_PLANT, pnt ) ) {
         p->add_msg_if_player( _( "You start churning up the earth here." ) );
         p->assign_activity( churn_activity_actor( 18000, item_location( *p, it ) ) );
-        p->activity.placement = here.getglobal( pnt );
+        p->activity.placement = here.get_abs( pnt );
         return 1;
     } else {
         p->add_msg_if_player( _( "You can't churn up this ground." ) );
@@ -3130,7 +3130,7 @@ static std::optional<int> dig_tool( Character *p, item *it, const tripoint_bub_m
 
     p->assign_activity( activity, moves );
     p->activity.targets.emplace_back( *p, it );
-    p->activity.placement = here.getglobal( pnt );
+    p->activity.placement = here.get_abs( pnt );
 
     // You can mine either furniture or terrain, and furniture goes first,
     // according to @ref map::bash_ter_furn()
@@ -3197,7 +3197,7 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint_bub_m
     }
 
     you.assign_activity( lockpick_activity_actor::use_item( to_moves<int>( duration ),
-                         item_location( you, it ), get_map().getglobal( *target ) ) );
+                         item_location( you, it ), get_map().get_abs( *target ) ) );
     return 1;
 }
 
@@ -4602,7 +4602,7 @@ void iuse::cut_log_into_planks( Character &p )
     p.add_msg_if_player( _( "You cut the log into planks." ) );
 
     p.assign_activity( chop_planks_activity_actor( moves ) );
-    p.activity.placement = get_map().getglobal( p.pos_bub() );
+    p.activity.placement = get_map().get_abs( p.pos_bub() );
 }
 
 std::optional<int> iuse::lumber( Character *p, item *it, const tripoint_bub_ms & )
@@ -4699,7 +4699,7 @@ std::optional<int> iuse::chop_tree( Character *p, item *it, const tripoint_bub_m
         add_msg( m_info, _( "%s helps with this task…" ), helpers[i]->get_name() );
     }
     p->assign_activity( chop_tree_activity_actor( moves, item_location( *p, it ) ) );
-    p->activity.placement = here.getglobal( pnt );
+    p->activity.placement = here.get_abs( pnt );
 
     return 1;
 }
@@ -4744,7 +4744,7 @@ std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint_bub_m
         add_msg( m_info, _( "%s helps with this task…" ), helpers[i]->get_name() );
     }
     p->assign_activity( chop_logs_activity_actor( moves, item_location( *p, it ) ) );
-    p->activity.placement = here.getglobal( pnt );
+    p->activity.placement = here.get_abs( pnt );
 
     return 1;
 }
@@ -6456,7 +6456,7 @@ static item::extended_photo_def photo_def_for_camera_point( const tripoint_bub_m
                                               obj_list );
     }
 
-    tripoint_abs_omt omp( coords::project_to<coords::omt>( here.getglobal( aim_point ) ) );
+    tripoint_abs_omt omp( coords::project_to<coords::omt>( here.get_abs( aim_point ) ) );
     const oter_id &cur_ter = overmap_buffer.ter( omp );
     om_vision_level vision = overmap_buffer.seen( omp );
     std::string overmap_desc = string_format( _( "In the background you can see a %s." ),
@@ -8003,12 +8003,12 @@ std::optional<int> iuse::lux_meter( Character *p, item *it, const tripoint_bub_m
 std::optional<int> iuse::dbg_lux_meter( Character *p, item *, const tripoint_bub_ms &pos )
 {
     map &here = get_map();
-    const float incident_light = incident_sunlight( current_weather( here.getglobal( pos ) ),
+    const float incident_light = incident_sunlight( current_weather( here.get_abs( pos ) ),
                                  calendar::turn );
     const float nat_light = g->natural_light_level( pos.z() );
     const float sunlight = sun_light_at( calendar::turn );
     const float sun_irrad = sun_irradiance( calendar::turn );
-    const float incident_irrad = incident_sun_irradiance( current_weather( here.getglobal( pos ) ),
+    const float incident_irrad = incident_sun_irradiance( current_weather( here.get_abs( pos ) ),
                                  calendar::turn );
     p->add_msg_if_player( m_neutral,
                           _( "Incident light: %.1f\nNatural light: %.1f\nSunlight: %.1f\nSun irradiance: %.1f\nIncident irradiance %.1f" ),
@@ -8330,7 +8330,7 @@ heater find_heater( Character *p, item *it )
                 optional_vpart_position vp = get_map().veh_at( app.value().first );
                 available_heater = vp->vehicle().connected_battery_power_level().first;
                 heating_effect = app.value().second->charges_to_use();
-                vpt = get_map().getglobal( app.value().first );
+                vpt = get_map().get_abs( app.value().first );
                 if( available_heater >= heating_effect ) {
                     return {loc, consume_flag, available_heater, heating_effect, vpt, pseudo_flag};
                 } else {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1361,7 +1361,7 @@ bool firestarter_actor::prep_firestarter_use( const Character &p, tripoint_bub_m
         target_is_firewood = true;
     } else {
         zone_manager &mgr = zone_manager::get_manager();
-        auto zones = mgr.get_zones( zone_type_SOURCE_FIREWOOD, here.getglobal( pos ) );
+        auto zones = mgr.get_zones( zone_type_SOURCE_FIREWOOD, here.get_abs( pos ) );
         if( !zones.empty() ) {
             target_is_firewood = true;
         }
@@ -1513,7 +1513,7 @@ std::optional<int> firestarter_actor::use( Character *p, item &it,
                         0, it.tname() );
     p->activity.targets.emplace_back( *p, &it );
     p->activity.values.push_back( g->natural_light_level( pos.z() ) );
-    p->activity.placement = get_map().getglobal( pos );
+    p->activity.placement = get_map().get_abs( pos );
     // charges to use are handled by the activity
     return 0;
 }
@@ -5018,7 +5018,7 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
         const bool using_power_cord = it.typeId() == itype_power_cord;
         if( using_power_cord && it.link().t_veh->is_powergrid() && sel_vp->vehicle().is_powergrid() ) {
             // If both vehicles are adjacent power grids, try to merge them together first.
-            const point_bub_ms prev_pos = here.bub_from_abs( it.link().t_veh->coord_translate(
+            const point_bub_ms prev_pos = here.get_bub( it.link().t_veh->coord_translate(
                                               it.link().t_mount ) +
                                           it.link().t_abs_pos ).xy();
             if( selection.xy().raw().distance( prev_pos.raw() ) <= 1.5f &&

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -856,7 +856,7 @@ bool map::pl_sees( const tripoint_bub_ms &t, const int max_range ) const
 
     const level_cache &map_cache = get_cache_ref( t.z() );
     Character &player_character = get_player_character();
-    if( max_range >= 0 && square_dist( getglobal( t ), player_character.get_location() ) > max_range &&
+    if( max_range >= 0 && square_dist( get_abs( t ), player_character.get_location() ) > max_range &&
         map_cache.camera_cache[t.x()][t.y()] == 0 ) {
         return false;    // Out of range!
     }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1772,11 +1772,11 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_m
     std::vector<tripoint_abs_ms> trajectory;
     trajectory.reserve( trajectory_local.size() );
     for( const tripoint_bub_ms &local_point : trajectory_local ) {
-        trajectory.push_back( here.getglobal( local_point ) );
+        trajectory.push_back( here.get_abs( local_point ) );
     }
     avatar *caster_you = caster.as_avatar();
     auto walk_point = trajectory.begin();
-    if( here.bub_from_abs( *walk_point ) == source ) {
+    if( here.get_bub( *walk_point ) == source ) {
         ++walk_point;
     }
     // save the amount of moves the caster has so we can restore them after the dash
@@ -1784,14 +1784,14 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_m
     creature_tracker &creatures = get_creature_tracker();
     while( walk_point != trajectory.end() ) {
         if( caster_you != nullptr ) {
-            if( creatures.creature_at( here.bub_from_abs( *walk_point ) ) ||
-                !g->walk_move( here.bub_from_abs( *walk_point ), false ) ) {
+            if( creatures.creature_at( here.get_bub( *walk_point ) ) ||
+                !g->walk_move( here.get_bub( *walk_point ), false ) ) {
                 if( walk_point != trajectory.begin() ) {
                     --walk_point;
                 }
                 break;
             } else if( walk_point != trajectory.begin() ) {
-                sp.create_field( here.bub_from_abs( *( walk_point - 1 ) ), caster );
+                sp.create_field( here.get_bub( *( walk_point - 1 ) ), caster );
                 g->draw_ter();
             }
         }
@@ -1805,7 +1805,7 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_m
 
     tripoint_bub_ms far_target;
     calc_ray_end( coord_to_angle( source, target ), sp.aoe( caster ),
-                  here.bub_from_abs( *walk_point ),
+                  here.get_bub( *walk_point ),
                   far_target );
 
     spell_effect::override_parameters params( sp, caster );
@@ -1900,7 +1900,7 @@ void spell_effect::effect_on_condition( const spell &sp, Creature &caster,
         }
         Creature *victim = creatures.creature_at<Creature>( potential_target );
         dialogue d( victim ? get_talker_for( victim ) : nullptr, get_talker_for( caster ) );
-        const tripoint_abs_ms target_abs = get_map().getglobal( potential_target );
+        const tripoint_abs_ms target_abs = get_map().get_abs( potential_target );
         write_var_value( var_type::context, "spell_location", &d,
                          target_abs.to_string() );
         d.amend_callstack( string_format( "Spell: %s Caster: %s", sp.id().c_str(), caster.disp_name() ) );

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -72,7 +72,7 @@ static std::optional<tripoint> find_valid_teleporters_omt( const tripoint_abs_om
     checker.load( omt_pt, true );
     for( const tripoint_omt_ms &p : checker.points_on_zlevel() ) {
         if( checker.has_flag_furn( ter_furn_flag::TFLAG_TRANSLOCATOR, p ) ) {
-            return checker.getglobal( p ).raw();
+            return checker.get_abs( p ).raw();
         }
     }
     return std::nullopt;
@@ -86,7 +86,7 @@ bool teleporter_list::place_avatar_overmap( Character &you, const tripoint_abs_o
     if( !global_dest ) {
         return false;
     }
-    tripoint_omt_ms local_dest = omt_dest.omt_from_abs( tripoint_abs_ms( *global_dest ) ) + point( 60,
+    tripoint_omt_ms local_dest = omt_dest.get_omt( tripoint_abs_ms( *global_dest ) ) + point( 60,
                                  60 );
     you.add_effect( effect_ignore_fall_damage, 1_seconds, false, 0, true );
     g->place_player_overmap( omt_pt );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -380,7 +380,7 @@ void map::memory_clear_vehicle_points( const vehicle &veh ) const
             continue;
         }
         memory_cache_dec_set_dirty( p, true );
-        player_character.memorize_clear_decoration( getglobal( p ), "vp_" );
+        player_character.memorize_clear_decoration( get_abs( p ), "vp_" );
     }
 }
 
@@ -606,7 +606,7 @@ std::unique_ptr<vehicle> map::detach_vehicle( vehicle *veh )
                 if( inbounds( pt ) ) {
                     memory_cache_dec_set_dirty( pt, true );
                 }
-                get_avatar().memorize_clear_decoration( getglobal( pt ), "vp_" );
+                get_avatar().memorize_clear_decoration( get_abs( pt ), "vp_" );
             }
             ch.vehicle_list.erase( veh );
             ch.zone_vehicles.erase( veh );
@@ -1227,7 +1227,7 @@ void map::register_vehicle_zone( vehicle *veh, const int zlev )
 
 bool map::deregister_vehicle_zone( zone_data &zone ) const
 {
-    const tripoint_bub_ms pos = bub_from_abs( zone.get_start_point() );
+    const tripoint_bub_ms pos = get_bub( zone.get_start_point() );
     if( const std::optional<vpart_reference> vp = veh_at( pos ).cargo() ) {
         vehicle &veh = vp->vehicle();
         auto bounds = veh.loot_zones.equal_range( vp->mount_pos() );
@@ -1313,7 +1313,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
 
 optional_vpart_position map::veh_at( const tripoint_abs_ms &p ) const
 {
-    return veh_at( bub_from_abs( p ) );
+    return veh_at( get_bub( p ) );
 }
 
 optional_vpart_position map::veh_at( const tripoint_bub_ms &p ) const
@@ -1726,7 +1726,7 @@ bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, cons
         return false;
     }
     if( avoid_creatures ) {
-        Creature *c = get_creature_tracker().creature_at( getglobal( p ), true );
+        Creature *c = get_creature_tracker().creature_at( get_abs( p ), true );
         if( c ) {
             return false;
         }
@@ -1817,7 +1817,7 @@ bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, cons
 
     memory_cache_dec_set_dirty( p, true );
     if( player_character.sees( p ) ) {
-        player_character.memorize_clear_decoration( getglobal( p ), "f_" );
+        player_character.memorize_clear_decoration( get_abs( p ), "f_" );
     }
 
     if( ( old_f.movecost < 0 ) != ( new_f.movecost < 0 ) ) {
@@ -1951,13 +1951,13 @@ uint8_t map::get_known_connections( const tripoint_bub_ms &p,
     if( use_tiles ) {
         is_memorized =
         [&]( const tripoint_bub_ms & q ) {
-            return !player_character.get_memorized_tile( getglobal( q ) ).get_ter_id().empty();
+            return !player_character.get_memorized_tile( get_abs( q ) ).get_ter_id().empty();
         };
     } else {
 #endif
         is_memorized =
         [&]( const tripoint_bub_ms & q ) {
-            return player_character.get_memorized_tile( getglobal( q ) ).symbol != 0;
+            return player_character.get_memorized_tile( get_abs( q ) ).symbol != 0;
         };
 #ifdef TILES
     }
@@ -2036,12 +2036,12 @@ uint8_t map::get_known_connections_f( const tripoint_bub_ms &p,
 #ifdef TILES
     if( use_tiles ) {
         is_memorized = [&]( const tripoint_bub_ms & q ) {
-            return !player_character.get_memorized_tile( getglobal( q ) ).get_dec_id().empty();
+            return !player_character.get_memorized_tile( get_abs( q ) ).get_dec_id().empty();
         };
     } else {
 #endif
         is_memorized = [&]( const tripoint_bub_ms & q ) {
-            return player_character.get_memorized_tile( getglobal( q ) ).symbol != 0;
+            return player_character.get_memorized_tile( get_abs( q ) ).symbol != 0;
         };
 #ifdef TILES
     }
@@ -2194,7 +2194,7 @@ bool map::ter_set( const tripoint_bub_ms &p, const ter_id &new_terrain, bool avo
         return false;
     }
     if( avoid_creatures ) {
-        Creature *c = get_creature_tracker().creature_at( getglobal( p ), true );
+        Creature *c = get_creature_tracker().creature_at( get_abs( p ), true );
         if( c ) {
             return false;
         }
@@ -2268,7 +2268,7 @@ bool map::ter_set( const tripoint_bub_ms &p, const ter_id &new_terrain, bool avo
     memory_cache_ter_set_dirty( p, true );
     avatar &player_character = get_avatar();
     if( player_character.sees( p ) ) {
-        player_character.memorize_clear_decoration( getglobal( p ), "t_" );
+        player_character.memorize_clear_decoration( get_abs( p ), "t_" );
     }
 
     if( ( old_t.movecost == 0 ) != ( new_t.movecost == 0 ) ) {
@@ -4353,7 +4353,7 @@ void map::batter( const tripoint_bub_ms &p, int power, int tries, const bool sil
 void map::crush( const tripoint_bub_ms &p )
 {
     creature_tracker &creatures = get_creature_tracker();
-    Character *crushed_player = creatures.creature_at<Character>( this->getglobal( p ) );
+    Character *crushed_player = creatures.creature_at<Character>( this->get_abs( p ) );
 
     if( crushed_player != nullptr ) {
         bool player_inside = false;
@@ -4699,9 +4699,9 @@ void map::translate_radius( const ter_id &from, const ter_id &to, float radi,
         return;
     }
 
-    const tripoint_abs_omt abs_omt_p = coords::project_to<coords::omt>( getglobal( p ) );
+    const tripoint_abs_omt abs_omt_p = coords::project_to<coords::omt>( get_abs( p ) );
     for( const tripoint_bub_ms &t : points_on_zlevel() ) {
-        const tripoint_abs_omt abs_omt_t = coords::project_to<coords::omt>( getglobal( t ) );
+        const tripoint_abs_omt abs_omt_t = coords::project_to<coords::omt>( get_abs( t ) );
         const float radiX = trig_dist( p, t );
         if( ter( t ) == from ) {
             // within distance, and either no submap limitation or same overmap coords.
@@ -4723,7 +4723,7 @@ void map::transform_radius( const ter_furn_transform_id &transform, int radi,
     if( !inbounds( p - point( radi, radi ) ) || !inbounds( p + point( radi, radi ) ) ) {
         debugmsg( "transform_radius called for area out of bounds" );
     }
-    tripoint_bub_ms const loc = bub_from_abs( p );
+    tripoint_bub_ms const loc = get_bub( p );
     for( tripoint_bub_ms const &t : points_in_radius( loc, radi, 0 ) ) {
         if( trig_dist( loc, t ) <= radi ) {
             transform->transform( *this, t );
@@ -4738,7 +4738,7 @@ void map::transform_line( const ter_furn_transform_id &transform, const tripoint
         debugmsg( "transform_line called for line out of bounds" );
     }
     for( const tripoint_abs_ms &t : line_to( first, second ) ) {
-        transform->transform( *this, bub_from_abs( t ) );
+        transform->transform( *this, get_bub( t ) );
     }
 }
 
@@ -5253,17 +5253,17 @@ item &map::add_item( const tripoint_bub_ms &p, item new_item, int copies )
 
     if( new_item.is_map() && !new_item.has_var( "reveal_map_center_omt" ) ) {
         new_item.set_var( "reveal_map_center_omt",
-                          coords::project_to<coords::omt>( getglobal( p ) ) );
+                          coords::project_to<coords::omt>( get_abs( p ) ) );
     }
 
     if( new_item.has_flag( json_flag_PRESERVE_SPAWN_OMT ) &&
         !new_item.has_var( "spawn_location_omt" ) ) {
-        new_item.set_var( "spawn_location_omt", coords::project_to<coords::omt>( getglobal( p ) ) );
+        new_item.set_var( "spawn_location_omt", coords::project_to<coords::omt>( get_abs( p ) ) );
     }
     for( item *const it : new_item.all_items_top( pocket_type::CONTAINER ) ) {
         if( it->has_flag( json_flag_PRESERVE_SPAWN_OMT ) &&
             !it->has_var( "spawn_location_omt" ) ) {
-            it->set_var( "spawn_location_omt", coords::project_to<coords::omt>( getglobal( p ) ) );
+            it->set_var( "spawn_location_omt", coords::project_to<coords::omt>( get_abs( p ) ) );
         }
     }
 
@@ -6105,7 +6105,7 @@ bool map::can_see_trap_at( const tripoint_bub_ms &p, const Character &c ) const
 
 const trap &map::tr_at( const tripoint_abs_ms &p ) const
 {
-    return tr_at( bub_from_abs( p ) );
+    return tr_at( get_bub( p ) );
 }
 
 const trap &map::tr_at( const tripoint_bub_ms &p ) const
@@ -6162,7 +6162,7 @@ void map::partial_con_remove( const tripoint_bub_ms &p )
     memory_cache_dec_set_dirty( p, true );
     avatar &player_character = get_avatar();
     if( player_character.sees( p ) ) {
-        player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
+        player_character.memorize_clear_decoration( get_abs( p ), "tr_" );
     }
 }
 
@@ -6205,7 +6205,7 @@ void map::trap_set( const tripoint_bub_ms &p, const trap_id &type )
     memory_cache_dec_set_dirty( p, true );
     avatar &player_character = get_avatar();
     if( player_character.sees( p ) ) {
-        player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
+        player_character.memorize_clear_decoration( get_abs( p ), "tr_" );
     }
     // If there was already a trap here, remove it.
     if( current_submap->get_trap( l ) != tr_null ) {
@@ -6237,7 +6237,7 @@ void map::remove_trap( const tripoint_bub_ms &p )
             memory_cache_dec_set_dirty( p, true );
             avatar &player_character = get_avatar();
             if( player_character.sees( p ) ) {
-                player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
+                player_character.memorize_clear_decoration( get_abs( p ), "tr_" );
             }
             player_character.add_known_trap( p, tr_null.obj() );
         }
@@ -6795,7 +6795,7 @@ visibility_type map::get_visibility( const lit_level ll,
 
 static std::optional<char32_t> get_memory_at( const tripoint_bub_ms &p )
 {
-    const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getglobal( p ) );
+    const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().get_abs( p ) );
     if( mt.symbol != 0 ) {
         return mt.symbol;
     }
@@ -6833,8 +6833,8 @@ void map::draw( const catacurses::window &w, const tripoint_bub_ms &center )
     };
     avatar &player_character = get_avatar();
     player_character.prepare_map_memory_region(
-        getglobal( { min_mm_reg, center.z() } ),
-        getglobal( { max_mm_reg, center.z() } ) );
+        get_abs( { min_mm_reg, center.z() } ),
+        get_abs( { max_mm_reg, center.z() } ) );
 
     const auto draw_background = [&]( const tripoint_bub_ms & p ) {
         int sym = ' ';
@@ -7133,7 +7133,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
     }
 
     if( param.memorize() && memory_cache_ter_is_dirty( p ) ) {
-        player_character.memorize_symbol( getglobal( p ), memory_sym );
+        player_character.memorize_symbol( get_abs( p ), memory_sym );
         memory_cache_ter_set_dirty( p, false );
     }
 
@@ -8234,9 +8234,9 @@ void map::handle_decayed_corpse( const item &it, const tripoint_abs_ms &pnt )
             if( harvest.has_temperature() ) {
                 harvest.set_item_temperature( get_weather().get_temperature( project_to<coords::omt>( pnt ) ) );
             }
-            add_item_or_charges( bub_from_abs( pnt ), harvest, false );
+            add_item_or_charges( get_bub( pnt ), harvest, false );
             if( anything_left && notify_player ) {
-                add_msg_if_player_sees( bub_from_abs( pnt ),
+                add_msg_if_player_sees( get_bub( pnt ),
                                         _( "You notice a %1$s has rotted away, leaving a %2$s." ),
                                         it.tname(), harvest.tname() );
             }
@@ -8296,7 +8296,7 @@ void map::fill_funnels( const tripoint_bub_ms &p, const time_point &since )
         }
     }
     if( biggest_container != items.end() ) {
-        retroactively_fill_from_funnel( *biggest_container, tr, since, calendar::turn, getglobal( p ) );
+        retroactively_fill_from_funnel( *biggest_container, tr, since, calendar::turn, get_abs( p ) );
     }
 }
 
@@ -8315,7 +8315,7 @@ void map::grow_plant( const tripoint_bub_ms &p )
     if( seed == items.end() ) {
         // No seed there anymore, we don't know what kind of plant it was.
         // TODO: Fix point types
-        const tripoint_abs_ms ms_pos( getglobal( p ) );
+        const tripoint_abs_ms ms_pos( get_abs( p ) );
         const tripoint_abs_sm sm_pos = project_to<coords::sm>( ms_pos );
         const oter_id ot = overmap_buffer.ter( project_to<coords::omt>( ms_pos ) );
         dbg( D_ERROR ) << "plant furniture has no seed item.  "
@@ -8733,7 +8733,7 @@ void map::spawn_monsters_submap_group( const tripoint_rel_sm &gp, mongroup &grou
         const tripoint_bub_ms upper_left{ SEEX * gp.x(), SEEY * gp.y(), gp.z()};
         if( !allow_on_terrain( upper_left ) ||
             ( !ignore_inside_checks && has_flag_ter_or_furn( ter_furn_flag::TFLAG_INDOORS, upper_left ) ) ) {
-            const tripoint_abs_ms glp = getglobal( tripoint_bub_ms( gp.x() * SEEX, gp.y() * SEEY, gp.z() ) );
+            const tripoint_abs_ms glp = get_abs( tripoint_bub_ms( gp.x() * SEEX, gp.y() * SEEY, gp.z() ) );
             dbg( D_WARNING ) << "Empty locations for group " << group.type.str() <<
                              " at uniform submap " << gp.x() << "," << gp.y() << "," << gp.z() <<
                              " global " << glp.x() << "," << glp.y() << "," << glp.z();
@@ -8772,7 +8772,7 @@ void map::spawn_monsters_submap_group( const tripoint_rel_sm &gp, mongroup &grou
     if( locations.empty() ) {
         // TODO: what now? there is no possible place to spawn monsters, most
         // likely because the player can see all the places.
-        const tripoint_abs_ms glp = getglobal( tripoint_bub_ms( gp.x() * SEEX, gp.y() * SEEY, gp.z() ) );
+        const tripoint_abs_ms glp = get_abs( tripoint_bub_ms( gp.x() * SEEX, gp.y() * SEEY, gp.z() ) );
         dbg( D_WARNING ) << "Empty locations for group " << group.type.str() <<
                          " at " << gp.x() << "," << gp.y() << "," << gp.z() <<
                          " global " << glp.x() << "," << glp.y() << "," << glp.z();
@@ -8811,7 +8811,7 @@ void map::spawn_monsters_submap_group( const tripoint_rel_sm &gp, mongroup &grou
     for( monster &tmp : group.monsters ) {
         for( int tries = 0; tries < 10 && !locations.empty(); tries++ ) {
             const tripoint_bub_ms local_pos = random_entry_removed( locations );
-            const tripoint_abs_ms abs_pos = get_map().getglobal( local_pos );
+            const tripoint_abs_ms abs_pos = get_map().get_abs( local_pos );
             if( !tmp.can_move_to( local_pos ) ) {
                 continue; // target can not contain the monster
             }
@@ -8970,7 +8970,7 @@ const std::vector<tripoint_bub_ms> &map::trap_locations( const trap_id &type ) c
 
 bool map::inbounds( const tripoint_abs_ms &p ) const
 {
-    return inbounds( bub_from_abs( p ) );
+    return inbounds( get_bub( p ) );
 }
 
 bool map::inbounds( const tripoint_bub_ms &p ) const
@@ -9511,7 +9511,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     seen_cache_dirty |= player_prev_pos != p || sr != player_prev_range || camera_cache_dirty;
     if( seen_cache_dirty ) {
         if( inbounds( p ) ) {
-            build_seen_cache( bub_from_abs( p ), zlev, sr );
+            build_seen_cache( get_bub( p ), zlev, sr );
         }
         player_prev_pos = p;
         player_prev_range = sr;
@@ -9529,7 +9529,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         for( Character::cached_moncam const &mon : u.moncam_cache ) {
             if( inbounds( mon.second ) ) {
                 int const range = mon.first->type->vision_day;
-                build_seen_cache( bub_from_abs( mon.second ), mon.second.z(), range, cumulative,
+                build_seen_cache( get_bub( mon.second ), mon.second.z(), range, cumulative,
                                   true, std::max( MAX_VIEW_DISTANCE - range, 0 ) );
                 cumulative = true;
             }
@@ -9543,12 +9543,12 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
 //////////
 ///// coordinate helpers
 
-tripoint_abs_ms map::getglobal( const tripoint_bub_ms &p ) const
+tripoint_abs_ms map::get_abs( const tripoint_bub_ms &p ) const
 {
     return tripoint_abs_ms{ p.x() + abs_ms.x(), p.y() + abs_ms.y(), p.z() };
 }
 
-tripoint_bub_ms map::bub_from_abs( const tripoint_abs_ms &p ) const
+tripoint_bub_ms map::get_bub( const tripoint_abs_ms &p ) const
 {
     return tripoint_bub_ms { p.x() - abs_ms.x(), p.y() - abs_ms.y(), p.z()};
 }

--- a/src/map.h
+++ b/src/map.h
@@ -1750,13 +1750,13 @@ class map
          * Coordinates is in the system that is used by the ter/furn/i_at functions.
          * Output is in the same scale, but in global system.
          */
-        tripoint_abs_ms getglobal( const tripoint_bub_ms &p ) const;
+        tripoint_abs_ms get_abs( const tripoint_bub_ms &p ) const;
         /**
-         * Inverse of @ref getglobal
+         * Inverse of @ref get_abs
          */
-        tripoint_bub_ms bub_from_abs( const tripoint_abs_ms &p ) const;
-        point_bub_ms bub_from_abs( const point_abs_ms &p ) const {
-            return bub_from_abs( tripoint_abs_ms( p, abs_sub.z() ) ).xy();
+        tripoint_bub_ms get_bub( const tripoint_abs_ms &p ) const;
+        point_bub_ms get_bub( const point_abs_ms &p ) const {
+            return get_bub( tripoint_abs_ms( p, abs_sub.z() ) ).xy();
         }
         bool inbounds( const tripoint_bub_ms &p ) const;
         bool inbounds( const tripoint_abs_ms &p ) const;
@@ -2474,11 +2474,11 @@ class tinymap : private map
         tripoint_abs_sm get_abs_sub() const {
             return map::get_abs_sub();
         }
-        tripoint_abs_ms getglobal( const tripoint_omt_ms &p ) const {
-            return map::getglobal( rebase_bub( p ) );
+        tripoint_abs_ms get_abs( const tripoint_omt_ms &p ) const {
+            return map::get_abs( rebase_bub( p ) );
         }
-        tripoint_omt_ms omt_from_abs( const tripoint_abs_ms &p ) const {
-            return rebase_omt( map::bub_from_abs( p ) );
+        tripoint_omt_ms get_omt( const tripoint_abs_ms &p ) const {
+            return rebase_omt( map::get_bub( p ) );
         };
         bool is_outside( const tripoint_omt_ms &p ) const {
             return map::is_outside( rebase_bub( p ) );

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -278,7 +278,7 @@ void map::spread_gas( field_entry &cur, const tripoint_bub_ms &p, int percent_sp
     const bool sheltered = g->is_sheltered( p );
     weather_manager &weather = get_weather();
     const int winddirection = weather.winddirection;
-    const int windpower = get_local_windpower( weather.windspeed, om_ter, getglobal( p ),
+    const int windpower = get_local_windpower( weather.windspeed, om_ter, get_abs( p ),
                           winddirection,
                           sheltered );
 
@@ -953,7 +953,7 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
     bool sheltered = g->is_sheltered( p );
     weather_manager &weather = get_weather();
     int winddirection = weather.winddirection;
-    int windpower = get_local_windpower( weather.windspeed, om_ter, get_map().getglobal( p ),
+    int windpower = get_local_windpower( weather.windspeed, om_ter, get_map().get_abs( p ),
                                          winddirection,
                                          sheltered );
     const ter_t &ter = map_tile.get_ter_t();

--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -75,7 +75,7 @@ std::optional<tripoint_bub_ms> random_point( const tripoint_range<tripoint_bub_m
     return random_entry( suitable );
 }
 
-map_cursor::map_cursor( const tripoint_bub_ms &pos ) : pos_abs_( g ? get_map().getglobal(
+map_cursor::map_cursor( const tripoint_bub_ms &pos ) : pos_abs_( g ? get_map().get_abs(
                 pos ) : tripoint_abs_ms::zero ), pos_bub_( g ? tripoint_bub_ms::zero : pos ) { }
 
 map_cursor::map_cursor( const tripoint_abs_ms &pos ) : pos_abs_( pos ),
@@ -83,5 +83,5 @@ map_cursor::map_cursor( const tripoint_abs_ms &pos ) : pos_abs_( pos ),
 
 tripoint_bub_ms map_cursor::pos() const
 {
-    return g ? get_map().bub_from_abs( pos_abs_ ) : pos_bub_;
+    return g ? get_map().get_bub( pos_abs_ ) : pos_bub_;
 }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2024,7 +2024,7 @@ class jmapgen_npc : public jmapgen_piece
             tripoint_bub_ms const dst( x.get(), y.get(), dat.zlevel() + z.get() );
             // TODO: Make place_npc 3D aware.
             character_id npc_id = dat.m.place_npc( dst.xy(), chosen_id );
-            if( get_map().inbounds( dat.m.getglobal( dst ) ) ) {
+            if( get_map().inbounds( dat.m.get_abs( dst ) ) ) {
                 dat.m.queue_main_cleanup();
             }
             if( dat.mission() && target ) {
@@ -2737,7 +2737,7 @@ class jmapgen_vehicle : public jmapgen_piece_with_has_vehicle_collision
             if( veh && !faction.empty() ) {
                 veh->set_owner( faction_id( faction ) );
             }
-            if( get_map().inbounds( dat.m.getglobal( dst ) ) ) {
+            if( get_map().inbounds( dat.m.get_abs( dst ) ) ) {
                 dat.m.queue_main_cleanup();
             }
         }
@@ -3482,9 +3482,9 @@ class jmapgen_zone : public jmapgen_piece
                     const std::string &/*context*/ ) const override {
             zone_type_id chosen_zone_type = zone_type.get( dat );
             faction_id chosen_faction = faction.get( dat );
-            const tripoint_abs_ms start = dat.m.getglobal( tripoint_bub_ms( int( x.val ), int( y.val ),
+            const tripoint_abs_ms start = dat.m.get_abs( tripoint_bub_ms( int( x.val ), int( y.val ),
                                           dat.zlevel() + z.get() ) );
-            const tripoint_abs_ms end = dat.m.getglobal( tripoint_bub_ms( int( x.valmax ), int( y.valmax ),
+            const tripoint_abs_ms end = dat.m.get_abs( tripoint_bub_ms( int( x.valmax ), int( y.valmax ),
                                         dat.zlevel() + z.get() ) );
             mapgen_place_zone( start, end, chosen_zone_type, chosen_faction, name, filter, &dat.m );
         }
@@ -3512,7 +3512,7 @@ class jmapgen_variable : public jmapgen_piece
         }
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
                     const std::string &/*context*/ ) const override {
-            queued_points[name] = dat.m.getglobal( tripoint_bub_ms( int( x.val ), int( y.val ),
+            queued_points[name] = dat.m.get_abs( tripoint_bub_ms( int( x.val ), int( y.val ),
                                                    dat.zlevel() + z.get() ) );
         }
 };
@@ -3604,7 +3604,7 @@ class jmapgen_remove_all : public jmapgen_piece
                 dat.m.clear_fields( p );
                 dat.m.delete_graffiti( p );
                 if( optional_vpart_position vp = dat.m.veh_at( p ) ) {
-                    if( get_map().inbounds( dat.m.getglobal( start ) ) ) {
+                    if( get_map().inbounds( dat.m.get_abs( start ) ) ) {
                         get_map().remove_vehicle_from_cache( &vp->vehicle(), start.z(), end.z() );
                     }
                     dat.m.destroy_vehicle( &vp->vehicle() );
@@ -5034,7 +5034,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
             }
             break;
             case JMAPGEN_SETMAP_CREATURE_REMOVE: {
-                Creature *tmp_critter = get_creature_tracker().creature_at( m.getglobal(
+                Creature *tmp_critter = get_creature_tracker().creature_at( m.get_abs(
                                             target_pos ), true );
                 if( tmp_critter && !tmp_critter->is_avatar() ) {
                     tmp_critter->die( nullptr );
@@ -5090,7 +5090,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
             }
             break;
             case JMAPGEN_SETMAP_VARIABLE: {
-                queued_points[string_val] = m.getglobal( target_pos );
+                queued_points[string_val] = m.get_abs( target_pos );
             }
             break;
             case JMAPGEN_SETMAP_LINE_TER: {
@@ -5135,7 +5135,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
                                                        point_bub_ms( x2_get(), y2_get() ),
                                                        0 );
                 for( const point_bub_ms &i : line ) {
-                    Creature *tmp_critter = get_creature_tracker().creature_at( tripoint_abs_ms( m.getglobal(
+                    Creature *tmp_critter = get_creature_tracker().creature_at( tripoint_abs_ms( m.get_abs(
                                                 tripoint_bub_ms( i.x(), i.y(),
                                                         z_level ) ) ), true );
                     if( tmp_critter && !tmp_critter->is_avatar() ) {
@@ -5218,7 +5218,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
                 const int cy2 = y2_get();
                 for( int tx = c.x(); tx <= cx2; tx++ ) {
                     for( int ty = c.y(); ty <= cy2; ty++ ) {
-                        Creature *tmp_critter = get_creature_tracker().creature_at( tripoint_abs_ms( m.getglobal(
+                        Creature *tmp_critter = get_creature_tracker().creature_at( tripoint_abs_ms( m.get_abs(
                                                     tripoint_bub_ms( tx,
                                                             ty, z_level ) ) ), true );
                         if( tmp_critter && !tmp_critter->is_avatar() ) {
@@ -6693,7 +6693,7 @@ character_id map::place_npc( const point_bub_ms &p, const string_id<npc_template
     shared_ptr_fast<npc> temp = make_shared_fast<npc>();
     temp->normalize();
     temp->load_npc_template( type );
-    temp->spawn_at_precise( getglobal( { p, abs_sub.z() } ) );
+    temp->spawn_at_precise( get_abs( { p, abs_sub.z() } ) );
     temp->toggle_trait( trait_NPC_STATIC_NPC );
     overmap_buffer.insert_npc( temp );
     return temp->getID();
@@ -7135,10 +7135,10 @@ void map::rotate( int turns )
         }
 
         // Translate bubble -> global -> current map.
-        const point_bub_ms old( bub_from_abs( get_map().getglobal( np.pos_bub() ).xy() ) );
+        const point_bub_ms old( get_bub( get_map().get_abs( np.pos_bub() ).xy() ) );
 
         const point_bub_ms new_pos( old.rotate( turns, {SEEX * 2, SEEY * 2} ) );
-        np.spawn_at_precise( getglobal( tripoint_bub_ms( new_pos, sq.z() ) ) );
+        np.spawn_at_precise( get_abs( tripoint_bub_ms( new_pos, sq.z() ) ) );
     }
 
     clear_vehicle_level_caches();
@@ -7217,7 +7217,7 @@ void map::rotate( int turns )
                 continue;
             }
             const point_abs_sm queued_point_sm( project_to<coords::sm>( queued_point.second.xy() ) );
-            const point_bub_ms queued_point_bub( get_map().bub_from_abs( queued_point.second.xy() ) );
+            const point_bub_ms queued_point_bub( get_map().get_bub( queued_point.second.xy() ) );
             point_bub_ms old( queued_point_bub.x() % SEEX, queued_point_bub.y() % SEEY );
 
             if( queued_point_sm.x() % 2 != 0 ) {
@@ -7227,7 +7227,7 @@ void map::rotate( int turns )
                 old.y() += SEEY;
             }
             const point_bub_ms new_pos( old.rotate( turns, {SEEX * 2, SEEY * 2} ) );
-            queued_points[queued_point.first] = getglobal( tripoint_bub_ms( new_pos,
+            queued_points[queued_point.first] = get_abs( tripoint_bub_ms( new_pos,
                                                 queued_point.second.z() ) );
         }
     }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3513,7 +3513,7 @@ class jmapgen_variable : public jmapgen_piece
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
                     const std::string &/*context*/ ) const override {
             queued_points[name] = dat.m.get_abs( tripoint_bub_ms( int( x.val ), int( y.val ),
-                                                   dat.zlevel() + z.get() ) );
+                                                 dat.zlevel() + z.get() ) );
         }
 };
 

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -774,7 +774,7 @@ void mapgen_forest( mapgendata &dat )
     for( int bd_x = 0; bd_x < 2; bd_x++ ) {
         for( int bd_y = 0; bd_y < 2; bd_y++ ) {
             // Use the corners of the overmap tiles as hash seeds.
-            point_abs_ms global_corner = m->getglobal( tripoint_bub_ms( bd_x * SEEX * 2, bd_y * SEEY * 2,
+            point_abs_ms global_corner = m->get_abs( tripoint_bub_ms( bd_x * SEEX * 2, bd_y * SEEY * 2,
                                          m->get_abs_sub().z() ) ).xy();
             uint32_t net_hash = std::hash<uint32_t> {}( global_corner.x() ) ^ ( std::hash<int> {}( global_corner.y() )
                                 << 1 );
@@ -2202,7 +2202,7 @@ void mremove_trap( map *m, const tripoint_bub_ms &p, trap_id type )
 void mtrap_set( map *m, const tripoint_bub_ms &p, trap_id type, bool avoid_creatures )
 {
     if( avoid_creatures ) {
-        Creature *c = get_creature_tracker().creature_at( m->getglobal( p ), true );
+        Creature *c = get_creature_tracker().creature_at( m->get_abs( p ), true );
         if( c ) {
             return;
         }
@@ -2213,7 +2213,7 @@ void mtrap_set( map *m, const tripoint_bub_ms &p, trap_id type, bool avoid_creat
 void mtrap_set( tinymap *m, const point_omt_ms &p, trap_id type, bool avoid_creatures )
 {
     if( avoid_creatures ) {
-        Creature *c = get_creature_tracker().creature_at( m->getglobal( tripoint_omt_ms( p,
+        Creature *c = get_creature_tracker().creature_at( m->get_abs( tripoint_omt_ms( p,
                       m->get_abs_sub().z() ) ), true );
         if( c ) {
             return;

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -387,7 +387,7 @@ diag_eval_dbl_f field_strength_eval( char scope, std::vector<diag_value> const &
             loc = d.const_actor( beta )->global_pos();
         }
         field_type_id ft = field_type_id( field_value.str( d ) );
-        field_entry *fp = here.field_at( here.bub_from_abs( loc ) ).find_field( ft );
+        field_entry *fp = here.field_at( here.get_bub( loc ) ).find_field( ft );
         return fp ? fp->get_field_intensity() :  0;
     };
 }
@@ -1534,7 +1534,7 @@ diag_eval_dbl_f vision_range_eval( char scope, std::vector<diag_value> const & /
             return chr->unimpaired_range();
         } else if( monster const *const mon = actor->get_const_monster(); mon != nullptr ) {
             map &here = get_map();
-            tripoint_bub_ms tripoint = get_map().bub_from_abs( mon->get_location() );
+            tripoint_bub_ms tripoint = get_map().get_bub( mon->get_location() );
             return mon->sight_range( here.ambient_light_at( tripoint ) );
         }
         throw math::runtime_error( "Tried to access vision range of a non-Character talker" );

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -143,7 +143,7 @@ bool leap_actor::call( monster &z ) const
         return false;
     }
     map &here = get_map();
-    const tripoint_bub_ms target = here.bub_from_abs( target_abs );
+    const tripoint_bub_ms target = here.get_bub( target_abs );
     add_msg_debug( debugmode::DF_MATTACK, "Target at coordinates %s",
                    target.to_string_writable() );
 

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -516,7 +516,7 @@ void milk_source( monster &source_mon )
         std::vector<tripoint_abs_ms> coords{};
         std::vector<std::string> str_values{};
         Character &player_character = get_player_character();
-        coords.push_back( get_map().getglobal( source_mon.pos_bub() ) );
+        coords.push_back( get_map().get_abs( source_mon.pos_bub() ) );
         // pin the cow in place if it isn't already
         bool temp_tie = !source_mon.has_effect( effect_tied );
         if( temp_tie ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -703,7 +703,7 @@ void monster::plan()
                 anger = 0;
                 remove_effect( effect_dragging );
             } else {
-                set_dest( here.getglobal( couch_loc ) );
+                set_dest( here.get_abs( couch_loc ) );
             }
         }
 
@@ -1004,7 +1004,7 @@ void monster::move()
 
     // If true, don't try to greedily avoid locally bad paths
     bool pathed = false;
-    tripoint_bub_ms local_dest = here.bub_from_abs( get_dest() );
+    tripoint_bub_ms local_dest = here.get_bub( get_dest() );
     if( try_to_move ) {
         // Move using vision by follow smells and sounds
         bool move_without_target = false;
@@ -1021,7 +1021,7 @@ void monster::move()
             if( !move_without_target && wandf > 0 && friendly == 0 ) {
                 unset_dest();
                 if( wander_pos != get_location() ) {
-                    local_dest = here.bub_from_abs( wander_pos );
+                    local_dest = here.get_bub( wander_pos );
                     move_without_target = true;
                     add_msg_debug( debugmode::DF_MONMOVE, "%s follows sound using vision", name() );
                 }
@@ -1081,7 +1081,7 @@ void monster::move()
     if( wandf > 0 && !moved && friendly == 0 ) { // No LOS, no scent, so as a fall-back follow sound
         unset_dest();
         if( wander_pos != get_location() ) {
-            destination = here.bub_from_abs( wander_pos );
+            destination = here.get_bub( wander_pos );
             moved = true;
             add_msg_debug( debugmode::DF_MONMOVE, "%s follows sound to not use vision", name() );
         }
@@ -1133,7 +1133,7 @@ void monster::move()
                 rampPos += 1;
                 candidate += tripoint_rel_ms::below;
             }
-            const tripoint_abs_ms candidate_abs = get_map().getglobal( candidate );
+            const tripoint_abs_ms candidate_abs = get_map().get_abs( candidate );
 
             if( candidate.z() != posz() ) {
                 bool can_z_move = true;
@@ -1218,7 +1218,7 @@ void monster::move()
                     continue;
                 }
                 // Don't bash if we're just tracking a noise.
-                if( !provocative_sound && is_wandering() && destination == here.bub_from_abs( wander_pos ) ) {
+                if( !provocative_sound && is_wandering() && destination == here.get_bub( wander_pos ) ) {
                     continue;
                 }
                 const int estimate = here.bash_rating( bash_estimate(), candidate );
@@ -1253,7 +1253,7 @@ void monster::move()
     // Finished logic section.  By this point, we should have chosen a square to
     //  move to (moved = true).
     if( moved ) { // Actual effects of moving to the square we've chosen
-        const tripoint_bub_ms local_next_step = here.bub_from_abs( next_step );
+        const tripoint_bub_ms local_next_step = here.get_bub( next_step );
         const bool did_something =
             ( !pacified && attack_at( local_next_step ) ) ||
             ( !pacified && can_open_doors &&
@@ -1327,7 +1327,7 @@ void monster::nursebot_operate( Character *dragged_foe )
     creature_tracker &creatures = get_creature_tracker();
     map &here = get_map();
     if( rl_dist( get_location(), get_dest() ) == 1 &&
-        !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, here.bub_from_abs( get_dest() ) ) &&
+        !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, here.get_bub( get_dest() ) ) &&
         !has_effect( effect_operating ) ) {
         if( dragged_foe->has_effect( effect_grabbed ) && !has_effect( effect_countdown ) &&
             ( creatures.creature_at( get_dest() ) == nullptr ||
@@ -1345,7 +1345,7 @@ void monster::nursebot_operate( Character *dragged_foe )
                            string_format(
                                _( "a soft robotic voice say, \"Please step away from the Autodoc, this patient needs immediate care.\"" ) ) );
             // TODO: Make it able to push NPC/player
-            push_to( here.bub_from_abs( get_dest() ), 4, 0 );
+            push_to( here.get_bub( get_dest() ), 4, 0 );
         }
     }
     if( get_effect_dur( effect_countdown ) == 1_turns && !has_effect( effect_operating ) ) {
@@ -1652,7 +1652,7 @@ bool monster::bash_at( const tripoint_bub_ms &p )
         return false;
     }
 
-    const bool cramped = will_be_cramped_in_vehicle_tile( get_map().getglobal( p ) );
+    const bool cramped = will_be_cramped_in_vehicle_tile( get_map().get_abs( p ) );
     bool try_bash = !can_move_to( p ) || one_in( 3 ) || cramped;
     if( !try_bash ) {
         return false;
@@ -1933,7 +1933,7 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
     optional_vpart_position vp_dest = here.veh_at( destination );
     if( vp_dest ) {
         vp_dest->vehicle().invalidate_mass();
-        if( will_be_cramped_in_vehicle_tile( here.getglobal( p ) ) ) {
+        if( will_be_cramped_in_vehicle_tile( here.get_abs( p ) ) ) {
             add_effect( effect_cramped_space, 2_turns, true );
         }
     }
@@ -2353,7 +2353,7 @@ bool monster::will_reach( const point_bub_ms &p )
         return true;
     }
 
-    if( can_hear() && wandf > 0 && rl_dist( get_map().bub_from_abs( wander_pos ).xy(), p ) <= 2 &&
+    if( can_hear() && wandf > 0 && rl_dist( get_map().get_bub( wander_pos ).xy(), p ) <= 2 &&
         rl_dist( get_location().xy(), wander_pos.xy() ) <= wandf ) {
         return true;
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2977,7 +2977,7 @@ void monster::die( Creature *nkiller )
     if( !is_hallucination() && has_flag( mon_flag_QUEEN ) ) {
         // The submap coordinates of this monster, monster groups coordinates are
         // submap coordinates.
-        const tripoint_abs_sm abssub = coords::project_to<coords::sm>( here.getglobal( pos_bub() ) );
+        const tripoint_abs_sm abssub = coords::project_to<coords::sm>( here.get_abs( pos_bub() ) );
         // Do it for overmap above/below too
         for( const tripoint_abs_sm &p : points_in_radius( abssub, HALF_MAPSIZE, 1 ) ) {
             // TODO: fix point types
@@ -3500,7 +3500,7 @@ void monster::process_effects()
         }
     }
 
-    if( !will_be_cramped_in_vehicle_tile( get_map().getglobal( pos_bub() ) ) ) {
+    if( !will_be_cramped_in_vehicle_tile( get_map().get_abs( pos_bub() ) ) ) {
         remove_effect( effect_cramped_space );
     }
 
@@ -3887,7 +3887,7 @@ void monster::hear_sound( const tripoint_bub_ms &source, const int vol, const in
         max_error = 1;
     }
 
-    tripoint_abs_ms target = get_map().getglobal( source ) + point( rng( -max_error, max_error ),
+    tripoint_abs_ms target = get_map().get_abs( source ) + point( rng( -max_error, max_error ),
                              rng( -max_error, max_error ) );
     // target_z will require some special check due to soil muffling sounds
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1758,7 +1758,7 @@ float npc::vehicle_danger( int radius ) const
         const wrapped_vehicle &wrapped_veh = vehicles[i];
         if( wrapped_veh.v->is_moving() ) {
             const auto &points_to_check = wrapped_veh.v->immediate_path();
-            point_abs_ms p( get_map().getglobal( pos_bub() ).xy() );
+            point_abs_ms p( get_map().get_abs( pos_bub() ).xy() );
             if( points_to_check.find( p ) != points_to_check.end() ) {
                 danger = i;
             }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -300,8 +300,8 @@ tripoint_bub_ms npc::good_escape_direction( bool include_pos )
         if( retreat_target && *retreat_target != abs_pos ) {
             add_msg_debug( debugmode::DF_NPC_MOVEAI,
                            "<color_light_gray>%s is </color><color_brown>repositioning</color> to %s", name,
-                           here.bub_from_abs( *retreat_target ).to_string_writable() );
-            update_path( here.bub_from_abs( *retreat_target ) );
+                           here.get_bub( *retreat_target ).to_string_writable() );
+            update_path( here.get_bub( *retreat_target ) );
         }
         if( !path.empty() ) {
             return path[0];
@@ -1221,9 +1221,9 @@ void npc::regen_ai_cache()
         }
     }
     while( i != std::end( ai_cache.sound_alerts ) ) {
-        if( sees( here.bub_from_abs( tripoint_abs_ms( i->abs_pos ) ) ) ) {
+        if( sees( here.get_bub( tripoint_abs_ms( i->abs_pos ) ) ) ) {
             // if they were responding to a call for guards because of thievery
-            npc *const sound_source = creatures.creature_at<npc>( here.bub_from_abs( tripoint_abs_ms(
+            npc *const sound_source = creatures.creature_at<npc>( here.get_bub( tripoint_abs_ms(
                                           i->abs_pos ) ) );
             if( sound_source ) {
                 if( my_fac == sound_source->my_fac && sound_source->known_stolen_item ) {
@@ -1470,7 +1470,7 @@ void npc::move()
         if( !activity_route.empty() && !has_destination_activity() ) {
             tripoint_bub_ms final_destination;
             if( destination_point ) {
-                final_destination = here.bub_from_abs( *destination_point );
+                final_destination = here.get_bub( *destination_point );
             } else {
                 final_destination = activity_route.back();
             }
@@ -1603,7 +1603,7 @@ void npc::execute_action( npc_action action )
 
         case npc_investigate_sound: {
             tripoint_bub_ms cur_pos = pos_bub();
-            update_path( here.bub_from_abs( tripoint_abs_ms( ai_cache.s_abs_pos ) ) );
+            update_path( here.get_bub( tripoint_abs_ms( ai_cache.s_abs_pos ) ) );
             move_to_next();
             if( pos_bub() == cur_pos ) {
                 ai_cache.stuck += 1;
@@ -1612,7 +1612,7 @@ void npc::execute_action( npc_action action )
         break;
 
         case npc_return_to_guard_pos: {
-            const tripoint_bub_ms local_guard_pos = here.bub_from_abs( *ai_cache.guard_pos );
+            const tripoint_bub_ms local_guard_pos = here.get_bub( *ai_cache.guard_pos );
             update_path( local_guard_pos );
             if( pos_bub() == local_guard_pos || path.empty() ) {
                 move_pause();
@@ -1743,8 +1743,8 @@ void npc::execute_action( npc_action action )
 
         case npc_look_for_player:
             if( saw_player_recently() && last_player_seen_pos &&
-                sees( here.bub_from_abs( *last_player_seen_pos ) ) ) {
-                update_path( here.bub_from_abs( *last_player_seen_pos ) );
+                sees( here.get_bub( *last_player_seen_pos ) ) ) {
+                update_path( here.get_bub( *last_player_seen_pos ) );
                 move_to_next();
             } else {
                 look_for_player( player_character );
@@ -1899,7 +1899,7 @@ void npc::execute_action( npc_action action )
             break;
 
         case npc_goto_to_this_pos: {
-            update_path( get_map().bub_from_abs( *goto_to_this_pos ) );
+            update_path( get_map().get_bub( *goto_to_this_pos ) );
             move_to_next();
 
             if( get_location() == *goto_to_this_pos ) {
@@ -2981,7 +2981,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
                 if( !activity_route.empty() && !np->has_destination_activity() ) {
                     tripoint_bub_ms final_destination;
                     if( destination_point ) {
-                        final_destination = here.bub_from_abs( *destination_point );
+                        final_destination = here.get_bub( *destination_point );
                     } else {
                         final_destination = activity_route.back();
                     }
@@ -3129,7 +3129,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         here.creature_on_trap( *this );
         here.creature_in_field( *this );
 
-        if( will_be_cramped_in_vehicle_tile( here.getglobal( p ) ) ) {
+        if( will_be_cramped_in_vehicle_tile( here.get_abs( p ) ) ) {
             if( !has_effect( effect_cramped_space ) ) {
                 add_msg_if_player_sees( *this, m_warning,
                                         string_format( _( "%s has to really cram their huge body to fit." ), disp_name() ) );
@@ -3294,7 +3294,7 @@ void npc::worker_downtime()
     //  already know of a chair, go there - if there isn't already another creature there.
     //  this is a bit of behind the scene omniscience for the npc, since ideally the npc
     //  should walk to the chair and then change their destination due to the seat being taken.
-    tripoint_bub_ms local_chair_pos = chair_pos ? here.bub_from_abs( *chair_pos ) :
+    tripoint_bub_ms local_chair_pos = chair_pos ? here.get_bub( *chair_pos ) :
                                       tripoint_bub_ms::zero;
     if( chair_pos && !creatures.creature_at( local_chair_pos ) ) {
         if( here.has_flag_furn( ter_furn_flag::TFLAG_CAN_SIT, local_chair_pos ) ) {
@@ -3316,9 +3316,9 @@ void npc::worker_downtime()
             for( const tripoint_bub_ms &elem : here.points_in_radius( pos_bub(), 30 ) ) {
                 if( here.has_flag_furn( ter_furn_flag::TFLAG_CAN_SIT, elem ) && !creatures.creature_at( elem ) &&
                     could_move_onto( elem ) &&
-                    here.point_within_camp( here.getglobal( elem ) ) ) {
+                    here.point_within_camp( here.get_abs( elem ) ) ) {
                     // this one will do
-                    chair_pos = here.getglobal( elem );
+                    chair_pos = here.get_abs( elem );
                     return;
                 }
             }
@@ -3327,7 +3327,7 @@ void npc::worker_downtime()
     // we got here if there are no chairs available.
     // wander back to near the bulletin board of the camp.
     if( wander_pos ) {
-        update_path( here.bub_from_abs( *wander_pos ) );
+        update_path( here.get_bub( *wander_pos ) );
         if( get_location() == *wander_pos || path.empty() ) {
             move_pause();
             path.clear();
@@ -3348,7 +3348,7 @@ void npc::worker_downtime()
         }
         basecamp *temp_camp = *bcp;
         std::vector<tripoint_bub_ms> pts;
-        for( const tripoint_bub_ms &elem : here.points_in_radius( here.bub_from_abs(
+        for( const tripoint_bub_ms &elem : here.points_in_radius( here.get_bub(
                     tripoint_abs_ms( temp_camp->get_bb_pos() ) ), 10 ) ) {
             if( creatures.creature_at( elem ) || !could_move_onto( elem ) ||
                 here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, elem ) ||
@@ -3358,7 +3358,7 @@ void npc::worker_downtime()
             pts.push_back( elem );
         }
         if( !pts.empty() ) {
-            wander_pos = here.getglobal( random_entry( pts ) );
+            wander_pos = here.get_abs( random_entry( pts ) );
             return;
         }
     }
@@ -3940,7 +3940,7 @@ bool npc::find_corpse_to_pulp()
 
     const item *corpse = nullptr;
     if( pulp_location && square_dist( get_location(), *pulp_location ) <= range ) {
-        corpse = check_tile( here.bub_from_abs( *pulp_location ) );
+        corpse = check_tile( here.get_bub( *pulp_location ) );
     }
 
     // Find the old target to avoid spamming
@@ -3954,7 +3954,7 @@ bool npc::find_corpse_to_pulp()
             corpse = check_tile( location.pos_bub() );
 
             if( corpse != nullptr ) {
-                pulp_location = here.getglobal( location.pos_bub() );
+                pulp_location = here.get_abs( location.pos_bub() );
                 break;
             }
 
@@ -4830,7 +4830,7 @@ void npc::reach_omt_destination()
         // No point recalculating the path to get home
         move_to_next();
     } else if( guard_pos ) {
-        update_path( here.bub_from_abs( *guard_pos ) );
+        update_path( here.get_bub( *guard_pos ) );
         move_to_next();
     } else {
         guard_pos = get_location();
@@ -4980,7 +4980,7 @@ void npc::go_to_omt_destination()
             return;
         }
     }
-    tripoint_bub_ms sm_tri = here.bub_from_abs( project_to<coords::ms>( omt_path.back() ) );
+    tripoint_bub_ms sm_tri = here.get_bub( project_to<coords::ms>( omt_path.back() ) );
     tripoint_bub_ms centre_sub = sm_tri + point( SEEX, SEEY );
     if( !here.passable( centre_sub ) ) {
         auto candidates = here.points_in_radius( centre_sub, 2 );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1244,11 +1244,11 @@ void game::chat()
 
             if( npcselect == follower_count ) {
                 for( npc *them : followers ) {
-                    them->goto_to_this_pos = here.getglobal( *p );
+                    them->goto_to_this_pos = here.get_abs( *p );
                 }
                 yell_msg = _( "Everyone move there!" );
             } else {
-                followers[npcselect]->goto_to_this_pos = here.getglobal( *p );
+                followers[npcselect]->goto_to_this_pos = here.get_abs( *p );
                 yell_msg = string_format( _( "Move there, %s!" ), followers[npcselect]->get_name() );
             }
             break;
@@ -1428,7 +1428,7 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
                         int heard_volume, const tripoint_bub_ms &spos )
 {
     const map &here = get_map();
-    const tripoint_abs_ms s_abs_pos = here.getglobal( spos );
+    const tripoint_abs_ms s_abs_pos = here.get_abs( spos );
     const tripoint_abs_ms my_abs_pos = get_location();
 
     add_msg_debug( debugmode::DF_NPC,
@@ -3549,11 +3549,11 @@ talk_effect_fun_t::func f_remove_var( const JsonObject &jo, std::string_view mem
 void map_add_item( item &it, tripoint_abs_ms target_pos )
 {
     if( get_map().inbounds( target_pos ) ) {
-        get_map().add_item_or_charges( get_map().bub_from_abs( target_pos ), it );
+        get_map().add_item_or_charges( get_map().get_bub( target_pos ), it );
     } else {
         tinymap target_bay;
         target_bay.load( project_to<coords::omt>( target_pos ), false );
-        target_bay.add_item_or_charges( target_bay.omt_from_abs( target_pos ), it );
+        target_bay.add_item_or_charges( target_bay.get_omt( target_pos ), it );
     }
 }
 
@@ -4133,7 +4133,7 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
                             is_npc, type, dov_x_adjust, dov_y_adjust, dov_z_adjust, z_override, true_eocs, false_eocs,
                     search_target, search_type, dov_target_min_radius, dov_target_max_radius]( dialogue & d ) {
         talker *target = d.actor( is_npc );
-        tripoint_abs_ms talker_pos = get_map().getglobal( target->pos_bub() );
+        tripoint_abs_ms talker_pos = get_map().get_abs( target->pos_bub() );
         tripoint_abs_ms target_pos = talker_pos;
         if( target_params.has_value() ) {
             const tripoint_abs_omt omt_pos = mission_util::get_om_terrain_pos( target_params.value(), d );
@@ -4156,15 +4156,15 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
             int min_target_dist = dov_target_min_radius.evaluate( d );
             std::string cur_search_target = search_target.value().evaluate( d );
             bool found = false;
-            tripoint_range<tripoint_bub_ms> points = here.points_in_radius( here.bub_from_abs( abs_ms ),
+            tripoint_range<tripoint_bub_ms> points = here.points_in_radius( here.get_bub( abs_ms ),
                     size_t( dov_target_max_radius.evaluate( d ) ), size_t( 0 ) );
             for( const tripoint_bub_ms &search_loc : points ) {
-                if( rl_dist( here.bub_from_abs( talker_pos ), search_loc ) <= min_target_dist ) {
+                if( rl_dist( here.get_bub( talker_pos ), search_loc ) <= min_target_dist ) {
                     continue;
                 }
                 if( search_type.value() == "terrain" ) {
                     if( here.ter( search_loc ).id().c_str() == cur_search_target ) {
-                        target_pos = here.getglobal( search_loc );
+                        target_pos = here.get_abs( search_loc );
                         found = true;
                         break;
                     }
@@ -4172,14 +4172,14 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
                     const furn_str_id &fi = here.furn( search_loc ).id();
                     if( fi.c_str() == cur_search_target ||
                         ( !fi.is_null() && cur_search_target.empty() ) ) {
-                        target_pos = here.getglobal( search_loc );
+                        target_pos = here.get_abs( search_loc );
                         found = true;
                         break;
                     }
                 } else if( search_type.value() == "field" ) {
                     field &fields_here = get_map().field_at( search_loc );
                     if( fields_here.find_field( field_type_id( cur_search_target ) ) || cur_search_target.empty() ) {
-                        target_pos = here.getglobal( search_loc );
+                        target_pos = here.get_abs( search_loc );
                         found = true;
                         break;
                     }
@@ -4188,16 +4188,16 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
                     if( tr.id.c_str() == cur_search_target ||
                         ( !tr.is_null() &&
                           cur_search_target.empty() ) ) {
-                        target_pos = here.getglobal( search_loc );
+                        target_pos = here.get_abs( search_loc );
                         found = true;
                         break;
                     }
                 } else if( search_type.value() == "monster" ) {
-                    Creature *tmp_critter = get_creature_tracker().creature_at( here.getglobal( search_loc ) );
+                    Creature *tmp_critter = get_creature_tracker().creature_at( here.get_abs( search_loc ) );
                     if( tmp_critter != nullptr && tmp_critter->is_monster() &&
                         ( tmp_critter->as_monster()->type->id.c_str() == cur_search_target ||
                           cur_search_target.empty() ) ) {
-                        target_pos = here.getglobal( search_loc );
+                        target_pos = here.get_abs( search_loc );
                         found = true;
                         g->despawn_nonlocal_monsters();
                         break;
@@ -4207,15 +4207,15 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
                             1 ) ) {
                         if( person->pos_bub() == search_loc && ( person->myclass.c_str() == cur_search_target ||
                                 cur_search_target.empty() ) ) {
-                            target_pos = here.getglobal( search_loc );
+                            target_pos = here.get_abs( search_loc );
                             found = true;
                             break;
                         }
                     }
                 } else if( search_type.value() == "zone" ) {
                     zone_manager &mgr = zone_manager::get_manager();
-                    if( mgr.get_zone_at( here.getglobal( search_loc ), zone_type_id( cur_search_target ) ) ) {
-                        target_pos = here.getglobal( search_loc );
+                    if( mgr.get_zone_at( here.get_abs( search_loc ), zone_type_id( cur_search_target ) ) ) {
+                        target_pos = here.get_abs( search_loc );
                         found = true;
                         break;
                     }
@@ -4239,8 +4239,8 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
                 target_pos = talker_pos + tripoint_rel_ms( rng( -max_radius, max_radius ), rng( -max_radius,
                              max_radius ),
                              0 );
-                if( ( !outdoor_only || here.is_outside( here.bub_from_abs( target_pos ) ) ) &&
-                    ( !passable_only || here.passable( here.bub_from_abs( target_pos ) ) ) &&
+                if( ( !outdoor_only || here.is_outside( here.get_bub( target_pos ) ) ) &&
+                    ( !passable_only || here.passable( here.get_bub( target_pos ) ) ) &&
                     rl_dist( target_pos, talker_pos ) >= min_radius ) {
                     found = true;
                     break;
@@ -5145,7 +5145,7 @@ talk_effect_fun_t::func f_cast_spell( const JsonObject &jo, std::string_view mem
                 }
             } else {
                 const tripoint_bub_ms target_pos = loc_var ?
-                                                   get_map().bub_from_abs( get_tripoint_from_var( loc_var, d, is_npc ) ) : caster->pos_bub();
+                                                   get_map().get_bub( get_tripoint_from_var( loc_var, d, is_npc ) ) : caster->pos_bub();
                 sp.cast_all_effects( *caster, target_pos );
                 caster->add_msg_player_or_npc( fake.trigger_message, fake.npc_trigger_message );
             }
@@ -5487,7 +5487,7 @@ talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view membe
                 if( target_var.has_value() ) {
                     tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
                     if( get_map().inbounds( target_pos ) ) {
-                        guy->invoke_item( it->get_item(), method_str, get_map().bub_from_abs( target_pos ) );
+                        guy->invoke_item( it->get_item(), method_str, get_map().get_bub( target_pos ) );
                         return;
                     }
                 }
@@ -5600,7 +5600,7 @@ talk_effect_fun_t::func f_make_sound( const JsonObject &jo, std::string_view mem
         } else {
             translated_message = message.evaluate( d );
         }
-        sounds::sound( get_map().bub_from_abs( target_pos ), volume.evaluate( d ), type, translated_message,
+        sounds::sound( get_map().get_bub( target_pos ), volume.evaluate( d ), type, translated_message,
                        ambient );
     };
 }
@@ -6114,7 +6114,7 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
         tripoint_abs_ms target_location = get_tripoint_from_var( loc_var, d, is_npc );
         std::vector<item_location> items;
         map &here = get_map();
-        tripoint_bub_ms center = here.bub_from_abs( target_location );
+        tripoint_bub_ms center = here.get_bub( target_location );
         int max_radius = dov_max_radius.evaluate( d );
         int min_radius = dov_min_radius.evaluate( d );
         for( const tripoint_bub_ms &pos : here.points_in_radius( center, max_radius ) ) {
@@ -6707,7 +6707,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub();
         if( target_var.has_value() ) {
-            target_pos = get_map().bub_from_abs( get_tripoint_from_var( target_var, d, is_npc ) );
+            target_pos = get_map().get_bub( get_tripoint_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -6842,7 +6842,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub();
         if( target_var.has_value() ) {
-            target_pos = get_map().bub_from_abs( get_tripoint_from_var( target_var, d, is_npc ) );
+            target_pos = get_map().get_bub( get_tripoint_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -6924,7 +6924,7 @@ talk_effect_fun_t::func f_field( const JsonObject &jo, std::string_view member,
         if( target_var.has_value() ) {
             target_pos = get_tripoint_from_var( target_var, d, is_npc );
         }
-        for( const tripoint_bub_ms &dest : get_map().points_in_radius( get_map().bub_from_abs( target_pos ),
+        for( const tripoint_bub_ms &dest : get_map().points_in_radius( get_map().get_bub( target_pos ),
                 radius ) ) {
             if( ( !outdoor_only || get_map().is_outside( dest ) ) && ( !indoor_only ||
                     !get_map().is_outside( dest ) ) ) {
@@ -6951,7 +6951,7 @@ talk_effect_fun_t::func f_emit( const JsonObject &jo, std::string_view member,
         if( target_var.has_value() ) {
             target_pos = get_tripoint_from_var( target_var, d, is_npc );
         }
-        tripoint_bub_ms target = get_map().bub_from_abs( target_pos );
+        tripoint_bub_ms target = get_map().get_bub( target_pos );
         get_map().emit_field( target, emit_id( emit.evaluate( d ) ), chance_mult.evaluate( d ) );
     };
 }
@@ -7047,7 +7047,7 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
         tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
         Creature *teleporter = d.actor( is_npc )->get_creature();
         if( teleporter ) {
-            if( teleport::teleport_to_point( *teleporter, get_map().bub_from_abs( target_pos ), true, false,
+            if( teleport::teleport_to_point( *teleporter, get_map().get_bub( target_pos ), true, false,
                                              false, force, force_safe ) ) {
                 teleporter->add_msg_if_player( success_message.evaluate( d ) );
             } else {

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -89,7 +89,7 @@ void add_fallback_zone( npc &guy )
 
     std::vector<tripoint_abs_ms> points;
     for( tripoint_abs_ms const &t : closest_points_first( loc, PICKUP_RANGE ) ) {
-        tripoint_bub_ms const t_here = here.bub_from_abs( t );
+        tripoint_bub_ms const t_here = here.get_bub( t );
         const furn_id &f = here.furn( t_here );
         if( f != furn_str_id::NULL_ID() &&
             ( f->max_volume > ter_t_floor->max_volume ||
@@ -136,7 +136,7 @@ std::list<item> distribute_items_to_npc_zones( std::list<item> &items, npc &guy 
 
         bool leftover = true;
         for( tripoint_abs_ms const &dpoint : dest ) {
-            tripoint_bub_ms const dpoint_here = here.bub_from_abs( dpoint );
+            tripoint_bub_ms const dpoint_here = here.get_bub( dpoint );
             std::optional<vpart_reference> const vp = here.veh_at( dpoint_here ).cargo();
             if( vp && vp->vehicle().get_owner() == fac_id ) {
                 leftover = _to_veh( it, vp );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2026,7 +2026,7 @@ static tripoint_abs_omt display()
             curs += mouse_pos->xy().raw();
         } else if( action == "look" ) {
             tripoint_abs_ms pos = project_combine( curs, g->overmap_data.origin_remainder );
-            tripoint_bub_ms pos_rel = get_map().bub_from_abs( pos );
+            tripoint_bub_ms pos_rel = get_map().get_bub( pos );
             uistate.open_menu = [pos_rel]() {
                 tripoint_bub_ms pos_cpy = pos_rel;
                 g->look_around( true, pos_cpy, pos_rel, false, false, false, false, pos_rel );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1594,7 +1594,7 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p, bool spawn_nonlocal
     [&]( std::pair<const tripoint_om_sm, monster> &monster_entry ) {
         monster &this_monster = monster_entry.second;
         const map &here = get_map();
-        const tripoint_bub_ms local = here.bub_from_abs( this_monster.get_location() );
+        const tripoint_bub_ms local = here.get_bub( this_monster.get_location() );
         // The monster position must be local to the main map when added to the game
         if( !spawn_nonlocal ) {
             cata_assert( here.inbounds( local ) );

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -185,7 +185,7 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
 
         if( type == ACT_BUILD ) {
             partial_con *pc =
-                get_map().partial_con_at( get_map().bub_from_abs( u.activity.placement ) );
+                get_map().partial_con_at( get_map().get_bub( u.activity.placement ) );
             if( pc ) {
                 int counter = std::min( pc->counter, 10000000 );
                 const int percentage = counter / 100000;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3209,7 +3209,7 @@ bool target_ui::try_reacquire_target( bool critter, tripoint_bub_ms &new_dst )
     }
 
     // Try to re-acquire target tile or tile where the target creature used to be
-    tripoint_bub_ms local_lt = get_map().bub_from_abs( *you->last_target_pos );
+    tripoint_bub_ms local_lt = get_map().get_bub( *you->last_target_pos );
     if( dist_fn( local_lt ) <= range ) {
         new_dst = local_lt;
         // Abort aiming if a creature moved in
@@ -3258,10 +3258,10 @@ int target_ui::dist_fn( const tripoint_bub_ms &p )
 void target_ui::set_last_target()
 {
     if( !you->last_target_pos.has_value() ||
-        you->last_target_pos.value() != get_map().getglobal( dst ) ) {
+        you->last_target_pos.value() != get_map().get_abs( dst ) ) {
         you->aim_cache_dirty = true;
     }
-    you->last_target_pos = get_map().getglobal( dst );
+    you->last_target_pos = get_map().get_abs( dst );
     if( dst_critter ) {
         you->last_target = g->shared_from( *dst_critter );
     } else {
@@ -3426,7 +3426,7 @@ void target_ui::recalc_aim_turning_penalty()
     if( lt_ptr ) {
         curr_recoil_pos = lt_ptr->pos_bub();
     } else if( you->last_target_pos ) {
-        curr_recoil_pos = get_map().bub_from_abs( *you->last_target_pos );
+        curr_recoil_pos = get_map().get_bub( *you->last_target_pos );
     } else {
         curr_recoil_pos = src;
     }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2434,12 +2434,12 @@ void monster::load( const JsonObject &data )
 
     // TEMPORARY until 0.G
     if( !data.has_member( "location" ) ) {
-        set_location( get_map().getglobal( read_legacy_creature_pos( data ) ) );
+        set_location( get_map().get_abs( read_legacy_creature_pos( data ) ) );
         tripoint_bub_ms wand;
         data.read( "wandx", wand.x() );
         data.read( "wandy", wand.y() );
         data.read( "wandz", wand.z() );
-        wander_pos = get_map().getglobal( wand );
+        wander_pos = get_map().get_abs( wand );
         tripoint destination;
         data.read( "destination", destination );
         if( destination != tripoint::zero ) {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -472,7 +472,7 @@ void sounds::process_sounds()
         int sig_power = get_signal_for_hordes( this_centroid );
         if( sig_power > 0 ) {
 
-            const point_abs_ms abs_ms = get_map().getglobal( source ).xy();
+            const point_abs_ms abs_ms = get_map().get_abs( source ).xy();
             const point_abs_sm abs_sm( coords::project_to<coords::sm>( abs_ms ) );
             const tripoint_abs_sm target( abs_sm, source.z() );
             overmap_buffer.signal_hordes( target, sig_power );

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -473,7 +473,7 @@ void start_location::place_player( avatar &you, const tripoint_abs_omt &omtstart
         if( zone.get_type() == zone_type_ZONE_START_POINT ) {
             if( here.inbounds( zone.get_center_point() ) ) {
                 found_good_spot = true;
-                best_spot = here.bub_from_abs( zone.get_center_point() );
+                best_spot = here.get_bub( zone.get_center_point() );
                 break;
             }
         }

--- a/src/talker_furniture.cpp
+++ b/src/talker_furniture.cpp
@@ -40,7 +40,7 @@ tripoint_bub_ms talker_furniture_const::pos_bub() const
 
 tripoint_abs_ms talker_furniture_const::global_pos() const
 {
-    return get_map().getglobal( me_comp->loc );
+    return get_map().get_abs( me_comp->loc );
 }
 
 tripoint_abs_omt talker_furniture_const::global_omt_location() const

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -48,7 +48,7 @@ tripoint_bub_ms talker_item_const::pos_bub() const
 
 tripoint_abs_ms talker_item_const::global_pos() const
 {
-    return get_map().getglobal( me_it_const->pos_bub() );
+    return get_map().get_abs( me_it_const->pos_bub() );
 }
 
 tripoint_abs_omt talker_item_const::global_omt_location() const

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -61,7 +61,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
     Character *const p = critter.as_character();
     const bool c_is_u = p != nullptr && p->is_avatar();
     map &here = get_map();
-    tripoint_abs_ms abs_ms( here.getglobal( target ) );
+    tripoint_abs_ms abs_ms( here.get_abs( target ) );
     if( abs_ms.z() > OVERMAP_HEIGHT || abs_ms.z() < -OVERMAP_DEPTH ) {
         debugmsg( "%s cannot teleport to point %s: too high or too deep.", critter.get_name(),
                   abs_ms.to_string() );
@@ -90,7 +90,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
             dest->load( project_to<coords::sm>( abs_ms ), false );
             dest->spawn_monsters( true, true );
         }
-        dest_target = dest->bub_from_abs( abs_ms );
+        dest_target = dest->get_bub( abs_ms );
     }
     //handles teleporting into solids.
     if( dest->impassable( dest_target ) ) {
@@ -125,8 +125,8 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
         }
     }
     //update pos
-    abs_ms = dest->getglobal( dest_target );
-    target = here.bub_from_abs( abs_ms );
+    abs_ms = dest->get_abs( dest_target );
+    target = here.get_bub( abs_ms );
     //handles telefragging other creatures
     int tfrag_attempts = 5;
     bool collision = false;
@@ -145,11 +145,11 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
             for( tripoint_abs_ms p : nearest_points ) {
                 // If point is not inbounds, ignore if spot is passible or not.  Creatures in impassable terrain will be automatically teleported out in their turn.
                 // some way of validating terrain passability out of bounds would be superior, however.
-                if( ( !dest->inbounds( here.bub_from_abs( p ) ) || dest->passable( here.bub_from_abs( p ) ) ) &&
+                if( ( !dest->inbounds( here.get_bub( p ) ) || dest->passable( here.get_bub( p ) ) ) &&
                     get_creature_tracker().creature_at<Creature>( p ) == nullptr ) {
                     found_new_spot = true;
                     abs_ms = p;
-                    target = here.bub_from_abs( p );
+                    target = here.get_bub( p );
                     break;
                 }
             }

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -283,7 +283,7 @@ void timed_event::actualize()
         case timed_event_type::DSA_ALRP_SUMMON: {
             const tripoint_abs_sm u_pos = player_character.global_sm_location();
             if( rl_dist( u_pos, map_point ) <= 4 ) {
-                const tripoint_bub_ms spot = here.bub_from_abs( project_to<coords::ms>( map_point ) );
+                const tripoint_bub_ms spot = here.get_bub( project_to<coords::ms>( map_point ) );
                 monster dispatcher( mon_dsa_alien_dispatch );
                 fake_spell summoning( spell_dks_summon_alrp, true, 12 );
                 summoning.get_spell( player_character ).cast_all_effects( dispatcher, spot );

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -373,7 +373,7 @@ bool trapfunc::eocs( const tripoint_bub_ms &p, Creature *critter, item * )
     }
     map &here = get_map();
     trap tr = here.tr_at( p );
-    const tripoint_abs_ms trap_location = get_map().getglobal( p );
+    const tripoint_abs_ms trap_location = get_map().get_abs( p );
     for( const effect_on_condition_id &eoc : tr.eocs ) {
         dialogue d( get_talker_for( critter ), nullptr );
         write_var_value( var_type::context, "trap_location", &d, trap_location.to_string() );

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -392,7 +392,7 @@ int vehicle::turrets_aim_and_fire( std::vector<vehicle_part *> &turrets )
             if( has_target ) {
                 turret_data turret = turret_query( *t );
                 npc &cpu = t->get_targeting_npc( *this );
-                shots += turret.fire( cpu, get_map().bub_from_abs( t->target.second ) );
+                shots += turret.fire( cpu, get_map().get_bub( t->target.second ) );
                 t->reset_target( bub_part_pos( *t ) );
             }
         }
@@ -433,7 +433,7 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
         // Set target for any turret in range
         for( vehicle_part *t : turrets ) {
             if( turret_query( *t ).in_range( target ) ) {
-                t->target.second = get_map().getglobal( target );
+                t->target.second = get_map().get_abs( target );
             }
         }
 
@@ -653,7 +653,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
 
     } else {
         // Target is already set, make sure we didn't move after aiming (it's a bug if we did).
-        if( pos != get_map().bub_from_abs( target.first ) ) {
+        if( pos != get_map().get_bub( target.first ) ) {
             target.second = target.first;
             debugmsg( "%s moved after aiming but before it could fire.", cpu.get_name() );
             return shots;
@@ -661,7 +661,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
     }
 
     // Get the turret's target and reset it
-    tripoint_bub_ms targ( get_map().bub_from_abs( target.second ) );
+    tripoint_bub_ms targ( get_map().get_bub( target.second ) );
     pt.reset_target( pos );
 
     shots = gun.fire( cpu, targ );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -408,10 +408,10 @@ void veh_app_interact::refill()
         const point_rel_ms q = veh->coord_translate( pt->mount );
         map &here = get_map();
         for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
-            act.coord_set.insert( here.getglobal( p ) );
+            act.coord_set.insert( here.get_abs( p ) );
         }
-        act.values.push_back( here.getglobal( veh->pos_bub() ).x() + q.x() );
-        act.values.push_back( here.getglobal( veh->pos_bub() ).y() + q.y() );
+        act.values.push_back( here.get_abs( veh->pos_bub() ).x() + q.x() );
+        act.values.push_back( here.get_abs( veh->pos_bub() ).y() + q.y() );
         act.values.push_back( a_point.x() );
         act.values.push_back( a_point.y() );
         act.values.push_back( -a_point.x() );
@@ -497,9 +497,9 @@ void veh_app_interact::remove()
         act = player_activity( ACT_VEHICLE, to_moves<int>( time ), static_cast<int>( 'O' ) );
         act.str_values.push_back( vpinfo.id.str() );
         for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
-            act.coord_set.insert( here.getglobal( p ) );
+            act.coord_set.insert( here.get_abs( p ) );
         }
-        const tripoint a_point_abs( here.getglobal( a_point_bub ).raw() );
+        const tripoint a_point_abs( here.get_abs( a_point_bub ).raw() );
         act.values.push_back( a_point_abs.x );
         act.values.push_back( a_point_abs.y );
         act.values.push_back( a_point.x() );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -178,10 +178,10 @@ player_activity veh_interact::serialize_activity()
     const vehicle_part *vpt = pt ? pt : &veh->part( 0 );
     map &here = get_map();
     for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
-        res.coord_set.insert( here.getglobal( p ) );
+        res.coord_set.insert( here.get_abs( p ) );
     }
-    res.values.push_back( here.getglobal( veh->pos_bub() ).x() + q.x() );   // values[0]
-    res.values.push_back( here.getglobal( veh->pos_bub() ).y() + q.y() );   // values[1]
+    res.values.push_back( here.get_abs( veh->pos_bub() ).x() + q.x() );   // values[0]
+    res.values.push_back( here.get_abs( veh->pos_bub() ).y() + q.y() );   // values[1]
     res.values.push_back( dd.x() );   // values[2]
     res.values.push_back( dd.y() );   // values[3]
     res.values.push_back( -dd.x() );   // values[4]
@@ -3054,7 +3054,7 @@ void veh_interact::complete_vehicle( Character &you )
         // during this player/NPCs activity.
         // check the vehicle points that were stored at beginning of activity.
         for( const tripoint_abs_ms &pt : you.activity.coord_set ) {
-            ovp = here.veh_at( here.bub_from_abs( pt ) );
+            ovp = here.veh_at( here.get_bub( pt ) );
             if( ovp ) {
                 break;
             }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -180,7 +180,7 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
     here.add_vehicle_to_cache( &veh );
     here.memory_cache_dec_set_dirty( part_pos, true );
     player_character.memorize_clear_decoration(
-        here.getglobal( part_pos ), "vp_" + vp.info().id.str() );
+        here.get_abs( part_pos ), "vp_" + vp.info().id.str() );
 }
 
 // Vehicle stack methods.
@@ -652,7 +652,7 @@ void vehicle::autopilot_patrol()
             autodrive_local_target = tripoint_abs_ms::zero;
             return;
         }
-        if( !here.inbounds( here.bub_from_abs( autodrive_local_target ) ) ) {
+        if( !here.inbounds( here.get_bub( autodrive_local_target ) ) ) {
             autodrive_local_target = tripoint_abs_ms::zero;
             is_patrolling = false;
             return;
@@ -711,8 +711,8 @@ std::set<point_abs_ms> vehicle::immediate_path( const units::angle &rotate )
     map &here = get_map();
     point_bub_ms top_left_actual = pos_bub().xy() + coord_translate( front_left );
     point_bub_ms top_right_actual = pos_bub().xy() + coord_translate( front_right );
-    std::vector<point_abs_ms> front_row = line_to( here.getglobal( tripoint_bub_ms{top_left_actual.x(), top_left_actual.y(), here.get_abs_sub().z()} ).xy(),
-                                          here.getglobal( tripoint_bub_ms{ top_right_actual.x(), top_right_actual.y(), here.get_abs_sub().z()} ).xy() );
+    std::vector<point_abs_ms> front_row = line_to( here.get_abs( tripoint_bub_ms{top_left_actual.x(), top_left_actual.y(), here.get_abs_sub().z()} ).xy(),
+                                          here.get_abs( tripoint_bub_ms{ top_right_actual.x(), top_right_actual.y(), here.get_abs_sub().z()} ).xy() );
     for( const point_abs_ms &elem : front_row ) {
         for( int i = 0; i < distance_to_check; ++i ) {
             collision_vector.advance( i );
@@ -784,12 +784,12 @@ void vehicle::drive_to_local_target( const tripoint_abs_ms &target, bool follow_
                                          player_character.current_movement_mode()->move_speed_mult();
     if( follow_protocol ) {
         if( ( ( turn_x > 0 || turn_x < 0 ) && velocity > safe_player_follow_speed ) ||
-            rl_dist( vehpos, here.getglobal( player_character.pos_bub() ) ) < 7 + ( (
+            rl_dist( vehpos, here.get_abs( player_character.pos_bub() ) ) < 7 + ( (
                         mount_max.y() * 3 ) + 4 ) ) {
             accel_y = 1;
         }
         if( ( velocity < std::min( safe_velocity(), safe_player_follow_speed ) && turn_x == 0 &&
-              rl_dist( vehpos, here.getglobal( player_character.pos_bub() ) ) > 8 + ( (
+              rl_dist( vehpos, here.get_abs( player_character.pos_bub() ) ) > 8 + ( (
                           mount_max.y() * 3 ) + 4 ) ) ||
             velocity < 100 ) {
             accel_y = -1;
@@ -821,7 +821,7 @@ bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_pr
     bool stop = false;
     creature_tracker &creatures = get_creature_tracker();
     for( const point_abs_ms &pt_elem : points_to_check ) {
-        point_bub_ms elem = here.bub_from_abs( point_abs_ms( pt_elem ) );
+        point_bub_ms elem = here.get_bub( point_abs_ms( pt_elem ) );
         if( stop ) {
             break;
         }
@@ -3613,7 +3613,7 @@ monster *vehicle::get_monster( int p ) const
 
 tripoint_abs_ms vehicle::global_square_location() const
 {
-    return get_map().getglobal( pos_bub() );
+    return get_map().get_abs( pos_bub() );
 }
 
 tripoint_abs_omt vehicle::global_omt_location() const
@@ -4794,8 +4794,8 @@ units::power vehicle::static_drag( bool actual ) const
                     is_actively_towed = false;
                 } else {
                     map &here = get_map();
-                    const tripoint_abs_ms towed_tow_point = here.getglobal( bub_part_pos( tow_index ) );
-                    const tripoint_abs_ms tower_tow_point = here.getglobal( towing_veh->bub_part_pos(
+                    const tripoint_abs_ms towed_tow_point = here.get_abs( bub_part_pos( tow_index ) );
+                    const tripoint_abs_ms tower_tow_point = here.get_abs( towing_veh->bub_part_pos(
                             other_tow_index ) );
                     is_actively_towed = rl_dist( towed_tow_point, tower_tow_point ) >= 6;
                 }
@@ -5305,7 +5305,7 @@ units::power vehicle::total_solar_epower() const
     for( const int p : solar_panels ) {
         const vehicle_part &vp = parts[p];
         const tripoint_bub_ms pos = bub_part_pos( vp );
-        if( vp.is_unavailable() || !is_sm_tile_outside( here.getglobal( pos ) ) ) {
+        if( vp.is_unavailable() || !is_sm_tile_outside( here.get_abs( pos ) ) ) {
             continue;
         }
 
@@ -5328,11 +5328,11 @@ units::power vehicle::total_wind_epower() const
     for( const int p : wind_turbines ) {
         const vehicle_part &vp = parts[p];
         const tripoint_bub_ms pos = bub_part_pos( vp );
-        if( vp.is_unavailable() || !is_sm_tile_outside( here.getglobal( pos ) ) ) {
+        if( vp.is_unavailable() || !is_sm_tile_outside( here.get_abs( pos ) ) ) {
             continue;
         }
 
-        int windpower = get_local_windpower( weather.windspeed, cur_om_ter, here.getglobal( pos ),
+        int windpower = get_local_windpower( weather.windspeed, cur_om_ter, here.get_abs( pos ),
                                              weather.winddirection, false );
         if( windpower <= ( weather.windspeed / 10.0 ) ) {
             continue;
@@ -5349,7 +5349,7 @@ units::power vehicle::total_water_wheel_epower() const
     for( const int p : water_wheels ) {
         const vehicle_part &vp = parts[p];
         const tripoint_bub_ms pos = bub_part_pos( vp );
-        if( vp.is_unavailable() || !is_sm_tile_over_water( here.getglobal( pos ) ) ) {
+        if( vp.is_unavailable() || !is_sm_tile_over_water( here.get_abs( pos ) ) ) {
             continue;
         }
 
@@ -6298,7 +6298,7 @@ void vehicle::place_zones( map &pmap ) const
         return;
     }
     for( vehicle_prototype::zone_def const &d : type->zone_defs ) {
-        tripoint_abs_ms const pt = pmap.getglobal( tripoint_bub_ms( rebase_bub( pos.raw() + d.pt ),
+        tripoint_abs_ms const pt = pmap.get_abs( tripoint_bub_ms( rebase_bub( pos.raw() + d.pt ),
                                    pmap.get_abs_sub().z() ) );
         mapgen_place_zone( pt, pt, d.zone_type, get_owner(), d.name, d.filter, &pmap );
     }
@@ -6936,8 +6936,8 @@ void vehicle::do_towing_move()
         return;
     }
     map &here = get_map();
-    const tripoint_abs_ms tower_tow_point = here.getglobal( bub_part_pos( tow_index ) );
-    const tripoint_abs_ms towed_tow_point = here.getglobal( towed_veh->bub_part_pos(
+    const tripoint_abs_ms tower_tow_point = here.get_abs( bub_part_pos( tow_index ) );
+    const tripoint_abs_ms towed_tow_point = here.get_abs( towed_veh->bub_part_pos(
             other_tow_index ) );
     // same as above, but where the pulling vehicle is pulling from
     units::angle towing_veh_angle = towed_veh->get_angle_from_targ( tower_tow_point );
@@ -6968,15 +6968,15 @@ void vehicle::do_towing_move()
 
         default:
             towed_veh->skidding = true;
-            std::vector<tripoint_bub_ms> lineto = line_to( here.bub_from_abs( towed_tow_point ),
-                                                  here.bub_from_abs( tower_tow_point ) );
+            std::vector<tripoint_bub_ms> lineto = line_to( here.get_bub( towed_tow_point ),
+                                                  here.get_bub( tower_tow_point ) );
             tripoint_bub_ms nearby_destination;
             if( lineto.size() >= 2 ) {
                 nearby_destination = lineto[1];
             } else {
-                nearby_destination = here.bub_from_abs( tower_tow_point );
+                nearby_destination = here.get_bub( tower_tow_point );
             }
-            const tripoint_rel_ms destination_delta( here.bub_from_abs( tower_tow_point ).xy() -
+            const tripoint_rel_ms destination_delta( here.get_bub( tower_tow_point ).xy() -
                     nearby_destination.xy() +
                     tripoint_rel_ms( 0, 0, towed_veh->pos_bub().z() ) );
             const tripoint_rel_ms move_destination( clamp( destination_delta.x(), -1, 1 ),
@@ -7154,7 +7154,7 @@ bool vehicle::tow_cable_too_far() const
         return false;
     }
     map &here = get_map();
-    tripoint_abs_ms towing_point = here.getglobal( bub_part_pos( index ) );
+    tripoint_abs_ms towing_point = here.get_abs( bub_part_pos( index ) );
     if( !tow_data.get_towed_by()->tow_data.get_towed() ) {
         debugmsg( "vehicle %s has data for a towing vehicle, but that towing vehicle does not have %s listed as towed",
                   disp_name(), disp_name() );
@@ -7165,7 +7165,7 @@ bool vehicle::tow_cable_too_far() const
         debugmsg( "towing data exists but no towing part" );
         return false;
     }
-    tripoint_abs_ms towed_point = here.getglobal( tow_data.get_towed_by()->bub_part_pos(
+    tripoint_abs_ms towed_point = here.get_abs( tow_data.get_towed_by()->bub_part_pos(
                                       other_index ) );
     if( towing_point == tripoint_abs_ms::zero || towed_point == tripoint_abs_ms::zero ) {
         debugmsg( "towing data exists but no towing part" );
@@ -7187,7 +7187,7 @@ bool vehicle::no_towing_slack() const
         return false;
     }
     map &here = get_map();
-    tripoint_abs_ms towing_point = here.getglobal( bub_part_pos( index ) );
+    tripoint_abs_ms towing_point = here.get_abs( bub_part_pos( index ) );
     if( !tow_data.get_towed()->tow_data.get_towed_by() ) {
         debugmsg( "vehicle %s has data for a towed vehicle, but that towed vehicle does not have %s listed as tower",
                   disp_name(), disp_name() );
@@ -7198,7 +7198,7 @@ bool vehicle::no_towing_slack() const
         debugmsg( "towing data exists but no towing part" );
         return false;
     }
-    tripoint_abs_ms towed_point = here.getglobal( tow_data.get_towed()->bub_part_pos( other_index ) );
+    tripoint_abs_ms towed_point = here.get_abs( tow_data.get_towed()->bub_part_pos( other_index ) );
     if( towing_point == tripoint_abs_ms::zero || towed_point == tripoint_abs_ms::zero ) {
         debugmsg( "towing data exists but no towing part" );
         return false;
@@ -7212,7 +7212,7 @@ std::optional<vpart_reference> vehicle::get_remote_part( const vehicle_part &vp_
     vehicle *veh = find_vehicle( tripoint_abs_ms( vp_local.target.second ) );
     // If the target vehicle is still there, ask it to remove its part
     if( veh != nullptr ) {
-        const tripoint_abs_ms local_abs = get_map().getglobal( bub_part_pos( vp_local ) );
+        const tripoint_abs_ms local_abs = get_map().get_abs( bub_part_pos( vp_local ) );
         for( const int remote_partnum : veh->loose_parts ) {
             if( veh->parts[remote_partnum].target.first == local_abs &&
                 veh->parts[remote_partnum].info().has_flag( VPFLAG_POWER_TRANSFER ) ) {
@@ -7252,7 +7252,7 @@ void vehicle::shed_loose_parts( const trinary shed_cables, const tripoint_bub_ms
                 // Skip cables if we're only calling shed_loose_parts to remove parts with UNMOUNT_ON_MOVE.
                 continue;
             }
-            tripoint_abs_ms vp_loose_dst = here.getglobal( dst ? *dst + vp_loose.precalc[1] : bub_part_pos(
+            tripoint_abs_ms vp_loose_dst = here.get_abs( dst ? *dst + vp_loose.precalc[1] : bub_part_pos(
                                                vp_loose ) );
             const int distance = rl_dist( vp_loose_dst, vp_loose.target.first );
             const int max_dist = vp_loose.get_base().max_link_length();
@@ -7266,7 +7266,7 @@ void vehicle::shed_loose_parts( const trinary shed_cables, const tripoint_bub_ms
                 const auto remote = get_remote_part( vp_loose );
                 if( remote ) {
                     remote->part().target.first = vp_loose_dst;
-                    remote->part().target.second = here.getglobal( dst ? *dst : pos_bub() );
+                    remote->part().target.second = here.get_abs( dst ? *dst : pos_bub() );
                 }
                 continue;
             }
@@ -8211,7 +8211,7 @@ void vehicle::update_time( const time_point &update_to )
         const vehicle_part &pt = parts[idx];
 
         // we need an unbroken funnel mounted on the exterior of the vehicle
-        if( pt.is_unavailable() || !is_sm_tile_outside( here.getglobal( bub_part_pos( pt ) ) ) ) {
+        if( pt.is_unavailable() || !is_sm_tile_outside( here.get_abs( bub_part_pos( pt ) ) ) ) {
             continue;
         }
 
@@ -8249,7 +8249,7 @@ void vehicle::update_time( const time_point &update_to )
         for( const int p : solar_panels ) {
             const vehicle_part &vp = parts[p];
             const tripoint_bub_ms pos = bub_part_pos( vp );
-            if( vp.is_unavailable() || !is_sm_tile_outside( here.getglobal( pos ) ) ) {
+            if( vp.is_unavailable() || !is_sm_tile_outside( here.get_abs( pos ) ) ) {
                 continue;
             }
             epower += part_epower( vp );
@@ -8574,7 +8574,7 @@ bool vehicle::refresh_zones()
                 // By continuing here and not adding to new_zones, we effectively remove it
                 continue;
             }
-            tripoint_abs_ms zone_pos = here.getglobal( bub_part_pos( part_idx ) );
+            tripoint_abs_ms zone_pos = here.get_abs( bub_part_pos( part_idx ) );
             //Set the position of the zone to that part
             zone.set_position( std::pair<tripoint_abs_ms, tripoint_abs_ms>( zone_pos, zone_pos ), false, false,
                                true );

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -353,7 +353,7 @@ struct auto_navigation_data {
     }
     // transforms a point from map bub coords into view map coords
     point to_view( const tripoint_bub_ms &p ) const {
-        return to_view( get_map().getglobal( p ) );
+        return to_view( get_map().get_abs( p ) );
     }
     // returns `p` adjusted so that the z-level is placed on the ground
     template<typename Tripoint>
@@ -711,7 +711,7 @@ bool vehicle::autodrive_controller::check_drivable( const tripoint_bub_ms &pt ) 
         return &ovp->vehicle() == &driven_veh;
     }
 
-    const tripoint_abs_ms pt_abs = here.getglobal( pt );
+    const tripoint_abs_ms pt_abs = here.get_abs( pt );
     const tripoint_abs_omt pt_omt = project_to<coords::omt>( pt_abs );
     // only check visibility for the current OMT, we'll check other OMTs when
     // we reach them
@@ -799,7 +799,7 @@ void vehicle::autodrive_controller::compute_obstacles()
     for( int dx = 0; dx < NAV_VIEW_SIZE_X; dx++ ) {
         for( int dy = 0; dy < NAV_VIEW_SIZE_Y; dy++ ) {
             const tripoint_abs_ms abs_map_pt( data.view_to_map.transform( point( dx, dy ), z ) );
-            const tripoint_bub_ms p = here.bub_from_abs( abs_map_pt );
+            const tripoint_bub_ms p = here.get_bub( abs_map_pt );
             data.is_obstacle[dx][dy] = !check_drivable( p );
             data.ground_z[dx][dy] = z;
             enqueue_if_ramp( ramp_points, here, p );

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -555,7 +555,7 @@ void vehicle_part::unset_crew()
 
 void vehicle_part::reset_target( const tripoint_bub_ms &pos )
 {
-    const tripoint_abs_ms tgt = get_map().getglobal( pos );
+    const tripoint_abs_ms tgt = get_map().get_abs( pos );
     target.first = tgt;
     target.second = tgt;
 }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1804,13 +1804,13 @@ bool vehicle::use_vehicle_tool( vehicle &veh, const tripoint_bub_ms &vp_pos,
           tool_type == itype_large_repairkit
         ) ) {
         act.index = INT_MIN; // tell activity the item doesn't really exist
-        act.coords.push_back( get_map().getglobal( vp_pos ) ); // tell it to search for the tool on `pos`
+        act.coords.push_back( get_map().get_abs( vp_pos ) ); // tell it to search for the tool on `pos`
         act.str_values.push_back( tool_type.str() ); // specific tool on the rig
     }
 
     //Hack for heat_activity_actor.
     if( act.id() == ACT_HEATING ) {
-        act.coords.push_back( get_map().getglobal( vp_pos ) );
+        act.coords.push_back( get_map().get_abs( vp_pos ) );
     }
 
     const int used_charges = ammo_in_tool - tool.ammo_remaining();

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -506,9 +506,9 @@ VisitResponse map_cursor::visit_items(
         // pos returns the pos_bub location of the target relative to the reality bubble
         // even though the location isn't actually inside of it. Thus, we're loading a map
         // around that location to do our work.
-        tripoint_abs_ms abs_pos = get_map().getglobal( pos() );
+        tripoint_abs_ms abs_pos = get_map().get_abs( pos() );
         here.load( project_to<coords::omt>( abs_pos ), false );
-        tripoint_omt_ms p = here.omt_from_abs( abs_pos );
+        tripoint_omt_ms p = here.get_omt( abs_pos );
         return visit_items_internal( here.cast_to_map(), rebase_bub( p ), func );
     }
 }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -788,7 +788,7 @@ int get_local_windpower( int windpower, const oter_id &omter, const tripoint_abs
         return 0;
     }
     rl_vec2d windvec = convert_wind_to_coord( winddirection );
-    const tripoint_bub_ms triblocker( get_map().bub_from_abs( location ) + point( windvec.x,
+    const tripoint_bub_ms triblocker( get_map().get_bub( location ) + point( windvec.x,
                                       windvec.y ) );
     // Over map terrain may modify the effect of wind.
     if( ( omter->get_type_id() == oter_type_forest ) ||

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -43,7 +43,7 @@ void run_activities( Character &u, int max_moves )
     while( ( !u.activity.is_null() || u.is_auto_moving() ) && turns < max_moves ) {
         u.set_moves( u.get_speed() );
         if( u.is_auto_moving() ) {
-            u.setpos( get_map().bub_from_abs( *u.destination_point ) );
+            u.setpos( get_map().get_bub( *u.destination_point ) );
             get_map().build_map_cache( u.posz() );
             u.start_destination_activity();
         }
@@ -89,8 +89,8 @@ construction setup_testcase( Character &u, std::string const &constr,
                 build.pre_terrain.begin(), build.group, build.id );
 
     map &here = get_map();
-    tripoint_abs_ms const loot_abs = here.getglobal( loot_loc );
-    tripoint_abs_ms const build_abs = here.getglobal( build_loc );
+    tripoint_abs_ms const loot_abs = here.get_abs( loot_loc );
+    tripoint_abs_ms const build_abs = here.get_abs( build_loc );
     faction_id const fac = u.get_faction()->id;
 
     zmgr.add( constr + " loot zone", zone_type_LOOT_UNSORTED, fac, false, true, loot_abs,

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -236,7 +236,7 @@ TEST_CASE( "check_monster_behavior_tree_locust", "[monster][behavior]" )
         CHECK( monster_goals.tick( &oracle ) == "idle" );
 
         // Gross but I couldn't figure out how to place a sealed item without manual mapgen and the mapgen helper version doesn't let you specify rel_ms and adding that as a defaulted arg breaks the templated manual_mapgen()...
-        const tripoint_abs_ms abs_pos = here.getglobal( monster_location );
+        const tripoint_abs_ms abs_pos = here.get_abs( monster_location );
         tripoint_abs_omt pos;
         point_omt_ms pos_rel;
         std::tie( pos, pos_rel ) = project_remain<coords::omt>( abs_pos );

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -75,7 +75,7 @@ TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
     clear_vehicles(); // extra safety
     here.add_vehicle( vehicle_prototype_character_volume_test_car, test_pos, 0_degrees, 0, 0 );
     you.setpos( test_pos );
-    const optional_vpart_position vp_there = here.veh_at( here.bub_from_abs( you.get_location() ) );
+    const optional_vpart_position vp_there = here.veh_at( here.get_bub( you.get_location() ) );
     REQUIRE( vp_there );
     tripoint_abs_ms dest_loc = you.get_location();
 

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -80,7 +80,7 @@ TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][u
     clear_avatar();
     clear_map();
 
-    tripoint_abs_ms const start = here.getglobal( tripoint_bub_ms::zero + tripoint::east );
+    tripoint_abs_ms const start = here.get_abs( tripoint_bub_ms::zero + tripoint::east );
     bool const move_act = GENERATE( true, false );
     dummy.set_location( start );
 

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -185,7 +185,7 @@ void check_ter_in_radius( tripoint_abs_ms const &center, int range, ter_id const
 {
     map tm;
     tm.load( project_to<coords::sm>( center - point{ range, range } ), false, false );
-    tripoint_bub_ms const center_local = tm.bub_from_abs( center );
+    tripoint_bub_ms const center_local = tm.get_bub( center );
     for( tripoint_bub_ms p : tm.points_in_radius( center_local, range ) ) {
         if( trig_dist( center_local, p ) <= range ) {
             REQUIRE( tm.ter( p ) == ter );
@@ -200,7 +200,7 @@ void check_ter_in_line( tripoint_abs_ms const &first, tripoint_abs_ms const &sec
     tripoint_abs_ms const orig = coord_min( first, second );
     tm.load( project_to<coords::sm>( orig ), false, false );
     for( tripoint_abs_ms p : line_to( first, second ) ) {
-        REQUIRE( tm.ter( tm.bub_from_abs( p ) ) == ter );
+        REQUIRE( tm.ter( tm.get_bub( p ) ) == ter );
     }
 }
 
@@ -1095,11 +1095,11 @@ TEST_CASE( "EOC_run_inv_test", "[eoc]" )
 
     // Activate test for item
     CHECK( effect_on_condition_EOC_item_activate_test->activate( d ) );
-    CHECK( get_map().furn( get_map().bub_from_abs( pos_after ) ) == furn_f_cardboard_box );
+    CHECK( get_map().furn( get_map().get_bub( pos_after ) ) == furn_f_cardboard_box );
 
     // Teleport test for item
     CHECK( effect_on_condition_EOC_item_teleport_test->activate( d ) );
-    CHECK( get_map().i_at( get_map().bub_from_abs( pos_after ) ).size() == 3 );
+    CHECK( get_map().i_at( get_map().get_bub( pos_after ) ).size() == 3 );
 
     // Math function test for armor
     CHECK( effect_on_condition_EOC_armor_math_test->activate( d ) );
@@ -1327,12 +1327,12 @@ TEST_CASE( "EOC_map_test", "[eoc]" )
 
     map &m = get_map();
     const tripoint_abs_ms start = get_avatar().get_location();
-    const tripoint_bub_ms tgt = m.bub_from_abs( start + tripoint::north );
+    const tripoint_bub_ms tgt = m.get_bub( start + tripoint::north );
     m.furn_set( tgt, furn_test_f_eoc );
     m.furn( tgt )->examine( get_avatar(), tgt );
 
     CHECK( globvars.get_global_value( "this" ) == "test_f_eoc" );
-    CHECK( globvars.get_global_value( "pos" ) == m.getglobal( tgt ).to_string() );
+    CHECK( globvars.get_global_value( "pos" ) == m.get_abs( tgt ).to_string() );
 
     const tripoint_bub_ms target_pos = get_avatar().pos_bub() + point::east * 10;
     npc &npc_dst = spawn_npc( target_pos.xy(), "thug" );
@@ -1354,7 +1354,7 @@ TEST_CASE( "EOC_loc_relative_test", "[eoc]" )
     g->place_player( tripoint_bub_ms::zero );
 
     const tripoint_abs_ms start = get_avatar().get_location();
-    const tripoint_bub_ms tgt = m.bub_from_abs( start + tripoint::north );
+    const tripoint_bub_ms tgt = m.get_bub( start + tripoint::north );
     m.furn_set( tgt, furn_test_f_eoc );
     m.furn( tgt )->examine( get_avatar(), tgt );
 
@@ -1367,8 +1367,8 @@ TEST_CASE( "EOC_loc_relative_test", "[eoc]" )
                                     globvars.get_global_value( "map_test_loc_a" ) ) );
     tripoint_abs_ms tmp_abs_b = tripoint_abs_ms( tripoint::from_string(
                                     globvars.get_global_value( "map_test_loc_b" ) ) );
-    CHECK( m.bub_from_abs( tmp_abs_a ) == tripoint_bub_ms( 70, 70, 0 ) );
-    CHECK( m.bub_from_abs( tmp_abs_b ) == tripoint_bub_ms( 70, 60, 0 ) );
+    CHECK( m.get_bub( tmp_abs_a ) == tripoint_bub_ms( 70, 70, 0 ) );
+    CHECK( m.get_bub( tmp_abs_b ) == tripoint_bub_ms( 70, 60, 0 ) );
 
     globvars.clear_global_values();
     clear_avatar();
@@ -1512,7 +1512,7 @@ TEST_CASE( "EOC_run_eocs", "[eoc]" )
     clear_npcs();
     npc &guy = spawn_npc( u.pos_bub().xy() + point::east, "thug" );
     tripoint_abs_ms mon_loc = u.get_location() + tripoint::west;
-    monster *zombie = g->place_critter_at( mon_zombie, get_map().bub_from_abs( mon_loc ) );
+    monster *zombie = g->place_critter_at( mon_zombie, get_map().get_bub( mon_loc ) );
     REQUIRE( zombie != nullptr );
 
     item hammer( itype_hammer );

--- a/tests/faction_camp_test.cpp
+++ b/tests/faction_camp_test.cpp
@@ -29,7 +29,7 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     clear_avatar();
     clear_map();
     map &m = get_map();
-    const tripoint_abs_ms zone_loc = m.getglobal( tripoint_bub_ms{ 5, 5, 0 } );
+    const tripoint_abs_ms zone_loc = m.get_abs( tripoint_bub_ms{ 5, 5, 0 } );
     mapgen_place_zone( zone_loc, zone_loc, zone_type_CAMP_FOOD, your_fac, {},
                        "food" );
     mapgen_place_zone( zone_loc, zone_loc, zone_type_CAMP_STORAGE, your_fac, {},
@@ -44,7 +44,7 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     WHEN( "a base item is added to larder" ) {
         food_supply *= 0;
         item test_100_kcal( itype_test_100_kcal );
-        tripoint_bub_ms zone_local = m.bub_from_abs( zone_loc );
+        tripoint_bub_ms zone_local = m.get_bub( zone_loc );
         m.i_clear( zone_local );
         m.add_item_or_charges( zone_local, test_100_kcal );
         REQUIRE( m.has_items( zone_local ) );
@@ -61,7 +61,7 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
         made_of.add( test_100_kcal );
         // Setting the actual components. This will return 185 unless it's actually made up of two 100kcal components!
         test_200_kcal.components = made_of;
-        tripoint_bub_ms zone_local = m.bub_from_abs( zone_loc );
+        tripoint_bub_ms zone_local = m.get_bub( zone_loc );
         m.i_clear( zone_local );
         m.add_item_or_charges( zone_local, test_200_kcal );
         test_camp->distribute_food();
@@ -71,7 +71,7 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     WHEN( "an item with vitamins is added to larder" ) {
         food_supply *= 0;
         item test_500_kcal( itype_test_500_kcal );
-        tripoint_bub_ms zone_local = m.bub_from_abs( zone_loc );
+        tripoint_bub_ms zone_local = m.get_bub( zone_loc );
         m.i_clear( zone_local );
         m.add_item_or_charges( zone_local, test_500_kcal );
         test_camp->distribute_food();

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -2815,7 +2815,7 @@ TEST_CASE( "auto_whitelist", "[item][pocket][item_spawn]" )
     clear_map();
     tripoint_abs_omt const this_omt =
         project_to<coords::omt>( get_avatar().get_location() );
-    tripoint_bub_ms const this_bub = get_map().bub_from_abs( project_to<coords::ms>( this_omt ) );
+    tripoint_bub_ms const this_bub = get_map().get_bub( project_to<coords::ms>( this_omt ) );
     manual_nested_mapgen( this_omt, nested_mapgen_auto_wl_test );
     REQUIRE( !get_map().i_at( this_bub + tripoint::zero ).empty() );
     REQUIRE( !get_map().i_at( this_bub + tripoint::east ).empty() );

--- a/tests/magic_spell_effect_test.cpp
+++ b/tests/magic_spell_effect_test.cpp
@@ -26,7 +26,7 @@ static std::set<tripoint_abs_ms> count_fields_near(
     map &m = get_map();
     std::set<tripoint_abs_ms> live_fields;
     for( const tripoint_abs_ms &cursor : closest_points_first( p, 10 ) ) {
-        field_entry *entry = m.get_field( m.bub_from_abs( cursor ), field_type );
+        field_entry *entry = m.get_field( m.get_bub( cursor ), field_type );
         if( entry && entry->is_field_alive() ) {
             live_fields.insert( cursor );
         }
@@ -104,10 +104,10 @@ TEST_CASE( "remove_field_fd_fatigue", "[magic]" )
         tripoint_abs_ms p2 = player_initial_pos + tripoint::east * 11;
         tripoint_abs_ms p3 = player_initial_pos + tripoint::east * 12;
         tripoint_abs_ms p4 = player_initial_pos + tripoint::east * 13;
-        m.add_field( m.bub_from_abs( p1 ), fd_fatigue, 1, 1_hours );
-        m.add_field( m.bub_from_abs( p2 ), fd_fatigue, 2, 1_hours );
-        m.add_field( m.bub_from_abs( p3 ), fd_fatigue, 3, 1_hours );
-        m.add_field( m.bub_from_abs( p4 ), fd_fatigue, 3, 1_hours );
+        m.add_field( m.get_bub( p1 ), fd_fatigue, 1, 1_hours );
+        m.add_field( m.get_bub( p2 ), fd_fatigue, 2, 1_hours );
+        m.add_field( m.get_bub( p3 ), fd_fatigue, 3, 1_hours );
+        m.add_field( m.get_bub( p4 ), fd_fatigue, 3, 1_hours );
 
         if( with_light ) {
             player_add_headlamp();
@@ -119,28 +119,28 @@ TEST_CASE( "remove_field_fd_fatigue", "[magic]" )
         m.build_map_cache( 0 );
         dummy.recalc_sight_limits();
 
-        CHECK( m.getglobal( dummy.pos_bub() ) == player_initial_pos );
+        CHECK( m.get_abs( dummy.pos_bub() ) == player_initial_pos );
         CHECK( count_fields_near( p1, fd_fatigue ) == std::set<tripoint_abs_ms> { p1, p2, p3, p4 } );
 
-        spell_effect::remove_field( sp, dummy, m.bub_from_abs( player_initial_pos ) );
+        spell_effect::remove_field( sp, dummy, m.get_bub( player_initial_pos ) );
         calendar::turn += 1_turns;
         m.process_fields();
         calendar::turn += 1_turns;
         m.process_fields();
 
-        CHECK( m.getglobal( dummy.pos_bub() ) == player_initial_pos );
+        CHECK( m.get_abs( dummy.pos_bub() ) == player_initial_pos );
         CHECK( count_fields_near( p1, fd_fatigue ) == std::set<tripoint_abs_ms> { p2, p3, p4 } );
 
-        spell_effect::remove_field( sp, dummy, m.bub_from_abs( player_initial_pos ) );
+        spell_effect::remove_field( sp, dummy, m.get_bub( player_initial_pos ) );
         calendar::turn += 1_turns;
         m.process_fields();
         calendar::turn += 1_turns;
         m.process_fields();
 
-        CHECK( m.getglobal( dummy.pos_bub() ) == player_initial_pos );
+        CHECK( m.get_abs( dummy.pos_bub() ) == player_initial_pos );
         CHECK( count_fields_near( p1, fd_fatigue ) == std::set<tripoint_abs_ms> { p3, p4 } );
 
-        spell_effect::remove_field( sp, dummy, m.bub_from_abs( player_initial_pos ) );
+        spell_effect::remove_field( sp, dummy, m.get_bub( player_initial_pos ) );
         calendar::turn += 1_turns;
         m.process_fields();
         calendar::turn += 1_turns;

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -62,8 +62,8 @@ TEST_CASE( "map_coordinate_conversion_functions" )
     CAPTURE( test_abs );
 
     // Verify round-tripping
-    CHECK( here.getglobal( here.bub_from_abs( test_abs ) ) == test_abs );
-    CHECK( here.bub_from_abs( here.getglobal( test_point ) ) == test_point );
+    CHECK( here.get_abs( here.get_bub( test_abs ) ) == test_abs );
+    CHECK( here.get_bub( here.get_abs( test_point ) ) == test_point );
 }
 
 TEST_CASE( "destroy_grabbed_furniture" )
@@ -182,7 +182,7 @@ TEST_CASE( "inactive_container_with_active_contents", "[active_item][map]" )
     REQUIRE( here.get_submaps_with_active_items().empty() );
     here.check_submap_active_item_consistency();
     tripoint_bub_ms const test_loc;
-    tripoint_abs_sm const test_loc_sm = project_to<coords::sm>( here.getglobal( test_loc ) );
+    tripoint_abs_sm const test_loc_sm = project_to<coords::sm>( here.get_abs( test_loc ) );
 
     item bottle_plastic( itype_bottle_plastic );
     REQUIRE( !bottle_plastic.needs_processing() );
@@ -222,7 +222,7 @@ TEST_CASE( "milk_rotting", "[active_item][map]" )
     here.check_submap_active_item_consistency();
     REQUIRE( here.get_submaps_with_active_items().empty() );
     tripoint_bub_ms const test_loc;
-    tripoint_abs_sm const test_loc_sm = project_to<coords::sm>( here.getglobal( test_loc ) );
+    tripoint_abs_sm const test_loc_sm = project_to<coords::sm>( here.get_abs( test_loc ) );
 
     restore_on_out_of_scope restore_temp(
         get_weather().forced_temperature );

--- a/tests/mapgen_place_vehicles_test.cpp
+++ b/tests/mapgen_place_vehicles_test.cpp
@@ -17,13 +17,13 @@ namespace
 void update_test( map &m, tripoint_abs_omt const &loc )
 {
     manual_mapgen( loc, manual_update_mapgen, update_mapgen_test_update_place_shopping_cart );
-    REQUIRE( m.veh_at( m.bub_from_abs( project_to<coords::ms>( loc ) ) ) );
+    REQUIRE( m.veh_at( m.get_bub( project_to<coords::ms>( loc ) ) ) );
 }
 
 void nested_test( map &m, tripoint_abs_omt const &loc )
 {
     manual_mapgen( loc, manual_nested_mapgen, nested_mapgen_test_nested_place_shopping_cart );
-    REQUIRE( m.veh_at( m.bub_from_abs( project_to<coords::ms>( loc ) ) ) );
+    REQUIRE( m.veh_at( m.get_bub( project_to<coords::ms>( loc ) ) ) );
 }
 } // namespace
 

--- a/tests/mapgen_remove_npcs_test.cpp
+++ b/tests/mapgen_remove_npcs_test.cpp
@@ -34,7 +34,7 @@ void place_npc_and_check( map &m, tripoint_bub_ms const &loc, update_mapgen_id c
                           string_id<npc_template> const &nid )
 {
     check_creature( loc, nid, false );
-    tripoint_abs_omt const omt = project_to<coords::omt>( m.getglobal( loc ) );
+    tripoint_abs_omt const omt = project_to<coords::omt>( m.get_abs( loc ) );
     manual_mapgen( omt, manual_update_mapgen, id );
     check_creature( loc, nid, true );
     g->mon_info_update();
@@ -44,7 +44,7 @@ void remove_npc_and_check( map &m, tripoint_bub_ms const &loc, update_mapgen_id 
                            string_id<npc_template> const &nid )
 {
     check_creature( loc, nid, true );
-    tripoint_abs_omt const omt = project_to<coords::omt>( m.getglobal( loc ) );
+    tripoint_abs_omt const omt = project_to<coords::omt>( m.get_abs( loc ) );
     manual_mapgen( omt, manual_update_mapgen, id );
     check_creature( loc, nid, false );
 
@@ -70,8 +70,8 @@ TEST_CASE( "mapgen_remove_npcs" )
 
         tripoint_abs_omt const omt = project_to<coords::omt>( get_avatar().get_location() );
         tripoint_abs_omt const omt2 = omt + tripoint::east;
-        tripoint_bub_ms const loc = here.bub_from_abs( project_to<coords::ms>( omt ) );
-        tripoint_bub_ms const loc2 = here.bub_from_abs( project_to<coords::ms>( omt2 ) );
+        tripoint_bub_ms const loc = here.get_bub( project_to<coords::ms>( omt ) );
+        tripoint_bub_ms const loc2 = here.get_bub( project_to<coords::ms>( omt2 ) );
         tripoint_bub_ms const loc3 = loc2 + tripoint::east;
         REQUIRE( get_map().inbounds( loc ) );
         place_npc_and_check( here, loc, update_mapgen_test_update_place_npc,

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -54,7 +54,7 @@ void local_test( vehicle *veh, tripoint_bub_ms const &test_loc, F const &fmg, ID
 {
     map &here = get_map();
     tripoint_abs_omt const this_test_omt =
-        project_to<coords::omt>( get_map().getglobal( test_loc ) );
+        project_to<coords::omt>( get_map().get_abs( test_loc ) );
     tripoint_bub_ms const this_test_loc = test_loc + point::east;
     vehicle *const veh2 = add_test_vehicle( here, this_test_loc );
     REQUIRE( here.veh_at( this_test_loc ).has_value() );
@@ -72,7 +72,7 @@ void remote_test( vehicle *veh, tripoint_bub_ms const &test_loc, F const &fmg, I
 {
     map &here = get_map();
     tripoint_abs_omt const this_test_omt =
-        project_to<coords::omt>( here.getglobal( test_loc ) ) + tripoint{ 20, 20, 0 };
+        project_to<coords::omt>( here.get_abs( test_loc ) ) + tripoint{ 20, 20, 0 };
     manual_mapgen( this_test_omt, fmg, id, remote_add_test_vehicle );
     REQUIRE( here.get_vehicles().size() == 1 );
     check_vehicle_still_works( *veh );
@@ -122,8 +122,8 @@ TEST_CASE( "mapgen_remove_vehicles" )
 
     SECTION( "update place then nested remove all on main map" ) {
         tripoint_abs_omt const this_test_omt =
-            project_to<coords::omt>( get_map().getglobal( test_loc ) );
-        tripoint_bub_ms const this_test_loc = get_map().bub_from_abs( project_to<coords::ms>
+            project_to<coords::omt>( get_map().get_abs( test_loc ) );
+        tripoint_bub_ms const this_test_loc = get_map().get_bub( project_to<coords::ms>
                                               ( this_test_omt ) );
         manual_mapgen( this_test_omt, manual_update_mapgen, update_mapgen_test_update_place_shopping_cart );
         REQUIRE( here.get_vehicles().size() == 2 );

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -44,7 +44,7 @@ static int moves_to_destination( const std::string &monster_type,
     monster &test_monster = spawn_test_monster( monster_type, start );
     // Get it riled up and give it a goal.
     test_monster.anger = 100;
-    test_monster.set_dest( get_map().getglobal( end ) );
+    test_monster.set_dest( get_map().get_abs( end ) );
     test_monster.set_moves( 0 );
     const int monster_speed = test_monster.get_speed();
     int moves_spent = 0;

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -157,7 +157,7 @@ TEST_CASE( "NPC-rules-close-doors", "[npc_rules]" )
     REQUIRE( !test_subject->path.empty() );
 
     // we must force them to actually walk the path for this test
-    test_subject->goto_to_this_pos = here.getglobal( test_subject->path.back() );
+    test_subject->goto_to_this_pos = here.get_abs( test_subject->path.back() );
 
     // copy our path before we lose it
     std::vector<tripoint_bub_ms> path_taken = test_subject->path;

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -121,7 +121,7 @@ static std::string gen_dynamic_line( dialogue &d )
 
 static void change_om_type( const std::string &new_type )
 {
-    const tripoint_abs_omt omt_pos( coords::project_to<coords::omt>( get_map().getglobal(
+    const tripoint_abs_omt omt_pos( coords::project_to<coords::omt>( get_map().get_abs(
                                         get_player_character().pos_bub() ) ) );
     overmap_buffer.ter_set( omt_pos, oter_id( new_type ) );
 }

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -333,7 +333,7 @@ static npc *make_companion( const tripoint_bub_ms &npc_pos )
     shared_ptr_fast<npc> guy = make_shared_fast<npc>();
     guy->normalize();
     guy->randomize();
-    guy->spawn_at_precise( get_map().getglobal( npc_pos ) );
+    guy->spawn_at_precise( get_map().get_abs( npc_pos ) );
     overmap_buffer.insert_npc( guy );
     g->load_npcs();
     guy->companion_mission_role_id.clear();
@@ -488,7 +488,7 @@ TEST_CASE( "npc-movement" )
                     return armor.covers( bodypart_id( "foot_r" ) ) || armor.covers( bodypart_id( "foot_l" ) );
                 } );
                 REQUIRE( !guy->is_immune_field( fd_acid ) );
-                guy->spawn_at_precise( get_map().getglobal( p ) );
+                guy->spawn_at_precise( get_map().get_abs( p ) );
                 // Set the shopkeep mission; this means that
                 // the NPC deems themselves to be guarding and stops them
                 // wandering off in search of distant ammo caches, etc.

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1815,7 +1815,7 @@ TEST_CASE( "activity_interruption_by_distractions", "[activity][interruption]" )
             CHECK( dists.empty() );
 
             THEN( "interruption by zombie moving towards dummy" ) {
-                zombie.set_dest( get_map().getglobal( dummy.pos_bub() ) );
+                zombie.set_dest( get_map().get_abs( dummy.pos_bub() ) );
                 int turns = 0;
                 do {
                     move_monster_turn( zombie );
@@ -1842,7 +1842,7 @@ TEST_CASE( "activity_interruption_by_distractions", "[activity][interruption]" )
             CHECK( dists.empty() );
 
             THEN( "interruption by zombie moving towards dummy" ) {
-                zombie.set_dest( get_map().getglobal( dummy.pos_bub() ) );
+                zombie.set_dest( get_map().get_abs( dummy.pos_bub() ) );
                 int turns = 0;
                 do {
                     move_monster_turn( zombie );

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
             debugmsg( "source same as target" );
         }
 
-        tripoint_abs_ms target_global = here.getglobal( target );
+        tripoint_abs_ms target_global = here.get_abs( target );
         const vpart_id vpid( cord.typeId().str() );
 
         point_rel_ms vcoords = source_vp->mount_pos();
@@ -80,7 +80,7 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
         tripoint_bub_ms source_global( cord.get_var( "source_x", 0 ),
                                        cord.get_var( "source_y", 0 ),
                                        cord.get_var( "source_z", 0 ) );
-        target_part.target.first = here.getglobal( source_global );
+        target_part.target.first = here.get_abs( source_global );
         target_part.target.second = source_veh->global_square_location();
         target_veh->install_part( vcoords, std::move( target_part ) );
     };

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -477,7 +477,7 @@ TEST_CASE( "power_cable_stretch_disconnect" )
 
         WHEN( "displacing first appliance to the left" ) {
             for( int i = 0;
-                 rl_dist( m.getglobal( app1.pos_bub() ), m.getglobal( app2.pos_bub() ) ) <= max_dist &&
+                 rl_dist( m.get_abs( app1.pos_bub() ), m.get_abs( app2.pos_bub() ) ) <= max_dist &&
                  i < max_displacement; i++ ) {
                 CHECK( app1.part_count() == 2 );
                 CHECK( app2.part_count() == 2 );
@@ -485,15 +485,15 @@ TEST_CASE( "power_cable_stretch_disconnect" )
                 app1.part_removal_cleanup();
                 app2.part_removal_cleanup();
             }
-            CAPTURE( m.getglobal( app1.pos_bub() ) );
-            CAPTURE( m.getglobal( app2.pos_bub() ) );
+            CAPTURE( m.get_abs( app1.pos_bub() ) );
+            CAPTURE( m.get_abs( app2.pos_bub() ) );
             CHECK( app1.part_count() == 1 );
             CHECK( app2.part_count() == 1 );
         }
 
         WHEN( "displacing second appliance to the right" ) {
             for( int i = 0;
-                 rl_dist( m.getglobal( app1.pos_bub() ), m.getglobal( app2.pos_bub() ) ) <= max_dist &&
+                 rl_dist( m.get_abs( app1.pos_bub() ), m.get_abs( app2.pos_bub() ) ) <= max_dist &&
                  i < max_displacement; i++ ) {
                 CHECK( app1.part_count() == 2 );
                 CHECK( app2.part_count() == 2 );
@@ -501,8 +501,8 @@ TEST_CASE( "power_cable_stretch_disconnect" )
                 app1.part_removal_cleanup();
                 app2.part_removal_cleanup();
             }
-            CAPTURE( m.getglobal( app1.pos_bub() ) );
-            CAPTURE( m.getglobal( app2.pos_bub() ) );
+            CAPTURE( m.get_abs( app1.pos_bub() ) );
+            CAPTURE( m.get_abs( app2.pos_bub() ) );
             CHECK( app1.part_count() == 1 );
             CHECK( app2.part_count() == 1 );
         }
@@ -520,7 +520,7 @@ TEST_CASE( "power_cable_stretch_disconnect" )
 
         WHEN( "displacing first appliance to the left" ) {
             for( int i = 0;
-                 rl_dist( m.getglobal( app1.pos_bub() ), m.getglobal( app2.pos_bub() ) ) <= max_dist &&
+                 rl_dist( m.get_abs( app1.pos_bub() ), m.get_abs( app2.pos_bub() ) ) <= max_dist &&
                  i < max_displacement; i++ ) {
                 CHECK( app1.part_count() == 2 );
                 CHECK( app2.part_count() == 2 );
@@ -528,15 +528,15 @@ TEST_CASE( "power_cable_stretch_disconnect" )
                 app1.part_removal_cleanup();
                 app2.part_removal_cleanup();
             }
-            CAPTURE( m.getglobal( app1.pos_bub() ) );
-            CAPTURE( m.getglobal( app2.pos_bub() ) );
+            CAPTURE( m.get_abs( app1.pos_bub() ) );
+            CAPTURE( m.get_abs( app2.pos_bub() ) );
             CHECK( app1.part_count() == 1 );
             CHECK( app2.part_count() == 1 );
         }
 
         WHEN( "displacing second appliance to the right" ) {
             for( int i = 0;
-                 rl_dist( m.getglobal( app1.pos_bub() ), m.getglobal( app2.pos_bub() ) ) <= max_dist &&
+                 rl_dist( m.get_abs( app1.pos_bub() ), m.get_abs( app2.pos_bub() ) ) <= max_dist &&
                  i < max_displacement; i++ ) {
                 CHECK( app1.part_count() == 2 );
                 CHECK( app2.part_count() == 2 );
@@ -544,8 +544,8 @@ TEST_CASE( "power_cable_stretch_disconnect" )
                 app1.part_removal_cleanup();
                 app2.part_removal_cleanup();
             }
-            CAPTURE( m.getglobal( app1.pos_bub() ) );
-            CAPTURE( m.getglobal( app2.pos_bub() ) );
+            CAPTURE( m.get_abs( app1.pos_bub() ) );
+            CAPTURE( m.get_abs( app2.pos_bub() ) );
             CHECK( app1.part_count() == 1 );
             CHECK( app2.part_count() == 1 );
         }

--- a/tests/zones_custom_test.cpp
+++ b/tests/zones_custom_test.cpp
@@ -20,12 +20,12 @@ TEST_CASE( "zones_custom", "[zones]" )
     WHEN( "overlapping custom zones" ) {
         clear_map();
         map &m = get_map();
-        tripoint_abs_ms const zone_loc = m.getglobal( tripoint_bub_ms{ 5, 5, 0 } );
+        tripoint_abs_ms const zone_loc = m.get_abs( tripoint_bub_ms{ 5, 5, 0 } );
         tripoint_abs_ms const zone_hammer_end = zone_loc + tripoint::north;
         tripoint_abs_ms const zone_bowsaw_end = zone_loc + tripoint::south;
         tripoint_abs_ms const zone_testgroup_end = zone_loc + tripoint::east;
         tripoint_abs_ms const zone_groupbatt_end = zone_loc + tripoint::west;
-        tripoint_abs_ms const where = m.getglobal( tripoint_bub_ms::zero );
+        tripoint_abs_ms const where = m.get_abs( tripoint_bub_ms::zero );
         item hammer( itype_hammer );
         item bow_saw( itype_bow_saw );
         item pants_fur( itype_test_pants_fur );
@@ -48,7 +48,7 @@ TEST_CASE( "zones_custom", "[zones]" )
                            "test_event_item_spawn" );
         mapgen_place_zone( zone_loc, zone_groupbatt_end, zone_type_LOOT_ITEM_GROUP, your_fac, {},
                            "test_group_disp" );
-        tripoint_abs_ms const m_zone_loc = m.getglobal( tripoint_bub_ms{-5, -5, 0 } );
+        tripoint_abs_ms const m_zone_loc = m.get_abs( tripoint_bub_ms{-5, -5, 0 } );
         mapgen_place_zone( m_zone_loc, m_zone_loc, zone_type_LOOT_CUSTOM, your_fac, {},
                            "plastic bag" );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #79118, i.e. rename operations.
This is really the first PR in a series, but there's no need to keep the suggestion open.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use the "rename" VS functionality to refactor the names of:
- map::getglobal ->map::get_abs
- map::bub_from_abs -> map::get_bub (two instances)
- map::omt_from_abs -> map::get_omt

Note that this shouldn't result in any functional changes.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkey, smash into stationary vehicle. Nothing odd seen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
As indicated, this is intended as the first in a string or PRs. The others will deal with variously named position getting operations.

This PR has a high risk of causing merge conflicts given that it affects a lot of spread out places, and thus shouldn't be merged as part of a batch. That's also the reason follow up PRs won't be produced until the previous one has been merged, as resolving merge conflicts between them seems like unnecessary work.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
