### PR TITLE
[Xedra Evolved] Arvore with enough power have neutrality from the triffids

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -1234,6 +1234,12 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_arvore_attacked_a_triffid",
+    "name": [ "Broken Green Pact " ],
+    "desc": [ "You broke the pact of the green and have no more protection from the triffids' wrath." ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_ierde_slow_enemies",
     "name": [ "Lithic Rigidity " ],
     "desc": [ "It's very hard for you to move." ],

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
@@ -95,6 +95,26 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_ARVORE_LOSE_PACT_OF_GREEN_IF_ATTACKING_TRIFFID",
+    "eoc_type": "EVENT",
+    "required_event": "monster_takes_damage",
+    "condition": { "and": [ { "u_has_species": "PLANT" }, "has_beta" ] },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_ARVORE_LOSE_PACT_OF_GREEN_IF_ATTACKING_TRIFFID_2",
+            "condition": {
+              "and": [ { "npc_has_trait": "ARVORE_TRIFFID_NEUTRALITY" }, { "not": { "npc_has_trait": "effect_arvore_attacked_a_triffid" } } ]
+            },
+            "effect": [ { "npc_add_effect": "effect_arvore_attacked_a_triffid", "duration": { "math": [ "10800 + rand(43200)" ] } } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_ARVORE_BRIARS_SELECTOR",
     "effect": [
       {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
@@ -83,6 +83,18 @@
   },
   {
     "type": "mutation",
+    "id": "ARVORE_TRIFFID_NEUTRALITY",
+    "name": { "str": "Pact of the Green" },
+    "description": "You are in tune with the forest and the triffids will allow you safe passage in their lands, so long as you do not harm them.",
+    "purifiable": false,
+    "valid": false,
+    "points": 3,
+    "visibility": 0,
+    "ugliness": 0,
+    "anger_relations": [ [ "PLANT", -100 ] ]
+  },
+  {
+    "type": "mutation",
     "id": "GREENSTRIDE",
     "name": { "str": "Greenstride" },
     "purifiable": false,

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_mutations.json
@@ -94,7 +94,25 @@
     "allowed_category": [ "ARVORE" ],
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "TREE_COMMUNION_PLUS", "ARVORE_POLLEN_IMMUNE" ]
+    "flags": [ "TREE_COMMUNION_PLUS", "ARVORE_POLLEN_IMMUNE" ],
+    "enchantments": [
+      {
+        "condition": {
+          "and": [
+            { "not": { "u_has_effect": "effect_arvore_attacked_a_triffid" } },
+            {
+              "and": [
+                { "u_has_trait": "ARVORE_VERDANT_HAIR" },
+                { "u_has_any_trait": [ "ARVORE_SKIN_2", "ARVORE_SKIN_3" ] },
+                { "u_has_any_trait": [ "ARVORE_FLORAL_SCENT", "ARVORE_MIND_CONTROL_POLLEN" ] },
+                { "u_has_any_trait": [ "ARVORE_BLOOD", "ARVORE_BLOOD_2", "ARVORE_BLOOD_3", "ARVORE_BLOOD_4" ] }
+              ]
+            }
+          ]
+        },
+        "mutations": [ "ARVORE_TRIFFID_NEUTRALITY" ]
+      }
+    ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Arvore with enough power have neutrality from the triffids"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Triffids have little interest in anything that filthy meatbags think or do. However, Arvore become more and more plantlike as they gain in power (and are never technically animals anyway).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

When Arvore have the following traits: one of Vegetal Cuticle or Bark Skin, Verdant Hair, one of their blood traits, and one of their scent traits, they gain the Pact of the Green trait, making them neutral to triffids. This neutrality is lost for a long time if the Arvore behaves with hostility toward a triffid.

This is done by putting the anger_relations on a mutation and using their Root and Branch trait as a container for it, with conditions on its applicability.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Teleported to triffids, saw that they were hostile.

Gained appropriate minimum traits, triffids became neutral.

Stabbed a triffid, they became hostile again. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
