### PR TITLE
[Xedra Evolved] Paraclesians passively gain traits (if they spend time in their native environment)

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_passive_trait_gain_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_passive_trait_gain_eocs.json
@@ -1,0 +1,287 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PARACLESIAN_ARVORE_GAIN_TRAIT_FROM_PASSIVE_POWER_CHECKER",
+    "recurrence": [ "30 minutes", "90 minutes" ],
+    "condition": { "u_has_trait": "ARVORE" },
+    "deactivate_condition": { "not": { "u_has_trait": "ARVORE" } },
+    "effect": [
+      {
+        "if": {
+          "and": [
+            { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" },
+            {
+              "or": [
+                {
+                  "and": [
+                    "u_is_outside",
+                    { "not": { "math": [ "u_val('pos_z') <= -1" ] } },
+                    { "u_near_om_location": "forest", "range": 2 },
+                    { "not": { "u_at_om_location": "field" } }
+                  ]
+                },
+                {
+                  "and": [
+                    "u_is_outside",
+                    { "not": { "math": [ "u_val('pos_z') <= -1" ] } },
+                    { "u_near_om_location": "forest_thick", "range": 2 },
+                    { "not": { "u_at_om_location": "field" } }
+                  ]
+                },
+                { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_FOREST" },
+                { "u_is_on_terrain": "t_barkfloor" }
+              ]
+            }
+          ]
+        },
+        "then": { "math": [ "u_paraclesian_passive_mutation_value", "+=", "1 " ] },
+        "else": {
+          "if": { "math": [ "u_paraclesian_passive_mutation_value", ">", "0 " ] },
+          "then": { "math": [ "u_paraclesian_passive_mutation_value", "-=", "1 " ] }
+        }
+      },
+      {
+        "if": {
+          "and": [
+            { "math": [ "u_paraclesian_passive_mutation_value", ">=", "500" ] },
+            { "math": [ "u_vitamin('mutagen')", "==", "0" ] }
+          ]
+        },
+        "then": [
+          { "run_eocs": "EOC_PARACLESIAN_GAIN_TRAIT_FROM_PASSIVE_POWER" },
+          { "math": [ "u_paraclesian_passive_mutation_value", "-=", "500" ] }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PARACLESIAN_HOMULLUS_GAIN_TRAIT_FROM_PASSIVE_POWER_CHECKER",
+    "recurrence": [ "30 minutes", "90 minutes" ],
+    "condition": { "u_has_trait": "HOMULLUS" },
+    "deactivate_condition": { "not": { "u_has_trait": "HOMULLUS" } },
+    "effect": [
+      {
+        "if": {
+          "or": [
+            { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" },
+            { "u_near_om_location": "FACTION_CAMP_ANY", "range": 2 },
+            { "map_in_city": { "mutator": "u_loc_relative", "target": "(0,0,0)" } }
+          ]
+        },
+        "then": { "math": [ "u_paraclesian_passive_mutation_value", "+=", "1 " ] },
+        "else": {
+          "if": { "math": [ "u_paraclesian_passive_mutation_value", ">", "0 " ] },
+          "then": { "math": [ "u_paraclesian_passive_mutation_value", "-=", "1 " ] }
+        }
+      },
+      {
+        "if": {
+          "and": [
+            { "math": [ "u_paraclesian_passive_mutation_value", ">=", "500" ] },
+            { "math": [ "u_vitamin('mutagen')", "==", "0" ] }
+          ]
+        },
+        "then": [
+          { "run_eocs": "EOC_PARACLESIAN_GAIN_TRAIT_FROM_PASSIVE_POWER" },
+          { "math": [ "u_paraclesian_passive_mutation_value", "-=", "500" ] }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PARACLESIAN_IERDE_GAIN_TRAIT_FROM_PASSIVE_POWER_CHECKER",
+    "recurrence": [ "30 minutes", "90 minutes" ],
+    "condition": { "u_has_trait": "IERDE" },
+    "deactivate_condition": { "not": { "u_has_trait": "IERDE" } },
+    "effect": [
+      {
+        "if": {
+          "or": [
+            { "math": [ "u_val('pos_z') <= -1" ] },
+            {
+              "and": [
+                { "u_is_on_terrain_with_flag": "DIGGABLE" },
+                { "not": { "u_is_on_terrain": "t_grass_alien" } },
+                { "not": { "u_is_on_terrain": "t_vitrified_sand" } },
+                { "not": { "u_is_on_terrain": "t_pit_corpsed" } },
+                { "not": { "u_is_on_terrain": "t_fungus" } },
+                { "not": { "u_is_on_terrain": "t_glassed_sand" } },
+                { "not": { "u_is_on_terrain": "t_rubber_mulch" } },
+                { "not": { "u_is_on_terrain": "t_swater_surf" } },
+                { "not": { "u_is_on_terrain": "t_woodchips" } }
+              ]
+            },
+            { "u_at_om_location": "ierde_genius_loci_NW" },
+            { "u_at_om_location": "ierde_genius_loci_NE" },
+            { "u_at_om_location": "ierde_genius_loci_SW" },
+            { "u_at_om_location": "ierde_genius_loci_SE" }
+          ]
+        },
+        "then": { "math": [ "u_paraclesian_passive_mutation_value", "+=", "1 " ] },
+        "else": {
+          "if": { "math": [ "u_paraclesian_passive_mutation_value", ">", "0 " ] },
+          "then": { "math": [ "u_paraclesian_passive_mutation_value", "-=", "1 " ] }
+        }
+      },
+      {
+        "if": {
+          "and": [
+            { "math": [ "u_paraclesian_passive_mutation_value", ">=", "500" ] },
+            { "math": [ "u_vitamin('mutagen')", "==", "0" ] }
+          ]
+        },
+        "then": [
+          { "run_eocs": "EOC_PARACLESIAN_GAIN_TRAIT_FROM_PASSIVE_POWER" },
+          { "math": [ "u_paraclesian_passive_mutation_value", "-=", "500" ] }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PARACLESIAN_SALAMANDER_GAIN_TRAIT_FROM_PASSIVE_POWER_CHECKER",
+    "recurrence": [ "30 minutes", "90 minutes" ],
+    "condition": { "u_has_trait": "SALAMANDER" },
+    "deactivate_condition": { "not": { "u_has_trait": "SALAMANDER" } },
+    "effect": [
+      {
+        "if": {
+          "or": [
+            { "u_has_item": "torch_lit" },
+            { "u_has_item": "candle_lit" },
+            { "u_has_item": "oil_lamp_on" },
+            { "u_has_item": "oil_lamp_clay_on" },
+            { "u_has_item": "cigar_lit" },
+            { "u_has_item": "cig_lit" },
+            { "math": [ "u_salamander_near_fire == 1" ] },
+            { "math": [ "weather('temperature') >= from_fahrenheit( 80 )" ] }
+          ]
+        },
+        "then": { "math": [ "u_paraclesian_passive_mutation_value", "+=", "1 " ] },
+        "else": {
+          "if": { "math": [ "u_paraclesian_passive_mutation_value", ">", "0 " ] },
+          "then": { "math": [ "u_paraclesian_passive_mutation_value", "-=", "1 " ] }
+        }
+      },
+      {
+        "if": {
+          "and": [
+            { "math": [ "u_paraclesian_passive_mutation_value", ">=", "500" ] },
+            { "math": [ "u_vitamin('mutagen')", "==", "0" ] }
+          ]
+        },
+        "then": [
+          { "run_eocs": "EOC_PARACLESIAN_GAIN_TRAIT_FROM_PASSIVE_POWER" },
+          { "math": [ "u_paraclesian_passive_mutation_value", "-=", "500" ] }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PARACLESIAN_SYLPH_GAIN_TRAIT_FROM_PASSIVE_POWER_CHECKER",
+    "recurrence": [ "30 minutes", "90 minutes" ],
+    "condition": { "u_has_trait": "SYLPH" },
+    "deactivate_condition": { "not": { "u_has_trait": "SYLPH" } },
+    "effect": [
+      {
+        "if": {
+          "or": [
+            { "and": [ { "math": [ "u_val('pos_z') >= 1" ] }, "u_is_outside" ] },
+            { "and": [ { "math": [ "weather('windpower') >= 15" ] }, "u_is_outside" ] },
+            {
+              "and": [
+                "u_is_outside",
+                {
+                  "or": [
+                    { "is_weather": "thunder" },
+                    { "is_weather": "lightning" },
+                    { "is_weather": "rain" },
+                    { "is_weather": "rainstorm" },
+                    { "is_weather": "drizzle" }
+                  ]
+                }
+              ]
+            },
+            { "u_at_om_location": "sylph_genius_loci_NW" },
+            { "u_at_om_location": "sylph_genius_loci_NE" },
+            { "u_at_om_location": "sylph_genius_loci_SW" },
+            { "u_at_om_location": "sylph_genius_loci_SE" }
+          ]
+        },
+        "then": { "math": [ "u_paraclesian_passive_mutation_value", "+=", "1 " ] },
+        "else": {
+          "if": { "math": [ "u_paraclesian_passive_mutation_value", ">", "0 " ] },
+          "then": { "math": [ "u_paraclesian_passive_mutation_value", "-=", "1 " ] }
+        }
+      },
+      {
+        "if": {
+          "and": [
+            { "math": [ "u_paraclesian_passive_mutation_value", ">=", "500" ] },
+            { "math": [ "u_vitamin('mutagen')", "==", "0" ] }
+          ]
+        },
+        "then": [
+          { "run_eocs": "EOC_PARACLESIAN_GAIN_TRAIT_FROM_PASSIVE_POWER" },
+          { "math": [ "u_paraclesian_passive_mutation_value", "-=", "500" ] }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PARACLESIAN_UNDINE_GAIN_TRAIT_FROM_PASSIVE_POWER_CHECKER",
+    "recurrence": [ "30 minutes", "90 minutes" ],
+    "condition": { "u_has_trait": "UNDINE" },
+    "deactivate_condition": { "not": { "u_has_trait": "UNDINE" } },
+    "effect": [
+      {
+        "if": {
+          "or": [ { "math": [ "u_undine_is_connected_to_waters == 1" ] }, { "test_eoc": "EOC_CONDITION_CHECK_UNDINE_IN_WATER" } ]
+        },
+        "then": { "math": [ "u_paraclesian_passive_mutation_value", "+=", "1 " ] },
+        "else": {
+          "if": { "math": [ "u_paraclesian_passive_mutation_value", ">", "0 " ] },
+          "then": { "math": [ "u_paraclesian_passive_mutation_value", "-=", "1 " ] }
+        }
+      },
+      {
+        "if": {
+          "and": [
+            { "math": [ "u_paraclesian_passive_mutation_value", ">=", "500" ] },
+            { "math": [ "u_vitamin('mutagen')", "==", "0" ] }
+          ]
+        },
+        "then": [
+          { "run_eocs": "EOC_PARACLESIAN_GAIN_TRAIT_FROM_PASSIVE_POWER" },
+          { "math": [ "u_paraclesian_passive_mutation_value", "-=", "500" ] }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PARACLESIAN_GAIN_TRAIT_FROM_PASSIVE_POWER",
+    "condition": { "math": [ "u_vitamin('mutagen')", "==", "0" ] },
+    "effect": [
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "if": { "u_has_trait": "IERDE" }, "then": { "math": [ "u_vitamin('mutagen_earthkin')", "+=", "550 " ] } },
+      { "if": { "u_has_trait": "UNDINE" }, "then": { "math": [ "u_vitamin('mutagen_waterkin')", "+=", "550 " ] } },
+      { "if": { "u_has_trait": "SALAMANDER" }, "then": { "math": [ "u_vitamin('mutagen_flamekin')", "+=", "550 " ] } },
+      { "if": { "u_has_trait": "SYLPH" }, "then": { "math": [ "u_vitamin('mutagen_airkin')", "+=", "550 " ] } },
+      { "if": { "u_has_trait": "HOMULLUS" }, "then": { "math": [ "u_vitamin('mutagen_dollkin')", "+=", "550 " ] } },
+      { "if": { "u_has_trait": "ARVORE" }, "then": { "math": [ "u_vitamin('mutagen_plantkin')", "+=", "550 " ] } },
+      { "u_mutate": 0 },
+      { "math": [ "u_vitamin('mutagen')", "=", "0" ] },
+      { "math": [ "u_vitamin('mutagen_earthkin')", "=", "0 " ] },
+      { "math": [ "u_vitamin('mutagen_waterkin')", "=", "0 " ] },
+      { "math": [ "u_vitamin('mutagen_flamekin')", "=", "0 " ] },
+      { "math": [ "u_vitamin('mutagen_airkin')", "=", "0 " ] },
+      { "math": [ "u_vitamin('mutagen_dollkin')", "=", "0 " ] },
+      { "math": [ "u_vitamin('mutagen_plantkin')", "=", "0 " ] }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Paraclesians passively gain traits (if they spend time in their native environment)"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Yet another thing I did for a personal mod and then thought "You know...I should just PR that."

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The longer you spend in an appropriate environment (faction bases/cities for Homullus, wilderness for Arvore, near bodies of water for Undine, etc) the higher a hidden counter will climb. When it hits 500, you gain a trait, then it resets.

This is very slow--it ticks once per 30-90 minutes, so the average time per trait is three weeks--but it is passive. Also, you cannot gain the threshold this way.

My basic idea is for a second path to power--you can wait, and hopefully in the future do a quest that gives you the threshold and so attain your birthright that way...or you can murder dozens of other elemental fae. You monster. Your parents were right to leave you behind during the Cataclysm. 

Well, unless you murder whatever fae type you're in opposition to (Arvore <-> Homullus etc), that's just good and proper.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded in, waited a while, made sure the counter went up and down and that it gave a trait and reset when it went high enough.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I really need to do that Sky Island integration PR that the Island counts as native terrain for all types of elemental fae.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
