### PR TITLE
[Xedra Evolved] Fix ierde sleep of stone trait / ban interaction

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
@@ -440,11 +440,12 @@
         "msg_try": { "text": "You settle down to rest on the living earth.", "rating": "good" }
       },
       {
-        "conditions": [ { "type": "terrain", "id": "t_ rock" } ],
+        "conditions": [ { "type": "terrain", "id": "t_rock" } ],
         "comfort": "very_comfortable",
         "msg_try": { "text": "Encased within the living earth, you drift off to sleep.", "rating": "good" }
       }
-    ]
+    ],
+    "enchantments": [ { "condition": { "u_is_on_terrain": "t_rock" }, "values": [ { "value": "CLIMATE_CONTROL_HEAT", "add": 300 } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
@@ -432,7 +432,19 @@
     "category": [ "IERDE" ],
     "activated_is_setup": false,
     "active": true,
-    "activated_eocs": [ "EOC_IERDE_SINK_INTO_EARTH_activate" ]
+    "activated_eocs": [ "EOC_IERDE_SINK_INTO_EARTH_activate" ],
+    "comfort": [
+      {
+        "conditions": [ { "type": "terrain", "flag": "DIGGABLE" } ],
+        "comfort": "very_comfortable",
+        "msg_try": { "text": "You settle down to rest on the living earth.", "rating": "good" }
+      },
+      {
+        "conditions": [ { "type": "terrain", "id": "t_ rock" } ],
+        "comfort": "very_comfortable",
+        "msg_try": { "text": "Encased within the living earth, you drift off to sleep.", "rating": "good" }
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -118,13 +118,20 @@
     "required_event": "character_wakes_up",
     "condition": {
       "and": [
-        { "u_has_trait": "THRESH_IERDE" },
+        {
+          "or": [
+            { "u_has_trait": "THRESH_IERDE" },
+            { "u_has_trait": "IERDE_SINK_INTO_EARTH" },
+            { "math": [ "u_sum_traits_of_category_char_has('IERDE') >= 15" ] }
+          ]
+        },
         {
           "or": [
             "u_is_outside",
             {
               "and": [
                 { "not": { "u_is_on_terrain": "t_rock_floor_no_roof" } },
+                { "not": { "u_is_on_terrain": "t_rock" } },
                 { "not": { "u_is_on_terrain": "t_rock_floor" } },
                 { "not": { "u_is_on_terrain": "t_rock_smooth" } },
                 { "not": { "u_is_on_terrain": "t_rock_wall_half" } },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix ierde sleep of stone trait / ban interaction"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Reported on Discord that sleeping within the earth broke a fae ban when sleeping on the earth did not. Doesn't make much sense. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make sure to check for t_rock

Also, set up the ban to trigger on the Ierde gaining the threshold, the trait that lets them sleep in the earth, or 15 total traits. Add comfort data so sleeping surrounded by rock is extremely comfortable 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Sank into the earth, it was a comfortable place to sleep, did not break a ban sleeping there.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
