### PR TITLE
Adjusted pos getter names in vehicle & map_selector

### DIFF
--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -57,7 +57,7 @@ static void serialize_liquid_source( player_activity &act, const vehicle &veh, c
     if( part_num != -1 ) {
         act.coords.push_back( get_map().get_abs( veh.bub_part_pos( part_num ) ) );
     } else {
-        act.coords.push_back( veh.global_square_location() );
+        act.coords.push_back( veh.pos_abs() );
     }
     act.str_values.push_back( serialize( liquid ) );
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14134,8 +14134,8 @@ ret_val<void> item::link_to( vehicle &veh, const point_rel_ms &mount, link_state
 
     // Prepare target tripoints for the cable parts that'll be added to the selected/previous vehicles
     const std::pair<tripoint_abs_ms, tripoint_abs_ms> prev_part_target = std::make_pair(
-                veh.global_square_location() + veh.coord_translate( mount ),
-                veh.global_square_location() );
+                veh.pos_abs() + veh.coord_translate( mount ),
+                veh.pos_abs() );
     const std::pair<tripoint_abs_ms, tripoint_abs_ms> sel_part_target = std::make_pair(
                 link().t_abs_pos + prev_veh->coord_translate( link().t_mount ),
                 link().t_abs_pos );

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -223,7 +223,7 @@ class item_location::impl::item_on_map : public item_location::impl
         }
 
         tripoint_bub_ms pos_bub() const override {
-            return cur.pos();
+            return cur.pos_bub();
         }
 
         Character *carrier() const override {
@@ -231,9 +231,9 @@ class item_location::impl::item_on_map : public item_location::impl
         }
 
         std::string describe( const Character *ch ) const override {
-            std::string res = get_map().name( cur.pos() );
+            std::string res = get_map().name( cur.pos_bub() );
             if( ch ) {
-                res += std::string( " " ) += direction_suffix( ch->pos_bub(), cur.pos() );
+                res += std::string( " " ) += direction_suffix( ch->pos_bub(), cur.pos_bub() );
             }
             return res;
         }
@@ -266,7 +266,7 @@ class item_location::impl::item_on_map : public item_location::impl
 
             item *obj = target();
             int mv = ch.item_handling_cost( *obj, true, MAP_HANDLING_PENALTY, qty );
-            mv += 100 * rl_dist( ch.pos_bub(), cur.pos() );
+            mv += 100 * rl_dist( ch.pos_bub(), cur.pos_bub() );
 
             // TODO: handle unpacking costs
 
@@ -283,7 +283,7 @@ class item_location::impl::item_on_map : public item_location::impl
         }
 
         units::volume volume_capacity() const override {
-            map_stack stack = get_map().i_at( cur.pos() );
+            map_stack stack = get_map().i_at( cur.pos_bub() );
             return stack.free_volume();
         }
 

--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -81,7 +81,12 @@ map_cursor::map_cursor( const tripoint_bub_ms &pos ) : pos_abs_( g ? get_map().g
 map_cursor::map_cursor( const tripoint_abs_ms &pos ) : pos_abs_( pos ),
     pos_bub_( tripoint_bub_ms::zero ) { }
 
-tripoint_bub_ms map_cursor::pos() const
+tripoint_bub_ms map_cursor::pos_bub() const
 {
     return g ? get_map().get_bub( pos_abs_ ) : pos_bub_;
+}
+
+tripoint_abs_ms map_cursor::pos_abs() const
+{
+    return g ? pos_abs_ : tripoint_abs_ms::invalid;
 }

--- a/src/map_selector.h
+++ b/src/map_selector.h
@@ -23,7 +23,9 @@ class map_cursor : public visitable
         explicit map_cursor( const tripoint_bub_ms &pos );
         // Marginally faster than the previous operation if you have the absolute coordinates at hand.
         explicit map_cursor( const tripoint_abs_ms &pos );
-        tripoint_bub_ms pos() const;
+        tripoint_bub_ms pos_bub() const;
+        // Will return tripoint_abs_ms::invalid if g hasn't been defined.
+        tripoint_abs_ms pos_abs() const;
 
         // inherited from visitable
         VisitResponse visit_items( const std::function<VisitResponse( item *, item * )> &func ) const

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7017,10 +7017,10 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
                                   "new vehicle %s (%s; origin %s; rot %g) "
                                   "out of map bounds at %s",
                                   first_veh->name, first_veh->type.str(),
-                                  first_veh->global_square_location().to_string(),
+                                  first_veh->pos_abs().to_string(),
                                   to_degrees( first_veh->turn_dir ),
                                   veh_to_add->name, veh_to_add->type.str(),
-                                  veh_to_add->global_square_location().to_string(),
+                                  veh_to_add->pos_abs().to_string(),
                                   to_degrees( veh_to_add->turn_dir ),
                                   map_pos.to_string() );
                     }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1810,7 +1810,7 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
         }
     }
     // literal "edge" case: the vehicle may be in a different OMT than the player
-    const tripoint_abs_omt start_omt_pos = driving ? player_veh->global_omt_location() : player_omt_pos;
+    const tripoint_abs_omt start_omt_pos = driving ? player_veh->pos_abs_omt() : player_omt_pos;
     if( dest == player_omt_pos || dest == start_omt_pos ) {
         return {};
     } else {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -717,7 +717,7 @@ void overmapbuffer::set_scent( const tripoint_abs_omt &loc, int strength )
 
 void overmapbuffer::move_vehicle( vehicle *veh, const point_abs_ms &old_msp )
 {
-    const point_abs_ms new_msp = veh->global_square_location().xy();
+    const point_abs_ms new_msp = veh->pos_abs().xy();
     const point_abs_omt old_omt = project_to<coords::omt>( old_msp );
     const point_abs_omt new_omt = project_to<coords::omt>( new_msp );
     const overmap_with_local_coords old_om_loc = get_om_global( old_omt );
@@ -745,7 +745,7 @@ void overmapbuffer::remove_camp( const basecamp &camp )
 
 void overmapbuffer::remove_vehicle( const vehicle *veh )
 {
-    const tripoint_abs_omt omt = veh->global_omt_location();
+    const tripoint_abs_omt omt = veh->pos_abs_omt();
     const overmap_with_local_coords om_loc = get_existing_om_global( omt );
     if( !om_loc.om ) {
         debugmsg( "Can't find overmap for vehicle at %s", omt.to_string_writable() );
@@ -756,7 +756,7 @@ void overmapbuffer::remove_vehicle( const vehicle *veh )
 
 void overmapbuffer::add_vehicle( vehicle *veh )
 {
-    const tripoint_abs_omt omt = veh->global_omt_location();
+    const tripoint_abs_omt omt = veh->pos_abs_omt();
     const overmap_with_local_coords om_loc = get_existing_om_global( omt );
     if( !om_loc.om ) {
         debugmsg( "Can't find overmap for vehicle at %s", omt.to_string_writable() );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -648,7 +648,7 @@ void vehicle::autopilot_patrol()
     map &here = get_map();
     // if we are close to a waypoint, then return to come back to this function next turn.
     if( autodrive_local_target != tripoint_abs_ms::zero ) {
-        if( rl_dist( global_square_location(), autodrive_local_target ) <= 3 ) {
+        if( rl_dist( pos_abs(), autodrive_local_target ) <= 3 ) {
             autodrive_local_target = tripoint_abs_ms::zero;
             return;
         }
@@ -662,7 +662,7 @@ void vehicle::autopilot_patrol()
     }
     zone_manager &mgr = zone_manager::get_manager();
     const auto &zone_src_set =
-        mgr.get_near( zone_type_VEHICLE_PATROL, global_square_location(), MAX_VIEW_DISTANCE );
+        mgr.get_near( zone_type_VEHICLE_PATROL, pos_abs(), MAX_VIEW_DISTANCE );
     if( zone_src_set.empty() ) {
         is_patrolling = false;
         return;
@@ -690,8 +690,8 @@ void vehicle::autopilot_patrol()
     const tripoint_abs_ms min_tri = x_side ? tripoint_abs_ms( point_along, min.y(), min.z() ) :
                                     tripoint_abs_ms( min.x(), point_along, min.z() );
     tripoint_abs_ms chosen_tri = min_tri;
-    if( rl_dist( max_tri, global_square_location() ) >=
-        rl_dist( min_tri, global_square_location() ) ) {
+    if( rl_dist( max_tri, pos_abs() ) >=
+        rl_dist( min_tri, pos_abs() ) ) {
         chosen_tri = max_tri;
     }
     // TODO: fix point types
@@ -759,7 +759,7 @@ void vehicle::drive_to_local_target( const tripoint_abs_ms &target, bool follow_
     }
     refresh();
     map &here = get_map();
-    tripoint_abs_ms vehpos = global_square_location();
+    tripoint_abs_ms vehpos = pos_abs();
     units::angle angle = get_angle_from_targ( target );
 
     bool stop = precollision_check( angle, here, follow_protocol );
@@ -864,7 +864,7 @@ bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_pr
 
 units::angle vehicle::get_angle_from_targ( const tripoint_abs_ms &targ ) const
 {
-    tripoint_abs_ms vehpos = global_square_location();
+    tripoint_abs_ms vehpos = pos_abs();
     rl_vec2d facevec = face_vec();
     point_rel_ms rel_pos_target = targ.xy() - vehpos.xy();
     rl_vec2d targetvec = rl_vec2d( rel_pos_target.x(), rel_pos_target.y() );
@@ -3611,14 +3611,14 @@ monster *vehicle::get_monster( int p ) const
     return nullptr;
 }
 
-tripoint_abs_ms vehicle::global_square_location() const
+tripoint_abs_ms vehicle::pos_abs() const
 {
     return get_map().get_abs( pos_bub() );
 }
 
-tripoint_abs_omt vehicle::global_omt_location() const
+tripoint_abs_omt vehicle::pos_abs_omt() const
 {
-    return project_to<coords::omt>( global_square_location() );
+    return project_to<coords::omt>( pos_abs() );
 }
 
 tripoint_bub_ms vehicle::pos_bub() const
@@ -3638,7 +3638,7 @@ tripoint_bub_ms vehicle::bub_part_pos( const vehicle_part &pt ) const
 
 void vehicle::set_submap_moved( const tripoint_bub_sm &p )
 {
-    const point_abs_ms old_msp = global_square_location().xy();
+    const point_abs_ms old_msp = pos_abs().xy();
     sm_pos = p;
     if( !tracking_on ) {
         return;
@@ -5311,7 +5311,7 @@ units::power vehicle::total_solar_epower() const
     }
     // Weather doesn't change much across the area of the vehicle, so just
     // sample it once.
-    weather_type_id wtype = current_weather( global_square_location() );
+    weather_type_id wtype = current_weather( pos_abs() );
     const float intensity = incident_sun_irradiance( wtype, calendar::turn ) / max_sun_irradiance();
     return epower * intensity;
 }
@@ -5319,7 +5319,7 @@ units::power vehicle::total_solar_epower() const
 units::power vehicle::total_wind_epower() const
 {
     map &here = get_map();
-    const oter_id &cur_om_ter = overmap_buffer.ter( global_omt_location() );
+    const oter_id &cur_om_ter = overmap_buffer.ter( pos_abs_omt() );
     weather_manager &weather = get_weather();
     const w_point weatherPoint = *weather.weather_precise;
     units::power epower = 0_W;
@@ -6941,7 +6941,7 @@ void vehicle::do_towing_move()
     units::angle towing_veh_angle = towed_veh->get_angle_from_targ( tower_tow_point );
     const bool reverse = towed_veh->tow_data.tow_direction == TOW_BACK;
     int accel_y = 0;
-    tripoint_abs_ms vehpos = global_square_location();
+    tripoint_abs_ms vehpos = pos_abs();
     int turn_x = get_turn_from_angle( towing_veh_angle, vehpos, tower_tow_point, reverse );
     if( rl_dist( towed_tow_point, tower_tow_point ) < 6 ) {
         accel_y = reverse ? -1 : 1;
@@ -8200,7 +8200,7 @@ void vehicle::update_time( const time_point &update_to )
     }
     // Get one weather data set per vehicle, they don't differ much across vehicle area
     const weather_sum accum_weather = sum_conditions( update_from, update_to,
-                                      global_square_location() );
+                                      pos_abs() );
     // make some reference objects to use to check for reload
     const item water( itype_water );
     const item water_clean( itype_water_clean );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1452,9 +1452,9 @@ class vehicle
 
         bool enclosed_at( const tripoint_bub_ms &pos ); // not const because it calls refresh_insides
         // Returns the location of the vehicle in global map square coordinates.
-        tripoint_abs_ms global_square_location() const;
+        tripoint_abs_ms pos_abs() const;
         // Returns the location of the vehicle in global overmap terrain coordinates.
-        tripoint_abs_omt global_omt_location() const;
+        tripoint_abs_omt pos_abs_omt() const;
         // Returns the coordinates (in map squares) of the vehicle relative to the local map.
         // Warning: Don't assume this position contains a vehicle part
         tripoint_bub_ms pos_bub() const;

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -917,7 +917,7 @@ void vehicle::autodrive_controller::compute_goal_zone()
 
 void vehicle::autodrive_controller::precompute_data()
 {
-    const tripoint_abs_omt current_omt = driven_veh.global_omt_location();
+    const tripoint_abs_omt current_omt = driven_veh.pos_abs_omt();
     const tripoint_abs_omt next_omt = driver.omt_path.back();
     const tripoint_abs_omt next_next_omt = driver.omt_path.size() >= 2 ?
                                            driver.omt_path[driver.omt_path.size() - 2] : next_omt;
@@ -1080,7 +1080,7 @@ std::optional<std::vector<navigation_step>> vehicle::autodrive_controller::compu
     std::unordered_map<node_address, navigation_node, node_address_hasher> known_nodes;
     std::priority_queue<scored_address, std::vector<scored_address>, std::greater<>>
             open_set;
-    const tripoint_abs_ms veh_pos = driven_veh.global_square_location();
+    const tripoint_abs_ms veh_pos = driven_veh.pos_abs();
     const node_address start = data.nav_to_map.inverse().transform(
                                    veh_pos.raw().xy(), to_orientation( driven_veh.face.dir() ) );
     known_nodes.emplace( start, make_start_node( start, driven_veh ) );
@@ -1224,7 +1224,7 @@ void vehicle::autodrive_controller::reduce_speed()
 std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step()
 {
     precompute_data();
-    const tripoint_abs_ms veh_pos = driven_veh.global_square_location();
+    const tripoint_abs_ms veh_pos = driven_veh.pos_abs();
     const bool had_cached_path = !data.path.empty();
     const bool two_steps = data.path.size() > 2;
     const navigation_step first_step = two_steps ? data.path.back() : navigation_step();
@@ -1275,7 +1275,7 @@ std::vector<std::tuple<point_rel_ms, int, std::string>> vehicle::get_debug_overl
     std::vector<std::tuple<point_rel_ms, int, std::string>> ret;
     ret.reserve( collision_check_points.size() );
 
-    const tripoint_abs_ms veh_pos = global_square_location();
+    const tripoint_abs_ms veh_pos = pos_abs();
     if( autodrive_local_target != tripoint_abs_ms::zero ) {
         ret.emplace_back( ( autodrive_local_target - veh_pos ).xy(), catacurses::red, "T" );
     }
@@ -1363,7 +1363,7 @@ autodrive_result vehicle::do_autodrive( Character &driver )
         stop_autodriving( false );
         return autodrive_result::abort;
     }
-    const tripoint_abs_ms veh_pos = global_square_location();
+    const tripoint_abs_ms veh_pos = pos_abs();
     const tripoint_abs_omt veh_omt = project_to<coords::omt>( veh_pos );
     std::vector<tripoint_abs_omt> &omt_path = driver.omt_path;
     while( !omt_path.empty() && veh_omt.xy() == omt_path.back().xy() ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -487,7 +487,7 @@ void vehicle::smash_security_system()
 void vehicle::autopilot_patrol_check()
 {
     zone_manager &mgr = zone_manager::get_manager();
-    if( mgr.has_near( zone_type_VEHICLE_PATROL, global_square_location(), MAX_VIEW_DISTANCE ) ) {
+    if( mgr.has_near( zone_type_VEHICLE_PATROL, pos_abs(), MAX_VIEW_DISTANCE ) ) {
         enable_patrol();
     } else {
         g->zones_manager();
@@ -1892,7 +1892,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
                 ///\EFFECT_MECHANICS speeds up vehicle hotwiring
                 const float skill = std::max( 1.0f, get_player_character().get_skill_level( skill_mechanics ) );
                 const int moves = to_moves<int>( 6000_seconds / skill );
-                const tripoint_abs_ms target = global_square_location() + coord_translate( parts[0].mount );
+                const tripoint_abs_ms target = pos_abs() + coord_translate( parts[0].mount );
                 const hotwire_car_activity_actor hotwire_act( moves, target );
                 get_player_character().assign_activity( hotwire_act );
             } );

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -499,14 +499,14 @@ static VisitResponse visit_items_internal( map *here,
 VisitResponse map_cursor::visit_items(
     const std::function<VisitResponse( item *, item * )> &func ) const
 {
-    if( get_map().inbounds( pos() ) ) {
-        return visit_items_internal( &get_map(), pos(), func );
+    if( get_map().inbounds( pos_bub() ) ) {
+        return visit_items_internal( &get_map(), pos_bub(), func );
     } else {
         tinymap here; // Tinymap is sufficient. Only looking at single location, so no Z level need.
         // pos returns the pos_bub location of the target relative to the reality bubble
         // even though the location isn't actually inside of it. Thus, we're loading a map
         // around that location to do our work.
-        tripoint_abs_ms abs_pos = get_map().get_abs( pos() );
+        const tripoint_abs_ms abs_pos = pos_abs();
         here.load( project_to<coords::omt>( abs_pos ), false );
         tripoint_omt_ms p = here.get_omt( abs_pos );
         return visit_items_internal( here.cast_to_map(), rebase_bub( p ), func );
@@ -709,14 +709,14 @@ std::list<item> map_cursor::remove_items_with( const
     }
 
     map &here = get_map();
-    if( !here.inbounds( pos() ) ) {
+    if( !here.inbounds( pos_bub() ) ) {
         debugmsg( "cannot remove items from map: cursor out-of-bounds" );
         return res;
     }
 
     // fetch the appropriate item stack
     point_sm_ms offset;
-    submap *sub = here.get_submap_at( pos(), offset );
+    submap *sub = here.get_submap_at( pos_bub(), offset );
     cata::colony<item> &stack = sub->get_items( offset );
 
     for( auto iter = stack.begin(); iter != stack.end(); ) {

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -72,7 +72,7 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
         point_rel_ms vcoords = source_vp->mount_pos();
         vehicle_part source_part( vpid, item( cord ) );
         source_part.target.first = target_global;
-        source_part.target.second = target_veh->global_square_location();
+        source_part.target.second = target_veh->pos_abs();
         source_veh->install_part( vcoords, std::move( source_part ) );
 
         vcoords = target_vp->mount_pos();
@@ -81,7 +81,7 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
                                        cord.get_var( "source_y", 0 ),
                                        cord.get_var( "source_z", 0 ) );
         target_part.target.first = here.get_abs( source_global );
-        target_part.target.second = source_veh->global_square_location();
+        target_part.target.second = source_veh->pos_abs();
         target_veh->install_part( vcoords, std::move( target_part ) );
     };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Change position getter operation names to use a common scheme.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Rename vehicle::global_square_location() -> pos_abs().
- Rename vehicle::global_omt_location() ->pos_abs_omt().
- Rename map_cursor::pos() -> pos_bub()
- Introduce map_cursor::pos_abs().

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
vehicle::bub_part_pos() could be renamed to bub_pos_part(),

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkey, smash into stationary vehicle. Nothing odd seen. Not surprising, since renaming doesn't result in functional changes.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I'm not aware of any other places where operations ought to be renamed, but I more or less expect there to be ones missed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
