### PR TITLE
use typed point in android code

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2761,7 +2761,7 @@ static void CheckMessages()
                         const tripoint_bub_ms bub_pos( pos );
                         // Check if we're near a vehicle, if so, vehicle controls should be top.
                         {
-                            const optional_vpart_position vp = here.veh_at( pos );
+                            const optional_vpart_position vp = here.veh_at( bub_pos );
                             if( vp ) {
                                 if( const std::optional<vpart_reference> controlpart = vp.part_with_feature( "CONTROLS", true ) ) {
                                     actions.insert( ACTION_CONTROL_VEHICLE );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix android build.

#### Describe the solution

Fix what the build error is complaining about.
There's a ton of spam about `warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-warning-option`, so there's actually a small chance more actual errors are hiding somewhere, but searching for "error" didn't point to anything else.

#### Describe alternatives you've considered



#### Testing

I can't.

#### Additional context

