### PR TITLE
Add Exodii castle starting scenario

### DIFF
--- a/data/json/mapgen/exodii/exodii_base.json
+++ b/data/json/mapgen/exodii/exodii_base.json
@@ -126,7 +126,8 @@
         { "type": "NPC_INVESTIGATE_ONLY", "faction": "exodii", "x": [ 72, 95 ], "y": [ 0, 23 ] },
         { "type": "NPC_INVESTIGATE_ONLY", "faction": "exodii", "x": [ 72, 95 ], "y": [ 24, 47 ] },
         { "type": "NPC_INVESTIGATE_ONLY", "faction": "exodii", "x": [ 72, 95 ], "y": [ 48, 71 ] },
-        { "type": "NPC_INVESTIGATE_ONLY", "faction": "exodii", "x": [ 72, 95 ], "y": [ 72, 95 ] }
+        { "type": "NPC_INVESTIGATE_ONLY", "faction": "exodii", "x": [ 72, 95 ], "y": [ 72, 95 ] },
+        { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 22, 23 ], "y": [ 83, 84 ] }
       ],
       "faction_owner": [
         { "id": "exodii", "x": [ 0, 23 ], "y": [ 0, 23 ] },

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -24,8 +24,8 @@
     "id": "exodiicastle",
     "name": "Strange Castle",
     "points": 0,
-    "description": "You have survived the initial wave of panic, and made your way to the wilderness. You happened upon a strange castle guarded by robots in an area you were expecting to be uninhabited.",
-    "allowed_locs": [ "exodii_base_x0y3z0" ],
+    "description": "You have survived the initial wave of panic, and made your way to the wilderness. You were expecting to be uninhabited, but instead you see a large castle guarded by strange robots. At the entrance stands a sign, it reads \"Traders Come Well Avaunt\"",
+    "allowed_locs": [ "sloc_exodii_castle" ],
     "start_name": "Strange Castle",
     "flags": [ "LONE_START" ]
   },

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -24,7 +24,7 @@
     "id": "exodiicastle",
     "name": "Strange Castle",
     "points": 0,
-    "description": "You have survived the initial wave of panic, and made your way to the wilderness. You were expecting to be uninhabited, but instead you see a large castle guarded by strange robots. At the entrance stands a sign, it reads \"Traders Come Well Avaunt\"",
+    "description": "You have survived the initial wave of panic, and made your way to the wilderness. You were expecting this area to be uninhabited, but instead you see a large castle guarded by strange robots. At the entrance stands a sign, it reads \"Traders Come Well Avaunt\"",
     "allowed_locs": [ "sloc_exodii_castle" ],
     "start_name": "Strange Castle",
     "flags": [ "LONE_START" ],

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -21,6 +21,16 @@
   },
   {
     "type": "scenario",
+    "id": "exodiicastle",
+    "name": "Strange Castle",
+    "points": 0,
+    "description": "You have survived the initial wave of panic, and made your way to the wilderness. You happened upon a strange castle guarded by robots in an area you were expecting to be uninhabited.",
+    "allowed_locs": [ "exodii_base_x0y3z0" ],
+    "start_name": "Strange Castle",
+    "flags": [ "LONE_START" ]
+  },
+  {
+    "type": "scenario",
     "id": "friend_liam",
     "name": "Friends to the End",
     "points": -10,

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -27,7 +27,8 @@
     "description": "You have survived the initial wave of panic, and made your way to the wilderness. You were expecting to be uninhabited, but instead you see a large castle guarded by strange robots. At the entrance stands a sign, it reads \"Traders Come Well Avaunt\"",
     "allowed_locs": [ "sloc_exodii_castle" ],
     "start_name": "Strange Castle",
-    "flags": [ "LONE_START" ]
+    "flags": [ "LONE_START" ],
+    "requirement": "achievement_reach_exodii_base"
   },
   {
     "type": "scenario",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -24,7 +24,7 @@
     "id": "exodiicastle",
     "name": "Strange Castle",
     "points": 0,
-    "description": "You have survived the initial wave of panic, and made your way to the wilderness. You were expecting this area to be uninhabited, but instead you see a large castle guarded by strange robots.  At the entrance stands a sign, it reads \"Traders Come Well Avaunt\"",
+    "description": "You have survived the initial wave of panic, and made your way to the wilderness.  You were expecting this area to be uninhabited, but instead you see a large castle guarded by strange robots.  At the entrance stands a sign, it reads \"Traders Come Well Avaunt\"",
     "allowed_locs": [ "sloc_exodii_castle" ],
     "start_name": "Strange Castle",
     "flags": [ "LONE_START" ],

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -24,7 +24,7 @@
     "id": "exodiicastle",
     "name": "Strange Castle",
     "points": 0,
-    "description": "You have survived the initial wave of panic, and made your way to the wilderness. You were expecting this area to be uninhabited, but instead you see a large castle guarded by strange robots. At the entrance stands a sign, it reads \"Traders Come Well Avaunt\"",
+    "description": "You have survived the initial wave of panic, and made your way to the wilderness. You were expecting this area to be uninhabited, but instead you see a large castle guarded by strange robots.  At the entrance stands a sign, it reads \"Traders Come Well Avaunt\"",
     "allowed_locs": [ "sloc_exodii_castle" ],
     "start_name": "Strange Castle",
     "flags": [ "LONE_START" ],

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -84,6 +84,13 @@
   },
   {
     "type": "start_location",
+    "id": "sloc_exodii_castle",
+    "name": "Exodii castle",
+    "terrain": [ "exodii_base_x0y3z0" ],
+    "flags": [ "ALLOW_OUTSIDE" ]
+  },
+  {
+    "type": "start_location",
     "id": "sloc_house_boarded",
     "copy-from": "sloc_house",
     "name": "House (boarded up)",


### PR DESCRIPTION
#### Summary
Content "Add Exodii castle starting scenario"

#### Purpose of change

Add a starting scenario where you are outside the entrance of the Exodii castle. The CBM access and weaponry this location offers could make for a good start to a run, especially combined with one of the modded bionic professions.

#### Describe the solution

I created added a ZONE_START_POINT location that was close to the ""Traders Come Well Avaunt" sign, then added a scenario that uses it as its start location. I locked it behind the "Strange Neighbors" achievement to reach the base.

#### Describe alternatives you've considered

I considered not gating this behind an achievement as one use case is for people who may not have found this location organically to check it out, however I felt that in that case if they really wanted to they could just unlock it via debug. Given the power you can get from this location I felt it made more sense as a reward for finding it previously.

#### Testing

I started 5 new games and checked if I started outside the front entrance each time.

#### Additional context

None.
