### PR TITLE
Add numpad binds for panning uilists

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3,25 +3,41 @@
     "type": "keybinding",
     "id": "UILIST.UP",
     "name": "Pan up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "keyboard_any", "key": "8" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_8" }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.DOWN",
     "name": "Pan down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "keyboard_any", "key": "2" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_2" }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.LEFT",
     "name": "Pan left",
-    "bindings": [ { "input_method": "keyboard_any", "key": "LEFT" } ]
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "keyboard_any", "key": "4" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_4" }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.RIGHT",
     "name": "Pan right",
-    "bindings": [ { "input_method": "keyboard_any", "key": "RIGHT" } ]
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "RIGHT" },
+      { "input_method": "keyboard_any", "key": "6" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_6" }
+    ]
   },
   {
     "type": "keybinding",


### PR DESCRIPTION
#### Summary
`SUMMARY: Interface "Add numpad keybinds for panning uilists"`

#### Purpose of change

The numpad keys are missing from the bindings for `UILIST` panning. 

#### Describe the solution

Add numpad keys to the default keybindings for `UILIST` pans in `data/raw/keybindings.json`.

#### Describe alternatives you've considered

No alternatives considered.

#### Testing

Open "Manage world" menu.
Move the cursor up and down with the numpad.

#### Additional context

This will address the issue mentioned in #79327, but won't automatically fix it. The end user will need to delete `config/keybindings.json` or reset the keybinding in-game. The user is also on 0.H so this would need to be backported (also 0.H does not have "reset keybinding")

`UILIST` already seems to support joystick by default (I tested with my controller, too), so I didn't add those to `keybindings.json`