### PR TITLE
Fix clang-tidy running on pushes to master branch

### DIFF
--- a/build-scripts/clang-tidy-run.sh
+++ b/build-scripts/clang-tidy-run.sh
@@ -94,6 +94,9 @@ fi
 
 printf "Subset to analyze: '%s'\n" "$CATA_CLANG_TIDY_SUBSET"
 
+# (temporary create ./files_changed and then clean up it later. This is a terrible hack, and I'm not proud)
+if [ ! -f ./files_changed ] ; then touch ./files_changed ; CLEANUP_FILES_CHANGED="yes" ; fi
+
 # We might need to analyze only a subset of the files if they have been split
 # into multiple jobs for efficiency. The paths from `compile_commands.json` can
 # be absolute but the paths from `get_affected_files.py` are relative, so both
@@ -110,6 +113,7 @@ case "$CATA_CLANG_TIDY_SUBSET" in
         tidyable_cpp_files=$(printf '%s\n' "$tidyable_cpp_files" | grep -Ev '(^|/)src/' | grep -vf ./files_changed || [[ $? == 1 ]])
         ;;
 esac
+if [ "${CLEANUP_FILES_CHANGED}" == "yes" ] ; then rm -f ./files_changed ; fi
 
 printf "full list of files to analyze (they might get shuffled around in practice):\n%s\n" "$tidyable_cpp_files"
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes this clang-tidy runner failures when trying to process PUSHES to `master` branch (these ones: https://github.com/CleverRaven/Cataclysm-DDA/actions/workflows/clang-tidy.yml?query=branch%3Amaster )

#### Describe the solution

An ugly hack. Create a dummy `./files_changed` file right before we try to access it and then promptly clean it up afterwards

#### Describe alternatives you've considered
I have found none that are both less ugly and also work. (And are not, like "rewrite this all from scratch in a language you're more comfortable in like python")

#### Testing

- [x] runs locally as `CATA_CLANG_TIDY=clang-tidy-17 ./build-scripts/clang-tidy-run.sh`
- [x] runs on pull requests - https://github.com/moxian/Cataclysm-DDA/actions/runs/12851267577
- [x] runs on pushes to master - https://github.com/moxian/Cataclysm-DDA/actions/runs/12851302043

#### Additional context
I feel bad about breaking the CI 😔 
I also feel bad that there are almost no tools available for testing the CI changes so we either have to embrace inevitable failures or not touch CI ever...