### PR TITLE
Fix MSVC build with lld linker

### DIFF
--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -113,8 +113,6 @@
         freetype$(VcpkgLibSuffix).lib;
         jpeg.lib;
         libpng16$(VcpkgLibSuffix).lib;
-        libwavpack.lib;
-        libxmp-static.lib;
         modplug.lib;
         mpg123.lib;
         ogg.lib;

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -20,5 +20,5 @@
           "version>=": "3.9#4"
         }
     ],
-    "builtin-baseline": "5b11232d00476c66724c81adfe5e3777a9aec38f"
+    "builtin-baseline": "3acb7541e854452d33f71037a8f63a88899e63d3"
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixup for #79121 

When trying to build with lld linker it was failing with:
```
4>lld-link : error : could not open 'brotlicommon.lib': no such file or directory
4>lld-link : error : could not open 'brotlidec.lib': no such file or directory
4>lld-link : error : could not open 'brotlienc.lib': no such file or directory
4>lld-link : error : could not open 'libwavpack.lib': no such file or directory
4>lld-link : error : could not open 'libxmp-static.lib': no such file or directory
4>Done building project "Cataclysm-vcpkg-static.vcxproj" -- FAILED.
```

#### Describe the solution

Bump `builtin-baseline` to after the point where `brotli` switched from building a static lib to a dynamic lib.
Remove dependencies on `libwavpack.lib;` and `libxmp-static.lib;` since they don't exist yet at the chosen builtin-baseline for `sdl2-mixer[libmodplug]`

#### Describe alternatives you've considered

Two really:
- Bump `builtin-baseline` further to where no `Cataclysm-common.props` changes are needed
- Align `Cataclysm-common.props` to where no changes to `vcpkg.json` are needed

There are no particularly strong pros and cons to either approach, so it shouldn't really matter either way...

#### Testing

Builds with lld successfully.
Builds without lld successfully.
Sound works.

#### Additional context
- #78548 was the PR last changing the linked in libs. (Just adding it here for reference and perhaps easier github nav)

The full list of packages as installed by vcpkg as of this PR:
<details>

```
> vcpkg.exe install  --dry-run --host-triplet=x64-windows-static
Detecting compiler hash for triplet x64-windows-static...
Compiler found: H:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.42.34433/bin/Hostx64/x64/cl.exe
The following packages will be built and installed:
  * brotli:x64-windows-static@1.1.0#1 -- ...
  * bzip2[core,tool]:x64-windows-static@1.0.8#5 -- ...
  * freetype[brotli,bzip2,core,png,zlib]:x64-windows-static@2.12.1#4 -- ...
  * libflac:x64-windows-static@1.4.3 -- ...
  * libjpeg-turbo:x64-windows-static@3.0.0#2 -- ...
  * libmodplug:x64-windows-static@0.8.9.0#10 -- ...
  * libogg:x64-windows-static@1.3.5#1 -- ...
  * libpng:x64-windows-static@1.6.39#1 -- ...
  * libvorbis:x64-windows-static@1.3.7#2 -- ...
  * mpg123:x64-windows-static@1.31.3#2 -- ...
    pdcurses:x64-windows-static@3.9#6 -- ...
    sdl2[base,core]:x64-windows-static@2.28.4 -- ...
    sdl2-image[core,libjpeg-turbo]:x64-windows-static@2.6.3 -- ...
    sdl2-mixer[core,libflac,libmodplug,mpg123]:x64-windows-static@2.6.3#1 -- ...
    sdl2-ttf:x64-windows-static@2.20.2 -- ...
  * vcpkg-cmake:x64-windows-static@2023-05-04 -- ...
  * vcpkg-cmake-config:x64-windows-static@2022-02-06#1 -- ...
  * yasm[core,tools]:x64-windows-static@1.3.0#5 -- ...
  * yasm-tool-helper:x64-windows-static@2020-03-11#1 -- ...
  * zlib:x64-windows-static@1.3 -- ...
Additional packages (*) will be modified to complete this operation.
```

</details>