### PR TITLE
[MOM] Make experience formulas take into account focus enchants

### DIFF
--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -14,14 +14,14 @@
   {
     "type": "jmath_function",
     "id": "psionic_power_experience_formula_channeling",
-    "num_args": 1,
-    "return": "(u_val('focus') / 100 ) * 80 * ( ( u_val('intelligence') + 10) / 20 ) * min( ( 0.5 + ( u_skill('metaphysics') / 20) ), 1) * u_nether_attunement_power_scaling"
+    "num_args": 0,
+    "return": "(u_val('focus_effective') / 100 ) * 80 * ( ( u_val('intelligence') + 10) / 20 ) * min( ( 0.5 + ( u_skill('metaphysics') / 20) ), 1) * u_nether_attunement_power_scaling"
   },
   {
     "type": "jmath_function",
     "id": "psionic_power_experience_formula",
-    "num_args": 1,
-    "return": "(_0 / 100) * 80 * ( ( u_val('intelligence') + 10) / 20 ) * min( ( 0.5 + ( u_skill('metaphysics') / 20) ), 1) * u_nether_attunement_power_scaling"
+    "num_args": 0,
+    "return": "(u_val('focus_effective') / 100) * 80 * ( ( u_val('intelligence') + 10) / 20 ) * min( ( 0.5 + ( u_skill('metaphysics') / 20) ), 1) * u_nether_attunement_power_scaling"
   },
   {
     "type": "jmath_function",
@@ -77,7 +77,7 @@
     "id": "contemplation_factor",
     "num_args": 1,
     "//": "This equates to about 400 XP per hour of contemplation when at minimum focus, modified by Nether Attunement",
-    "return": "(u_val('focus') * 0.004) * (_0) * u_nether_attunement_power_scaling"
+    "return": "(u_val('focus_effective') * 0.004) * (_0) * u_nether_attunement_power_scaling"
   },
   {
     "type": "jmath_function",

--- a/data/mods/MindOverMatter/powers/biokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/biokinesis_concentration_eocs.json
@@ -66,9 +66,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('biokin_overcome_pain')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('biokin_overcome_pain')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_OVERCOME_PAIN_DRAIN",
@@ -127,9 +125,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('biokin_physical_enhance')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('biokin_physical_enhance')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_PHYSICAL_ENHANCE_DRAIN",
@@ -313,9 +309,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('biokin_climate_control')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('biokin_climate_control')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_CLIMATE_CONTROL_DRAIN",
@@ -389,9 +383,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('biokin_enhance_mobility')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('biokin_enhance_mobility')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_ENHANCE_MOBILITY_DRAIN",
@@ -514,9 +506,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('biokin_reflex_enhance')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('biokin_reflex_enhance')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_REFLEX_ENHANCE_DRAIN",
@@ -575,9 +565,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('biokin_metabolism_enhance')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('biokin_metabolism_enhance')", "+=", "psionic_power_experience_formula()" ] },
       { "math": [ "u_val('sleep_deprivation')", "-=", "10" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {

--- a/data/mods/MindOverMatter/powers/biokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/biokinesis_concentration_eocs.json
@@ -67,7 +67,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('biokin_overcome_pain')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('biokin_overcome_pain')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -128,7 +128,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('biokin_physical_enhance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('biokin_physical_enhance')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -194,7 +194,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_breathe_skin')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('biokin_breathe_skin')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_BREATH_SKIN_DRAIN",
@@ -253,7 +253,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_armor_skin')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('biokin_armor_skin')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_HARDENED_SKIN_DRAIN",
@@ -314,7 +314,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('biokin_climate_control')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('biokin_climate_control')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -390,7 +390,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('biokin_enhance_mobility')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('biokin_enhance_mobility')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -455,7 +455,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('biokin_hammerhand')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('biokin_hammerhand')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_BIOKIN_HAMMERHAND_DRAIN",
@@ -515,7 +515,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('biokin_reflex_enhance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('biokin_reflex_enhance')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -576,7 +576,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('biokin_metabolism_enhance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('biokin_metabolism_enhance')", "+=", "psionic_power_experience_formula()" ]
       },
       { "math": [ "u_val('sleep_deprivation')", "-=", "10" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },

--- a/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
@@ -296,9 +296,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('clair_ranged_enhance')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('clair_ranged_enhance')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_RANGED_ENHANCE_DRAIN",

--- a/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
@@ -53,7 +53,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_night_vision')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_night_vision')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_NIGHT_EYES_DRAIN",
@@ -116,7 +116,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_speed_reading')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_speed_reading')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_SPEED_READING_DRAIN",
@@ -175,7 +175,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_see_auras')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_see_auras')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_SEE_AURAS_DRAIN",
@@ -234,7 +234,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_danger_sense')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_danger_sense')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_DANGER_SENSE_DRAIN",
@@ -297,7 +297,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('clair_ranged_enhance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('clair_ranged_enhance')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -357,7 +357,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_dodge_power')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_dodge_power')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_DODGE_POWER_DRAIN",
@@ -440,7 +440,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_craft_bonus')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_craft_bonus')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_CRAFT_BONUS_DRAIN",
@@ -499,7 +499,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 8" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_clear_sight')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_clear_sight')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_CLEAR_SIGHT_DRAIN",
@@ -564,7 +564,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 9" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('clair_group_tactics')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('clair_group_tactics')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_GROUP_TACTICS_DRAIN",

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -38,9 +38,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('electrokinetic_see_electric')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('electrokinetic_see_electric')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_SEE_ELECTRICITY_DRAIN",
@@ -99,9 +97,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('electrokinetic_zap_enemies')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('electrokinetic_zap_enemies')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_ZAP_ENEMIES_DRAIN",
@@ -160,9 +156,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('electrokinetic_melee_attacks')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('electrokinetic_melee_attacks')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_MELEE_ATTACKS_DRAIN",
@@ -258,9 +252,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('electrokinetic_hacking_interface')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('electrokinetic_hacking_interface')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_HACKING_INTERFACE_DRAIN",
@@ -463,9 +455,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('electrokinetic_personal_battery')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('electrokinetic_personal_battery')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_DRAIN",
@@ -523,9 +513,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('electrokinetic_reduce_pain')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('electrokinetic_reduce_pain')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_REDUCE_PAIN_DRAIN",
@@ -584,9 +572,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('electrokinetic_speed_boost')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('electrokinetic_speed_boost')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_SPEED_BOOST_DRAIN",
@@ -650,9 +636,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 8" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('electrokinetic_lightning_aura')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('electrokinetic_lightning_aura')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_ELECTROKIN_LIGHTNING_AURA_DRAIN",

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -39,7 +39,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('electrokinetic_see_electric')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('electrokinetic_see_electric')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -100,7 +100,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('electrokinetic_zap_enemies')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('electrokinetic_zap_enemies')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -161,7 +161,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('electrokinetic_melee_attacks')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('electrokinetic_melee_attacks')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -259,7 +259,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('electrokinetic_hacking_interface')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('electrokinetic_hacking_interface')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -464,7 +464,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('electrokinetic_personal_battery')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('electrokinetic_personal_battery')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -524,7 +524,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('electrokinetic_reduce_pain')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('electrokinetic_reduce_pain')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -585,7 +585,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('electrokinetic_speed_boost')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('electrokinetic_speed_boost')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -651,7 +651,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 8" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('electrokinetic_lightning_aura')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('electrokinetic_lightning_aura')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {

--- a/data/mods/MindOverMatter/powers/photokinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/photokinesis_concentration_eoc.json
@@ -38,9 +38,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('photokinetic_light_local')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('photokinetic_light_local')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_LIGHT_LOCAL_DRAIN",
@@ -99,9 +97,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('photokinetic_light_dodge')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('photokinetic_light_dodge')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_LIGHT_DODGE_DRAIN",
@@ -160,9 +156,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('photokinetic_rad_immunity')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('photokinetic_rad_immunity')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_RAD_IMMUNITY_DRAIN",
@@ -230,9 +224,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('photokinetic_camouflage')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('photokinetic_camouflage')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_CAMOUFLAGE_DRAIN",
@@ -301,9 +293,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('photokinetic_hide_ugly')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('photokinetic_hide_ugly')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_HIDE_UGLY_DRAIN",
@@ -430,9 +420,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('photokinetic_invisibility')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('photokinetic_invisibility')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_INVISIBILITY_DRAIN",
@@ -491,9 +479,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('photokinetic_blinding_glare')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('photokinetic_blinding_glare')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_BLINDING_GLARE_DRAIN",

--- a/data/mods/MindOverMatter/powers/photokinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/photokinesis_concentration_eoc.json
@@ -39,7 +39,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('photokinetic_light_local')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('photokinetic_light_local')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -100,7 +100,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('photokinetic_light_dodge')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('photokinetic_light_dodge')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -161,7 +161,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('photokinetic_rad_immunity')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('photokinetic_rad_immunity')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -231,7 +231,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('photokinetic_camouflage')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('photokinetic_camouflage')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -302,7 +302,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('photokinetic_hide_ugly')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('photokinetic_hide_ugly')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -368,7 +368,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('photokinetic_radio')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('photokinetic_radio')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PHOTOKIN_RADIO_DRAIN",
@@ -431,7 +431,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('photokinetic_invisibility')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('photokinetic_invisibility')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -492,7 +492,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('photokinetic_blinding_glare')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('photokinetic_blinding_glare')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {

--- a/data/mods/MindOverMatter/powers/pyrokinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis_concentration_eoc.json
@@ -75,9 +75,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('pyrokinetic_call_flames')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('pyrokinetic_call_flames')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PYROKIN_CALL_FLAME_DRAIN",
@@ -260,9 +258,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PYROKIN_BLAZING_AURA_DRAIN",
@@ -321,9 +317,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PYROKIN_FLAME_IMMUNITY_DRAIN",

--- a/data/mods/MindOverMatter/powers/pyrokinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis_concentration_eoc.json
@@ -76,7 +76,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('pyrokinetic_call_flames')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('pyrokinetic_call_flames')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -136,7 +136,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('pyrokinetic_cloak')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('pyrokinetic_cloak')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PYROKIN_WARMTH_CLOAK_DRAIN",
@@ -201,7 +201,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('pyrokinetic_lance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('pyrokinetic_lance')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_PYROKIN_TORCH_WELD_DRAIN",
@@ -261,7 +261,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -322,7 +322,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {

--- a/data/mods/MindOverMatter/powers/telekinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_concentration_eoc.json
@@ -39,7 +39,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('telekinetic_momentum')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('telekinetic_momentum')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -103,7 +103,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('telekinetic_water_walk')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('telekinetic_water_walk')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -245,7 +245,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('telekinetic_lifting_field')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('telekinetic_lifting_field')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -306,7 +306,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('telekinetic_strength')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('telekinetic_strength')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -366,7 +366,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telekinetic_shield')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('telekinetic_shield')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_SHIELD_DRAIN",
@@ -536,7 +536,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('telekinetic_vehicle_lift')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('telekinetic_vehicle_lift')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -600,7 +600,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('telekinetic_levitation')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('telekinetic_levitation')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {

--- a/data/mods/MindOverMatter/powers/telekinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_concentration_eoc.json
@@ -38,9 +38,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('telekinetic_momentum')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('telekinetic_momentum')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_MOMENTUM_DRAIN",
@@ -102,9 +100,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('telekinetic_water_walk')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('telekinetic_water_walk')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_WATER_WALKING_DRAIN",
@@ -244,9 +240,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('telekinetic_lifting_field')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('telekinetic_lifting_field')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_LIFTING_FIELD_DRAIN",
@@ -305,9 +299,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('telekinetic_strength')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('telekinetic_strength')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_STRENGTH_DRAIN",
@@ -535,9 +527,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('telekinetic_vehicle_lift')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('telekinetic_vehicle_lift')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_SUMMON_JACKING_TOOL_DRAIN",
@@ -599,9 +589,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('telekinetic_levitation')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('telekinetic_levitation')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEKIN_LEVITATION_DRAIN",

--- a/data/mods/MindOverMatter/powers/telepathy_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_concentration_eoc.json
@@ -38,9 +38,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('telepathic_concentration')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('telepathic_concentration')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPATH_CONCENTRATION_DRAIN",
@@ -158,9 +156,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('telepathic_mind_sense')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('telepathic_mind_sense')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPATH_SENSE_MINDS_DRAIN",

--- a/data/mods/MindOverMatter/powers/telepathy_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_concentration_eoc.json
@@ -39,7 +39,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('telepathic_concentration')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('telepathic_concentration')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -99,7 +99,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telepathic_shield')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('telepathic_shield')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPATH_SHIELD_DRAIN",
@@ -159,7 +159,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('telepathic_mind_sense')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('telepathic_mind_sense')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -238,7 +238,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('telepathic_morale')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('telepathic_morale')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "u_add_morale": "morale_telepathy",

--- a/data/mods/MindOverMatter/powers/teleportation_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_concentration_eoc.json
@@ -38,7 +38,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 3" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('teleport_stride')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('teleport_stride')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPORT_STRIDE_DRAIN",
@@ -98,7 +98,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('teleport_ephemeral_walk')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('teleport_ephemeral_walk')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -159,7 +159,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('teleport_reactive_displacement') += (psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('teleport_reactive_displacement') += psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
@@ -221,7 +221,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       {
-        "math": [ "u_spell_exp('teleport_loci_establishment') +=(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('teleport_loci_establishment') +=psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {

--- a/data/mods/MindOverMatter/powers/teleportation_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_concentration_eoc.json
@@ -97,9 +97,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('teleport_ephemeral_walk')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('teleport_ephemeral_walk')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPORT_EPHEMERAL_WALK_DRAIN",
@@ -158,9 +156,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('teleport_reactive_displacement') += psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('teleport_reactive_displacement') += psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPORT_REACTIVE_DISPLACEMENT_DRAIN",
@@ -220,9 +216,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 6" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      {
-        "math": [ "u_spell_exp('teleport_loci_establishment') +=psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('teleport_loci_establishment') +=psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_TELEPORT_LOCI_ESTABLISHMENT_DRAIN",

--- a/data/mods/MindOverMatter/powers/vitakinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_concentration_eoc.json
@@ -60,7 +60,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('vita_slow_bleeding')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_slow_bleeding')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_SLOW_BLEEDING_DRAIN",
@@ -119,7 +119,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 1" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('vita_health_power')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_health_power')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_HEALTH_POWER_DRAIN",
@@ -372,7 +372,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 2" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('vita_slow_bleeding')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_slow_bleeding')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_CONCENTRATED_HEALING_DRAIN",
@@ -438,7 +438,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 4" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('vita_cure_disease')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_cure_disease')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_CURE_DISEASE_DRAIN",
@@ -515,7 +515,7 @@
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty = 9" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
-      { "math": [ "u_spell_exp('vita_super_heal')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_super_heal')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_SUPER_HEAL_DRAIN",
@@ -586,7 +586,7 @@
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       { "math": [ "u_vitakin_return_from_death_kcal = u_calories()" ] },
       {
-        "math": [ "u_spell_exp('vita_return_from_death')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('vita_return_from_death')", "+=", "psionic_power_experience_formula()" ]
       },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {

--- a/data/mods/MindOverMatter/powers/vitakinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_concentration_eoc.json
@@ -585,9 +585,7 @@
       { "math": [ "u_latest_channeled_power_difficulty = 10" ] },
       { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
       { "math": [ "u_vitakin_return_from_death_kcal = u_calories()" ] },
-      {
-        "math": [ "u_spell_exp('vita_return_from_death')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('vita_return_from_death')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_VITAKIN_RETURN_FROM_DEATH_DRAIN",

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -220,9 +220,7 @@
     "condition": { "u_has_effect": "effect_vitakin_wakeful_resting" },
     "effect": [
       { "if": { "math": [ "u_val('focus') >= 25" ] }, "then": { "math": [ "u_val('focus')", "-=", "rand(10) + 5" ] } },
-      {
-        "math": [ "u_spell_exp('vita_sleeping_trance')", "+=", "psionic_power_experience_formula()" ]
-      },
+      { "math": [ "u_spell_exp('vita_sleeping_trance')", "+=", "psionic_power_experience_formula()" ] },
       {
         "run_eocs": "EOC_VITAKIN_SLEEP_EXPERIENCE",
         "time_in_future": [

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -221,7 +221,7 @@
     "effect": [
       { "if": { "math": [ "u_val('focus') >= 25" ] }, "then": { "math": [ "u_val('focus')", "-=", "rand(10) + 5" ] } },
       {
-        "math": [ "u_spell_exp('vita_sleeping_trance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ]
+        "math": [ "u_spell_exp('vita_sleeping_trance')", "+=", "psionic_power_experience_formula()" ]
       },
       {
         "run_eocs": "EOC_VITAKIN_SLEEP_EXPERIENCE",
@@ -341,7 +341,7 @@
     "condition": { "u_has_effect": "effect_vitakin_healing_trance" },
     "effect": [
       { "if": { "math": [ "u_val('focus') >= 25" ] }, "then": { "math": [ "u_val('focus')", "-=", "rand(10) + 5" ] } },
-      { "math": [ "u_spell_exp('vita_healing_trance')", "+=", "(psionic_power_experience_formula(u_val('focus')))" ] },
+      { "math": [ "u_spell_exp('vita_healing_trance')", "+=", "psionic_power_experience_formula()" ] },
       {
         "run_eocs": "EOC_VITAKIN_HEALING_TRANCE_EXPERIENCE",
         "time_in_future": [

--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -1410,6 +1410,7 @@ These can be read or written to with `val()`.
 | `sleepiness` | ✅ | Current sleepiness level. |
 | `fine_detail_vision_mod` | ❌ | Returned values range from 1.0 (unimpeded vision) to 11.0 (totally blind). |
 | `focus` | ✅ | Current focus level. |
+| `focus_effective` | ❌ | Effective focus level, modified by focus enchants. |
 | `friendly` | ✅ | Current friendly level. Only works for monsters. |
 | `grab_strength` | ❌ | Grab strength as defined in the monster definition. Only works for monsters |
 | `height` | ✅ | Current height in cm. When setting there is a range for your character size category. Setting it too high or low will use the limit instead. For tiny its 58, and 87. For small its 88 and 144. For medium its 145 and 200. For large its 201 and 250. For huge its 251 and 320. |

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10074,7 +10074,7 @@ std::unordered_set<trait_id> Character::get_opposite_traits( const trait_id &fla
     return traits;
 }
 
-float Character::adjust_for_focus( float amount ) const
+int Character::get_effective_focus() const
 {
     int effective_focus = get_focus();
     effective_focus = enchantment_cache->modify_value( enchant_vals::mod::LEARNING_FOCUS,
@@ -10082,8 +10082,12 @@ float Character::adjust_for_focus( float amount ) const
     effective_focus *= 1.0 + ( 0.01f * ( get_int() -
                                          get_option<int>( "INT_BASED_LEARNING_BASE_VALUE" ) ) *
                                get_option<int>( "INT_BASED_LEARNING_FOCUS_ADJUSTMENT" ) );
-    effective_focus = std::max( effective_focus, 1 );
-    return amount * ( effective_focus / 100.0f );
+    return std::max( effective_focus, 1 );
+}
+
+float Character::adjust_for_focus( float amount ) const
+{
+    return amount * ( get_effective_focus() / 100.0f );
 }
 
 std::function<bool( const tripoint_bub_ms & )> Character::get_path_avoid() const

--- a/src/character.h
+++ b/src/character.h
@@ -2795,6 +2795,7 @@ class Character : public Creature, public visitable
         int get_focus() const {
             return std::max( 1, focus_pool / 1000 );
         }
+        int get_effective_focus() const;
         void mod_focus( int amount ) {
             focus_pool += amount * 1000;
             focus_pool = std::max( focus_pool, 0 );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2299,6 +2299,7 @@ std::unordered_map<std::string_view, int ( const_talker::* )() const> const f_ge
     { "sleepiness", &const_talker::get_sleepiness },
     { "fine_detail_vision_mod", &const_talker::get_fine_detail_vision_mod },
     { "focus", &const_talker::focus_cur },
+    { "focus_effective", &const_talker::focus_effective_cur },
     { "friendly", &const_talker::get_friendly },
     { "grab_strength", &const_talker::get_grab_strength },
     { "height", &const_talker::get_height },

--- a/src/talker.h
+++ b/src/talker.h
@@ -551,6 +551,9 @@ class const_talker
         virtual int focus_cur() const {
             return 0;
         }
+        virtual int focus_effective_cur() const {
+            return 0;
+        }
         virtual int get_pkill() const {
             return 0;
         }

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -928,6 +928,11 @@ int talker_character_const::focus_cur() const
     return me_chr_const->get_focus();
 }
 
+int talker_character_const::focus_effective_cur() const
+{
+    return me_chr_const->get_effective_focus();
+}
+
 void talker_character::mod_focus( int amount )
 {
     me_chr->mod_focus( amount );

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -193,6 +193,7 @@ class talker_character_const: virtual public const_talker
         bool can_see_location( const tripoint_bub_ms &pos ) const override;
         int morale_cur() const override;
         int focus_cur() const override;
+        int focus_effective_cur() const override;
         int get_rad() const override;
         int get_stim() const override;
         int get_addiction_intensity( const addiction_id &add_id ) const override;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Make experience formulas take into account focus enchants"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Realized that u_val('focus') doesn't return the modified focus value altered by traits such as fast learner or effects such as concentration trance, and that there isn't any way to get this value in jmath.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add focus_effective to u_val() options, which returns a characters focus modified by the LEARNING_FOCUS enchant and the INT_BASED_LEARNING game options, which is what is used for other focus calculations in c.
Apply this focus_effective value to MOM's experience formulas.
Minor amounts of refactoring in the experience formula definitions.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added a print statement in neuro acceleration drain eoc that printed the power experience formula value
Observed that adding fast_learner and concentration trance modified how much experience was being gained by the neuro acceleration's concentration eoc
Also checked that normal powers experience gain is changed by effective focus

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
