### PR TITLE
Simple parts are always simple

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4620,9 +4620,7 @@ bool vehicle::would_repair_prevent_flyable( const vehicle_part &vp, const Charac
     if( flyable && !rotors.empty() ) {
         if( vp.info().has_flag( "SIMPLE_PART" ) ||
             vp.info().has_flag( "AIRCRAFT_REPAIRABLE_NOPROF" ) ) {
-            vpart_position vppos = vpart_position( const_cast<vehicle &>( *this ),
-                                                   index_of_part( const_cast<vehicle_part *>( &vp ) ) );
-            return !vppos.is_inside();
+            return false;
         } else {
             return !pc.has_proficiency( proficiency_prof_aircraft_mechanic );
         }


### PR DESCRIPTION
#### Summary
Bugfixes "Can always repair simple parts on helicopters, inside or outside"

#### Purpose of change
vehicle::would_repair_prevent_flyable is a bit weird. For simple parts it checks if the part is outside. For some reason, a simple part is no longer simple if it's on the outside. But then why have the flag at all?

It doesn't check the aircraft mechanic proficiency at all for such simple parts(!). Which means that someone with the (debug only) proficiency could still not repair a simple part, by 'virtue' of the part being on the outside of the helicopter.

#### Describe the solution
Simple:

Simple parts are always simple.

Align the functionality of these two flags with their actually documented effect.

The debug proficiency remains as permissive as possible (although we still don't bother evaluating it if we're dealing with a simple part).

#### Describe alternatives you've considered
-Introduce more finely grained flags. SIMPLE_PART_INSIDE, SIMPLE_PART_OUTSIDE, etc. Needless.

-Change the order of evaluation so the proficiency is checked first. But then the weirdness with simple parts would remain

#### Testing
Did not personally test. Pretty simple code change IMO.
Testing suggestions for mergers:
Add SIMPLE_PART to one of the parts of the 'wings' of the apache helicopter. Try to repair, notice failure.

Apply patch. Try to repair, notice success.

#### Additional context
