### PR TITLE
Expand responses for first exodii mission

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -273,6 +273,7 @@
       "//~": "It's a bit of a surprise, isn't it?  Before we came here, we were in a place about 600 years earlier in time, or so.  We landed in the middle of a war that turned wrong when the dead started joining back in.  Truth be told, not a very unusual situation.  The Enemy makes us fight.  By and by, we came in, and by then the killing fields were ready for us to harvest their bronze.  It's not Avalonian steel, but it's a good strong metal for stopping a nibbling mouth, so we kept some of their armor and weapons to trade.",
       "str": "That be a right welcher, eh?  Afore us'n were to this land, the preface were on a half-score century by the reckonin'.  Landed us in amidst of a war'd turned wrong, for an' as the dead had come back in.  By the butcher's block, not much an unusual case, really.  The Enemy makes us fight.  By an' by, we came in, an' by then the killin' fields were plump and ready to harvest the bronze.  'Tain't no steel-of-the-lake, but 'tis a good dross metal for holdin' off a nibblin' mouth, so we kept a few o' their vestments an' stickers for to trade."
     },
+    "speaker_effect": { "effect": { "u_add_var": "u_talk_exodii_about_medieval_stock", "value": "yes" } },
     "responses": [
       {
         "text": "You seem to have a bunch of blueprints.  Can you tell me more about those?",
@@ -1447,6 +1448,7 @@
       "//~": "Aside from just having a safe place to live?  We're here to mine, you understand.  Picking the scraps, seeing if this world has any tech worth reverse engineering.  No sense letting good scraps go to waste.  If we're lucky, maybe we'll get some new Exodii before we teleport out.  Pickin' up the pieces of our sweet, shattered dreams, such as they are.",
       "str": "Aside from jus' livin' in such a cozy nook?  Us be minin', ye kennit.  Pickin' the scraps, seein' if for your otherland has any tech worth an upside-down.  No sense lettin' good scraps go to waste.  If we're lucky, pickin' a few new Exodii afore we wobble out.  Pickin' up the pieces of our sweet, shattered dreams, suchlike."
     },
+    "speaker_effect": { "effect": { "u_add_var": "u_know_exodii_purpose2", "value": "yes" } },
     "responses": [
       {
         "text": "What do you mean 'go to waste'?  The zombies aren't using the scrap, and there's plenty to go around.",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -597,12 +597,7 @@
         "text": "Actually I was just joking. Our meeting is indeed a fortunate accident but now that I have your attention would you be interested in trading in some goods?",
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO",
         "trial": { "type": "LIE", "difficulty": 80 },
-        "failure": {
-          "effect": [
-            { "u_add_faction_trust": -3 },
-            { "u_add_effect": "robofac_surveillance", "duration": "30 days" }
-          ]
-        }
+        "failure": { "effect": [ { "u_add_faction_trust": -3 }, { "u_add_effect": "robofac_surveillance", "duration": "30 days" } ] }
       },
       {
         "text": "Some mercenaries I met mentioned this place, said its a good place to find some work and possibly some valuable post-apocalyptic gear.",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -561,7 +561,7 @@
         "effect": [ { "math": [ "u_talked_to_hub = 1" ] } ]
       },
       {
-        "text": "Well truth be told, this encouter ain't quite so random.",
+        "text": "Well truth be told, this encounter ain't quite so random.",
         "condition": {
           "and": [
             { "compare_string": [ "yes", { "u_val": "mission_completed_u_scouted_bunker" } ] },
@@ -591,7 +591,7 @@
   {
     "id": "TALK_ROBOFAC_WHO_SENT_YOU",
     "type": "talk_topic",
-    "dynamic_line": "We are listening…\n\nYou detect a slight elevation in their voice, with a start you realise they are nervous.",
+    "dynamic_line": "We are listening…\n\nYou detect a slight elevation in their voice, with a start you realize they are nervous.",
     "responses": [
       {
         "text": "Actually I was just joking.  Our meeting is indeed a fortunate accident but now that I have your attention would you be interested in trading in some goods?",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -192,7 +192,8 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] } },
-            { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_1" } }
+            { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_1" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "u_informed_robofac_of_exodii" } ] } }
           ]
         }
       },
@@ -202,7 +203,29 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] } },
-            { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_1" }
+            { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_1" },
+            { "not": { "compare_string": [ "yes", { "u_val": "u_informed_robofac_of_exodii" } ] } }
+          ]
+        }
+      },
+      {
+        "text": "[Press the button.]",
+        "topic": "TALK_ROBOFAC_INTERCOM_INTRO_3",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "u_informed_robofac_of_exodii" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] } }
+          ]
+        }
+      },
+      {
+        "text": "[Press the button.]",
+        "topic": "TALK_ROBOFAC_INTERCOM_INTRO_4",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] } }
           ]
         }
       },
@@ -537,6 +560,17 @@
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO_2",
         "effect": [ { "math": [ "u_talked_to_hub = 1" ] } ]
       },
+      {
+        "text": "Well truth be told, this encouter ain't quite so random.",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "mission_completed_u_scouted_bunker" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "u_informed_robofac_of_exodii" } ] } }
+          ]
+        },
+        "topic": "TALK_EXODII_EXISTENCE",
+        "effect": [ { "math": [ "u_talked_to_hub = 1" ] } ]
+      },
       { "text": "[Leave.]", "topic": "TALK_DONE" }
     ]
   },
@@ -552,6 +586,217 @@
     "responses": [
       { "text": "I'm listening.", "topic": "MISSION_ROBOFAC_INTERCOM_1_OFFER" },
       { "text": "Risk my neck for the privilege of trading with you?  Maybe another time.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_EXISTENCE",
+    "type": "talk_topic",
+    "dynamic_line": "We are listening...\n\nYou detect a slight elevation in their voice, with a start you realise they are nervous.",
+    "responses": [
+      {
+      "text": "Actually I was just joking. Our meeting is indeed a fortunate accident but now that I have your attention would you be interested in trading in some goods?",
+      "topic": "TALK_ROBOFAC_INTERCOM_INTRO",
+      "trial": { "type": "LIE", "difficulty": 90 },
+      "failure": {
+        "effect": { "u_add_faction_trust": -3 }
+      }
+    },
+      { "text": "A bunch of high tech dudes have scouted out this place and wanted me to check it out.",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] } },
+        "topic": "TALK_ABOUT_EXODII_1"
+      },
+      {
+        "text": "I am in tight with a bunch of inter-dimensional travellers who observed this base and sent me out to investigate this place.",
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] },
+        "topic": "TALK_ABOUT_EXODII_2"
+      }
+    ]
+  },
+  {
+    "id": "TALK_ABOUT_EXODII_1",
+    "type": "talk_topic",
+    "dynamic_line": "I see and do you have more information regarding these interested parties?",
+    "speaker_effect": {
+      "effect": [
+        { "u_add_var": "u_informed_robofac_of_exodii", "value": "yes" },
+        { "math": [ "hub01_knows_exodii = 1" ] },
+        { "u_add_effect": "robofac_surveillance", "duration": "30 days" },
+        { "u_add_faction_trust": 1 }
+      ]
+    },
+    "responses": [
+      { "text": "Not really.", "topic": "TALK_EXODII_MORE_INFO" },
+      { "text": "Not much actually but I do know they have pretty sweet looking technology as I saw them having advanced machinery everywhere. Nothing like I've ever seen.", "topic": "TALK_EXODII_MORE_INFO" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MORE_INFO",
+    "type": "talk_topic",
+    "dynamic_line": "We need more information on these folks, we will be making covert visual contact ourselves but for obvious reasons we can't get inside information without alerting these guys. That's where you come in...we want you to gather as much information on these people without raising any suspicions and bring it back to us. Most importantly find who they are and why are they here.",
+    "responses": [
+      { "text": "Right. I'll be back with the juicy details.", "topic": "TALK_DONE" },
+      { "text": "I don't know man sounds kind of dangerous. What can I expect in return?", "topic": "TALK_EXODII_INFO_REWARD" },
+      { "text": "Absolutely not, these guys are far more powerful than me and one wrong move will get me killed, besides I'm no rat.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ABOUT_EXODII_2",
+    "type": "talk_topic",
+    "dynamic_line": "Inter-dimensional travellers you say? What kind of tech do these beings operate? And how were you able to communicate with them?",
+    "speaker_effect": {
+      "effect": [
+        { "u_add_var": "u_informed_robofac_of_exodii", "value": "yes" },
+        { "math": [ "hub01_knows_exodii = 1" ] },
+        { "u_add_effect": "robofac_surveillance", "duration": "30 days" },
+        { "u_add_faction_trust": 1 }
+      ]
+    },
+    "responses": [
+      { "text": "Alright listen up.", "topic": "TALK_GIVE_EXODII_INFO" },
+      { "text": "Information doesn't come cheap my friend.", "topic": "TALK_EXODII_INFO_REWARD" },
+      { "text": "I've said more than I ought to have. I'm leaving.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_GIVE_EXODII_INFO",
+    "type": "talk_topic",
+    "dynamic_line": "Well?",
+    "speaker_effect": {
+      "effect": [
+        { "u_add_var": "u_give_robofac_exodii_info", "value": "yes" }
+      ]
+    },
+    "responses": [
+      {
+        "text": "They are a race of inter-dimensional beings. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
+        "topic": "TALK_FINISH_EXODII_DISCUSSION",
+        "effect": { "u_add_faction_trust": 1 }
+      },
+      {
+        "text": "They are a race of inter-dimensional beings and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. While their choice for personal defense was more along the lines of ancient gear like spears and swords. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
+        "topic": "TALK_FINISH_EXODII_DISCUSSION",
+        "condition": { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] },
+        "effect": { "u_add_faction_trust": 2 }
+      },
+      {
+        "text": "They are a race of inter-dimensional beings. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic. They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "topic": "TALK_FINISH_EXODII_DISCUSSION",
+        "condition": { "compare_string": [ "yes", { "u_val": "u_know_exodii_purpose2" } ] },
+        "effect": { "u_add_faction_trust": 2 }
+      },
+      {
+        "text": "They are a race of inter-dimensional beings and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. However their choice for personal defense was more along the lines of ancient gear like spears and swords. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic. They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "topic": "TALK_FINISH_EXODII_DISCUSSION",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "u_know_exodii_purpose2" } ] },
+            { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] }
+          ]
+        },
+        "effect": { "u_add_faction_trust": 3 }
+      }
+    ]
+  },
+  {
+    "id": "TALK_FINISH_EXODII_DISCUSSION",
+    "type": "talk_topic",
+    "dynamic_line": "Thank you for bring this information to us...",
+    "responses": [
+      { "text": "Let's talk reward.", "topic": "TALK_EXODII_INFO_REWARD" },
+      {
+        "text": "No problem, if you ask me to choose between us and aliens you best believe I ain't betraying my race. Is there anything else I can do for you guys?",
+        "topic": "TALK_ROBOFAC_INTERCOM_INTRO_4",
+        "effect": [ { "u_add_faction_trust": 2 } ]
+      }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_INFO_REWARD",
+    "type": "talk_topic",
+    "dynamic_line": "For your service rendered we can either offer you some riot gear armor or the USP 9x19mm pistol with compatible magazines.",
+    "responses": [
+      {
+        "text": "Sounds equitable to me be back with that information in a jiff",
+        "topic": "TALK_DONE",
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] } }
+          ]
+        }
+      },
+      {
+        "text": "That's too little for a whole lot of risk. I'll pass on this.",
+        "topic": "TALK_DONE",
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] } }
+          ]
+        }
+      },
+      {
+        "text": "Deal! Now listen close..",
+        "topic": "TALK_GIVE_EXODII_INFO",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] } }
+          ]
+        }
+      },
+      {
+        "text": "I'll take the riot armor.",
+        "topic": "TALK_ROBOFAC_INTERCOM_INTRO_4",
+        "condition": { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] },
+        "effect": [
+          { "u_spawn_item": "armor_riot" }
+        ]
+      },
+      {
+        "text": "I'll take the USP.",
+        "condition": { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] },
+        "topic": "TALK_ROBOFAC_INTERCOM_INTRO_4",
+        "effect": [
+          { "u_spawn_item": "usp_9mm" },
+          { "u_spawn_item": "usp9mag", "count": 2 }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_INTRO_3",
+    "type": "talk_topic",
+    "dynamic_line": "Ah its you. Mind giving your fellow American information regarding possible terrorist aliens?",
+    "responses": [
+      {
+        "text": "You know what? I've changed my mind. I'll do your dirty work. Give me some time to chat up these folks",
+        "topic": "TALK_DONE",
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] } }
+          ]
+        }
+      },
+      { "text": "Please... I stopped being an American the moment the government left us to fend for ourselves.", "topic": "TALK_DONE" },
+      {
+        "text": "Fine. I'll tell you about these inter-dimensional beings.",
+        "topic": "TALK_ABOUT_EXODII_2",
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_INTRO_4",
+    "type": "talk_topic",
+    "dynamic_line": "There is something else that has come up on our side which requires some field agents. Would you like to hear about it?",
+    "responses": [
+      {
+        "text": "Sounds like you have work for me? Count me in.",
+        "topic": "MISSION_ROBOFAC_INTERCOM_1_OFFER"
+      },
+      { "text": "Maybe not right now.", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -603,12 +603,7 @@
         "text": "Some mercenaries I met mentioned this place, said its a good place to find some work and possibly some valuable post-apocalyptic gear.",
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO",
         "trial": { "type": "LIE", "difficulty": 90 },
-        "failure": {
-          "effect": [
-            { "u_add_faction_trust": -3 },
-            { "u_add_effect": "robofac_surveillance", "duration": "30 days" }
-          ]
-        }
+        "failure": { "effect": [ { "u_add_faction_trust": -3 }, { "u_add_effect": "robofac_surveillance", "duration": "30 days" } ] }
       },
       {
         "text": "You guys aren't as slick as you think. You think no one's gonna notice a pristine looking meteorological station in the middle of nowhere with not a potted plant out of place?",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -591,10 +591,10 @@
   {
     "id": "TALK_ROBOFAC_WHO_SENT_YOU",
     "type": "talk_topic",
-    "dynamic_line": "We are listening...\n\nYou detect a slight elevation in their voice, with a start you realise they are nervous.",
+    "dynamic_line": "We are listening…\n\nYou detect a slight elevation in their voice, with a start you realise they are nervous.",
     "responses": [
       {
-        "text": "Actually I was just joking. Our meeting is indeed a fortunate accident but now that I have your attention would you be interested in trading in some goods?",
+        "text": "Actually I was just joking.  Our meeting is indeed a fortunate accident but now that I have your attention would you be interested in trading in some goods?",
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO",
         "trial": { "type": "LIE", "difficulty": 80 },
         "failure": { "effect": [ { "u_add_faction_trust": -3 }, { "u_add_effect": "robofac_surveillance", "duration": "30 days" } ] }
@@ -606,7 +606,7 @@
         "failure": { "effect": [ { "u_add_faction_trust": -3 }, { "u_add_effect": "robofac_surveillance", "duration": "30 days" } ] }
       },
       {
-        "text": "You guys aren't as slick as you think. You think no one's gonna notice a pristine looking meteorological station in the middle of nowhere with not a potted plant out of place?",
+        "text": "You guys aren't as slick as you think.  You think no one's gonna notice a pristine looking meteorological station in the middle of nowhere with not a potted plant out of place?",
         "topic": "TALK_ROBOFAC_EXODII_EXISTENCE"
       }
     ]
@@ -643,7 +643,7 @@
     "responses": [
       { "text": "Not really.", "topic": "TALK_ROBOFAC_EXODII_MORE_INFO" },
       {
-        "text": "Not much actually but I do know they have pretty sweet looking technology as I saw them having advanced machinery everywhere. Nothing like I've ever seen.",
+        "text": "Not much actually but I do know they have pretty sweet looking technology as I saw them having advanced machinery everywhere.  Nothing like I've ever seen.",
         "topic": "TALK_ROBOFAC_EXODII_MORE_INFO"
       }
     ]
@@ -651,11 +651,11 @@
   {
     "id": "TALK_ROBOFAC_EXODII_MORE_INFO",
     "type": "talk_topic",
-    "dynamic_line": "We need more information on these folks, we will be making covert visual contact ourselves but for obvious reasons we can't get inside information without alerting these guys. That's where you come in...we want you to gather as much information on these people without raising any suspicions and bring it back to us. Most importantly find who they are and why are they here.",
+    "dynamic_line": "We need more information on these folks, we will be making covert visual contact ourselves but for obvious reasons we can't get inside information without alerting these guys. That's where you come in…we want you to gather as much information on these people without raising any suspicions and bring it back to us.  Most importantly find who they are and why are they here.",
     "responses": [
-      { "text": "Right. I'll be back with the juicy details.", "topic": "TALK_DONE" },
+      { "text": "Right.  I'll be back with the juicy details.", "topic": "TALK_DONE" },
       {
-        "text": "I don't know man sounds kind of dangerous. What can I expect in return?",
+        "text": "I don't know man sounds kind of dangerous.  What can I expect in return?",
         "topic": "TALK_ROBOFAC_EXODII_INFO_REWARD"
       },
       {
@@ -679,7 +679,7 @@
     "responses": [
       { "text": "Alright listen up.", "topic": "TALK_GIVE_ROBOFAC_EXODII_INFO" },
       { "text": "Information doesn't come cheap my friend.", "topic": "TALK_ROBOFAC_EXODII_INFO_REWARD" },
-      { "text": "I've said more than I ought to have. I'm leaving.", "topic": "TALK_DONE" }
+      { "text": "I've said more than I ought to have.  I'm leaving.", "topic": "TALK_DONE", "effect": { "u_add_faction_trust": -1 } }
     ]
   },
   {
@@ -689,24 +689,24 @@
     "speaker_effect": { "effect": [ { "u_add_var": "u_give_robofac_exodii_info", "value": "yes" } ] },
     "responses": [
       {
-        "text": "They are a race of inter-dimensional beings who call themseleves the Exodii. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii.  I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "effect": { "u_add_faction_trust": 1 }
       },
       {
-        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. While their choice for personal defense was more along the lines of ancient gear like spears and swords. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort.  I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting.  While their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] },
         "effect": { "u_add_faction_trust": 2 }
       },
       {
-        "text": "They are a race of inter-dimensional beings who call themselves the Exodii. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic. They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii.  I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": { "compare_string": [ "yes", { "u_val": "u_know_exodii_purpose2" } ] },
         "effect": { "u_add_faction_trust": 2 }
       },
       {
-        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. However their choice for personal defense was more along the lines of ancient gear like spears and swords. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic. They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort.  I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. However their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": {
           "and": [
@@ -721,11 +721,11 @@
   {
     "id": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
     "type": "talk_topic",
-    "dynamic_line": "Thank you for bringing this information to us...",
+    "dynamic_line": "Thank you for bringing this information to us…",
     "responses": [
       { "text": "Let's talk reward.", "topic": "TALK_ROBOFAC_EXODII_INFO_REWARD" },
       {
-        "text": "No problem, if you ask me to choose between us and cyborg tyrants, you best believe I ain't betraying my race. It's unnatural you know? Please let me know if there is anything else I can do for you guys.",
+        "text": "No problem, if you ask me to choose between us and cyborg tyrants, you best believe I ain't betraying my race.  It's unnatural you know? Please let me know if there is anything else I can do for you guys.",
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO_4",
         "effect": [ { "u_add_faction_trust": 2 } ]
       }
@@ -747,7 +747,7 @@
         }
       },
       {
-        "text": "That's too little for a whole lot of risk. I'll pass on this.",
+        "text": "That's too little for a whole lot of risk.  I'll pass on this.",
         "topic": "TALK_DONE",
         "condition": {
           "and": [
@@ -783,10 +783,10 @@
   {
     "id": "TALK_ROBOFAC_INTERCOM_INTRO_3",
     "type": "talk_topic",
-    "dynamic_line": "Ah its you. Mind giving your fellow American information regarding possible terrorist aliens?",
+    "dynamic_line": "Ah its you.  Mind giving your fellow American information regarding possible terrorist aliens?",
     "responses": [
       {
-        "text": "You know what? I've changed my mind. I'll do your dirty work. Give me some time to chat up these folks",
+        "text": "You know what? I've changed my mind.  I'll do your dirty work. Give me some time to chat up these folks",
         "topic": "TALK_DONE",
         "condition": {
           "and": [
@@ -796,11 +796,11 @@
         }
       },
       {
-        "text": "Please... I stopped being an American the moment the government left us to fend for ourselves.",
+        "text": "Please… I stopped being an American the moment the government left us to fend for ourselves.",
         "topic": "TALK_DONE"
       },
       {
-        "text": "Fine. I'll tell you about these inter-dimensional beings.",
+        "text": "Fine.  I'll tell you about these inter-dimensional beings.",
         "topic": "TALK_ROBOFAC_ABOUT_EXODII_2",
         "condition": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] }
       }
@@ -809,7 +809,7 @@
   {
     "id": "TALK_ROBOFAC_INTERCOM_INTRO_4",
     "type": "talk_topic",
-    "dynamic_line": "There is something else that has come up on our side which requires some field agents. Would you like to hear about it?",
+    "dynamic_line": "There is something else that has come up on our side which requires some field agents.  Would you like to hear about it?",
     "responses": [
       { "text": "Sounds like you have work for me? Count me in.", "topic": "MISSION_ROBOFAC_INTERCOM_1_OFFER" },
       { "text": "Maybe not right now.", "topic": "TALK_DONE" }

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -787,7 +787,7 @@
   {
     "id": "TALK_ROBOFAC_INTERCOM_INTRO_3",
     "type": "talk_topic",
-    "dynamic_line": "Ah its you.  Mind giving your fellow American information regarding possible terrorist aliens?",
+    "dynamic_line": "Ah its you.  Mind giving your fellow American information regarding possible terrorist cyborgs?",
     "responses": [
       {
         "text": "You know what?  I've changed my mind.  I'll do your dirty work.  Give me some time to chat up these folks.",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -568,7 +568,7 @@
             { "not": { "compare_string": [ "yes", { "u_val": "u_informed_robofac_of_exodii" } ] } }
           ]
         },
-        "topic": "TALK_EXODII_EXISTENCE",
+        "topic": "TALK_ROBOFAC_WHO_SENT_YOU",
         "effect": [ { "math": [ "u_talked_to_hub = 1" ] } ]
       },
       { "text": "[Leave.]", "topic": "TALK_DONE" }
@@ -589,30 +589,57 @@
     ]
   },
   {
-    "id": "TALK_EXODII_EXISTENCE",
+    "id": "TALK_ROBOFAC_WHO_SENT_YOU",
     "type": "talk_topic",
     "dynamic_line": "We are listening...\n\nYou detect a slight elevation in their voice, with a start you realise they are nervous.",
     "responses": [
       {
         "text": "Actually I was just joking. Our meeting is indeed a fortunate accident but now that I have your attention would you be interested in trading in some goods?",
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO",
+        "trial": { "type": "LIE", "difficulty": 80 },
+        "failure": {
+          "effect": [
+            { "u_add_faction_trust": -3 },
+            { "u_add_effect": "robofac_surveillance", "duration": "30 days" }
+          ]
+        }
+      },
+      {
+        "text": "Some mercenaries I met mentioned this place, said its a good place to find some work and possibly some valuable post-apocalyptic gear.",
+        "topic": "TALK_ROBOFAC_INTERCOM_INTRO",
         "trial": { "type": "LIE", "difficulty": 90 },
-        "failure": { "effect": { "u_add_faction_trust": -3 } }
+        "failure": {
+          "effect": [
+            { "u_add_faction_trust": -3 },
+            { "u_add_effect": "robofac_surveillance", "duration": "30 days" }
+          ]
+        }
       },
       {
-        "text": "A bunch of high tech dudes have scouted out this place and wanted me to check it out.",
-        "condition": { "not": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] } },
-        "topic": "TALK_ABOUT_EXODII_1"
-      },
-      {
-        "text": "I am in tight with a bunch of inter-dimensional travellers who observed this base and sent me out to investigate this place.",
-        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] },
-        "topic": "TALK_ABOUT_EXODII_2"
+        "text": "You guys aren't as slick as you think. You think no one's gonna notice a pristine looking meteorological station in the middle of nowhere with not a potted plant out of place?",
+        "topic": "TALK_ROBOFAC_EXODII_EXISTENCE"
       }
     ]
   },
   {
-    "id": "TALK_ABOUT_EXODII_1",
+    "id": "TALK_ROBOFAC_EXODII_EXISTENCE",
+    "type": "talk_topic",
+    "dynamic_line": "Not without significantly advanced surveillance tech most of which were either decommissioned or destroyed post cataclysm.",
+    "responses": [
+      {
+        "text": "Actually a bunch of high tech dudes HAVE scouted out this place and wanted me to check it out.",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] } },
+        "topic": "TALK_ROBOFAC_ABOUT_EXODII_1"
+      },
+      {
+        "text": "I am in tight with a bunch of inter-dimensional travellers who observed this base and sent me out to investigate this place.",
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] },
+        "topic": "TALK_ROBOFAC_ABOUT_EXODII_2"
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_ABOUT_EXODII_1",
     "type": "talk_topic",
     "dynamic_line": "I see and do you have more information regarding these interested parties?",
     "speaker_effect": {
@@ -624,22 +651,22 @@
       ]
     },
     "responses": [
-      { "text": "Not really.", "topic": "TALK_EXODII_MORE_INFO" },
+      { "text": "Not really.", "topic": "TALK_ROBOFAC_EXODII_MORE_INFO" },
       {
         "text": "Not much actually but I do know they have pretty sweet looking technology as I saw them having advanced machinery everywhere. Nothing like I've ever seen.",
-        "topic": "TALK_EXODII_MORE_INFO"
+        "topic": "TALK_ROBOFAC_EXODII_MORE_INFO"
       }
     ]
   },
   {
-    "id": "TALK_EXODII_MORE_INFO",
+    "id": "TALK_ROBOFAC_EXODII_MORE_INFO",
     "type": "talk_topic",
     "dynamic_line": "We need more information on these folks, we will be making covert visual contact ourselves but for obvious reasons we can't get inside information without alerting these guys. That's where you come in...we want you to gather as much information on these people without raising any suspicions and bring it back to us. Most importantly find who they are and why are they here.",
     "responses": [
       { "text": "Right. I'll be back with the juicy details.", "topic": "TALK_DONE" },
       {
         "text": "I don't know man sounds kind of dangerous. What can I expect in return?",
-        "topic": "TALK_EXODII_INFO_REWARD"
+        "topic": "TALK_ROBOFAC_EXODII_INFO_REWARD"
       },
       {
         "text": "Absolutely not, these guys are far more powerful than me and one wrong move will get me killed, besides I'm no rat.",
@@ -648,7 +675,7 @@
     ]
   },
   {
-    "id": "TALK_ABOUT_EXODII_2",
+    "id": "TALK_ROBOFAC_ABOUT_EXODII_2",
     "type": "talk_topic",
     "dynamic_line": "Inter-dimensional travellers you say? What kind of tech do these beings operate? And how were you able to communicate with them?",
     "speaker_effect": {
@@ -660,37 +687,37 @@
       ]
     },
     "responses": [
-      { "text": "Alright listen up.", "topic": "TALK_GIVE_EXODII_INFO" },
-      { "text": "Information doesn't come cheap my friend.", "topic": "TALK_EXODII_INFO_REWARD" },
+      { "text": "Alright listen up.", "topic": "TALK_GIVE_ROBOFAC_EXODII_INFO" },
+      { "text": "Information doesn't come cheap my friend.", "topic": "TALK_ROBOFAC_EXODII_INFO_REWARD" },
       { "text": "I've said more than I ought to have. I'm leaving.", "topic": "TALK_DONE" }
     ]
   },
   {
-    "id": "TALK_GIVE_EXODII_INFO",
+    "id": "TALK_GIVE_ROBOFAC_EXODII_INFO",
     "type": "talk_topic",
     "dynamic_line": "Well?",
     "speaker_effect": { "effect": [ { "u_add_var": "u_give_robofac_exodii_info", "value": "yes" } ] },
     "responses": [
       {
-        "text": "They are a race of inter-dimensional beings. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
-        "topic": "TALK_FINISH_EXODII_DISCUSSION",
+        "text": "They are a race of inter-dimensional beings who call themseleves the Exodii. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
+        "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "effect": { "u_add_faction_trust": 1 }
       },
       {
-        "text": "They are a race of inter-dimensional beings and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. While their choice for personal defense was more along the lines of ancient gear like spears and swords. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
-        "topic": "TALK_FINISH_EXODII_DISCUSSION",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. While their choice for personal defense was more along the lines of ancient gear like spears and swords. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
+        "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] },
         "effect": { "u_add_faction_trust": 2 }
       },
       {
-        "text": "They are a race of inter-dimensional beings. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic. They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
-        "topic": "TALK_FINISH_EXODII_DISCUSSION",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic. They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": { "compare_string": [ "yes", { "u_val": "u_know_exodii_purpose2" } ] },
         "effect": { "u_add_faction_trust": 2 }
       },
       {
-        "text": "They are a race of inter-dimensional beings and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. However their choice for personal defense was more along the lines of ancient gear like spears and swords. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic. They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
-        "topic": "TALK_FINISH_EXODII_DISCUSSION",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. However their choice for personal defense was more along the lines of ancient gear like spears and swords. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic. They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": {
           "and": [
             { "compare_string": [ "yes", { "u_val": "u_know_exodii_purpose2" } ] },
@@ -702,22 +729,22 @@
     ]
   },
   {
-    "id": "TALK_FINISH_EXODII_DISCUSSION",
+    "id": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
     "type": "talk_topic",
-    "dynamic_line": "Thank you for bring this information to us...",
+    "dynamic_line": "Thank you for bringing this information to us...",
     "responses": [
-      { "text": "Let's talk reward.", "topic": "TALK_EXODII_INFO_REWARD" },
+      { "text": "Let's talk reward.", "topic": "TALK_ROBOFAC_EXODII_INFO_REWARD" },
       {
-        "text": "No problem, if you ask me to choose between us and aliens you best believe I ain't betraying my race. Is there anything else I can do for you guys?",
+        "text": "No problem, if you ask me to choose between us and cyborg tyrants, you best believe I ain't betraying my race. It's unnatural you know? Please let me know if there is anything else I can do for you guys.",
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO_4",
         "effect": [ { "u_add_faction_trust": 2 } ]
       }
     ]
   },
   {
-    "id": "TALK_EXODII_INFO_REWARD",
+    "id": "TALK_ROBOFAC_EXODII_INFO_REWARD",
     "type": "talk_topic",
-    "dynamic_line": "For your service rendered we can either offer you some riot gear armor or the USP 9x19mm pistol with compatible magazines.",
+    "dynamic_line": "For your services rendered we can either offer you some riot gear armor or the USP 9x19mm pistol with compatible magazines.",
     "responses": [
       {
         "text": "Sounds equitable to me be back with that information in a jiff",
@@ -741,7 +768,7 @@
       },
       {
         "text": "Deal! Now listen close..",
-        "topic": "TALK_GIVE_EXODII_INFO",
+        "topic": "TALK_GIVE_ROBOFAC_EXODII_INFO",
         "condition": {
           "and": [
             { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] },
@@ -784,7 +811,7 @@
       },
       {
         "text": "Fine. I'll tell you about these inter-dimensional beings.",
-        "topic": "TALK_ABOUT_EXODII_2",
+        "topic": "TALK_ROBOFAC_ABOUT_EXODII_2",
         "condition": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] }
       }
     ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -651,7 +651,7 @@
   {
     "id": "TALK_ROBOFAC_EXODII_MORE_INFO",
     "type": "talk_topic",
-    "dynamic_line": "We need more information on these folks, we will be making covert visual contact ourselves but for obvious reasons we can't get inside information without alerting these guys. That's where you come in…we want you to gather as much information on these people without raising any suspicions and bring it back to us.  Most importantly find who they are and why are they here.",
+    "dynamic_line": "We need more information on these folks, we will be making covert visual contact ourselves but for obvious reasons we can't get inside information without alerting these guys.  That's where you come in…we want you to gather as much information on these people without raising any suspicions and bring it back to us.  Most importantly find who they are and why are they here.",
     "responses": [
       { "text": "Right.  I'll be back with the juicy details.", "topic": "TALK_DONE" },
       {
@@ -667,7 +667,7 @@
   {
     "id": "TALK_ROBOFAC_ABOUT_EXODII_2",
     "type": "talk_topic",
-    "dynamic_line": "Inter-dimensional travellers you say? What kind of tech do these beings operate? And how were you able to communicate with them?",
+    "dynamic_line": "Inter-dimensional travellers you say?  What kind of tech do these beings operate?  And how were you able to communicate with them?",
     "speaker_effect": {
       "effect": [
         { "u_add_var": "u_informed_robofac_of_exodii", "value": "yes" },
@@ -710,7 +710,7 @@
         "effect": { "u_add_faction_trust": 2 }
       },
       {
-        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting. However their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  However their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": {
           "and": [
@@ -729,7 +729,7 @@
     "responses": [
       { "text": "Let's talk reward.", "topic": "TALK_ROBOFAC_EXODII_INFO_REWARD" },
       {
-        "text": "No problem, if you ask me to choose between us and cyborg tyrants, you best believe I ain't betraying my race.  It's unnatural you know? Please let me know if there is anything else I can do for you guys.",
+        "text": "No problem, if you ask me to choose between us and cyborg tyrants, you best believe I ain't betraying my race.  It's unnatural you know?  Please let me know if there is anything else I can do for you guys.",
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO_4",
         "effect": [ { "u_add_faction_trust": 2 } ]
       }
@@ -761,7 +761,7 @@
         }
       },
       {
-        "text": "Deal! Now listen close..",
+        "text": "Deal!  Now listen close.",
         "topic": "TALK_GIVE_ROBOFAC_EXODII_INFO",
         "condition": {
           "and": [
@@ -790,7 +790,7 @@
     "dynamic_line": "Ah its you.  Mind giving your fellow American information regarding possible terrorist aliens?",
     "responses": [
       {
-        "text": "You know what? I've changed my mind.  I'll do your dirty work. Give me some time to chat up these folks",
+        "text": "You know what?  I've changed my mind.  I'll do your dirty work.  Give me some time to chat up these folks.",
         "topic": "TALK_DONE",
         "condition": {
           "and": [
@@ -815,7 +815,7 @@
     "type": "talk_topic",
     "dynamic_line": "There is something else that has come up on our side which requires some field agents.  Would you like to hear about it?",
     "responses": [
-      { "text": "Sounds like you have work for me? Count me in.", "topic": "MISSION_ROBOFAC_INTERCOM_1_OFFER" },
+      { "text": "Sounds like you have work for me?  Count me in.", "topic": "MISSION_ROBOFAC_INTERCOM_1_OFFER" },
       { "text": "Maybe not right now.", "topic": "TALK_DONE" }
     ]
   },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -594,14 +594,13 @@
     "dynamic_line": "We are listening...\n\nYou detect a slight elevation in their voice, with a start you realise they are nervous.",
     "responses": [
       {
-      "text": "Actually I was just joking. Our meeting is indeed a fortunate accident but now that I have your attention would you be interested in trading in some goods?",
-      "topic": "TALK_ROBOFAC_INTERCOM_INTRO",
-      "trial": { "type": "LIE", "difficulty": 90 },
-      "failure": {
-        "effect": { "u_add_faction_trust": -3 }
-      }
-    },
-      { "text": "A bunch of high tech dudes have scouted out this place and wanted me to check it out.",
+        "text": "Actually I was just joking. Our meeting is indeed a fortunate accident but now that I have your attention would you be interested in trading in some goods?",
+        "topic": "TALK_ROBOFAC_INTERCOM_INTRO",
+        "trial": { "type": "LIE", "difficulty": 90 },
+        "failure": { "effect": { "u_add_faction_trust": -3 } }
+      },
+      {
+        "text": "A bunch of high tech dudes have scouted out this place and wanted me to check it out.",
         "condition": { "not": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] } },
         "topic": "TALK_ABOUT_EXODII_1"
       },
@@ -626,7 +625,10 @@
     },
     "responses": [
       { "text": "Not really.", "topic": "TALK_EXODII_MORE_INFO" },
-      { "text": "Not much actually but I do know they have pretty sweet looking technology as I saw them having advanced machinery everywhere. Nothing like I've ever seen.", "topic": "TALK_EXODII_MORE_INFO" }
+      {
+        "text": "Not much actually but I do know they have pretty sweet looking technology as I saw them having advanced machinery everywhere. Nothing like I've ever seen.",
+        "topic": "TALK_EXODII_MORE_INFO"
+      }
     ]
   },
   {
@@ -635,8 +637,14 @@
     "dynamic_line": "We need more information on these folks, we will be making covert visual contact ourselves but for obvious reasons we can't get inside information without alerting these guys. That's where you come in...we want you to gather as much information on these people without raising any suspicions and bring it back to us. Most importantly find who they are and why are they here.",
     "responses": [
       { "text": "Right. I'll be back with the juicy details.", "topic": "TALK_DONE" },
-      { "text": "I don't know man sounds kind of dangerous. What can I expect in return?", "topic": "TALK_EXODII_INFO_REWARD" },
-      { "text": "Absolutely not, these guys are far more powerful than me and one wrong move will get me killed, besides I'm no rat.", "topic": "TALK_DONE" }
+      {
+        "text": "I don't know man sounds kind of dangerous. What can I expect in return?",
+        "topic": "TALK_EXODII_INFO_REWARD"
+      },
+      {
+        "text": "Absolutely not, these guys are far more powerful than me and one wrong move will get me killed, besides I'm no rat.",
+        "topic": "TALK_DONE"
+      }
     ]
   },
   {
@@ -661,11 +669,7 @@
     "id": "TALK_GIVE_EXODII_INFO",
     "type": "talk_topic",
     "dynamic_line": "Well?",
-    "speaker_effect": {
-      "effect": [
-        { "u_add_var": "u_give_robofac_exodii_info", "value": "yes" }
-      ]
-    },
+    "speaker_effect": { "effect": [ { "u_add_var": "u_give_robofac_exodii_info", "value": "yes" } ] },
     "responses": [
       {
         "text": "They are a race of inter-dimensional beings. I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
@@ -749,18 +753,13 @@
         "text": "I'll take the riot armor.",
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO_4",
         "condition": { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] },
-        "effect": [
-          { "u_spawn_item": "armor_riot" }
-        ]
+        "effect": [ { "u_spawn_item": "armor_riot" } ]
       },
       {
         "text": "I'll take the USP.",
         "condition": { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] },
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO_4",
-        "effect": [
-          { "u_spawn_item": "usp_9mm" },
-          { "u_spawn_item": "usp9mag", "count": 2 }
-        ]
+        "effect": [ { "u_spawn_item": "usp_9mm" }, { "u_spawn_item": "usp9mag", "count": 2 } ]
       }
     ]
   },
@@ -779,7 +778,10 @@
           ]
         }
       },
-      { "text": "Please... I stopped being an American the moment the government left us to fend for ourselves.", "topic": "TALK_DONE" },
+      {
+        "text": "Please... I stopped being an American the moment the government left us to fend for ourselves.",
+        "topic": "TALK_DONE"
+      },
       {
         "text": "Fine. I'll tell you about these inter-dimensional beings.",
         "topic": "TALK_ABOUT_EXODII_2",
@@ -792,10 +794,7 @@
     "type": "talk_topic",
     "dynamic_line": "There is something else that has come up on our side which requires some field agents. Would you like to hear about it?",
     "responses": [
-      {
-        "text": "Sounds like you have work for me? Count me in.",
-        "topic": "MISSION_ROBOFAC_INTERCOM_1_OFFER"
-      },
+      { "text": "Sounds like you have work for me? Count me in.", "topic": "MISSION_ROBOFAC_INTERCOM_1_OFFER" },
       { "text": "Maybe not right now.", "topic": "TALK_DONE" }
     ]
   },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -679,7 +679,11 @@
     "responses": [
       { "text": "Alright listen up.", "topic": "TALK_GIVE_ROBOFAC_EXODII_INFO" },
       { "text": "Information doesn't come cheap my friend.", "topic": "TALK_ROBOFAC_EXODII_INFO_REWARD" },
-      { "text": "I've said more than I ought to have.  I'm leaving.", "topic": "TALK_DONE", "effect": { "u_add_faction_trust": -1 } }
+      {
+        "text": "I've said more than I ought to have.  I'm leaving.",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_faction_trust": -1 }
+      }
     ]
   },
   {

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -689,24 +689,24 @@
     "speaker_effect": { "effect": [ { "u_add_var": "u_give_robofac_exodii_info", "value": "yes" } ] },
     "responses": [
       {
-        "text": "They are a race of inter-dimensional beings who call themselves the Exodii.  I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "effect": { "u_add_faction_trust": 1 }
       },
       {
-        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort.  I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting.  While their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  While their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] },
         "effect": { "u_add_faction_trust": 2 }
       },
       {
-        "text": "They are a race of inter-dimensional beings who call themselves the Exodii.  I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": { "compare_string": [ "yes", { "u_val": "u_know_exodii_purpose2" } ] },
         "effect": { "u_add_faction_trust": 2 }
       },
       {
-        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort.  I observed they were using bionic enhancements and automated machinery to do their fighting and heavy lifting. However their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being a ancient battlefield of some sort.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting. However their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": {
           "and": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Expand story line for Exodii mission 1"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently other than locating the Hub01 the first mission given by Exodii does nothing. This PR is to address that, taking suggestions from #59904 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a bunch of variables according to information you gather from exodii and create custom responses to hub01 based on them. This will increase your respect with the Robofaction. This could cause a fall in respect with the Exodii faction based on whether they find out about your deception.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Go through various dialogue tree based on the information we gathered from the Exodii.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Added stuff:
After getting mission from Rubik to investigate mysterious bunker we have the option to:
1. Lie and tell you got this location from mercenaries or random encounter. Failure will cause faction trust to fall
2. Tell we got it from a high tech faction(trust++ and surveillance)
3. Then we have an option to either tell them more information regarding Exodii(trust++) depending on what we know about the Exodii or refuse information regarding them(this will cause them to keep asking about the Exodii and you can't proceed with the hub missions 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
