### PR TITLE
Fix "Build Dirt Floor" requirements

### DIFF
--- a/data/json/construction/floors_indoors.json
+++ b/data/json/construction/floors_indoors.json
@@ -455,6 +455,7 @@
     "required_skills": [ [ "survival", 1 ] ],
     "time": "15 m",
     "qualities": [ { "id": "DIG", "level": 1 } ],
+    "pre_flags": [ "DIGGABLE", "PLOWABLE" ],
     "pre_note": "Must be supported on at least two sides.",
     "pre_special": "check_support",
     "post_terrain": "t_dirtfloor",

--- a/data/json/construction/floors_indoors.json
+++ b/data/json/construction/floors_indoors.json
@@ -457,7 +457,7 @@
     "qualities": [ { "id": "DIG", "level": 1 } ],
     "pre_flags": [ "DIGGABLE", "PLOWABLE" ],
     "pre_note": "Must be supported on at least two sides.",
-    "pre_special": "check_support",
+    "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_dirtfloor",
     "activity_level": "LIGHT_EXERCISE"
   },

--- a/data/json/construction/floors_indoors.json
+++ b/data/json/construction/floors_indoors.json
@@ -452,11 +452,13 @@
     "id": "constr_dirtfloor",
     "group": "build_dirt_floor",
     "category": "CONSTRUCT",
-    "required_skills": [ [ "fabrication", 3 ] ],
+    "required_skills": [ [ "survival", 1 ] ],
     "time": "15 m",
+    "qualities": [ { "id": "DIG", "level": 1 } ],
     "pre_note": "Must be supported on at least two sides.",
     "pre_special": "check_support",
-    "post_terrain": "t_dirtfloor"
+    "post_terrain": "t_dirtfloor",
+    "activity_level": "LIGHT_EXERCISE"
   },
   {
     "type": "construction",


### PR DESCRIPTION


#### Summary
Bugfixes "Require "Dirt Floor" to be built on dirt with a shovel"


#### Purpose of change

Fixes #79161. Dirt floor now must be built on dirt, using a shovel. Changes skill to "survival" to match similar tasks.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Changing the JSON to prohibit building the dirt floor out of thin air. Requires a tool with "digging" 1 or higher
since shovels are described in-game as being able to tamp ground. Makes sense realistically too.

#### Describe alternatives you've considered

None.

#### Testing

Going in game, spawning a shovel, successfully making a dirt floor on dirt but being unable to do so on pavement.
![screenshot](https://github.com/user-attachments/assets/dd34a5da-09d3-4763-987c-5682e9b395bf)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
