### PR TITLE
Fix Debug configuration linking with MSVS + lld

### DIFF
--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -37,6 +37,7 @@
     <LinkToolExe>lld-link.exe</LinkToolExe>
     <!-- vcpkg passes dependecy libs via a glob pattern which lld-link doesn't accept. We have to manually enumerate the deps now. -->
     <VcpkgAutoLink>false</VcpkgAutoLink>
+    <!-- debug versions of libs often (but not always) use `d` suffix, as a convention. E.g. "SDL2-staticd.lib" -->
     <VcpkgLibSuffix></VcpkgLibSuffix>
     <VcpkgLibSuffix Condition="$(Configuration.StartsWith(Debug))">d</VcpkgLibSuffix>
   </PropertyGroup>
@@ -120,7 +121,7 @@
         pdcurses.lib;
         SDL2_image-static$(VcpkgLibSuffix).lib;
         SDL2_mixer-static$(VcpkgLibSuffix).lib;
-        SDL2_ttf$(VcpkgLibSuffix).lib;
+        SDL2_ttf.lib;
         SDL2-static$(VcpkgLibSuffix).lib;
         syn123.lib;
         turbojpeg.lib;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fixup to the fixup #79178 

```
7>lld-link : error : could not open 'SDL2_ttfd.lib': no such file or directory
```


At the time I did not understand the whole system quite enough, and didn't test the corner cases thoroughly enough to catch this.
As my excuse, I'll mention that Debug builds seem to be very heavily discouraged right now, so I didn't pay any mind to those...

#### Describe the solution

Inspect `.\x64-windows-static\x64-windows-static\debug\lib` folder, see that, indeed, it has no `SDL2_ttf.lib` and no `SDL2_ttfd.lib` which would be a later addition.
Remove the extra `d` that we put into the lib name.

#### Describe alternatives you've considered

#### Testing

Builds with lld linker, both debug and release build.

#### Additional context
I'm not actually entirely sure when did the change happen.. I think it's in the 2.20.2#1 - > 2.22.0 version bump of sdl2-ttf, but maybe not. It's (seemingly?) not driven by vcpkg portfile (as is done for other sdl libs?), but rather by sdl themselves.
(This is useless information)