### PR TITLE
[MoM] Psionics `magic_type` edits

### DIFF
--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -13,9 +13,15 @@
   },
   {
     "type": "jmath_function",
-    "id": "maintenance_exp_factor",
+    "id": "psionic_power_experience_formula_channeling",
     "num_args": 1,
-    "return": "(_0 / 100) * 75 * ( ( u_val('intelligence') + 10) / 20 ) * min( ( 0.5 + ( u_skill('metaphysics') / 20) ), 1)"
+    "return": "60 * ( ( u_val('intelligence') + 10) / 20 ) * min( ( 0.5 + ( u_skill('metaphysics') / 20) ), 1) * u_nether_attunement_power_scaling"
+  },
+  {
+    "type": "jmath_function",
+    "id": "psionic_power_experience_formula",
+    "num_args": 1,
+    "return": "(_0 / 100) * 60 * ( ( u_val('intelligence') + 10) / 20 ) * min( ( 0.5 + ( u_skill('metaphysics') / 20) ), 1) * u_nether_attunement_power_scaling"
   },
   {
     "type": "jmath_function",
@@ -33,7 +39,7 @@
     "type": "jmath_function",
     "id": "psionics_contemplation_kcal_cost",
     "num_args": 1,
-    "return": "(1.2 * _0) * rng( 0.3, 1.7)"
+    "return": "(1.2 * _0) * rng( 0.3, 1.7) * u_nether_attunement_power_scaling"
   },
   {
     "type": "jmath_function",
@@ -70,8 +76,8 @@
     "type": "jmath_function",
     "id": "contemplation_factor",
     "num_args": 1,
-    "//": "This equates to about 500 XP per hour of contemplation when at minimum focus",
-    "return": "(u_val('focus') * 0.005) * (_0)"
+    "//": "This equates to about 400 XP per hour of contemplation when at minimum focus, modified by Nether Attunement",
+    "return": "(u_val('focus') * 0.004) * (_0) * u_nether_attunement_power_scaling"
   },
   {
     "type": "jmath_function",

--- a/data/mods/MindOverMatter/powers/biokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/biokinesis_concentration_eocs.json
@@ -62,7 +62,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_overcome_pain')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('biokin_overcome_pain')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_OVERCOME_PAIN_DRAIN",
@@ -121,7 +123,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_physical_enhance')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('biokin_physical_enhance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_PHYSICAL_ENHANCE_DRAIN",
@@ -186,7 +190,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_breathe_skin')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('biokin_breathe_skin')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_BREATH_SKIN_DRAIN",
@@ -245,7 +249,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_armor_skin')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('biokin_armor_skin')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_HARDENED_SKIN_DRAIN",
@@ -305,7 +309,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_climate_control')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('biokin_climate_control')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_CLIMATE_CONTROL_DRAIN",
@@ -379,7 +385,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_enhance_mobility')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('biokin_enhance_mobility')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_ENHANCE_MOBILITY_DRAIN",
@@ -443,7 +451,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_hammerhand')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('biokin_hammerhand')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_HAMMERHAND_DRAIN",
@@ -502,7 +510,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_reflex_enhance')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('biokin_reflex_enhance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_REFLEX_ENHANCE_DRAIN",
@@ -561,7 +571,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_metabolism_enhance')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('biokin_metabolism_enhance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "math": [ "u_val('sleep_deprivation')", "-=", "10" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {

--- a/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
@@ -49,7 +49,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_night_vision')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_night_vision')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_NIGHT_EYES_DRAIN",
@@ -112,7 +112,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_speed_reading')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_speed_reading')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_SPEED_READING_DRAIN",
@@ -171,7 +171,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_see_auras')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_see_auras')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_SEE_AURAS_DRAIN",
@@ -230,7 +230,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_danger_sense')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_danger_sense')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_DANGER_SENSE_DRAIN",
@@ -292,7 +292,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_ranged_enhance')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('clair_ranged_enhance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_RANGED_ENHANCE_DRAIN",
@@ -351,7 +353,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_dodge_power')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_dodge_power')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_DODGE_POWER_DRAIN",
@@ -434,7 +436,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_craft_bonus')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_craft_bonus')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_CRAFT_BONUS_DRAIN",
@@ -493,7 +495,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 8" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_clear_sight')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_clear_sight')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_CLEAR_SIGHT_DRAIN",
@@ -558,7 +560,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 9" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_group_tactics')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_group_tactics')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_GROUP_TACTICS_DRAIN",

--- a/data/mods/MindOverMatter/powers/classless.json
+++ b/data/mods/MindOverMatter/powers/classless.json
@@ -4,14 +4,18 @@
     "type": "magic_type",
     "energy_source": "STAMINA",
     "cannot_cast_flags": "NO_PSIONICS",
-    "cannot_cast_message": "You can't channel any of the powers you know!"
+    "cannot_cast_message": "You can't channel any of the powers you know!",
+    "failure_cost_percent": 0.2,
+    "failure_exp_percent": 0.3,
+    "max_book_level": 0,
+    "casting_xp_formula_id": "psionic_power_experience_formula_channeling"
   },
   {
     "id": "classless_toggleable_concentration_end",
     "type": "SPELL",
     "name": "[Ψ]Stop Concentrating",
     "description": "End your concentration on all of your maintained powers.\n\nChanneling this power <color_green>always succeeds</color>.",
-    "message": "You stop concentrating.",
+    "message": "You stop concentrating on your powers.",
     "teachable": false,
     "valid_targets": [ "self" ],
     "skill": "metaphysics",

--- a/data/mods/MindOverMatter/powers/classless.json
+++ b/data/mods/MindOverMatter/powers/classless.json
@@ -5,7 +5,7 @@
     "energy_source": "STAMINA",
     "cannot_cast_flags": "NO_PSIONICS",
     "cannot_cast_message": "You can't channel any of the powers you know!",
-    "failure_cost_percent": 0.2,
+    "failure_cost_percent": 0.5,
     "failure_exp_percent": 0.3,
     "max_book_level": 0,
     "casting_xp_formula_id": "psionic_power_experience_formula_channeling"

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -38,7 +38,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('electrokinetic_see_electric')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('electrokinetic_see_electric')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_SEE_ELECTRICITY_DRAIN",
@@ -97,7 +99,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('electrokinetic_zap_enemies')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('electrokinetic_zap_enemies')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_ZAP_ENEMIES_DRAIN",
@@ -156,7 +160,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('electrokinetic_melee_attacks')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('electrokinetic_melee_attacks')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_MELEE_ATTACKS_DRAIN",
@@ -253,7 +259,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('electrokinetic_hacking_interface')", "+=", "(maintenance_exp_factor(u_val('focus')))" ]
+        "math": [ "u_spell_exp('electrokinetic_hacking_interface')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -458,7 +464,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('electrokinetic_personal_battery')", "+=", "(maintenance_exp_factor(u_val('focus')))" ]
+        "math": [ "u_spell_exp('electrokinetic_personal_battery')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -517,7 +523,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('electrokinetic_reduce_pain')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('electrokinetic_reduce_pain')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_REDUCE_PAIN_DRAIN",
@@ -576,7 +584,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('electrokinetic_speed_boost')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('electrokinetic_speed_boost')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_SPEED_BOOST_DRAIN",
@@ -640,7 +650,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 8" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('electrokinetic_lightning_aura')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('electrokinetic_lightning_aura')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_LIGHTNING_AURA_DRAIN",

--- a/data/mods/MindOverMatter/powers/photokinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/photokinesis_concentration_eoc.json
@@ -38,7 +38,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('photokinetic_light_local')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('photokinetic_light_local')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_LIGHT_LOCAL_DRAIN",
@@ -97,7 +99,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('photokinetic_light_dodge')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('photokinetic_light_dodge')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_LIGHT_DODGE_DRAIN",
@@ -156,7 +160,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('photokinetic_rad_immunity')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('photokinetic_rad_immunity')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_RAD_IMMUNITY_DRAIN",
@@ -224,7 +230,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('photokinetic_camouflage')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('photokinetic_camouflage')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_CAMOUFLAGE_DRAIN",
@@ -293,7 +301,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('photokinetic_hide_ugly')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('photokinetic_hide_ugly')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_HIDE_UGLY_DRAIN",
@@ -358,7 +368,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('photokinetic_radio')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('photokinetic_radio')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_RADIO_DRAIN",
@@ -420,7 +430,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('photokinetic_invisibility')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('photokinetic_invisibility')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_INVISIBILITY_DRAIN",
@@ -479,7 +491,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('photokinetic_blinding_glare')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('photokinetic_blinding_glare')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_BLINDING_GLARE_DRAIN",

--- a/data/mods/MindOverMatter/powers/pyrokinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis_concentration_eoc.json
@@ -75,7 +75,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('pyrokinetic_call_flames')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('pyrokinetic_call_flames')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PYROKIN_CALL_FLAME_DRAIN",
@@ -134,7 +136,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('pyrokinetic_cloak')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('pyrokinetic_cloak')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PYROKIN_WARMTH_CLOAK_DRAIN",
@@ -199,7 +201,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('pyrokinetic_lance')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('pyrokinetic_lance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PYROKIN_TORCH_WELD_DRAIN",
@@ -258,7 +260,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PYROKIN_BLAZING_AURA_DRAIN",
@@ -317,7 +321,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PYROKIN_FLAME_IMMUNITY_DRAIN",

--- a/data/mods/MindOverMatter/powers/telekinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_concentration_eoc.json
@@ -38,7 +38,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telekinetic_momentum')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('telekinetic_momentum')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_MOMENTUM_DRAIN",
@@ -100,7 +102,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telekinetic_water_walk')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('telekinetic_water_walk')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_WATER_WALKING_DRAIN",
@@ -240,7 +244,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telekinetic_lifting_field')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('telekinetic_lifting_field')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_LIFTING_FIELD_DRAIN",
@@ -299,7 +305,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telekinetic_strength')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('telekinetic_strength')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_STRENGTH_DRAIN",
@@ -358,7 +366,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telekinetic_shield')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('telekinetic_shield')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_SHIELD_DRAIN",
@@ -527,7 +535,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telekinetic_vehicle_lift')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('telekinetic_vehicle_lift')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_SUMMON_JACKING_TOOL_DRAIN",
@@ -589,7 +599,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telekinetic_levitation')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('telekinetic_levitation')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_LEVITATION_DRAIN",

--- a/data/mods/MindOverMatter/powers/telepathy_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_concentration_eoc.json
@@ -38,7 +38,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telepathic_concentration')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('telepathic_concentration')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPATH_CONCENTRATION_DRAIN",
@@ -97,7 +99,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telepathic_shield')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('telepathic_shield')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPATH_SHIELD_DRAIN",
@@ -156,7 +158,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telepathic_mind_sense')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('telepathic_mind_sense')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPATH_SENSE_MINDS_DRAIN",
@@ -234,7 +238,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telepathic_morale')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('telepathic_morale')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "u_add_morale": "morale_telepathy",

--- a/data/mods/MindOverMatter/powers/teleportation_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_concentration_eoc.json
@@ -38,7 +38,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('teleport_stride')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('teleport_stride')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPORT_STRIDE_DRAIN",
@@ -97,7 +97,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('teleport_ephemeral_walk')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('teleport_ephemeral_walk')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPORT_EPHEMERAL_WALK_DRAIN",
@@ -156,7 +158,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('teleport_reactive_displacement') += (maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('teleport_reactive_displacement') += (psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPORT_REACTIVE_DISPLACEMENT_DRAIN",
@@ -216,7 +220,9 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('teleport_loci_establishment') +=(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('teleport_loci_establishment') +=(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPORT_LOCI_ESTABLISHMENT_DRAIN",

--- a/data/mods/MindOverMatter/powers/vitakinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_concentration_eoc.json
@@ -56,7 +56,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('vita_slow_bleeding')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_slow_bleeding')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_SLOW_BLEEDING_DRAIN",
@@ -115,7 +115,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('vita_health_power')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_health_power')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_HEALTH_POWER_DRAIN",
@@ -373,7 +373,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('vita_slow_bleeding')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_slow_bleeding')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_CONCENTRATED_HEALING_DRAIN",
@@ -439,7 +439,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('vita_cure_disease')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_cure_disease')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_CURE_DISEASE_DRAIN",
@@ -516,7 +516,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 9" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('vita_super_heal')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_super_heal')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_SUPER_HEAL_DRAIN",
@@ -586,7 +586,9 @@
       { "math": [ "u_latest_channeled_power_difficulty = 10" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       { "math": [ "u_vitakin_return_from_death_kcal = u_calories()" ] },
-      { "math": [ "u_spell_exp('vita_return_from_death')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('vita_return_from_death')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_RETURN_FROM_DEATH_DRAIN",

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -236,7 +236,9 @@
     "condition": { "u_has_effect": "effect_vitakin_wakeful_resting" },
     "effect": [
       { "if": { "math": [ "u_val('focus') >= 25" ] }, "then": { "math": [ "u_val('focus')", "-=", "rand(10) + 5" ] } },
-      { "math": [ "u_spell_exp('vita_sleeping_trance')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "math": [ "u_spell_exp('vita_sleeping_trance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+      },
       {
         "run_eocs": "EOC_VITAKIN_SLEEP_EXPERIENCE",
         "time_in_future": [
@@ -355,7 +357,7 @@
     "condition": { "u_has_effect": "effect_vitakin_healing_trance" },
     "effect": [
       { "if": { "math": [ "u_val('focus') >= 25" ] }, "then": { "math": [ "u_val('focus')", "-=", "rand(10) + 5" ] } },
-      { "math": [ "u_spell_exp('vita_healing_trance')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_healing_trance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
       {
         "run_eocs": "EOC_VITAKIN_HEALING_TRANCE_EXPERIENCE",
         "time_in_future": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Psionics `magic_type` edits"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Taking advantage of new fields
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the following fields now that they exist:

- "failure_cost_percent": 0.5 (50%). It still takes effort when you're unsuccessful. 
- "failure_exp_percent": 0.3 (30%). More generous than Magiclysm's 20% 
- "max_book_level": 0. There are no psi spellbooks, but just making it explicit.
- "casting_xp_formula_id": Set up the same formula for maintenance of powers and channeling powers. This is lower than casting spells in Magiclysm, initially, but the XP is affected by Nether Attunement.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

New fields work.

I did discover that `casting_xp_formula_id` isn't affected by focus when it should be, but I'm not sure of the best way to fix that.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

As loath as I am to ever refer to MoM with the word `magic`, that is what the type is.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
