### PR TITLE
misc fixes for unloading via AIM

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -85,6 +85,10 @@
     "C_Cpp.formatting": "disabled",
     "astyle.astylerc": "${workspaceRoot}/.astylerc",
     "files.associations": {
-        "vector": "cpp"
+        "vector": "cpp",
+        "array": "cpp",
+        "string_view": "cpp",
+        "span": "cpp",
+        "regex": "cpp"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -85,10 +85,6 @@
     "C_Cpp.formatting": "disabled",
     "astyle.astylerc": "${workspaceRoot}/.astylerc",
     "files.associations": {
-        "vector": "cpp",
-        "array": "cpp",
-        "string_view": "cpp",
-        "span": "cpp",
-        "regex": "cpp"
+        "vector": "cpp"
     }
 }

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1830,7 +1830,7 @@ bool advanced_inventory::action_unload( advanced_inv_listitem *sitem,
     do_return_entry();
     // always exit to proc do_return_entry even when no activity was assigned
     exit = true;
-    return u.unload( loc );;
+    return u.unload( loc );
 }
 
 void advanced_inventory::display()

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1818,17 +1818,14 @@ bool advanced_inventory::action_unload( advanced_inv_listitem *sitem,
 {
     avatar &u = get_avatar();
     item_location loc;
+    item it = *sitem->items.front();
+
     if( spane.get_area() == AIM_CONTAINER && spane.container->can_unload() ) {
         loc = spane.container;
-    } else if( sitem && sitem->items.front()->can_unload() ) {
-        if( sitem -> contents_count > 0 ) {
-            loc = sitem->items.front();
-        } else {
-            popup_getkey( _( "%1$s is already empty." ), sitem->items.front()->display_name() );
-        }
-
+    } else if( sitem && it.can_unload() && !it.empty() ) {
+        loc = sitem->items.front();
     } else {
-        popup_getkey( _( "%1$s can't be unloaded." ), sitem->items.front()->display_name() );
+        popup_getkey( _( "%1$s can't be unloaded." ), it.display_name() );
         return false;
     }
 

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1818,22 +1818,19 @@ bool advanced_inventory::action_unload( advanced_inv_listitem *sitem,
 {
     avatar &u = get_avatar();
     item_location loc;
-    item it = *sitem->items.front();
 
-    if( spane.get_area() == AIM_CONTAINER && spane.container->can_unload() ) {
+    if( spane.get_area() == AIM_CONTAINER ) {
         loc = spane.container;
-    } else if( sitem && it.can_unload() && !it.empty() ) {
+    } else if( sitem ) {
         loc = sitem->items.front();
     } else {
-        popup_getkey( _( "%1$s can't be unloaded." ), it.display_name() );
         return false;
     }
 
-    if( loc != item_location::nowhere && !loc->is_container_empty() ) {
-        do_return_entry();
-        return u.unload( loc );;
-    }
-    return false;
+    do_return_entry();
+    // always exit to proc do_return_entry even when no activity was assigned
+    exit = true;
+    return u.unload( loc );;
 }
 
 void advanced_inventory::display()
@@ -2046,8 +2043,7 @@ void advanced_inventory::display()
                 action_examine( sitem, spane );
             }
         } else if( action == "UNLOAD_CONTAINER" ) {
-            recalc = exit = action_unload( sitem, spane );
-
+            recalc = action_unload( sitem, spane );
         } else if( action == "QUIT" ) {
             exit = true;
         } else if( action == "PAGE_DOWN" ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Follow-up to #79187, where I introduced unloading via AIM.
Clothing containing items could not be unloaded.
De-duplicate checks and error-messages already in Character::unload().

#### Describe the solution
`sitem -> contents_count` returns 0 for clothing with items in them. Replace it with correct empty check.
Be less picky what to pass to unload() and let it display the error message.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
fix sitem -> contents_count, but I don't know if its intended or how it affects other parts.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Clothing can be unloaded
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
