### PR TITLE
fix vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,8 @@
     "C_Cpp.default.configurationProvider": "ms-vscode.makefile-tools",
     "makefile.launchConfigurations": [
         {
-            "cwd": "${workspaceRoot}",
-            "binaryPath": "${workspaceRoot}/${buildTarget}",
+            "cwd": "${workspaceFolder}",
+            "binaryPath": "${workspaceFolder}/${buildTarget}",
             "binaryArgs": [],
             "stopAtEntry": true
         }
@@ -83,7 +83,7 @@
     "github-actions.remote-name": "upstream",
     // NOTE: This disable the plugins formatting so astyle is used.
     "C_Cpp.formatting": "disabled",
-    "astyle.astylerc": "${workspaceRoot}/.astylerc",
+    "astyle.astylerc": "${workspaceFolder}/.astylerc",
     "files.associations": {
         "vector": "cpp"
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The makefile extension could not find any launch targets.

#### Describe the solution
${workspaceRoot} got [depricated](https://code.visualstudio.com/docs/editor/variables-reference#_why-isnt-workspaceroot-documented). Use ${workspaceFolder} instead.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Testing
not the cause
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
