### PR TITLE
refactor `map::shoot` bashing, part 1

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3798,7 +3798,7 @@ void map::smash_items( const tripoint_bub_ms &p, int power, const std::string &c
             }
         } else {
             const field_type_id type_blood = i->is_corpse() ? i->get_mtype()->bloodType() : fd_null;
-            while( ( damage_chance > material_factor || x_in_y( damage_chance, material_factor ) ) ) {
+            while( damage_chance > material_factor || x_in_y( damage_chance, material_factor ) ) {
                 add_splash( type_blood, p, 1, damage_chance );
                 damage_chance -= material_factor;
                 item_was_damaged = true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4405,7 +4405,7 @@ void map::crush( const tripoint_bub_ms &p )
         vp->vehicle().damage( *this, vp->part_index(), rng( 100, 1000 ), damage_bash, false );
     }
 }
-void map::shoot( const tripoint_bub_ms &p, projectile &proj, const bool hit_items )
+double map::shoot( const tripoint_bub_ms &p, projectile &proj, const bool hit_items )
 {
     // TODO: make bashing better a destroying, worse at penetrating
     std::map<damage_type_id, float> dmg_by_type {};
@@ -4420,7 +4420,7 @@ void map::shoot( const tripoint_bub_ms &p, projectile &proj, const bool hit_item
         return acc + dmg.second;
     } );
     if( initial_damage < 0 ) {
-        return;
+        return 0;
     }
     // TODO: use this for more than just vehicle parts
     const damage_type_id &main_damage_type = std::max_element( dmg_by_type.begin(), dmg_by_type.end(),
@@ -4436,72 +4436,72 @@ void map::shoot( const tripoint_bub_ms &p, projectile &proj, const bool hit_item
     const bool incendiary = ammo_effects.count( ammo_effect_INCENDIARY );
     const bool ignite = ammo_effects.count( ammo_effect_IGNITE );
     const bool laser = ammo_effects.count( ammo_effect_LASER );
+    bool hit_something = false;
 
     if( const optional_vpart_position vp = veh_at( p ) ) {
         dam = vp->vehicle().damage( *this, vp->part_index(), dam, main_damage_type, hit_items );
-    }
+    } else {
+        // This lambda is only called if the furniture/terrain has shoot data!
+        const auto shoot_furn_ter = [&]( const map_data_common_t &data ) {
+            const map_shoot_info &shoot = *data.shoot;
+            bool destroyed = false;
 
-    // This lambda is only called if the furniture/terrain has shoot data!
-    const auto shoot_furn_ter = [&]( const map_data_common_t &data ) {
-        const map_shoot_info &shoot = *data.shoot;
-        bool destroyed = false;
+            // if you are aiming at this tile, you can never miss
+            if( hit_items || x_in_y( shoot.chance_to_hit, 100 ) ) {
+                if( laser ) {
+                    dam -= rng( shoot.reduce_dmg_min_laser, shoot.reduce_dmg_max_laser );
+                } else {
+                    dam -= rng( shoot.reduce_dmg_min, shoot.reduce_dmg_max );
+                }
+                // lasers can't destroy some types of furn/ter you can shoot through
+                if( !laser || !shoot.no_laser_destroy ) {
+                    // important to use initial damage, energy from reduction has gone into the furn/ter
+                    const int min_damage = int( initial_damage ) - shoot.destroy_dmg_min;
+                    const int max_damage = shoot.destroy_dmg_max - shoot.destroy_dmg_min;
+                    if( x_in_y( min_damage, max_damage ) ) {
+                        // don't need to duplicate all the destruction logic here
+                        bash_params bsh{ 0, false, true, false, 0.0, false, false, false, false };
+                        bash_ter_furn( p, bsh );
+                        destroyed = true;
+                    }
+                }
+                if( dam <= 0 && get_player_view().sees( p ) ) {
+                    add_msg( _( "The shot is stopped by the %s!" ), data.name() );
+                }
+                // only very flammable furn/ter can be set alight with incendiary rounds
+                if( data.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {
+                    if( incendiary && x_in_y( initial_damage, 100 ) ) {
+                        // 1% chance for 1 damage
+                        add_field( p, fd_fire, 1 );
+                    }
+                    if( ignite ) {
+                        add_field( p, fd_fire, 1 );
+                    }
+                }
+                // bash_ter_furn already triggers the alarm
+                // TODO: fix alarm event weirdness (not just here, also in bash, hack, etc)
+                if( !destroyed && data.has_flag( ter_furn_flag::TFLAG_ALARMED ) ) {
+                    sounds::sound( p, 40, sounds::sound_t::alarm, _( "an alarm go off!" ),
+                                   false, "environment", "alarm" );
+                }
+                return true;
+            }
+            return false;
+        };
 
-        // if you are aiming at this tile, you can never miss
-        if( hit_items || x_in_y( shoot.chance_to_hit, 100 ) ) {
-            if( laser ) {
-                dam -= rng( shoot.reduce_dmg_min_laser, shoot.reduce_dmg_max_laser );
-            } else {
-                dam -= rng( shoot.reduce_dmg_min, shoot.reduce_dmg_max );
-            }
-            // lasers can't destroy some types of furn/ter you can shoot through
-            if( !laser || !shoot.no_laser_destroy ) {
-                // important to use initial damage, energy from reduction has gone into the furn/ter
-                const int min_damage = int( initial_damage ) - shoot.destroy_dmg_min;
-                const int max_damage = shoot.destroy_dmg_max - shoot.destroy_dmg_min;
-                if( x_in_y( min_damage, max_damage ) ) {
-                    // don't need to duplicate all the destruction logic here
-                    bash_params bsh{ 0, false, true, false, 0.0, false, false, false, false };
-                    bash_ter_furn( p, bsh );
-                    destroyed = true;
-                }
-            }
-            if( dam <= 0 && get_player_view().sees( p ) ) {
-                add_msg( _( "The shot is stopped by the %s!" ), data.name() );
-            }
-            // only very flammable furn/ter can be set alight with incendiary rounds
-            if( data.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {
-                if( incendiary && x_in_y( initial_damage, 100 ) ) {
-                    // 1% chance for 1 damage
-                    add_field( p, fd_fire, 1 );
-                }
-                if( ignite ) {
-                    add_field( p, fd_fire, 1 );
-                }
-            }
-            // bash_ter_furn already triggers the alarm
-            // TODO: fix alarm event weirdness (not just here, also in bash, hack, etc)
-            if( !destroyed && data.has_flag( ter_furn_flag::TFLAG_ALARMED ) ) {
-                sounds::sound( p, 40, sounds::sound_t::alarm, _( "an alarm go off!" ),
-                               false, "environment", "alarm" );
-            }
-            return true;
+        const furn_id &furniture = furn( p );
+        const ter_id &terrain = ter( p );
+
+        // shoot through furniture or terrain and see if we hit something
+        if( furniture->shoot ) { // Shoot data is optional, most furniture will never trigger this
+            hit_something |= shoot_furn_ter( furniture.obj() );
+        } else if( terrain->shoot ) { // Shoot data is optional, most terrain will never trigger this
+            hit_something |= shoot_furn_ter( terrain.obj() );
+            // fall back to just bashing when shoot data is not defined
+        } else if( impassable( p ) && !is_transparent( p ) ) {
+            bash( p, dam, false );
+            dam = 0;
         }
-        return false;
-    };
-
-    const furn_id &furniture = furn( p );
-    const ter_id &terrain = ter( p );
-    bool hit_something = false;
-
-    // shoot through furniture or terrain and see if we hit something
-    if( furniture->shoot ) { // Shoot data is optional, most furniture will never trigger this
-        hit_something |= shoot_furn_ter( furniture.obj() );
-    } else if( terrain->shoot ) { // Shoot data is optional, most terrain will never trigger this
-        hit_something |= shoot_furn_ter( terrain.obj() );
-        // fall back to just bashing when shoot data is not defined
-    } else if( impassable( p ) && !is_transparent( p ) ) {
-        bash( p, dam, false );
-        dam = 0;
     }
     dam = std::max( 0.0f, dam );
 
@@ -4533,33 +4533,33 @@ void map::shoot( const tripoint_bub_ms &p, projectile &proj, const bool hit_item
     }
 
     // Rescale the damage
+    double multiplier = 1.0;
     if( dam <= 0 ) {
         impact.clear();
-        return;
+        return 0;
     } else if( dam < initial_damage ) {
-        impact.mult_damage( dam / static_cast<double>( initial_damage ) );
+        multiplier = dam / static_cast<double>( initial_damage );
     }
 
     // for now, shooting furniture or terrain protects any items
-    if( !hit_items || hit_something ) {
-        return;
-    }
+    if( hit_items && !hit_something ) {
+        // Make sure the message is sensible for the ammo effects. Lasers aren't projectiles.
+        std::string damage_message;
+        if( ammo_effects.count( ammo_effect_LASER ) ) {
+            damage_message = _( "laser beam" );
+        } else if( ammo_effects.count( ammo_effect_LIGHTNING ) ) {
+            damage_message = _( "bolt of electricity" );
+        } else if( ammo_effects.count( ammo_effect_PLASMA ) ) {
+            damage_message = _( "bolt of plasma" );
+        } else {
+            damage_message = _( "flying projectile" );
+        }
 
-    // Make sure the message is sensible for the ammo effects. Lasers aren't projectiles.
-    std::string damage_message;
-    if( ammo_effects.count( ammo_effect_LASER ) ) {
-        damage_message = _( "laser beam" );
-    } else if( ammo_effects.count( ammo_effect_LIGHTNING ) ) {
-        damage_message = _( "bolt of electricity" );
-    } else if( ammo_effects.count( ammo_effect_PLASMA ) ) {
-        damage_message = _( "bolt of plasma" );
-    } else {
-        damage_message = _( "flying projectile" );
+        // Now, smash items on that tile.
+        // dam / 3, because bullets aren't all that good at destroying items...
+        smash_items( p, dam / 3, damage_message );
     }
-
-    // Now, smash items on that tile.
-    // dam / 3, because bullets aren't all that good at destroying items...
-    smash_items( p, dam / 3, damage_message );
+    return multiplier;
 }
 
 bool map::hit_with_acid( const tripoint_bub_ms &p )

--- a/src/map.h
+++ b/src/map.h
@@ -1128,7 +1128,7 @@ class map
         /** Keeps bashing a square until there is no more vehicle part */
         void destroy_vehicle( const tripoint_bub_ms &, bool silent = false );
         void crush( const tripoint_bub_ms &p );
-        void shoot( const tripoint_bub_ms &p, projectile &proj, bool hit_items );
+        double shoot( const tripoint_bub_ms &p, projectile &proj, bool hit_items );
         /** Checks if a square should collapse, returns the X for the one_in(X) collapse chance */
         int collapse_check( const tripoint_bub_ms &p ) const;
         /** Causes a collapse at p, such as from destroying a wall */

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -440,7 +440,7 @@ bool map_shoot_info::load( const JsonObject &jsobj, const std::string_view membe
 {
     JsonObject j = jsobj.get_object( member );
 
-    optional( j, was_loaded, "chance_to_hit", chance_to_hit, 100 );
+    optional( j, false, "chance_to_hit", chance_to_hit, 100 );
 
     std::pair<int, int> reduce_damage;
     std::pair<int, int> reduce_damage_laser;
@@ -457,7 +457,7 @@ bool map_shoot_info::load( const JsonObject &jsobj, const std::string_view membe
     destroy_dmg_min = destroy_damage.first;
     destroy_dmg_max = destroy_damage.second;
 
-    optional( j, was_loaded, "no_laser_destroy", no_laser_destroy, false );
+    optional( j, false, "no_laser_destroy", no_laser_destroy, false );
 
     return true;
 }

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -120,7 +120,7 @@ struct map_furn_deconstruct_info : map_common_deconstruct_info {
 };
 struct map_shoot_info {
     // Base chance to hit the object at all (defaults to 100%)
-    int chance_to_hit = 0;
+    int chance_to_hit = 100;
     // Minimum damage reduction to apply to shot when hit
     int reduce_dmg_min = 0;
     // Maximum damage reduction to apply to shot when hit


### PR DESCRIPTION
#### Summary
Bugfixes "fix `map::shoot` bashing items"
#### Purpose of change
Turns out that at point-blank shotgun shell can bash items `projectile_count` times with a power of `damage`, and can bash ter/furn `projectile_count` - 1 extra times with a power of `shot_damage`.
#### Describe the solution
Now a shot will only bash items one time at point-blank.
In addition, there is a chance that a proj will incorrectly bash vehicle one more time, fixed it.
Also fixed `map::smash_items` may not bash and show msg correctly when targeting a pulped corpse.
#### Describe alternatives you've considered
Further limit the amount of items one proj can damage.
#### Testing
Compiled and passed tests loaclly.
Before:

https://github.com/user-attachments/assets/d903fa2d-9cd7-4b26-9c20-04e006caec7a

After:

https://github.com/user-attachments/assets/22573501-a702-4717-8258-60cb023c552d

#### Additional context
There are also points about bashing ter/furn that need to be refactored in `map::shoot`, but I'll leave them to the next PR.