### PR TITLE
Make the pump station sewer station stinky

### DIFF
--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -155,7 +155,14 @@
     "id": "sewer_morale_debuff",
     "global": false,
     "recurrence": [ "20 minutes", "1 hour" ],
-    "condition": { "u_at_om_location": "sewer" },
+    "condition": {
+      "or": [
+        { "u_at_om_location": "sewer" },
+        { "u_at_om_location": "pump_station_3" },
+        { "u_at_om_location": "pump_station_4" },
+        { "u_at_om_location": "pump_station_5" }
+      ]
+    },
     "effect": [
       { "u_message": "<SEWER_MORALE_DEBUFF>", "snippet": true },
       {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I've heard in the community discord that the sewer part of the pump station mapgen is not stinky, so for consistency's sake imma stink it.

#### Describe the solution

Add the sewer part of the mapgen to the sewer morale debuff eoc.

#### Describe alternatives you've considered

Not doing so.
#### Testing

After i made the change on my build, i waited in the sewer part of the pump station until i got the morale debuff message.

Forgot to mention that i also waited in the regular sewer mapgen and i also got the morale debuff.
![Screenshot_20250123_014513](https://github.com/user-attachments/assets/fe1dca71-68f3-48b6-8732-04f01f178a48)
![Screenshot_20250123_014459](https://github.com/user-attachments/assets/8258de8a-d546-4c63-81a0-c227b238fe2b)


#### Additional context

Heh.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
