### PR TITLE
Add an option to allow players add full Chinese glyphs ranges.

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -428,6 +428,9 @@ void cataimgui::client::load_fonts( UNUSED const Font_Ptr &gui_font,
         b.AddRanges( io.Fonts->GetGlyphRangesDefault() );
         AddGlyphRangesFromCLDR( &b, lang );
         AddGlyphRangesMisc( &b );
+        if ( get_option<bool>( "IMGUI_LOAD_CHINESE" ) ) {
+            b.AddRanges( io.Fonts->GetGlyphRangesChineseFull() );
+        }
         ImVector<ImWchar> ranges;
         b.BuildRanges( &ranges );
 

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -428,7 +428,7 @@ void cataimgui::client::load_fonts( UNUSED const Font_Ptr &gui_font,
         b.AddRanges( io.Fonts->GetGlyphRangesDefault() );
         AddGlyphRangesFromCLDR( &b, lang );
         AddGlyphRangesMisc( &b );
-        if ( get_option<bool>( "IMGUI_LOAD_CHINESE" ) ) {
+        if( get_option<bool>( "IMGUI_LOAD_CHINESE" ) ) {
             b.AddRanges( io.Fonts->GetGlyphRangesChineseFull() );
         }
         ImVector<ImWchar> ranges;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2391,6 +2391,11 @@ void options_manager::add_options_graphics()
              to_translation( "If true, use SDL ASCII line drawing routine instead of Unicode Line Drawing characters.  Use this option when your selected font doesn't contain necessary glyphs." ),
              true, COPT_CURSES_HIDE
            );
+
+        add("IMGUI_LOAD_CHINESE", page_id, to_translation( "Chinese glyph ranges in imgui" ),
+            to_translation( "If true, imgui will add glyphs of full Chinese, include zh_CN, zh_TW, ja. Use this option when your need all Chinese glyphs." ),
+            false, COPT_CURSES_HIDE
+        );
     } );
 #endif // TILES
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2393,7 +2393,7 @@ void options_manager::add_options_graphics()
            );
 
         add( "IMGUI_LOAD_CHINESE", page_id, to_translation( "Chinese glyph ranges in ImGui" ),
-             to_translation( "If true, ImGui will add glyphs of full Chinese, include zh_CN, zh_TW, ja. Use this option when your need all Chinese glyphs." ),
+             to_translation( "If true, ImGui will add glyphs of full Chinese, include zh_CN, zh_TW, ja. Use this option when your need all Chinese glyphs. Requires restart." ),
              false, COPT_CURSES_HIDE
            );
     } );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2392,8 +2392,8 @@ void options_manager::add_options_graphics()
              true, COPT_CURSES_HIDE
            );
 
-        add( "IMGUI_LOAD_CHINESE", page_id, to_translation( "Chinese glyph ranges in Imgui" ),
-             to_translation( "If true, Imgui will add glyphs of full Chinese, include zh_CN, zh_TW, ja. Use this option when your need all Chinese glyphs." ),
+        add( "IMGUI_LOAD_CHINESE", page_id, to_translation( "Chinese glyph ranges in ImGui" ),
+             to_translation( "If true, ImGui will add glyphs of full Chinese, include zh_CN, zh_TW, ja. Use this option when your need all Chinese glyphs." ),
              false, COPT_CURSES_HIDE
            );
     } );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2392,8 +2392,8 @@ void options_manager::add_options_graphics()
              true, COPT_CURSES_HIDE
            );
 
-        add( "IMGUI_LOAD_CHINESE", page_id, to_translation( "Chinese glyph ranges in imgui" ),
-             to_translation( "If true, imgui will add glyphs of full Chinese, include zh_CN, zh_TW, ja. Use this option when your need all Chinese glyphs." ),
+        add( "IMGUI_LOAD_CHINESE", page_id, to_translation( "Chinese glyph ranges in Imgui" ),
+             to_translation( "If true, Imgui will add glyphs of full Chinese, include zh_CN, zh_TW, ja. Use this option when your need all Chinese glyphs." ),
              false, COPT_CURSES_HIDE
            );
     } );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2392,10 +2392,10 @@ void options_manager::add_options_graphics()
              true, COPT_CURSES_HIDE
            );
 
-        add("IMGUI_LOAD_CHINESE", page_id, to_translation( "Chinese glyph ranges in imgui" ),
-            to_translation( "If true, imgui will add glyphs of full Chinese, include zh_CN, zh_TW, ja. Use this option when your need all Chinese glyphs." ),
-            false, COPT_CURSES_HIDE
-        );
+        add( "IMGUI_LOAD_CHINESE", page_id, to_translation( "Chinese glyph ranges in imgui" ),
+             to_translation( "If true, imgui will add glyphs of full Chinese, include zh_CN, zh_TW, ja. Use this option when your need all Chinese glyphs." ),
+             false, COPT_CURSES_HIDE
+           );
     } );
 #endif // TILES
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Two reasons:
- Zh_CN, zh_TW, jp all use a common glyphs ranges in the game, which mean they can't handle uncommon glyphs. And, some 'uncommon glyphs' is common in the game, like '躯' in zh_CN, which mean 'torso'. There is no reason to block players from persuing a full glyphs coverage.
- For loading which language's glyph ranges is determined by your language, if players don't use any Chinese language, no Chinese glyphs will be load, even though the player might use a mod contains Chinese ( especially some Japanese mods ). And, this will cause some serious mistakes: *calculating your glyphs' width uncorrectly*.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add an option, to allow players to load full Chinese glyph ranges if they want.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Add options for each language.
- Defaultly load a wide range.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Use the option and check the glyphs: all Chinese glyphs loaded.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I don't sure if similar option could be useful for other language. but this is **VERY** helpful for Chinese lang to kill those not-in-range glyphs at large.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
