### PR TITLE
fix not being able to move items with charges with AIM

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1637,8 +1637,8 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
         return false;
     }
     item it_copy = *sitem->items.front();
-    if ( it_copy.count_by_charges()){
-        it_copy.charges = std::min(amount_to_move, sitem->items.front()->charges);
+    if( it_copy.count_by_charges() ) {
+        it_copy.charges = std::min( amount_to_move, sitem->items.front()->charges );
     }
     if( spane.get_area() == AIM_CONTAINER &&
         spane.container.get_item()->has_flag( json_flag_NO_UNLOAD ) ) {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1636,6 +1636,10 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
     if( !query_charges( destarea, *sitem, action, amount_to_move ) ) {
         return false;
     }
+    item it_copy = *sitem->items.front();
+    if ( it_copy.count_by_charges()){
+        it_copy.charges = std::min(amount_to_move, sitem->items.front()->charges);
+    }
     if( spane.get_area() == AIM_CONTAINER &&
         spane.container.get_item()->has_flag( json_flag_NO_UNLOAD ) ) {
         popup_getkey( _( "Source container can't be unloaded." ) );
@@ -1646,9 +1650,9 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
             popup_getkey( _( "Destination container can't be reloaded." ) );
             return false;
         }
-        ret_val<void> can_contain = dpane.container->can_contain( *sitem->items.front() );
+        ret_val<void> can_contain = dpane.container->can_contain( it_copy );
         if( can_contain.success() ) {
-            can_contain = dpane.container.parents_can_contain_recursive( &*sitem->items.front() );
+            can_contain = dpane.container.parents_can_contain_recursive( &it_copy );
         }
         if( !can_contain.success() ) {
             popup_getkey( can_contain.str().empty() ?
@@ -1699,7 +1703,7 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
             player_character.takeoff( Character::worn_position_to_index( sitem->idx ) + 1 );
         } else {
             // important if item is worn
-            if( player_character.can_drop( *sitem->items.front() ).success() ) {
+            if( player_character.can_drop( it_copy ).success() ) {
                 if( destarea == AIM_CONTAINER ) {
                     do_return_entry();
                     start_activity( destarea, srcarea, sitem, amount_to_move, from_vehicle, to_vehicle );
@@ -1730,14 +1734,7 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
         exit = true;
     } else {
         if( destarea == AIM_INVENTORY ) {
-            bool can_stash = false;
-            if( sitem->items.front()->count_by_charges() ) {
-                item dummy = *sitem->items.front();
-                dummy.charges = amount_to_move;
-                can_stash = player_character.can_stash( dummy );
-            } else {
-                can_stash = player_character.can_stash( *sitem->items.front() );
-            }
+            bool can_stash = player_character.can_stash( it_copy );
             if( !can_stash ) {
                 popup_getkey( _( "You have no space for the %s." ), sitem->items.front()->tname() );
                 return false;


### PR DESCRIPTION

#### Summary
Bugfixes "check charges when trying to move item with AIM"

#### Purpose of change
fix #79150
when moving items with count_by_charges via AIM, it checks if the item fits using the max amount of charges, instead of the number supplied via query.

#### Describe the solution
move solution from https://github.com/CleverRaven/Cataclysm-DDA/blob/69a4eb7ec0cfeb3019c57dabb4a050684f680c39/src/advanced_inv.cpp#L1734-L1740
up and make checks with that dummy

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
https://github.com/CleverRaven/Cataclysm-DDA/blob/69a4eb7ec0cfeb3019c57dabb4a050684f680c39/src/item_pocket.cpp#L1442
already can take an argument for copies_remaining, make it  work with charges?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
compiled,
When trying to move ammo with charges above what dest can hold, get dialog asking amount
When entering a number below max, it moves that amount
When entering number above max, it moves max amount
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
charges are pain
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
