### PR TITLE
[MoM] Update and simplify Nether Attunement backlash EoC

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -325,221 +325,29 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES",
-    "//": "Switch statement below is to ensure there is always a chance of something happening.",
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 15" ] },
     "effect": {
-      "switch": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] },
-      "cases": [
-        {
-          "case": 15,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ]
-            ]
-          }
-        },
-        {
-          "case": 25,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ]
-            ]
-          }
-        },
-        {
-          "case": 50,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ]
-            ]
-          }
-        },
-        {
-          "case": 70,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ]
-            ]
-          }
-        },
-        {
-          "case": 85,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ]
-            ]
-          }
-        },
-        {
-          "case": 100,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ]
-            ]
-          }
-        },
-        {
-          "case": 125,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
-              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ]
-            ]
-          }
-        },
-        {
-          "case": 150,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
-              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 2 ]
-            ]
-          }
-        },
-        {
-          "case": 175,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
-              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 2 ],
-              [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 2 ]
-            ]
-          }
-        },
-        {
-          "case": 200,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
-              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 2 ],
-              [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 2 ],
-              [ "EOC_NETHER_EFFECT_CHECK_SUMMON_HOUNDS", 1 ]
-            ]
-          }
-        },
-        {
-          "case": 235,
-          "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 12 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 9 ],
-              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 6 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 6 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 12 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 5 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 11 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 8 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 5 ],
-              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 5 ],
-              [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 8 ],
-              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 5 ],
-              [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 5 ],
-              [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 3 ],
-              [ "EOC_NETHER_EFFECT_CHECK_SUMMON_HOUNDS", 2 ],
-              [ "EOC_NETHER_EFFECT_CHECK_MUTATION", 2 ],
-              [ "EOC_NETHER_EFFECT_CHECK_RIFT", 1 ]
-            ]
-          }
-        }
+      "weighted_list_eocs": [
+        [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 12 ],
+        [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 9 ],
+        [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 6 ],
+        [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 6 ],
+        [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 12 ],
+        [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 8 ],
+        [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 5 ],
+        [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 5 ],
+        [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 11 ],
+        [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 8 ],
+        [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 5 ],
+        [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 5 ],
+        [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 8 ],
+        [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 5 ],
+        [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 5 ],
+        [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 3 ],
+        [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 3 ],
+        [ "EOC_NETHER_EFFECT_CHECK_SUMMON_HOUNDS", 2 ],
+        [ "EOC_NETHER_EFFECT_CHECK_MUTATION", 2 ],
+        [ "EOC_NETHER_EFFECT_CHECK_RIFT", 1 ]
       ]
     }
   },
@@ -547,10 +355,10 @@
     "type": "effect_on_condition",
     "id": "EOC_DRAIN_EFFECT_CHECK_HEADACHE",
     "//": "Base is 0.5% chance from 15 attunement to 60 attunement, then scaling up 0.1% per attunement up to 10.5% chance at 160 attunement, then scaling up 0.25% chance per attunement up to 33% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 15" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 15" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -559,27 +367,28 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "Your head begins to throb.", "type": "bad" },
-      {
-        "u_add_effect": "psionic_overload",
-        "duration": {
-          "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-        }
+        },
+        "then": [
+          { "u_message": "Your head begins to throb.", "type": "bad" },
+          {
+            "u_add_effect": "psionic_overload",
+            "duration": {
+              "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
+          }
+        ]
       }
-    ]
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_COLD_WIND",
     "//": "Base is 3% chance from 15 attunement to 50 attunement, then scaling up 0.1% per attunement up to 11% chance at 130 attunement, then scaling up 0.25% chance per attunement up to 41% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 15" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 15" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -588,22 +397,23 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "The temperature suddenly drops!", "type": "bad" },
-      { "u_cast_spell": { "id": "nether_attunement_cold_chill", "hit_self": true } }
-    ]
+        },
+        "then": [
+          { "u_message": "The temperature suddenly drops!", "type": "bad" },
+          { "u_cast_spell": { "id": "nether_attunement_cold_chill", "hit_self": true } }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT",
     "//": "Base is 2% chance from 15 attunement to 150 attunement, then scaling up 0.05% per attunement up 10.5% chance at 160 attunement, then scaling up 0.25% chance per attunement up to 33% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 15" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 15" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -612,22 +422,23 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "You feel a strange tingling sensation.", "type": "mixed" },
-      { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(5) + 2" ] }
-    ]
+        },
+        "then": [
+          { "u_message": "You feel a strange tingling sensation.", "type": "mixed" },
+          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(5) + 2" ] }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE",
     "//": "Base is 1.5% chance from 25 attunement to 70 attunement, then scaling up 0.1% per attunement up to 6.5% chance at 120 attunement, then scaling up 0.2% chance per attunement up to 32.5% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 25" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 25" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -636,36 +447,26 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      {
-        "run_eocs": [
+        },
+        "then": [
           {
-            "id": "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE_2",
-            "condition": { "math": [ "rand(1) >= 1" ] },
-            "effect": [
-              { "u_add_effect": "effect_nether_attunement_health_bonus", "duration": "30 seconds" },
-              { "u_message": "You feel filled with vigor.", "type": "good" }
-            ],
-            "false_effect": [
-              { "u_add_effect": "effect_nether_attunement_health_penalty", "duration": "30 seconds" },
-              { "u_message": "You feel drained of vitality.", "type": "bad" }
-            ]
+            "if": { "math": [ "rand(2) >= 2" ] },
+            "then": [ { "math": [ "u_health() += (rand(25) + 5)" ] }, { "u_message": "You feel filled with vigor.", "type": "good" } ],
+            "else": [ { "math": [ "u_health() -= (rand(25) + 5)" ] }, { "u_message": "You feel drained of vitality.", "type": "bad" } ]
           }
         ]
       }
-    ]
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED",
     "//": "Base is 1% chance from 25 attunement to 60 attunement, then scaling up 0.1% per attunement up to 12% chance at 150 attunement, then scaling up 0.25% chance per attunement up to 37% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 25" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 25" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -674,23 +475,24 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "Blood drips from your nose.", "type": "bad" },
-      { "u_add_effect": "bleed", "intensity": 1, "target_part": "head", "duration": "5 minutes" },
-      { "math": [ "u_hp('head')", "-=", "1" ] }
-    ]
+        },
+        "then": [
+          { "u_message": "Blood drips from your nose.", "type": "bad" },
+          { "u_add_effect": "bleed", "intensity": 1, "target_part": "head", "duration": "5 minutes" },
+          { "math": [ "u_hp('head')", "-=", "1" ] }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS",
     "//": "Base is 2% chance from 50 attunement to 100 attunement, then scaling up 0.1% per attunement up to 8% chance at 160 attunement, then scaling up 0.28% chance per attunement up to 17.2% chance at 200 attunement, then scaling up 0.18% to 26.2% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 50" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 50" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -699,22 +501,23 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "You feel a sudden wave of fatigue.", "type": "bad" },
-      { "math": [ "u_val('stamina')", "-=", "rng(3000,9000)" ] }
-    ]
+        },
+        "then": [
+          { "u_message": "You feel a sudden wave of fatigue.", "type": "bad" },
+          { "math": [ "u_val('stamina')", "-=", "rng(3000,9000)" ] }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS",
     "//": "Base is 2% chance from 70 attunement to 125 attunement, then scaling up 0.15% per attunement up to 9.5% chance at 175 attunement, then scaling up 0.45% chance per attunement up to 32% chance at 225 attunement, then scaling up 0.3% to 39.5% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 70" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 70" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -723,50 +526,44 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "You feel a sudden wave of exhaustion.", "type": "bad" },
-      { "math": [ "u_val('sleepiness')", "+=", "rng(30,90)" ] }
-    ]
+        },
+        "then": [
+          { "u_message": "You feel a sudden wave of exhaustion and stifle a yawn.", "type": "bad" },
+          { "math": [ "u_val('sleepiness')", "+=", "rng(30,90)" ] }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT",
     "//": "Base is 3% chance from 70 attunement to 90 attunement, then scaling up 0.15% per attunement up to 15.75% chance at 175 attunement, then scaling up 0.3% chance per attunement up to 38.25% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 70" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 70" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
-                "( clamp( ((u_vitamin('vitamin_psionic_drain') - 90) * 1.5), 0, 120) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 175) * 1.5 ), 0, 375) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 30)"
+                "( clamp( ( (u_vitamin('vitamin_psionic_drain') - 90) * 1.5), 0, 120) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 175) * 1.5 ), 0, 375) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 30)"
               ]
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": {
-      "run_eocs": [
-        {
-          "id": "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT_2",
-          "condition": { "not": { "u_has_proficiency": "effect_nether_attunement_attenuation" } },
-          "effect": [
-            { "u_message": "You feel a strange tingling sensation that does not go away.", "type": "mixed" },
-            {
-              "u_add_effect": "effect_nether_attunement_raiser",
-              "duration": {
-                "math": [ "time(' 10 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-              }
+        },
+        "then": [
+          { "u_message": "You feel a strange tingling sensation that does not go away.", "type": "mixed" },
+          {
+            "u_add_effect": "effect_nether_attunement_raiser",
+            "duration": {
+              "math": [ "time(' 10 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
             }
-          ]
-        }
-      ]
-    }
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -704,8 +704,8 @@
         "then": [
           { "u_message": "The flow of Netherum energy resists your control.", "type": "bad" },
           {
-            "u_add_effect": ""effect_nether_attunement_attenuation"",
-            "duration": {  
+            "u_add_effect": "effect_nether_attunement_attenuation",
+            "duration": {
               "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
             }
           }
@@ -719,9 +719,9 @@
     "id": "EOC_NETHER_EFFECT_CHECK_BREATHING",
     "//": "Base is 2% chance from 100 attunement to 150 attunement, then scaling up 0.1% per attunement up to 9% chance at 220 attunement, then scaling up 0.5% chance per attunement up to 24% chance at max, plus 1/10th the Difficulty squared.",
     "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 100" ] },
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 100" ] },
-        {
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -730,27 +730,28 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "You gasp and your breath gives out.", "type": "bad" },
-      {
-        "u_add_effect": "effect_psi_reduced_breathing",
-        "duration": {
-          "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-        }
+        },
+        "then": [
+          { "u_message": "You gasp and your breath gives out.", "type": "bad" },
+          {
+            "u_add_effect": "effect_psi_reduced_breathing",
+            "duration": {
+              "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
+          }
+        ]
       }
-    ]
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS",
     "//": "Base is 1% chance from 125 attunement to 160 attunement, then scaling up 0.1% per attunement up to 6% chance at 210 attunement, then scaling up 0.35% chance per attunement up to 20% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 125" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 125" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -759,27 +760,28 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "You begin to feel a sudden sense of dread and paranoia!", "type": "bad" },
-      {
-        "u_add_effect": "hallu",
-        "duration": {
-          "math": [ "time(' 90 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-        }
+        },
+        "then": [
+          { "u_message": "You begin to feel a sudden sense of dread and paranoia!", "type": "bad" },
+          {
+            "u_add_effect": "hallu",
+            "duration": {
+              "math": [ "time(' 90 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
+          }
+        ]
       }
-    ]
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE",
     "//": "Base is 3% chance from 125 attunement to 160 attunement, then scaling up 0.15% per attunement up to 9.75% chance at 205 attunement, then scaling up 0.45% chance per attunement up to 29.75% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 125" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 125" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -788,22 +790,23 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "A soundless explosion hurls you off your feet.", "type": "bad" },
-      { "u_cast_spell": { "id": "nether_attunement_everyone_downed", "hit_self": true } }
-    ]
+        },
+        "then": [
+          { "u_message": "A soundless explosion hurls you off your feet.", "type": "bad" },
+          { "u_cast_spell": { "id": "nether_attunement_everyone_downed", "hit_self": true } }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS",
     "//": "Base is 2% chance from 150 attunement to 200 attunement, then scaling up 0.15% per attunement up to 5.75% chance at 225 attunement, then scaling up 0.5% chance per attunement up to 18.25% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 150" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 150" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -812,28 +815,29 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "The flow of Nether energy is suddenly cut off!", "type": "bad" },
-      {
-        "u_add_effect": "effect_psi_null_unbound",
-        "duration": {
-          "math": [ "time(' 3 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-        }
-      },
-      { "u_add_effect": "effect_psi_neutralized", "duration": 2 }
-    ]
+        },
+        "then": [
+          { "u_message": "The flow of Nether energy is suddenly cut off!", "type": "bad" },
+          {
+            "u_add_effect": "effect_psi_null_unbound",
+            "duration": {
+              "math": [ "time(' 3 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
+          },
+          { "u_add_effect": "effect_psi_neutralized", "duration": 2 }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING",
     "//": "Base is 3% chance from 175 attunement to 200 attunement, then scaling up 0.2% per attunement up to 8% chance at 225 attunement, then scaling up 0.45% chance per attunement up to 19.25% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 175" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 175" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -842,13 +846,14 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "Crackling energy erupts all around you!", "type": "bad" },
-      { "u_cast_spell": { "id": "nether_attunement_nether_lightning", "hit_self": false } }
-    ]
+        },
+        "then": [
+          { "u_message": "Crackling energy erupts all around you!", "type": "bad" },
+          { "u_cast_spell": { "id": "nether_attunement_nether_lightning", "hit_self": false } }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
@@ -857,8 +862,12 @@
     "condition": {
       "and": [
         { "or": [ { "u_has_effect": "psi_nether_attention" }, { "u_has_effect": "effect_nether_attunement_raiser" } ] },
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 200" ] },
-        {
+        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 200" ] }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -867,22 +876,23 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_add_effect": "tindrift", "duration": "1 day" },
-      { "u_message": "You feel a horrible sensation of watching eyes.", "type": "bad" }
-    ]
+        },
+        "then": [
+          { "u_add_effect": "tindrift", "duration": "1 day" },
+          { "u_message": "You feel a horrible sensation of watching eyes.", "type": "bad" }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_MUTATION",
     "//": "Base is 3% chance at 235 attunement, scaling up 0.2% per attunement up to 6% chance at 250 attunement, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 235" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 235" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -891,13 +901,14 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "run_eocs": "EOC_NETHER_ATTUNEMENT_MUTATION_GAINER" },
-      { "u_message": "You feel an internal wrenching sensation.", "type": "bad" }
-    ]
+        },
+        "then": [
+          { "run_eocs": "EOC_NETHER_ATTUNEMENT_MUTATION_GAINER" },
+          { "u_message": "You feel an internal wrenching sensation.", "type": "bad" }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
@@ -906,8 +917,12 @@
     "condition": {
       "and": [
         { "or": [ { "u_has_effect": "psi_nether_attention" }, { "u_has_effect": "effect_nether_attunement_raiser" } ] },
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 235" ] },
-        {
+        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 235" ] }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -916,13 +931,14 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_set_field": "fd_fatigue", "radius": 0, "intensity": 3, "hit_player": false },
-      { "u_message": "The air around you twists and warps in on itself.", "type": "bad" }
-    ]
+        },
+        "then": [
+          { "u_set_field": "fd_fatigue", "radius": 0, "intensity": 3, "hit_player": false },
+          { "u_message": "The air around you twists and warps in on itself.", "type": "bad" }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -569,10 +569,10 @@
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_FEEDBACK",
     "//": "Base is 3% chance from 100 attunement to 135 attunement, then scaling up 0.1% per attunement up to 7.5% chance at 175 attunement, then scaling up 0.25% chance per attunement up to 32% chance at 210 attunement, then scaling up 0.5% to 39.5% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 100" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 100" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -581,28 +581,29 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "You feel a stabbing pain!", "type": "good" },
-      { "math": [ "u_pain()", "+=", "rand(7) + 3" ] },
-      {
-        "u_add_effect": "effect_nether_attunement_feedback",
-        "duration": {
-          "math": [ "time(' 2 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-        }
+        },
+        "then": [
+          { "u_message": "You feel a stabbing pain!", "type": "good" },
+          { "math": [ "u_pain()", "+=", "rand(7) + 3" ] },
+          {
+            "u_add_effect": "effect_nether_attunement_feedback",
+            "duration": {
+              "math": [ "time(' 2 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
+          }
+        ]
       }
-    ]
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE",
     "//": "Base is 1.5% chance from 80 attunement to 120 attunement, then scaling up 0.1% per attunement up to 7.5% chance at 180 attunement, then scaling up 0.45% chance per attunement up to 32% chance at 225 attunement, then scaling up 0.3% to 39.5% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 85" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 85" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -611,25 +612,26 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "You feel a surge of strength!", "type": "good" },
-      {
-        "u_add_effect": "effect_nether_attunement_power_surge",
-        "duration": { "math": [ "u_vitamin('vitamin_psionic_drain') * rng(1,10)" ] }
+        },
+        "then": [
+          { "u_message": "You feel a surge of strength!", "type": "good" },
+          {
+            "u_add_effect": "effect_nether_attunement_power_surge",
+            "duration": { "math": [ "u_vitamin('vitamin_psionic_drain') * rng(1,10)" ] }
+          }
+        ]
       }
-    ]
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK",
     "//": "Base is 1% chance from 85 attunement to 120 attunement, then scaling up 0.1% per attunement up to 8% chance at 190 attunement, then scaling up 0.35% chance per attunement up to 29% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 85" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 85" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -638,27 +640,28 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "Your skin feels tight!", "type": "bad" },
-      {
-        "u_add_effect": "effect_psi_teleport_lock",
-        "duration": {
-          "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-        }
+        },
+        "then": [
+          { "u_message": "Your skin feels tight!", "type": "bad" },
+          {
+            "u_add_effect": "effect_psi_teleport_lock",
+            "duration": {
+              "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
+          }
+        ]
       }
-    ]
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_DRAIN_EFFECT_CHECK_WEAKNESS",
     "//": "Base is 2% chance from 100 attunement to 150 attunement, then scaling up 0.1% per attunement up to 9% chance at 220 attunement, then scaling up 0.5% chance per attunement up to 24% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 100" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 100" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -667,27 +670,28 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": [
-      { "u_message": "Your muscles tremble and weaken.", "type": "bad" },
-      {
-        "u_add_effect": "effect_biokin_overload",
-        "duration": {
-          "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-        }
+        },
+        "then": [
+          { "u_message": "Your muscles tremble and weaken.", "type": "bad" },
+          {
+            "u_add_effect": "effect_biokin_overload",
+            "duration": {
+              "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
+          }
+        ]
       }
-    ]
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_ATTENUATION",
     "//": "Base is 4% chance from 125 attunement to 160 attunement, then scaling up 0.15% per attunement up to 11.5% chance at 210 attunement, then scaling up 0.35% chance per attunement up to 25.5% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 125" ] },
-        {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 125" ] },
+    "effect": [
+      {
+        "if": {
           "x_in_y_chance": {
             "x": {
               "math": [
@@ -696,32 +700,25 @@
             },
             "y": 1000
           }
-        }
-      ]
-    },
-    "effect": {
-      "run_eocs": [
-        {
-          "id": "EOC_NETHER_EFFECT_CHECK_ATTENUATION_2",
-          "condition": { "not": { "u_has_proficiency": "effect_nether_attunement_raiser" } },
-          "effect": [
-            { "u_message": "The flow of Netherum energy slows to a trickle!", "type": "bad" },
-            {
-              "u_add_effect": "effect_nether_attunement_attenuation",
-              "duration": {
-                "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-              }
+        },
+        "then": [
+          { "u_message": "The flow of Netherum energy resists your control.", "type": "bad" },
+          {
+            "u_add_effect": ""effect_nether_attunement_attenuation"",
+            "duration": {  
+              "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
             }
-          ]
-        }
-      ]
-    }
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_BREATHING",
     "//": "Base is 2% chance from 100 attunement to 150 attunement, then scaling up 0.1% per attunement up to 9% chance at 220 attunement, then scaling up 0.5% chance per attunement up to 24% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
+    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 100" ] },
       "and": [
         { "math": [ "u_vitamin('vitamin_psionic_drain') >= 100" ] },
         {

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -87,8 +87,8 @@
     "type": "effect_type",
     "id": "effect_nether_attunement_attenuation",
     "name": [ "Nether Attenuation" ],
-    "desc": [ "You feel strangely listless." ],
-    "remove_message": "The listless feeling vanishes.",
+    "desc": [ "You have to work extra hard to draw enough energy to use your powers." ],
+    "remove_message": "Your difficulty in drawing on the Nether fades.",
     "enchantments": [ { "values": [ { "value": "CASTING_TIME_MULTIPLIER", "multiply": 4 } ] } ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Update and simplify Nether Attunement backlash EoC"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Right now the EoC for Nether Attunement backlash is a sprawling mess. There's a giant switch statement with multiple weighted lists, to curate exactly which effects you are eligible for. But making the Paraclesian spell-improvement EoCs taught me the performance impact of running through a weighted list multiple times until you find one option that fits is very low from a user perspective, so a _lot_ of simplification is possible.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replace the switch statement with a single weighted list, making it _much_ easier to add new options and control their relative weights.

Go through each sub EoC and make the condition a check of your Nether Attunement level (and whether you have the Observed effect, if applicable). If you don't have enough, it rerolls another check for a different effect.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked at both minimum and maximum possible Nether Attunement to have backlash occur. Backlash could occur in both occasions, no infinite loops.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
