### PR TITLE
Expand NULL_ID() usage

### DIFF
--- a/data/core/sentinels.json
+++ b/data/core/sentinels.json
@@ -59,6 +59,12 @@
     "description": "This fault id is a reserved sentinel."
   },
   {
+    "type": "attack_vector",
+    "id": "vector_null",
+    "//": "Fallback weapon vector, unarmed attacks always go through techs",
+    "weapon": true
+  },
+  {
     "type": "SPELL",
     "id": "null",
     "name": { "str": "none" },

--- a/data/core/sentinels.json
+++ b/data/core/sentinels.json
@@ -17,7 +17,15 @@
     "base_hp": 60,
     "drench_capacity": 1,
     "legacy_id": "NUM_BP",
-    "sub_parts": [ "sub_limb_debug" ]
+    "sub_parts": [ "sub_bp_null" ]
+  },
+  {
+    "id": "sub_bp_null",
+    "type": "sub_body_part",
+    "parent": "bp_null",
+    "side": 0,
+    "opposite": "sub_bp_null",
+    "name": { "str": "Null sub_body_part, if you see this please report it", "//~": "NO_I18N" }
   },
   {
     "id": "mx_null",

--- a/data/json/attack_vectors.json
+++ b/data/json/attack_vectors.json
@@ -1,12 +1,6 @@
 [
   {
     "type": "attack_vector",
-    "id": "vector_null",
-    "//": "Fallback weapon vector, unarmed attacks always go through techs",
-    "weapon": true
-  },
-  {
-    "type": "attack_vector",
     "id": "test_test",
     "limbs": [ "debug_tail" ],
     "encumbrance_limit": 33,

--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -900,7 +900,7 @@
     "parent": "bp_null",
     "side": 0,
     "opposite": "sub_limb_debug",
-    "name": "debug limb should never be seen"
+    "name": { "str": "debug limb should never be seen", "//~": "NO_I18N" }
   },
   {
     "id": "sub_limb_debug_tail",
@@ -908,7 +908,7 @@
     "parent": "debug_tail",
     "side": 0,
     "opposite": "sub_limb_debug_tail",
-    "name": "debug limb for debug tail"
+    "name": { "str": "debug limb for debug tail", "//~": "NO_I18N" }
   },
   {
     "id": "torso_upper",

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -251,7 +251,7 @@ std::vector<std::string> clothing_properties(
                                         _( "Item provides no protection" ) ) );
         return props;
     }
-    if( bp == bodypart_id( "bp_null" ) ) {
+    if( bp == bodypart_str_id::NULL_ID() ) {
         // if the armor has no protection data
         if( worn_item.find_armor_data()->sub_data.empty() ) {
             props.push_back( string_format( "<color_c_red>%s</color>",
@@ -356,7 +356,7 @@ std::vector<std::string> clothing_protection( const item &worn_item, const int w
     }
 
     // if bp is null its gonna be impossible to really get good info
-    if( bp == bodypart_id( "bp_null" ) ) {
+    if( bp == bodypart_str_id::NULL_ID() ) {
         // if we have exactly one entry for armor we can use that data
         if( worn_item.find_armor_data()->sub_data.size() == 1 ) {
             used_bp = *worn_item.get_covered_body_parts().begin();
@@ -464,7 +464,7 @@ item_penalties outfit::get_item_penalties( std::list<item>::const_iterator worn_
     std::vector<std::set<std::string>> lists_of_bad_items_within;
 
     for( const bodypart_id &bp : c.get_all_body_parts() ) {
-        if( bp != _bp && _bp != bodypart_id( "bp_null" ) ) {
+        if( bp != _bp && _bp != bodypart_str_id::NULL_ID() ) {
             continue;
         }
         if( !worn_item_it->covers( bp ) ) {
@@ -614,7 +614,7 @@ void outfit::sort_armor( Character &guy )
     for( const bodypart_id &it : guy.get_all_body_parts() ) {
         armor_cat.insert( it );
     }
-    armor_cat.insert( bodypart_id( "bp_null" ) );
+    armor_cat.insert( bodypart_str_id::NULL_ID() );
     const int num_of_parts = guy.get_all_body_parts().size();
 
     int win_h = 0;
@@ -713,7 +713,7 @@ void outfit::sort_armor( Character &guy )
         // Create ptr list of items to display
         tmp_worn.clear();
         const bodypart_id &bp = armor_cat[ tabindex ];
-        if( bp == bodypart_id( "bp_null" ) ) {
+        if( bp == bodypart_str_id::NULL_ID() ) {
             // All
             for( auto it = worn.begin(); it != worn.end(); ++it ) {
                 tmp_worn.push_back( it );
@@ -754,7 +754,8 @@ void outfit::sort_armor( Character &guy )
         // top bar
         std::string header_title = _( "Sort Armor" );
         wprintz( w_sort_cat, c_white, header_title );
-        std::string temp = bp != bodypart_id( "bp_null" ) ? body_part_name_as_heading( bp, 1 ) : _( "All" );
+        std::string temp = bp == bodypart_str_id::NULL_ID() ?  _( "All" ) : body_part_name_as_heading( bp,
+                           1 );
         temp = string_format( "  << %s >>", temp );
         wprintz( w_sort_cat, c_yellow, temp );
         int keyhint_offset = utf8_width( header_title ) + utf8_width( temp ) + 1;
@@ -864,7 +865,7 @@ void outfit::sort_armor( Character &guy )
         // Right list
         rightListSize = 0;
         for( const bodypart_id &cover : armor_cat ) {
-            if( cover == bodypart_id( "bp_null" ) ) {
+            if( cover == bodypart_str_id::NULL_ID() ) {
                 continue;
             }
             if( !combine_bp( cover ) || rl.count( cover.obj().opposite_part ) == 0 ) {
@@ -882,7 +883,7 @@ void outfit::sort_armor( Character &guy )
         int encumbrance_char_allowance = 4; //Enough for " 99+", will increase if necessary
         int item_name_offset = 2;
         for( const bodypart_id &cover : rl ) {
-            if( cover == bodypart_id( "bp_null" ) ) {
+            if( cover == bodypart_str_id::NULL_ID() ) {
                 continue;
             }
             if( curr >= rightListOffset && pos <= rightListLines ) {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1840,7 +1840,7 @@ void avatar::add_pain_msg( int val, const bodypart_id &bp ) const
     if( has_flag( json_flag_PAIN_IMMUNE ) ) {
         return;
     }
-    if( bp == bodypart_id( "bp_null" ) ) {
+    if( bp == bodypart_str_id::NULL_ID() ) {
         if( val > 20 ) {
             add_msg_if_player( _( "Your body is wracked with excruciating pain!" ) );
         } else if( val > 10 ) {

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -23,7 +23,6 @@
 
 const bodypart_str_id body_part_arm_l( "arm_l" );
 const bodypart_str_id body_part_arm_r( "arm_r" );
-const bodypart_str_id body_part_bp_null( "bp_null" );
 const bodypart_str_id body_part_eyes( "eyes" );
 const bodypart_str_id body_part_foot_l( "foot_l" );
 const bodypart_str_id body_part_foot_r( "foot_r" );

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -35,8 +35,6 @@ const bodypart_str_id body_part_leg_r( "leg_r" );
 const bodypart_str_id body_part_mouth( "mouth" );
 const bodypart_str_id body_part_torso( "torso" );
 
-const sub_bodypart_str_id sub_body_part_sub_limb_debug( "sub_limb_debug" );
-
 side opposite_side( side s )
 {
     switch( s ) {
@@ -641,7 +639,7 @@ std::set<translation, localized_comparator> body_part_type::consolidate(
     //first try to compress sets of sub body parts together into a full limb
     for( size_t i = 0; i < covered.size(); i++ ) {
         const sub_bodypart_id &sbp = covered[i];
-        if( sbp == sub_body_part_sub_limb_debug ) {
+        if( sbp == sub_bodypart_str_id::NULL_ID() ) {
             // if we have already covered this continue
             continue;
         }
@@ -650,9 +648,10 @@ std::set<translation, localized_comparator> body_part_type::consolidate(
         bool found_all = true;
         for( const sub_bodypart_str_id &searching : sbp->parent->sub_parts ) {
             //skip secondary locations for this
-            if( !searching->secondary ) {
-                found_all = std::find( covered.begin(), covered.end(), searching.id() ) != covered.end() &&
-                            found_all;
+            if( !searching->secondary &&
+                std::find( covered.begin(), covered.end(), searching.id() ) == covered.end() ) {
+                found_all = false;
+                break;
             }
         }
 
@@ -664,7 +663,7 @@ std::set<translation, localized_comparator> body_part_type::consolidate(
             for( const sub_bodypart_str_id &searching : sbp->parent->sub_parts ) {
                 if( !searching->secondary ) {
                     auto sbp_it = std::find( covered.begin(), covered.end(), searching.id() );
-                    *sbp_it = sub_body_part_sub_limb_debug;
+                    *sbp_it = sub_bodypart_str_id::NULL_ID();
                 }
             }
         }
@@ -698,13 +697,13 @@ std::set<translation, localized_comparator> body_part_type::consolidate(
 
     for( size_t i = 0; i < covered.size(); i++ ) {
         const sub_bodypart_id &sbp = covered[i];
-        if( sbp == sub_body_part_sub_limb_debug ) {
+        if( sbp == sub_bodypart_str_id::NULL_ID() ) {
             // if we have already covered this value as a pair continue
             continue;
         }
         sub_bodypart_id temp;
         // if our sub part has an opposite
-        if( sbp->opposite != sub_body_part_sub_limb_debug ) {
+        if( sbp->opposite != sub_bodypart_str_id::NULL_ID() ) {
             temp = sbp->opposite;
         } else {
             // if it doesn't have an opposite add it to the return vector alone and continue
@@ -720,7 +719,7 @@ std::set<translation, localized_comparator> body_part_type::consolidate(
                 to_return.insert( sbp->name_multiple );
                 found = true;
                 // set the found part to a null value
-                sbp_it = sub_body_part_sub_limb_debug;
+                sbp_it = sub_bodypart_str_id::NULL_ID();
                 break;
             }
         }

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -45,8 +45,6 @@ extern const bodypart_str_id body_part_foot_l;
 extern const bodypart_str_id body_part_leg_r;
 extern const bodypart_str_id body_part_foot_r;
 
-extern const sub_bodypart_str_id sub_body_part_sub_limb_debug;
-
 // The order is important ; pldata.h has to be in the same order
 enum body_part : int {
     bp_torso = 0,

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -31,7 +31,6 @@ template <typename T> class generic_factory;
 using bodypart_str_id = string_id<body_part_type>;
 using bodypart_id = int_id<body_part_type>;
 
-extern const bodypart_str_id body_part_bp_null;
 extern const bodypart_str_id body_part_head;
 extern const bodypart_str_id body_part_eyes;
 extern const bodypart_str_id body_part_mouth;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1835,7 +1835,7 @@ void Character::forced_dismount()
         }
         const int dodge = get_dodge();
         const int damage = std::max( 0, rng( 1, 20 ) - rng( dodge, dodge * 2 ) );
-        bodypart_id hit( "bp_null" );
+        bodypart_id hit = bodypart_str_id::NULL_ID();
         switch( rng( 1, 10 ) ) {
             case  1:
                 if( one_in( 2 ) ) {
@@ -3710,8 +3710,7 @@ void Character::apply_skill_boost()
 
 std::pair<bodypart_id, int> Character::best_part_to_smash() const
 {
-    const bodypart_id bp_null( "bp_null" );
-    std::pair<bodypart_id, int> best_part_to_smash = {bp_null, 0};
+    std::pair<bodypart_id, int> best_part_to_smash = {bodypart_str_id::NULL_ID().id(), 0};
     int tmp_bash_armor = 0;
     for( const bodypart_id &bp : get_all_body_parts() ) {
         tmp_bash_armor += worn.damage_resist( damage_bash, bp );

--- a/src/character.h
+++ b/src/character.h
@@ -3202,7 +3202,7 @@ class Character : public Creature, public visitable
         void on_item_acquire( const item &it );
         /** Called when effect intensity has been changed */
         void on_effect_int_change( const efftype_id &eid, int intensity,
-                                   const bodypart_id &bp = bodypart_id( "bp_null" ) ) override;
+                                   const bodypart_id &bp = bodypart_str_id::NULL_ID() ) override;
         /** Called when a mutation is gained */
         void on_mutation_gain( const trait_id &mid );
         /** Called when a mutation is lost */

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2348,7 +2348,7 @@ void Creature::set_body()
 
 bool Creature::has_part( const bodypart_id &id, body_part_filter filter ) const
 {
-    return get_part_id( id, filter, true ) != body_part_bp_null;
+    return get_part_id( id, filter, true ) != bodypart_str_id::NULL_ID();
 }
 
 bodypart *Creature::get_part( const bodypart_id &id )
@@ -2423,7 +2423,7 @@ bodypart_id Creature::get_part_id( const bodypart_id &id,
         }
     }
     // try to find the next best thing
-    std::pair<bodypart_id, float> best = { body_part_bp_null, 0.0f };
+    std::pair<bodypart_id, float> best = { bodypart_str_id::NULL_ID().id(), 0.0f };
     if( filter >= body_part_filter::next_best ) {
         for( const std::pair<const bodypart_str_id, bodypart> &bp : body ) {
             for( const std::pair<const body_part_type::type, float> &mp : bp.first->limbtypes ) {
@@ -2436,7 +2436,7 @@ bodypart_id Creature::get_part_id( const bodypart_id &id,
             }
         }
     }
-    if( best.first == body_part_bp_null && !suppress_debugmsg ) {
+    if( best.first == bodypart_str_id::NULL_ID() && !suppress_debugmsg ) {
         debugmsg( "Could not find equivalent bodypart id %s in %s's body", id.id().c_str(), get_name() );
     }
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2062,7 +2062,7 @@ static void character_edit_hp_menu( Character &you )
         hotkey++;
     }
     smenu.addentry( pos, true, hotkey, "%s: %d", _( "All" ), you.get_lowest_hp() );
-    part_ids.emplace_back( body_part_bp_null );
+    part_ids.emplace_back( bodypart_str_id::NULL_ID().id() );
     smenu.query();
     bodypart_str_id bp = body_part_no_a_real_part;
     bool all_select = false;
@@ -2071,11 +2071,11 @@ static void character_edit_hp_menu( Character &you )
         return;
     }
     bp = part_ids.at( smenu.ret ).id();
-    if( bp == body_part_bp_null ) {
+    if( bp == bodypart_str_id::NULL_ID() ) {
         all_select = true;
     }
 
-    if( bp.is_valid() && bp != body_part_bp_null ) {
+    if( bp.is_valid() && bp != bodypart_str_id::NULL_ID() ) {
         int value;
         if( query_int( value, _( "Set the hitpoints to?  Currently: %d" ),
                        you.get_part_hp_cur( bp.id() ) ) &&

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -407,7 +407,7 @@ class wear_inventory_preset: public armor_inventory_preset
             return loc->is_armor() &&
                    ( !loc.has_parent() || !is_worn_ablative( loc.parent_item(), loc ) ) &&
                    !you.is_worn( *loc ) &&
-                   ( bp != bodypart_id( "bp_null" ) ? loc->covers( bp ) : true );
+                   ( bp != bodypart_str_id::NULL_ID() ? loc->covers( bp ) : true );
         }
 
         std::string get_denial( const item_location &loc ) const override {

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -163,7 +163,7 @@ item_location molle_attach( Character &you, item &tool );
 item_location veh_tool_attach( Character &you, const std::string &vp_name,
                                const std::set<itype_id> &allowed_types );
 /** Choose item to wear. */
-item_location wear( Character &you, const bodypart_id &bp = bodypart_id( "bp_null" ) );
+item_location wear( Character &you, const bodypart_id &bp = bodypart_str_id::NULL_ID() );
 /** Choose item to take off. */
 item_location take_off();
 /** Item cut up menu. */

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1047,9 +1047,8 @@ avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
     }
 
     if( !has_weapon() ) {
-        const bodypart_id bp_null( "bp_null" );
         std::pair<bodypart_id, int> best_part_to_smash = this->best_part_to_smash();
-        if( best_part_to_smash.first != bp_null && here.is_bashable( smashp ) ) {
+        if( best_part_to_smash.first != bodypart_str_id::NULL_ID() && here.is_bashable( smashp ) ) {
             std::string name_to_bash = _( "thing" );
             if( here.is_bashable_furn( smashp ) ) {
                 name_to_bash = here.furnname( smashp );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2319,7 +2319,7 @@ double item::effective_dps( const Character &guy, Creature &mon ) const
         double subtotal_damage = 0;
         damage_instance base_damage;
         guy.roll_all_damage( crit, base_damage, true, *this, attack_vector_vector_null,
-                             sub_body_part_sub_limb_debug, &mon, bp );
+                             sub_bodypart_str_id::NULL_ID(), &mon, bp );
         damage_instance dealt_damage = base_damage;
         dealt_damage = guy.modify_damage_dealt_with_enchantments( dealt_damage );
         // TODO: Modify DPS calculation to consider weakpoints.
@@ -2346,7 +2346,7 @@ double item::effective_dps( const Character &guy, Creature &mon ) const
             Creature *temp_rs_mon = &mon;
             damage_instance rs_base_damage;
             guy.roll_all_damage( crit, rs_base_damage, true, *this, attack_vector_vector_null,
-                                 sub_body_part_sub_limb_debug, &mon, bp );
+                                 sub_bodypart_str_id::NULL_ID(), &mon, bp );
             damage_instance dealt_rs_damage = rs_base_damage;
             for( damage_unit &dmg_unit : dealt_rs_damage.damage_units ) {
                 dmg_unit.damage_multiplier *= 0.66;
@@ -5623,10 +5623,10 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
         bodypart_id bp = bodypart_id( "torso" );
         damage_instance non_crit;
         player_character.roll_all_damage( false, non_crit, true, *this, attack_vector_vector_null,
-                                          sub_body_part_sub_limb_debug, nullptr, bp );
+                                          sub_bodypart_str_id::NULL_ID(), nullptr, bp );
         damage_instance crit;
         player_character.roll_all_damage( true, crit, true, *this, attack_vector_vector_null,
-                                          sub_body_part_sub_limb_debug, nullptr, bp );
+                                          sub_bodypart_str_id::NULL_ID(), nullptr, bp );
         int attack_cost = player_character.attack_speed( *this );
         insert_separation_line( info );
         if( parts->test( iteminfo_parts::DESCRIPTION_MELEEDMG ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -132,8 +132,6 @@ static const ammotype ammo_bolt( "bolt" );
 static const ammotype ammo_money( "money" );
 static const ammotype ammo_plutonium( "plutonium" );
 
-static const attack_vector_id attack_vector_vector_null( "vector_null" );
-
 static const bionic_id bio_digestion( "bio_digestion" );
 
 static const bodygraph_id bodygraph_full_body_iteminfo( "full_body_iteminfo" );
@@ -2318,7 +2316,7 @@ double item::effective_dps( const Character &guy, Creature &mon ) const
         Creature *temp_mon = &mon;
         double subtotal_damage = 0;
         damage_instance base_damage;
-        guy.roll_all_damage( crit, base_damage, true, *this, attack_vector_vector_null,
+        guy.roll_all_damage( crit, base_damage, true, *this, attack_vector_id::NULL_ID(),
                              sub_bodypart_str_id::NULL_ID(), &mon, bp );
         damage_instance dealt_damage = base_damage;
         dealt_damage = guy.modify_damage_dealt_with_enchantments( dealt_damage );
@@ -2345,7 +2343,7 @@ double item::effective_dps( const Character &guy, Creature &mon ) const
         if( has_technique( RAPID ) ) {
             Creature *temp_rs_mon = &mon;
             damage_instance rs_base_damage;
-            guy.roll_all_damage( crit, rs_base_damage, true, *this, attack_vector_vector_null,
+            guy.roll_all_damage( crit, rs_base_damage, true, *this, attack_vector_id::NULL_ID(),
                                  sub_bodypart_str_id::NULL_ID(), &mon, bp );
             damage_instance dealt_rs_damage = rs_base_damage;
             for( damage_unit &dmg_unit : dealt_rs_damage.damage_units ) {
@@ -5622,10 +5620,10 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
           ( !dmg_types.empty() || type->m_to_hit > 0 ) ) || debug_mode ) {
         bodypart_id bp = bodypart_id( "torso" );
         damage_instance non_crit;
-        player_character.roll_all_damage( false, non_crit, true, *this, attack_vector_vector_null,
+        player_character.roll_all_damage( false, non_crit, true, *this, attack_vector_id::NULL_ID(),
                                           sub_bodypart_str_id::NULL_ID(), nullptr, bp );
         damage_instance crit;
-        player_character.roll_all_damage( true, crit, true, *this, attack_vector_vector_null,
+        player_character.roll_all_damage( true, crit, true, *this, attack_vector_id::NULL_ID(),
                                           sub_bodypart_str_id::NULL_ID(), nullptr, bp );
         int attack_cost = player_character.attack_speed( *this );
         insert_separation_line( info );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3702,8 +3702,8 @@ static bodypart_id pick_part_to_heal(
         bodypart_id healed_part = patient.body_window( menu_header, force, precise,
                                   limb_power, head_bonus, torso_bonus,
                                   bleed_stop, bite_chance, infect_chance, bandage_power, disinfectant_power );
-        if( healed_part == bodypart_id( "bp_null" ) ) {
-            return bodypart_id( "bp_null" );
+        if( healed_part == bodypart_str_id::NULL_ID() ) {
+            return healed_part;
         }
 
         if( healed_part->has_flag( json_flag_BIONIC_LIMB ) ) {
@@ -3738,7 +3738,7 @@ static bodypart_id pick_part_to_heal(
 bodypart_id heal_actor::use_healing_item( Character &healer, Character &patient, item &it,
         bool force ) const
 {
-    bodypart_id healed = bodypart_id( "bp_null" );
+    bodypart_id healed = bodypart_str_id::NULL_ID();
     const int head_bonus = get_heal_value( healer, bodypart_id( "head" ) );
     const int limb_power = get_heal_value( healer, bodypart_id( "arm_l" ) );
     const int torso_bonus = get_heal_value( healer, bodypart_id( "torso" ) );
@@ -3747,7 +3747,7 @@ bodypart_id heal_actor::use_healing_item( Character &healer, Character &patient,
         patient.add_msg_player_or_npc( m_bad,
                                        _( "Your biology is not compatible with that item." ),
                                        _( "<npcname>'s biology is not compatible with that item." ) );
-        return bodypart_id( "bp_null" ); // canceled
+        return bodypart_str_id::NULL_ID().id(); // canceled
     }
 
     if( healer.is_npc() ) {
@@ -3779,9 +3779,9 @@ bodypart_id heal_actor::use_healing_item( Character &healer, Character &patient,
             healed = pick_part_to_heal( healer, patient, menu_header, limb_power, head_bonus, torso_bonus,
                                         get_stopbleed_level( healer ), bite, infect, force, get_bandaged_level( healer ),
                                         get_disinfected_level( healer ) );
-            if( healed == bodypart_id( "bp_null" ) ) {
+            if( healed == bodypart_str_id::NULL_ID() ) {
                 add_msg( m_info, _( "Never mind." ) );
-                return bodypart_id( "bp_null" ); // canceled
+                return bodypart_str_id::NULL_ID().id(); // canceled
             }
             return healed;
         } else {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -651,7 +651,7 @@ static void damage_targets( const spell &sp, Creature &caster,
                 cr->add_damage_over_time( sp.damage_over_time( { cr->get_random_body_part() }, caster ) );
             }
         } else {
-            cr->add_damage_over_time( sp.damage_over_time( { body_part_bp_null }, caster ) );
+            cr->add_damage_over_time( sp.damage_over_time( { bodypart_str_id::NULL_ID().id() }, caster ) );
         }
     }
 }

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1482,7 +1482,7 @@ std::optional<std::pair<attack_vector_id, sub_bodypart_str_id>>
             // Store a dummy sublimb to show we're attacking with a weapon
             weight = weapon->base_damage_melee().total_damage();
             list.add_or_replace( vec, weight );
-            storage.emplace_back( vec, sub_body_part_sub_limb_debug );
+            storage.emplace_back( vec, sub_bodypart_str_id::NULL_ID() );
             add_msg_debug( debugmode::DF_MELEE, "Weapon %s eligable for attack vector %s with weight %.1f",
                            weapon->display_name(),
                            vec.c_str(), weight );

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -589,7 +589,8 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
             target->add_effect( grab_data.grab_effect, 1_days, bp_id, true, eff_grab_strength );
         } else {
             // Monsters don't have limb scores, no need to target limbs
-            target->add_effect( grab_data.grab_effect, 1_days, body_part_bp_null, true, eff_grab_strength );
+            target->add_effect( grab_data.grab_effect, 1_days, bodypart_str_id::NULL_ID().id(), true,
+                                eff_grab_strength );
             z.add_effect( effect_grabbing, 1_days, true, 1 );
         }
     }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -942,7 +942,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     did_hit( t );
     if( t.as_character() ) {
         dealt_projectile_attack dp = dealt_projectile_attack();
-        t.as_character()->on_hit( this, bodypart_id( "bp_null" ), 0.0f, &dp );
+        t.as_character()->on_hit( this, bodypart_str_id::NULL_ID().id(), 0.0f, &dp );
     }
     return true;
 }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -734,11 +734,11 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         // Unarmed needs a defined technique
         if( has_force_technique ) {
             attack = std::make_tuple( force_technique, attack_vector_vector_null,
-                                      sub_body_part_sub_limb_debug );
+                                      sub_bodypart_str_id::NULL_ID() );
         } else if( allow_special ) {
             attack = pick_technique( t, cur_weapon, critical_hit, false, false );
         } else {
-            attack = std::make_tuple( tec_none, attack_vector_vector_null, sub_body_part_sub_limb_debug );
+            attack = std::make_tuple( tec_none, attack_vector_vector_null, sub_bodypart_str_id::NULL_ID() );
         }
         // Unpack our data
         matec_id attack_id;
@@ -747,7 +747,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         std::tie( attack_id, vector_id, contact_area ) = attack;
 
         // If no weapon is selected, use highest layer of clothing for attack vector instead.
-        if( contact_area != sub_body_part_sub_limb_debug ) {
+        if( contact_area != sub_bodypart_str_id::NULL_ID() ) {
             // todo: simplify this by using item_location everywhere
             // so only cur_weapon = worn.current_unarmed_weapon remains
             // Check if our vector allows armor-derived damage
@@ -1420,9 +1420,8 @@ std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> Character::pick_tech
         }
     }
 
-    return random_entry( possible,
-                         std::make_tuple( tec_none, attack_vector_vector_null,
-                                          sub_body_part_sub_limb_debug ) );
+    return random_entry( possible, std::make_tuple( tec_none, attack_vector_vector_null,
+                         sub_bodypart_str_id::NULL_ID() ) );
 }
 std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
         Character::evaluate_technique( const matec_id &tec_id, Creature const &t, const item_location &weap,

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -74,8 +74,6 @@
 
 static const anatomy_id anatomy_human_anatomy( "human_anatomy" );
 
-static const attack_vector_id attack_vector_vector_null( "vector_null" );
-
 static const bionic_id bio_cqb( "bio_cqb" );
 static const bionic_id bio_heat_absorb( "bio_heat_absorb" );
 static const bionic_id bio_shock( "bio_shock" );
@@ -699,7 +697,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         if( !has_active_bionic( bio_cqb ) && !t.is_hallucination() &&
             !( t.has_flag( json_flag_CANNOT_MOVE ) &&
                t.has_flag( json_flag_CANNOT_TAKE_DAMAGE ) ) ) {
-            melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap, attack_vector_vector_null );
+            melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap, attack_vector_id::NULL_ID() );
         }
 
         // Cap stumble penalty, heavy weapons are quite weak already
@@ -733,12 +731,12 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         // Pick our attack
         // Unarmed needs a defined technique
         if( has_force_technique ) {
-            attack = std::make_tuple( force_technique, attack_vector_vector_null,
+            attack = std::make_tuple( force_technique, attack_vector_id::NULL_ID(),
                                       sub_bodypart_str_id::NULL_ID() );
         } else if( allow_special ) {
             attack = pick_technique( t, cur_weapon, critical_hit, false, false );
         } else {
-            attack = std::make_tuple( tec_none, attack_vector_vector_null, sub_bodypart_str_id::NULL_ID() );
+            attack = std::make_tuple( tec_none, attack_vector_id::NULL_ID(), sub_bodypart_str_id::NULL_ID() );
         }
         // Unpack our data
         matec_id attack_id;
@@ -1420,7 +1418,7 @@ std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> Character::pick_tech
         }
     }
 
-    return random_entry( possible, std::make_tuple( tec_none, attack_vector_vector_null,
+    return random_entry( possible, std::make_tuple( tec_none, attack_vector_id::NULL_ID(),
                          sub_bodypart_str_id::NULL_ID() ) );
 }
 std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4115,7 +4115,7 @@ bool mattack::bio_op_takedown( monster *z )
         return true;
     }
     // Yes, it has the CQC bionic.
-    bodypart_id hit( "bp_null" );
+    bodypart_id hit = bodypart_str_id::NULL_ID();
     if( one_in( 2 ) ) {
         hit = bodypart_id( "leg_l" );
     } else {

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -701,7 +701,6 @@ mon_effect_data::mon_effect_data() :
     chance( 100.0f ),
     permanent( false ),
     affect_hit_bp( false ),
-    bp( body_part_bp_null ),
     duration( 1, 1 ),
     intensity( 0, 0 ) {}
 
@@ -711,7 +710,7 @@ void mon_effect_data::load( const JsonObject &jo )
     optional( jo, false, "chance", chance, 100.f );
     optional( jo, false, "permanent", permanent, false );
     optional( jo, false, "affect_hit_bp", affect_hit_bp, false );
-    optional( jo, false, "bp", bp, body_part_bp_null );
+    optional( jo, false, "bp", bp );
     optional( jo, false, "message", message );
     // Support shorthand for a single value.
     if( jo.has_int( "duration" ) ) {

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -979,14 +979,13 @@ void player_morale::on_worn_item_washed( const item &it )
 void player_morale::on_effect_int_change( const efftype_id &eid, int intensity,
         const bodypart_id &bp )
 {
-    const bodypart_id bp_null( "bp_null" );
-    if( eid == effect_took_prozac && bp == bp_null ) {
+    if( eid == effect_took_prozac && bp == bodypart_str_id::NULL_ID() ) {
         set_prozac( intensity != 0 );
-    } else if( eid == effect_took_prozac_bad && bp == bp_null ) {
+    } else if( eid == effect_took_prozac_bad && bp == bodypart_str_id::NULL_ID() ) {
         set_prozac_bad( intensity != 0 );
-    } else if( eid == effect_cold && bp != bp_null ) {
+    } else if( eid == effect_cold && bp != bodypart_str_id::NULL_ID() ) {
         body_parts[bp].cold = intensity;
-    } else if( eid == effect_hot && bp != bp_null ) {
+    } else if( eid == effect_hot && bp != bodypart_str_id::NULL_ID() ) {
         body_parts[bp].hot = intensity;
     }
 }

--- a/src/morale.h
+++ b/src/morale.h
@@ -66,7 +66,7 @@ class player_morale
         void on_worn_item_transform( const item &old_it, const item &new_it );
         void on_worn_item_washed( const item &it );
         void on_effect_int_change( const efftype_id &eid, int intensity,
-                                   const bodypart_id &bp = bodypart_id( "bp_null" ) );
+                                   const bodypart_id &bp = bodypart_str_id::NULL_ID().id() );
 
         void store( JsonOut &jsout ) const;
         void load( const JsonObject &jsin );

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -214,7 +214,7 @@ struct mon_effect_data {
     // Whether the effect is permanent.
     bool permanent;
     bool affect_hit_bp;
-    bodypart_str_id bp;
+    bodypart_str_id bp = bodypart_str_id::NULL_ID();
     // The range of the durations (in turns) of the effect.
     std::pair<int, int> duration;
     // The range of the intensities of the effect.

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6596,7 +6596,7 @@ talk_effect_fun_t::func f_deal_damage( const JsonObject &jo, std::string_view me
         }
 
         if( d.actor( is_npc )->get_monster() ) {
-            bp = bodypart_id( "bp_null" );
+            bp = bodypart_str_id::NULL_ID();
         }
 
         dmg_inst.add_damage( damage_type, dmg_amount.evaluate( d ), arpen.evaluate( d ),

--- a/src/string_id_null_ids.cpp
+++ b/src/string_id_null_ids.cpp
@@ -63,6 +63,7 @@ MAKE_NULL_ID( spell_type, "null" )
     }
 
 //NOLINTNEXTLINE(cata-static-string_id-constants)
+MAKE_NULL_ID2( attack_vector, "vector_null" )
 MAKE_NULL_ID2( itype, "null" )
 MAKE_NULL_ID2( mtype, "mon_null" )
 MAKE_NULL_ID2( oter_t, "" )

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -465,7 +465,7 @@ bool trapfunc::crossbow( const tripoint_bub_ms &p, Creature *c, item * )
         if( you != nullptr ) {
             ///\EFFECT_DODGE reduces chance of being hit by crossbow trap
             if( !one_in( 4 ) && rng( 8, 20 ) > you->get_dodge() ) {
-                bodypart_id hit( "bp_null" );
+                bodypart_id hit = bodypart_str_id::NULL_ID();
                 switch( rng( 1, 10 ) ) {
                     case  1:
                         if( one_in( 2 ) ) {
@@ -571,7 +571,7 @@ bool trapfunc::shotgun( const tripoint_bub_ms &p, Creature *c, item * )
             }
             ///\EFFECT_DODGE reduces chance of being hit by shotgun trap
             if( rng( 5, 50 ) > you->get_dodge() ) {
-                bodypart_id hit = bodypart_id( "bp_null" );
+                bodypart_id hit = bodypart_str_id::NULL_ID();
                 switch( rng( 1, 10 ) ) {
                     case  1:
                         if( one_in( 2 ) ) {
@@ -1013,7 +1013,7 @@ bool trapfunc::pit_spikes( const tripoint_bub_ms &p, Creature *c, item * )
         } else if( 0 == damage || rng( 5, 30 ) < dodge ) {
             you->add_msg_if_player( _( "You avoid the spikes within." ) );
         } else {
-            bodypart_id hit( "bp_null" );
+            bodypart_id hit = bodypart_str_id::NULL_ID();
             switch( rng( 1, 10 ) ) {
                 case  1:
                     hit = bodypart_id( "leg_l" );
@@ -1098,7 +1098,7 @@ bool trapfunc::pit_glass( const tripoint_bub_ms &p, Creature *c, item * )
         } else if( 0 == damage || rng( 5, 30 ) < dodge ) {
             you->add_msg_if_player( _( "You avoid the glass shards within." ) );
         } else {
-            bodypart_id hit( "bp_null" );
+            bodypart_id hit = bodypart_str_id::NULL_ID();
             switch( rng( 1, 10 ) ) {
                 case  1:
                     hit = bodypart_id( "leg_l" );

--- a/tests/effect_test.cpp
+++ b/tests/effect_test.cpp
@@ -92,7 +92,8 @@ TEST_CASE( "effect_initialization_test", "[effect][init]" )
 TEST_CASE( "effect_duration", "[effect][duration]" )
 {
     // "debugged" and "intensified" effects come from JSON effect data (data/mods/TEST_DATA/effects.json)
-    effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 1_turns, body_part_bp_null,
+    effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 1_turns,
+                         bodypart_str_id::NULL_ID(),
                          false, 1, calendar::turn );
 
     // Current duration from effect initialization
@@ -121,7 +122,8 @@ TEST_CASE( "effect_duration", "[effect][duration]" )
     // 1000 rounded up, and it has "max_intensity": 3 meaning the highest its intensity will go is 3 at
     // a duration of 3000 or higher.
     SECTION( "set_duration modifies intensity if effect is duration-based" ) {
-        effect eff_intense( effect_source::empty(), &effect_intensified.obj(), 1_turns, body_part_bp_null,
+        effect eff_intense( effect_source::empty(), &effect_intensified.obj(), 1_turns,
+                            bodypart_str_id::NULL_ID(),
                             false, 1, calendar::turn );
         REQUIRE( eff_intense.get_int_dur_factor() == 1_minutes );
 
@@ -165,7 +167,8 @@ TEST_CASE( "effect_duration", "[effect][duration]" )
 //
 TEST_CASE( "effect_intensity", "[effect][intensity]" )
 {
-    effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 3_turns, body_part_bp_null,
+    effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 3_turns,
+                         bodypart_str_id::NULL_ID(),
                          false, 1, calendar::turn );
 
     REQUIRE( eff_debugged.get_intensity() == 1 );
@@ -192,7 +195,7 @@ TEST_CASE( "effect_intensity", "[effect][intensity]" )
 TEST_CASE( "effect_intensity_removal", "[effect][intensity]" )
 {
     effect eff_test_int_remove( effect_source::empty(), &effect_test_int_remove.obj(), 3_turns,
-                                body_part_bp_null,
+                                bodypart_str_id::NULL_ID(),
                                 false, 1, calendar::turn );
 
     REQUIRE( eff_test_int_remove.get_intensity() == 1 );
@@ -207,7 +210,8 @@ TEST_CASE( "effect_intensity_removal", "[effect][intensity]" )
 
 TEST_CASE( "max_effective_intensity", "[effect][max][intensity]" )
 {
-    effect eff_maxed( effect_source::empty(), &effect_max_effected.obj(), 3_turns, body_part_bp_null,
+    effect eff_maxed( effect_source::empty(), &effect_max_effected.obj(), 3_turns,
+                      bodypart_str_id::NULL_ID(),
                       false, 1, calendar::turn );
 
     REQUIRE( eff_maxed.get_intensity() == 1 );
@@ -251,7 +255,8 @@ TEST_CASE( "effect_decay", "[effect][decay]" )
     std::vector<bodypart_id> rem_bps;
 
     SECTION( "decay reduces effect duration by 1 turn and triggers intensity decay" ) {
-        effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 2_turns, body_part_bp_null,
+        effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 2_turns,
+                             bodypart_str_id::NULL_ID(),
                              false, 5, calendar::turn );
         // Ensure it will last 2 turns, and is not permanent/paused
         REQUIRE( to_turns<int>( eff_debugged.get_duration() ) == 2 );
@@ -283,7 +288,8 @@ TEST_CASE( "effect_decay", "[effect][decay]" )
     }
 
     SECTION( "decay does not reduce paused/permanent effect duration" ) {
-        effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 2_turns, body_part_bp_null,
+        effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 2_turns,
+                             bodypart_str_id::NULL_ID(),
                              true, 1, calendar::turn );
         // Ensure it will last 2 turns, and is permanent/paused
         REQUIRE( to_turns<int>( eff_debugged.get_duration() ) == 2 );
@@ -297,7 +303,8 @@ TEST_CASE( "effect_decay", "[effect][decay]" )
     }
 
     SECTION( "intensity decay triggers on the appropriate turns" ) {
-        effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 1_hours, body_part_bp_null,
+        effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 1_hours,
+                             bodypart_str_id::NULL_ID(),
                              false, 10, calendar::turn );
         // Ensure it has a decay tick  of 2 turns and a decay step of -1, and int removal is allwed
         // Also check max duration
@@ -361,7 +368,7 @@ TEST_CASE( "effect_decay", "[effect][decay]" )
 
     SECTION( "int_decay_remove == false protects an effect from removal" ) {
         effect eff_test_int_remove( effect_source::empty(), &effect_test_int_remove.obj(), 3_turns,
-                                    body_part_bp_null,
+                                    bodypart_str_id::NULL_ID(),
                                     false, 3, calendar::turn );
         // Ensure it has the -2 int decay step, is protected from removal and has a decay tick of 1
         REQUIRE( eff_test_int_remove.get_int_decay_step() == -2 );
@@ -456,7 +463,7 @@ TEST_CASE( "effect_display_and_speed_name_may_vary_with_intensity",
         // "name": [ "Whoa", "Wut?", "Wow!" ]
         // "max_intensity": 3
         effect eff_intense( effect_source::empty(), &effect_intensified.obj(), 1_turns,
-                            body_part_bp_null, false, 1, calendar::turn );
+                            bodypart_str_id::NULL_ID(), false, 1, calendar::turn );
         REQUIRE( eff_intense.get_max_intensity() == 3 );
 
         // use_name_ints is true if there are names for each intensity
@@ -489,7 +496,7 @@ TEST_CASE( "effect_display_and_speed_name_may_vary_with_intensity",
         // "name": [ "Debugged" ]
         // "speed_name": "Optimized"
         effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 1_minutes,
-                             body_part_bp_null, false, 1, calendar::turn );
+                             bodypart_str_id::NULL_ID(), false, 1, calendar::turn );
 
         THEN( "disp_name has the name, and current intensity if > 1" ) {
             eff_debugged.set_intensity( 1 );
@@ -572,7 +579,8 @@ TEST_CASE( "effect_body_part", "[effect][bodypart]" )
 TEST_CASE( "effect_modifiers", "[effect][modifier]" )
 {
     SECTION( "base_mods apply equally for any intensity" ) {
-        effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 1_minutes, body_part_bp_null,
+        effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 1_minutes,
+                             bodypart_str_id::NULL_ID(),
                              false, 1, calendar::turn );
 
         CHECK( eff_debugged.get_mod( "STR" ) == 1 );
@@ -586,7 +594,8 @@ TEST_CASE( "effect_modifiers", "[effect][modifier]" )
 
     // Scaling mods - vary based on intensity
     SECTION( "scaling_mods vary based on intensity" ) {
-        effect eff_intense( effect_source::empty(), &effect_intensified.obj(), 1_turns, body_part_bp_null,
+        effect eff_intense( effect_source::empty(), &effect_intensified.obj(), 1_turns,
+                            bodypart_str_id::NULL_ID(),
                             false, 1, calendar::turn );
         REQUIRE( eff_intense.get_max_intensity() == 3 );
 
@@ -635,7 +644,7 @@ TEST_CASE( "bleed_effect_attribution", "[effect][bleed][monster]" )
         WHEN( "when player cuts monster" ) {
             REQUIRE( test_monster.get_hp() == test_monster.get_hp_max() );
             THEN( "bleed effect gets attributed to player" ) {
-                test_monster.deal_damage( player.as_character(), body_part_bp_null, cut_damage );
+                test_monster.deal_damage( player.as_character(), bodypart_str_id::NULL_ID(), cut_damage );
                 const effect &bleed = test_monster.get_effect( effect_bleed );
                 CHECK( test_monster.get_hp() < test_monster.get_hp_max() );
                 CHECK( !bleed.is_null() );

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -344,7 +344,7 @@ static void check_damage_from_test_fire( const std::string &mon_id, int expected
         standard_npc dude( "TestCharacter", dude_pos, {}, 8, 10, 10, 10, 10 );
         monster &mon = spawn_test_monster( mon_id, dude.pos_bub() + tripoint::east );
         REQUIRE( mon.pos_bub() == dude.pos_bub() + tripoint::east );
-        REQUIRE( mon.get_armor_type( damage_test_fire, body_part_bp_null ) == expected_resist );
+        REQUIRE( mon.get_armor_type( damage_test_fire, bodypart_str_id::NULL_ID() ) == expected_resist );
         REQUIRE( mon.is_immune_damage( damage_test_fire ) == is_immune );
         REQUIRE( mon.get_hp() == mon.get_hp_max() );
         REQUIRE( dude.get_value( "general_dmg_type_test_test_fire" ).empty() );

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -114,16 +114,16 @@ TEST_CASE( "stats_tracker_total_events", "[stats]" )
 
     CHECK( s.get_events( ctd ).total( "damage", damage_to_u ) == 0 );
     CHECK( s.get_events( ctd ).total( "damage", damage_to_any ) == 0 );
-    b.send<ctd>( u_id, 10, body_part_bp_null, 0 );
+    b.send<ctd>( u_id, 10, bodypart_str_id::NULL_ID(), 0 );
     CHECK( s.get_events( ctd ).total( "damage", damage_to_u ) == 10 );
     CHECK( s.get_events( ctd ).total( "damage", damage_to_any ) == 10 );
-    b.send<ctd>( other_id, 10, body_part_bp_null, 0 );
+    b.send<ctd>( other_id, 10, bodypart_str_id::NULL_ID(), 0 );
     CHECK( s.get_events( ctd ).total( "damage", damage_to_u ) == 10 );
     CHECK( s.get_events( ctd ).total( "damage", damage_to_any ) == 20 );
-    b.send<ctd>( u_id, 10, body_part_bp_null, 0 );
+    b.send<ctd>( u_id, 10, bodypart_str_id::NULL_ID(), 0 );
     CHECK( s.get_events( ctd ).total( "damage", damage_to_u ) == 20 );
     CHECK( s.get_events( event_type::character_takes_damage ).total( "damage", damage_to_any ) == 30 );
-    b.send<event_type::character_takes_damage>( u_id, 5, body_part_bp_null, 0 );
+    b.send<event_type::character_takes_damage>( u_id, 5, bodypart_str_id::NULL_ID(), 0 );
     CHECK( s.get_events( event_type::character_takes_damage ).total( "damage", damage_to_u ) == 25 );
     CHECK( s.get_events( event_type::character_takes_damage ).total( "damage", damage_to_any ) == 35 );
 }
@@ -193,11 +193,11 @@ TEST_CASE( "stats_tracker_event_time_bounds", "[stats]" )
 
     CHECK( !s.get_events( ctd ).first() );
     CHECK( !s.get_events( ctd ).last() );
-    b.send<ctd>( u_id, 10, body_part_bp_null, 0 );
+    b.send<ctd>( u_id, 10, bodypart_str_id::NULL_ID(), 0 );
     CHECK( s.get_events( ctd ).first()->second.first == start );
     CHECK( s.get_events( ctd ).last()->second.last == calendar::turn );
     calendar::turn += 1_minutes;
-    b.send<ctd>( u_id, 10, body_part_bp_null, 0 );
+    b.send<ctd>( u_id, 10, bodypart_str_id::NULL_ID(), 0 );
     CHECK( s.get_events( ctd ).first()->second.first == start );
     CHECK( s.get_events( ctd ).last()->second.last == calendar::turn );
 }
@@ -337,7 +337,7 @@ TEST_CASE( "stats_tracker_with_event_statistics", "[stats]" )
 
     SECTION( "damage" ) {
         const cata::event avatar_2_damage =
-            cata::event::make<event_type::character_takes_damage>( u_id, 2, body_part_bp_null, 0 );
+            cata::event::make<event_type::character_takes_damage>( u_id, 2, bodypart_str_id::NULL_ID(), 0 );
 
         send_game_start( b, u_id );
         CHECK( score_score_damage_taken->value( s ).get<int>() == 0 );
@@ -556,7 +556,7 @@ TEST_CASE( "stats_tracker_watchers", "[stats]" )
 
     SECTION( "damage" ) {
         const cata::event avatar_2_damage =
-            cata::event::make<event_type::character_takes_damage>( u_id, 2, body_part_bp_null, 0 );
+            cata::event::make<event_type::character_takes_damage>( u_id, 2, bodypart_str_id::NULL_ID(), 0 );
         watch_stat damage_watcher;
         s.add_watcher( event_statistic_avatar_damage_taken, &damage_watcher );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Some code was using a debug limb sub body part as a null id instead of the already existing NULL_ID, me no likey
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add attack_vector_id::NULL_ID()
Use sub_bodypart_str_id::NULL_ID() rather than sub_bodypart_str_id( "sub_limb_debug" ). I did consider changing the null id to sub_limb_debug or adding migration for one id to the other but as far as I can tell this should be fine.
Use bodypart_str_id::NULL_ID() when initialising and comparing bodypart_id (the int_id)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Bodyparts use externs and alot of just raw string initialising that also wants cleaning up into static consts
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game compiles
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
