### PR TITLE
Fix minor issues with clang-tidy workflow

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -88,6 +88,7 @@ jobs:
     - name: checkout repository
       uses: actions/checkout@v4
     - name: download plugin from the previous job in this workflow run
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       uses: actions/download-artifact@v4
       with:
         name: cata-analyzer-plugin

--- a/build-scripts/clang-tidy-run.sh
+++ b/build-scripts/clang-tidy-run.sh
@@ -14,22 +14,19 @@ TILES=${TILES:-1}
 SOUND=${SOUND:-1}
 
 # create compilation database (compile_commands.json)
-if [ ! -f compile_commands.json ]
-then
-    mkdir -p build
-    cd build
-    cmake \
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        ${COMPILER:+-DCMAKE_CXX_COMPILER=$COMPILER} \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBACKTRACE=${BACKTRACE} \
-        -DLOCALIZE=${LOCALIZE} \
-        -DTILES=${TILES} \
-        -DSOUND=${SOUND} \
-        ..
-    cd ..
-    ln -s build/compile_commands.json .
-fi
+mkdir -p build
+cd build
+cmake \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    ${COMPILER:+-DCMAKE_CXX_COMPILER=$COMPILER} \
+    -DCMAKE_BUILD_TYPE="Release" \
+    -DBACKTRACE=${BACKTRACE} \
+    -DLOCALIZE=${LOCALIZE} \
+    -DTILES=${TILES} \
+    -DSOUND=${SOUND} \
+    ..
+cd ..
+ln --force --symbolic build/compile_commands.json .
 
 if [ ! -f build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so ]
 then


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This is a followup to #79100 

@akrieger  brought up two issues with the change in https://github.com/CleverRaven/Cataclysm-DDA/pull/78801#issuecomment-2599443987 
- the LOCALIZE flag is no longer set by default in the script, and gets its value from env. This is actually undesirable, since `LOCALIZE=0` makes clang-tidy complain about every use of `_`, among others. 
More generally speaking, it's probably worth it to have the stock scripts run as close as CI as possible
- the workflow sometimes fails on json-only changes, since no plugin gets built, and thus cannot be downloaded afterwards ([example](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12838010130/job/35802803651#step:4:17))

#### Describe the solution

- Set all the relevant default env vars in the script itself, not relying on the CI
  -  this is a behavior change - the defaults for `TILES` and `SOUND` switch from `0` to `1`
- (drive-by change) ~~don't rebuild compilation database if it already exists~~ force-overwrite the compilation database if it exists (local runs were failing on me trying to symlink the already exiting one)
- add the missing "should we even run clang-tidy here in the first place?" check to download-artifact step

#### Describe alternatives you've considered


#### Testing

` CATA_CLANG_TIDY=clang-tidy-17 ./build-scripts/clang-tidy-run.sh` with no extra args works for me locally

On this PR, before I un-drafted it, here's the job that properly skips attempting to download the plugin: [link](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12848494567/job/35825902139?pr=79234) 

#### Additional context

This is mostly unrelated and a problem for another time, but

skip_duplicate check actually doesn't do what we want it to do. For example it thinks that CMakeLists.txt changed in this JSON-only PR: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12826245046?pr=79204
This is because it checks the difference between the branch base and the *merge* pr, which includes all the other changes between when the branch was created and now.
skip_duplicates also *can* fail the other direction too. For example the *intent* is there for draft prs to [not trigger](https://github.com/CleverRaven/Cataclysm-DDA/pull/73646) clang-tidy checks. However that means that one can create a draft PR, skip clang-tidy checks, and then un-draft it, and skip the checks again because `skip_duplicates` treats it as a duplicate (see this check on this PR itself https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12848556910?pr=79234) 

Now, we are also not *abiding* to what `skip_duplicates` tells us to do, because (i think) it sets the `should_skip` to `"Yes"` and we later check whether `should_skip == "true"` and assuming we should never skip things... (see last link above again) 
This is all rather broken overall...