### PR TITLE
fix `map cache` item/EOC

### DIFF
--- a/data/json/effects_on_condition/computer_eocs.json
+++ b/data/json/effects_on_condition/computer_eocs.json
@@ -48,25 +48,21 @@
     "type": "effect_on_condition",
     "id": "EOC_CHECK_MAP_CACHE",
     "//": "todo: make it not reveal fungal towers and such? would require edits in reveal_map code, to accept blacklist of locations?",
-    "condition": { "or": [ { "compare_string": [ { "npc_val": "map_cache" }, "has", "lack", "read" ] } ] },
-    "false_effect": [ { "npc_add_var": "map_cache", "possible_values": [ "has", "lack" ] }, { "run_eocs": "EOC_CHECK_MAP_CACHE" } ],
     "effect": [
       {
         "if": { "compare_string": [ "read", { "npc_val": "map_cache" } ] },
-        "then": [ { "u_message": "You already noted everything this map cache can offer." } ]
-      },
-      {
-        "if": { "compare_string": [ "has", { "npc_val": "map_cache" } ] },
-        "then": [
-          { "location_variable_adjust": { "npc_val": "spawn_location_omt" }, "z_adjust": 0, "z_override": true },
+        "then": [ { "u_message": "You already noted everything this map cache can offer." } ],
+        "else": [
+          {
+            "location_variable_adjust": { "npc_val": "spawn_location_omt" },
+            "z_adjust": 0,
+            "z_override": true,
+            "overmap_tile": true
+          },
           { "reveal_map": { "npc_val": "spawn_location_omt" }, "radius": { "math": [ "rng(11, 36)" ] } },
           { "npc_add_var": "map_cache", "value": "read" },
           { "u_message": "You found some useful data in the map cache and noted it.", "type": "good" }
         ]
-      },
-      {
-        "if": { "compare_string": [ "lack", { "npc_val": "map_cache" } ] },
-        "then": [ { "u_message": "Whoever used this device didn't ever open their map application.  Worthless." } ]
       }
     ]
   }

--- a/data/json/items/software.json
+++ b/data/json/items/software.json
@@ -155,7 +155,8 @@
     "name": "map cache",
     "description": "Information about nearby locations stored from previous use.",
     "ememory_size": "32 MB",
-    "use_action": { "type": "effect_on_conditions", "effect_on_conditions": [ "EOC_CHECK_MAP_CACHE" ] }
+    "use_action": { "type": "effect_on_conditions", "effect_on_conditions": [ "EOC_CHECK_MAP_CACHE" ] },
+    "extend": { "flags": [ "PRESERVE_SPAWN_OMT" ] }
   },
   {
     "abstract": "abstract_efile_recipes",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -759,17 +759,7 @@
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
-    "flags": [
-      "WATCH",
-      "ALARMCLOCK",
-      "USE_UPS",
-      "NO_UNLOAD",
-      "NO_RELOAD",
-      "WATER_BREAK",
-      "CALORIES_INTAKE",
-      "ELECTRONIC",
-      "PRESERVE_SPAWN_OMT"
-    ],
+    "flags": [ "WATCH", "ALARMCLOCK", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "CALORIES_INTAKE", "ELECTRONIC" ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 56 } },
       {

--- a/src/condition.h
+++ b/src/condition.h
@@ -59,8 +59,13 @@ duration_or_var get_duration_or_var( const JsonObject &jo, const std::string_vie
 duration_or_var_part get_duration_or_var_part( const JsonValue &jv, const std::string_view &member,
         bool required = true,
         time_duration default_val = 0_seconds );
-tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const_dialogue const &d,
-                                       bool is_npc );
+template<typename T>
+T convert_tripoint_from_var( std::optional<var_info> &var, const_dialogue const &d,
+                             bool is_npc );
+tripoint_abs_ms get_tripoint_ms_from_var( std::optional<var_info> var, const_dialogue const &d,
+        bool is_npc );
+tripoint_abs_omt get_tripoint_omt_from_var( std::optional<var_info> var, const_dialogue const &d,
+        bool is_npc );
 var_info read_var_info( const JsonObject &jo );
 translation_var_info read_translation_var_info( const JsonObject &jo );
 void write_var_value( var_type type, const std::string &name, dialogue *d,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15816,6 +15816,17 @@ std::list<const item *> item::all_items_ptr() const
     return all_items_internal;
 }
 
+std::list<item *> item::all_items_ptr()
+{
+    std::list<item *> all_items_internal;
+    for( int i = static_cast<int>( pocket_type::CONTAINER );
+         i < static_cast<int>( pocket_type::LAST ); i++ ) {
+        std::list<item *> inserted{ all_items_top_recursive( static_cast<pocket_type>( i ) ) };
+        all_items_internal.insert( all_items_internal.end(), inserted.begin(), inserted.end() );
+    }
+    return all_items_internal;
+}
+
 std::list<const item *> item::all_items_ptr( pocket_type pk_type ) const
 {
     return all_items_top_recursive( pk_type );

--- a/src/item.h
+++ b/src/item.h
@@ -3060,16 +3060,18 @@ class item : public visitable
         aggregate_t aggregated_contents( int depth = 0, int maxdepth = 2 ) const;
 
         /**
-         * returns a list of pointers to all items inside recursively
+         * returns a list of pointers to *all items in all pockets* inside recursively
          * includes mods.  used for item_location::unpack()
          */
         std::list<const item *> all_items_ptr() const;
+        std::list<item *> all_items_ptr();
         /** returns a list of pointers to all items inside recursively */
         std::list<const item *> all_items_ptr( pocket_type pk_type ) const;
         /** returns a list of pointers to all items inside recursively */
         std::list<item *> all_items_ptr( pocket_type pk_type );
 
-        /** returns a list of pointers to all visible or remembered top-level items */
+        /** returns a list of pointers to all visible or remembered
+        * top-level items in standard pockets */
         std::list<item *> all_known_contents();
         std::list<const item *> all_known_contents() const;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5258,16 +5258,14 @@ item &map::add_item( const tripoint_bub_ms &p, item new_item, int copies )
                           coords::project_to<coords::omt>( get_abs( p ) ) );
     }
 
-    if( new_item.has_flag( json_flag_PRESERVE_SPAWN_OMT ) &&
-        !new_item.has_var( "spawn_location_omt" ) ) {
-        new_item.set_var( "spawn_location_omt", coords::project_to<coords::omt>( get_abs( p ) ) );
-    }
-    for( item *const it : new_item.all_items_top( pocket_type::CONTAINER ) ) {
+    std::list<item *> all_items = new_item.all_items_ptr();
+    all_items.emplace_back( &new_item );
+    for( item *it : all_items ) {
         if( it->has_flag( json_flag_PRESERVE_SPAWN_OMT ) &&
             !it->has_var( "spawn_location_omt" ) ) {
             it->set_var( "spawn_location_omt", coords::project_to<coords::omt>( get_abs( p ) ) );
         }
-    }
+    };
 
     if( new_item.has_flag( flag_ACTIVATE_ON_PLACE ) ) {
         new_item.activate();

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -382,7 +382,7 @@ diag_eval_dbl_f field_strength_eval( char scope, std::vector<diag_value> const &
         map &here = get_map();
         tripoint_abs_ms loc;
         if( loc_var.has_value() ) {
-            loc = get_tripoint_from_var( loc_var, d, beta );
+            loc = get_tripoint_ms_from_var( loc_var, d, beta );
         } else {
             loc = d.const_actor( beta )->pos_abs();
         }
@@ -788,7 +788,7 @@ diag_eval_dbl_f _characters_nearby_eval( char scope, std::vector<diag_value> con
          allow_hallucinations_val ]( const_dialogue const & d ) {
         tripoint_abs_ms loc;
         if( loc_var.has_value() ) {
-            loc = get_tripoint_from_var( loc_var, d, beta );
+            loc = get_tripoint_ms_from_var( loc_var, d, beta );
         } else {
             loc = d.const_actor( beta )->pos_abs();
         }
@@ -906,7 +906,7 @@ diag_eval_dbl_f _monsters_nearby_eval( char scope, std::vector<diag_value> const
          f]( const_dialogue const & d ) {
         tripoint_abs_ms loc;
         if( loc_var.has_value() ) {
-            loc = get_tripoint_from_var( loc_var, d, beta );
+            loc = get_tripoint_ms_from_var( loc_var, d, beta );
         } else {
             loc = d.const_actor( beta )->pos_abs();
         }

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -179,7 +179,7 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
     tripoint_abs_omt target_pos = tripoint_abs_omt::invalid;
 
     if( params.target_var.has_value() ) {
-        return project_to<coords::omt>( get_tripoint_from_var( params.target_var.value(), d, false ) );
+        return project_to<coords::omt>( get_tripoint_ms_from_var( params.target_var.value(), d, false ) );
     }
 
     omt_find_params find_params;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3705,7 +3705,7 @@ talk_effect_fun_t f_spawn_item( const JsonObject &jo, std::string_view member,
     }
     talk_effect_fun_t ret( [item_name, count, container_name, use_item_group, suppress_message,
                add_talker, loc_var, force_equip, flags]( dialogue & d ) {
-        const tripoint_abs_ms target_location = get_tripoint_from_var( loc_var, d, false );
+        const tripoint_abs_ms target_location = get_tripoint_ms_from_var( loc_var, d, false );
         std::vector<std::string> flags_str;
         flags_str.reserve( flags.size() );
         for( const str_or_var &flat_sov : flags ) {
@@ -4306,7 +4306,7 @@ talk_effect_fun_t::func f_location_variable_adjust( const JsonObject &jo,
     }
     return [input_var, dov_x_adjust, dov_y_adjust, dov_z_adjust, z_override,
                output_var, overmap_tile ]( dialogue & d ) {
-        tripoint_abs_ms target_pos = get_tripoint_from_var( input_var, d, false );
+        tripoint_abs_ms target_pos = get_tripoint_ms_from_var( input_var, d, false );
 
         if( overmap_tile ) {
             target_pos = target_pos + tripoint( dov_x_adjust.evaluate( d ) * coords::map_squares_per(
@@ -4349,7 +4349,7 @@ talk_effect_fun_t::func f_transform_radius( const JsonObject &jo, std::string_vi
     return [dov, transform, target_var, dov_time_in_future, key, is_npc]( dialogue & d ) {
         tripoint_abs_ms target_pos = d.actor( is_npc )->pos_abs();
         if( target_var.has_value() ) {
-            target_pos = get_tripoint_from_var( target_var, d, is_npc );
+            target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         }
 
         int radius = dov.evaluate( d );
@@ -4411,7 +4411,7 @@ talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view memb
                 is_npc]( dialogue const & d ) {
         tripoint_bub_ms target_pos;
         if( target_var.has_value() ) {
-            tripoint_abs_ms abs_ms = get_tripoint_from_var( target_var, d, is_npc );
+            tripoint_abs_ms abs_ms = get_tripoint_ms_from_var( target_var, d, is_npc );
             target_pos = get_map().get_bub( abs_ms );
         } else {
             target_pos = d.actor( is_npc )->pos_bub();
@@ -4458,7 +4458,7 @@ talk_effect_fun_t::func f_query_omt( const JsonObject &jo, std::string_view memb
 
             tripoint_abs_omt target_pos = d.actor( is_npc )->pos_abs_omt();
             if( target_var.has_value() ) {
-                tripoint_abs_ms abs_ms = get_tripoint_from_var( target_var, d, is_npc );
+                tripoint_abs_ms abs_ms = get_tripoint_ms_from_var( target_var, d, is_npc );
                 target_pos = project_to<coords::omt>( abs_ms );
             }
 
@@ -4486,8 +4486,8 @@ talk_effect_fun_t::func f_transform_line( const JsonObject &jo, std::string_view
     var_info second = read_var_info( jo.get_object( "second" ) );
 
     return [transform, first, second]( dialogue const & d ) {
-        tripoint_abs_ms const t_first = get_tripoint_from_var( first, d, false );
-        tripoint_abs_ms const t_second = get_tripoint_from_var( second, d, false );
+        tripoint_abs_ms const t_first = get_tripoint_ms_from_var( first, d, false );
+        tripoint_abs_ms const t_second = get_tripoint_ms_from_var( second, d, false );
         tripoint_abs_ms const orig = coord_min( t_first, t_second );
         map tm;
         tm.load( project_to<coords::sm>( orig ), false );
@@ -4541,7 +4541,7 @@ talk_effect_fun_t::func f_mapgen_update( const JsonObject &jo, std::string_view 
     return [target_params, update_ids, target_var, dov_time_in_future, key]( dialogue & d ) {
         tripoint_abs_omt omt_pos;
         if( target_var.has_value() ) {
-            const tripoint_abs_ms abs_ms( get_tripoint_from_var( target_var, d, false ) );
+            const tripoint_abs_ms abs_ms( get_tripoint_ms_from_var( target_var, d, false ) );
             omt_pos = project_to<coords::omt>( abs_ms );
         } else {
             mission_target_params update_params = target_params;
@@ -4593,7 +4593,7 @@ talk_effect_fun_t::func f_revert_location( const JsonObject &jo, std::string_vie
     }
     std::optional<var_info> target_var = read_var_info( jo.get_object( member ) );
     return [target_var, dov_time_in_future, key]( dialogue & d ) {
-        const tripoint_abs_ms abs_ms( get_tripoint_from_var( target_var, d, false ) );
+        const tripoint_abs_ms abs_ms( get_tripoint_ms_from_var( target_var, d, false ) );
         tripoint_abs_omt omt_pos = project_to<coords::omt>( abs_ms );
         time_point tif = calendar::turn + dov_time_in_future.evaluate( d ) + 1_seconds;
         // Timed events happen before the player turn and eocs are during so we add a second here to sync them up using the same variable
@@ -4664,7 +4664,7 @@ talk_effect_fun_t::func f_guard_pos( const JsonObject &jo, std::string_view memb
             if( unique_id ) {
                 cur_var.name.insert( 0, guy->get_unique_id() );
             }
-            tripoint_abs_ms target_location = get_tripoint_from_var( cur_var, d, is_npc );
+            tripoint_abs_ms target_location = get_tripoint_ms_from_var( cur_var, d, is_npc );
             guy->set_guard_pos( target_location );
         }
     };
@@ -5271,7 +5271,7 @@ talk_effect_fun_t::func f_cast_spell( const JsonObject &jo, std::string_view mem
                 }
             } else {
                 const tripoint_bub_ms target_pos = loc_var ?
-                                                   get_map().get_bub( get_tripoint_from_var( loc_var, d, is_npc ) ) : caster->pos_bub();
+                                                   get_map().get_bub( get_tripoint_ms_from_var( loc_var, d, is_npc ) ) : caster->pos_bub();
                 sp.cast_all_effects( *caster, target_pos );
                 caster->add_msg_player_or_npc( fake.trigger_message, fake.npc_trigger_message );
             }
@@ -5611,7 +5611,7 @@ talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view membe
                     return;
                 }
                 if( target_var.has_value() ) {
-                    tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
+                    tripoint_abs_ms target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
                     if( get_map().inbounds( target_pos ) ) {
                         guy->invoke_item( it->get_item(), method_str, get_map().get_bub( target_pos ) );
                         return;
@@ -5707,7 +5707,7 @@ talk_effect_fun_t::func f_make_sound( const JsonObject &jo, std::string_view mem
     }
     return [is_npc, snip_id, message, volume, ambient, type, target_var, snippet,
             same_snippet]( dialogue & d ) {
-        tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
+        tripoint_abs_ms target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         std::string translated_message;
         if( snippet ) {
             if( same_snippet ) {
@@ -6237,7 +6237,7 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
 
     return [is_npc, option, true_eocs, false_eocs, data, loc_var, dov_min_radius, dov_max_radius,
             title]( dialogue & d ) {
-        tripoint_abs_ms target_location = get_tripoint_from_var( loc_var, d, is_npc );
+        tripoint_abs_ms target_location = get_tripoint_ms_from_var( loc_var, d, is_npc );
         std::vector<item_location> items;
         map &here = get_map();
         tripoint_bub_ms center = here.get_bub( target_location );
@@ -6316,7 +6316,7 @@ talk_effect_fun_t::func f_map_run_eocs( const JsonObject &jo, std::string_view m
 
         tripoint_abs_ms pos;
         if( target_var.has_value() ) {
-            pos = get_tripoint_from_var( target_var, d, is_npc );
+            pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         } else {
             pos = d.actor( is_npc )->pos_abs();
         }
@@ -6833,7 +6833,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub();
         if( target_var.has_value() ) {
-            target_pos = get_map().get_bub( get_tripoint_from_var( target_var, d, is_npc ) );
+            target_pos = get_map().get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -6968,7 +6968,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub();
         if( target_var.has_value() ) {
-            target_pos = get_map().get_bub( get_tripoint_from_var( target_var, d, is_npc ) );
+            target_pos = get_map().get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -7048,7 +7048,7 @@ talk_effect_fun_t::func f_field( const JsonObject &jo, std::string_view member,
 
         tripoint_abs_ms target_pos = d.actor( is_npc )->pos_abs();
         if( target_var.has_value() ) {
-            target_pos = get_tripoint_from_var( target_var, d, is_npc );
+            target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         }
         for( const tripoint_bub_ms &dest : get_map().points_in_radius( get_map().get_bub( target_pos ),
                 radius ) ) {
@@ -7075,7 +7075,7 @@ talk_effect_fun_t::func f_emit( const JsonObject &jo, std::string_view member,
     return [emit, target_var, chance_mult, is_npc ]( dialogue & d ) {
         tripoint_abs_ms target_pos = d.actor( is_npc )->pos_abs();
         if( target_var.has_value() ) {
-            target_pos = get_tripoint_from_var( target_var, d, is_npc );
+            target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         }
         tripoint_bub_ms target = get_map().get_bub( target_pos );
         get_map().emit_field( target, emit_id( emit.evaluate( d ) ), chance_mult.evaluate( d ) );
@@ -7089,9 +7089,7 @@ talk_effect_fun_t::func f_reveal_map( const JsonObject &jo, std::string_view mem
     dbl_or_var radius = get_dbl_or_var( jo, "radius", false, 0 );
 
     return [ radius, target_var ]( dialogue & d ) {
-        tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, false );
-        tripoint_abs_omt omt = project_to<coords::omt>( target_pos );
-
+        tripoint_abs_omt omt = get_tripoint_omt_from_var( target_var, d, false );
         overmap_buffer.reveal( omt, radius.evaluate( d ) );
     };
 }
@@ -7105,9 +7103,9 @@ talk_effect_fun_t::func f_reveal_route( const JsonObject &jo, std::string_view m
     bool road_only = jo.get_bool( "road_only", false );
 
     return [ radius, from, to, road_only ]( dialogue & d ) {
-        tripoint_abs_ms from_pos = get_tripoint_from_var( from, d, false );
+        tripoint_abs_ms from_pos = get_tripoint_ms_from_var( from, d, false );
         tripoint_abs_omt omt_from = project_to<coords::omt>( from_pos );
-        tripoint_abs_ms to_pos = get_tripoint_from_var( to, d, false );
+        tripoint_abs_ms to_pos = get_tripoint_ms_from_var( to, d, false );
         tripoint_abs_omt omt_to = project_to<coords::omt>( to_pos );
 
         overmap_buffer.reveal_route( omt_from, omt_to, radius.evaluate( d ), road_only );
@@ -7123,7 +7121,7 @@ talk_effect_fun_t::func f_closest_city( const JsonObject &jo, std::string_view m
     bool known = jo.get_bool( "known", true );
 
     return [var, type, var_name, known]( dialogue & d ) {
-        tripoint_abs_ms loc_ms = get_tripoint_from_var( var, d, false );
+        tripoint_abs_ms loc_ms = get_tripoint_ms_from_var( var, d, false );
         tripoint_abs_sm loc_sm = project_to<coords::sm>( loc_ms );
 
         if( known ) {
@@ -7170,7 +7168,7 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
     bool force_safe = jo.get_bool( "force_safe", false );
     return [is_npc, target_var, fail_message, success_message, force,
             force_safe]( dialogue const & d ) {
-        tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
+        tripoint_abs_ms target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         Creature *teleporter = d.actor( is_npc )->get_creature();
         if( teleporter ) {
             if( teleport::teleport_to_point( *teleporter, get_map().get_bub( target_pos ), true, false,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "fix map cache item/EOC"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Follow-up to #79097, which broke the new `map_cache` item. This item should work identically to the previous "check map application" action on a smartphone.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

There were several issues:
1) I forgot to include the `PRESERVE_SPAWN_OMT` JSON flag, so `spawn_location_omt` would not be set -- and then when I did include it, `spawn_location_omt` would only be set to items and their `CONTAINER` pockets -- i.e. not `map_cache`, which is in an `E_FILE_STORAGE` pocket. I made a non-const all_items_ptr() function to indiscriminately iterate across all contents.

2) The `reveal_map()` EOC function was loading a tripoint_abs_ms, but `spawn_location_omt` is stored as a tripoint_abs_omt. Now, tripoint_abs_omt can be loaded by EOC functions. This means that **map caches now reveal a radius around where they were spawned**, as was originally intended (I think).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Generated a map_cache, teleported away from it, read map cache, noted revealed bubble in spawned location
Read other maps to make sure I didn't break anything

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

clang-tidy run locally, but tests were NOT run locally

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
