### PR TITLE
Optionally accept precise OMT coordinates in debug "Teleport - to specific overmap" function

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1791,7 +1791,7 @@ static void teleport_overmap( bool specific_coordinates = false )
                    coord_strings.size() );
             return;
         }
-        std::vector<std::pair<int, int>> coord_ints;
+        std::vector<std::pair<int, int>> coord_ints
         for( const std::string &coord_string : coord_strings ) {
             const std::vector<std::string> coord_parts = string_split( coord_string, '\'' );
             if( coord_parts.size() < 1 || coord_parts.size() > 2 ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1791,7 +1791,7 @@ static void teleport_overmap( bool specific_coordinates = false )
                    coord_strings.size() );
             return;
         }
-        std::vector<std::pair<int, int>> coord_ints
+        std::vector<std::pair<int, int>> coord_ints;
         for( const std::string &coord_string : coord_strings ) {
             const std::vector<std::string> coord_parts = string_split( coord_string, '\'' );
             if( coord_parts.size() < 1 || coord_parts.size() > 2 ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1794,7 +1794,7 @@ static void teleport_overmap( bool specific_coordinates = false )
         std::vector<std::pair<int, int>> coord_ints;
         for( const std::string &coord_string : coord_strings ) {
             const std::vector<std::string> coord_parts = string_split( coord_string, '\'' );
-            if( coord_parts.size() < 1 || coord_parts.size() > 2 ) {
+            if( coord_parts.empty() || coord_parts.size() > 2 ) {
                 popup( _( "Error interpreting teleport target: "
                           "expected an integer or two integers separated by \'; got %s" ), coord_string );
                 return;
@@ -1814,13 +1814,12 @@ static void teleport_overmap( bool specific_coordinates = false )
                 }
                 minor_coord = parsed_coord2.value();
             }
-            coord_ints.push_back( std::pair<int, int>( major_coord, minor_coord ) );
+            coord_ints.emplace_back( std::pair<int, int>( major_coord, minor_coord ) );
         }
         cata_assert( coord_ints.size() >= 2 );
-        int x = OMAPX * coord_ints[0].first + coord_ints[0].second;
-        int y = OMAPY * coord_ints[1].first + coord_ints[1].second;
-        int z = coord_ints.size() >= 3 ? coord_ints[2].first : 0;
-        where = tripoint_abs_omt( x, y, z );
+        where = tripoint_abs_omt( OMAPX * coord_ints[0].first + coord_ints[0].second,
+                                  OMAPY * coord_ints[1].first + coord_ints[1].second, 
+                                  (coord_ints.size() >= 3 ? coord_ints[2].first : 0) );
     } else {
         const std::optional<tripoint_rel_ms> dir_ = choose_direction(
                     _( "Where is the desired overmap?" ) );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1818,8 +1818,8 @@ static void teleport_overmap( bool specific_coordinates = false )
         }
         cata_assert( coord_ints.size() >= 2 );
         where = tripoint_abs_omt( OMAPX * coord_ints[0].first + coord_ints[0].second,
-                                  OMAPY * coord_ints[1].first + coord_ints[1].second, 
-                                  (coord_ints.size() >= 3 ? coord_ints[2].first : 0) );
+                                  OMAPY * coord_ints[1].first + coord_ints[1].second,
+                                  ( coord_ints.size() >= 3 ? coord_ints[2].first : 0 ) );
     } else {
         const std::optional<tripoint_rel_ms> dir_ = choose_direction(
                     _( "Where is the desired overmap?" ) );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1791,21 +1791,36 @@ static void teleport_overmap( bool specific_coordinates = false )
                    coord_strings.size() );
             return;
         }
-        std::vector<int> coord_ints;
+        std::vector<std::pair<int, int>> coord_ints;
         for( const std::string &coord_string : coord_strings ) {
-            ret_val<int> parsed_coord = try_parse_integer<int>( coord_string, true );
+            const std::vector<std::string> coord_parts = string_split( coord_string, '\'' );
+            if( coord_parts.size() < 1 || coord_parts.size() > 2 ) {
+                popup( _( "Error interpreting teleport target: "
+                          "expected an integer or two integers separated by \'; got %s" ), coord_string );
+                return;
+            }
+            ret_val<int> parsed_coord = try_parse_integer<int>( coord_parts[0], true );
             if( !parsed_coord.success() ) {
                 popup( _( "Error interpreting teleport target: %s" ), parsed_coord.str() );
                 return;
             }
-            coord_ints.push_back( parsed_coord.value() );
+            int major_coord = parsed_coord.value();
+            int minor_coord = 0;
+            if( coord_parts.size() >= 2 ) {
+                ret_val<int> parsed_coord2 = try_parse_integer<int>( coord_parts[1], true );
+                if( !parsed_coord2.success() ) {
+                    popup( _( "Error interpreting teleport target: %s" ), parsed_coord2.str() );
+                    return;
+                }
+                minor_coord = parsed_coord2.value();
+            }
+            coord_ints.push_back( std::pair<int, int>( major_coord, minor_coord ) );
         }
         cata_assert( coord_ints.size() >= 2 );
-        tripoint coord;
-        coord.x = coord_ints[0];
-        coord.y = coord_ints[1];
-        coord.z = coord_ints.size() >= 3 ? coord_ints[2] : 0;
-        where = tripoint_abs_omt( OMAPX * coord.x, OMAPY * coord.y, coord.z );
+        int x = OMAPX * coord_ints[0].first + coord_ints[0].second;
+        int y = OMAPY * coord_ints[1].first + coord_ints[1].second;
+        int z = coord_ints.size() >= 3 ? coord_ints[2].first : 0;
+        where = tripoint_abs_omt( x, y, z );
     } else {
         const std::optional<tripoint_rel_ms> dir_ = choose_direction(
                     _( "Where is the desired overmap?" ) );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1814,7 +1814,7 @@ static void teleport_overmap( bool specific_coordinates = false )
                 }
                 minor_coord = parsed_coord2.value();
             }
-            coord_ints.emplace_back( std::pair<int, int>( major_coord, minor_coord ) );
+            coord_ints.emplace_back( major_coord, minor_coord );
         }
         cata_assert( coord_ints.size() >= 2 );
         where = tripoint_abs_omt( OMAPX * coord_ints[0].first + coord_ints[0].second,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Optionally allows a specific overmap tile to be specified for the debug 'Teleport - to specific overmap' function."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
It is sometimes useful to teleport to a specific overmap tile, either when testing or when cheating/working around an issue. The existing 'teleport to specific overmap' option in the debug menu takes single integer x and y coordinates separated by a comma specifying a whole overmap (128x128 block of OMTs). Extending this syntax so that the existing overmap teleport works in the same way as before but more precise OMT coordinates can be used if desired makes it more useful.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Extend parsing to understand the OMT coordinate system used in the overmap display - an integer overmap coordinate followed by a single quote/apostrophe and then an integer OMT offset within the overmap for each of x and y. If no OMT offset is given then a value of 0 is used, giving the same behaviour as existed previously. So you can now choose to teleport to 1'123,0'42 instead of just 1,0.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this. You can still reasonably quickly teleport to a specific OMT by teleporting to the origin of an overmap and then using the 'Teleport - Long Range' option to precisely select an OMT on the overmap view.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used the feature to teleport around the map. Also checked that just specifying overmap coordinates as integers and that using optional integer z-coordinates continues to work as before.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
