### PR TITLE
set default_value bodypart_str_id::NULL_ID() correctly

### DIFF
--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -701,6 +701,7 @@ mon_effect_data::mon_effect_data() :
     chance( 100.0f ),
     permanent( false ),
     affect_hit_bp( false ),
+    bp( bodypart_str_id::NULL_ID() ),
     duration( 1, 1 ),
     intensity( 0, 0 ) {}
 
@@ -710,7 +711,7 @@ void mon_effect_data::load( const JsonObject &jo )
     optional( jo, false, "chance", chance, 100.f );
     optional( jo, false, "permanent", permanent, false );
     optional( jo, false, "affect_hit_bp", affect_hit_bp, false );
-    optional( jo, false, "bp", bp );
+    optional( jo, false, "bp", bp, bodypart_str_id::NULL_ID() );
     optional( jo, false, "message", message );
     // Support shorthand for a single value.
     if( jo.has_int( "duration" ) ) {

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -214,7 +214,7 @@ struct mon_effect_data {
     // Whether the effect is permanent.
     bool permanent;
     bool affect_hit_bp;
-    bodypart_str_id bp = bodypart_str_id::NULL_ID();
+    bodypart_str_id bp;
     // The range of the durations (in turns) of the effect.
     std::pair<int, int> duration;
     // The range of the intensities of the effect.


### PR DESCRIPTION
#### Summary
Bugfixes "set default_value bodypart_str_id::NULL_ID() correctly"
#### Purpose of change
Fix #79226 
#### Describe the solution
set default_value bodypart_str_id::NULL_ID() in mon_effect_data
#### Describe alternatives you've considered

#### Testing
No more debug msg
#### Additional context
