### PR TITLE
Rename "dissoluted devourer" to "dissolving devourer"

### DIFF
--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -29,7 +29,7 @@
   {
     "id": "mon_devourer",
     "type": "MONSTER",
-    "name": { "str": "dissoluted devourer" },
+    "name": { "str": "dissolving devourer" },
     "description": "Human bodies fused together into a colossus, with heads and limbs sticking out of its bloated body.  The nature of the thing makes it difficult to estimate how close it is to dying, and its capabilities might change if it manages to assimilate more zombies into itself.",
     "default_faction": "zombie",
     "bodytype": "human",

--- a/doc/design-balance-lore/GAME_BALANCE.md
+++ b/doc/design-balance-lore/GAME_BALANCE.md
@@ -91,7 +91,7 @@ Minimum dice: 1 (predictable damage; black cat, Atlantic cod, blank body, feral 
 
 Standard dice: 2 (minimal variation; zombie, giant wasp, wolf)
 
-Higher risk: 3 (higher day one threat; dissoluted devourer, tough zombie )
+Higher risk: 3 (higher day one threat; dissolving devourer, tough zombie )
 
 High risk: 4 (dangerous threat; hulk, zombie predator, mi-go)
 

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -1545,7 +1545,6 @@ disdainer
 Diskobolus
 dispersor
 dispersors
-dissoluted
 dist
 distaves
 divemask


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

The word "dissoluted" has several problems. First, it's not a word, because "dissolute" is an adjective, not a verb. Second, "dissolute" means "debauched", not "dissolving" or "dissolved".

#### Describe the solution

I renamed this to "dissolving devourer".

#### Additional context

I think there are a few other names that could work:

* dissolved devourer
* melted devourer
* melting devourer

And more along those lines. I think "dissolving" is good, but I'm fine with of these choices.
