### PR TITLE
optimize sorting loot activity

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -590,12 +590,12 @@ static bool vehicle_activity( Character &you, const tripoint_bub_ms &src_loc, in
     // for someone else who stored that position at the start of their activity.
     // so we may need to go looking a bit further afield to find it , at activities end.
     for( const tripoint_bub_ms &pt : veh->get_points( true ) ) {
-        you.activity.coord_set.insert( here.get_abs( pt ) );
+        you.activity.coord_set.insert( here.getglobal( pt ) );
     }
     // values[0]
-    you.activity.values.push_back( here.get_abs( src_loc ).x() );
+    you.activity.values.push_back( here.getglobal( src_loc ).x() );
     // values[1]
-    you.activity.values.push_back( here.get_abs( src_loc ).y() );
+    you.activity.values.push_back( here.getglobal( src_loc ).y() );
     // values[2]
     you.activity.values.push_back( point::zero.x );
     // values[3]
@@ -611,7 +611,7 @@ static bool vehicle_activity( Character &you, const tripoint_bub_ms &src_loc, in
     // this would only be used for refilling tasks
     item_location target;
     you.activity.targets.emplace_back( std::move( target ) );
-    you.activity.placement = here.get_abs( src_loc );
+    you.activity.placement = here.getglobal( src_loc );
     you.activity_vehicle_part_index = -1;
     return true;
 }
@@ -953,7 +953,7 @@ static bool are_requirements_nearby(
             // skip tiles in IGNORE zone and tiles on fire
             // (to prevent taking out wood off the lit brazier)
             // and inaccessible furniture, like filled charcoal kiln
-            if( mgr.has( zone_type_LOOT_IGNORE, here.get_abs( elem ), _fac_id( you ) ) ||
+            if( mgr.has( zone_type_LOOT_IGNORE, here.getglobal( elem ), _fac_id( you ) ) ||
                 here.dangerous_field_at( elem ) ||
                 !here.can_put_items_ter_furn( elem ) ) {
                 continue;
@@ -1035,11 +1035,11 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             tripoint_bub_ms guy_work_spot;
             if( guy.has_player_activity() &&
                 guy.activity.placement != player_activity::invalid_place ) {
-                guy_work_spot = here.get_bub( guy.activity.placement );
+                guy_work_spot = here.bub_from_abs( guy.activity.placement );
             }
             // If their position or intended position or player position/intended position
             // then discount, don't need to move each other out of the way.
-            if( here.get_bub( player_character.activity.placement ) == src_loc ||
+            if( here.bub_from_abs( player_character.activity.placement ) == src_loc ||
                 guy_work_spot == src_loc || guy.pos_bub() == src_loc ||
                 ( you.is_npc() && player_character.pos_bub() == src_loc ) ) {
                 return activity_reason_info::fail( do_activity_reason::ALREADY_WORKING );
@@ -1272,15 +1272,15 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
         return activity_reason_info::fail( do_activity_reason::NO_ZONE );
     }
     if( act == ACT_TIDY_UP ) {
-        if( mgr.has_near( zone_type_LOOT_UNSORTED, here.get_abs( src_loc ), distance, _fac_id( you ) ) ||
-            mgr.has_near( zone_type_CAMP_STORAGE, here.get_abs( src_loc ), distance, _fac_id( you ) ) ) {
+        if( mgr.has_near( zone_type_LOOT_UNSORTED, here.getglobal( src_loc ), distance, _fac_id( you ) ) ||
+            mgr.has_near( zone_type_CAMP_STORAGE, here.getglobal( src_loc ), distance, _fac_id( you ) ) ) {
             return activity_reason_info::ok( do_activity_reason::CAN_DO_FETCH );
         }
         return activity_reason_info::fail( do_activity_reason::NO_ZONE );
     }
     if( act == ACT_MULTIPLE_CONSTRUCTION ) {
         zones = mgr.get_zones( zone_type_CONSTRUCTION_BLUEPRINT,
-                               here.get_abs( src_loc ), _fac_id( you ) );
+                               here.getglobal( src_loc ), _fac_id( you ) );
         const partial_con *part_con = here.partial_con_at( src_loc );
         std::optional<construction_id> part_con_idx;
         if( part_con ) {
@@ -1306,7 +1306,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                                            index );
         }
     } else if( act == ACT_MULTIPLE_FARM ) {
-        zones = mgr.get_zones( zone_type_FARM_PLOT, here.get_abs( src_loc ), _fac_id( you ) );
+        zones = mgr.get_zones( zone_type_FARM_PLOT, here.getglobal( src_loc ), _fac_id( you ) );
         for( const zone_data &zone : zones ) {
             const plot_options &options = dynamic_cast<const plot_options &>( zone.get_options() );
             const itype_id seed = options.get_seed();
@@ -1454,13 +1454,13 @@ static void add_basecamp_storage_to_loot_zone_list(
     if( npc *const guy = dynamic_cast<npc *>( &you ) ) {
         map &here = get_map();
         if( guy->assigned_camp &&
-            mgr.has_near( zone_type_CAMP_STORAGE, here.get_abs( src_loc ), MAX_VIEW_DISTANCE,
+            mgr.has_near( zone_type_CAMP_STORAGE, here.getglobal( src_loc ), MAX_VIEW_DISTANCE,
                           _fac_id( you ) ) ) {
             std::unordered_set<tripoint_abs_ms> bc_storage_set =
-                mgr.get_near( zone_type_CAMP_STORAGE, here.get_abs( src_loc ),
+                mgr.get_near( zone_type_CAMP_STORAGE, here.getglobal( src_loc ),
                               MAX_VIEW_DISTANCE, nullptr, _fac_id( you ) );
             for( const tripoint_abs_ms &elem : bc_storage_set ) {
-                tripoint_bub_ms here_local = here.get_bub( elem );
+                tripoint_bub_ms here_local = here.bub_from_abs( elem );
 
                 // Check that a coordinate is not already in the combined list, otherwise actions
                 // like construction may erroneously count materials twice if an object is both
@@ -1505,7 +1505,7 @@ static std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> requirements_map(
     std::vector<tripoint_bub_ms> combined_spots;
     std::map<itype_id, int> total_map;
     map &here = get_map();
-    tripoint_bub_ms src_loc = here.get_bub( you.backlog.front().placement );
+    tripoint_bub_ms src_loc = here.bub_from_abs( you.backlog.front().placement );
     for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc,
             PICKUP_RANGE - 1 ) ) {
         already_there_spots.push_back( elem );
@@ -1810,7 +1810,7 @@ static bool construction_activity( Character &you, const zone_data * /*zone*/,
     }
     you.backlog.emplace_front( activity_to_restore );
     you.assign_activity( ACT_BUILD );
-    you.activity.placement = here.get_abs( src_loc );
+    you.activity.placement = here.getglobal( src_loc );
     return true;
 }
 
@@ -1820,7 +1820,7 @@ static bool tidy_activity( Character &you, const tripoint_bub_ms &src_loc,
 {
     zone_manager &mgr = zone_manager::get_manager();
     map &here = get_map();
-    tripoint_abs_ms loot_abspos = here.get_abs( src_loc );
+    tripoint_abs_ms loot_abspos = here.getglobal( src_loc );
     tripoint_bub_ms loot_src_lot;
     const auto &zone_src_set = mgr.get_near( zone_type_LOOT_UNSORTED, loot_abspos, distance, nullptr,
                                _fac_id( you ) );
@@ -1829,10 +1829,10 @@ static bool tidy_activity( Character &you, const tripoint_bub_ms &src_loc,
                     loot_abspos, zone_src_set );
         // Find the nearest unsorted zone to dump objects at
         for( const tripoint_abs_ms &src_elem : zone_src_sorted ) {
-            if( !here.can_put_items_ter_furn( here.get_bub( src_elem ) ) ) {
+            if( !here.can_put_items_ter_furn( here.bub_from_abs( src_elem ) ) ) {
                 continue;
             }
-            loot_src_lot = here.get_bub( src_elem );
+            loot_src_lot = here.bub_from_abs( src_elem );
             break;
         }
     }
@@ -1847,7 +1847,7 @@ static bool tidy_activity( Character &you, const tripoint_bub_ms &src_loc,
     _tidy_move_items( you, stack, src_loc, loot_src_lot, std::nullopt, activity_to_restore );
 
     // we are adjacent to an unsorted zone, we came here to just drop items we are carrying
-    if( mgr.has( zone_type_LOOT_UNSORTED, here.get_abs( src_loc ), _fac_id( you ) ) ) {
+    if( mgr.has( zone_type_LOOT_UNSORTED, here.getglobal( src_loc ), _fac_id( you ) ) ) {
         for( item *inv_elem : you.inv_dump() ) {
             if( inv_elem->has_var( "activity_var" ) ) {
                 inv_elem->erase_var( "activity_var" );
@@ -1864,7 +1864,7 @@ static bool fetch_activity(
     const int distance = MAX_VIEW_DISTANCE )
 {
     map &here = get_map();
-    if( !here.can_put_items_ter_furn( here.get_bub(
+    if( !here.can_put_items_ter_furn( here.bub_from_abs(
                                           you.backlog.front().coords.back() ) ) ) {
         return false;
     }
@@ -1881,7 +1881,7 @@ static bool fetch_activity(
                 if( std::get<0>( elem ) == src_loc && veh_elem.typeId() == std::get<1>( elem ) ) {
                     if( !you.backlog.empty() && you.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ) {
                         move_item( you, veh_elem, veh_elem.count_by_charges() ? std::get<2>( elem ) : 1, src_loc,
-                                   here.get_bub( you.backlog.front().coords.back() ), ovp,
+                                   here.bub_from_abs( you.backlog.front().coords.back() ), ovp,
                                    activity_to_restore );
                         return true;
                     }
@@ -1897,7 +1897,7 @@ static bool fetch_activity(
                 if( !you.backlog.empty() && ( you.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ||
                                               you.backlog.front().id() == ACT_MULTIPLE_DIS ) ) {
                     move_item( you, it, it.count_by_charges() ? std::get<2>( elem ) : 1, src_loc,
-                               here.get_bub( you.backlog.front().coords.back() ), ovp,
+                               here.bub_from_abs( you.backlog.front().coords.back() ), ovp,
                                activity_to_restore );
 
                     return true;
@@ -1968,7 +1968,7 @@ static bool butcher_corpse_activity( Character &you, const tripoint_bub_ms &src_
             elem.set_var( "activity_var", you.name );
             you.assign_activity( ACT_BUTCHER_FULL, 0, true );
             you.activity.targets.emplace_back( map_cursor( src_loc ), &elem );
-            you.activity.placement = here.get_abs( src_loc );
+            you.activity.placement = here.getglobal( src_loc );
             return true;
         }
     }
@@ -1991,7 +1991,7 @@ static bool chop_plank_activity( Character &you, const tripoint_bub_ms &src_loc 
             int moves = to_moves<int>( 20_minutes );
             you.add_msg_if_player( _( "You cut the log into planks." ) );
             you.assign_activity( chop_planks_activity_actor( moves ) );
-            you.activity.placement = here.get_abs( src_loc );
+            you.activity.placement = here.getglobal( src_loc );
             return true;
         }
     }
@@ -2050,7 +2050,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
             act.placement = src;
             act.coord_set.erase( src );
 
-            const tripoint_bub_ms src_loc = here.get_bub( src );
+            const tripoint_bub_ms src_loc = here.bub_from_abs( src );
             if( !here.inbounds( src_loc ) ) {
                 if( !here.inbounds( you.pos_bub() ) ) {
                     // p is implicitly an NPC that has been moved off the map, so reset the activity
@@ -2074,7 +2074,6 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                 return;
             }
 
-            std::vector<zone_data const *> zones;
             bool ignore_contents = false;
 
             // check ignorable zones for ignore_contents enabled
@@ -2103,11 +2102,127 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                 continue;
             }
 
-            //nothing to sort?
+
+            bool unload_mods = false;
+            bool unload_molle = false;
+            // bool unload_sparse_only = false;
+            // int unload_sparse_threshold = 20;
+            bool unload_always = false;
+            bool ignore_favorite = false;
+            bool unload_all = false;
+            bool unload_corpses = false;
+
+            std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_UNLOAD_ALL,
+                _fac_id( you ) );
+
+            // get most open rules out of all stacked zones
+            for( zone_data const *zone : zones )
+            {
+                if( !zone->get_enabled() ) {
+                    continue;
+                };
+                unload_options const &options = dynamic_cast<const unload_options &>( zone->get_options() );
+                unload_molle |= options.unload_molle();
+                unload_mods |= options.unload_mods();
+                unload_always |= options.unload_always();
+                ignore_favorite |= zone->get_type() == zone_type_LOOT_IGNORE_FAVORITES;
+
+                unload_all |= zone->get_type() == zone_type_UNLOAD_ALL;
+                unload_corpses |= zone->get_type() == zone_type_STRIP_CORPSES;
+            }
+
             const std::optional<vpart_reference> vp = here.veh_at( src_loc ).cargo();
-            if( ( !vp || vp->items().empty() ) && here.i_at( src_loc ).empty() ) {
+            std::vector<const item *> items;
+            // populate items from the appropriate source
+            if( vp )
+            {
+                for( const item& it : vp->items() ) {
+                    items.push_back( &it );
+                }
+            } else
+            {
+                for( const item& it : here.i_at( src_loc ) ) {
+                    items.push_back( &it );
+                }
+            }
+            // check if there is valid destination for any item of the tile
+            bool has_items_to_work_on = false;
+
+            for( const item * it : items )
+            {
+
+                const zone_type_id zone_type_id = mgr.get_near_zone_type_for_item( *it, abspos,
+                                                  MAX_VIEW_DISTANCE, _fac_id( you ) );
+
+
+                if( has_items_to_work_on ) {
+                    break;
+                }
+
+                // skip items that allready sorted
+                if( zone_type_id != zone_type_LOOT_CUSTOM && mgr.has( zone_type_id, src, _fac_id( you ) ) ) {
+                    continue;
+                }
+
+                if( zone_type_id == zone_type_LOOT_CUSTOM &&
+                    mgr.custom_loot_has( src, it, zone_type_LOOT_CUSTOM, _fac_id( you ) ) ) {
+                    continue;
+                }
+
+                if( !it->is_owned_by( you, true ) ) {
+                    continue;
+                }
+
+                // skip unpickable liquid
+                if( !it->made_of_from_type( phase_id::SOLID ) ) {
+                    continue;
+                }
+
+                if( it->is_favorite && ignore_favorite ) {
+                    continue;
+                }
+
+                const std::unordered_set<tripoint_abs_ms> dest_set =
+                    mgr.get_near( zone_type_id, abspos, MAX_VIEW_DISTANCE, it, _fac_id( you ) );
+
+                if( unload_all || ( unload_corpses && it->is_corpse() ) ) {
+                    if( dest_set.empty() || unload_always ) {
+                        if( you.rate_action_unload( *it ) == hint_rating::good &&
+                            !it->any_pockets_sealed() ) {
+                            has_items_to_work_on = true;
+                            break;
+                        }
+
+                        // if unloading mods
+                        if( unload_mods ) {
+                            // remove each mod, skip irremovable
+                            for( const item *mod : it->gunmods() ) {
+                                if( mod->is_irremovable() ) {
+                                    continue;
+                                }
+                                has_items_to_work_on = true;
+                                break;
+                            }
+                        }
+
+                        // if unloading molle
+                        if( unload_molle and ! it->get_contents().get_added_pockets().empty() ) {
+                            has_items_to_work_on = true;
+                            break;
+                        }
+                    }
+                }
+                // if item has destination
+                if( !dest_set.empty() ) {
+                    has_items_to_work_on = true;
+                    break;
+                }
+            }
+            if( !has_items_to_work_on )
+            {
                 continue;
             }
+
 
             bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_loc ) <= 1;
             // before we move any item, check if player is at or
@@ -2155,7 +2270,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
     }
     if( stage == DO ) {
         const tripoint_abs_ms src( act.placement );
-        const tripoint_bub_ms src_loc = here.get_bub( src );
+        const tripoint_bub_ms src_loc = here.bub_from_abs( src );
 
         bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_loc ) <= 1;
         // before we move any item, check if player is at or
@@ -2342,7 +2457,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
             }
 
             for( const tripoint_abs_ms &dest : dest_set ) {
-                const tripoint_bub_ms dest_loc = here.get_bub( dest );
+                const tripoint_bub_ms dest_loc = here.bub_from_abs( dest );
                 units::volume free_space;
 
                 //Check destination for cargo part
@@ -2446,7 +2561,7 @@ static bool mine_activity( Character &you, const tripoint_bub_ms &src_loc )
     }
     you.assign_activity( powered ? ACT_JACKHAMMER : ACT_PICKAXE, moves );
     you.activity.targets.emplace_back( you, chosen_item );
-    you.activity.placement = here.get_abs( src_loc );
+    you.activity.placement = here.getglobal( src_loc );
     return true;
 
 }
@@ -2456,7 +2571,7 @@ static bool mop_activity( Character &you, const tripoint_bub_ms &src_loc )
 {
     // iuse::mop costs 15 moves per use
     you.assign_activity( mop_activity_actor( 15 ) );
-    you.activity.placement = get_map().get_abs( src_loc );
+    you.activity.placement = get_map().getglobal( src_loc );
     return true;
 }
 
@@ -2474,11 +2589,11 @@ static bool chop_tree_activity( Character &you, const tripoint_bub_ms &src_loc )
     const ter_id &ter = here.ter( src_loc );
     if( here.has_flag( ter_furn_flag::TFLAG_TREE, src_loc ) ) {
         you.assign_activity( chop_tree_activity_actor( moves, item_location( you, &best_qual ) ) );
-        you.activity.placement = here.get_abs( src_loc );
+        you.activity.placement = here.getglobal( src_loc );
         return true;
     } else if( ter == ter_t_trunk || ter == ter_t_stump ) {
         you.assign_activity( chop_logs_activity_actor( moves, item_location( you, &best_qual ) ) );
-        you.activity.placement = here.get_abs( src_loc );
+        you.activity.placement = here.getglobal( src_loc );
         return true;
     }
     return false;
@@ -2532,7 +2647,7 @@ static zone_type_id get_zone_for_act( const tripoint_bub_ms &src_loc, const zone
         ret = zone_type_DISASSEMBLE;
     }
     if( src_loc != tripoint_bub_ms() && act_id == ACT_FETCH_REQUIRED ) {
-        const zone_data *zd = mgr.get_zone_at( get_map().get_abs( src_loc ), false, fac_id );
+        const zone_data *zd = mgr.get_zone_at( get_map().getglobal( src_loc ), false, fac_id );
         if( zd ) {
             ret = zd->get_type();
         }
@@ -2551,14 +2666,14 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
     zone_manager &mgr = zone_manager::get_manager();
     const tripoint_bub_ms localpos = you.pos_bub();
     map &here = get_map();
-    const tripoint_abs_ms abspos = here.get_abs( localpos );
+    const tripoint_abs_ms abspos = here.getglobal( localpos );
     if( act_id == ACT_TIDY_UP ) {
         dark_capable = true;
         tripoint_bub_ms unsorted_spot;
         std::unordered_set<tripoint_abs_ms> unsorted_set =
             mgr.get_near( zone_type_LOOT_UNSORTED, abspos, MAX_VIEW_DISTANCE, nullptr, _fac_id( you ) );
         if( !unsorted_set.empty() ) {
-            unsorted_spot = here.get_bub( random_entry( unsorted_set ) );
+            unsorted_spot = here.bub_from_abs( random_entry( unsorted_set ) );
         }
         bool found_one_point = false;
         bool found_route = true;
@@ -2581,7 +2696,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
                 if( stack_elem.has_var( "activity_var" ) && stack_elem.get_var( "activity_var", "" ) == you.name ) {
                     const furn_t &f = here.furn( elem ).obj();
                     if( !f.has_flag( ter_furn_flag::TFLAG_PLANT ) ) {
-                        src_set.insert( here.get_abs( elem ) );
+                        src_set.insert( here.getglobal( elem ) );
                         found_one_point = true;
                         // only check for a valid path, as that is all that is needed to tidy something up.
                         if( square_dist( you.pos_bub(), elem ) > 1 ) {
@@ -2599,7 +2714,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
             for( const item *inv_elem : you.inv_dump() ) {
                 if( inv_elem->has_var( "activity_var" ) ) {
                     // we've gone to tidy up all the things lying around, now tidy up the things we picked up.
-                    src_set.insert( here.get_abs( unsorted_spot ) );
+                    src_set.insert( here.getglobal( unsorted_spot ) );
                     break;
                 }
             }
@@ -2607,12 +2722,12 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
     } else if( act_id == ACT_MULTIPLE_READ ) {
         // anywhere well lit
         for( const tripoint_bub_ms &elem : here.points_in_radius( localpos, MAX_VIEW_DISTANCE ) ) {
-            src_set.insert( here.get_abs( elem ) );
+            src_set.insert( here.getglobal( elem ) );
         }
     } else if( act_id == ACT_MULTIPLE_CRAFT ) {
         // Craft only with what is on the spot
         // TODO: add zone type like zone_type_CRAFT?
-        src_set.insert( here.get_abs( localpos ) );
+        src_set.insert( here.getglobal( localpos ) );
     } else if( act_id != ACT_FETCH_REQUIRED ) {
         zone_type_id zone_type = get_zone_for_act( tripoint_bub_ms::zero, mgr, act_id, _fac_id( you ) );
         src_set = mgr.get_near( zone_type, abspos, MAX_VIEW_DISTANCE, nullptr, _fac_id( you ) );
@@ -2621,7 +2736,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
             for( const tripoint_bub_ms &elem : here.points_in_radius( localpos, MAX_VIEW_DISTANCE ) ) {
                 partial_con *pc = here.partial_con_at( elem );
                 if( pc ) {
-                    src_set.insert( here.get_abs( elem ) );
+                    src_set.insert( here.getglobal( elem ) );
                 }
             }
             // farming activities encompass tilling, planting, harvesting.
@@ -2637,7 +2752,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
                     requirements_map( you, MAX_VIEW_DISTANCE );
         for( const auto &elem : mental_map ) {
             const tripoint_bub_ms &elem_point = std::get<0>( elem );
-            src_set.insert( here.get_abs( elem_point ) );
+            src_set.insert( here.getglobal( elem_point ) );
         }
     }
     // prune the set to remove tiles that are never gonna work out.
@@ -2649,7 +2764,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
 
     for( auto it2 = src_set.begin(); it2 != src_set.end(); ) {
         // remove dangerous tiles
-        const tripoint_bub_ms set_pt = here.get_bub( *it2 );
+        const tripoint_bub_ms set_pt = here.bub_from_abs( *it2 );
         if( MOP_ACTIVITY ) {
             if( !here.mopsafe_field_at( set_pt ) ) {
                 it2 = src_set.erase( it2 );
@@ -2712,7 +2827,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
     const std::unordered_set<tripoint_abs_ms> &src_set, const bool check_only = false )
 {
     map &here = get_map();
-    const tripoint_abs_ms abspos = here.get_abs( you.pos_bub() );
+    const tripoint_abs_ms abspos = here.getglobal( you.pos_bub() );
     zone_manager &mgr = zone_manager::get_manager();
 
     bool &can_do_it = act_info.can_do;
@@ -2962,7 +3077,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
                     std::vector<tripoint_bub_ms> local_src_set;
                     local_src_set.reserve( src_set.size() );
                     for( const tripoint_abs_ms &elem : src_set ) {
-                        local_src_set.push_back( here.get_bub( elem ) );
+                        local_src_set.push_back( here.bub_from_abs( elem ) );
                     }
                     std::vector<tripoint_bub_ms> candidates;
                     for( const tripoint_bub_ms &point_elem :
@@ -2981,7 +3096,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
                         return requirement_check_result::SKIP_LOCATION_NO_LOCATION;
                     }
                     act_prev.coords.push_back(
-                        here.get_abs(
+                        here.getglobal(
                             candidates[std::max( 0, static_cast<int>( candidates.size() / 2 ) )] )
                     );
                 }
@@ -3157,7 +3272,7 @@ static bool generic_multi_activity_do(
                     player_activity act = player_activity( disassemble_activity_actor( r.time_to_craft_moves( you,
                                                            recipe_time_flag::ignore_proficiencies ) * qty ) );
                     act.targets.emplace_back( map_cursor( src_loc ), &elem );
-                    act.placement = here.get_abs( src_loc );
+                    act.placement = here.getglobal( src_loc );
                     act.position = qty;
                     act.index = false;
                     you.assign_activity( act );
@@ -3189,7 +3304,7 @@ struct failure_reasons {
 bool generic_multi_activity_handler( player_activity &act, Character &you, bool check_only )
 {
     map &here = get_map();
-    const tripoint_abs_ms abspos = here.get_abs( you.pos_bub() );
+    const tripoint_abs_ms abspos = here.getglobal( you.pos_bub() );
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     activity_id activity_to_restore = act.id();
     // Nuke the current activity, leaving the backlog alone
@@ -3222,7 +3337,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
     failure_reasons reason;
 
     for( const tripoint_abs_ms &src : src_sorted ) {
-        const tripoint_bub_ms &src_loc = here.get_bub( src );
+        const tripoint_bub_ms &src_loc = here.bub_from_abs( src );
         if( !here.inbounds( src_loc ) && !check_only ) {
             if( !here.inbounds( you.pos_bub() ) ) {
                 // p is implicitly an NPC that has been moved off the map, so reset the activity
@@ -3439,7 +3554,7 @@ static std::optional<tripoint_bub_ms> find_refuel_spot_zone( const tripoint_bub_
 {
     const zone_manager &mgr = zone_manager::get_manager();
     map &here = get_map();
-    const tripoint_abs_ms center_abs = here.get_abs( center );
+    const tripoint_abs_ms center_abs = here.getglobal( center );
 
     const std::unordered_set<tripoint_abs_ms> tiles_abs_unordered =
         mgr.get_near( zone_type_SOURCE_FIREWOOD, center_abs, PICKUP_RANGE, nullptr, fac );
@@ -3447,7 +3562,7 @@ static std::optional<tripoint_bub_ms> find_refuel_spot_zone( const tripoint_bub_
         get_sorted_tiles_by_distance( center_abs, tiles_abs_unordered );
 
     for( const tripoint_abs_ms &tile_abs : tiles_abs ) {
-        const tripoint_bub_ms tile = here.get_bub( tile_abs );
+        const tripoint_bub_ms tile = here.bub_from_abs( tile_abs );
         if( has_clear_path_to_pickup_items( center, tile ) ) {
             return tile;
         }
@@ -3568,7 +3683,7 @@ int get_auto_consume_moves( Character &you, const bool food )
     }
     map &here = get_map();
     const std::unordered_set<tripoint_abs_ms> &dest_set =
-        mgr.get_near( consume_type_zone, here.get_abs( pos ), MAX_VIEW_DISTANCE, nullptr,
+        mgr.get_near( consume_type_zone, here.getglobal( pos ), MAX_VIEW_DISTANCE, nullptr,
                       _fac_id( you ) );
     if( dest_set.empty() ) {
         return 0;
@@ -3629,7 +3744,7 @@ int get_auto_consume_moves( Character &you, const bool food )
             return VisitResponse::NEXT;
         };
 
-        const optional_vpart_position vp = here.veh_at( here.get_bub( loc ) );
+        const optional_vpart_position vp = here.veh_at( here.bub_from_abs( loc ) );
         if( vp ) {
             if( const std::optional<vpart_reference> vp_cargo = vp.cargo() ) {
                 for( item &it : vp_cargo->items() ) {
@@ -3638,7 +3753,7 @@ int get_auto_consume_moves( Character &you, const bool food )
                 }
             }
         } else {
-            for( item &it : here.i_at( here.get_bub( loc ) ) ) {
+            for( item &it : here.i_at( here.bub_from_abs( loc ) ) ) {
                 item_location i_loc( map_cursor( loc ), &it );
                 visit_item_contents( i_loc, visit );
             }
@@ -3671,7 +3786,7 @@ bool try_fuel_fire( player_activity &act, Character &you, const bool starting_fi
 
     map &here = get_map();
     std::optional<tripoint_bub_ms> best_fire =
-        starting_fire ? here.get_bub( act.placement ) : find_best_fire( adjacent, pos );
+        starting_fire ? here.bub_from_abs( act.placement ) : find_best_fire( adjacent, pos );
 
     if( !best_fire || !here.accessible_items( *best_fire ) ) {
         return false;


### PR DESCRIPTION
If this commit is applied it will prevent PC running to sorted zones.

It was made because PC was running across the map when there was no items to move

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Sorting loot: stop player running to items that's not going to be moved"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Player or NPC were travelling all across the map to unsorted loot zone with items that does not have a valid destination stockpile. This was annoying and time consuming.  NPCs were perceived as being dumb
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The issue was there because we did not check in the "THINK" stage of activity if unsorted zone tile has any items that require action. I copied all the logic from the "DO" stage carefully to predict if we need to run to the source tile at all.  
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I thought about extracting the logic to separate function instead of mimicking it but it would require a full rewrite of the DO stage. And I'm not yet comfortable with tasks of this size.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I did the ./tests/cata_test and a lot of manual testing to prevent any regressions:
I checked cases with disabling source and target zones, stripping corpses, unloading containers, custom loot target zones, removing mods from a gun  
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
After this change NPC will think  better about his destination and stop wasting his time running between stockpiles. This makes him 'smarter' for the player. 
<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
