### PR TITLE
Add apt-get update step into the clang-tidy job

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -41,6 +41,7 @@ jobs:
     - name: install LLVM 17
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: |
+          sudo apt-get update
           sudo apt install llvm-17 llvm-17-dev llvm-17-tools clang-17 clang-tidy-17 clang-tools-17 libclang-17-dev
           sudo apt install python3-pip ninja-build cmake
           pip3 install --user lit
@@ -83,6 +84,7 @@ jobs:
     - name: install dependencies
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: |
+          sudo apt-get update
           sudo apt install clang-17 clang-tidy-17 cmake ccache jq
           sudo apt install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext 
     - name: checkout repository


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Clang-tidy runners are spuriously failing https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12967965940/job/36170475239?pr=79311


#### Describe the solution

The error message says 
>  E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

So I thought I should maybe do that...

#### Describe alternatives you've considered

Unclear. 
I'm not exactly sure what's the root of the problem because *sometimes* apt-get install works totally fine. E.g. https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12967965940/job/36170475187?pr=79311 which is part of the exact same matrix as the failing one in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12967965940/job/36170475239?pr=79311
(I'm also a bit surprised that github actions don't come with `apt-get update` pre-run - doing so would save them a small amount of CPU cycles, but guess there're other complications with that)

#### Testing
Seems to be working in my fork https://github.com/moxian/Cataclysm-DDA/actions/runs/12970195966?pr=16
But, again, I'm not 100% sure this fixes the issue for good, or if i was just lucky here

#### Additional context
