### PR TITLE
Add message when trying to hack unhackable card-readers

### DIFF
--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -196,6 +196,8 @@ void cardreader_examine_actor::call( Character &you, const tripoint_bub_ms &exam
     } else if( allow_hacking && iexamine::can_hack( you ) &&
                query_yn( _( "Attempt to hack this card-reader?" ) ) ) {
         iexamine::try_start_hacking( you, examp );
+    } else if( !allow_hacking && iexamine::can_hack( you ) ) {
+        add_msg( _( "This card-reader cannot be hacked." ) );
     }
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Partially resolves #79193
Previously when you examined a unhackable card-reader with a functional hacking tool, nothing would happen, which was confusing.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a message when examining a unhackable card-reader.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Examine unhackable reader, get message
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
@kevingranade is there a reason some readers introduced in #50033 are unhackable? EG `t_card_science_transport_1`
There doesn't seem to be anything that differentiates them to explain it. Maybe the description should be updated to mention why they are unhackable?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
