### PR TITLE
Item groups don't spawn blacklisted items

### DIFF
--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -706,6 +706,9 @@ void Item_modifier::check_consistency( const std::string &context ) const
     if( ammo != nullptr ) {
         ammo->check_consistency( true );
     }
+    if( contents != nullptr ) {
+        contents->check_consistency( true );
+    }
     if( container != nullptr ) {
         container->check_consistency( true );
     }
@@ -723,6 +726,11 @@ bool Item_modifier::remove_item( const itype_id &itemid )
     if( ammo != nullptr ) {
         if( ammo->remove_item( itemid ) ) {
             ammo.reset();
+        }
+    }
+    if( contents != nullptr ) {
+        if( contents->remove_item( itemid ) ) {
+            contents.reset();
         }
     }
     if( container != nullptr ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Item groups don't spawn blacklisted items"

#### Purpose of change

In #79285 it came to light that blacklists weren't regarded with item group spawns.

#### Describe the solution

Add containers to item removal in item modifiers.
Also add containers to consistency check in item modifiers.
There's potential (and need honestly) for test cases here, but I want to see if it breaks existing tests before I work on that.

#### Describe alternatives you've considered



#### Testing

Ran tests with this PR on top of #79285 and `[force_load_game] --mods=dda,generic_guns`.

#### Additional context

