### PR TITLE
[Aftershock] Ensure Outfitter always has at least one full EVA suit

### DIFF
--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_outfitter.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_outfitter.json
@@ -38,11 +38,22 @@
     "subtype": "collection",
     "items": [
       { "group": "afs_wintersuit_generic_advanced", "count": [ 1, 3 ] },
+      { "group": "afs_frontier_cryo_g_full_combo", "count": 1 },
       { "group": "afs_basic_armor", "count": [ 0, 3 ] },
       { "group": "afs_colonist_outfit", "count": [ 1, 3 ] },
       { "group": "afs_civilian_hazard_outfit", "count": [ 1, 3 ], "prob": 60 },
       { "group": "afs_pals_pieces", "count": [ 6, 12 ] },
       { "group": "afs_augustmoon_outfitter_bags", "count": [ 10, 28 ] }
+    ]
+  },
+  {
+    "id": "afs_frontier_cryo_g_full_combo",
+    "type": "item_group",
+    "//": "The bare minimum matching suit to vist Salus. Prevents having to restart because Port Augustmoon is mising a part like the mask.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "afs_frontier_cryo" },
+      { "item": "afs_frontier_cryomask" }
     ]
   },
   {

--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_outfitter.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_outfitter.json
@@ -51,10 +51,7 @@
     "type": "item_group",
     "//": "The bare minimum matching suit to vist Salus. Prevents having to restart because Port Augustmoon is mising a part like the mask.",
     "subtype": "collection",
-    "entries": [
-      { "item": "afs_frontier_cryo" },
-      { "item": "afs_frontier_cryomask" }
-    ]
+    "entries": [ { "item": "afs_frontier_cryo" }, { "item": "afs_frontier_cryomask" } ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Aftershock] Bugfix Outfitter to always have at least one full EVA suit"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While mostly unlikely it is technically possible under current circumstances for the Outfitter to spawn without a Cyrosuit mask or with all Cryosuit body gloves. (Something well beyond the players starting price range.)

This essentially forces you to restart and reset your world because it's not possible to survive from the Shuttlepad without at least EVA gear. (Heat retention cream is not sold in the port to my knowledge). 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Create a small item group that grantees spawning of both a frontier suit and mask. Creating a safety net so players can always buy at least something to go down to Salus with.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered making a quest on Port Augustmoon to buy a full EVA suit. I did consider the implications that this might make it easier for new players to understand the EVA suit is essential. While simultaneously guaranteeing their access to one. For now I didn't do this.

But for tutorial purposes it may be prudent to have the Port Master warn the player if they are not wearing EVA gear when attempting to leave. I might do that myself in a follow up PR but NPCs aren't exactly my specialty. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Started a new world went to the Outfitter. Quite hilariously they only sold the one mask from the item group I added. Indicating this change was immediately effective for stopping a no win scenario. Not sure how I keep getting so unlucky though.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
