### PR TITLE
refactor: template implementation

### DIFF
--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -548,74 +548,53 @@ static void rotate_direction_cw( int &dx, int &dy )
     dy = dir_num / 3 - 1;
 }
 
-std::optional<tripoint_rel_ms> input_context::get_direction_rel_ms( const std::string &action )
-const
+// This templating ensures that only coord_point with origin::relative is accepted.
+// See src/coords_fwd.h and src/coordinates.h
+template<typename Point, coords::scale Scale>
+static std::optional<coords::coord_point<Point, coords::origin::relative, Scale>>
+        get_direction( const std::string &action, bool iso_mode )
 {
-    static const auto noop = static_cast<tripoint_rel_ms( * )( tripoint_rel_ms )>( [](
-    tripoint_rel_ms p ) {
+    using CoordPoint = coords::coord_point<Point, coords::origin::relative, Scale>;
+    static const auto noop = static_cast<CoordPoint( * )( CoordPoint )>( []( CoordPoint p ) {
         return p;
     } );
-    static const auto rotate = static_cast<tripoint_rel_ms( * )( tripoint_rel_ms )>( [](
-    tripoint_rel_ms p ) {
+    static const auto rotate = static_cast<CoordPoint( * )( CoordPoint )>( []( CoordPoint p ) {
         rotate_direction_cw( p.x(), p.y() );
         return p;
     } );
     const auto transform = iso_mode && g->is_tileset_isometric() ? rotate : noop;
 
     if( action == "UP" ) {
-        return transform( tripoint_rel_ms::north );
+        return transform( CoordPoint::north );
     } else if( action == "DOWN" ) {
-        return transform( tripoint_rel_ms::south );
+        return transform( CoordPoint::south );
     } else if( action == "LEFT" ) {
-        return transform( tripoint_rel_ms::west );
+        return transform( CoordPoint::west );
     } else if( action == "RIGHT" ) {
-        return transform( tripoint_rel_ms::east );
+        return transform( CoordPoint::east );
     } else if( action == "LEFTUP" ) {
-        return transform( tripoint_rel_ms::north_west );
+        return transform( CoordPoint::north_west );
     } else if( action == "RIGHTUP" ) {
-        return transform( tripoint_rel_ms::north_east );
+        return transform( CoordPoint::north_east );
     } else if( action == "LEFTDOWN" ) {
-        return transform( tripoint_rel_ms::south_west );
+        return transform( CoordPoint::south_west );
     } else if( action == "RIGHTDOWN" ) {
-        return transform( tripoint_rel_ms::south_east );
+        return transform( CoordPoint::south_east );
     } else {
         return std::nullopt;
     }
 }
 
+std::optional<tripoint_rel_ms> input_context::get_direction_rel_ms( const std::string &action )
+const
+{
+    return get_direction<tripoint, coords::ms>( action, iso_mode );
+}
+
 std::optional<tripoint_rel_omt> input_context::get_direction_rel_omt( const std::string &action )
 const
 {
-    static const auto noop = static_cast<tripoint_rel_omt( * )( tripoint_rel_omt )>( [](
-    tripoint_rel_omt p ) {
-        return p;
-    } );
-    static const auto rotate = static_cast<tripoint_rel_omt( * )( tripoint_rel_omt )>( [](
-    tripoint_rel_omt p ) {
-        rotate_direction_cw( p.x(), p.y() );
-        return p;
-    } );
-    const auto transform = iso_mode && g->is_tileset_isometric() ? rotate : noop;
-
-    if( action == "UP" ) {
-        return transform( tripoint_rel_omt::north );
-    } else if( action == "DOWN" ) {
-        return transform( tripoint_rel_omt::south );
-    } else if( action == "LEFT" ) {
-        return transform( tripoint_rel_omt::west );
-    } else if( action == "RIGHT" ) {
-        return transform( tripoint_rel_omt::east );
-    } else if( action == "LEFTUP" ) {
-        return transform( tripoint_rel_omt::north_west );
-    } else if( action == "RIGHTUP" ) {
-        return transform( tripoint_rel_omt::north_east );
-    } else if( action == "LEFTDOWN" ) {
-        return transform( tripoint_rel_omt::south_west );
-    } else if( action == "RIGHTDOWN" ) {
-        return transform( tripoint_rel_omt::south_east );
-    } else {
-        return std::nullopt;
-    }
+    return get_direction<tripoint, coords::omt>( action, iso_mode );
 }
 
 // Custom set of hotkeys that explicitly don't include the hardcoded


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

There are two almost identical methods differing only in the tripoint type they operate on.

Less code duplication is better.

#### Describe the solution

Template them.

Do so only in the implementation (.cpp, not .h)

#### Describe alternatives you've considered

Do it in .h file too. This would require to move the implementation to the .h file.

#### Testing

Compiles.

#### Additional context

