### PR TITLE
monstergroup "name" to "id"

### DIFF
--- a/data/json/mapgen/animalpound.json
+++ b/data/json/mapgen/animalpound.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_ANIMALPOUND_CATS",
+    "id": "GROUP_ANIMALPOUND_CATS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_null", "weight": 580 },
@@ -19,7 +19,7 @@
     ]
   },
   {
-    "name": "GROUP_ANIMALPOUND_DOGS",
+    "id": "GROUP_ANIMALPOUND_DOGS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_dog", "weight": 250, "cost_multiplier": 0 },

--- a/data/json/mapgen/animalshelter.json
+++ b/data/json/mapgen/animalshelter.json
@@ -78,7 +78,7 @@
     ]
   },
   {
-    "name": "GROUP_ANIMALSHELTER_DOGS",
+    "id": "GROUP_ANIMALSHELTER_DOGS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_dog", "weight": 200, "cost_multiplier": 0 },
@@ -87,7 +87,7 @@
     ]
   },
   {
-    "name": "GROUP_ANIMALSHELTER_OTHER",
+    "id": "GROUP_ANIMALSHELTER_OTHER",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_null", "weight": 5 },

--- a/data/json/mapgen/arcade.json
+++ b/data/json/mapgen/arcade.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_ARCADE",
+    "id": "GROUP_ARCADE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_null", "weight": 400 }, { "monster": "mon_zombie_child", "weight": 600, "pack_size": [ 2, 5 ] } ]
   },

--- a/data/json/mapgen/campsite.json
+++ b/data/json/mapgen/campsite.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "CAMPERS",
+    "id": "CAMPERS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_null", "weight": 500 },

--- a/data/json/mapgen/collapsed_tower.json
+++ b/data/json/mapgen/collapsed_tower.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_COLLAPSED_TOWER",
+    "id": "GROUP_COLLAPSED_TOWER",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie", "weight": 600 },
@@ -11,7 +11,7 @@
     ]
   },
   {
-    "name": "GROUP_COLLAPSED_TOWER_BASEMENT",
+    "id": "GROUP_COLLAPSED_TOWER_BASEMENT",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_gasbag_immobile", "weight": 650 },

--- a/data/json/mapgen/cs_open_sewer_small.json
+++ b/data/json/mapgen/cs_open_sewer_small.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_SEWER",
+    "id": "GROUP_ZOMBIE_SEWER",
     "monsters": [
       { "monster": "mon_zombie_technician", "weight": 850, "cost_multiplier": 3 },
       { "monster": "mon_zombie_static", "weight": 150, "cost_multiplier": 5 }

--- a/data/json/mapgen/house/house_quiverfull.json
+++ b/data/json/mapgen/house/house_quiverfull.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_QUIVERFULL",
+    "id": "GROUP_QUIVERFULL",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_null", "weight": 900 },

--- a/data/json/mapgen/irradiator_1.json
+++ b/data/json/mapgen/irradiator_1.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_NUCLEAR_INDUSTRY",
+    "id": "GROUP_ZOMBIE_NUCLEAR_INDUSTRY",
     "monsters": [
       { "monster": "mon_zombie_technician", "weight": 450, "cost_multiplier": 3 },
       { "monster": "mon_zombie_hazmat", "weight": 250, "cost_multiplier": 3 },

--- a/data/json/mapgen/map_extras/laststand.json
+++ b/data/json/mapgen/map_extras/laststand.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_LAST_STAND",
+    "id": "GROUP_LAST_STAND",
     "default": "mon_null",
     "monsters": [
       { "monster": "mon_civilian_police", "weight": 1, "cost_multiplier": 1, "ends": "5 days" },

--- a/data/json/mapgen/map_extras/military.json
+++ b/data/json/mapgen/map_extras/military.json
@@ -22,7 +22,7 @@
     ]
   },
   {
-    "name": "GROUP_MIL_EXTRA",
+    "id": "GROUP_MIL_EXTRA",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_zombie_soldier", "weight": 76 }, { "monster": "mon_feral_soldier", "weight": 20 } ]
   },

--- a/data/json/mapgen/map_extras/toxic_waste.json
+++ b/data/json/mapgen/map_extras/toxic_waste.json
@@ -98,7 +98,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TOXIC_WASTE",
+    "id": "GROUP_TOXIC_WASTE",
     "monsters": [
       { "monster": "mon_sewer_rat", "weight": 60 },
       { "monster": "mon_blob", "weight": 30 },
@@ -107,7 +107,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TOXIC_WASTE_CORPSES",
+    "id": "GROUP_TOXIC_WASTE_CORPSES",
     "monsters": [
       { "monster": "mon_mutant_experimental", "weight": 60 },
       { "monster": "mon_mutant_antler", "weight": 30 },

--- a/data/json/mapgen/microlab/microlab_moster_nests.json
+++ b/data/json/mapgen/microlab/microlab_moster_nests.json
@@ -5,7 +5,7 @@
     "terrain": [ { "result": [ "t_strconc_floor", [ "t_region_groundcover_forest", 3 ] ], "valid_terrain": [ "t_strconc_floor" ] } ]
   },
   {
-    "name": "GROUP_MLAB_RUST_ZOMBIE",
+    "id": "GROUP_MLAB_RUST_ZOMBIE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_rust", "weight": 250 },
@@ -13,7 +13,7 @@
     ]
   },
   {
-    "name": "GROUP_MLAB_ACID_ZOMBIE",
+    "id": "GROUP_MLAB_ACID_ZOMBIE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_acidic", "weight": 250 },
@@ -21,7 +21,7 @@
     ]
   },
   {
-    "name": "GROUP_MLAB_PHASE_ZOMBIE",
+    "id": "GROUP_MLAB_PHASE_ZOMBIE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_phase_skulker", "weight": 250 },
@@ -29,7 +29,7 @@
     ]
   },
   {
-    "name": "GROUP_MLAB_HUNTER_ZOMBIE",
+    "id": "GROUP_MLAB_HUNTER_ZOMBIE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_hunter", "weight": 250 },
@@ -37,7 +37,7 @@
     ]
   },
   {
-    "name": "GROUP_MLAB_RAPTOR_ZOMBIE",
+    "id": "GROUP_MLAB_RAPTOR_ZOMBIE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_pupa", "weight": 50 },
@@ -46,7 +46,7 @@
     ]
   },
   {
-    "name": "GROUP_MLAB_MUTANTS",
+    "id": "GROUP_MLAB_MUTANTS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_mutant_experimental", "weight": 150 },
@@ -56,7 +56,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MLAB_ROBOT",
+    "id": "GROUP_MLAB_ROBOT",
     "monsters": [
       { "monster": "mon_science_bot", "weight": 200 },
       { "monster": "mon_manhack", "weight": 200 },
@@ -70,7 +70,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MLAB_LEECH_PLANT",
+    "id": "GROUP_MLAB_LEECH_PLANT",
     "monsters": [
       { "monster": "mon_leech_root_drone", "weight": 200 },
       { "monster": "mon_leech_root_runner", "weight": 200 },
@@ -79,7 +79,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MLAB_YRAX",
+    "id": "GROUP_MLAB_YRAX",
     "monsters": [
       { "monster": "mon_yrax_trifacet", "weight": 200 },
       { "monster": "mon_yrax_triakis", "weight": 200 },

--- a/data/json/mapgen/mine/mine_spiral.json
+++ b/data/json/mapgen/mine/mine_spiral.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_MINER",
+    "id": "GROUP_MINER",
     "monsters": [ { "monster": "mon_zombie_miner" } ]
   },
   {

--- a/data/json/mapgen/pool.json
+++ b/data/json/mapgen/pool.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_MAPGEN_POOL",
+    "id": "GROUP_MAPGEN_POOL",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_null", "weight": 1 }, { "monster": "mon_zombie_swimmer_base", "weight": 4 } ]
   },

--- a/data/json/mapgen/sewage_treatment.json
+++ b/data/json/mapgen/sewage_treatment.json
@@ -130,7 +130,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SEWAGE_TREATMENT",
+    "id": "GROUP_SEWAGE_TREATMENT",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_sewer_fish", "weight": 300, "cost_multiplier": 0, "pack_size": [ 2, 6 ] },

--- a/data/json/mapgen/standing_stones.json
+++ b/data/json/mapgen/standing_stones.json
@@ -21,7 +21,7 @@
     "entries": [ { "item": "mead", "container-item": "bowl_clay", "charges": [ 2, 7 ] } ]
   },
   {
-    "name": "GROUP_STANDING_STONES",
+    "id": "GROUP_STANDING_STONES",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_null", "weight": 900 }, { "monster": "mon_darkman", "weight": 100, "conditions": [ "NIGHT" ] } ]
   },

--- a/data/json/mapgen/zoo.json
+++ b/data/json/mapgen/zoo.json
@@ -444,7 +444,7 @@
     }
   },
   {
-    "name": "GROUP_INSECT_ZOO",
+    "id": "GROUP_INSECT_ZOO",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_WILDERNESS_SWAMP_INSECT", "weight": 2 },
@@ -452,7 +452,7 @@
     ]
   },
   {
-    "name": "GROUP_PETTING_ZOO",
+    "id": "GROUP_PETTING_ZOO",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_goat_kid", "weight": 2 },
@@ -465,7 +465,7 @@
     ]
   },
   {
-    "name": "GROUP_LLAMA_ZOO",
+    "id": "GROUP_LLAMA_ZOO",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_llama", "weight": 7 },
@@ -474,17 +474,17 @@
     ]
   },
   {
-    "name": "GROUP_COYOTES_ZOO",
+    "id": "GROUP_COYOTES_ZOO",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_coyote" } ]
   },
   {
-    "name": "GROUP_TIGERS_ZOO",
+    "id": "GROUP_TIGERS_ZOO",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_tiger", "weight": 8 }, { "monster": "mon_ziger", "weight": 2 } ]
   },
   {
-    "name": "GROUP_COUGARS_ZOO",
+    "id": "GROUP_COUGARS_ZOO",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_cougar", "weight": 7 },
@@ -493,7 +493,7 @@
     ]
   },
   {
-    "name": "GROUP_FROGS_ZOO",
+    "id": "GROUP_FROGS_ZOO",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_leo_frog", "weight": 10 },
@@ -502,7 +502,7 @@
     ]
   },
   {
-    "name": "GROUP_SPIDERS_ZOO",
+    "id": "GROUP_SPIDERS_ZOO",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_SPIDER" },
@@ -512,32 +512,32 @@
     ]
   },
   {
-    "name": "GROUP_SNAKES_ZOO",
+    "id": "GROUP_SNAKES_ZOO",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_rattlesnake", "weight": 9 }, { "monster": "mon_rattlesnake_s", "weight": 1 } ]
   },
   {
-    "name": "GROUP_FOXES_ZOO",
+    "id": "GROUP_FOXES_ZOO",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fox_gray", "weight": 10 } ]
   },
   {
-    "name": "GROUP_REINDEERS_ZOO",
+    "id": "GROUP_REINDEERS_ZOO",
     "type": "monstergroup",
     "monsters": [ { "group": "GROUP_REINDEERS", "weight": 9 }, { "monster": "mon_zeindeer", "weight": 1 } ]
   },
   {
-    "name": "GROUP_BEARS_ZOO",
+    "id": "GROUP_BEARS_ZOO",
     "type": "monstergroup",
     "monsters": [ { "group": "GROUP_BEARS", "weight": 9 }, { "monster": "mon_zombear", "weight": 1 } ]
   },
   {
-    "name": "GROUP_MOOSE_ZOO",
+    "id": "GROUP_MOOSE_ZOO",
     "type": "monstergroup",
     "monsters": [ { "group": "GROUP_MOOSE", "weight": 9 }, { "monster": "mon_zoose", "weight": 1 } ]
   },
   {
-    "name": "GROUP_PIGS_ZOO",
+    "id": "GROUP_PIGS_ZOO",
     "type": "monstergroup",
     "monsters": [ { "group": "GROUP_PIGS", "weight": 950 }, { "monster": "mon_zombie_pig", "weight": 50 } ]
   }

--- a/data/json/monstergroups/amphibian.json
+++ b/data/json/monstergroups/amphibian.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_TADPOLES_ALL",
+    "id": "GROUP_TADPOLES_ALL",
     "type": "monstergroup",
     "default": "mon_peeper_tadpole",
     "monsters": [
@@ -39,7 +39,7 @@
     ]
   },
   {
-    "name": "GROUP_TADPOLES_SEWER",
+    "id": "GROUP_TADPOLES_SEWER",
     "type": "monstergroup",
     "default": "mon_leo_tadpole",
     "monsters": [
@@ -57,7 +57,7 @@
     ]
   },
   {
-    "name": "GROUP_TADPOLES_RIVER",
+    "id": "GROUP_TADPOLES_RIVER",
     "type": "monstergroup",
     "default": "mon_bullfrog_tadpole",
     "monsters": [
@@ -75,7 +75,7 @@
     ]
   },
   {
-    "name": "GROUP_TADPOLES_SWAMP",
+    "id": "GROUP_TADPOLES_SWAMP",
     "type": "monstergroup",
     "default": "mon_bullfrog_tadpole",
     "monsters": [
@@ -109,7 +109,7 @@
     ]
   },
   {
-    "name": "GROUP_FROGS_ALL",
+    "id": "GROUP_FROGS_ALL",
     "type": "monstergroup",
     "default": "mon_peeper_frog",
     "monsters": [
@@ -254,7 +254,7 @@
     ]
   },
   {
-    "name": "GROUP_FROGS_NATURAL",
+    "id": "GROUP_FROGS_NATURAL",
     "type": "monstergroup",
     "default": "mon_peeper_frog",
     "monsters": [
@@ -322,7 +322,7 @@
     ]
   },
   {
-    "name": "GROUP_FROGS_SEWER",
+    "id": "GROUP_FROGS_SEWER",
     "type": "monstergroup",
     "default": "mon_bullfrog_frog",
     "monsters": [
@@ -426,7 +426,7 @@
     ]
   },
   {
-    "name": "GROUP_FROGS_FOREST",
+    "id": "GROUP_FROGS_FOREST",
     "type": "monstergroup",
     "default": "mon_peeper_frog",
     "monsters": [
@@ -558,7 +558,7 @@
     ]
   },
   {
-    "name": "GROUP_FROGS_SWAMP",
+    "id": "GROUP_FROGS_SWAMP",
     "type": "monstergroup",
     "default": "mon_bullfrog_frog",
     "monsters": [
@@ -698,7 +698,7 @@
     ]
   },
   {
-    "name": "GROUP_FROGS_RIVER",
+    "id": "GROUP_FROGS_RIVER",
     "type": "monstergroup",
     "default": "mon_bullfrog_frog",
     "monsters": [
@@ -759,7 +759,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_ALL",
+    "id": "GROUP_MUTAFROGS_ALL",
     "type": "monstergroup",
     "default": "mon_strange_bigfrog",
     "monsters": [
@@ -780,7 +780,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_BIG",
+    "id": "GROUP_MUTAFROGS_BIG",
     "type": "monstergroup",
     "default": "mon_strange_bigfrog",
     "monsters": [
@@ -794,7 +794,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_GIANT",
+    "id": "GROUP_MUTAFROGS_GIANT",
     "type": "monstergroup",
     "default": "mon_strange_giganfrog",
     "monsters": [
@@ -805,7 +805,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_MEGA",
+    "id": "GROUP_MUTAFROGS_MEGA",
     "type": "monstergroup",
     "default": "mon_strange_megafrog",
     "monsters": [
@@ -815,7 +815,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_PATTERN",
+    "id": "GROUP_MUTAFROGS_PATTERN",
     "type": "monstergroup",
     "default": "mon_pattern_bigfrog",
     "monsters": [
@@ -824,7 +824,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_STRANGE",
+    "id": "GROUP_MUTAFROGS_STRANGE",
     "type": "monstergroup",
     "default": "mon_strange_bigfrog",
     "monsters": [
@@ -834,7 +834,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_FOUL",
+    "id": "GROUP_MUTAFROGS_FOUL",
     "type": "monstergroup",
     "default": "mon_foul_bigfrog",
     "monsters": [
@@ -844,7 +844,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_ODD",
+    "id": "GROUP_MUTAFROGS_ODD",
     "type": "monstergroup",
     "default": "mon_odd_bigfrog",
     "monsters": [
@@ -854,7 +854,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_VOCAL",
+    "id": "GROUP_MUTAFROGS_VOCAL",
     "type": "monstergroup",
     "default": "mon_jumbo_bigfrog",
     "monsters": [
@@ -863,7 +863,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_SEWER",
+    "id": "GROUP_MUTAFROGS_SEWER",
     "type": "monstergroup",
     "default": "mon_strange_bigfrog",
     "monsters": [
@@ -874,7 +874,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_FOREST",
+    "id": "GROUP_MUTAFROGS_FOREST",
     "type": "monstergroup",
     "default": "mon_odd_bigfrog",
     "monsters": [
@@ -887,7 +887,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_SWAMP",
+    "id": "GROUP_MUTAFROGS_SWAMP",
     "type": "monstergroup",
     "default": "mon_strange_bigfrog",
     "monsters": [
@@ -900,13 +900,13 @@
     ]
   },
   {
-    "name": "GROUP_MUTAFROGS_RIVER",
+    "id": "GROUP_MUTAFROGS_RIVER",
     "type": "monstergroup",
     "default": "mon_strange_bigfrog",
     "monsters": [ { "group": "GROUP_MUTAFROGS_PATTERN", "weight": 60 }, { "group": "GROUP_MUTAFROGS_STRANGE", "weight": 100 } ]
   },
   {
-    "name": "GROUP_TADPOLE_LEO",
+    "id": "GROUP_TADPOLE_LEO",
     "type": "monstergroup",
     "default": "mon_leo_frog",
     "monsters": [
@@ -916,103 +916,103 @@
     ]
   },
   {
-    "name": "GROUP_TADPOLE_BULLFROG",
+    "id": "GROUP_TADPOLE_BULLFROG",
     "type": "monstergroup",
     "default": "mon_bullfrog_frog",
     "monsters": [ { "monster": "mon_bullfrog_frog", "weight": 90 }, { "monster": "mon_strange_frog", "weight": 10 } ]
   },
   {
-    "name": "GROUP_TADPOLE_FOWLER",
+    "id": "GROUP_TADPOLE_FOWLER",
     "type": "monstergroup",
     "default": "mon_fowler_toad",
     "monsters": [ { "monster": "mon_fowler_toad", "weight": 90 }, { "monster": "mon_foul_toad", "weight": 10 } ]
   },
   {
-    "name": "GROUP_TADPOLE_FREEDOM",
+    "id": "GROUP_TADPOLE_FREEDOM",
     "type": "monstergroup",
     "default": "mon_freedom_toad",
     "monsters": [ { "monster": "mon_freedom_toad", "weight": 90 }, { "monster": "mon_odd_toad", "weight": 10 } ]
   },
   {
-    "name": "GROUP_TADPOLE_PEEPER",
+    "id": "GROUP_TADPOLE_PEEPER",
     "type": "monstergroup",
     "default": "mon_peeper_frog",
     "monsters": [ { "monster": "mon_peeper_frog", "weight": 90 }, { "monster": "mon_vocal_frog", "weight": 10 } ]
   },
   {
-    "name": "GROUP_TADPOLE_GRAY",
+    "id": "GROUP_TADPOLE_GRAY",
     "type": "monstergroup",
     "default": "mon_gray_frog",
     "monsters": [ { "monster": "mon_gray_frog", "weight": 90 }, { "monster": "mon_shift_frog", "weight": 10 } ]
   },
   {
-    "name": "GROUP_TADPOLE_PICKEREL",
+    "id": "GROUP_TADPOLE_PICKEREL",
     "type": "monstergroup",
     "default": "mon_pickerel_frog",
     "monsters": [ { "monster": "mon_pickerel_frog", "weight": 90 }, { "monster": "mon_palette_frog", "weight": 10 } ]
   },
   {
-    "name": "GROUP_TADPOLE_GREEN",
+    "id": "GROUP_TADPOLE_GREEN",
     "type": "monstergroup",
     "default": "mon_green_frog",
     "monsters": [ { "monster": "mon_green_frog", "weight": 99 }, { "monster": "mon_green_worm", "weight": 1 } ]
   },
   {
-    "name": "GROUP_TADPOLE_WOOD",
+    "id": "GROUP_TADPOLE_WOOD",
     "type": "monstergroup",
     "default": "mon_wood_frog",
     "monsters": [ { "monster": "mon_wood_frog", "weight": 99 }, { "monster": "mon_wood_worm", "weight": 1 } ]
   },
   {
-    "name": "GROUP_BIGTAD_VOCAL",
+    "id": "GROUP_BIGTAD_VOCAL",
     "type": "monstergroup",
     "default": "mon_jumbo_bigfrog",
     "monsters": [ { "monster": "mon_jumbo_bigfrog", "weight": 50 }, { "monster": "mon_vocal_bigfrog", "weight": 50 } ]
   },
   {
-    "name": "GROUP_FROGS_UPGRADE_PATTERN",
+    "id": "GROUP_FROGS_UPGRADE_PATTERN",
     "type": "monstergroup",
     "default": "mon_pattern_bigfrog",
     "monsters": [ { "monster": "mon_pattern_bigfrog", "weight": 100 }, { "monster": "mon_pattern_giganfrog", "weight": 30 } ]
   },
   {
-    "name": "GROUP_FROGS_UPGRADE_STRANGE",
+    "id": "GROUP_FROGS_UPGRADE_STRANGE",
     "type": "monstergroup",
     "default": "mon_strange_bigfrog",
     "monsters": [ { "monster": "mon_strange_bigfrog", "weight": 100 }, { "monster": "mon_strange_giganfrog", "weight": 40 } ]
   },
   {
-    "name": "GROUP_FROGS_UPGRADE_STRANGE_MEGA",
+    "id": "GROUP_FROGS_UPGRADE_STRANGE_MEGA",
     "type": "monstergroup",
     "default": "mon_strange_giganfrog",
     "monsters": [ { "monster": "mon_strange_giganfrog", "weight": 100 }, { "monster": "mon_strange_megafrog", "weight": 10 } ]
   },
   {
-    "name": "GROUP_FROGS_UPGRADE_FOUL",
+    "id": "GROUP_FROGS_UPGRADE_FOUL",
     "type": "monstergroup",
     "default": "mon_foul_bigfrog",
     "monsters": [ { "monster": "mon_foul_bigfrog", "weight": 100 }, { "monster": "mon_foul_giganfrog", "weight": 40 } ]
   },
   {
-    "name": "GROUP_FROGS_UPGRADE_FOUL_MEGA",
+    "id": "GROUP_FROGS_UPGRADE_FOUL_MEGA",
     "type": "monstergroup",
     "default": "mon_foul_giganfrog",
     "monsters": [ { "monster": "mon_foul_giganfrog", "weight": 100 }, { "monster": "mon_foul_megafrog", "weight": 30 } ]
   },
   {
-    "name": "GROUP_FROGS_UPGRADE_ODD",
+    "id": "GROUP_FROGS_UPGRADE_ODD",
     "type": "monstergroup",
     "default": "mon_odd_bigfrog",
     "monsters": [ { "monster": "mon_odd_bigfrog", "weight": 100 }, { "monster": "mon_odd_giganfrog", "weight": 40 } ]
   },
   {
-    "name": "GROUP_FROGS_UPGRADE_ODD_MEGA",
+    "id": "GROUP_FROGS_UPGRADE_ODD_MEGA",
     "type": "monstergroup",
     "default": "mon_odd_giganfrog",
     "monsters": [ { "monster": "mon_odd_giganfrog", "weight": 100 }, { "monster": "mon_odd_megafrog", "weight": 10 } ]
   },
   {
-    "name": "GROUP_FROGS_UPGRADE_VOCAL",
+    "id": "GROUP_FROGS_UPGRADE_VOCAL",
     "type": "monstergroup",
     "default": "mon_vocal_frog",
     "monsters": [
@@ -1022,7 +1022,7 @@
     ]
   },
   {
-    "name": "GROUP_FROGS_UPGRADE_SHIFT",
+    "id": "GROUP_FROGS_UPGRADE_SHIFT",
     "type": "monstergroup",
     "default": "mon_shift_frog",
     "monsters": [ { "monster": "mon_shift_frog", "weight": 70 }, { "monster": "mon_shift_bigfrog", "weight": 30 } ]

--- a/data/json/monstergroups/blob.json
+++ b/data/json/monstergroups/blob.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_GOO",
+    "id": "GROUP_GOO",
     "monsters": [
       { "monster": "mon_blob_small", "weight": 200, "cost_multiplier": 0 },
       { "monster": "mon_blob_small", "weight": 100, "cost_multiplier": 0, "pack_size": [ 2, 12 ] },
@@ -13,7 +13,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SLIME",
+    "id": "GROUP_SLIME",
     "//": "GROUP_GOO has a shoggoth, which isn't even the same faction as blobs. Also removes brain blob.",
     "monsters": [
       { "monster": "mon_blob_small", "weight": 200, "cost_multiplier": 0 },

--- a/data/json/monstergroups/bugs.json
+++ b/data/json/monstergroups/bugs.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ANT",
+    "id": "GROUP_ANT",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_ant_larva", "weight": 40, "cost_multiplier": 0 },
@@ -12,7 +12,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ANT_SURFACE",
+    "id": "GROUP_ANT_SURFACE",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_ant_soldier", "weight": 90, "cost_multiplier": 5 },
@@ -25,7 +25,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ACID_ANT",
+    "id": "GROUP_ACID_ANT",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_ant_acid_larva", "weight": 35, "cost_multiplier": 0 },
@@ -36,7 +36,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ACID_ANT_SURFACE",
+    "id": "GROUP_ACID_ANT_SURFACE",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_ant_acid_soldier", "weight": 90, "cost_multiplier": 5 },
@@ -49,21 +49,21 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BEEHIVE",
+    "id": "GROUP_BEEHIVE",
     "monsters": [ { "monster": "mon_bee_small", "cost_multiplier": 0 }, { "monster": "mon_bee", "cost_multiplier": 5 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BEE",
+    "id": "GROUP_BEE",
     "monsters": [ { "monster": "mon_bee_small", "cost_multiplier": 0 } ]
   },
   {
-    "name": "GROUP_DERMATIK",
+    "id": "GROUP_DERMATIK",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_dermatik" } ]
   },
   {
-    "name": "GROUP_DERMATIK_INCUB",
+    "id": "GROUP_DERMATIK_INCUB",
     "type": "monstergroup",
     "default": "mon_dermatik_incubator_deer",
     "monsters": [
@@ -74,7 +74,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROACH",
+    "id": "GROUP_ROACH",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_large_cockroach", "weight": 975, "cost_multiplier": 0 },
@@ -84,7 +84,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PLAGUE_ROACH",
+    "id": "GROUP_PLAGUE_ROACH",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_skittering_plague", "weight": 975, "cost_multiplier": 0 },
@@ -94,7 +94,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIDER",
+    "id": "GROUP_SPIDER",
     "monsters": [
       { "monster": "mon_spider_web_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_spider_web", "weight": 5, "starts": "30 days" },
@@ -103,7 +103,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIDER_BASEMENT",
+    "id": "GROUP_SPIDER_BASEMENT",
     "default": "mon_spider_cellar_small",
     "//": "`monster` ignores group-level pack size, so numbers are set in mapgen",
     "monsters": [
@@ -116,7 +116,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIDER_CELLAR_GIANT",
+    "id": "GROUP_SPIDER_CELLAR_GIANT",
     "monsters": [
       { "monster": "mon_spider_cellar_giant", "weight": 5 },
       { "monster": "mon_spider_cellar_mom", "weight": 2 },
@@ -125,7 +125,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIDER_TRAPDOOR",
+    "id": "GROUP_SPIDER_TRAPDOOR",
     "monsters": [
       { "monster": "mon_spider_trapdoor_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_spider_trapdoor_giant", "weight": 5, "starts": "30 days" },
@@ -134,7 +134,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIDER_WIDOW",
+    "id": "GROUP_SPIDER_WIDOW",
     "monsters": [
       { "monster": "mon_spider_widow_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_spider_widow_giant", "weight": 5, "starts": "30 days" },
@@ -143,7 +143,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIDER_WOLF",
+    "id": "GROUP_SPIDER_WOLF",
     "monsters": [
       { "monster": "mon_spider_wolf_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_spider_wolf_giant", "weight": 5, "starts": "30 days" },
@@ -152,7 +152,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIDER_JUMPING",
+    "id": "GROUP_SPIDER_JUMPING",
     "monsters": [
       { "monster": "mon_spider_jumping_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_spider_jumping_giant", "weight": 5, "starts": "30 days" },
@@ -160,7 +160,7 @@
     ]
   },
   {
-    "name": "GROUP_WASP_NEST",
+    "id": "GROUP_WASP_NEST",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_wasp_small", "weight": 500, "ends": "180 hours", "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
@@ -217,7 +217,7 @@
     ]
   },
   {
-    "name": "GROUP_WASP_FORAGER",
+    "id": "GROUP_WASP_FORAGER",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_wasp_small", "weight": 1000, "ends": "180 hours", "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
@@ -246,7 +246,7 @@
     ]
   },
   {
-    "name": "GROUP_WASP_GUARD",
+    "id": "GROUP_WASP_GUARD",
     "type": "monstergroup",
     "monsters": [
       {
@@ -280,7 +280,7 @@
     ]
   },
   {
-    "name": "GROUP_WASP_QUEEN",
+    "id": "GROUP_WASP_QUEEN",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_wasp_queen", "weight": 1000, "cost_multiplier": 50, "ends": "30 days" },
@@ -288,7 +288,7 @@
     ]
   },
   {
-    "name": "GROUP_WASP_PUPA",
+    "id": "GROUP_WASP_PUPA",
     "type": "monstergroup",
     "default": "mon_wasp",
     "monsters": [
@@ -299,7 +299,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WORM",
+    "id": "GROUP_WORM",
     "monsters": [
       { "monster": "mon_worm_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_worm", "weight": 5, "starts": "30 days" },
@@ -308,7 +308,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FLY",
+    "id": "GROUP_FLY",
     "monsters": [
       { "monster": "mon_fly_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_fly", "weight": 5, "starts": "30 days" },
@@ -317,7 +317,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MOSQUITO",
+    "id": "GROUP_MOSQUITO",
     "monsters": [
       { "monster": "mon_mosquito_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_mosquito_giant", "weight": 5, "starts": "30 days" },
@@ -326,7 +326,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GRASSHOPPER",
+    "id": "GROUP_GRASSHOPPER",
     "monsters": [
       { "monster": "mon_grasshopper_small", "ends": "45 days" },
       { "monster": "mon_grasshopper_giant", "starts": "30 days" }
@@ -334,7 +334,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LOCUST",
+    "id": "GROUP_LOCUST",
     "monsters": [
       { "monster": "mon_locust_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_locust", "weight": 5, "starts": "30 days" },
@@ -343,12 +343,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WATER_STRIDER",
+    "id": "GROUP_WATER_STRIDER",
     "monsters": [ { "monster": "mon_strider_small", "ends": "45 days" }, { "monster": "mon_strider_giant", "starts": "30 days" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PRAYING_MANTIS",
+    "id": "GROUP_PRAYING_MANTIS",
     "monsters": [
       { "monster": "mon_mantis_small", "weight": 5, "ends": "63 days" },
       { "monster": "mon_mantis_giant", "weight": 5, "starts": "42 days" },
@@ -357,17 +357,17 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_APHID",
+    "id": "GROUP_APHID",
     "monsters": [ { "monster": "mon_aphid_small", "ends": "45 days" }, { "monster": "mon_aphid", "starts": "30 days" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LADY_BUG",
+    "id": "GROUP_LADY_BUG",
     "monsters": [ { "monster": "mon_lady_bug", "ends": "63 days" }, { "monster": "mon_lady_bug_giant", "starts": "42 days" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CENTIPEDE",
+    "id": "GROUP_CENTIPEDE",
     "monsters": [
       { "monster": "mon_centipede_small", "weight": 30, "ends": "45 days" },
       { "monster": "mon_centipede_giant", "weight": 22, "starts": "30 days", "ends": "72 days" },
@@ -378,7 +378,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_STAG_BEETLE",
+    "id": "GROUP_STAG_BEETLE",
     "monsters": [
       { "monster": "mon_stag_beetle_small", "weight": 5, "ends": "90 days" },
       { "monster": "mon_stag_beetle_giant", "weight": 5, "starts": "60 days" },
@@ -387,7 +387,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BUTTERFLY",
+    "id": "GROUP_BUTTERFLY",
     "monsters": [
       { "monster": "mon_butterfly", "weight": 5, "ends": "45 days" },
       { "monster": "mon_butterfly_giant", "weight": 5, "starts": "30 days" },
@@ -396,7 +396,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MOTH",
+    "id": "GROUP_MOTH",
     "monsters": [
       { "monster": "mon_moth", "weight": 5, "ends": "45 days" },
       { "monster": "mon_moth_giant", "weight": 5, "starts": "30 days" },
@@ -405,7 +405,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SNAIL",
+    "id": "GROUP_SNAIL",
     "monsters": [
       { "monster": "mon_snail_forest", "weight": 5, "ends": "45 days" },
       { "monster": "mon_snail_small", "weight": 5, "starts": "30 days" },
@@ -414,7 +414,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SLUG",
+    "id": "GROUP_SLUG",
     "monsters": [
       { "monster": "mon_slug_forest", "weight": 5, "ends": "45 days" },
       { "monster": "mon_slug_small", "weight": 5, "starts": "30 days" },
@@ -423,17 +423,17 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MOTH_FLY",
+    "id": "GROUP_MOTH_FLY",
     "monsters": [ { "monster": "mon_moth_fly_small", "ends": "45 days" }, { "monster": "mon_moth_fly", "starts": "30 days" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SILVERFISH",
+    "id": "GROUP_SILVERFISH",
     "monsters": [ { "monster": "mon_silverfish_small", "ends": "45 days" }, { "monster": "mon_silverfish", "starts": "30 days" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CENTIPEDE_HOUSE",
+    "id": "GROUP_CENTIPEDE_HOUSE",
     "monsters": [
       { "monster": "mon_centipede_house_small", "ends": "45 days" },
       { "monster": "mon_centipede_house", "starts": "30 days" }
@@ -441,7 +441,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BUGS_SUBTERRANEAN",
+    "id": "GROUP_BUGS_SUBTERRANEAN",
     "//": "Invertebrate friends that like dark and moist places.  Put them in basements, subways, sewers, etc.",
     "monsters": [
       { "group": "GROUP_FLY", "weight": 25 },
@@ -457,12 +457,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CENTIPEDE_MOM_SUMMON",
+    "id": "GROUP_CENTIPEDE_MOM_SUMMON",
     "monsters": [ { "monster": "mon_centipede_small", "weight": 67 }, { "monster": "mon_centipede_larva", "weight": 33 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIDER_MOM_SUMMON",
+    "id": "GROUP_SPIDER_MOM_SUMMON",
     "monsters": [ { "monster": "mon_spider_cellar_small", "weight": 67 }, { "monster": "mon_spider_cellar_giant_s", "weight": 33 } ]
   }
 ]

--- a/data/json/monstergroups/exodii.json
+++ b/data/json/monstergroups/exodii.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_Exodii_Stowaway",
+    "id": "GROUP_Exodii_Stowaway",
     "//": "An enemy that caught an interdimensional ride along with an Exodii.",
     "monsters": [
       { "monster": "mon_zomborg", "weight": 850 },
@@ -11,7 +11,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_Exodii_Scout_Small",
+    "id": "GROUP_Exodii_Scout_Small",
     "//": "A small Exodii scouting unit or party.",
     "monsters": [
       { "monster": "mon_exodii_quad", "weight": 800 },

--- a/data/json/monstergroups/fish.json
+++ b/data/json/monstergroups/fish.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_FISH",
+    "id": "GROUP_FISH",
     "default": "mon_fish_whitefish",
     "is_animal": true,
     "monsters": [
@@ -273,7 +273,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_STOCKED_POND",
+    "id": "GROUP_STOCKED_POND",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_fish_rainbow_trout", "weight": 50, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
@@ -312,7 +312,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RAZORCLAW",
+    "id": "GROUP_RAZORCLAW",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_razorclaw", "weight": 667, "cost_multiplier": 0 },
@@ -321,7 +321,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CRAYFISH",
+    "id": "GROUP_CRAYFISH",
     "monsters": [
       { "monster": "mon_crayfish_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_giant_crayfish", "weight": 5, "starts": "30 days" },

--- a/data/json/monstergroups/fungi.json
+++ b/data/json/monstergroups/fungi.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI",
+    "id": "GROUP_FUNGI",
     "default": "mon_spore",
     "monsters": [
       { "monster": "mon_spore", "weight": 200, "cost_multiplier": 0 },
@@ -18,7 +18,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_FUNGALOID",
+    "id": "GROUP_FUNGI_FUNGALOID",
     "monsters": [
       { "monster": "mon_fungaloid", "weight": 500, "cost_multiplier": 0 },
       { "monster": "mon_fungaloid_shambler", "weight": 250, "cost_multiplier": 0 },
@@ -28,7 +28,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_TOWER",
+    "id": "GROUP_FUNGI_TOWER",
     "monsters": [
       { "monster": "mon_fungal_tendril", "weight": 755, "cost_multiplier": 0 },
       { "monster": "mon_fungaloid", "weight": 10, "cost_multiplier": 0 },
@@ -44,7 +44,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_FLOWERS",
+    "id": "GROUP_FUNGI_FLOWERS",
     "monsters": [
       { "monster": "mon_fungal_blossom", "weight": 680, "cost_multiplier": 0 },
       { "monster": "mon_fungaloid", "weight": 20, "cost_multiplier": 0 },
@@ -59,7 +59,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_ZOMBIE",
+    "id": "GROUP_FUNGI_ZOMBIE",
     "monsters": [
       { "monster": "mon_fungal_blossom", "weight": 200, "cost_multiplier": 0 },
       { "monster": "mon_fungaloid", "weight": 100, "cost_multiplier": 0 },

--- a/data/json/monstergroups/kraken.json
+++ b/data/json/monstergroups/kraken.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_KRAKEN",
+    "id": "GROUP_KRAKEN",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_octupus_stalker_spawn", "weight": 40, "cost_multiplier": 0 },
@@ -12,7 +12,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_KRAKEN_SURFACE",
+    "id": "GROUP_KRAKEN_SURFACE",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_kraken_guard", "weight": 90, "cost_multiplier": 5 },

--- a/data/json/monstergroups/lab.json
+++ b/data/json/monstergroups/lab.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_CENTRAL_LAB",
+    "id": "GROUP_CENTRAL_LAB",
     "default": "mon_zombie_scientist",
     "monsters": [
       { "monster": "mon_zombie_scientist", "weight": 150, "cost_multiplier": 0 },
@@ -27,7 +27,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB",
+    "id": "GROUP_LAB",
     "default": "mon_zombie_scientist",
     "monsters": [
       { "monster": "mon_blob_small", "weight": 25, "cost_multiplier": 0, "pack_size": [ 1, 4 ] },
@@ -63,7 +63,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_SURFACE",
+    "id": "GROUP_LAB_SURFACE",
     "default": "mon_zombie_scientist",
     "monsters": [
       { "monster": "mon_feral_labsecurity_9mm", "weight": 18, "cost_multiplier": 8 },
@@ -98,7 +98,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_SECURITY",
+    "id": "GROUP_LAB_SECURITY",
     "default": "mon_zombie_labsecurity",
     "monsters": [
       { "monster": "mon_feral_labsecurity_9mm", "weight": 22, "cost_multiplier": 8 },
@@ -121,7 +121,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_FEMA",
+    "id": "GROUP_LAB_FEMA",
     "default": "mon_zombie_scientist",
     "//": "Mostly scientists, lab personnel and regular zombies.",
     "monsters": [
@@ -145,11 +145,11 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_CYBORG",
+    "id": "GROUP_LAB_CYBORG",
     "monsters": [ { "monster": "mon_prototype_cyborg", "weight": 400, "cost_multiplier": 0 } ]
   },
   {
-    "name": "GROUP_LAB_MUTANT_BOSS",
+    "id": "GROUP_LAB_MUTANT_BOSS",
     "type": "monstergroup",
     "default": "mon_mutant_evolved",
     "monsters": [
@@ -162,7 +162,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MICROLAB",
+    "id": "GROUP_MICROLAB",
     "monsters": [
       { "monster": "mon_blob_small", "weight": 40, "cost_multiplier": 0, "pack_size": [ 3, 6 ] },
       { "monster": "mon_feral_labsecurity_9mm", "weight": 18, "cost_multiplier": 8 },
@@ -195,7 +195,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DISTORTED_MICROLAB",
+    "id": "GROUP_DISTORTED_MICROLAB",
     "default": "mon_zombie_scientist",
     "monsters": [
       { "monster": "mon_zombie_phase_skulker", "weight": 100, "cost_multiplier": 0, "pack_size": [ 2, 3 ] },
@@ -216,7 +216,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MEATLAB",
+    "id": "GROUP_MEATLAB",
     "monsters": [
       { "monster": "mon_null", "weight": 9 },
       { "monster": "mon_amalgamation_swarmer", "weight": 5, "pack_size": [ 1, 2 ] },
@@ -232,7 +232,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_BASIC_SECURITY",
+    "id": "GROUP_LAB_BASIC_SECURITY",
     "monsters": [
       { "monster": "mon_feral_labsecurity_9mm", "weight": 18, "cost_multiplier": 12 },
       { "monster": "mon_feral_labsecurity_flashlight", "weight": 18, "cost_multiplier": 2, "pack_size": [ 1, 2 ] },
@@ -250,7 +250,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_MILITARY",
+    "id": "GROUP_LAB_MILITARY",
     "monsters": [
       { "monster": "mon_feral_labsecurity_9mm", "weight": 12, "cost_multiplier": 8 },
       { "monster": "mon_feral_labsecurity_flashlight", "weight": 12, "cost_multiplier": 2 },
@@ -263,7 +263,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_MAINTENANCE",
+    "id": "GROUP_LAB_MAINTENANCE",
     "monsters": [
       { "monster": "mon_zombie_technician", "weight": 819 },
       { "monster": "mon_feral_human_tool", "weight": 25 },
@@ -282,7 +282,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_RESEARCHERS",
+    "id": "GROUP_LAB_RESEARCHERS",
     "monsters": [
       { "monster": "mon_zombie_technician", "weight": 5, "cost_multiplier": 5 },
       { "monster": "mon_feral_human_tool", "weight": 1, "cost_multiplier": 5 },
@@ -300,7 +300,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_HOSPITAL",
+    "id": "GROUP_LAB_HOSPITAL",
     "monsters": [
       { "monster": "mon_zombie_medical", "weight": 20, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "monster": "mon_zombie_medical_brute", "weight": 10, "cost_multiplier": 3 },
@@ -318,7 +318,7 @@
     ]
   },
   {
-    "name": "GROUP_RATKIN_LAB",
+    "id": "GROUP_RATKIN_LAB",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_lab_ratkin", "weight": 250, "pack_size": [ 2, 6 ] },

--- a/data/json/monstergroups/mammal.json
+++ b/data/json/monstergroups/mammal.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_COWS_DAIRY",
+    "id": "GROUP_COWS_DAIRY",
     "type": "monstergroup",
     "is_safe": true,
     "monsters": [
@@ -12,7 +12,7 @@
     ]
   },
   {
-    "name": "GROUP_COWS",
+    "id": "GROUP_COWS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_cow", "weight": 150, "cost_multiplier": 2 },
@@ -21,7 +21,7 @@
     ]
   },
   {
-    "name": "GROUP_BEARS",
+    "id": "GROUP_BEARS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_bear", "weight": 150, "cost_multiplier": 2 },
@@ -30,7 +30,7 @@
     ]
   },
   {
-    "name": "GROUP_BOARS",
+    "id": "GROUP_BOARS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_boar_wild", "weight": 150, "cost_multiplier": 2 },
@@ -39,7 +39,7 @@
     ]
   },
   {
-    "name": "GROUP_PIGS",
+    "id": "GROUP_PIGS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_pig", "weight": 150, "cost_multiplier": 2 },
@@ -48,7 +48,7 @@
     ]
   },
   {
-    "name": "GROUP_SHEEPS",
+    "id": "GROUP_SHEEPS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_sheep", "weight": 150, "cost_multiplier": 2 },
@@ -57,7 +57,7 @@
     ]
   },
   {
-    "name": "GROUP_DEERS",
+    "id": "GROUP_DEERS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_deer", "weight": 150, "cost_multiplier": 2 },
@@ -66,7 +66,7 @@
     ]
   },
   {
-    "name": "GROUP_REINDEERS",
+    "id": "GROUP_REINDEERS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_reindeer", "weight": 150, "cost_multiplier": 2 },
@@ -87,7 +87,7 @@
     ]
   },
   {
-    "name": "GROUP_DEER_MUT_SPIDERS",
+    "id": "GROUP_DEER_MUT_SPIDERS",
     "type": "monstergroup",
     "//": "Mutant deer are better prepared to protect/escape with their spawn than normal deer, so, contrary to normal wildlife, their spawn becomes more common as time goes on.",
     "monsters": [
@@ -107,7 +107,7 @@
     ]
   },
   {
-    "name": "GROUP_WOLFS",
+    "id": "GROUP_WOLFS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_wolf", "weight": 150, "cost_multiplier": 2 },
@@ -128,7 +128,7 @@
     ]
   },
   {
-    "name": "GROUP_COUGARS",
+    "id": "GROUP_COUGARS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_cougar", "weight": 150, "cost_multiplier": 2 },
@@ -149,7 +149,7 @@
     ]
   },
   {
-    "name": "GROUP_HORSES",
+    "id": "GROUP_HORSES",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_horse", "weight": 150, "cost_multiplier": 2 },
@@ -158,12 +158,12 @@
     ]
   },
   {
-    "name": "GROUP_HORSES_STABLES",
+    "id": "GROUP_HORSES_STABLES",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_null", "weight": 50 }, { "group": "GROUP_HORSES", "weight": 50, "ends": "14 days" } ]
   },
   {
-    "name": "GROUP_MOOSE",
+    "id": "GROUP_MOOSE",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_MOOSE_NORMAL", "weight": 19 },
@@ -171,7 +171,7 @@
     ]
   },
   {
-    "name": "GROUP_MOOSE_NORMAL",
+    "id": "GROUP_MOOSE_NORMAL",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_moose", "weight": 150, "cost_multiplier": 2 },
@@ -180,7 +180,7 @@
     ]
   },
   {
-    "name": "GROUP_TUSKED_MOOSE",
+    "id": "GROUP_TUSKED_MOOSE",
     "type": "monstergroup",
     "//": "Same as mutant deer.",
     "monsters": [
@@ -190,7 +190,7 @@
     ]
   },
   {
-    "name": "GROUP_COYOTE",
+    "id": "GROUP_COYOTE",
     "type": "monstergroup",
     "//": "Not doing the whole weird thing with timers and weight halving for babies as the groups above me did. I have no idea what's that hoping to accomplish and nobody else seems to either.",
     "monsters": [
@@ -200,7 +200,7 @@
     ]
   },
   {
-    "name": "GROUP_BEAVER",
+    "id": "GROUP_BEAVER",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_beaver", "weight": 38 },
@@ -209,7 +209,7 @@
     ]
   },
   {
-    "name": "GROUP_STRAY_DOGS",
+    "id": "GROUP_STRAY_DOGS",
     "type": "monstergroup",
     "default": "mon_dog",
     "monsters": [
@@ -221,7 +221,7 @@
     ]
   },
   {
-    "name": "GROUP_STRAY_CATS",
+    "id": "GROUP_STRAY_CATS",
     "type": "monstergroup",
     "default": "mon_cat",
     "monsters": [
@@ -232,7 +232,7 @@
     ]
   },
   {
-    "name": "GROUP_PET_DOGS",
+    "id": "GROUP_PET_DOGS",
     "type": "monstergroup",
     "default": "mon_dog",
     "monsters": [
@@ -265,7 +265,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTANT_PET_DOGS",
+    "id": "GROUP_MUTANT_PET_DOGS",
     "type": "monstergroup",
     "default": "mon_dog_mutant_mongrel",
     "monsters": [
@@ -276,7 +276,7 @@
     ]
   },
   {
-    "name": "GROUP_PET_CATS",
+    "id": "GROUP_PET_CATS",
     "type": "monstergroup",
     "default": "mon_cat",
     "//": "Both persian and sphynx cats are not really fit to survive without human assistance and will die off eventually. persians will overheat in the summer and have trouble breathing because of their flat faces and sphynx cats will freeze in the cold season.",
@@ -308,7 +308,7 @@
     ]
   },
   {
-    "name": "GROUP_PETS",
+    "id": "GROUP_PETS",
     "type": "monstergroup",
     "default": "mon_dog",
     "monsters": [
@@ -319,7 +319,7 @@
     ]
   },
   {
-    "name": "GROUP_RABBIT_WILD",
+    "id": "GROUP_RABBIT_WILD",
     "type": "monstergroup",
     "default": "mon_wild_rabbit",
     "monsters": [

--- a/data/json/monstergroups/mi-go.json
+++ b/data/json/monstergroups/mi-go.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_CAMP_OM",
+    "id": "GROUP_MI-GO_CAMP_OM",
     "//": "Mi-go raiding parties spawning in the vicinity of a mi-go camp.  Puts slavers later on and keeps large groups from spawning until the player can deal with them.",
     "monsters": [
       { "monster": "mon_mi_go", "weight": 530 },
@@ -22,7 +22,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_COMMON",
+    "id": "GROUP_MI-GO_BASE_COMMON",
     "//": "Basic mi-go base defenders.",
     "monsters": [
       { "monster": "mon_mi_go", "weight": 100, "pack_size": [ 2, 4 ] },
@@ -42,7 +42,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_CAPTORS",
+    "id": "GROUP_MI-GO_BASE_CAPTORS",
     "//": "Mi-go base defenders for rooms where captives are being held.",
     "monsters": [
       { "monster": "mon_mi_go_guard", "weight": 700 },
@@ -54,7 +54,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_BOSS",
+    "id": "GROUP_MI-GO_BASE_BOSS",
     "//": "Mi-go base defenders for major boss battles.",
     "monsters": [
       { "monster": "mon_mi_go_guard", "weight": 620 },
@@ -71,7 +71,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_SCOUT_TOWER",
+    "id": "GROUP_MI-GO_SCOUT_TOWER",
     "//": "Mi-go scout tower prisoner room.",
     "monsters": [
       { "monster": "mon_mi_go_surgeon", "weight": 100, "cost_multiplier": 3 },

--- a/data/json/monstergroups/military.json
+++ b/data/json/monstergroups/military.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_MAYBE_MIL",
+    "id": "GROUP_MAYBE_MIL",
     "//": "50% chance military zombie or robot",
     "monsters": [
       { "monster": "mon_null", "weight": 925 },
@@ -14,7 +14,7 @@
     ]
   },
   {
-    "name": "GROUP_MIL_WEAK",
+    "id": "GROUP_MIL_WEAK",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_soldier", "weight": 645 },
@@ -24,7 +24,7 @@
     ]
   },
   {
-    "name": "GROUP_MIL_STRONG",
+    "id": "GROUP_MIL_STRONG",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_soldier", "weight": 565 },
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "name": "GROUP_MIL_HELIPAD",
+    "id": "GROUP_MIL_HELIPAD",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_soldier", "weight": 645 },
@@ -47,12 +47,12 @@
     ]
   },
   {
-    "name": "GROUP_MIL_PILOT",
+    "id": "GROUP_MIL_PILOT",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_zombie_military_pilot" } ]
   },
   {
-    "name": "GROUP_MIL_PASSENGER",
+    "id": "GROUP_MIL_PASSENGER",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_soldier", "weight": 245 },
@@ -65,7 +65,7 @@
     ]
   },
   {
-    "name": "GROUP_MIL_BASE",
+    "id": "GROUP_MIL_BASE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_soldier", "weight": 580 },
@@ -84,7 +84,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MIL_BASE_CIVILIAN",
+    "id": "GROUP_MIL_BASE_CIVILIAN",
     "//": "Civilians with soldiers and burned ones.",
     "monsters": [
       { "monster": "mon_zombie", "weight": 415 },
@@ -122,7 +122,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MIL_BASE_HOSPITAL",
+    "id": "GROUP_MIL_BASE_HOSPITAL",
     "//": "Civilians with soldiers, doctors and burned ones. More hazmat.",
     "monsters": [
       { "monster": "mon_zombie", "weight": 50, "cost_multiplier": 2 },
@@ -160,7 +160,7 @@
     ]
   },
   {
-    "name": "GROUP_AIRCRAFT_CARRIER",
+    "id": "GROUP_AIRCRAFT_CARRIER",
     "type": "monstergroup",
     "//": "no children, 40% tech personel 20% civilian personel (med, fire, cook, clercs etc), 20% uniformed zombie, 10% army pilots, and 10% military zeds",
     "monsters": [
@@ -190,7 +190,7 @@
     ]
   },
   {
-    "name": "GROUP_AIRCRAFT_CARRIER_TECHNICIANS",
+    "id": "GROUP_AIRCRAFT_CARRIER_TECHNICIANS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_technician", "weight": 67 },
@@ -209,7 +209,7 @@
     ]
   },
   {
-    "name": "GROUP_MIL_MASS_GRAVE",
+    "id": "GROUP_MIL_MASS_GRAVE",
     "type": "monstergroup",
     "//": "Lots of hazmats.",
     "monsters": [ { "monster": "mon_zombie_soldier", "weight": 10 }, { "monster": "mon_zombie_hazmat", "weight": 20 } ]

--- a/data/json/monstergroups/misc.json
+++ b/data/json/monstergroups/misc.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_NULL",
+    "id": "GROUP_NULL",
     "is_safe": true,
     "monsters": [ { "monster": "mon_null" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BLACK_ROAD",
+    "id": "GROUP_BLACK_ROAD",
     "monsters": [
       { "monster": "mon_zombie", "weight": 407 },
       { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 7, "pack_size": [ 5, 20 ] },
@@ -62,7 +62,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MANSION_START",
+    "id": "GROUP_MANSION_START",
     "//": "Nonsense ferals for the mansion escape challenge scenario, shouldn't be used for general spawns",
     "monsters": [
       { "group": "GROUP_MANSION_PURSUERS", "weight": 1600 },
@@ -72,7 +72,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MANSION_PURSUERS",
+    "id": "GROUP_MANSION_PURSUERS",
     "monsters": [
       { "monster": "mon_feral_maid_broom", "weight": 600 },
       { "monster": "mon_feral_maid_candlestick", "weight": 600 },
@@ -81,12 +81,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MANSION_ARMORED",
+    "id": "GROUP_MANSION_ARMORED",
     "monsters": [ { "monster": "mon_feral_armored_mace", "weight": 100 }, { "monster": "mon_feral_armored_battleaxe", "weight": 100 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CHUD",
+    "id": "GROUP_CHUD",
     "monsters": [
       { "monster": "mon_chud", "weight": 875, "cost_multiplier": 0 },
       { "monster": "mon_crawler", "weight": 35, "cost_multiplier": 0 }
@@ -94,7 +94,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SUBWAY",
+    "id": "GROUP_SUBWAY",
     "//": "Z-2 subways, some lost nether things but otherwise mostly normal mobs",
     "default": "mon_silverfish_small",
     "monsters": [
@@ -127,7 +127,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SUBWAY_CITY",
+    "id": "GROUP_SUBWAY_CITY",
     "//": "Normal subway, extra spawns underneath a city",
     "default": "mon_chud",
     "monsters": [
@@ -153,7 +153,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SUBWAY_LAB",
+    "id": "GROUP_SUBWAY_LAB",
     "//": "Lower subway with eldritch nasties and lab escapees",
     "default": "mon_kreck",
     "//2": "1W 42, 1M 180, 1,5M 270, 2M 360, 3M 540, sum 930",
@@ -193,7 +193,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DOMESTIC",
+    "id": "GROUP_DOMESTIC",
     "default": "mon_dog",
     "is_animal": true,
     "monsters": [
@@ -235,7 +235,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BIRD_DOMESTIC",
+    "id": "GROUP_BIRD_DOMESTIC",
     "default": "mon_chicken",
     "is_animal": true,
     "monsters": [
@@ -248,7 +248,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BIRD_DOMESTIC_WATERFOWL",
+    "id": "GROUP_BIRD_DOMESTIC_WATERFOWL",
     "default": "mon_duck_domestic",
     "is_animal": true,
     "monsters": [
@@ -258,7 +258,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SAFE",
+    "id": "GROUP_SAFE",
     "is_safe": true,
     "is_animal": true,
     "monsters": [
@@ -306,7 +306,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BASEMENT_HOUSE",
+    "id": "GROUP_BASEMENT_HOUSE",
     "//": "60-30-10% chance of zombies/roaches/cellar spiders, no mixing enemies in the same spawn",
     "monsters": [
       { "group": "GROUP_HOUSE", "weight": 6, "pack_size": [ 2, 6 ] },
@@ -316,7 +316,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "DUMP_ANIMALS",
+    "id": "DUMP_ANIMALS",
     "monsters": [
       { "monster": "mon_null", "weight": 378 },
       { "group": "GROUP_FLY", "weight": 100 },
@@ -342,7 +342,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PEST",
+    "id": "GROUP_PEST",
     "monsters": [
       { "monster": "mon_crow", "weight": 760 },
       {
@@ -367,7 +367,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SEWER",
+    "id": "GROUP_SEWER",
     "monsters": [
       { "monster": "mon_null", "weight": 370, "cost_multiplier": 0 },
       { "monster": "mon_zombie_crawler", "weight": 75, "cost_multiplier": 0 },
@@ -382,7 +382,7 @@
     ]
   },
   {
-    "name": "GROUP_VETS",
+    "id": "GROUP_VETS",
     "type": "monstergroup",
     "//": "for veterinarian",
     "monsters": [
@@ -396,7 +396,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BUNKER",
+    "id": "GROUP_BUNKER",
     "monsters": [
       { "monster": "mon_zombie_armored", "weight": 25, "cost_multiplier": 20, "pack_size": [ 2, 6 ] },
       { "monster": "mon_zombie_soldier", "weight": 600, "cost_multiplier": 3 }
@@ -404,12 +404,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SCI",
+    "id": "GROUP_SCI",
     "monsters": [ { "monster": "mon_zombie_scientist", "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_INFESTED_SPAWN",
+    "id": "GROUP_INFESTED_SPAWN",
     "//": "For Compromised Shelter scenario.",
     "monsters": [
       { "monster": "mon_zombie", "weight": 250, "pack_size": [ 2, 3 ], "cost_multiplier": 2 },
@@ -422,7 +422,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_YOUR_FEARS",
+    "id": "GROUP_YOUR_FEARS",
     "//": "For monsters, spawned by hallucinator effects.  Must represent the awful monsters the player want never see.  Put here every asshole you want.",
     "monsters": [
       { "monster": "mon_wasp_small" },
@@ -476,7 +476,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NUCLEAR_PLANT_BEASTS",
+    "id": "GROUP_NUCLEAR_PLANT_BEASTS",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_bat", "weight": 600, "cost_multiplier": 5, "pack_size": [ 6, 32 ] },
@@ -495,18 +495,18 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BEEKEEPER",
+    "id": "GROUP_BEEKEEPER",
     "monsters": [ { "monster": "mon_beekeeper", "cost_multiplier": 0 } ]
   },
   {
-    "name": "GROUP_RATTLESNAKE",
+    "id": "GROUP_RATTLESNAKE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_rattlesnake", "weight": 19 }, { "monster": "mon_rattlesnake_big", "weight": 1 } ],
     "//": "Normally for the time until mutants start spawning we take the growth time of a mutant baby with default evolution rates. But because rattlesnakes follow the mutation logic of invertebrates, we assume there were some mildly oversized variations at the start of the Cataclysm already."
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAMP_HUNTING",
+    "id": "GROUP_CAMP_HUNTING",
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//2": "This group always has a chance of being the result, regardless of mission type.",
     "monsters": [
@@ -521,7 +521,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAMP_TRAPPING",
+    "id": "GROUP_CAMP_TRAPPING",
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//2": "This group can only be picked from when the trapping mission is used, in addition to GROUP_CAMP_HUNTING.",
     "monsters": [
@@ -540,7 +540,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAMP_HUNTING_LARGE",
+    "id": "GROUP_CAMP_HUNTING_LARGE",
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//2": "This group can only be picked from when the hunt large animals mission is used, in addition to GROUP_CAMP_HUNTING.",
     "monsters": [
@@ -558,7 +558,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DEBUG_EXACTLY_ONE",
+    "id": "GROUP_DEBUG_EXACTLY_ONE",
     "//": "Hardcoded reference in debug() (debug_menu.cpp). Used for debugging, duh.",
     "monsters": [ { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 1, "pack_size": [ 1, 1 ] } ]
   }

--- a/data/json/monstergroups/missions.json
+++ b/data/json/monstergroups/missions.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_REFUGEE_BOSS_ZOMBIE",
+    "id": "GROUP_REFUGEE_BOSS_ZOMBIE",
     "default": "mon_zombie_tough",
     "//": "The refugee center mission 1 enemy is chosen from here",
     "monsters": [

--- a/data/json/monstergroups/mutant_upgrades.json
+++ b/data/json/monstergroups/mutant_upgrades.json
@@ -1,19 +1,19 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_CROW_MUTANT",
+    "id": "GROUP_CROW_MUTANT",
     "monsters": [
       { "monster": "mon_crow_mutant_small", "weight": 650 },
       { "monster": "mon_crow_mutant", "weight": 350, "cost_multiplier": 2 }
     ]
   },
   {
-    "name": "GROUP_CENTIPEDE_ADULT",
+    "id": "GROUP_CENTIPEDE_ADULT",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_centipede_giant", "weight": 9 }, { "monster": "mon_centipede_mom", "weight": 1 } ]
   },
   {
-    "name": "GROUP_CENTIPEDE_GIANT",
+    "id": "GROUP_CENTIPEDE_GIANT",
     "type": "monstergroup",
     "default": "mon_centipede_mom",
     "monsters": [
@@ -23,7 +23,7 @@
     ]
   },
   {
-    "name": "GROUP_CENTIPEDE_MOM",
+    "id": "GROUP_CENTIPEDE_MOM",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_centipede_giant", "weight": 65 },
@@ -32,7 +32,7 @@
     ]
   },
   {
-    "name": "GROUP_MUTANT_EVOLVED",
+    "id": "GROUP_MUTANT_EVOLVED",
     "type": "monstergroup",
     "default": "mon_mutant_evolved",
     "monsters": [
@@ -46,7 +46,7 @@
     ]
   },
   {
-    "name": "GROUP_RATKIN_EVOLVED",
+    "id": "GROUP_RATKIN_EVOLVED",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zap_rat", "weight": 300 },

--- a/data/json/monstergroups/mutant_vertebrate_reproduction.json
+++ b/data/json/monstergroups/mutant_vertebrate_reproduction.json
@@ -1,11 +1,11 @@
 [
   {
-    "name": "REPRODUCTION_MUT_MOOSE",
+    "id": "REPRODUCTION_MUT_MOOSE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_moose_calf", "weight": 19 }, { "monster": "mon_tusked_moose_calf", "weight": 1 } ]
   },
   {
-    "name": "REPRODUCTION_MUT_COYOTE",
+    "id": "REPRODUCTION_MUT_COYOTE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_coyote_pup", "weight": 38 },
@@ -14,7 +14,7 @@
     ]
   },
   {
-    "name": "REPRODUCTION_MUT_BEAVER",
+    "id": "REPRODUCTION_MUT_BEAVER",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_beaver_kit", "weight": 38 },
@@ -23,7 +23,7 @@
     ]
   },
   {
-    "name": "REPRODUCTION_MUT_RATTLESNAKE",
+    "id": "REPRODUCTION_MUT_RATTLESNAKE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_rattlesnake_s", "weight": 19 }, { "monster": "mon_rattlesnake_big_s", "weight": 1 } ]
   }

--- a/data/json/monstergroups/nether.json
+++ b/data/json/monstergroups/nether.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_BREATHER",
+    "id": "GROUP_BREATHER",
     "monsters": [
       { "monster": "mon_breather", "weight": 990 },
       { "monster": "mon_breather", "weight": 10, "cost_multiplier": 2, "pack_size": [ 2, 4 ] }
@@ -9,22 +9,22 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BREATHER_HUB",
+    "id": "GROUP_BREATHER_HUB",
     "monsters": [ { "monster": "mon_breather_hub" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CHURCH_BLANK",
+    "id": "GROUP_CHURCH_BLANK",
     "monsters": [ { "monster": "mon_blank", "cost_multiplier": 0 } ]
   },
   {
-    "name": "GROUP_DARK_WYRM",
+    "id": "GROUP_DARK_WYRM",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_dark_wyrm" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_REALITY_TEAR_FIELD",
+    "id": "GROUP_NETHER_REALITY_TEAR_FIELD",
     "default": "mon_blank",
     "monsters": [
       { "monster": "mon_flying_polyp", "weight": 100, "cost_multiplier": 0 },
@@ -42,7 +42,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER",
+    "id": "GROUP_NETHER",
     "default": "mon_blank",
     "monsters": [
       { "monster": "mon_blank", "weight": 135, "cost_multiplier": 0 },
@@ -61,7 +61,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_CAPTURED",
+    "id": "GROUP_NETHER_CAPTURED",
     "default": "mon_gracke",
     "monsters": [
       { "monster": "mon_gelatin", "weight": 250, "cost_multiplier": 0 },
@@ -73,7 +73,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_UNVIABLE",
+    "id": "GROUP_NETHER_UNVIABLE",
     "default": "mon_nether_unviable_bug",
     "monsters": [
       { "monster": "mon_nether_unviable_bug", "weight": 4, "cost_multiplier": 0, "pack_size": [ 2, 6 ] },
@@ -85,7 +85,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_PORTAL",
+    "id": "GROUP_NETHER_PORTAL",
     "default": "mon_gracke",
     "monsters": [
       { "monster": "mon_gelatin", "weight": 200, "cost_multiplier": 0 },
@@ -99,7 +99,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIRAL",
+    "id": "GROUP_SPIRAL",
     "monsters": [
       { "monster": "mon_human_snail", "weight": 740, "cost_multiplier": 0 },
       { "monster": "mon_twisted_body", "weight": 180, "cost_multiplier": 0 },
@@ -108,12 +108,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TINDALOS",
+    "id": "GROUP_TINDALOS",
     "monsters": [ { "monster": "mon_hound_tindalos" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_CORPSE",
+    "id": "GROUP_NETHER_CORPSE",
     "default": "mon_gracke",
     "monsters": [
       { "monster": "mon_gelatin", "weight": 100, "cost_multiplier": 0 },
@@ -130,7 +130,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_CORPSE_PORTAL",
+    "id": "GROUP_NETHER_CORPSE_PORTAL",
     "default": "mon_gracke",
     "monsters": [
       { "monster": "mon_gelatin", "weight": 70, "cost_multiplier": 0 },
@@ -146,7 +146,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_CORPSE_TENTACLES",
+    "id": "GROUP_NETHER_CORPSE_TENTACLES",
     "monsters": [
       { "monster": "mon_hanging_roper", "weight": 200, "cost_multiplier": 0 },
       { "monster": "mon_nether_spearfisher", "weight": 150, "cost_multiplier": 0 },
@@ -156,7 +156,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_CORPSE_BOWELS",
+    "id": "GROUP_NETHER_CORPSE_BOWELS",
     "monsters": [
       { "monster": "mon_nether_spearfisher", "weight": 150, "cost_multiplier": 0 },
       { "monster": "mon_nether_fish", "weight": 300, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },

--- a/data/json/monstergroups/resort.json
+++ b/data/json/monstergroups/resort.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_RESORT_DANCERS",
+    "id": "GROUP_RESORT_DANCERS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_resort_dancer", "weight": 775 },
@@ -10,7 +10,7 @@
     ]
   },
   {
-    "name": "GROUP_RESORT_MIXED",
+    "id": "GROUP_RESORT_MIXED",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_resort_dancer", "weight": 10, "cost_multiplier": 2, "pack_size": [ 1, 3 ] },
@@ -25,7 +25,7 @@
     ]
   },
   {
-    "name": "GROUP_RESORT_MIXED_STAFF",
+    "id": "GROUP_RESORT_MIXED_STAFF",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie", "weight": 890 },
@@ -35,7 +35,7 @@
     ]
   },
   {
-    "name": "GROUP_RESORT_STAFF",
+    "id": "GROUP_RESORT_STAFF",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie", "weight": 800 },
@@ -43,7 +43,7 @@
     ]
   },
   {
-    "name": "GROUP_RESORT_BOUNCER",
+    "id": "GROUP_RESORT_BOUNCER",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie", "weight": 800 },

--- a/data/json/monstergroups/robots.json
+++ b/data/json/monstergroups/robots.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ROBOT",
+    "id": "GROUP_ROBOT",
     "monsters": [
       { "monster": "mon_manhack", "weight": 515, "cost_multiplier": 0 },
       { "monster": "mon_skitterbot", "weight": 220, "cost_multiplier": 0 },
@@ -12,7 +12,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TURRET",
+    "id": "GROUP_TURRET",
     "monsters": [
       {
         "monster": "mon_turret_rifle",
@@ -29,7 +29,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROBOT_SECUBOT",
+    "id": "GROUP_ROBOT_SECUBOT",
     "monsters": [ { "monster": "mon_secubot", "cost_multiplier": 0, "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": 30 } ] } } ]
   }
 ]

--- a/data/json/monstergroups/triffid.json
+++ b/data/json/monstergroups/triffid.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID",
+    "id": "GROUP_TRIFFID",
     "default": "mon_triffid",
     "monsters": [
       { "monster": "mon_triffid_sprig", "weight": 200, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
@@ -19,7 +19,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_OUTER",
+    "id": "GROUP_TRIFFID_OUTER",
     "default": "mon_triffid",
     "monsters": [
       { "monster": "mon_triffid_sprig", "weight": 80, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
@@ -36,7 +36,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_HEARTGUARDS",
+    "id": "GROUP_TRIFFID_HEARTGUARDS",
     "default": "mon_triffid",
     "monsters": [
       { "monster": "mon_triffid", "weight": 280, "cost_multiplier": 0 },
@@ -47,7 +47,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_HEART",
+    "id": "GROUP_TRIFFID_HEART",
     "monsters": [ { "monster": "mon_triffid_heart" } ]
   }
 ]

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_CAVE",
+    "id": "GROUP_CAVE",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_bat", "weight": 600, "pack_size": [ 2, 5 ] },
@@ -17,7 +17,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -127,7 +127,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_MAMMAL",
+    "id": "GROUP_WILDERNESS_FOREST_MAMMAL",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -158,7 +158,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_MAMMAL_WINTER",
+    "id": "GROUP_WILDERNESS_FOREST_MAMMAL_WINTER",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -175,7 +175,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_MAMMAL_MUTANT",
+    "id": "GROUP_WILDERNESS_FOREST_MAMMAL_MUTANT",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -185,7 +185,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_BIRD",
+    "id": "GROUP_WILDERNESS_FOREST_BIRD",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -218,7 +218,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_REPTILE",
+    "id": "GROUP_WILDERNESS_FOREST_REPTILE",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -230,7 +230,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_INSECT_HARMLESS",
+    "id": "GROUP_WILDERNESS_FOREST_INSECT_HARMLESS",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -241,7 +241,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_INSECT",
+    "id": "GROUP_WILDERNESS_FOREST_INSECT",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -265,7 +265,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_ZOMBIE",
+    "id": "GROUP_WILDERNESS_FOREST_ZOMBIE",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -280,7 +280,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RIVER",
+    "id": "GROUP_RIVER",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -394,7 +394,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_OCEAN_SHORE",
+    "id": "GROUP_OCEAN_SHORE",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -412,7 +412,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_OCEAN_DEEP",
+    "id": "GROUP_OCEAN_DEEP",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -434,7 +434,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SWAMP",
+    "id": "GROUP_SWAMP",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -479,7 +479,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FRESHWATER_REPTILE",
+    "id": "GROUP_WILDERNESS_FRESHWATER_REPTILE",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -489,7 +489,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_SWAMP_INSECT",
+    "id": "GROUP_WILDERNESS_SWAMP_INSECT",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -504,7 +504,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PARK_ANIMAL",
+    "id": "GROUP_PARK_ANIMAL",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_crow", "weight": 50, "cost_multiplier": 0 },
@@ -536,7 +536,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROOF_ANIMAL",
+    "id": "GROUP_ROOF_ANIMAL",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_crow", "weight": 45, "cost_multiplier": 0 },
@@ -576,7 +576,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_POND_ANIMAL",
+    "id": "GROUP_POND_ANIMAL",
     "is_animal": true,
     "monsters": [
       { "group": "GROUP_RABBIT_WILD", "weight": 50, "cost_multiplier": 0 },
@@ -593,7 +593,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_POND_BIRD",
+    "id": "GROUP_POND_BIRD",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_duck", "weight": 50, "cost_multiplier": 0 },
@@ -607,7 +607,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_POND_FISH",
+    "id": "GROUP_POND_FISH",
     "is_animal": true,
     "monsters": [
       { "group": "GROUP_POND_FISH_2", "weight": 200, "cost_multiplier": 0 },
@@ -618,7 +618,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_POND_FISH_2",
+    "id": "GROUP_POND_FISH_2",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_fish_bluegill", "weight": 50, "cost_multiplier": 0 },
@@ -629,7 +629,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BIRDFEEDER",
+    "id": "GROUP_BIRDFEEDER",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_bluejay", "weight": 50, "cost_multiplier": 0 },
@@ -645,7 +645,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_STREAM",
+    "id": "GROUP_STREAM",
     "is_animal": true,
     "monsters": [
       { "group": "GROUP_STREAM_SMALL", "weight": 30 },
@@ -657,7 +657,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_STREAM_DOMESTIC",
+    "id": "GROUP_STREAM_DOMESTIC",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_goat", "weight": 1, "pack_size": [ 1, 4 ] },
@@ -666,7 +666,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_STREAM_BIRDS",
+    "id": "GROUP_STREAM_BIRDS",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_duck", "weight": 20, "pack_size": [ 1, 4 ], "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
@@ -678,7 +678,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_STREAM_SMALL",
+    "id": "GROUP_STREAM_SMALL",
     "is_animal": true,
     "monsters": [
       {

--- a/data/json/monstergroups/zanimal_upgrades.json
+++ b/data/json/monstergroups/zanimal_upgrades.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_DOG_UPGRADE",
+    "id": "GROUP_ZOMBIE_DOG_UPGRADE",
     "//": "No bionics or fungal",
     "monsters": [
       { "monster": "mon_dog_skeleton", "weight": 340, "cost_multiplier": 5 },
@@ -13,7 +13,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_PIG_UPGRADE",
+    "id": "GROUP_ZOMBIE_PIG_UPGRADE",
     "//": "No bionics or fungal",
     "monsters": [
       { "monster": "mon_zpig_brute", "weight": 45, "cost_multiplier": 2 },
@@ -22,7 +22,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOLF_UPGRADE",
+    "id": "GROUP_ZOLF_UPGRADE",
     "default": "mon_wolf_skeleton",
     "//": "No bionics or fungal",
     "monsters": [
@@ -32,7 +32,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_HORSE_UPGRADE",
+    "id": "GROUP_ZOMBIE_HORSE_UPGRADE",
     "monsters": [
       { "monster": "mon_zombie_horse_white", "weight": 250, "cost_multiplier": 2 },
       { "monster": "mon_zombie_horse_red", "weight": 250, "cost_multiplier": 2 },
@@ -42,7 +42,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBEAR_UPGRADE",
+    "id": "GROUP_ZOMBEAR_UPGRADE",
     "default": "mon_zombear_skeleton",
     "//": "No bionics or fungal",
     "monsters": [
@@ -52,7 +52,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOOSE_UPGRADE",
+    "id": "GROUP_ZOOSE_UPGRADE",
     "default": "mon_zoose_brute",
     "monsters": [
       { "monster": "mon_zoose_brute", "weight": 500, "cost_multiplier": 15 },
@@ -61,7 +61,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOUGAR_UPGRADE",
+    "id": "GROUP_ZOUGAR_UPGRADE",
     "monsters": [
       { "monster": "mon_zougar_hunter", "weight": 600, "cost_multiplier": 4 },
       { "monster": "mon_zougar_shady", "weight": 400, "cost_multiplier": 6 }

--- a/data/json/monstergroups/zombie_amalgamations.json
+++ b/data/json/monstergroups/zombie_amalgamations.json
@@ -1,12 +1,12 @@
 [
   {
-    "name": "GROUP_COCOON_TINY",
+    "id": "GROUP_COCOON_TINY",
     "type": "monstergroup",
     "//": "All cocoon groups have a token mon_null spawn, increase its weight if they turn out to be too common",
     "monsters": [ { "monster": "mon_null", "weight": 1 }, { "monster": "mon_amalgamation_swarmer", "weight": 1, "starts": "2 days" } ]
   },
   {
-    "name": "GROUP_COCOON_SMALL",
+    "id": "GROUP_COCOON_SMALL",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_null", "weight": 1 },
@@ -16,7 +16,7 @@
     ]
   },
   {
-    "name": "GROUP_COCOON_MED_1",
+    "id": "GROUP_COCOON_MED_1",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_null", "weight": 1 },
@@ -25,7 +25,7 @@
     ]
   },
   {
-    "name": "GROUP_COCOON_MED_2",
+    "id": "GROUP_COCOON_MED_2",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_null", "weight": 1 },
@@ -34,7 +34,7 @@
     ]
   },
   {
-    "name": "GROUP_COCOON_LARGE",
+    "id": "GROUP_COCOON_LARGE",
     "type": "monstergroup",
     "//": "TODO: big amalgamation line for this (and larger) groups",
     "monsters": [
@@ -45,12 +45,12 @@
     ]
   },
   {
-    "name": "GROUP_AMALGAMATION_BREATHER_HUB_SPARSE",
+    "id": "GROUP_AMALGAMATION_BREATHER_HUB_SPARSE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_null", "weight": 9 }, { "monster": "mon_amalgamation_breather_hub" } ]
   },
   {
-    "name": "GROUP_AMALGAMATION_SMALL",
+    "id": "GROUP_AMALGAMATION_SMALL",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_amalgamation_swarmer", "weight": 3, "pack_size": [ 1, 2 ] },
@@ -60,7 +60,7 @@
     ]
   },
   {
-    "name": "GROUP_AMALGAMATION_MED",
+    "id": "GROUP_AMALGAMATION_MED",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_amalgamation_jumper", "pack_size": [ 1, 2 ], "weight": 4 },

--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_UPGRADE",
+    "id": "GROUP_ZOMBIE_UPGRADE",
     "//": "Masters pick from here when upgrading; no dogs, bionics, or profession-types.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
       { "monster": "mon_zombie_tough", "weight": 110 },
@@ -34,7 +34,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_CRAWLER_UPGRADE",
+    "id": "GROUP_ZOMBIE_CRAWLER_UPGRADE",
     "default": "mon_zombie_crawler",
     "//": "crawling zombie upgrades",
     "monsters": [
@@ -44,13 +44,13 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_BRAINLESS_UPGRADE",
+    "id": "GROUP_ZOMBIE_BRAINLESS_UPGRADE",
     "//": "No bionics or fungal",
     "monsters": [ { "monster": "mon_zombie_ears", "weight": 245 }, { "monster": "mon_afs_headless_horror", "weight": 40 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_FAT",
+    "id": "GROUP_ZOMBIE_FAT",
     "default": "mon_zombie_gasbag",
     "//": "fat zombie upgrades",
     "monsters": [
@@ -63,7 +63,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_GRAB",
+    "id": "GROUP_ZOMBIE_GRAB",
     "monsters": [
       { "monster": "mon_zombie_grappler", "weight": 960, "cost_multiplier": 0 },
       { "monster": "mon_zombie_biter", "weight": 40, "cost_multiplier": 2 }
@@ -71,7 +71,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SOLDIER_UPGRADE",
+    "id": "GROUP_SOLDIER_UPGRADE",
     "default": "mon_zombie_kevlar_0",
     "//": "Masters pick from here when upgrading.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
@@ -87,7 +87,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FIREMAN_UPGRADE",
+    "id": "GROUP_FIREMAN_UPGRADE",
     "//": "Masters pick from here when upgrading.",
     "monsters": [
       { "monster": "mon_zombie_fireproof", "weight": 250 },
@@ -97,7 +97,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MEDICAL_UPGRADE",
+    "id": "GROUP_MEDICAL_UPGRADE",
     "//": "Masters pick from here when upgrading.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
       { "monster": "mon_zombie_medical_brute", "weight": 200 },
@@ -112,7 +112,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MEDICAL_CRAWLER_UPGRADE",
+    "id": "GROUP_MEDICAL_CRAWLER_UPGRADE",
     "default": "mon_zombie_medical_pupa",
     "//": "crawling medical zombie upgrades",
     "monsters": [
@@ -122,7 +122,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_BRUTE",
+    "id": "GROUP_ZOMBIE_BRUTE",
     "default": "mon_zombie_brute",
     "//": "Brute upgrades.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
@@ -135,7 +135,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CHILD_ZOMBIE_UPGRADE",
+    "id": "GROUP_CHILD_ZOMBIE_UPGRADE",
     "default": "mon_zombie_shriekling",
     "//": "this is a sub-group of mutated zombie types that can only evolve from zombified human children.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
@@ -150,13 +150,13 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BRUTE_PUPA",
+    "id": "GROUP_BRUTE_PUPA",
     "//": "this is a sub-group of pupating zombies that can only evolve from pupating zombie brutes.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [ { "monster": "mon_hulk_pupa", "weight": 500 }, { "monster": "mon_hulk_pupa_decoy", "weight": 500 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_ELECTRIC_UPGRADE",
+    "id": "GROUP_ZOMBIE_ELECTRIC_UPGRADE",
     "//": "Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
       { "monster": "mon_zombie_nullfield", "weight": 400 },
@@ -166,7 +166,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_RAPTOR_UPGRADES",
+    "id": "GROUP_ZOMBIE_RAPTOR_UPGRADES",
     "default": "mon_spawn_raptor",
     "//": "Raptor upgrades.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
@@ -177,7 +177,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_SHADY_UPGRADES",
+    "id": "GROUP_ZOMBIE_SHADY_UPGRADES",
     "default": "mon_zombie_shady",
     "//": "Shady upgrades.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
@@ -188,7 +188,7 @@
     ]
   },
   {
-    "name": "GROUP_FERROUS_UPGRADE",
+    "id": "GROUP_FERROUS_UPGRADE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_shell", "weight": 250 },
@@ -198,7 +198,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_BOOMER_UPGRADE",
+    "id": "GROUP_ZOMBIE_BOOMER_UPGRADE",
     "default": "mon_boomer",
     "//": "Boomer upgrades.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
@@ -212,7 +212,7 @@
     ]
   },
   {
-    "name": "GROUP_SKELETON_UPGRADE",
+    "id": "GROUP_SKELETON_UPGRADE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_skeleton_slasher", "weight": 120, "cost_multiplier": 2 },
@@ -222,7 +222,7 @@
     ]
   },
   {
-    "name": "GROUP_ZOMBIE_MINER_UPGRADE",
+    "id": "GROUP_ZOMBIE_MINER_UPGRADE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_shady", "weight": 150 },

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_PARK_SCENIC",
+    "id": "GROUP_PARK_SCENIC",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100, "cost_multiplier": 0 },
@@ -17,12 +17,12 @@
     ]
   },
   {
-    "name": "GROUP_SURVIVOR_FOREST",
+    "id": "GROUP_SURVIVOR_FOREST",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_zombie_survivor", "weight": 50 }, { "monster": "mon_feral_sapien_spear", "weight": 50 } ]
   },
   {
-    "name": "GROUP_ROOF_ZOMBIE",
+    "id": "GROUP_ROOF_ZOMBIE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_null", "weight": 540 },
@@ -42,7 +42,7 @@
     ]
   },
   {
-    "name": "GROUP_PARK_PLAYGROUND",
+    "id": "GROUP_PARK_PLAYGROUND",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100, "cost_multiplier": 0 },
@@ -57,7 +57,7 @@
     ]
   },
   {
-    "name": "GROUP_PARK_DOG",
+    "id": "GROUP_PARK_DOG",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100, "cost_multiplier": 0 },
@@ -75,7 +75,7 @@
     ]
   },
   {
-    "name": "GROUP_DOGS",
+    "id": "GROUP_DOGS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_dog", "weight": 135, "cost_multiplier": 0, "pack_size": [ 5, 8 ] },
@@ -83,7 +83,7 @@
     ]
   },
   {
-    "name": "GROUP_ZOMBIE_SCORCHED",
+    "id": "GROUP_ZOMBIE_SCORCHED",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_scorched", "weight": 985 },
@@ -93,7 +93,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE",
+    "id": "GROUP_ZOMBIE",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 500, "cost_multiplier": 0 },
       { "group": "GROUP_VANILLA_DORMANT", "weight": 250, "cost_multiplier": 0 },
@@ -135,7 +135,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_GASSTATION",
+    "id": "GROUP_ZOMBIE_GASSTATION",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 7, "pack_size": [ 5, 20 ] },
@@ -177,18 +177,18 @@
   {
     "type": "monstergroup",
     "default": "mon_null",
-    "name": "GROUP_ZOMBIE_GAS",
+    "id": "GROUP_ZOMBIE_GAS",
     "monsters": [ { "monster": "mon_gas_zombie", "weight": 250, "cost_multiplier": 2, "starts": "7 days" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NEMESIS",
+    "id": "GROUP_NEMESIS",
     "//": "nemesis squad",
     "monsters": [ { "monster": "mon_zombie_nemesis", "weight": 1000, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FERAL",
+    "id": "GROUP_FERAL",
     "//": "default ferals",
     "default": "mon_feral_human_crowbar",
     "monsters": [
@@ -202,7 +202,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_VANILLA_ONLY_HUMANS",
+    "id": "GROUP_VANILLA_ONLY_HUMANS",
     "//": "only human zombies, used in the refugee center",
     "default": "mon_zombie",
     "monsters": [
@@ -217,7 +217,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_VANILLA_NO_FERAL",
+    "id": "GROUP_VANILLA_NO_FERAL",
     "//": "also no civilians, currently used in the sealed hazardous waste sarcophagus chamber",
     "default": "mon_zombie",
     "monsters": [
@@ -227,7 +227,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_VANILLA_DORMANT",
+    "id": "GROUP_VANILLA_DORMANT",
     "default": "mon_pseudo_dormant_zombie",
     "//": "only dormant zombies",
     "//2": "These are generated in MonsterGenerator::generate_fake_pseudo_dormant_monster",
@@ -243,7 +243,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_VANILLA",
+    "id": "GROUP_VANILLA",
     "default": "mon_zombie",
     "//": "Normalized to 1300",
     "monsters": [
@@ -255,7 +255,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_POLICE",
+    "id": "GROUP_POLICE",
     "//": "+30% cops, much higher chance of paramilitary people",
     "default": "mon_zombie",
     "monsters": [
@@ -285,7 +285,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_POLICE_EXTRA",
+    "id": "GROUP_POLICE_EXTRA",
     "//": "100% cops, 0% civilians",
     "default": "mon_zombie",
     "monsters": [
@@ -296,7 +296,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_HOUSE",
+    "id": "GROUP_HOUSE",
     "//": "+15% child",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 200, "cost_multiplier": 0 },
@@ -328,7 +328,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PREPPER_HOUSE",
+    "id": "GROUP_PREPPER_HOUSE",
     "default": "mon_zombie",
     "monsters": [
       { "monster": "mon_zombie_milbase_personnel", "weight": 400, "cost_multiplier": 0, "starts": "540 hours" },
@@ -354,7 +354,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PHARM",
+    "id": "GROUP_PHARM",
     "//": "+13% fast",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100, "cost_multiplier": 0 },
@@ -383,7 +383,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ELECTRO",
+    "id": "GROUP_ELECTRO",
     "//": "+15% electric",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 50, "cost_multiplier": 0 },
@@ -410,7 +410,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GROCERY",
+    "id": "GROUP_GROCERY",
     "//": "+15% fat",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 200, "cost_multiplier": 0 },
@@ -438,7 +438,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PUBLICWORKERS",
+    "id": "GROUP_PUBLICWORKERS",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_zombie", "weight": 100, "cost_multiplier": 5 },
@@ -452,7 +452,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MAYBE_ZOMBIE",
+    "id": "GROUP_MAYBE_ZOMBIE",
     "//": "10% chance of a zombie",
     "monsters": [
       { "monster": "mon_null", "weight": 700 },
@@ -468,12 +468,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_FAT_BASE",
+    "id": "GROUP_ZOMBIE_FAT_BASE",
     "monsters": [ { "monster": "mon_zombie_fat", "cost_multiplier": 2 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SCHOOL",
+    "id": "GROUP_SCHOOL",
     "//": "School monster spawns.",
     "monsters": [
       { "monster": "mon_null", "weight": 10 },
@@ -488,7 +488,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SMALL_STATION",
+    "id": "GROUP_SMALL_STATION",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 20, "cost_multiplier": 0 },
       { "monster": "mon_zombie_static", "weight": 55, "cost_multiplier": 4, "pack_size": [ 1, 2 ] },
@@ -501,7 +501,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LARGE_STATION",
+    "id": "GROUP_LARGE_STATION",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_zombie_static", "weight": 55, "cost_multiplier": 4, "pack_size": [ 1, 2 ] },
@@ -512,7 +512,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_OIL_PLATFORM",
+    "id": "GROUP_OIL_PLATFORM",
     "monsters": [
       { "monster": "mon_zombie_technician", "weight": 60 },
       { "monster": "mon_zombie", "weight": 90 },
@@ -539,7 +539,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CHURCH_ZOMBIE",
+    "id": "GROUP_CHURCH_ZOMBIE",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 200, "cost_multiplier": 0 },
       { "monster": "mon_zombie", "weight": 694 },
@@ -563,7 +563,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_PRISON",
+    "id": "GROUP_ZOMBIE_PRISON",
     "default": "mon_zombie_prisoner",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100, "cost_multiplier": 0 },
@@ -575,7 +575,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_COP",
+    "id": "GROUP_ZOMBIE_COP",
     "monsters": [
       { "monster": "mon_zombie_cop", "weight": 900, "cost_multiplier": 0 },
       { "monster": "mon_feral_cop", "weight": 1, "cost_multiplier": 1 },
@@ -585,7 +585,7 @@
     ]
   },
   {
-    "name": "GROUP_SCENARIO_PANICROOM",
+    "id": "GROUP_SCENARIO_PANICROOM",
     "type": "monstergroup",
     "//": "Flavor spawn group for scenario panic rooms for better story-telling.  Improved chance of dogs, fancy dogs, and (still) breathing people and children.",
     "monsters": [
@@ -597,7 +597,7 @@
     ]
   },
   {
-    "name": "GROUP_PANICROOM",
+    "id": "GROUP_PANICROOM",
     "type": "monstergroup",
     "//": "Same as above, but more lethal.",
     "monsters": [
@@ -609,7 +609,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBULL_FROG_UPGRADE",
+    "id": "GROUP_ZOMBULL_FROG_UPGRADE",
     "monsters": [
       { "monster": "mon_zombullfrog", "weight": 100, "cost_multiplier": 3 },
       { "monster": "mon_frog_mummy", "weight": 25, "cost_multiplier": 3 },
@@ -620,7 +620,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DEADTOAD_UPGRADE",
+    "id": "GROUP_DEADTOAD_UPGRADE",
     "monsters": [
       { "monster": "mon_toad_zombie", "weight": 25, "cost_multiplier": 1 },
       { "monster": "mon_toad_bloat", "weight": 50, "cost_multiplier": 1 },
@@ -629,7 +629,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BLOAT_TOAD_UPGRADE",
+    "id": "GROUP_BLOAT_TOAD_UPGRADE",
     "monsters": [
       { "monster": "mon_toad_bloat", "weight": 25, "cost_multiplier": 1 },
       { "monster": "mon_toad_wart", "weight": 25, "cost_multiplier": 1 },
@@ -640,7 +640,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBTREEFROG_UPGRADE",
+    "id": "GROUP_ZOMBTREEFROG_UPGRADE",
     "monsters": [
       { "monster": "mon_zombtreefrog", "weight": 75, "cost_multiplier": 3 },
       { "monster": "mon_frog_shadow", "weight": 25, "cost_multiplier": 3 },
@@ -649,7 +649,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_HOSPITAL",
+    "id": "GROUP_HOSPITAL",
     "//": "Hospital monster spawns. Same as GROUP_ZOMBIE, but without Z-dogs + 20% medical",
     "monsters": [
       { "group": "GROUP_VANILLA_DORMANT", "weight": 100, "cost_multiplier": 3 },
@@ -683,7 +683,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_STEEL_MILL",
+    "id": "GROUP_STEEL_MILL",
     "//": "Steel mill monster spawns.",
     "monsters": [
       { "monster": "mon_null", "weight": 486 },
@@ -711,7 +711,7 @@
     ]
   },
   {
-    "name": "GROUP_MALL",
+    "id": "GROUP_MALL",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100, "cost_multiplier": 0 },
@@ -727,7 +727,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_SEXSHOP_A",
+    "id": "GROUP_ZOMBIE_SEXSHOP_A",
     "monsters": [
       { "monster": "mon_zombie_cop", "weight": 250, "cost_multiplier": 2 },
       { "monster": "mon_feral_cop", "weight": 2, "cost_multiplier": 3 },
@@ -747,7 +747,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_SEXSHOP_B",
+    "id": "GROUP_ZOMBIE_SEXSHOP_B",
     "default": "mon_zombie",
     "monsters": [
       { "monster": "mon_zombie", "weight": 250 },
@@ -756,7 +756,7 @@
     ]
   },
   {
-    "name": "GROUP_FIRE",
+    "id": "GROUP_FIRE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_fireman", "weight": 860 },
@@ -765,7 +765,7 @@
     ]
   },
   {
-    "name": "FERAL_HUMANS",
+    "id": "FERAL_HUMANS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_prepper_knife", "weight": 14, "cost_multiplier": 2, "starts": "29 days" },
@@ -792,7 +792,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "DUMP_ZOMBIES",
+    "id": "DUMP_ZOMBIES",
     "monsters": [
       { "monster": "mon_zombie_technician", "weight": 150 },
       { "monster": "mon_zombie_fat", "weight": 150 },
@@ -806,12 +806,12 @@
     ]
   },
   {
-    "name": "GROUP_PLAIN",
+    "id": "GROUP_PLAIN",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_zombie" } ]
   },
   {
-    "name": "GROUP_HOTEL_POOL",
+    "id": "GROUP_HOTEL_POOL",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_swimmer", "weight": 100, "cost_multiplier": 2, "starts": "5 days" },
@@ -827,7 +827,7 @@
     ]
   },
   {
-    "name": "GROUP_HOTEL_GYM",
+    "id": "GROUP_HOTEL_GYM",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_fat", "weight": 977, "cost_multiplier": 2 },
@@ -836,7 +836,7 @@
     ]
   },
   {
-    "name": "GROUP_SEARCH_FITNESS",
+    "id": "GROUP_SEARCH_FITNESS",
     "//": "Civilians that died/went crazy while trying to improve their bodies doing exercise. Lesser improved chance of brute/hulk.",
     "type": "monstergroup",
     "monsters": [
@@ -852,7 +852,7 @@
     ]
   },
   {
-    "name": "GROUP_DOJO",
+    "id": "GROUP_DOJO",
     "//": "Civilians that died/went crazy while in a dojo, no runner and less fat zombies. Improved chance of brute/wrestler/hulk.",
     "type": "monstergroup",
     "monsters": [
@@ -870,7 +870,7 @@
     ]
   },
   {
-    "name": "GROUP_ZOMBIE_POOL",
+    "id": "GROUP_ZOMBIE_POOL",
     "type": "monstergroup",
     "default": "mon_zombie",
     "monsters": [
@@ -880,7 +880,7 @@
     ]
   },
   {
-    "name": "GROUP_POOL_NOKIDS",
+    "id": "GROUP_POOL_NOKIDS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_swimmer_base", "weight": 950, "cost_multiplier": 2 },
@@ -895,7 +895,7 @@
     ]
   },
   {
-    "name": "GROUP_DIVING",
+    "id": "GROUP_DIVING",
     "type": "monstergroup",
     "//": "Zombies/ferals that could be found on a diving related place.",
     "monsters": [
@@ -913,7 +913,7 @@
     ]
   },
   {
-    "name": "GROUP_BEACH",
+    "id": "GROUP_BEACH",
     "type": "monstergroup",
     "//": "Zombies/ferals that could be found on the beach/riverside.",
     "monsters": [
@@ -944,7 +944,7 @@
     ]
   },
   {
-    "name": "GROUP_ZOMBIE_BOVINE",
+    "id": "GROUP_ZOMBIE_BOVINE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zow", "weight": 825 },
@@ -953,7 +953,7 @@
     ]
   },
   {
-    "name": "GROUP_HOSPITAL_INCUBATOR",
+    "id": "GROUP_HOSPITAL_INCUBATOR",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_anklebiter", "weight": 995, "cost_multiplier": 10 },
@@ -961,12 +961,12 @@
     ]
   },
   {
-    "name": "GROUP_FORT",
+    "id": "GROUP_FORT",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_zombie_reenactor" } ]
   },
   {
-    "name": "GROUP_CIVILIAN",
+    "id": "GROUP_CIVILIAN",
     "//": "Civilians/Normal people that died, represents a lot of different common professions.  No children or dogs.",
     "type": "monstergroup",
     "monsters": [
@@ -983,7 +983,7 @@
     ]
   },
   {
-    "name": "GROUP_CIVILIAN_NO_FERAL",
+    "id": "GROUP_CIVILIAN_NO_FERAL",
     "//": "Civilians/Normal people that died, represents a lot of different common professions.  No children, dogs or ferals.",
     "type": "monstergroup",
     "monsters": [
@@ -997,7 +997,7 @@
     ]
   },
   {
-    "name": "GROUP_FERROUS",
+    "id": "GROUP_FERROUS",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 100 },
@@ -1010,13 +1010,13 @@
     ]
   },
   {
-    "name": "GROUP_MINERS",
+    "id": "GROUP_MINERS",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_zombie_miner" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MASS_GRAVE",
+    "id": "GROUP_MASS_GRAVE",
     "//": "Corpses buried at a mass grave. No ferals, and few animals.",
     "default": "mon_zombie",
     "monsters": [
@@ -1032,7 +1032,7 @@
     ]
   },
   {
-    "name": "GROUP_FOOTBALL",
+    "id": "GROUP_FOOTBALL",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_null", "weight": 300 },
@@ -1042,7 +1042,7 @@
     ]
   },
   {
-    "name": "GROUP_NURSING_HOME",
+    "id": "GROUP_NURSING_HOME",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 10, "cost_multiplier": 0 },
@@ -1057,7 +1057,7 @@
     ]
   },
   {
-    "name": "GROUP_NURSING_HOME_LAB",
+    "id": "GROUP_NURSING_HOME_LAB",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_labsecurity", "weight": 15 },
@@ -1067,7 +1067,7 @@
     ]
   },
   {
-    "name": "GROUP_RETIREMENT_COMMUNITY",
+    "id": "GROUP_RETIREMENT_COMMUNITY",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 10, "cost_multiplier": 0 },
@@ -1085,7 +1085,7 @@
     ]
   },
   {
-    "name": "GROUP_NUCLEAR_PLANT_WORK_ZOMBIES",
+    "id": "GROUP_NUCLEAR_PLANT_WORK_ZOMBIES",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 10, "cost_multiplier": 0 },

--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -225,7 +225,7 @@
     "copy-from": "mon_civilian_panic"
   },
   {
-    "name": "GROUP_CIVILIANS_UPGRADE",
+    "id": "GROUP_CIVILIANS_UPGRADE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie", "weight": 264, "cost_multiplier": 0 },
@@ -237,7 +237,7 @@
     ]
   },
   {
-    "name": "GROUP_CIVILIANS_STANDARD",
+    "id": "GROUP_CIVILIANS_STANDARD",
     "//": "Used for deduplication only, so one does not have to repeat the same standard ratio over and over again",
     "type": "monstergroup",
     "monsters": [

--- a/data/json/monsters/singularities.json
+++ b/data/json/monsters/singularities.json
@@ -311,7 +311,7 @@
     ]
   },
   {
-    "name": "GROUP_AMALGAMATIONS_SPAWNED",
+    "id": "GROUP_AMALGAMATIONS_SPAWNED",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_amalgamation_swarmer", "weight": 20 },

--- a/data/mods/Aftershock/mobs/monster_groups.json
+++ b/data/mods/Aftershock/mobs/monster_groups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE",
+    "id": "GROUP_ZOMBIE",
     "monsters": [
       { "monster": "mon_afs_headless_horror", "weight": 20, "cost_multiplier": 2, "starts": 400 },
       { "monster": "mon_zombie_upliftedbear", "weight": 5, "cost_multiplier": 10, "starts": 1086 },
@@ -10,7 +10,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_MID",
+    "id": "GROUP_ZOMBIE_MID",
     "monsters": [
       { "monster": "mon_afs_headless_horror", "weight": 10, "cost_multiplier": 20 },
       { "monster": "mon_zombie_upliftedbear", "weight": 3, "cost_multiplier": 10, "starts": 1086 },
@@ -19,7 +19,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PrepNet",
+    "id": "GROUP_PrepNet",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_cat", "weight": 100, "cost_multiplier": 0 },
@@ -35,18 +35,18 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_COMMON",
+    "id": "GROUP_MI-GO_BASE_COMMON",
     "monsters": [ { "monster": "afs_mon_migoturret", "weight": 120 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_BOSS",
+    "id": "GROUP_MI-GO_BASE_BOSS",
     "//": "Mi-go base defenders for major boss battles.",
     "monsters": [ { "monster": "afs_mon_migoturret", "weight": 150, "pack_size": [ 2, 3 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_uplifted_bear", "weight": 1, "cost_multiplier": 10, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
@@ -108,11 +108,11 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAVE",
+    "id": "GROUP_CAVE",
     "monsters": [ { "monster": "mon_uplifted_bear", "weight": 50, "cost_multiplier": 10, "pack_size": [ 1, 3 ] } ]
   },
   {
-    "name": "GROUP_PARK_SCENIC",
+    "id": "GROUP_PARK_SCENIC",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_upliftedbear", "weight": 10, "pack_size": [ 2, 3 ], "starts": 1086 },
@@ -121,7 +121,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_AUG_CLINIC",
+    "id": "AFS_GROUP_AUG_CLINIC",
     "monsters": [
       { "monster": "mon_broken_cyborg", "weight": 100 },
       { "monster": "mon_zombie_electric", "weight": 450 },
@@ -132,7 +132,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_BRUTE",
+    "id": "GROUP_ZOMBIE_BRUTE",
     "//": "Brute upgrades",
     "monsters": [
       { "monster": "mon_zombie_upliftedbear", "weight": 112, "cost_multiplier": 10 },
@@ -142,7 +142,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CENTRAL_LAB",
+    "id": "GROUP_CENTRAL_LAB",
     "monsters": [
       { "monster": "mon_zombie_upliftedbear", "weight": 3, "cost_multiplier": 10 },
       { "monster": "mon_uplifted_ape_zed", "weight": 10, "cost_multiplier": 5 },
@@ -151,7 +151,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RIVER",
+    "id": "GROUP_RIVER",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_uplifted_octupus", "weight": 3, "cost_multiplier": 10 },
@@ -162,7 +162,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CRYO_LAB",
+    "id": "GROUP_CRYO_LAB",
     "monsters": [
       { "monster": "mon_mutant_experimental", "weight": 30, "cost_multiplier": 2 },
       { "monster": "mon_mutant_evolved", "weight": 5, "cost_multiplier": 10 },
@@ -175,7 +175,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB",
+    "id": "GROUP_LAB",
     "monsters": [
       { "monster": "mon_moxie_scavenger", "weight": 25, "cost_multiplier": 0, "pack_size": [ 1, 4 ] },
       { "monster": "mon_moxie_spartan", "weight": 25, "cost_multiplier": 0 },
@@ -186,7 +186,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SWAMP",
+    "id": "GROUP_SWAMP",
     "is_animal": true,
     "monsters": [
       {
@@ -211,7 +211,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RUINS",
+    "id": "GROUP_RUINS",
     "monsters": [
       { "monster": "afs_mon_reaver", "weight": 25, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
       { "monster": "afs_mon_reaver_rifle", "weight": 25, "cost_multiplier": 0 }

--- a/data/mods/Aftershock/mobs/monster_groups/fauna_monsters_groups.json
+++ b/data/mods/Aftershock/mobs/monster_groups/fauna_monsters_groups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_FAUNA_TUNNELS",
+    "id": "AFS_GROUP_FAUNA_TUNNELS",
     "monsters": [
       { "group": "AFS_GROUP_FAUNA_HERBIVORE", "weight": 70, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "group": "AFS_GROUP_FAUNA_PREDATORS_LOW_RISK", "weight": 25, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
@@ -10,7 +10,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_FAUNA_HERBIVORE",
+    "id": "AFS_GROUP_FAUNA_HERBIVORE",
     "monsters": [
       { "monster": "afs_runner", "weight": 350, "cost_multiplier": 0 },
       { "monster": "afs_grazer", "weight": 250, "cost_multiplier": 0, "pack_size": [ 1, 4 ] },
@@ -19,7 +19,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_FAUNA_PREDATORS_LOW_RISK",
+    "id": "AFS_GROUP_FAUNA_PREDATORS_LOW_RISK",
     "monsters": [
       { "monster": "afs_mon_garlander", "weight": 90, "cost_multiplier": 0 },
       { "group": "AFS_GROUP_FAUNA_PREDATORS_MEDIUM_RISK", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 2 ] }
@@ -27,7 +27,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_FAUNA_PREDATORS_MEDIUM_RISK",
+    "id": "AFS_GROUP_FAUNA_PREDATORS_MEDIUM_RISK",
     "monsters": [
       { "monster": "afs_titanis", "weight": 350, "cost_multiplier": 0 },
       { "monster": "afs_venandi", "weight": 250, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },

--- a/data/mods/Aftershock/mobs/monster_groups/moxie_monster_groups.json
+++ b/data/mods/Aftershock/mobs/monster_groups/moxie_monster_groups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_MOXIE_LOW_RISK",
+    "id": "AFS_GROUP_MOXIE_LOW_RISK",
     "monsters": [
       { "monster": "mon_moxie_scavenger", "weight": 350, "cost_multiplier": 1 },
       { "monster": "mon_moxie_scavenger", "weight": 250, "cost_multiplier": 1, "pack_size": [ 1, 4 ] },
@@ -12,7 +12,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_RUIN_MOXIE",
+    "id": "AFS_GROUP_RUIN_MOXIE",
     "monsters": [
       { "monster": "mon_human_biomachine", "weight": 70, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "monster": "mon_human_biomachine", "weight": 20, "cost_multiplier": 0, "pack_size": [ 5, 6 ] },

--- a/data/mods/Aftershock/mobs/monster_groups/robot_monster_groups.json
+++ b/data/mods/Aftershock/mobs/monster_groups/robot_monster_groups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_ROBOT_NEUTRAL_OLD",
+    "id": "AFS_GROUP_ROBOT_NEUTRAL_OLD",
     "//": "Neutral bots from the original colony.",
     "monsters": [
       { "monster": "mon_utilibot_const", "weight": 550, "cost_multiplier": 0 },
@@ -13,7 +13,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_ROBOT_NEUTRAL_OLD_DOMESTIC",
+    "id": "AFS_GROUP_ROBOT_NEUTRAL_OLD_DOMESTIC",
     "//": "Neutral bots from the original colony.  Specifcally those suited for use in a domestic or residental settings.",
     "monsters": [
       { "monster": "mon_utilibot", "weight": 550, "cost_multiplier": 0 },
@@ -23,7 +23,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_ROBOT_LOW_RISK",
+    "id": "AFS_GROUP_ROBOT_LOW_RISK",
     "default": "mon_skitterbot_rat",
     "monsters": [
       { "monster": "mon_bloodhound_drone", "weight": 100, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
@@ -34,7 +34,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PIRATE__BOT_AMBUSH",
+    "id": "GROUP_PIRATE__BOT_AMBUSH",
     "default": "mon_manhack",
     "monsters": [
       { "monster": "mon_bloodhound_drone", "weight": 500, "cost_multiplier": 50, "pack_size": [ 1, 2 ] },
@@ -45,7 +45,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROBOT_FARM_HOSTILE",
+    "id": "GROUP_ROBOT_FARM_HOSTILE",
     "default": "mon_manhack",
     "monsters": [
       { "monster": "mon_utilibot_hostile", "weight": 500, "cost_multiplier": 70 },
@@ -56,7 +56,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROBOT_COPS_HOSTILE",
+    "id": "GROUP_ROBOT_COPS_HOSTILE",
     "default": "mon_manhack",
     "monsters": [
       { "monster": "mon_zenit", "weight": 50, "cost_multiplier": 100 },

--- a/data/mods/Aftershock/mobs/robot_groups.json
+++ b/data/mods/Aftershock/mobs/robot_groups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_UTILIBOT",
+    "id": "GROUP_UTILIBOT",
     "monsters": [
       { "monster": "mon_utilibot_fire", "weight": 200, "cost_multiplier": 3 },
       { "monster": "mon_utilibot", "weight": 550 },
@@ -11,7 +11,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SEWER",
+    "id": "GROUP_SEWER",
     "monsters": [
       { "monster": "mon_utilibot", "weight": 50, "cost_multiplier": 0, "pack_size": [ 2, 3 ] },
       { "monster": "mon_utilibot_const", "weight": 50, "cost_multiplier": 0, "pack_size": [ 2, 3 ] }
@@ -19,12 +19,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TURRET",
+    "id": "GROUP_TURRET",
     "monsters": [ { "monster": "mon_laserturret_xray", "weight": 50, "cost_multiplier": 2 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB",
+    "id": "GROUP_LAB",
     "auto_total": true,
     "monsters": [
       { "monster": "mon_utilibot", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
@@ -37,7 +37,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CENTRAL_LAB",
+    "id": "GROUP_CENTRAL_LAB",
     "auto_total": true,
     "monsters": [
       { "monster": "mon_secubot", "weight": 0, "cost_multiplier": 10 },
@@ -50,7 +50,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROBOT",
+    "id": "GROUP_ROBOT",
     "auto_total": true,
     "monsters": [
       { "monster": "mon_medibot", "weight": 3, "cost_multiplier": 0 },
@@ -69,7 +69,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PUBLICWORKERS",
+    "id": "GROUP_PUBLICWORKERS",
     "monsters": [
       { "monster": "mon_utilibot", "weight": 10, "cost_multiplier": 0, "pack_size": [ 2, 4 ] },
       { "monster": "mon_utilibot_const", "weight": 10, "cost_multiplier": 0, "pack_size": [ 2, 3 ] }
@@ -77,7 +77,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SMALL_STATION",
+    "id": "GROUP_SMALL_STATION",
     "monsters": [
       { "monster": "mon_utilibot", "weight": 10, "cost_multiplier": 0 },
       { "monster": "mon_utilibot_const", "weight": 10, "cost_multiplier": 0 }
@@ -85,31 +85,31 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LARGE_STATION",
+    "id": "GROUP_LARGE_STATION",
     "monsters": [
       { "monster": "mon_utilibot", "weight": 10, "cost_multiplier": 0 },
       { "monster": "mon_utilibot_const", "weight": 10, "cost_multiplier": 0 }
     ]
   },
   {
-    "name": "GROUP_MANSION_START",
+    "id": "GROUP_MANSION_START",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_utilibot_butler", "weight": 80 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_HOSPITAL",
+    "id": "GROUP_HOSPITAL",
     "//": "Hospital monster spawns.  Same as GROUP_ZOMBIE, but without Z-dogs.",
     "monsters": [ { "monster": "mon_medibot", "weight": 15, "cost_multiplier": 20, "pack_size": [ 2, 3 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FIRE",
+    "id": "GROUP_FIRE",
     "monsters": [ { "monster": "mon_utilibot_fire", "weight": 200, "cost_multiplier": 2, "pack_size": [ 4, 6 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MIL_BASE",
+    "id": "GROUP_MIL_BASE",
     "monsters": [
       { "monster": "mon_tripod", "weight": 5, "cost_multiplier": 0 },
       { "monster": "mon_chickenbot", "weight": 5, "cost_multiplier": 0 },
@@ -118,7 +118,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MAYBE_MIL",
+    "id": "GROUP_MAYBE_MIL",
     "monsters": [
       { "monster": "mon_tripod", "weight": 5, "cost_multiplier": 0 },
       { "monster": "mon_chickenbot", "weight": 5, "cost_multiplier": 0 },
@@ -127,7 +127,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MIL_STRONG",
+    "id": "GROUP_MIL_STRONG",
     "monsters": [
       { "monster": "mon_tripod", "weight": 5, "cost_multiplier": 0 },
       { "monster": "mon_chickenbot", "weight": 5, "cost_multiplier": 0 },

--- a/data/mods/Aftershock/mod_interactions/defense_mode/monstergroups.json
+++ b/data/mods/Aftershock/mod_interactions/defense_mode/monstergroups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "AFS_GROUP_DM",
+    "id": "AFS_GROUP_DM",
     "monsters": [
       { "monster": "mon_moxie_scavenger_dm", "weight": 350, "cost_multiplier": 1 },
       { "monster": "mon_moxie_regenerator_dm", "weight": 200, "cost_multiplier": 1 },

--- a/data/mods/Backrooms/monstergroups.json
+++ b/data/mods/Backrooms/monstergroups.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_BACKROOMS",
+    "id": "GROUP_BACKROOMS",
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_ZOMBIE", "pack_size": [ 1, 2 ], "weight": 920 },

--- a/data/mods/CrazyCataclysm/crazy_monstergroups.json
+++ b/data/mods/CrazyCataclysm/crazy_monstergroups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE",
+    "id": "GROUP_ZOMBIE",
     "monsters": [
       { "monster": "mon_zombie_skeltal", "weight": 1, "cost_multiplier": 60 },
       { "monster": "mon_zombie_skeltal", "weight": 1, "cost_multiplier": 30, "conditions": [ "AUTUMN" ] }
@@ -10,7 +10,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_HOSPITAL",
+    "id": "GROUP_HOSPITAL",
     "monsters": [
       { "monster": "mon_zombie_skeltal", "weight": 1, "cost_multiplier": 60 },
       { "monster": "mon_zombie_skeltal", "weight": 1, "cost_multiplier": 30, "conditions": [ "AUTUMN" ] }
@@ -18,7 +18,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GROCERY",
+    "id": "GROUP_GROCERY",
     "monsters": [
       { "monster": "mon_zombie_skeltal", "weight": 1, "cost_multiplier": 60 },
       { "monster": "mon_zombie_skeltal", "weight": 1, "cost_multiplier": 30, "conditions": [ "AUTUMN" ] }
@@ -26,7 +26,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_HOUSE",
+    "id": "GROUP_HOUSE",
     "monsters": [
       { "monster": "mon_zombie_skeltal", "weight": 1, "cost_multiplier": 60 },
       { "monster": "mon_zombie_skeltal", "weight": 1, "cost_multiplier": 30, "conditions": [ "AUTUMN" ] }
@@ -34,7 +34,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "monsters": [
       {
         "monster": "mon_bear_smoky",
@@ -47,7 +47,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SWAMP",
+    "id": "GROUP_SWAMP",
     "monsters": [
       {
         "monster": "mon_bear_smoky",
@@ -60,7 +60,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RIVER",
+    "id": "GROUP_RIVER",
     "monsters": [
       {
         "monster": "mon_bear_smoky",
@@ -73,7 +73,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAVE",
+    "id": "GROUP_CAVE",
     "monsters": [
       { "monster": "mon_bear_smoky", "weight": 10, "cost_multiplier": 0, "starts": 672 },
       { "monster": "mon_bear_smoky", "weight": 100, "cost_multiplier": 0, "conditions": [ "WINTER" ] }
@@ -82,13 +82,13 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SEWAGE_TREATMENT",
+    "id": "GROUP_SEWAGE_TREATMENT",
     "is_animal": true,
     "monsters": [ { "monster": "mon_gator", "weight": 40, "cost_multiplier": 2, "pack_size": [ 1, 2 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NUCLEAR_PLANT_BEASTS",
+    "id": "GROUP_NUCLEAR_PLANT_BEASTS",
     "is_animal": true,
     "monsters": [ { "monster": "mon_gator", "weight": 25, "cost_multiplier": 2 } ]
   }

--- a/data/mods/Defense_Mode/monstergroups.json
+++ b/data/mods/Defense_Mode/monstergroups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_DM",
+    "id": "GROUP_TRIFFID_DM",
     "default": "mon_triffid",
     "monsters": [
       { "monster": "mon_triffid", "weight": 205 },
@@ -12,7 +12,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIDER_DM",
+    "id": "GROUP_SPIDER_DM",
     "default": "mon_spider_web_dm",
     "monsters": [
       { "monster": "mon_spider_cellar_giant_dm", "weight": 205 },
@@ -23,7 +23,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROBOT_DM",
+    "id": "GROUP_ROBOT_DM",
     "monsters": [
       { "monster": "mon_manhack", "weight": 515, "cost_multiplier": 0 },
       { "monster": "mon_skitterbot", "weight": 220, "cost_multiplier": 0 },
@@ -32,7 +32,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_DM",
+    "id": "GROUP_NETHER_DM",
     "default": "mon_blank",
     "monsters": [
       { "monster": "mon_blank", "weight": 135, "cost_multiplier": 0 },
@@ -44,14 +44,14 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NEMESIS",
+    "id": "GROUP_NEMESIS",
     "default": "mon_zombie_nemesis",
     "//": "nemesis squad, exists here to remove them from Defense Mode",
     "monsters": [ { "monster": "mon_zombie", "weight": 1000, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE",
+    "id": "GROUP_ZOMBIE",
     "monsters": [
       { "monster": "mon_zombie", "weight": 10, "cost_multiplier": 7, "pack_size": [ 5, 20 ] },
       { "monster": "mon_zombie", "weight": 10, "cost_multiplier": 13, "pack_size": [ 15, 40 ] },

--- a/data/mods/DinoMod/monstergroups/dinosaur.json
+++ b/data/mods/DinoMod/monstergroups/dinosaur.json
@@ -2,7 +2,7 @@
   {
     "//": "These groups are called by the exhibit, zoo, and science basements, and NPC missions",
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR",
+    "id": "GROUP_DINOSAUR",
     "monsters": [
       { "group": "GROUP_WILDERNESS_FOREST_DINO", "weight": 250 },
       { "group": "GROUP_DINOSAUR_SAUROPODS_WILDERNESS", "weight": 150 },
@@ -14,7 +14,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_SOUTH_AMERICA",
+    "id": "GROUP_DINOSAUR_SOUTH_AMERICA",
     "monsters": [
       { "monster": "mon_eoraptor", "weight": 20, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "monster": "mon_giganotosaurus", "weight": 10, "cost_multiplier": 40, "pack_size": [ 1, 2 ] },
@@ -23,7 +23,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_ASIA",
+    "id": "GROUP_DINOSAUR_ASIA",
     "monsters": [
       { "monster": "mon_qianzhousaurus", "weight": 200, "cost_multiplier": 40, "pack_size": [ 1, 2 ] },
       { "monster": "mon_therizinosaurus", "weight": 200, "cost_multiplier": 30, "pack_size": [ 1, 2 ] },
@@ -32,7 +32,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_EUROPE",
+    "id": "GROUP_DINOSAUR_EUROPE",
     "monsters": [
       { "monster": "mon_compsognathus", "weight": 100, "cost_multiplier": 40, "pack_size": [ 1, 2 ] },
       { "monster": "mon_iguanodon", "weight": 100, "pack_size": [ 1, 2 ] }
@@ -40,7 +40,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_HARMLESS",
+    "id": "GROUP_DINOSAUR_HARMLESS",
     "monsters": [
       { "monster": "mon_compsognathus", "weight": 100, "pack_size": [ 1, 2 ] },
       { "monster": "mon_nedcolbertia", "weight": 50, "pack_size": [ 1, 2 ] },
@@ -71,7 +71,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_DANGEROUS",
+    "id": "GROUP_DINOSAUR_DANGEROUS",
     "monsters": [
       { "monster": "mon_tawa", "weight": 200, "cost_multiplier": 5, "pack_size": [ 1, 2 ] },
       { "monster": "mon_coelophysis", "weight": 200, "cost_multiplier": 5, "pack_size": [ 1, 2 ] },
@@ -90,7 +90,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_HARMLESS_HATCHLING",
+    "id": "GROUP_DINOSAUR_HARMLESS_HATCHLING",
     "monsters": [
       { "monster": "mon_compsognathus_hatchling", "weight": 20, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "monster": "mon_nedcolbertia_hatchling", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
@@ -166,7 +166,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_DANGEROUS_HATCHLING",
+    "id": "GROUP_DINOSAUR_DANGEROUS_HATCHLING",
     "monsters": [
       { "monster": "mon_tawa_hatchling", "weight": 4, "cost_multiplier": 5, "pack_size": [ 1, 2 ] },
       { "monster": "mon_coelophysis_hatchling", "weight": 4, "cost_multiplier": 5, "pack_size": [ 1, 2 ] },
@@ -195,7 +195,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_HARMLESS_JUVENILE",
+    "id": "GROUP_DINOSAUR_HARMLESS_JUVENILE",
     "monsters": [
       { "monster": "mon_nedcolbertia_juvenile", "weight": 50, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "monster": "mon_gallimimus_juvenile", "weight": 50, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
@@ -237,7 +237,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_DANGEROUS_JUVENILE",
+    "id": "GROUP_DINOSAUR_DANGEROUS_JUVENILE",
     "monsters": [
       { "monster": "mon_dilophosaurus_juvenile", "weight": 15, "cost_multiplier": 10, "pack_size": [ 1, 2 ] },
       { "monster": "mon_ceratosaurus_juvenile", "cost_multiplier": 30, "pack_size": [ 1, 2 ] },
@@ -252,7 +252,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_MEGA_HERBIVORE",
+    "id": "GROUP_DINOSAUR_MEGA_HERBIVORE",
     "monsters": [
       { "monster": "mon_issi", "weight": 5, "cost_multiplier": 25, "pack_size": [ 1, 2 ] },
       { "monster": "mon_haplocanthosaurus", "weight": 5, "cost_multiplier": 25, "pack_size": [ 1, 2 ] },
@@ -300,7 +300,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_MEGA_CARNIVORE",
+    "id": "GROUP_DINOSAUR_MEGA_CARNIVORE",
     "monsters": [
       { "monster": "mon_spinosaurus", "weight": 50, "cost_multiplier": 40 },
       { "monster": "mon_torvosaurus", "weight": 50, "cost_multiplier": 40 },
@@ -316,7 +316,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_FLY",
+    "id": "GROUP_DINOSAUR_FLY",
     "monsters": [
       { "monster": "mon_dimorphodon", "weight": 10, "cost_multiplier": 0, "pack_size": [ 2, 4 ] },
       { "monster": "mon_pteranodon", "weight": 935, "cost_multiplier": 0 },
@@ -326,7 +326,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_SWIM",
+    "id": "GROUP_DINOSAUR_SWIM",
     "monsters": [
       { "monster": "mon_mosasaurus", "weight": 4, "cost_multiplier": 60 },
       { "monster": "mon_spinosaurus", "weight": 4, "cost_multiplier": 40 }
@@ -334,7 +334,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_PREDATOR_STREAM",
+    "id": "GROUP_DINOSAUR_PREDATOR_STREAM",
     "monsters": [
       { "monster": "mon_tawa", "pack_size": [ 4, 8 ] },
       { "monster": "mon_coelophysis", "pack_size": [ 4, 8 ] },
@@ -347,7 +347,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_PREDATOR_SWAMP",
+    "id": "GROUP_DINOSAUR_PREDATOR_SWAMP",
     "monsters": [
       { "monster": "mon_dryptosaurus", "cost_multiplier": 35 },
       { "monster": "mon_appalachiosaurus", "cost_multiplier": 35 },
@@ -367,7 +367,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_ZREDATOR_STREAM",
+    "id": "GROUP_DINOSAUR_ZREDATOR_STREAM",
     "monsters": [
       { "monster": "mon_zeratosaurus", "cost_multiplier": 35 },
       { "monster": "mon_zorvosaurus", "cost_multiplier": 35 },
@@ -378,7 +378,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_ZREDATOR_SWAMP",
+    "id": "GROUP_DINOSAUR_ZREDATOR_SWAMP",
     "monsters": [
       { "monster": "mon_zryptosaurus", "cost_multiplier": 35 },
       { "monster": "mon_zappalachiosaurus", "cost_multiplier": 35 },
@@ -396,7 +396,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_SAUROPODS_WILDERNESS",
+    "id": "GROUP_DINOSAUR_SAUROPODS_WILDERNESS",
     "monsters": [
       { "monster": "mon_sarahsaurus", "weight": 10, "cost_multiplier": 10, "pack_size": [ 4, 12 ] },
       { "monster": "mon_anchisaurus", "weight": 10, "cost_multiplier": 10, "pack_size": [ 4, 12 ] },
@@ -414,7 +414,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_ZAUROPODS_WILDERNESS",
+    "id": "GROUP_DINOSAUR_ZAUROPODS_WILDERNESS",
     "monsters": [
       { "monster": "mon_zarahsaurus", "weight": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ] },
       { "monster": "mon_zanchisaurus", "weight": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ] },
@@ -431,7 +431,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_HADROSAURS_WILDERNESS",
+    "id": "GROUP_DINOSAUR_HADROSAURS_WILDERNESS",
     "monsters": [
       { "monster": "mon_tenontosaurus", "weight": 20, "pack_size": [ 4, 12 ] },
       { "monster": "mon_dryosaurus", "weight": 20, "pack_size": [ 4, 12 ] },
@@ -451,7 +451,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_ZADROSAURS_WILDERNESS",
+    "id": "GROUP_DINOSAUR_ZADROSAURS_WILDERNESS",
     "monsters": [
       { "monster": "mon_zamptosaurus", "weight": 5, "cost_multiplier": 10, "pack_size": [ 4, 12 ] },
       { "monster": "mon_zeolambia", "weight": 5, "cost_multiplier": 20, "pack_size": [ 4, 12 ] },
@@ -469,7 +469,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_CAVE",
+    "id": "GROUP_DINOSAUR_CAVE",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_compsognathus", "weight": 400, "pack_size": [ 4, 12 ] },

--- a/data/mods/DinoMod/monstergroups/fungi.json
+++ b/data/mods/DinoMod/monstergroups/fungi.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_DINO",
+    "id": "GROUP_FUNGI_DINO",
     "monsters": [
       { "monster": "mon_zilophosaurus_fungus", "starts": "3 days" },
       { "monster": "mon_zeratosaurus_fungus", "starts": "3 days" },
@@ -86,12 +86,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_TOWER",
+    "id": "GROUP_FUNGI_TOWER",
     "monsters": [ { "group": "GROUP_FUNGI_DINO", "weight": 200 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_FLOWERS",
+    "id": "GROUP_FUNGI_FLOWERS",
     "monsters": [ { "group": "GROUP_FUNGI_DINO", "weight": 200 } ]
   }
 ]

--- a/data/mods/DinoMod/monstergroups/lab.json
+++ b/data/mods/DinoMod/monstergroups/lab.json
@@ -1,12 +1,12 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_Exodii_Stowaway",
+    "id": "GROUP_Exodii_Stowaway",
     "monsters": [ { "group": "GROUP_BIO_DINO_HERB", "weight": 200 }, { "group": "GROUP_BIO_DINO_PRED", "weight": 200 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOLAB",
+    "id": "GROUP_DINOLAB",
     "monsters": [
       { "group": "GROUP_BIO_DINO_HERB", "weight": 300 },
       { "group": "GROUP_BIO_DINO_PRED", "weight": 300 },
@@ -15,12 +15,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_CYBORG",
+    "id": "GROUP_LAB_CYBORG",
     "monsters": [ { "group": "GROUP_BIO_DINO_PRED", "weight": 300 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BIO_DINO_PRED",
+    "id": "GROUP_BIO_DINO_PRED",
     "monsters": [
       { "monster": "mon_spinosaurus", "weight": 100, "cost_multiplier": 20, "starts": "3 days", "ends": "28 days" },
       { "monster": "mon_zpinosaurus", "weight": 25, "cost_multiplier": 30, "starts": "3 days" },
@@ -111,7 +111,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BIO_DINO_HERB",
+    "id": "GROUP_BIO_DINO_HERB",
     "monsters": [
       { "monster": "mon_nedcolbertia_bio_op", "weight": 100, "cost_multiplier": 10, "ends": "28 days" },
       { "monster": "mon_zedcolbertia_bio_op", "weight": 25, "cost_multiplier": 20, "starts": "3 days" },

--- a/data/mods/DinoMod/monstergroups/misc.json
+++ b/data/mods/DinoMod/monstergroups/misc.json
@@ -1,17 +1,17 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_SUBWAY",
+    "id": "GROUP_SUBWAY",
     "monsters": [ { "group": "GROUP_SEWER_DINO", "weight": 200 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SUBWAY_CITY",
+    "id": "GROUP_SUBWAY_CITY",
     "monsters": [ { "group": "GROUP_SEWER_ZINO", "weight": 200 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SUBWAY_LAB",
+    "id": "GROUP_SUBWAY_LAB",
     "monsters": [
       { "group": "GROUP_BIO_DINO_HERB", "weight": 100 },
       { "group": "GROUP_BIO_DINO_PRED", "weight": 100 },
@@ -21,7 +21,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SAFE",
+    "id": "GROUP_SAFE",
     "is_safe": true,
     "monsters": [
       { "monster": "mon_nedcolbertia", "weight": 50, "pack_size": [ 4, 8 ] },
@@ -40,7 +40,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "DUMP_ANIMALS",
+    "id": "DUMP_ANIMALS",
     "monsters": [
       { "monster": "mon_compsognathus", "weight": 100 },
       { "monster": "mon_anzu", "weight": 50 },
@@ -50,7 +50,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PEST",
+    "id": "GROUP_PEST",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_compsognathus", "weight": 50 },
@@ -61,13 +61,13 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SEWER",
+    "id": "GROUP_SEWER",
     "is_animal": true,
     "monsters": [ { "group": "GROUP_SEWER_DINO", "weight": 200 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SEWER_DINO",
+    "id": "GROUP_SEWER_DINO",
     "monsters": [
       { "monster": "mon_tawa", "weight": 100, "cost_multiplier": 5, "pack_size": [ 4, 8 ] },
       { "monster": "mon_coelophysis", "weight": 100, "cost_multiplier": 5, "pack_size": [ 4, 8 ] },
@@ -96,7 +96,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SEWER_ZINO",
+    "id": "GROUP_SEWER_ZINO",
     "monsters": [
       { "monster": "mon_zilophosaurus", "weight": 2, "cost_multiplier": 10, "pack_size": [ 1, 2 ], "starts": 72 },
       { "monster": "mon_zilophosaurus", "weight": 2, "cost_multiplier": 10, "pack_size": [ 1, 2 ], "starts": 168 },
@@ -114,7 +114,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAMP_HUNTING",
+    "id": "GROUP_CAMP_HUNTING",
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//1": "No heavier than 21 kg.",
     "//2": "This group always has a chance of being the result, regardless of mission type.",
@@ -122,7 +122,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAMP_TRAPPING",
+    "id": "GROUP_CAMP_TRAPPING",
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//1": "No heavier than 10 kg.",
     "//2": "This group can only be picked from when the trapping mission is used, in addition to GROUP_CAMP_HUNTING.",
@@ -138,7 +138,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAMP_HUNTING_LARGE",
+    "id": "GROUP_CAMP_HUNTING_LARGE",
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//1": "No heavier than 400 kg.",
     "//2": "This group can only be picked from when the hunt large animals mission is used, in addition to GROUP_CAMP_HUNTING.",

--- a/data/mods/DinoMod/monstergroups/monstergroups_egg.json
+++ b/data/mods/DinoMod/monstergroups/monstergroups_egg.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_EGG_DINO",
+    "id": "GROUP_EGG_DINO",
     "//": "North American dinos not theropods at least 50 kg and not largest",
     "type": "monstergroup",
     "monsters": [
@@ -50,7 +50,7 @@
     ]
   },
   {
-    "name": "GROUP_EGG_DINO_SMALL",
+    "id": "GROUP_EGG_DINO_SMALL",
     "//": "North American dinos not theropods smaller than 50 kg",
     "type": "monstergroup",
     "monsters": [
@@ -63,7 +63,7 @@
     ]
   },
   {
-    "name": "GROUP_EGG_DINO_LARGE",
+    "id": "GROUP_EGG_DINO_LARGE",
     "//": "North American dinos not theropods largest",
     "type": "monstergroup",
     "monsters": [
@@ -78,7 +78,7 @@
     ]
   },
   {
-    "name": "GROUP_EGG_THEROPOD",
+    "id": "GROUP_EGG_THEROPOD",
     "//": "North American theropod dinos at least 50 kg and not largest",
     "type": "monstergroup",
     "monsters": [
@@ -106,7 +106,7 @@
     ]
   },
   {
-    "name": "GROUP_EGG_THEROPOD_SMALL",
+    "id": "GROUP_EGG_THEROPOD_SMALL",
     "//": "North American theropod dinos smaller than 50 kg",
     "type": "monstergroup",
     "monsters": [
@@ -118,13 +118,13 @@
     ]
   },
   {
-    "name": "GROUP_EGG_THEROPOD_LARGE",
+    "id": "GROUP_EGG_THEROPOD_LARGE",
     "//": "North American theropod dinos largest",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_spinosaurus_hatchling", "weight": 1 }, { "monster": "mon_tyrannosaurus_hatchling", "weight": 8 } ]
   },
   {
-    "name": "GROUP_EGG_SNAKE",
+    "id": "GROUP_EGG_SNAKE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_dimorphodon_hatchling", "weight": 2 },

--- a/data/mods/DinoMod/monstergroups/wilderness.json
+++ b/data/mods/DinoMod/monstergroups/wilderness.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "is_animal": true,
     "monsters": [
       { "group": "GROUP_WILDERNESS_FOREST_DINO", "weight": 150 },
@@ -10,7 +10,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_DINO",
+    "id": "GROUP_WILDERNESS_FOREST_DINO",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_nedcolbertia", "weight": 5, "pack_size": [ 4, 8 ] },
@@ -56,7 +56,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_SAUROPODS",
+    "id": "GROUP_WILDERNESS_FOREST_SAUROPODS",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_sarahsaurus", "weight": 1, "pack_size": [ 4, 12 ] },
@@ -75,7 +75,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RIVER",
+    "id": "GROUP_RIVER",
     "monsters": [
       { "monster": "mon_pteranodon", "weight": 25, "cost_multiplier": 20, "pack_size": [ 2, 4 ] },
       { "monster": "mon_quetzalcoatlus", "weight": 4, "cost_multiplier": 30, "pack_size": [ 1, 2 ] },
@@ -98,7 +98,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_STREAM",
+    "id": "GROUP_STREAM",
     "monsters": [
       { "group": "GROUP_DINOSAUR_PREDATOR_STREAM", "weight": 10, "starts": "3 days" },
       { "group": "GROUP_DINOSAUR_PREDATOR_STREAM", "weight": 20, "starts": "3 days", "ends": "7 days" },
@@ -140,7 +140,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_OCEAN_SHORE",
+    "id": "GROUP_OCEAN_SHORE",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -163,7 +163,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_OCEAN_DEEP",
+    "id": "GROUP_OCEAN_DEEP",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -186,7 +186,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SWAMP",
+    "id": "GROUP_SWAMP",
     "monsters": [
       { "group": "GROUP_DINOSAUR_PREDATOR_SWAMP", "weight": 20, "starts": "3 days" },
       { "group": "GROUP_DINOSAUR_PREDATOR_SWAMP", "weight": 20, "starts": "3 days", "ends": "7 days" },
@@ -208,25 +208,25 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PARK_ANIMAL",
+    "id": "GROUP_PARK_ANIMAL",
     "is_animal": true,
     "monsters": [ { "monster": "mon_dimorphodon", "weight": 50, "cost_multiplier": 0, "pack_size": [ 2, 4 ], "conditions": [ "DAY" ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_POND_BIRD",
+    "id": "GROUP_POND_BIRD",
     "is_animal": true,
     "monsters": [ { "monster": "mon_dimorphodon", "weight": 50, "cost_multiplier": 0, "pack_size": [ 2, 4 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAVE",
+    "id": "GROUP_CAVE",
     "is_animal": true,
     "monsters": [ { "group": "GROUP_DINOSAUR_CAVE", "weight": 200 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROOF_ANIMAL",
+    "id": "GROUP_ROOF_ANIMAL",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_albertonykus", "weight": 25, "pack_size": [ 1, 2 ], "conditions": [ "DUSK", "DAY", "DAWN" ] },

--- a/data/mods/DinoMod/monstergroups/zinosaur.json
+++ b/data/mods/DinoMod/monstergroups/zinosaur.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_ZOMBIE",
+    "id": "GROUP_DINOSAUR_ZOMBIE",
     "//": "Random North American dino zombie list",
     "monsters": [
       { "monster": "mon_zilophosaurus", "weight": 10, "cost_multiplier": 20, "starts": "3 days", "pack_size": [ 1, 2 ] },
@@ -88,7 +88,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DINOSAUR_ZOMBIE_SCORCHED",
+    "id": "GROUP_DINOSAUR_ZOMBIE_SCORCHED",
     "//": "Random North American scorched dino zombie list",
     "monsters": [
       { "monster": "mon_zilophosaurus_scorched", "weight": 10, "cost_multiplier": 20, "starts": "3 days" },
@@ -166,7 +166,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zilophosaurus_UPGRADE",
+    "id": "GROUP_zilophosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_silophosaurus", "weight": 400 },
       { "monster": "mon_zilophosaurus_shady", "weight": 150 },
@@ -176,7 +176,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zeratosaurus_UPGRADE",
+    "id": "GROUP_zeratosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_seratosaurus", "weight": 400 },
       { "monster": "mon_zeratosaurus_shady", "weight": 150 },
@@ -186,7 +186,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zpinosaurus_UPGRADE",
+    "id": "GROUP_zpinosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_skinosaurus", "weight": 400 },
       { "monster": "mon_zpinosaurus_shady", "weight": 300 },
@@ -195,7 +195,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zorvosaurus_UPGRADE",
+    "id": "GROUP_zorvosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_sorvosaurus", "weight": 400 },
       { "monster": "mon_zorvosaurus_shady", "weight": 300 },
@@ -204,7 +204,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zallosaurus_UPGRADE",
+    "id": "GROUP_zallosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_sallosaurus", "weight": 400 },
       { "monster": "mon_zallosaurus_shady", "weight": 300 },
@@ -213,7 +213,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zacrocanthosaurus_UPGRADE",
+    "id": "GROUP_zacrocanthosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_sacrocanthosaurus", "weight": 400 },
       { "monster": "mon_zacrocanthosaurus_shady", "weight": 300 },
@@ -222,7 +222,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ziganotosaurus_UPGRADE",
+    "id": "GROUP_ziganotosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_siganotosaurus", "weight": 400 },
       { "monster": "mon_ziganotosaurus_shady", "weight": 300 },
@@ -231,7 +231,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ziats_UPGRADE",
+    "id": "GROUP_ziats_UPGRADE",
     "monsters": [
       { "monster": "mon_skiats", "weight": 400 },
       { "monster": "mon_ziats_shady", "weight": 300 },
@@ -240,7 +240,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zryptosaurus_UPGRADE",
+    "id": "GROUP_zryptosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_sryptosaurus", "weight": 400 },
       { "monster": "mon_zryptosaurus_shady", "weight": 300 },
@@ -249,7 +249,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zappalachiosaurus_UPGRADE",
+    "id": "GROUP_zappalachiosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_sappalachiosaurus", "weight": 400 },
       { "monster": "mon_zappalachiosaurus_shady", "weight": 300 },
@@ -258,7 +258,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zorgosaurus_UPGRADE",
+    "id": "GROUP_zorgosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_sorgosaurus", "weight": 400 },
       { "monster": "mon_zorgosaurus_shady", "weight": 300 },
@@ -267,7 +267,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zalbertosaurus_UPGRADE",
+    "id": "GROUP_zalbertosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_salbertosaurus", "weight": 400 },
       { "monster": "mon_zalbertosaurus_shady", "weight": 300 },
@@ -276,7 +276,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zianzhousaurus_UPGRADE",
+    "id": "GROUP_zianzhousaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_sianzhousaurus", "weight": 400 },
       { "monster": "mon_zianzhousaurus_shady", "weight": 300 },
@@ -285,7 +285,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zanuqsaurus_UPGRADE",
+    "id": "GROUP_zanuqsaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_sanuqsaurus", "weight": 400 },
       { "monster": "mon_zanuqsaurus_shady", "weight": 300 },
@@ -294,7 +294,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zaspletosaurus_UPGRADE",
+    "id": "GROUP_zaspletosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_saspletosaurus", "weight": 400 },
       { "monster": "mon_zaspletosaurus_shady", "weight": 300 },
@@ -303,7 +303,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zyrannosaurus_UPGRADE",
+    "id": "GROUP_zyrannosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_syrannosaurus", "weight": 400 },
       { "monster": "mon_zyrannosaurus_shady", "weight": 300 },
@@ -312,7 +312,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zedcolbertia_UPGRADE",
+    "id": "GROUP_zedcolbertia_UPGRADE",
     "monsters": [
       { "monster": "mon_sedcolbertia", "weight": 400 },
       { "monster": "mon_zedcolbertia_shady", "weight": 300 },
@@ -321,7 +321,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zallimimus_UPGRADE",
+    "id": "GROUP_zallimimus_UPGRADE",
     "monsters": [
       { "monster": "mon_sallimimus", "weight": 400 },
       { "monster": "mon_zallimimus_shady", "weight": 300 },
@@ -330,7 +330,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ztruthiomimus_UPGRADE",
+    "id": "GROUP_ztruthiomimus_UPGRADE",
     "monsters": [
       { "monster": "mon_sktruthiomimus", "weight": 400 },
       { "monster": "mon_ztruthiomimus_shady", "weight": 300 },
@@ -339,7 +339,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zornithomimus_UPGRADE",
+    "id": "GROUP_zornithomimus_UPGRADE",
     "monsters": [
       { "monster": "mon_sornithomimus", "weight": 400 },
       { "monster": "mon_zornithomimus_shady", "weight": 300 },
@@ -348,7 +348,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zalcarius_UPGRADE",
+    "id": "GROUP_zalcarius_UPGRADE",
     "monsters": [
       { "monster": "mon_salcarius", "weight": 400 },
       { "monster": "mon_zalcarius_shady", "weight": 300 },
@@ -357,7 +357,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zerizinosaurus_UPGRADE",
+    "id": "GROUP_zerizinosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_serizinosaurus", "weight": 400 },
       { "monster": "mon_zerizinosaurus_shady", "weight": 300 },
@@ -366,7 +366,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zothronychus_UPGRADE",
+    "id": "GROUP_zothronychus_UPGRADE",
     "monsters": [
       { "monster": "mon_sothronychus", "weight": 400 },
       { "monster": "mon_zothronychus_shady", "weight": 300 },
@@ -375,7 +375,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zanzu_UPGRADE",
+    "id": "GROUP_zanzu_UPGRADE",
     "monsters": [
       { "monster": "mon_sanzu", "weight": 400 },
       { "monster": "mon_zanzu_shady", "weight": 300 },
@@ -384,7 +384,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zeinonychus_UPGRADE",
+    "id": "GROUP_zeinonychus_UPGRADE",
     "monsters": [
       { "monster": "mon_seinonychus", "weight": 400 },
       { "monster": "mon_zeinonychus_shady", "weight": 300 },
@@ -393,7 +393,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zutahraptor_UPGRADE",
+    "id": "GROUP_zutahraptor_UPGRADE",
     "monsters": [
       { "monster": "mon_sutahraptor", "weight": 400 },
       { "monster": "mon_zutahraptor_shady", "weight": 300 },
@@ -402,122 +402,122 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zarahsaurus_UPGRADE",
+    "id": "GROUP_zarahsaurus_UPGRADE",
     "monsters": [ { "monster": "mon_skarahsaurus", "weight": 600 }, { "monster": "mon_zarahsaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zanchisaurus_UPGRADE",
+    "id": "GROUP_zanchisaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sanchisaurus", "weight": 600 }, { "monster": "mon_zanchisaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zissi_UPGRADE",
+    "id": "GROUP_zissi_UPGRADE",
     "monsters": [ { "monster": "mon_sissi", "weight": 600 }, { "monster": "mon_zissi_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zaplocanthosaurus_UPGRADE",
+    "id": "GROUP_zaplocanthosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_saplocanthosaurus", "weight": 600 }, { "monster": "mon_zaplocanthosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zamargasaurus_UPGRADE",
+    "id": "GROUP_zamargasaurus_UPGRADE",
     "monsters": [ { "monster": "mon_samargasaurus", "weight": 600 }, { "monster": "mon_zamargasaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zapatosaurus_UPGRADE",
+    "id": "GROUP_zapatosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sapatosaurus", "weight": 600 }, { "monster": "mon_zapatosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zrontosaurus_UPGRADE",
+    "id": "GROUP_zrontosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_srontosaurus", "weight": 600 }, { "monster": "mon_zrontosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ziplodocus_UPGRADE",
+    "id": "GROUP_ziplodocus_UPGRADE",
     "monsters": [ { "monster": "mon_siplodocus", "weight": 600 }, { "monster": "mon_ziplodocus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zarosaurus_UPGRADE",
+    "id": "GROUP_zarosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sarosaurus", "weight": 600 }, { "monster": "mon_zarosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zamarasaurus_UPGRADE",
+    "id": "GROUP_zamarasaurus_UPGRADE",
     "monsters": [ { "monster": "mon_samarasaurus", "weight": 600 }, { "monster": "mon_zamarasaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zrachiosaurus_UPGRADE",
+    "id": "GROUP_zrachiosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_srachiosaurus", "weight": 600 }, { "monster": "mon_zrachiosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zastrodon_UPGRADE",
+    "id": "GROUP_zastrodon_UPGRADE",
     "monsters": [ { "monster": "mon_sastrodon", "weight": 600 }, { "monster": "mon_zastrodon_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zalamosaurus_UPGRADE",
+    "id": "GROUP_zalamosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_salamosaurus", "weight": 600 }, { "monster": "mon_zalamosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ztegosaurus_UPGRADE",
+    "id": "GROUP_ztegosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sktegosaurus", "weight": 600 }, { "monster": "mon_ztegosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zesperosaurus_UPGRADE",
+    "id": "GROUP_zesperosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sesperosaurus", "weight": 600 }, { "monster": "mon_zesperosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zastonia_UPGRADE",
+    "id": "GROUP_zastonia_UPGRADE",
     "monsters": [ { "monster": "mon_sastonia", "weight": 600 }, { "monster": "mon_zastonia_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zargoyleosaurus_UPGRADE",
+    "id": "GROUP_zargoyleosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sargoyleosaurus", "weight": 600 }, { "monster": "mon_zargoyleosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zauropelta_UPGRADE",
+    "id": "GROUP_zauropelta_UPGRADE",
     "monsters": [ { "monster": "mon_skauropelta", "weight": 600 }, { "monster": "mon_zauropelta_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zodosaurus_UPGRADE",
+    "id": "GROUP_zodosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sodosaurus", "weight": 600 }, { "monster": "mon_zodosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zanoplosaurus_UPGRADE",
+    "id": "GROUP_zanoplosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sanoplosaurus", "weight": 600 }, { "monster": "mon_zanoplosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zedmontonia_UPGRADE",
+    "id": "GROUP_zedmontonia_UPGRADE",
     "monsters": [ { "monster": "mon_sedmontonia", "weight": 600 }, { "monster": "mon_zedmontonia_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zzuul_UPGRADE",
+    "id": "GROUP_zzuul_UPGRADE",
     "monsters": [ { "monster": "mon_suul", "weight": 600 }, { "monster": "mon_zzuul_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zyoplosaurus_UPGRADE",
+    "id": "GROUP_zyoplosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_syoplosaurus", "weight": 600 }, { "monster": "mon_zyoplosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zankylosaurus_UPGRADE",
+    "id": "GROUP_zankylosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_sankylosaurus", "weight": 400 },
       { "monster": "mon_zankylosaurus_shady", "weight": 300 },
@@ -526,162 +526,162 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zuoplocephalus_UPGRADE",
+    "id": "GROUP_zuoplocephalus_UPGRADE",
     "monsters": [ { "monster": "mon_suoplocephalus", "weight": 600 }, { "monster": "mon_zuoplocephalus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zcolosaurus_UPGRADE",
+    "id": "GROUP_zcolosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_skcolosaurus", "weight": 600 }, { "monster": "mon_zcolosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zenontosaurus_UPGRADE",
+    "id": "GROUP_zenontosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_senontosaurus", "weight": 600 }, { "monster": "mon_zenontosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zryosaurus_UPGRADE",
+    "id": "GROUP_zryosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sryosaurus", "weight": 600 }, { "monster": "mon_zryosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zamptosaurus_UPGRADE",
+    "id": "GROUP_zamptosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_samptosaurus", "weight": 600 }, { "monster": "mon_zamptosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ziguanodon_UPGRADE",
+    "id": "GROUP_ziguanodon_UPGRADE",
     "monsters": [ { "monster": "mon_siguanodon", "weight": 600 }, { "monster": "mon_ziguanodon_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zeolambia_UPGRADE",
+    "id": "GROUP_zeolambia_UPGRADE",
     "monsters": [ { "monster": "mon_seolambia", "weight": 600 }, { "monster": "mon_zeolambia_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zadrosaurus_UPGRADE",
+    "id": "GROUP_zadrosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sadrosaurus", "weight": 600 }, { "monster": "mon_zadrosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zaiasaura_UPGRADE",
+    "id": "GROUP_zaiasaura_UPGRADE",
     "monsters": [ { "monster": "mon_saiasaura", "weight": 600 }, { "monster": "mon_zaiasaura_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zryposaurus_UPGRADE",
+    "id": "GROUP_zryposaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sryposaurus", "weight": 600 }, { "monster": "mon_zryposaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zrosaurolophus_UPGRADE",
+    "id": "GROUP_zrosaurolophus_UPGRADE",
     "monsters": [ { "monster": "mon_srosaurolophus", "weight": 600 }, { "monster": "mon_zrosaurolophus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zaurolophus_UPGRADE",
+    "id": "GROUP_zaurolophus_UPGRADE",
     "monsters": [ { "monster": "mon_skaurolophus", "weight": 600 }, { "monster": "mon_zaurolophus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zedmontosaurus_UPGRADE",
+    "id": "GROUP_zedmontosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sedmontosaurus", "weight": 600 }, { "monster": "mon_zedmontosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zarasaurolophus_UPGRADE",
+    "id": "GROUP_zarasaurolophus_UPGRADE",
     "monsters": [ { "monster": "mon_sarasaurolophus", "weight": 600 }, { "monster": "mon_zarasaurolophus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zambeosaurus_UPGRADE",
+    "id": "GROUP_zambeosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sambeosaurus", "weight": 600 }, { "monster": "mon_zambeosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zorythosaurus_UPGRADE",
+    "id": "GROUP_zorythosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sorythosaurus", "weight": 600 }, { "monster": "mon_zorythosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zypacrosaurus_UPGRADE",
+    "id": "GROUP_zypacrosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sypacrosaurus", "weight": 600 }, { "monster": "mon_zypacrosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zachycephalosaurus_UPGRADE",
+    "id": "GROUP_zachycephalosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sachycephalosaurus", "weight": 600 }, { "monster": "mon_zachycephalosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zeptoceratops_UPGRADE",
+    "id": "GROUP_zeptoceratops_UPGRADE",
     "monsters": [ { "monster": "mon_septoceratops", "weight": 600 }, { "monster": "mon_zeptoceratops_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zzuniceratops_UPGRADE",
+    "id": "GROUP_zzuniceratops_UPGRADE",
     "monsters": [ { "monster": "mon_suniceratops", "weight": 600 }, { "monster": "mon_zzuniceratops_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zokiceratops_UPGRADE",
+    "id": "GROUP_zokiceratops_UPGRADE",
     "monsters": [ { "monster": "mon_sokiceratops", "weight": 600 }, { "monster": "mon_zokiceratops_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ztyracosaurus_UPGRADE",
+    "id": "GROUP_ztyracosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sktyracosaurus", "weight": 600 }, { "monster": "mon_ztyracosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zentrosaurus_UPGRADE",
+    "id": "GROUP_zentrosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sentrosaurus", "weight": 600 }, { "monster": "mon_zentrosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zeiniosaurus_UPGRADE",
+    "id": "GROUP_zeiniosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_seiniosaurus", "weight": 600 }, { "monster": "mon_zeiniosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zachelousaurus_UPGRADE",
+    "id": "GROUP_zachelousaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sachelousaurus", "weight": 600 }, { "monster": "mon_zachelousaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zachyrhinosaurus_UPGRADE",
+    "id": "GROUP_zachyrhinosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sachyrhinosaurus", "weight": 600 }, { "monster": "mon_zachyrhinosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zasmosaurus_UPGRADE",
+    "id": "GROUP_zasmosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sasmosaurus", "weight": 600 }, { "monster": "mon_zasmosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zentaceratops_UPGRADE",
+    "id": "GROUP_zentaceratops_UPGRADE",
     "monsters": [ { "monster": "mon_sentaceratops", "weight": 600 }, { "monster": "mon_zentaceratops_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zosmoceratops_UPGRADE",
+    "id": "GROUP_zosmoceratops_UPGRADE",
     "monsters": [ { "monster": "mon_sosmoceratops", "weight": 600 }, { "monster": "mon_zosmoceratops_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zorosaurus_UPGRADE",
+    "id": "GROUP_zorosaurus_UPGRADE",
     "monsters": [ { "monster": "mon_sorosaurus", "weight": 600 }, { "monster": "mon_zorosaurus_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zriceratops_UPGRADE",
+    "id": "GROUP_zriceratops_UPGRADE",
     "monsters": [ { "monster": "mon_sriceratops", "weight": 600 }, { "monster": "mon_zriceratops_brute", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zona_UPGRADE",
+    "id": "GROUP_zona_UPGRADE",
     "monsters": [
       { "monster": "mon_sona", "weight": 400 },
       { "monster": "mon_zona_shady", "weight": 300 },
@@ -690,7 +690,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zescelosaurus_UPGRADE",
+    "id": "GROUP_zescelosaurus_UPGRADE",
     "monsters": [
       { "monster": "mon_sescelosaurus", "weight": 400 },
       { "monster": "mon_zescelosaurus_shady", "weight": 300 },
@@ -699,7 +699,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zallosaurus_BRUTE",
+    "id": "GROUP_zallosaurus_BRUTE",
     "monsters": [
       { "monster": "mon_zallosaurus_hulk", "weight": 400 },
       { "monster": "mon_zallosaurus_truck", "weight": 300 },
@@ -708,7 +708,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zyrannosaurus_BRUTE",
+    "id": "GROUP_zyrannosaurus_BRUTE",
     "monsters": [
       { "monster": "mon_zyrannosaurus_hulk", "weight": 400 },
       { "monster": "mon_zyrannosaurus_truck", "weight": 300 },
@@ -717,12 +717,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zapatosaurus_BRUTE",
+    "id": "GROUP_zapatosaurus_BRUTE",
     "monsters": [ { "monster": "mon_zapatosaurus_hulk", "weight": 600 }, { "monster": "mon_zapatosaurus_tank", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zankylosaurus_BRUTE",
+    "id": "GROUP_zankylosaurus_BRUTE",
     "monsters": [
       { "monster": "mon_zankylosaurus_hulk", "weight": 400 },
       { "monster": "mon_zankylosaurus_tank", "weight": 300 },
@@ -731,12 +731,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_zriceratops_BRUTE",
+    "id": "GROUP_zriceratops_BRUTE",
     "monsters": [ { "monster": "mon_zriceratops_hulk", "weight": 600 }, { "monster": "mon_zriceratops_tank", "weight": 400 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE",
+    "id": "GROUP_ZOMBIE",
     "//": "Only dinos that can fit through a standard door frame should be here",
     "monsters": [
       { "monster": "mon_zilophosaurus", "starts": "3 days" },
@@ -760,7 +760,7 @@
     ]
   },
   {
-    "name": "GROUP_ROOF_ZOMBIE",
+    "id": "GROUP_ROOF_ZOMBIE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zteranodon", "weight": 20, "starts": "3 days", "pack_size": [ 4, 6 ] },

--- a/data/mods/Magiclysm/mod_interactions/defense_mode/monstergroups.json
+++ b/data/mods/Magiclysm/mod_interactions/defense_mode/monstergroups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_LIZARDFOLK_DM",
+    "id": "GROUP_LIZARDFOLK_DM",
     "monsters": [
       { "monster": "mon_lizardfolk_warrior_dm", "weight": 900 },
       { "monster": "mon_lizardfolk_warrior_dm", "weight": 20, "pack_size": [ 2, 4 ] },
@@ -12,7 +12,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GOLEM_DM",
+    "id": "GROUP_GOLEM_DM",
     "monsters": [
       { "monster": "mon_plasticgolem_dm", "weight": 965 },
       { "monster": "mon_claygolem_dm", "weight": 20 },
@@ -22,7 +22,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GOBLIN_DM",
+    "id": "GROUP_GOBLIN_DM",
     "monsters": [
       { "monster": "mon_goblin_warrior_dm", "weight": 900 },
       { "monster": "mon_goblin_warrior_dm", "weight": 35, "pack_size": [ 2, 4 ] },
@@ -31,7 +31,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ORC_DM",
+    "id": "GROUP_ORC_DM",
     "monsters": [
       { "monster": "mon_orc_warrior_dm", "weight": 960, "cost_multiplier": 5 },
       { "monster": "mon_orc_archer_dm", "weight": 25, "cost_multiplier": 7 },

--- a/data/mods/Magiclysm/monstergroup_upgrades.json
+++ b/data/mods/Magiclysm/monstergroup_upgrades.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_DWARF_UPGRADE",
+    "id": "GROUP_ZOMBIE_DWARF_UPGRADE",
     "monsters": [
       { "monster": "mon_zombie_tough", "weight": 110 },
       { "monster": "mon_zombie_grabber", "weight": 30 },
@@ -29,7 +29,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_ELF_UPGRADE",
+    "id": "GROUP_ZOMBIE_ELF_UPGRADE",
     "monsters": [
       { "monster": "mon_zombie_tough", "weight": 25 },
       { "monster": "mon_zombie_grabber", "weight": 25 },
@@ -57,7 +57,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_GOBLIN_UPGRADE",
+    "id": "GROUP_ZOMBIE_GOBLIN_UPGRADE",
     "//": "Child-type zombies that evoke no guilt.",
     "monsters": [
       { "monster": "mon_zombie_anklebiter", "weight": 300 },
@@ -69,7 +69,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_RAVENFOLK_UPGRADE",
+    "id": "GROUP_ZOMBIE_RAVENFOLK_UPGRADE",
     "monsters": [
       { "monster": "mon_zombie_necro", "weight": 30 },
       { "monster": "mon_zombie_necro_boomer", "weight": 20 },
@@ -82,7 +82,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_LIZARDFOLK_UPGRADE",
+    "id": "GROUP_ZOMBIE_LIZARDFOLK_UPGRADE",
     "//": "Heavily weighted toward the more feral variants but with some other options too.",
     "monsters": [
       { "monster": "mon_zombie_hunter", "weight": 200 },

--- a/data/mods/Magiclysm/monstergroups.json
+++ b/data/mods/Magiclysm/monstergroups.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_NULL",
+    "id": "GROUP_NULL",
     "is_safe": true,
     "monsters": [ { "monster": "mon_null", "weight": 920 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_null", "weight": 860 },
@@ -78,7 +78,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FERAL_WIZARDS",
+    "id": "GROUP_FERAL_WIZARDS",
     "monsters": [
       { "monster": "mon_feral_human_magician", "weight": 50, "cost_multiplier": 2 },
       { "monster": "mon_feral_druid", "weight": 50, "cost_multiplier": 2 },
@@ -95,7 +95,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FERAL_TECHNOMANCERS",
+    "id": "GROUP_FERAL_TECHNOMANCERS",
     "monsters": [
       { "monster": "mon_feral_technomancer", "weight": 50, "cost_multiplier": 2 },
       { "monster": "mon_feral_technomancer_enhanced", "weight": 5, "cost_multiplier": 4 }
@@ -103,7 +103,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SWAMP",
+    "id": "GROUP_SWAMP",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_null", "weight": 940 },
@@ -121,7 +121,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAVE",
+    "id": "GROUP_CAVE",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_null", "weight": 782 },
@@ -154,7 +154,7 @@
     ]
   },
   {
-    "name": "GROUP_ZOMBIE_FANTASY_SPECIES",
+    "id": "GROUP_ZOMBIE_FANTASY_SPECIES",
     "type": "monstergroup",
     "//": "same ratio as ferals",
     "monsters": [
@@ -167,7 +167,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE",
+    "id": "GROUP_ZOMBIE",
     "monsters": [
       { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 4720 },
       { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 10, "cost_multiplier": 7, "pack_size": [ 5, 20 ] },
@@ -177,7 +177,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_GASSTATION",
+    "id": "GROUP_ZOMBIE_GASSTATION",
     "monsters": [
       { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 472 },
       { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 1, "cost_multiplier": 7, "pack_size": [ 5, 20 ] },
@@ -186,43 +186,43 @@
     ]
   },
   {
-    "name": "GROUP_MINERS",
+    "id": "GROUP_MINERS",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_zombie_miner", "weight": 100 }, { "monster": "mon_zombie_dwarf_miner", "weight": 40 } ]
   },
   {
-    "name": "GROUP_PARK_DOG",
+    "id": "GROUP_PARK_DOG",
     "type": "monstergroup",
     "monsters": [ { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 125 } ]
   },
   {
-    "name": "GROUP_PARK_PLAYGROUND",
+    "id": "GROUP_PARK_PLAYGROUND",
     "type": "monstergroup",
     "monsters": [ { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 100 } ]
   },
   {
-    "name": "GROUP_PARK_SCENIC",
+    "id": "GROUP_PARK_SCENIC",
     "type": "monstergroup",
     "monsters": [ { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 100 } ]
   },
   {
-    "name": "GROUP_ROOF_ZOMBIE",
+    "id": "GROUP_ROOF_ZOMBIE",
     "type": "monstergroup",
     "monsters": [ { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 100, "pack_size": [ 2, 3 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "DUMP_ANIMALS",
+    "id": "DUMP_ANIMALS",
     "monsters": [ { "monster": "mon_otyugh", "weight": 5 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SEWER",
+    "id": "GROUP_SEWER",
     "monsters": [ { "monster": "mon_otyugh", "weight": 15 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB",
+    "id": "GROUP_LAB",
     "monsters": [
       { "monster": "mon_feral_lab_magician", "weight": 25, "cost_multiplier": 5 },
       { "monster": "mon_feral_technomancer", "weight": 8, "cost_multiplier": 5 },
@@ -231,7 +231,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_SURFACE",
+    "id": "GROUP_LAB_SURFACE",
     "monsters": [
       { "monster": "mon_feral_lab_magician", "weight": 25, "cost_multiplier": 5 },
       { "monster": "mon_feral_technomancer", "weight": 8, "cost_multiplier": 5 },
@@ -241,7 +241,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MICROLAB",
+    "id": "GROUP_MICROLAB",
     "monsters": [
       { "monster": "mon_feral_lab_magician", "weight": 2, "cost_multiplier": 5 },
       { "monster": "mon_feral_technomancer", "weight": 2, "cost_multiplier": 5 },
@@ -250,7 +250,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_RESEARCHERS",
+    "id": "GROUP_LAB_RESEARCHERS",
     "monsters": [
       { "monster": "mon_feral_lab_magician", "weight": 20, "cost_multiplier": 5 },
       { "monster": "mon_feral_technomancer", "weight": 10, "cost_multiplier": 5 },
@@ -260,13 +260,13 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_POLYMORPH_SHADOW",
+    "id": "GROUP_POLYMORPH_SHADOW",
     "is_animal": true,
     "monsters": [ { "monster": "mon_magi_shadow", "weight": 990 }, { "monster": "mon_shadow_snake", "weight": 10 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DOMESTIC",
+    "id": "GROUP_DOMESTIC",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_dog", "weight": 980 },
@@ -275,7 +275,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WORM",
+    "id": "GROUP_WORM",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_worm_small", "weight": 500 },
@@ -286,7 +286,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BLACKDRAGON_LAIR_1",
+    "id": "GROUP_BLACKDRAGON_LAIR_1",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_null", "weight": 880 },
@@ -307,7 +307,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BLACKDRAGON_LAIR_2",
+    "id": "GROUP_BLACKDRAGON_LAIR_2",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_black_pudding", "weight": 14, "pack_size": [ 4, 6 ] },
@@ -323,7 +323,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LIZARDFOLK",
+    "id": "GROUP_LIZARDFOLK",
     "//": "A lizard humanoid race, they are allies and servants of the black dragons.",
     "is_animal": true,
     "monsters": [
@@ -337,7 +337,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_OGRE",
+    "id": "GROUP_OGRE",
     "//": "Contains ogres and their various mutations",
     "monsters": [
       { "monster": "mon_ogre", "weight": 500 },
@@ -352,7 +352,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_OGRE_MUTANTS",
+    "id": "GROUP_OGRE_MUTANTS",
     "monsters": [
       { "monster": "mon_ogre_twoheaded", "weight": 500 },
       { "monster": "mon_ogre_spider", "weight": 400 },
@@ -361,7 +361,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TOWER_GOLEM",
+    "id": "GROUP_TOWER_GOLEM",
     "//": "Cheap golems used to defend the average wizard's tower.",
     "monsters": [
       { "monster": "mon_plasticgolem", "weight": 965 },
@@ -371,7 +371,7 @@
     ]
   },
   {
-    "name": "GROUP_FROGS_CLOAK",
+    "id": "GROUP_FROGS_CLOAK",
     "//": "Nature frogs with no seasonal limits",
     "type": "monstergroup",
     "default": "mon_peeper_frog",
@@ -386,7 +386,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ALL_GOBLINS",
+    "id": "GROUP_ALL_GOBLINS",
     "monsters": [
       { "monster": "mon_goblin_warrior", "weight": 335 },
       { "monster": "mon_feral_goblin", "weight": 50 },
@@ -406,7 +406,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GOBLIN_MUTANTS",
+    "id": "GROUP_GOBLIN_MUTANTS",
     "monsters": [
       { "monster": "mon_orc_warrior", "weight": 400 },
       { "monster": "mon_orc_archer", "weight": 150 },
@@ -418,7 +418,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GOBLIN_STANDARD",
+    "id": "GROUP_GOBLIN_STANDARD",
     "monsters": [
       { "monster": "mon_goblin_warrior", "weight": 900 },
       { "monster": "mon_goblin_warrior", "weight": 35, "pack_size": [ 2, 4 ] },
@@ -427,12 +427,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GOBLIN_ADVANCED",
+    "id": "GROUP_GOBLIN_ADVANCED",
     "monsters": [ { "monster": "mon_goblin_chieftain" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FORGE_STANDARD",
+    "id": "GROUP_FORGE_STANDARD",
     "monsters": [
       { "monster": "mon_null", "weight": 978 },
       { "monster": "mon_forgeborn", "weight": 10, "cost_multiplier": 10 },
@@ -444,22 +444,22 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FORGEDEMONS",
+    "id": "GROUP_FORGEDEMONS",
     "monsters": [ { "monster": "mon_forgedemons", "cost_multiplier": 3 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FORGE_DWARVES",
+    "id": "GROUP_FORGE_DWARVES",
     "monsters": [ { "monster": "mon_forgedwarves", "cost_multiplier": 3 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FORGE_AUTOMATA",
+    "id": "GROUP_FORGE_AUTOMATA",
     "monsters": [ { "monster": "mon_forgeborn", "cost_multiplier": 3 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ORC",
+    "id": "GROUP_ORC",
     "monsters": [
       { "monster": "mon_orc_warrior", "weight": 960, "cost_multiplier": 5 },
       { "monster": "mon_orc_archer", "weight": 25, "cost_multiplier": 7 },
@@ -468,13 +468,13 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WORKSHOP",
+    "id": "GROUP_WORKSHOP",
     "default": "mon_workshop_elf",
     "monsters": [ { "monster": "mon_workshop_elf", "weight": 100, "cost_multiplier": 2 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FERAL",
+    "id": "GROUP_FERAL",
     "monsters": [
       { "monster": "mon_feral_elf_pipe", "weight": 20, "pack_size": [ 2, 3 ] },
       { "monster": "mon_feral_dwarf_pipe", "weight": 20, "pack_size": [ 2, 3 ] },
@@ -490,7 +490,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST_SPIRIT",
+    "id": "GROUP_FOREST_SPIRIT",
     "monsters": [
       { "monster": "mon_mossling", "weight": 48, "cost_multiplier": 1 },
       { "monster": "mon_mossling", "weight": 16, "cost_multiplier": 2, "pack_size": [ 3, 6 ] },
@@ -503,7 +503,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST_SPIRIT_SWAMP",
+    "id": "GROUP_FOREST_SPIRIT_SWAMP",
     "monsters": [
       { "monster": "mon_mossling", "weight": 25, "cost_multiplier": 1 },
       { "monster": "mon_mossling", "weight": 10, "cost_multiplier": 2, "pack_size": [ 2, 4 ] },
@@ -512,7 +512,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_EARTH_SPIRIT",
+    "id": "GROUP_EARTH_SPIRIT",
     "monsters": [
       { "monster": "mon_earth_gnome", "weight": 25, "cost_multiplier": 1 },
       { "monster": "mon_earth_gnome", "weight": 5, "cost_multiplier": 1, "pack_size": [ 2, 4 ] }
@@ -520,7 +520,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_EARTH_SPIRIT_CAVE",
+    "id": "GROUP_EARTH_SPIRIT_CAVE",
     "monsters": [
       { "monster": "mon_earth_gnome", "weight": 25, "cost_multiplier": 1 },
       { "monster": "mon_earth_gnome", "weight": 15, "cost_multiplier": 3, "pack_size": [ 2, 4 ] }
@@ -528,12 +528,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MAGIC_FIELD",
+    "id": "GROUP_MAGIC_FIELD",
     "monsters": [ { "group": "GROUP_FOREST", "weight": 2 }, { "group": "GROUP_FOREST_SPIRIT", "weight": 1 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID",
+    "id": "GROUP_TRIFFID",
     "default": "mon_triffid",
     "monsters": [
       { "monster": "mon_triffid_seedshaper", "weight": 25, "cost_multiplier": 5 },
@@ -542,7 +542,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_OUTER",
+    "id": "GROUP_TRIFFID_OUTER",
     "default": "mon_triffid",
     "monsters": [
       { "monster": "mon_triffid_seedshaper", "weight": 50, "cost_multiplier": 2 },
@@ -551,7 +551,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_HEARTGUARDS",
+    "id": "GROUP_TRIFFID_HEARTGUARDS",
     "default": "mon_triffid",
     "monsters": [
       { "monster": "mon_triffid_seedshaper", "weight": 150, "cost_multiplier": 2 },
@@ -560,7 +560,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_HERBALISM_SEEDSHAPER",
+    "id": "GROUP_TRIFFID_HERBALISM_SEEDSHAPER",
     "//": "For placing in magic fields",
     "monsters": [
       { "monster": "mon_triffid_seedshaper", "weight": 1 },
@@ -570,7 +570,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_HERBALISM_VINEWEAVER",
+    "id": "GROUP_TRIFFID_HERBALISM_VINEWEAVER",
     "//": "For placing in magic fields",
     "monsters": [
       { "monster": "mon_triffid_vineweaver", "weight": 1 },
@@ -580,7 +580,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_CAMP_OM",
+    "id": "GROUP_MI-GO_CAMP_OM",
     "monsters": [
       { "monster": "mon_mi_go_fleshwarper", "weight": 50, "cost_multiplier": 20, "starts": "210 hours" },
       { "monster": "mon_mi_go_nethermancer", "weight": 50, "cost_multiplier": 20, "starts": "210 hours" }
@@ -588,7 +588,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_COMMON",
+    "id": "GROUP_MI-GO_BASE_COMMON",
     "monsters": [
       { "monster": "mon_mi_go_fleshwarper", "weight": 50, "cost_multiplier": 2, "starts": "210 hours" },
       { "monster": "mon_mi_go_nethermancer", "weight": 50, "cost_multiplier": 2, "starts": "210 hours" }
@@ -596,7 +596,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_CAPTORS",
+    "id": "GROUP_MI-GO_BASE_CAPTORS",
     "monsters": [
       { "monster": "mon_mi_go_fleshwarper", "weight": 300, "cost_multiplier": 2, "starts": "210 hours" },
       { "monster": "mon_mi_go_nethermancer", "weight": 100, "cost_multiplier": 2, "starts": "210 hours" }
@@ -604,7 +604,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_BOSS",
+    "id": "GROUP_MI-GO_BASE_BOSS",
     "monsters": [
       { "monster": "mon_mi_go_fleshwarper", "weight": 200, "cost_multiplier": 2 },
       { "monster": "mon_mi_go_fleshwarper", "weight": 50, "cost_multiplier": 5, "pack_size": [ 2, 3 ] },
@@ -614,7 +614,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHERMANCER_SUMMON",
+    "id": "GROUP_NETHERMANCER_SUMMON",
     "default": "mon_blank",
     "monsters": [
       { "monster": "mon_flying_polyp_migo", "weight": 100, "cost_multiplier": 0 },
@@ -628,7 +628,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIFIED_ANIMALS",
+    "id": "GROUP_ZOMBIFIED_ANIMALS",
     "default": "mon_zombie_dog",
     "//": "For overrun or feral druid spaces",
     "monsters": [

--- a/data/mods/Magiclysm/monstergroups_egg.json
+++ b/data/mods/Magiclysm/monstergroups_egg.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_EGG_OWLBEAR",
+    "id": "GROUP_EGG_OWLBEAR",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_owlbear_cub" } ]
   }

--- a/data/mods/Magiclysm/worldgen/druid_tower.json
+++ b/data/mods/Magiclysm/worldgen/druid_tower.json
@@ -99,7 +99,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DRUID_TOWER_DRUID_HEAD",
+    "id": "GROUP_DRUID_TOWER_DRUID_HEAD",
     "monsters": [ { "monster": "mon_feral_druid", "weight": 150 }, { "monster": "mon_feral_druid_enhanced", "weight": 850 } ]
   },
   {

--- a/data/mods/Megafauna/mod_interactions/defense_mode/monstergroups.json
+++ b/data/mods/Megafauna/mod_interactions/defense_mode/monstergroups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_MEGAFAUNA_DM",
+    "id": "GROUP_MEGAFAUNA_DM",
     "default": "mon_direwolf",
     "monsters": [
       { "monster": "mon_direwolf_dm", "weight": 10 },

--- a/data/mods/Megafauna/monstergroups/misc.json
+++ b/data/mods/Megafauna/monstergroups/misc.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_DOMESTIC",
+    "id": "GROUP_DOMESTIC",
     "default": "mon_peccary_flathead",
     "is_animal": true,
     "monsters": [
@@ -21,7 +21,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SAFE",
+    "id": "GROUP_SAFE",
     "is_safe": true,
     "is_animal": true,
     "monsters": [

--- a/data/mods/Megafauna/monstergroups/monstergroups_egg.json
+++ b/data/mods/Megafauna/monstergroups/monstergroups_egg.json
@@ -1,11 +1,11 @@
 [
   {
-    "name": "GROUP_EGG_AUK",
+    "id": "GROUP_EGG_AUK",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_auk_chick" } ]
   },
   {
-    "name": "GROUP_EGG_TITANIS_WALLERI",
+    "id": "GROUP_EGG_TITANIS_WALLERI",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_titanis_walleri_chick" } ]
   }

--- a/data/mods/Megafauna/monstergroups/wilderness.json
+++ b/data/mods/Megafauna/monstergroups/wilderness.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_sabcat", "weight": 25, "cost_multiplier": 0, "pack_size": [ 1, 1 ] },
@@ -86,7 +86,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RIVER",
+    "id": "GROUP_RIVER",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_sabcat", "weight": 8, "cost_multiplier": 0, "pack_size": [ 1, 1 ] },
@@ -115,7 +115,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SWAMP",
+    "id": "GROUP_SWAMP",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_sabcat", "weight": 15, "cost_multiplier": 0, "pack_size": [ 1, 1 ] },
@@ -141,7 +141,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAVE",
+    "id": "GROUP_CAVE",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_direwolf", "weight": 100, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },

--- a/data/mods/MindOverMatter/mod_interactions/defense_mode/monstergroups.json
+++ b/data/mods/MindOverMatter/mod_interactions/defense_mode/monstergroups.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_FERAL_PSYCHIC_DM",
+    "id": "GROUP_FERAL_PSYCHIC_DM",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_human_bio_dm", "weight": 1, "cost_multiplier": 2 },

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_PARK_SCENIC",
+    "id": "GROUP_PARK_SCENIC",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_human_bio", "weight": 2, "cost_multiplier": 2 },
@@ -15,7 +15,7 @@
     ]
   },
   {
-    "name": "GROUP_PARK_DOG",
+    "id": "GROUP_PARK_DOG",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_human_bio", "weight": 2, "cost_multiplier": 2 },
@@ -31,7 +31,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE",
+    "id": "GROUP_ZOMBIE",
     "monsters": [
       { "monster": "mon_feral_human_bio", "weight": 1, "cost_multiplier": 4 },
       { "monster": "mon_feral_human_clair", "weight": 1, "cost_multiplier": 3 },
@@ -46,7 +46,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PREPPER_HOUSE",
+    "id": "GROUP_PREPPER_HOUSE",
     "monsters": [
       { "monster": "mon_feral_human_bio", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_feral_human_clair", "weight": 15 },
@@ -61,19 +61,19 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CHURCH_ZOMBIE",
+    "id": "GROUP_CHURCH_ZOMBIE",
     "monsters": [
       { "monster": "mon_feral_human_clair", "weight": 15, "cost_multiplier": 2 },
       { "monster": "mon_feral_human_vita", "weight": 15 }
     ]
   },
   {
-    "name": "GROUP_MANSION_START",
+    "id": "GROUP_MANSION_START",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_feral_human_clair", "weight": 40 }, { "monster": "mon_feral_human_teep", "weight": 40 } ]
   },
   {
-    "name": "FERAL_HUMANS",
+    "id": "FERAL_HUMANS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_human_bio", "weight": 1, "cost_multiplier": 4 },
@@ -89,7 +89,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CENTRAL_LAB",
+    "id": "GROUP_CENTRAL_LAB",
     "monsters": [
       { "monster": "mon_feral_scientist_psychic", "weight": 10, "cost_multiplier": 10 },
       { "monster": "mon_feral_security_psychic", "weight": 12, "cost_multiplier": 4 },
@@ -100,7 +100,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB",
+    "id": "GROUP_LAB",
     "monsters": [
       { "monster": "mon_feral_scientist_psychic", "weight": 15, "cost_multiplier": 10 },
       { "monster": "mon_feral_security_psychic", "weight": 12, "cost_multiplier": 4 },
@@ -111,7 +111,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_SURFACE",
+    "id": "GROUP_LAB_SURFACE",
     "monsters": [
       { "monster": "mon_feral_scientist_psychic", "weight": 10, "cost_multiplier": 10 },
       { "monster": "mon_feral_security_psychic", "weight": 12, "cost_multiplier": 4 },
@@ -122,7 +122,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MICROLAB",
+    "id": "GROUP_MICROLAB",
     "monsters": [
       { "monster": "mon_feral_scientist_psychic", "weight": 2, "cost_multiplier": 10 },
       { "monster": "mon_feral_security_psychic", "weight": 12, "cost_multiplier": 4 },
@@ -134,7 +134,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_BASIC_SECURITY",
+    "id": "GROUP_LAB_BASIC_SECURITY",
     "monsters": [
       { "monster": "mon_feral_security_psychic", "weight": 5, "cost_multiplier": 4 },
       { "monster": "mon_feral_security_captain_psychic", "weight": 2, "cost_multiplier": 10 }
@@ -142,7 +142,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DISTORTED_MICROLAB",
+    "id": "GROUP_DISTORTED_MICROLAB",
     "monsters": [
       { "monster": "mon_feral_scientist_psychic", "weight": 20, "cost_multiplier": 1 },
       { "monster": "mon_feral_human_porter3", "weight": 35, "cost_multiplier": 1 },
@@ -151,7 +151,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_RESEARCHERS",
+    "id": "GROUP_LAB_RESEARCHERS",
     "monsters": [
       { "monster": "mon_feral_scientist_psychic", "weight": 10, "cost_multiplier": 5 },
       { "monster": "mon_zombie_scientist_phavian", "weight": 150 },
@@ -160,44 +160,44 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_REALITY_TEAR_FIELD",
+    "id": "GROUP_NETHER_REALITY_TEAR_FIELD",
     "monsters": [ { "monster": "mon_nether_eater", "weight": 100, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER",
+    "id": "GROUP_NETHER",
     "monsters": [ { "monster": "mon_nether_eater", "weight": 120, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_PORTAL",
+    "id": "GROUP_NETHER_PORTAL",
     "monsters": [ { "monster": "mon_nether_eater", "weight": 200, "cost_multiplier": 0 } ]
   },
   {
-    "name": "GROUP_CIVILIANS_STANDARD",
+    "id": "GROUP_CIVILIANS_STANDARD",
     "type": "monstergroup",
     "monsters": [ { "group": "GROUP_CIVILIANS_PSYCHIC_FERAL", "weight": 10, "cost_multiplier": 2 } ]
   },
   {
-    "name": "GROUP_BEARS",
+    "id": "GROUP_BEARS",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_bandersnatch", "weight": 20, "starts": "2 days", "cost_multiplier": 5 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAVE",
+    "id": "GROUP_CAVE",
     "monsters": [ { "monster": "mon_hidebehind", "weight": 10, "starts": "2 days", "cost_multiplier": 5 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_MAMMAL_WINTER",
+    "id": "GROUP_WILDERNESS_FOREST_MAMMAL_WINTER",
     "monsters": [
       { "monster": "mon_hidebehind", "weight": 1, "starts": "2 days", "cost_multiplier": 10 },
       { "monster": "mon_psi_gremlin", "weight": 1, "starts": "2 days", "cost_multiplier": 10 }
     ]
   },
   {
-    "name": "GROUP_COWS",
+    "id": "GROUP_COWS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_hodag_calf", "weight": 10, "starts": "7 days", "cost_multiplier": 5 },
@@ -205,7 +205,7 @@
     ]
   },
   {
-    "name": "GROUP_COWS_DAIRY",
+    "id": "GROUP_COWS_DAIRY",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_cow_biokinetic", "weight": 10, "starts": "2 days", "cost_multiplier": 5 },
@@ -215,7 +215,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -227,7 +227,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_MAMMAL_MUTANT",
+    "id": "GROUP_WILDERNESS_FOREST_MAMMAL_MUTANT",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -237,7 +237,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROOF_ANIMAL",
+    "id": "GROUP_ROOF_ANIMAL",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -255,13 +255,13 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SAFE",
+    "id": "GROUP_SAFE",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [ { "monster": "mon_cockatrice", "weight": 2, "starts": "21 days" }, { "monster": "mon_psi_gremlin", "weight": 2 } ]
   },
   {
-    "name": "GROUP_PET_DOGS",
+    "id": "GROUP_PET_DOGS",
     "type": "monstergroup",
     "default": "mon_dog",
     "monsters": [
@@ -270,7 +270,7 @@
     ]
   },
   {
-    "name": "GROUP_STRAY_DOGS",
+    "id": "GROUP_STRAY_DOGS",
     "type": "monstergroup",
     "default": "mon_dog",
     "monsters": [
@@ -280,13 +280,13 @@
     ]
   },
   {
-    "name": "GROUP_MUTANT_PET_DOGS",
+    "id": "GROUP_MUTANT_PET_DOGS",
     "type": "monstergroup",
     "default": "mon_dog_mutant_mongrel",
     "monsters": [ { "monster": "mon_dire_hound", "weight": 1, "starts": "58 days", "cost_multiplier": 0 } ]
   },
   {
-    "name": "GROUP_ANIMALPOUND_DOGS",
+    "id": "GROUP_ANIMALPOUND_DOGS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_hellhound", "weight": 5, "cost_multiplier": 0 },
@@ -295,7 +295,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_CAMP_OM",
+    "id": "GROUP_MI-GO_CAMP_OM",
     "monsters": [
       { "monster": "mon_mi_go_telepath", "weight": 50, "cost_multiplier": 20, "starts": "210 hours" },
       { "monster": "mon_mi_go_photokinetic", "weight": 50, "cost_multiplier": 2, "starts": "210 hours" },
@@ -304,7 +304,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_COMMON",
+    "id": "GROUP_MI-GO_BASE_COMMON",
     "monsters": [
       { "monster": "mon_mi_go_telepath", "weight": 50, "cost_multiplier": 2, "starts": "210 hours" },
       { "monster": "mon_mi_go_photokinetic", "weight": 50, "cost_multiplier": 2, "starts": "210 hours" },
@@ -313,7 +313,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_CAPTORS",
+    "id": "GROUP_MI-GO_BASE_CAPTORS",
     "monsters": [
       { "monster": "mon_mi_go_telepath", "weight": 300, "cost_multiplier": 2, "starts": "210 hours" },
       { "monster": "mon_mi_go_photokinetic", "weight": 300, "cost_multiplier": 2, "starts": "210 hours" },
@@ -322,7 +322,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_BOSS",
+    "id": "GROUP_MI-GO_BASE_BOSS",
     "monsters": [
       { "monster": "mon_mi_go_telepath", "weight": 200, "cost_multiplier": 2 },
       { "monster": "mon_mi_go_telepath", "weight": 50, "cost_multiplier": 5, "pack_size": [ 2, 3 ] },
@@ -334,25 +334,25 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID",
+    "id": "GROUP_TRIFFID",
     "default": "mon_triffid",
     "monsters": [ { "group": "GROUP_TRIFFID_PSIONS", "weight": 25, "cost_multiplier": 5 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_OUTER",
+    "id": "GROUP_TRIFFID_OUTER",
     "default": "mon_triffid",
     "monsters": [ { "group": "GROUP_TRIFFID_PSIONS", "weight": 50, "cost_multiplier": 2 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_HEARTGUARDS",
+    "id": "GROUP_TRIFFID_HEARTGUARDS",
     "default": "mon_triffid",
     "monsters": [ { "group": "GROUP_TRIFFID_PSIONS", "weight": 150, "cost_multiplier": 2 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_PSIONS",
+    "id": "GROUP_TRIFFID_PSIONS",
     "monsters": [
       { "monster": "mon_triffid_clairsentient", "weight": 400 },
       { "monster": "mon_triffid_pyrokinetic", "weight": 400 },

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_ANIMAL_PSIONS",
+    "id": "GROUP_ANIMAL_PSIONS",
     "type": "monstergroup",
     "default": "mon_null",
     "is_animal": true,
@@ -17,7 +17,7 @@
     ]
   },
   {
-    "name": "GROUP_FERAL_PSYCHIC",
+    "id": "GROUP_FERAL_PSYCHIC",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_human_bio", "weight": 1, "cost_multiplier": 2 },
@@ -32,7 +32,7 @@
     ]
   },
   {
-    "name": "GROUP_FERAL_BIOKINETIC",
+    "id": "GROUP_FERAL_BIOKINETIC",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_human_bio", "weight": 25 },
@@ -41,7 +41,7 @@
     ]
   },
   {
-    "name": "GROUP_FERAL_CLAIRSENTIENT",
+    "id": "GROUP_FERAL_CLAIRSENTIENT",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_human_clair", "weight": 25 },
@@ -50,7 +50,7 @@
     ]
   },
   {
-    "name": "GROUP_FERAL_CLAIRSENTIENT_TELEPATH",
+    "id": "GROUP_FERAL_CLAIRSENTIENT_TELEPATH",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_human_clair", "weight": 25 },
@@ -62,12 +62,12 @@
     ]
   },
   {
-    "name": "GROUP_FERAL_TELEPATH",
+    "id": "GROUP_FERAL_TELEPATH",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_feral_human_teep", "weight": 25 }, { "monster": "mon_feral_human_teep2", "weight": 8 } ]
   },
   {
-    "name": "GROUP_FERAL_TELEPORTER",
+    "id": "GROUP_FERAL_TELEPORTER",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_human_porter", "weight": 25 },
@@ -76,7 +76,7 @@
     ]
   },
   {
-    "name": "GROUP_CRYSTAL_FIELD",
+    "id": "GROUP_CRYSTAL_FIELD",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_feral_human_bio", "weight": 60, "cost_multiplier": 2 },
@@ -108,18 +108,18 @@
     ]
   },
   {
-    "name": "GROUP_FEAR_HAWKS",
+    "id": "GROUP_FEAR_HAWKS",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fear_hawk", "weight": 1000 } ]
   },
   {
-    "name": "GROUP_CRYSTAL_FIELD_PSYCHOACTIVE",
+    "id": "GROUP_CRYSTAL_FIELD_PSYCHOACTIVE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_swarm_structure", "weight": 60, "cost_multiplier": 2 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_RESEARCH",
+    "id": "GROUP_LAB_RESEARCH",
     "default": "mon_zombie_scientist_phavian",
     "monsters": [
       { "monster": "mon_feral_labsecurity_9mm", "weight": 18, "cost_multiplier": 8 },
@@ -160,7 +160,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PHAVIAN_OFFICE",
+    "id": "GROUP_PHAVIAN_OFFICE",
     "default": "mon_zombie_scientist_phavian",
     "monsters": [
       { "monster": "mon_feral_labsecurity_9mm", "weight": 18, "cost_multiplier": 8 },
@@ -187,7 +187,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PHAVIAN_SKYSCRAPER_LAB",
+    "id": "GROUP_PHAVIAN_SKYSCRAPER_LAB",
     "default": "mon_zombie_scientist_phavian",
     "monsters": [
       { "monster": "mon_feral_labsecurity_9mm", "weight": 25, "cost_multiplier": 8 },
@@ -213,7 +213,7 @@
     ]
   },
   {
-    "name": "GROUP_CIVILIANS_PSYCHIC_FERAL",
+    "id": "GROUP_CIVILIANS_PSYCHIC_FERAL",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_civilian_biokinetic", "weight": 1, "cost_multiplier": 0, "ends": "3 days" },
@@ -228,7 +228,7 @@
     ]
   },
   {
-    "name": "GROUP_NETHER_BREACH",
+    "id": "GROUP_NETHER_BREACH",
     "type": "monstergroup",
     "//": "Weights slightly adjusted from base Nether group, additional things added",
     "monsters": [
@@ -253,7 +253,7 @@
     ]
   },
   {
-    "name": "GROUP_NETHER_LAB_DEVOURER_BREACH",
+    "id": "GROUP_NETHER_LAB_DEVOURER_BREACH",
     "type": "monstergroup",
     "//": "same as above except in the SCIENCE faction, which sadly requires new monsters",
     "monsters": [
@@ -276,42 +276,42 @@
     ]
   },
   {
-    "name": "GROUP_REPRODUCTION_COW_MUTANT_BABIES",
+    "id": "GROUP_REPRODUCTION_COW_MUTANT_BABIES",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_cow_calf", "weight": 95 }, { "monster": "mon_hodag_calf", "weight": 95 } ]
   },
   {
-    "name": "GROUP_REPRODUCTION_COW_PRE_HODAG_MUTANT_BABIES",
+    "id": "GROUP_REPRODUCTION_COW_PRE_HODAG_MUTANT_BABIES",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_cow_calf", "weight": 75 }, { "monster": "mon_hodag_calf", "weight": 25 } ]
   },
   {
-    "name": "GROUP_REPRODUCTION_DOG_HELLHOUND_BABIES",
+    "id": "GROUP_REPRODUCTION_DOG_HELLHOUND_BABIES",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_dog_pup", "weight": 80 }, { "monster": "mon_hellhound_pup", "weight": 20 } ]
   },
   {
-    "name": "GROUP_EGG_COCKATRICE",
+    "id": "GROUP_EGG_COCKATRICE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_cockatrice_chick", "weight": 100 } ]
   },
   {
-    "name": "GROUP_EGG_CHICKEN",
+    "id": "GROUP_EGG_CHICKEN",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_cockatrice_chick", "weight": 5 }, { "monster": "mon_chicken_chick", "weight": 95 } ]
   },
   {
-    "name": "GROUP_EGG_PIGEON",
+    "id": "GROUP_EGG_PIGEON",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_pigeon_passenger_chick", "weight": 5 }, { "monster": "mon_pigeon_chick", "weight": 95 } ]
   },
   {
-    "name": "GROUP_ALIEN_MEADOW",
+    "id": "GROUP_ALIEN_MEADOW",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_nether_unviable_butterfly", "weight": 5 } ]
   },
   {
-    "name": "GROUP_ALIEN_TRAP_TREE",
+    "id": "GROUP_ALIEN_TRAP_TREE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_nether_unviable_butterfly", "weight": 5 } ]
   }

--- a/data/mods/MindOverMatter/monstergroups/zombie_upgrades.json
+++ b/data/mods/MindOverMatter/monstergroups/zombie_upgrades.json
@@ -1,12 +1,12 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_UPGRADE",
+    "id": "GROUP_ZOMBIE_UPGRADE",
     "monsters": [ { "monster": "mon_zombie_blank", "weight": 30 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_BLANK_UPGRADE",
+    "id": "GROUP_ZOMBIE_BLANK_UPGRADE",
     "default": "mon_zombie_blank",
     "monsters": [
       { "monster": "mon_zombie_blank", "weight": 450 },

--- a/data/mods/My_Sweet_Cataclysm/mod_interactions/defense_mode/monstergroups.json
+++ b/data/mods/My_Sweet_Cataclysm/mod_interactions/defense_mode/monstergroups.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_SWEET_HORDE",
+    "id": "GROUP_SWEET_HORDE",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_marshmallow_guy_dm" },

--- a/data/mods/My_Sweet_Cataclysm/sweet_monster_groups.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_monster_groups.json
@@ -1,61 +1,61 @@
 [
   {
-    "name": "GROUP_EGG_MARSHMALLOW",
+    "id": "GROUP_EGG_MARSHMALLOW",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_marshmallow_kid" } ]
   },
   {
-    "name": "GROUP_EGG_SMORES",
+    "id": "GROUP_EGG_SMORES",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_marshmallow_kid_armored" } ]
   },
   {
-    "name": "GROUP_EGG_GUMMY",
+    "id": "GROUP_EGG_GUMMY",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_gummy_cub" } ]
   },
   {
-    "name": "GROUP_EGG_GUMMY_GATOR",
+    "id": "GROUP_EGG_GUMMY_GATOR",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_gummy_gator" } ]
   },
   {
-    "name": "GROUP_EGG_CRACKER",
+    "id": "GROUP_EGG_CRACKER",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_small_cracker" } ]
   },
   {
-    "name": "GROUP_EGG_CRACKER_ROE",
+    "id": "GROUP_EGG_CRACKER_ROE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_cracker_lbass" } ]
   },
   {
-    "name": "GROUP_EGG_COOKIE",
+    "id": "GROUP_EGG_COOKIE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_cookie" } ]
   },
   {
-    "name": "GROUP_EGG_COOKIE_EGG",
+    "id": "GROUP_EGG_COOKIE_EGG",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_cookie_hydra_youth" } ]
   },
   {
-    "name": "GROUP_EGG_GUM",
+    "id": "GROUP_EGG_GUM",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_spider_gum_baby" } ]
   },
   {
-    "name": "GROUP_EGG_CAFFGUM",
+    "id": "GROUP_EGG_CAFFGUM",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_gum_spider_wolf_baby" } ]
   },
   {
-    "name": "GROUP_EGG_CHOC_COW",
+    "id": "GROUP_EGG_CHOC_COW",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_cow_calf_choc" } ]
   },
   {
-    "name": "GROUP_EGG_LICORICE",
+    "id": "GROUP_EGG_LICORICE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_licorice_snake_hatchling" } ]
   }

--- a/data/mods/Mythos-Creatures/mod_interactions/defense_mode/monstergroups.json
+++ b/data/mods/Mythos-Creatures/mod_interactions/defense_mode/monstergroups.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_MYTHOS_SPAWN",
+    "id": "GROUP_MYTHOS_SPAWN",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_rat_thing_dm" },

--- a/data/mods/Mythos-Creatures/monstergroups/blob.json
+++ b/data/mods/Mythos-Creatures/monstergroups/blob.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_GOO",
+    "id": "GROUP_GOO",
     "//": "Remove shoggoth from group.",
     "override": true,
     "monsters": [

--- a/data/mods/Mythos-Creatures/monstergroups/misc.json
+++ b/data/mods/Mythos-Creatures/monstergroups/misc.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_BLACK_ROAD",
+    "id": "GROUP_BLACK_ROAD",
     "override": true,
     "default": "mon_null",
     "monsters": [
@@ -22,7 +22,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SUBWAY_CITY",
+    "id": "GROUP_SUBWAY_CITY",
     "override": true,
     "//": "Normal subway, extra spawns underneath a city",
     "default": "mon_null",
@@ -37,7 +37,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "DUMP_ANIMALS",
+    "id": "DUMP_ANIMALS",
     "monsters": [
       { "monster": "mon_ghast", "weight": 10, "conditions": [ "NIGHT", "DUSK" ] },
       { "monster": "mon_ghoul", "weight": 15 }
@@ -45,7 +45,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SEWER",
+    "id": "GROUP_SEWER",
     "//": "Add rat things to sewers.",
     "monsters": [ { "monster": "mon_rat_thing", "weight": 50, "cost_multiplier": 0, "pack_size": [ 3, 12 ] } ]
   }

--- a/data/mods/Mythos-Creatures/monstergroups/mythos.json
+++ b/data/mods/Mythos-Creatures/monstergroups/mythos.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_PARK_SCENIC",
+    "id": "GROUP_PARK_SCENIC",
     "type": "monstergroup",
     "override": true,
     "default": "mon_null",
@@ -25,7 +25,7 @@
     ]
   },
   {
-    "name": "GROUP_ROOF_ZOMBIE",
+    "id": "GROUP_ROOF_ZOMBIE",
     "type": "monstergroup",
     "override": true,
     "default": "mon_null",
@@ -46,7 +46,7 @@
     ]
   },
   {
-    "name": "GROUP_PARK_PLAYGROUND",
+    "id": "GROUP_PARK_PLAYGROUND",
     "type": "monstergroup",
     "override": true,
     "default": "mon_null",
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "name": "GROUP_PARK_DOG",
+    "id": "GROUP_PARK_DOG",
     "type": "monstergroup",
     "override": true,
     "default": "mon_null",
@@ -79,14 +79,14 @@
     ]
   },
   {
-    "name": "GROUP_ZOMBIE_SCORCHED",
+    "id": "GROUP_ZOMBIE_SCORCHED",
     "type": "monstergroup",
     "override": true,
     "monsters": [ { "monster": "mon_null" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE",
+    "id": "GROUP_ZOMBIE",
     "override": true,
     "default": "mon_null",
     "monsters": [
@@ -113,14 +113,14 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NEMESIS",
+    "id": "GROUP_NEMESIS",
     "override": true,
     "//": "nemesis squad",
     "monsters": [ { "monster": "mon_null" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_VANILLA",
+    "id": "GROUP_VANILLA",
     "override": true,
     "default": "mon_null",
     "monsters": [
@@ -147,7 +147,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_POLICE",
+    "id": "GROUP_POLICE",
     "override": true,
     "//": "+30% cops",
     "default": "mon_null",
@@ -175,7 +175,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_HOUSE",
+    "id": "GROUP_HOUSE",
     "override": true,
     "//": "+15% child",
     "default": "mon_null",
@@ -202,7 +202,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PREPPER_HOUSE",
+    "id": "GROUP_PREPPER_HOUSE",
     "override": true,
     "default": "mon_null",
     "monsters": [
@@ -228,7 +228,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PHARM",
+    "id": "GROUP_PHARM",
     "override": true,
     "//": "+13% fast",
     "default": "mon_null",
@@ -255,7 +255,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ELECTRO",
+    "id": "GROUP_ELECTRO",
     "//": "+15% electric",
     "override": true,
     "default": "mon_null",
@@ -282,7 +282,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GROCERY",
+    "id": "GROUP_GROCERY",
     "//": "+15% fat",
     "override": true,
     "default": "mon_null",
@@ -309,7 +309,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PUBLICWORKERS",
+    "id": "GROUP_PUBLICWORKERS",
     "override": true,
     "default": "mon_null",
     "monsters": [
@@ -335,7 +335,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MAYBE_ZOMBIE",
+    "id": "GROUP_MAYBE_ZOMBIE",
     "override": true,
     "//": "10% chance of a zombie",
     "default": "mon_null",
@@ -358,7 +358,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SCHOOL",
+    "id": "GROUP_SCHOOL",
     "override": true,
     "//": "School monster spawns.",
     "default": "mon_null",
@@ -385,7 +385,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SMALL_STATION",
+    "id": "GROUP_SMALL_STATION",
     "override": true,
     "default": "mon_null",
     "monsters": [
@@ -411,7 +411,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LARGE_STATION",
+    "id": "GROUP_LARGE_STATION",
     "override": true,
     "default": "mon_null",
     "monsters": [
@@ -437,7 +437,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CHURCH_ZOMBIE",
+    "id": "GROUP_CHURCH_ZOMBIE",
     "override": true,
     "default": "mon_null",
     "monsters": [
@@ -463,7 +463,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_PRISON",
+    "id": "GROUP_ZOMBIE_PRISON",
     "override": true,
     "default": "mon_null",
     "monsters": [
@@ -489,7 +489,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_COP",
+    "id": "GROUP_ZOMBIE_COP",
     "override": true,
     "default": "mon_null",
     "monsters": [
@@ -515,7 +515,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_HOSPITAL",
+    "id": "GROUP_HOSPITAL",
     "override": true,
     "//": "Hospital monster spawns. Same as GROUP_ZOMBIE, but without Z-dogs + 20% medical",
     "default": "mon_null",
@@ -542,7 +542,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_STEEL_MILL",
+    "id": "GROUP_STEEL_MILL",
     "override": true,
     "//": "Steel mill monster spawns.",
     "default": "mon_null",
@@ -568,7 +568,7 @@
     ]
   },
   {
-    "name": "GROUP_MALL",
+    "id": "GROUP_MALL",
     "override": true,
     "type": "monstergroup",
     "default": "mon_null",
@@ -594,7 +594,7 @@
     ]
   },
   {
-    "name": "GROUP_FIRE",
+    "id": "GROUP_FIRE",
     "override": true,
     "type": "monstergroup",
     "default": "mon_null",
@@ -620,7 +620,7 @@
     ]
   },
   {
-    "name": "FERAL_HUMANS",
+    "id": "FERAL_HUMANS",
     "override": true,
     "type": "monstergroup",
     "monsters": [
@@ -633,7 +633,7 @@
   {
     "type": "monstergroup",
     "override": true,
-    "name": "DUMP_ZOMBIES",
+    "id": "DUMP_ZOMBIES",
     "default": "mon_null",
     "monsters": [
       { "monster": "mon_null", "weight": 865 },
@@ -657,7 +657,7 @@
     ]
   },
   {
-    "name": "GROUP_PLAIN",
+    "id": "GROUP_PLAIN",
     "override": true,
     "type": "monstergroup",
     "default": "mon_null",
@@ -683,7 +683,7 @@
     ]
   },
   {
-    "name": "GROUP_HOTEL_POOL",
+    "id": "GROUP_HOTEL_POOL",
     "type": "monstergroup",
     "override": true,
     "default": "mon_null",
@@ -709,7 +709,7 @@
     ]
   },
   {
-    "name": "GROUP_HOTEL_GYM",
+    "id": "GROUP_HOTEL_GYM",
     "type": "monstergroup",
     "override": true,
     "default": "mon_null",
@@ -735,7 +735,7 @@
     ]
   },
   {
-    "name": "GROUP_POOL_NOKIDS",
+    "id": "GROUP_POOL_NOKIDS",
     "override": true,
     "type": "monstergroup",
     "default": "mon_null",

--- a/data/mods/Mythos-Creatures/monstergroups/nether.json
+++ b/data/mods/Mythos-Creatures/monstergroups/nether.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_BREATHER",
+    "id": "GROUP_BREATHER",
     "monsters": [
       { "monster": "mon_breather", "weight": 990 },
       { "monster": "mon_breather", "weight": 10, "cost_multiplier": 2, "pack_size": [ 2, 4 ] }
@@ -9,27 +9,27 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BREATHER_HUB",
+    "id": "GROUP_BREATHER_HUB",
     "monsters": [ { "monster": "mon_breather_hub" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CHURCH_BLANK",
+    "id": "GROUP_CHURCH_BLANK",
     "monsters": [ { "monster": "mon_blank", "cost_multiplier": 0 } ]
   },
   {
-    "name": "GROUP_DARK_WYRM",
+    "id": "GROUP_DARK_WYRM",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_dark_wyrm" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DOG_THING",
+    "id": "GROUP_DOG_THING",
     "monsters": [ { "monster": "mon_dog_thing" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_REALITY_TEAR_FIELD",
+    "id": "GROUP_NETHER_REALITY_TEAR_FIELD",
     "default": "mon_blank",
     "monsters": [
       { "monster": "mon_flying_polyp", "weight": 100, "cost_multiplier": 0 },
@@ -47,7 +47,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER",
+    "id": "GROUP_NETHER",
     "default": "mon_blank",
     "monsters": [
       { "monster": "mon_blank", "weight": 135, "cost_multiplier": 0 },
@@ -64,7 +64,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_CAPTURED",
+    "id": "GROUP_NETHER_CAPTURED",
     "default": "mon_gracke",
     "monsters": [
       { "monster": "mon_gelatin", "weight": 250, "cost_multiplier": 0 },
@@ -76,7 +76,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_PORTAL",
+    "id": "GROUP_NETHER_PORTAL",
     "default": "mon_gracke",
     "monsters": [
       { "monster": "mon_gelatin", "weight": 200, "cost_multiplier": 0 },
@@ -89,7 +89,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIRAL",
+    "id": "GROUP_SPIRAL",
     "monsters": [
       { "monster": "mon_human_snail", "weight": 740, "cost_multiplier": 0 },
       { "monster": "mon_twisted_body", "weight": 180, "cost_multiplier": 0 },
@@ -98,7 +98,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TINDALOS",
+    "id": "GROUP_TINDALOS",
     "monsters": [ { "monster": "mon_hound_tindalos" } ]
   }
 ]

--- a/data/mods/Mythos-Creatures/monstergroups/wilderness.json
+++ b/data/mods/Mythos-Creatures/monstergroups/wilderness.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_CAVE",
+    "id": "GROUP_CAVE",
     "//": "Current count is 925.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
     "monsters": [
@@ -11,7 +11,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "default": "mon_null",
     "//": "Current SPRING first DAY count is 513.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
@@ -37,7 +37,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RIVER",
+    "id": "GROUP_RIVER",
     "default": "mon_null",
     "//": "Current SPRING first DAY count is 944.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
@@ -59,7 +59,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SWAMP",
+    "id": "GROUP_SWAMP",
     "default": "mon_null",
     "//": "Current SPRING first DAY count is 417.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
@@ -76,7 +76,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROOF_ANIMAL",
+    "id": "GROUP_ROOF_ANIMAL",
     "//": "Current SPRING first DAY count is 350.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
     "monsters": [

--- a/data/mods/No_Hope/monster_groups.json
+++ b/data/mods/No_Hope/monster_groups.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_NECROPOLIS",
+    "id": "GROUP_NECROPOLIS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie", "weight": 899 },
@@ -10,7 +10,7 @@
     ]
   },
   {
-    "name": "GROUP_NECROPOLIS_SEWERS",
+    "id": "GROUP_NECROPOLIS_SEWERS",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_irradiated_wanderer_1", "weight": 848 },
@@ -22,7 +22,7 @@
     ]
   },
   {
-    "name": "GROUP_NECROPOLIS_VAULT",
+    "id": "GROUP_NECROPOLIS_VAULT",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_irradiated_wanderer_1", "weight": 40 },
@@ -33,7 +33,7 @@
     ]
   },
   {
-    "name": "GROUP_NECROPOLIS_VAULT2",
+    "id": "GROUP_NECROPOLIS_VAULT2",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_irradiated_wanderer_2", "weight": 30 },
@@ -43,7 +43,7 @@
     ]
   },
   {
-    "name": "GROUP_NECROPOLIS_VAULT3",
+    "id": "GROUP_NECROPOLIS_VAULT3",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_irradiated_wanderer_4", "weight": 890 },
@@ -52,18 +52,18 @@
     ]
   },
   {
-    "name": "GROUP_NECROPOLIS_SWIMMING",
+    "id": "GROUP_NECROPOLIS_SWIMMING",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_sewer_fish", "weight": 995 }, { "monster": "mon_irradiated_wanderer_2", "weight": 5 } ]
   },
   {
-    "name": "GROUP_NECROPOLIS_ROBOT",
+    "id": "GROUP_NECROPOLIS_ROBOT",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_tankbot", "weight": 20, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CENTRAL_LAB",
+    "id": "GROUP_CENTRAL_LAB",
     "monsters": [
       { "monster": "mon_chickenbot", "weight": 1, "cost_multiplier": 50 },
       { "monster": "mon_zombie_bio_op", "weight": 20, "cost_multiplier": 50 }
@@ -71,7 +71,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROBOT",
+    "id": "GROUP_ROBOT",
     "monsters": [
       { "monster": "mon_tripod", "weight": 110, "cost_multiplier": 0 },
       { "monster": "mon_chickenbot", "weight": 60, "cost_multiplier": 0 },
@@ -81,7 +81,7 @@
   {
     "type": "monstergroup",
     "//": "Used in the military bunker",
-    "name": "GROUP_MIL_BASE",
+    "id": "GROUP_MIL_BASE",
     "monsters": [
       { "monster": "mon_tripod", "weight": 5, "cost_multiplier": 0 },
       { "monster": "mon_chickenbot", "weight": 5, "cost_multiplier": 0 },
@@ -91,7 +91,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MAYBE_MIL",
+    "id": "GROUP_MAYBE_MIL",
     "monsters": [
       { "monster": "mon_tripod", "weight": 5, "cost_multiplier": 0 },
       { "monster": "mon_chickenbot", "weight": 5, "cost_multiplier": 0 },
@@ -101,7 +101,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MIL_STRONG",
+    "id": "GROUP_MIL_STRONG",
     "//": "Used in the military bunker, LIXA and Hub01 convoy ambush",
     "monsters": [
       { "monster": "mon_tripod", "weight": 5, "cost_multiplier": 0 },
@@ -111,7 +111,7 @@
     ]
   },
   {
-    "name": "GROUP_MIL_MASS_GRAVE",
+    "id": "GROUP_MIL_MASS_GRAVE",
     "type": "monstergroup",
     "//": "Lots of hazmats and burners.",
     "monsters": [
@@ -122,22 +122,22 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_REALITY_TEAR_FIELD",
+    "id": "GROUP_NETHER_REALITY_TEAR_FIELD",
     "monsters": [ { "monster": "mon_staring_eye", "weight": 100, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER",
+    "id": "GROUP_NETHER",
     "monsters": [ { "monster": "mon_staring_eye", "weight": 120, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_NETHER_PORTAL",
+    "id": "GROUP_NETHER_PORTAL",
     "monsters": [ { "monster": "mon_staring_eye", "weight": 200, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_WILDERNESS_FOREST_ZOMBIE",
+    "id": "GROUP_WILDERNESS_FOREST_ZOMBIE",
     "monsters": [ { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10 } ]
   }
 ]

--- a/data/mods/Sky_Island/monstergroups.json
+++ b/data/mods/Sky_Island/monstergroups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_SI_ZOMEASY",
+    "id": "GROUP_SI_ZOMEASY",
     "//": "A simple mix of common low level zombies.  Threat level keeps below around 7.",
     "monsters": [
       { "monster": "mon_zombie", "weight": 2000 },
@@ -38,7 +38,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SI_ZOMMID",
+    "id": "GROUP_SI_ZOMMID",
     "//": "A simple mix of evolved zombies.  Threat level to mid/low teens.  A few exceptions made for special effects like acid or speed, like dogs.",
     "monsters": [
       { "monster": "mon_zombie_tough", "weight": 1000 },
@@ -82,7 +82,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SI_ZOMHARD",
+    "id": "GROUP_SI_ZOMHARD",
     "//": "A mix of powerful zombies.  Threat level high teens up to mid 20s.  Exceptions made for especially tough monsters.",
     "monsters": [
       { "monster": "mon_zombie_brute", "weight": 1000 },
@@ -116,7 +116,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SI_ZOMELITE",
+    "id": "GROUP_SI_ZOMELITE",
     "//": "A blend of truly elite zombies.  Threat level up to the ceiling.",
     "monsters": [
       { "monster": "mon_zombie_soldier_blackops_1", "weight": 100 },
@@ -149,7 +149,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SI_ZOMBOSS",
+    "id": "GROUP_SI_ZOMBOSS",
     "//": "Boss tier encounters.  Extreme danger level.",
     "monsters": [
       { "monster": "mon_zombie_hulk", "weight": 100 },
@@ -163,7 +163,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SI_ZOMBOSSMULT",
+    "id": "GROUP_SI_ZOMBOSSMULT",
     "//": "Boss tier encounters for enemies that show up in bunches.  Extreme danger level.",
     "monsters": [
       { "monster": "mon_zombie_hulk", "weight": 10 },
@@ -176,7 +176,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SI_MIGO",
+    "id": "GROUP_SI_MIGO",
     "//": "Powerful migo.",
     "monsters": [
       { "monster": "mon_mi_go", "weight": 200 },
@@ -187,7 +187,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SI_MIGO_ELITE",
+    "id": "GROUP_SI_MIGO_ELITE",
     "//": "Evolved migo.",
     "monsters": [ { "monster": "mon_mi_go_myrmidon", "weight": 25 }, { "monster": "mon_mi_go_guard", "weight": 75 } ]
   }

--- a/data/mods/Sky_Island/monsters/monstergroups_extended.json
+++ b/data/mods/Sky_Island/monsters/monstergroups_extended.json
@@ -1,52 +1,52 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_CENTRAL_LAB",
+    "id": "GROUP_CENTRAL_LAB",
     "monsters": [ { "monster": "mon_zombie_bio_op", "weight": 20, "cost_multiplier": 50 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB",
+    "id": "GROUP_LAB",
     "default": "mon_zombie_scientist",
     "monsters": [ { "monster": "mon_zombie_bio_op", "weight": 50, "cost_multiplier": 5 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_SURFACE",
+    "id": "GROUP_LAB_SURFACE",
     "default": "mon_zombie_scientist",
     "monsters": [ { "monster": "mon_zombie_bio_op", "weight": 50, "cost_multiplier": 5 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_LAB_SECURITY",
+    "id": "GROUP_LAB_SECURITY",
     "default": "mon_zombie_labsecurity",
     "monsters": [ { "monster": "mon_zombie_bio_op", "weight": 50, "cost_multiplier": 5 } ]
   },
   {
     "type": "monstergroup",
     "//": "Used in the military bunker",
-    "name": "GROUP_MIL_BASE",
+    "id": "GROUP_MIL_BASE",
     "monsters": [ { "monster": "mon_zombie_bio_op", "weight": 20, "cost_multiplier": 50 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MAYBE_MIL",
+    "id": "GROUP_MAYBE_MIL",
     "monsters": [ { "monster": "mon_zombie_bio_op", "weight": 20, "cost_multiplier": 50 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MIL_STRONG",
+    "id": "GROUP_MIL_STRONG",
     "//": "Used in the military bunker, LIXA and Hub01 convoy ambush",
     "monsters": [ { "monster": "mon_zombie_bio_op", "weight": 20, "cost_multiplier": 50 } ]
   },
   {
-    "name": "GROUP_MIL_EXTRA",
+    "id": "GROUP_MIL_EXTRA",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_zombie_bio_op", "weight": 4 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BUNKER",
+    "id": "GROUP_BUNKER",
     "monsters": [ { "monster": "mon_zombie_bio_op", "weight": 150, "cost_multiplier": 10 } ]
   }
 ]

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -434,7 +434,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_mon_nearby_test",
+    "id": "GROUP_mon_nearby_test",
     "monsters": [ { "monster": "mon_triffid", "weight": 1 }, { "monster": "mon_zombie_tough", "weight": 1 } ]
   },
   {

--- a/data/mods/TEST_DATA/monstergroups.json
+++ b/data/mods/TEST_DATA/monstergroups.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "test_event_mongroup",
+    "id": "test_event_mongroup",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_test_non_shearable", "weight": 50, "event": "christmas" },
@@ -12,7 +12,7 @@
     ]
   },
   {
-    "name": "test_event_only",
+    "id": "test_event_only",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_test_non_shearable", "weight": 50, "event": "christmas" },
@@ -21,7 +21,7 @@
     ]
   },
   {
-    "name": "test_default_monster",
+    "id": "test_default_monster",
     "type": "monstergroup",
     "default": "mon_null",
     "monsters": [
@@ -39,7 +39,7 @@
   },
   {
     "//": "Extends the test_default_monster group",
-    "name": "test_default_monster",
+    "id": "test_default_monster",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_test_CBM", "weight": 50 },
@@ -48,7 +48,7 @@
     ]
   },
   {
-    "name": "test_group_default_monster",
+    "id": "test_group_default_monster",
     "type": "monstergroup",
     "default": "mon_null",
     "monsters": [
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "name": "test_l2_nested_mongroup",
+    "id": "test_l2_nested_mongroup",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_test_speed_desc_base", "weight": 50 },
@@ -66,7 +66,7 @@
     ]
   },
   {
-    "name": "test_l1_nested_mongroup",
+    "id": "test_l1_nested_mongroup",
     "type": "monstergroup",
     "monsters": [
       { "group": "test_l2_nested_mongroup", "weight": 5 },
@@ -75,7 +75,7 @@
     ]
   },
   {
-    "name": "test_top_level_mongroup",
+    "id": "test_top_level_mongroup",
     "type": "monstergroup",
     "monsters": [
       { "group": "test_l1_nested_mongroup", "weight": 5 },
@@ -84,32 +84,32 @@
     ]
   },
   {
-    "name": "test_nested_packsize",
+    "id": "test_nested_packsize",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_test_CBM", "pack_size": [ 2, 4 ] } ]
   },
   {
-    "name": "test_top_level_packsize",
+    "id": "test_top_level_packsize",
     "type": "monstergroup",
     "monsters": [ { "group": "test_nested_packsize", "pack_size": [ 4, 6 ] } ]
   },
   {
-    "name": "test_top_level_no_packsize",
+    "id": "test_top_level_no_packsize",
     "type": "monstergroup",
     "monsters": [ { "group": "test_nested_packsize" } ]
   },
   {
-    "name": "test_upgrades_multi",
+    "id": "test_upgrades_multi",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_test_shearable", "pack_size": [ 4, 6 ] } ]
   },
   {
-    "name": "test_upgrades_multi_null",
+    "id": "test_upgrades_multi_null",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_null" }, { "monster": "mon_test_zombie_cop", "pack_size": [ 4, 6 ], "starts": "2 days" } ]
   },
   {
-    "name": "test_upgrades_multi_late",
+    "id": "test_upgrades_multi_late",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_test_shearable", "pack_size": [ 4, 6 ], "starts": "7 days" },

--- a/data/mods/TropiCataclysm/monstergroups/eggs.json
+++ b/data/mods/TropiCataclysm/monstergroups/eggs.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "GROUP_EGG_CONSTRICTOR",
+    "id": "GROUP_EGG_CONSTRICTOR",
     "type": "monstergroup",
     "default": "mon_anaconda",
     "monsters": [
@@ -10,147 +10,147 @@
     ]
   },
   {
-    "name": "GROUP_EGG_LIZARD",
+    "id": "GROUP_EGG_LIZARD",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_beaded_lizard" } ]
   },
   {
-    "name": "GROUP_EGG_MONITOR",
+    "id": "GROUP_EGG_MONITOR",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_monitor_lizard" } ]
   },
   {
-    "name": "GROUP_EGG_IGUANA",
+    "id": "GROUP_EGG_IGUANA",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_iguana" } ]
   },
   {
-    "name": "GROUP_EGG_TURTLE",
+    "id": "GROUP_EGG_TURTLE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_turtle" } ]
   },
   {
-    "name": "GROUP_EGG_SNAPPER",
+    "id": "GROUP_EGG_SNAPPER",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_turtle_snapper" } ]
   },
   {
-    "name": "GROUP_EGG_TORTOISE",
+    "id": "GROUP_EGG_TORTOISE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_tortoise" } ]
   },
   {
-    "name": "GROUP_EGG_TRIFFID",
+    "id": "GROUP_EGG_TRIFFID",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_triffid_podling" } ]
   },
   {
-    "name": "GROUP_EGG_FUNGUS",
+    "id": "GROUP_EGG_FUNGUS",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fungaloid_saproling" } ]
   },
   {
-    "name": "GROUP_EGG_SALAMANDER",
+    "id": "GROUP_EGG_SALAMANDER",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_axolotl" } ]
   },
   {
-    "name": "GROUP_EGG_TADFISH",
+    "id": "GROUP_EGG_TADFISH",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_tadpole_small" } ]
   },
   {
-    "name": "GROUP_EGG_LUNGFISH",
+    "id": "GROUP_EGG_LUNGFISH",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_lungfish" } ]
   },
   {
-    "name": "GROUP_EGG_EEL_ELECTRIC",
+    "id": "GROUP_EGG_EEL_ELECTRIC",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_eel_electric" } ]
   },
   {
-    "name": "GROUP_EGG_PACU",
+    "id": "GROUP_EGG_PACU",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_pacu" } ]
   },
   {
-    "name": "GROUP_EGG_TAMBAQUI",
+    "id": "GROUP_EGG_TAMBAQUI",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_tambaqui" } ]
   },
   {
-    "name": "GROUP_EGG_PIRANHA",
+    "id": "GROUP_EGG_PIRANHA",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_piranha" } ]
   },
   {
-    "name": "GROUP_EGG_AROWANA",
+    "id": "GROUP_EGG_AROWANA",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_arowana" } ]
   },
   {
-    "name": "GROUP_EGG_ARAPAIMA",
+    "id": "GROUP_EGG_ARAPAIMA",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_arapaima" } ]
   },
   {
-    "name": "GROUP_EGG_PIRAIBA",
+    "id": "GROUP_EGG_PIRAIBA",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_piraiba" } ]
   },
   {
-    "name": "GROUP_EGG_PLECO",
+    "id": "GROUP_EGG_PLECO",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_pleco" } ]
   },
   {
-    "name": "GROUP_EGG_GAR",
+    "id": "GROUP_EGG_GAR",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_gar" } ]
   },
   {
-    "name": "GROUP_EGG_TUCUNARE",
+    "id": "GROUP_EGG_TUCUNARE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_tucunare" } ]
   },
   {
-    "name": "GROUP_EGG_DISCUS",
+    "id": "GROUP_EGG_DISCUS",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_discus" } ]
   },
   {
-    "name": "GROUP_EGG_ANGELFISH",
+    "id": "GROUP_EGG_ANGELFISH",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_angelfish" } ]
   },
   {
-    "name": "GROUP_EGG_KOI",
+    "id": "GROUP_EGG_KOI",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_koi" } ]
   },
   {
-    "name": "GROUP_EGG_TILAPIA",
+    "id": "GROUP_EGG_TILAPIA",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_tilapia" } ]
   },
   {
-    "name": "GROUP_EGG_SABALO",
+    "id": "GROUP_EGG_SABALO",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_sabalo" } ]
   },
   {
-    "name": "GROUP_EGG_OSCAR",
+    "id": "GROUP_EGG_OSCAR",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_oscar" } ]
   },
   {
-    "name": "GROUP_EGG_GUAPOTE",
+    "id": "GROUP_EGG_GUAPOTE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_guapote" } ]
   },
   {
-    "name": "GROUP_EGG_MAYAHEROS",
+    "id": "GROUP_EGG_MAYAHEROS",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_fry_mayaheros" } ]
   }

--- a/data/mods/TropiCataclysm/monstergroups/fungi.json
+++ b/data/mods/TropiCataclysm/monstergroups/fungi.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI",
+    "id": "GROUP_FUNGI",
     "default": "mon_spore",
     "monsters": [
       { "monster": "mon_spore", "weight": 200, "cost_multiplier": 0 },
@@ -23,7 +23,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_FUNGALOID",
+    "id": "GROUP_FUNGI_FUNGALOID",
     "monsters": [
       { "monster": "mon_fungaloid", "weight": 500, "cost_multiplier": 0 },
       { "monster": "mon_fungaloid_shambler", "weight": 250, "cost_multiplier": 0 },
@@ -32,7 +32,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_TOWER",
+    "id": "GROUP_FUNGI_TOWER",
     "monsters": [
       { "monster": "mon_fungal_tendril", "weight": 755, "cost_multiplier": 0 },
       { "monster": "mon_fungaloid", "weight": 10, "cost_multiplier": 0 },
@@ -53,7 +53,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_FLOWERS",
+    "id": "GROUP_FUNGI_FLOWERS",
     "monsters": [
       { "monster": "mon_fungal_blossom", "weight": 680, "cost_multiplier": 0 },
       { "monster": "mon_fungaloid", "weight": 20, "cost_multiplier": 0 },
@@ -73,7 +73,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGAL_CARETAKER",
+    "id": "GROUP_FUNGAL_CARETAKER",
     "default": "mon_fungaloid",
     "//": "Group for fungal caretakers to evolve",
     "monsters": [
@@ -90,7 +90,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_URBAN",
+    "id": "GROUP_FUNGI_URBAN",
     "default": "mon_fungaloid",
     "monsters": [
       { "monster": "mon_fungaloid_caretaker", "weight": 300, "cost_multiplier": 0, "pack_size": [ 2, 4 ] },

--- a/data/mods/TropiCataclysm/monstergroups/misc.json
+++ b/data/mods/TropiCataclysm/monstergroups/misc.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_DOMESTIC",
+    "id": "GROUP_DOMESTIC",
     "default": "mon_dog",
     "is_animal": true,
     "monsters": [
@@ -12,7 +12,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SAFE",
+    "id": "GROUP_SAFE",
     "is_safe": true,
     "is_animal": true,
     "monsters": [
@@ -27,7 +27,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SUBWAY",
+    "id": "GROUP_SUBWAY",
     "//": "Z-2 subways, some lost nether things but otherwise mostly normal mobs",
     "default": "mon_spider_cellar_giant",
     "monsters": [

--- a/data/mods/TropiCataclysm/monstergroups/nether.json
+++ b/data/mods/TropiCataclysm/monstergroups/nether.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_ALIEN_REEF",
+    "id": "GROUP_ALIEN_REEF",
     "default": "mon_shrimp_flying",
     "monsters": [
       { "monster": "mon_shrimp_flying", "weight": 250, "cost_multiplier": 0 },

--- a/data/mods/TropiCataclysm/monstergroups/triffid.json
+++ b/data/mods/TropiCataclysm/monstergroups/triffid.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID",
+    "id": "GROUP_TRIFFID",
     "default": "mon_triffid",
     "monsters": [
       { "monster": "mon_triffid_sprig", "weight": 200, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
@@ -24,7 +24,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_URBAN",
+    "id": "GROUP_TRIFFID_URBAN",
     "default": "mon_triffid",
     "//": "Group for triffids + plant zeds on special urban locations",
     "monsters": [
@@ -53,7 +53,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_GARDENLING",
+    "id": "GROUP_TRIFFID_GARDENLING",
     "default": "mon_triffid",
     "//": "Group for triffids gardenlings to evolve",
     "monsters": [
@@ -74,7 +74,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PLANT_ZEDS",
+    "id": "GROUP_PLANT_ZEDS",
     "default": "mon_zombie_garden",
     "//": "Group for plant zeds",
     "monsters": [
@@ -88,7 +88,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_OUTER",
+    "id": "GROUP_TRIFFID_OUTER",
     "default": "mon_triffid",
     "monsters": [
       { "monster": "mon_triffid_sprig", "weight": 80, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
@@ -110,7 +110,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_HEARTGUARDS",
+    "id": "GROUP_TRIFFID_HEARTGUARDS",
     "default": "mon_triffid",
     "monsters": [
       { "monster": "mon_triffid", "weight": 280, "cost_multiplier": 0 },
@@ -123,7 +123,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TRIFFID_HEART",
+    "id": "GROUP_TRIFFID_HEART",
     "monsters": [ { "monster": "mon_triffid_heart" } ]
   }
 ]

--- a/data/mods/TropiCataclysm/monstergroups/tropical_bugs.json
+++ b/data/mods/TropiCataclysm/monstergroups/tropical_bugs.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_TERMITES",
+    "id": "GROUP_TERMITES",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_termite_nymph", "weight": 4, "cost_multiplier": 0 },
@@ -13,7 +13,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TERMITE_SURFACE",
+    "id": "GROUP_TERMITE_SURFACE",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_termite_soldier", "weight": 90, "cost_multiplier": 5 },
@@ -24,13 +24,13 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TERMITE_ALATE",
+    "id": "GROUP_TERMITE_ALATE",
     "default": "mon_termite_queen",
     "monsters": [ { "monster": "mon_termite_king" }, { "monster": "mon_termite_queen" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_TERMITE",
+    "id": "GROUP_TERMITE",
     "default": "mon_termite_soldier",
     "monsters": [
       { "monster": "mon_termite_soldier", "weight": 35 },
@@ -40,12 +40,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SCORPION",
+    "id": "GROUP_SCORPION",
     "monsters": [ { "monster": "mon_large_scorpion", "ends": "45 days" }, { "monster": "mon_scorpion_giant", "starts": "30 days" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ONICOPHORE",
+    "id": "GROUP_ONICOPHORE",
     "monsters": [
       { "monster": "mon_onicophore_small", "weight": 5, "ends": "45 days" },
       { "monster": "mon_onicophore", "weight": 5, "starts": "30 days" },

--- a/data/mods/TropiCataclysm/monstergroups/wilderness.json
+++ b/data/mods/TropiCataclysm/monstergroups/wilderness.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_CAVE",
+    "id": "GROUP_CAVE",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -12,7 +12,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -70,7 +70,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RIVER",
+    "id": "GROUP_RIVER",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -120,7 +120,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SWAMP",
+    "id": "GROUP_SWAMP",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -139,7 +139,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_PARK_ANIMAL",
+    "id": "GROUP_PARK_ANIMAL",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_parrot", "weight": 25, "cost_multiplier": 0 },
@@ -152,7 +152,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ROOF_ANIMAL",
+    "id": "GROUP_ROOF_ANIMAL",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_parrot", "weight": 25, "cost_multiplier": 0 },
@@ -173,7 +173,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_POND_ANIMAL",
+    "id": "GROUP_POND_ANIMAL",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
@@ -190,7 +190,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_BIRDFEEDER",
+    "id": "GROUP_BIRDFEEDER",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_parrot", "weight": 35, "cost_multiplier": 0 },

--- a/data/mods/TropiCataclysm/monstergroups/zombie_upgrades.json
+++ b/data/mods/TropiCataclysm/monstergroups/zombie_upgrades.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_MOSSY_BOOMER_UPGRADE",
+    "id": "GROUP_MOSSY_BOOMER_UPGRADE",
     "default": "mon_boomer_moss",
     "//": "Upgrades for the Thorny Boomer.",
     "monsters": [
@@ -12,7 +12,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GARDEN_ZOMBIE_UPGRADE",
+    "id": "GROUP_GARDEN_ZOMBIE_UPGRADE",
     "default": "mon_zombie_garden",
     "//": "Upgrades for the Thorny Shambler.",
     "monsters": [

--- a/data/mods/Xedra_Evolved/mod_interactions/defense_mode/monstergroups.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/defense_mode/monstergroups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_DEFENSE_MODE_EXODII",
+    "id": "GROUP_DEFENSE_MODE_EXODII",
     "//": "A small Exodii hunter/killer unit or party, respecialized for Defense Mode.",
     "monsters": [
       { "monster": "mon_dm_exodii_quad_jotunn", "weight": 20 },
@@ -11,7 +11,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DEFENSE_MODE_XEDRA",
+    "id": "GROUP_DEFENSE_MODE_XEDRA",
     "monsters": [
       { "monster": "mon_dm_changeling", "weight": 100, "cost_multiplier": 1 },
       { "monster": "mon_dm_fetch_child", "weight": 400, "cost_multiplier": 0 },

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/monstergroups/monstergroup_overrides.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/monstergroups/monstergroup_overrides.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_RENFIELD_UPGRADE_INNAWOOD",
+    "id": "GROUP_RENFIELD_UPGRADE_INNAWOOD",
     "monsters": [ { "monster": "mon_renfield", "weight": 950 }, { "monster": "mon_renfield_abomination", "weight": 50 } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mod_interactions/innawood/monstergroups/monstergroups_new.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/innawood/monstergroups/monstergroups_new.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "is_animal": true,
     "monsters": [
       { "group": "GROUP_CHANGELING_MIRRORED_FIELD", "weight": 10, "cost_multiplier": 10 },
@@ -12,7 +12,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SWAMP",
+    "id": "GROUP_SWAMP",
     "//": "Current SPRING first DAY count is X.",
     "is_animal": true,
     "monsters": [
@@ -24,13 +24,13 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_OVERLAND_RENFIELD",
+    "id": "GROUP_OVERLAND_RENFIELD",
     "is_animal": true,
     "monsters": [ { "monster": "mon_renfield", "weight": 200 }, { "monster": "mon_renfield", "weight": 50, "pack_size": [ 2, 5 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CAVE_VAMPIRE",
+    "id": "GROUP_CAVE_VAMPIRE",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_renfield", "weight": 200 },

--- a/data/mods/Xedra_Evolved/monsters/monster_evolutions.json
+++ b/data/mods/Xedra_Evolved/monsters/monster_evolutions.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_RENFIELD_UPGRADE",
+    "id": "GROUP_RENFIELD_UPGRADE",
     "monsters": [
       { "monster": "mon_renfield", "weight": 910 },
       { "monster": "mon_renfield_9mm", "weight": 450 },

--- a/data/mods/Xedra_Evolved/monsters/monstergroup.json
+++ b/data/mods/Xedra_Evolved/monsters/monstergroup.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_SPIDER",
+    "id": "GROUP_SPIDER",
     "monsters": [
       { "monster": "mon_spider_disease", "weight": 40, "cost_multiplier": 0 },
       { "monster": "mon_spider_web_small", "weight": 400, "cost_multiplier": 0 }
@@ -9,7 +9,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CHANGELING_MIRRORED_FIELD",
+    "id": "GROUP_CHANGELING_MIRRORED_FIELD",
     "monsters": [
       { "monster": "mon_changeling", "weight": 100, "cost_multiplier": 1 },
       { "monster": "mon_fetch_child", "weight": 400, "cost_multiplier": 0 },
@@ -18,7 +18,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CHANGELING_STRIKE_FORCE",
+    "id": "GROUP_CHANGELING_STRIKE_FORCE",
     "monsters": [
       { "monster": "mon_changeling_bannerman", "weight": 100, "cost_multiplier": 1 },
       { "monster": "mon_fetch_daffodil_warrior", "weight": 400, "cost_multiplier": 0 },
@@ -28,7 +28,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GOBLIN_SPIDER",
+    "id": "GROUP_GOBLIN_SPIDER",
     "monsters": [
       { "monster": "mon_goblin_spider", "weight": 100, "cost_multiplier": 1 },
       { "monster": "mon_fetch_child", "weight": 200, "cost_multiplier": 1 }
@@ -36,7 +36,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_DREAM_WOUND_SHADOW",
+    "id": "GROUP_DREAM_WOUND_SHADOW",
     "default": "mon_dream_shadow",
     "monsters": [
       { "monster": "mon_dream_shadow", "weight": 500, "cost_multiplier": 0 },
@@ -45,7 +45,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FOREST",
+    "id": "GROUP_FOREST",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_xe_unicorn", "weight": 10, "cost_multiplier": 10, "starts": 240, "pack_size": [ 1, 5 ] },
@@ -55,17 +55,17 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RIVER",
+    "id": "GROUP_RIVER",
     "is_animal": true,
     "monsters": [ { "monster": "mon_xe_mavka", "weight": 1, "cost_multiplier": 10, "starts": 500, "pack_size": [ 1, 5 ] } ]
   },
   {
-    "name": "GROUP_PARK_SCENIC",
+    "id": "GROUP_PARK_SCENIC",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_vampire_moroi", "weight": 10 }, { "monster": "mon_vampire_strigoi", "weight": 1 } ]
   },
   {
-    "name": "GROUP_PARK_PLAYGROUND",
+    "id": "GROUP_PARK_PLAYGROUND",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_vampire_moroi", "weight": 10 },
@@ -74,38 +74,38 @@
     ]
   },
   {
-    "name": "GROUP_HOUSE",
+    "id": "GROUP_HOUSE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_vampire_moroi", "weight": 5 }, { "monster": "mon_vampire_strigoi", "weight": 1 } ]
   },
   {
-    "name": "GROUP_MANSION_START",
+    "id": "GROUP_MANSION_START",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_vampire_moroi", "weight": 80 } ]
   },
   {
-    "name": "GROUP_HOSPITAL",
+    "id": "GROUP_HOSPITAL",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_vampire_moroi", "weight": 5 }, { "monster": "mon_vampire_strigoi", "weight": 1 } ]
   },
   {
-    "name": "FERAL_HUMANS",
+    "id": "FERAL_HUMANS",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_vampire_moroi", "weight": 5 }, { "monster": "mon_vampire_strigoi", "weight": 1 } ]
   },
   {
-    "name": "GROUP_RETIREMENT_COMMUNITY",
+    "id": "GROUP_RETIREMENT_COMMUNITY",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_vampire_moroi", "weight": 5 }, { "monster": "mon_vampire_strigoi", "weight": 1 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MOROI",
+    "id": "GROUP_MOROI",
     "monsters": [ { "monster": "mon_vampire_moroi", "weight": 35 }, { "monster": "mon_renfield", "weight": 50, "pack_size": [ 1, 2 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_VAMPIRE_CATHEDRAL",
+    "id": "GROUP_VAMPIRE_CATHEDRAL",
     "monsters": [
       { "monster": "mon_bat_giant", "weight": 35, "pack_size": [ 1, 2 ] },
       { "monster": "mon_renfield", "weight": 50, "pack_size": [ 1, 3 ] }
@@ -113,7 +113,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_STRIGOI",
+    "id": "GROUP_STRIGOI",
     "monsters": [
       { "monster": "mon_renfield", "weight": 50, "pack_size": [ 1, 2 ] },
       { "monster": "mon_vampire_strigoi", "weight": 25 },
@@ -123,7 +123,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_VAMPIRES_MIXED",
+    "id": "GROUP_VAMPIRES_MIXED",
     "monsters": [
       { "monster": "mon_renfield", "weight": 50, "pack_size": [ 1, 2 ] },
       { "monster": "mon_vampire_moroi", "weight": 25 },
@@ -132,30 +132,30 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_RENFIELDS",
+    "id": "GROUP_RENFIELDS",
     "monsters": [ { "monster": "mon_renfield", "weight": 50, "pack_size": [ 1, 2 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SWARM_BATS",
+    "id": "GROUP_SWARM_BATS",
     "is_animal": true,
     "monsters": [ { "monster": "xe_mon_bat", "weight": 10, "pack_size": [ 1, 2 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GIANT_BATS",
+    "id": "GROUP_GIANT_BATS",
     "is_animal": true,
     "monsters": [ { "monster": "mon_bat_giant", "weight": 10 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_VAMPIRE_BATS",
+    "id": "GROUP_VAMPIRE_BATS",
     "is_animal": true,
     "monsters": [ { "monster": "mon_vampire_bat", "weight": 10, "pack_size": [ 1, 2 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ALL_BATS",
+    "id": "GROUP_ALL_BATS",
     "is_animal": true,
     "monsters": [
       { "monster": "xe_mon_bat", "weight": 10, "pack_size": [ 1, 2 ] },
@@ -165,7 +165,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_Exodii_Jotunn",
+    "id": "GROUP_Exodii_Jotunn",
     "//": "A small Exodii hunter/killer unit or party.  Hunting for Xedra Survivors or Balthazar pawns.",
     "monsters": [
       { "monster": "mon_exodii_quad", "weight": 100 },
@@ -175,12 +175,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FERAL_AGENTS",
+    "id": "GROUP_FERAL_AGENTS",
     "monsters": [ { "monster": "mon_feral_zebra_agent", "weight": 100, "pack_size": [ 1, 2 ] } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FERAL_AGENTS_BORDER_PATROL_OFFICE",
+    "id": "GROUP_FERAL_AGENTS_BORDER_PATROL_OFFICE",
     "monsters": [
       { "monster": "mon_feral_zebra_agent", "weight": 100, "pack_size": [ 2, 4 ] },
       { "monster": "mon_feral_zebra_agent_p90", "weight": 100, "pack_size": [ 0, 2 ] }
@@ -188,7 +188,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_IERDE",
+    "id": "GROUP_GENIUS_IERDE",
     "monsters": [
       { "monster": "mon_monstrous_badger", "weight": 150, "cost_multiplier": 0 },
       { "monster": "mon_stoneling", "weight": 250, "cost_multiplier": 0 },
@@ -197,7 +197,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_IERDE_LESSER",
+    "id": "GROUP_GENIUS_IERDE_LESSER",
     "monsters": [
       { "monster": "mon_monstrous_badger", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_stoneling", "weight": 200, "cost_multiplier": 0 }
@@ -205,12 +205,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_IERDE_MEDIAL",
+    "id": "GROUP_GENIUS_IERDE_MEDIAL",
     "monsters": [ { "monster": "mon_shamir_worm", "weight": 50, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_UNDINE",
+    "id": "GROUP_GENIUS_UNDINE",
     "monsters": [
       { "monster": "mon_water_sprite", "weight": 125, "cost_multiplier": 0 },
       { "monster": "mon_spitting_lizard", "weight": 300, "cost_multiplier": 0 },
@@ -226,7 +226,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_UNDINE_LESSER",
+    "id": "GROUP_GENIUS_UNDINE_LESSER",
     "monsters": [
       { "monster": "mon_water_sprite", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_spitting_lizard", "weight": 100, "cost_multiplier": 0 }
@@ -234,7 +234,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_UNDINE_MEDIAL",
+    "id": "GROUP_GENIUS_UNDINE_MEDIAL",
     "monsters": [
       { "monster": "mon_undertow", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_shabriri", "weight": 50, "cost_multiplier": 0 }
@@ -242,12 +242,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_UNDINE_GREATER",
+    "id": "GROUP_GENIUS_UNDINE_GREATER",
     "monsters": [ { "monster": "mon_nuckalavee", "weight": 20, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_SALAMANDER",
+    "id": "GROUP_GENIUS_SALAMANDER",
     "monsters": [
       { "monster": "mon_smoke_mephit", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_salamander_tiny", "weight": 300, "cost_multiplier": 0 },
@@ -256,7 +256,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_SALAMANDER_LESSER",
+    "id": "GROUP_GENIUS_SALAMANDER_LESSER",
     "monsters": [
       { "monster": "mon_smoke_mephit", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_salamander_tiny", "weight": 100, "cost_multiplier": 0 }
@@ -264,12 +264,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_SALAMANDER_GREATER",
+    "id": "GROUP_GENIUS_SALAMANDER_GREATER",
     "monsters": [ { "monster": "mon_elemental_saraph", "weight": 50, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_SYLPH",
+    "id": "GROUP_GENIUS_SYLPH",
     "monsters": [
       { "monster": "mon_skyglass_butterflies", "weight": 150, "cost_multiplier": 0 },
       { "monster": "mon_dragonfly_fae", "weight": 250, "cost_multiplier": 0 },
@@ -278,7 +278,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_SYLPH_LESSER",
+    "id": "GROUP_GENIUS_SYLPH_LESSER",
     "monsters": [
       { "monster": "mon_skyglass_butterflies", "weight": 80, "cost_multiplier": 0 },
       { "monster": "mon_dragonfly_fae", "weight": 40, "cost_multiplier": 0 }
@@ -286,12 +286,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_SYLPH_MEDIAL",
+    "id": "GROUP_GENIUS_SYLPH_MEDIAL",
     "monsters": [ { "monster": "mon_sheyd", "weight": 50, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_ARVORE",
+    "id": "GROUP_GENIUS_ARVORE",
     "monsters": [
       { "monster": "mon_vineling", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_ratatosk_children", "weight": 300, "cost_multiplier": 0 },
@@ -301,7 +301,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_ARVORE_LESSER",
+    "id": "GROUP_GENIUS_ARVORE_LESSER",
     "monsters": [
       { "monster": "mon_vineling", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_ratatosk_children", "weight": 100, "cost_multiplier": 0 }
@@ -309,17 +309,17 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_ARVORE_MEDIAL",
+    "id": "GROUP_GENIUS_ARVORE_MEDIAL",
     "monsters": [ { "monster": "mon_bear_thorn", "weight": 50, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_ARVORE_GREATER",
+    "id": "GROUP_GENIUS_ARVORE_GREATER",
     "monsters": [ { "monster": "mon_defender_wood", "weight": 50, "cost_multiplier": 0 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_GENIUS_HOMULLUS",
+    "id": "GROUP_GENIUS_HOMULLUS",
     "monsters": [
       { "monster": "mon_zoomorphic_figure_small", "weight": 40, "cost_multiplier": 0 },
       { "monster": "mon_venus_doll", "weight": 400, "cost_multiplier": 0 }
@@ -327,22 +327,22 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_CAMP_OM",
+    "id": "GROUP_MI-GO_CAMP_OM",
     "monsters": [ { "monster": "mon_mi_go_stalking_warper", "weight": 50, "cost_multiplier": 20, "starts": "210 hours" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_COMMON",
+    "id": "GROUP_MI-GO_BASE_COMMON",
     "monsters": [ { "monster": "mon_mi_go_stalking_warper", "weight": 50, "cost_multiplier": 2, "starts": "210 hours" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_CAPTORS",
+    "id": "GROUP_MI-GO_BASE_CAPTORS",
     "monsters": [ { "monster": "mon_mi_go_stalking_warper", "weight": 300, "cost_multiplier": 2, "starts": "210 hours" } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_MI-GO_BASE_BOSS",
+    "id": "GROUP_MI-GO_BASE_BOSS",
     "monsters": [
       { "monster": "mon_mi_go_stalking_warper", "weight": 200, "cost_multiplier": 2 },
       { "monster": "mon_mi_go_stalking_warper", "weight": 50, "cost_multiplier": 5, "pack_size": [ 2, 3 ] }
@@ -350,7 +350,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SALAMANDER_ERUPTION_SURFACE",
+    "id": "GROUP_SALAMANDER_ERUPTION_SURFACE",
     "monsters": [
       { "monster": "mon_smoke_mephit", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_salamander_tiny", "weight": 300, "cost_multiplier": 0 },
@@ -361,7 +361,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SALAMANDER_ERUPTION",
+    "id": "GROUP_SALAMANDER_ERUPTION",
     "monsters": [
       { "monster": "mon_smoke_mephit", "weight": 10, "cost_multiplier": 0 },
       { "monster": "mon_salamander_tiny", "weight": 30, "cost_multiplier": 0 },
@@ -371,7 +371,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_SALAMANDER_FINALE",
+    "id": "GROUP_SALAMANDER_FINALE",
     "monsters": [
       { "monster": "mon_salamagman_warlord_butterfly", "weight": 100, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "monster": "mon_salamagman_small", "weight": 25, "cost_multiplier": 0, "pack_size": [ 1, 6 ] },
@@ -380,7 +380,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_HEDGE_TO_CAUSE_ARMED_MEN",
+    "id": "GROUP_HEDGE_TO_CAUSE_ARMED_MEN",
     "monsters": [
       { "monster": "mon_hedge_armed_warrior_sword", "weight": 400 },
       { "monster": "mon_hedge_armed_warrior_spear", "weight": 400 },
@@ -390,7 +390,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_HOSTS_OF_SAMHAIN",
+    "id": "GROUP_HOSTS_OF_SAMHAIN",
     "monsters": [
       { "monster": "mon_samhain_ghost_mace", "weight": 333 },
       { "monster": "mon_samhain_ghost_axe", "weight": 333 },
@@ -399,12 +399,12 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_UPGRADE",
+    "id": "GROUP_ZOMBIE_UPGRADE",
     "monsters": [ { "monster": "mon_zombie_monochrome", "weight": 30 } ]
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_MONOCHROME_UPGRADE",
+    "id": "GROUP_ZOMBIE_MONOCHROME_UPGRADE",
     "default": "mon_zombie_monochrome",
     "monsters": [
       { "monster": "mon_zombie_monochrome", "weight": 450 },

--- a/data/mods/desert_region/monsters/desert_monstergroups.json
+++ b/data/mods/desert_region/monsters/desert_monstergroups.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "monstergroup",
-    "name": "GROUP_DESERT",
+    "id": "GROUP_DESERT",
     "default": "mon_null",
     "is_animal": true,
     "monsters": [

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -918,7 +918,7 @@ void resonance_cascade( const tripoint_bub_ms &p )
                     std::vector<MonsterGroupResult> spawn_details =
                         MonsterGroupManager::GetResultFromGroup( GROUP_NETHER );
                     for( const MonsterGroupResult &mgr : spawn_details ) {
-                        g->place_critter_at( mgr.name, dest );
+                        g->place_critter_at( mgr.id, dest );
                     }
                 }
                 break;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4871,7 +4871,7 @@ void basecamp::hunting_results( int skill, const mission_id &miss_id, int attemp
 void basecamp::make_corpse_from_group( const std::vector<MonsterGroupResult> &group )
 {
     for( const MonsterGroupResult &monster : group ) {
-        const mtype_id target = monster.name;
+        const mtype_id target = monster.id;
         item result = item::make_corpse( target, calendar::turn, "" );
         if( !result.is_null() ) {
             int num_to_spawn = monster.pack_size;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8791,10 +8791,10 @@ void map::spawn_monsters_submap_group( const tripoint_rel_sm &gp, mongroup &grou
             std::vector<MonsterGroupResult> spawn_details =
                 MonsterGroupManager::GetResultFromGroup( group.type, &pop );
             for( const MonsterGroupResult &mgr : spawn_details ) {
-                if( !mgr.name ) {
+                if( !mgr.id ) {
                     continue;
                 }
-                monster tmp( mgr.name );
+                monster tmp( mgr.id );
 
                 // If a monster came from a horde population, configure them to always be willing to rejoin a horde.
                 if( group.horde ) {

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -770,7 +770,7 @@ static void field_processor_monster_spawn( const tripoint_bub_ms &p, field_entry
             std::vector<MonsterGroupResult> spawn_details =
                 MonsterGroupManager::GetResultFromGroup( int_level.monster_spawn_group, &monster_spawn_count );
             for( const MonsterGroupResult &mgr : spawn_details ) {
-                if( !mgr.name ) {
+                if( !mgr.id ) {
                     continue;
                 }
                 if( const std::optional<tripoint_bub_ms> spawn_point =

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -366,7 +366,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
                     std::vector<MonsterGroupResult> spawn_details =
                         MonsterGroupManager::GetResultFromGroup( spawns.group, &pop );
                     for( const MonsterGroupResult &mgr : spawn_details ) {
-                        if( !mgr.name ) {
+                        if( !mgr.id ) {
                             continue;
                         }
                         if( const std::optional<tripoint_bub_ms> pt =
@@ -2654,7 +2654,7 @@ class jmapgen_monster : public jmapgen_piece
                     MonsterGroupManager::GetResultFromGroup( chosen_group, nullptr, nullptr, false, nullptr,
                             use_pack_size );
                 for( const MonsterGroupResult &mgr : spawn_details ) {
-                    dat.m.add_spawn( mgr.name, spawn_count * pack_size.get(),
+                    dat.m.add_spawn( mgr.id, spawn_count * pack_size.get(),
                     { x.get(), y.get(), dat.zlevel() + z.get()},
                     friendly, -1, mission_id, chosen_name, data );
                 }
@@ -6630,7 +6630,7 @@ void map::place_spawns( const mongroup_id &group, const int chance,
         std::vector<MonsterGroupResult> spawn_details =
             MonsterGroupManager::GetResultFromGroup( group, &num );
         for( const MonsterGroupResult &mgr : spawn_details ) {
-            add_spawn( mgr.name, mgr.pack_size, { p, abs_sub.z() },
+            add_spawn( mgr.id, mgr.pack_size, { p, abs_sub.z() },
                        friendly, -1, mission_id, name, mgr.data );
         }
     }
@@ -6830,7 +6830,7 @@ std::vector<item *> map::put_items_from_loc( const item_group_id &group_id,
 
 void map::add_spawn( const MonsterGroupResult &spawn_details, const tripoint_bub_ms &p )
 {
-    add_spawn( spawn_details.name, spawn_details.pack_size, p, false, -1, -1, std::nullopt,
+    add_spawn( spawn_details.id, spawn_details.pack_size, p, false, -1, -1, std::nullopt,
                spawn_details.data );
 }
 

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -468,7 +468,15 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
     int freq_total = 0;
     std::pair<mtype_id, int> max_freq( { mon_null, 0 } );
 
-    g.name = mongroup_id( jo.get_string( "id" ) );
+    //TODO: Remove after 0.I
+    if( !jo.has_string( "id" ) && jo.has_string( "name" ) ) {
+        g.name = mongroup_id( jo.get_string( "name" ) );
+        debugmsg( R"((safely ignorable) monstergroup %s's "name" member should be renamed "id" before 0.I stable, you can use /tools/json-tools/monstergroup_name_to_id.py to automate this change)",
+                  g.name.c_str() );
+    } else {
+        g.name = mongroup_id( jo.get_string( "id" ) );
+    }
+
     bool extending = false;  //If already a group with that name, add to it instead of overwriting it
     if( monsterGroupMap.count( g.name ) != 0 && !jo.get_bool( "override", false ) ) {
         g = monsterGroupMap[g.name];

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -468,7 +468,7 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
     int freq_total = 0;
     std::pair<mtype_id, int> max_freq( { mon_null, 0 } );
 
-    g.name = mongroup_id( jo.get_string( "name" ) );
+    g.name = mongroup_id( jo.get_string( "id" ) );
     bool extending = false;  //If already a group with that name, add to it instead of overwriting it
     if( monsterGroupMap.count( g.name ) != 0 && !jo.get_bool( "override", false ) ) {
         g = monsterGroupMap[g.name];

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -99,7 +99,7 @@ float mongroup::avg_speed() const
                 // TODO: recursively derive average speed from subgroups
                 avg_speed += elem.frequency * 100;
             } else {
-                avg_speed += elem.frequency * elem.name.obj().speed;
+                avg_speed += elem.frequency * elem.mtype->speed;
             }
             remaining_frequency -= elem.frequency;
         }
@@ -247,7 +247,7 @@ std::vector<MonsterGroupResult> MonsterGroupManager::GetResultFromGroup(
         } else {
             if( use_pack_size ) {
                 for( int i = 0; i < pack_size; i++ ) {
-                    spawn_details.emplace_back( entry.name, pack_size, entry.data );
+                    spawn_details.emplace_back( entry.mtype, pack_size, entry.data );
                     // And if a quantity pointer with remaining value was passed, will modify the external
                     // value as a side effect.  We will reduce it by the spawn rule's cost multiplier.
                     if( quantity ) {
@@ -255,7 +255,7 @@ std::vector<MonsterGroupResult> MonsterGroupManager::GetResultFromGroup(
                     }
                 }
             } else {
-                spawn_details.emplace_back( entry.name, pack_size, entry.data );
+                spawn_details.emplace_back( entry.mtype, pack_size, entry.data );
                 // And if a quantity pointer with remaining value was passed, will modify the external
                 // value as a side effect.  We will reduce it by the spawn rule's cost multiplier.
                 if( quantity ) {
@@ -288,7 +288,7 @@ std::vector<MonsterGroupResult> MonsterGroupManager::GetResultFromGroup(
 bool MonsterGroup::IsMonsterInGroup( const mtype_id &mtypeid ) const
 {
     for( const MonsterGroupEntry &m : monsters ) {
-        if( m.name == mtypeid ) {
+        if( m.mtype == mtypeid ) {
             return true;
         }
     }
@@ -321,7 +321,7 @@ const mongroup_id &MonsterGroupManager::Monster2Group( const mtype_id &monster )
 {
     for( auto &g : monsterGroupMap ) {
         if( g.second.IsMonsterInGroup( monster ) ) {
-            return g.second.name;
+            return g.second.id;
         }
     }
     return mongroup_id::NULL_ID();
@@ -347,7 +347,7 @@ std::vector<mtype_id> MonsterGroupManager::GetMonstersFromGroup( const mongroup_
                 monsters.insert( monsters.end(), submons.begin(), submons.end() );
             }
         } else {
-            monsters.push_back( elem.name );
+            monsters.push_back( elem.mtype );
         }
     }
     return monsters;
@@ -366,7 +366,7 @@ const MonsterGroup &MonsterGroupManager::GetMonsterGroup( const mongroup_id &gro
         // Initialize the group with a null-monster, it's ignored while spawning,
         // but it prevents further messages about invalid monster type id
         auto &g = monsterGroupMap[group];
-        g.name = group;
+        g.id = group;
         g.defaultMonster = mtype_id::NULL_ID();
         return g;
     } else {
@@ -443,7 +443,7 @@ void MonsterGroupManager::FinalizeMonsterGroups()
     for( auto &elem : monsterGroupMap ) {
         MonsterGroup &mg = elem.second;
         for( FreqDef::iterator c = mg.monsters.begin(); c != mg.monsters.end(); ) {
-            if( !c->is_group() && MonsterGroupManager::monster_is_blacklisted( c->name ) ) {
+            if( !c->is_group() && MonsterGroupManager::monster_is_blacklisted( c->mtype ) ) {
                 c = mg.monsters.erase( c );
             } else {
                 ++c;
@@ -470,16 +470,16 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
 
     //TODO: Remove after 0.I
     if( !jo.has_string( "id" ) && jo.has_string( "name" ) ) {
-        g.name = mongroup_id( jo.get_string( "name" ) );
+        g.id = mongroup_id( jo.get_string( "name" ) );
         debugmsg( R"((safely ignorable) monstergroup %s's "name" member should be renamed "id" before 0.I stable, you can use /tools/json-tools/monstergroup_name_to_id.py to automate this change)",
-                  g.name.c_str() );
+                  g.id.c_str() );
     } else {
-        g.name = mongroup_id( jo.get_string( "id" ) );
+        g.id = mongroup_id( jo.get_string( "id" ) );
     }
 
     bool extending = false;  //If already a group with that name, add to it instead of overwriting it
-    if( monsterGroupMap.count( g.name ) != 0 && !jo.get_bool( "override", false ) ) {
-        g = monsterGroupMap[g.name];
+    if( monsterGroupMap.count( g.id ) != 0 && !jo.get_bool( "override", false ) ) {
+        g = monsterGroupMap[g.id];
         extending = true;
     }
     bool explicit_def_null = false;
@@ -580,7 +580,7 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
         g.freq_total = total;
     }
 
-    monsterGroupMap[g.name] = g;
+    monsterGroupMap[g.id] = g;
 }
 
 bool MonsterGroupManager::is_animal( const mongroup_id &group_name )
@@ -610,8 +610,8 @@ static void check_group_def( const mongroup_id &g )
             } else {
                 check_group_def( m.group );
             }
-        } else if( !m.name.is_valid() ) {
-            debugmsg( "monster group %s contains unknown monster %s", g.c_str(), m.name.c_str() );
+        } else if( !m.mtype.is_valid() ) {
+            debugmsg( "monster group %s contains unknown monster %s", g.c_str(), m.mtype.c_str() );
         }
     }
 }
@@ -619,29 +619,16 @@ static void check_group_def( const mongroup_id &g )
 void MonsterGroupManager::check_group_definitions()
 {
     for( const auto &e : monsterGroupMap ) {
-        const MonsterGroup &mg = e.second;
-        for( const MonsterGroupEntry &mge : mg.monsters ) {
-            if( mge.is_group() ) {
-                if( !mge.group.is_valid() ) {
-                    debugmsg( "monster group %s contains unknown subgroup %s", mg.name.c_str(), mge.group.c_str() );
-                } else {
-                    check_group_def( mge.group );
-                }
-            } else if( !mge.name.is_valid() ) {
-                // mon_null should not be valid here
-                debugmsg( "monster group %s contains unknown monster %s", mg.name.c_str(), mge.name.c_str() );
-            }
-        }
+        check_group_def( e.first );
     }
 }
 
-const mtype_id &MonsterGroupManager::GetRandomMonsterFromGroup( const mongroup_id &group_name )
+const mtype_id &MonsterGroupManager::GetRandomMonsterFromGroup( const mongroup_id &group )
 {
-    const MonsterGroup &group = group_name.obj();
-    int spawn_chance = rng( 1, group.event_adjusted_freq_total() );
+    int spawn_chance = rng( 1, group->event_adjusted_freq_total() );
     std::string opt = get_option<std::string>( "EVENT_SPAWNS" );
     const bool can_spawn_events = opt == "monsters" || opt == "both";
-    for( const MonsterGroupEntry &monster_type : group.monsters ) {
+    for( const MonsterGroupEntry &monster_type : group->monsters ) {
         if( monster_type.event != holiday::none && ( !can_spawn_events ||
                 monster_type.event != get_holiday_from_time() ) ) {
             continue;
@@ -650,11 +637,11 @@ const mtype_id &MonsterGroupManager::GetRandomMonsterFromGroup( const mongroup_i
             if( monster_type.is_group() ) {
                 return GetRandomMonsterFromGroup( monster_type.group );
             }
-            return monster_type.name;
+            return monster_type.mtype;
         } else {
             spawn_chance -= monster_type.frequency;
         }
     }
 
-    return group.defaultMonster;
+    return group->defaultMonster;
 }

--- a/src/mongroup.h
+++ b/src/mongroup.h
@@ -26,7 +26,7 @@ using FreqDef = std::vector<MonsterGroupEntry>;
 using FreqDef_iter = FreqDef::iterator;
 
 struct MonsterGroupEntry {
-    mtype_id name;
+    mtype_id mtype;
     mongroup_id group;
     int frequency;
     int cost_multiplier;
@@ -44,10 +44,10 @@ struct MonsterGroupEntry {
         return group != mongroup_id();
     }
 
-    MonsterGroupEntry( const mtype_id &id, int new_freq, int new_cost, int new_pack_min,
+    MonsterGroupEntry( const mtype_id &new_id, int new_freq, int new_cost, int new_pack_min,
                        int new_pack_max, const spawn_data &new_data, const time_duration &new_starts,
                        const time_duration &new_ends, holiday new_event )
-        : name( id )
+        : mtype( new_id )
         , frequency( new_freq )
         , cost_multiplier( new_cost )
         , pack_minimum( new_pack_min )
@@ -58,10 +58,10 @@ struct MonsterGroupEntry {
         , event( new_event ) {
     }
 
-    MonsterGroupEntry( const mongroup_id &id, int new_freq, int new_cost, int new_pack_min,
+    MonsterGroupEntry( const mongroup_id &new_id, int new_freq, int new_cost, int new_pack_min,
                        int new_pack_max, const spawn_data &new_data, const time_duration &new_starts,
                        const time_duration &new_ends, holiday new_event )
-        : group( id )
+        : group( new_id )
         , frequency( new_freq )
         , cost_multiplier( new_cost )
         , pack_minimum( new_pack_min )
@@ -74,15 +74,15 @@ struct MonsterGroupEntry {
 };
 
 struct MonsterGroupResult {
-    mtype_id name;
+    mtype_id id;
     int pack_size;
     spawn_data data;
 
-    MonsterGroupResult() : name( mtype_id::NULL_ID() ), pack_size( 0 ) {
+    MonsterGroupResult() : id( mtype_id::NULL_ID() ), pack_size( 0 ) {
     }
 
-    MonsterGroupResult( const mtype_id &id, int new_pack_size, const spawn_data &new_data )
-        : name( id ), pack_size( new_pack_size ), data( new_data ) {
+    MonsterGroupResult( const mtype_id &new_id, int new_pack_size, const spawn_data &new_data )
+        : id( new_id ), pack_size( new_pack_size ), data( new_data ) {
     }
 };
 
@@ -90,7 +90,7 @@ struct MonsterGroupResult {
  * MonsterGroup is a theoretical distribution of monsters to spawn, as opposed to a mongroup which is an instance of group of monsters to be spawned together.
 */
 struct MonsterGroup {
-    mongroup_id name;
+    mongroup_id id;
     mtype_id defaultMonster;
     FreqDef monsters;
     bool IsMonsterInGroup( const mtype_id &id ) const;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -484,17 +484,17 @@ void monster::try_upgrade( bool pin_time )
                         type->upgrade_group, nullptr, nullptr, false, &ret_default );
                 if( !res.empty() && !ret_default ) {
                     // Set the type to poly the current monster (preserves inventory)
-                    new_type = res.front().name;
+                    new_type = res.front().id;
                     res.front().pack_size--;
                     for( const MonsterGroupResult &mgr : res ) {
-                        if( !mgr.name ) {
+                        if( !mgr.id ) {
                             continue;
                         }
                         for( int i = 0; i < mgr.pack_size; i++ ) {
                             tripoint_bub_ms spawn_pos;
-                            if( g->find_nearby_spawn_point( pos_bub(), mgr.name, 1, *type->upgrade_multi_range,
+                            if( g->find_nearby_spawn_point( pos_bub(), mgr.id, 1, *type->upgrade_multi_range,
                                                             spawn_pos, false, false ) ) {
-                                monster *spawned = g->place_critter_at( mgr.name, spawn_pos );
+                                monster *spawned = g->place_critter_at( mgr.id, spawn_pos );
                                 if( spawned ) {
                                     spawned->friendly = friendly;
                                 }
@@ -594,7 +594,7 @@ void monster::try_reproduce()
                             type->baby_type.baby_monster_group, &spawn_cnt,
                             nullptr, false, nullptr, true );
                 for( const MonsterGroupResult &mgr : babies ) {
-                    here.add_spawn( mgr.name, std::max( 1, spawn_cnt * mgr.pack_size ), pos_bub(), friendly );
+                    here.add_spawn( mgr.id, std::max( 1, spawn_cnt * mgr.pack_size ), pos_bub(), friendly );
                 }
             }
             if( !type->baby_type.baby_egg.is_null() ) {

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -661,7 +661,7 @@ static void eff_fun_teleglow( Character &u, effect &it )
                 std::vector<MonsterGroupResult> spawn_details =
                     MonsterGroupManager::GetResultFromGroup( GROUP_NETHER );
                 for( const MonsterGroupResult &mgr : spawn_details ) {
-                    g->place_critter_at( mgr.name, dest );
+                    g->place_critter_at( mgr.id, dest );
                 }
                 if( uistate.distraction_hostile_spotted && player_character.sees( dest ) ) {
                     g->cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,
@@ -1315,7 +1315,7 @@ void Character::hardcoded_effects( effect &it )
                 std::vector<MonsterGroupResult> spawn_details =
                     MonsterGroupManager::GetResultFromGroup( GROUP_NETHER );
                 for( const MonsterGroupResult &mgr : spawn_details ) {
-                    g->place_critter_at( mgr.name, dest );
+                    g->place_critter_at( mgr.id, dest );
                 }
                 if( uistate.distraction_hostile_spotted && player_character.sees( dest ) ) {
                     g->cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,

--- a/tests/mongroup_test.cpp
+++ b/tests/mongroup_test.cpp
@@ -40,7 +40,7 @@ static void spawn_x_monsters( int x, const mongroup_id &grp, const std::vector<m
             rand_gets.emplace( tmp_get );
         }
 
-        mtype_id tmp_res = MonsterGroupManager::GetResultFromGroup( grp ).front().name;
+        mtype_id tmp_res = MonsterGroupManager::GetResultFromGroup( grp ).front().id;
         if( !tmp_res.is_null() ) {
             rand_results.emplace( tmp_res );
         }
@@ -196,12 +196,12 @@ TEST_CASE( "Nested_monster_groups_spawn_chance", "[mongroup]" )
 
     for( int i = 0; i < iters; i++ ) {
         MonsterGroupResult res = MonsterGroupManager::GetResultFromGroup( mg ).front();
-        auto iter = results.find( res.name );
-        CAPTURE( res.name.c_str() );
+        auto iter = results.find( res.id );
+        CAPTURE( res.id.c_str() );
         REQUIRE( iter != results.end() );
         if( iter != results.end() ) {
             layers[std::get<0>( iter->second )].second++;
-            std::get<2>( results[res.name] )++;
+            std::get<2>( results[res.id] )++;
         }
     }
 

--- a/tools/json_tools/monstergroup_name_to_id.py
+++ b/tools/json_tools/monstergroup_name_to_id.py
@@ -5,7 +5,7 @@
 Example usage:
 py monstergroup_name_to_id.py ../../data/mods/my_mod
 
-See https://github.com/CleverRaven/Cataclysm-DDA/pull/79177 for context and motivation
+See https://github.com/CleverRaven/Cataclysm-DDA/pull/79177
 Should be removed after 0.I
 
 """

--- a/tools/json_tools/monstergroup_name_to_id.py
+++ b/tools/json_tools/monstergroup_name_to_id.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 
 """
-Example usage py monstergroup_name_to_id.py ../data/mods/my_mod
+
+Example usage:
+py monstergroup_name_to_id.py ../../data/mods/my_mod
+
+See https://github.com/CleverRaven/Cataclysm-DDA/pull/79177 for context and motivation
 Should be removed after 0.I
+
 """
 import argparse
 import json
@@ -18,9 +23,9 @@ failures = set()
 def format_json(path):
     file_path = os.path.dirname(__file__)
     # Might need changing to match your setup
-    format_path_linux = os.path.join(file_path, "/format/json_formatter.cgi")
-    path_win = "../json_formatter.exe"
-    alt_path_win = "/format/json_formatter.exe"
+    format_path_linux = os.path.join(file_path, "../format/json_formatter.cgi")
+    path_win = "../../json_formatter.exe"
+    alt_path_win = "../format/json_formatter.exe"
     format_path_win = os.path.join(file_path, path_win)
     format_alt_path_win = os.path.join(file_path, alt_path_win)
     if os.path.exists(format_path_linux):

--- a/tools/monstergroup_name_to_id.py
+++ b/tools/monstergroup_name_to_id.py
@@ -14,6 +14,7 @@ args_dict = vars(args.parse_args())
 
 failures = set()
 
+
 def format_json(path):
     file_path = os.path.dirname(__file__)
     # Might need changing to match your setup
@@ -34,8 +35,8 @@ def format_json(path):
 
 def readWriteJson(path, jo_function):
     change = False
-    format_error = "Json Decode Error at:\n{0}\nEnsure that the file is a JSON"\
-        " file consisting of an object or array of objects!".format(path)
+    format_error = "Json Decode Error at:\n{0}\nEnsure that the file is a "\
+        "JSON file consisting of an object or array of objects!".format(path)
     with open(path, "r", encoding="utf-8") as json_file:
         try:
             json_data = json.load(json_file)
@@ -44,14 +45,14 @@ def readWriteJson(path, jo_function):
             return
         if type(json_data) is dict:  # File with a single json object
             json_data = jo_function(json_data)
-            change = json_data != None
+            change = json_data is not None
         elif type(json_data) is list:
             for jo in json_data:
                 if type(jo) is not dict:
                     failures.add(format_error)
                     return
                 jo_new = jo_function(jo)
-                changed = jo_new != None
+                changed = jo_new is not None
                 if changed:
                     change = True
                     pos = json_data.index(jo)
@@ -66,9 +67,9 @@ def readWriteJson(path, jo_function):
 
 
 def migrateMonsterGroupNameToId(jo):
-    assert("type" in jo)
+    assert "type" in jo
     if jo["type"] == "monstergroup" and "name" in jo:
-        assert(type(jo["name"]) is str)
+        assert type(jo["name"]) is str
         # While dicts are ordered they have no way to directly edit keys
         # or access by index
         pos = list(jo.keys()).index("name")

--- a/tools/monstergroup_name_to_id.py
+++ b/tools/monstergroup_name_to_id.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+"""
+Example usage py monstergroup_name_to_id.py ../data/mods/my_mod
+Should be removed after 0.I
+"""
+import argparse
+import json
+import os
+
+args = argparse.ArgumentParser()
+args.add_argument("dir", action="store", help="specify json directory")
+args_dict = vars(args.parse_args())
+
+failures = set()
+
+def format_json(path):
+    file_path = os.path.dirname(__file__)
+    # Might need changing to match your setup
+    format_path_linux = os.path.join(file_path, "/format/json_formatter.cgi")
+    path_win = "../json_formatter.exe"
+    alt_path_win = "/format/json_formatter.exe"
+    format_path_win = os.path.join(file_path, path_win)
+    format_alt_path_win = os.path.join(file_path, alt_path_win)
+    if os.path.exists(format_path_linux):
+        os.system(f"{format_path_linux} {path}")
+    elif os.path.exists(format_path_win):
+        os.system(f"{format_path_win} {path}")
+    elif os.path.exists(format_alt_path_win):
+        os.system(f"{format_alt_path_win} {path}")
+    else:
+        print("No json formatter found")
+
+
+def readWriteJson(path, jo_function):
+    change = False
+    format_error = "Json Decode Error at:\n{0}\nEnsure that the file is a JSON"\
+        " file consisting of an object or array of objects!".format(path)
+    with open(path, "r", encoding="utf-8") as json_file:
+        try:
+            json_data = json.load(json_file)
+        except json.JSONDecodeError:
+            failures.add(format_error)
+            return
+        if type(json_data) is dict:  # File with a single json object
+            json_data = jo_function(json_data)
+            change = json_data != None
+        elif type(json_data) is list:
+            for jo in json_data:
+                if type(jo) is not dict:
+                    failures.add(format_error)
+                    return
+                jo_new = jo_function(jo)
+                changed = jo_new != None
+                if changed:
+                    change = True
+                    pos = json_data.index(jo)
+                    json_data.insert(pos, jo_new)
+                    json_data.remove(jo)
+        else:
+            failures.add(format_error)
+        if change:
+            with open(path, "w", encoding="utf-8") as jf:
+                json.dump(json_data, jf, ensure_ascii=False)
+            format_json(path)
+
+
+def migrateMonsterGroupNameToId(jo):
+    assert("type" in jo)
+    if jo["type"] == "monstergroup" and "name" in jo:
+        assert(type(jo["name"]) is str)
+        # While dicts are ordered they have no way to directly edit keys
+        # or access by index
+        pos = list(jo.keys()).index("name")
+        items = list(jo.items())
+        items.insert(pos, ("id", jo["name"]))
+        new_jo = dict(items)
+        new_jo.pop("name")
+        return new_jo
+    return None
+
+
+for root, directories, filenames in os.walk(args_dict["dir"]):
+    for filename in filenames:
+        path = os.path.join(root, filename)
+        if path.endswith(".json"):
+            readWriteJson(path, migrateMonsterGroupNameToId)
+
+for statement in failures:
+    print(statement)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "monstergroup name field changed to id"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This field is an id, calling it otherwise is confusing and nonstandard to the rest of our types
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Uses a lil python script to automate the json change
Script is included so out of repo mods/personal mods/forks etc can use it (Should be removed post 0.I stable)
Leaves a legacy load until 0.I stable
Also changes monster group fields called name
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
~~The C++ field is also called name but I don't feel like changing that rn and our C++ naming is far less standardised so idk whether it'd be accepted to begin with~~ Changed my mind
Not super happy with the C++ name choices but eh
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game loads
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
