### PR TITLE
Don't hardcode help text: Overmap filter popup

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1330,11 +1330,21 @@ static bool create_note( const tripoint_abs_omt &curs, std::optional<std::string
 // if false, search yielded no results
 static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripoint_abs_omt &orig )
 {
+    input_context ctxt( "STRING_INPUT" );
+    std::vector<std::string> act_descs;
+    const auto add_action_desc = [&]( const std::string & act, const std::string & txt ) {
+        act_descs.emplace_back( ctxt.get_desc( act, txt, input_context::allow_all_keys ) );
+    };
+    
+    add_action_desc( "HISTORY_UP", pgettext( "string input", "History" ) );
+    add_action_desc( "TEXT.CLEAR", pgettext( "string input", "Clear text" ) );
+    add_action_desc( "TEXT.QUIT", pgettext( "string input", "Abort" ) );
+    add_action_desc( "TEXT.CONFIRM", pgettext( "string input", "Save" ) );
     std::string term = string_input_popup()
                        .title( _( "Search term:" ) )
                        .description( string_format( "%s\n%s",
                                      _( "Multiple entries separated with comma (,). Excludes starting with hyphen (-)." ),
-                                     colorize( _( "UP: history, CTRL-U: clear line, ESC: abort, ENTER: save" ), c_green ) ) )
+                                     colorize( enumerate_as_string( act_descs, enumeration_conjunction::none ), c_green ) ) )
                        .desc_color( c_white )
                        .identifier( "overmap_search" )
                        .query_string();
@@ -1395,7 +1405,6 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
     } );
     ui.mark_resize();
 
-    input_context ctxt( "OVERMAP_SEARCH" );
     ctxt.register_action( "NEXT_TAB", to_translation( "Next result" ) );
     ctxt.register_action( "PREV_TAB", to_translation( "Previous result" ) );
     ctxt.register_action( "CONFIRM" );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1335,7 +1335,6 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
     const auto add_action_desc = [&]( const std::string & act, const std::string & txt ) {
         act_descs.emplace_back( ctxt.get_desc( act, txt, input_context::allow_all_keys ) );
     };
-    
     add_action_desc( "HISTORY_UP", pgettext( "string input", "History" ) );
     add_action_desc( "TEXT.CLEAR", pgettext( "string input", "Clear text" ) );
     add_action_desc( "TEXT.QUIT", pgettext( "string input", "Abort" ) );


### PR DESCRIPTION
#### Summary
`SUMMARY: Interface "Don't hardcode help text: Overmap filter popup"`

#### Purpose of change

Help text should not be hardcoded as, if end user changes their keybinds, it will cause discrepancies in the UI.  
This PR targets the filter pop up window for the Overmap UI and partially addresses #78986

#### Describe the solution

Pull the currently set keybind for each command, then replace the help text string with a function that enumerates the keybinds.

#### Describe alternatives you've considered

A lot of different ways of handling displaying help text. I used the Crafting window implementation as a reference again because it looks clean, even though it has some features that won't be relevant for this popup.

#### Testing

Game compiles and loads.  
Open overmap, open filter popup.  
Confirm all filter commands work.
Query something, confirm all search result commands work (previous/next result, confirm, quit, etc.)
Change keybind for `TEXT.CLEAR` and confirm it updates.

#### Additional context
This popup is always the same width, regardless of terminal size.

Before
![Screenshot 2025-01-24 120622](https://github.com/user-attachments/assets/e3163b28-dbf9-4e7f-b415-7c248133caff)
After (looks a little better too, right 🙂)
![Screenshot 2025-01-24 120437](https://github.com/user-attachments/assets/34c62ab0-7829-40ca-9b93-52aeddf63539)
After changed the keybind for clear
![Screenshot 2025-01-24 121019](https://github.com/user-attachments/assets/9df1b21b-dc9d-4745-8497-9370e84178eb)

