### PR TITLE
Fix dirt floor durability and materials

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -604,7 +604,7 @@
     "connects_to": "DIRT",
     "move_cost": 2,
     "roof": "t_shingle_flat_roof",
-      "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "DIGGABLE" ],
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "DIGGABLE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_null",

--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -604,14 +604,15 @@
     "connects_to": "DIRT",
     "move_cost": 2,
     "roof": "t_shingle_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "DIGGABLE" ],
+      "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "DIGGABLE" ],
     "bash": {
-      "sound": "SMASH!",
+      "sound": "thump",
       "ter_set": "t_null",
-      "str_min": 50,
-      "str_max": 400,
-      "str_min_supported": 100,
-      "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
+      "str_min": 1,
+      "str_max": 6,
+      "sound_vol": 8,
+      "sound_fail_vol": 8,
+      "items": [ { "item": "material_soil", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -629,11 +630,12 @@
     "roof": "t_thatch_roof",
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "DIGGABLE" ],
     "bash": {
-      "sound": "SMASH!",
+      "sound": "thump",
       "ter_set": "t_null",
-      "str_min": 50,
-      "str_max": 400,
-      "str_min_supported": 100,
+      "str_min": 5,
+      "str_max": 15,
+      "sound_vol": 8,
+      "sound_fail_vol": 8,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "straw_pile", "count": [ 5, 10 ] } ]
     }
   },


### PR DESCRIPTION


#### Summary
Bugfixes "Fix "dirt floor" durability and materials"

#### Purpose of change

Not related to #79334. Dirt floors exhibit bugged behaviour: they are
flammable, drop splinters and nails when broken/burnt, and have a
"SMASH!" sound when broken or hit. They are also almost impossible to
get rid of. Now that players are intended to be able to make them these
issues should be fixed to prevent exploitation. Especially the infinite 
nails! 

#### Describe the solution

This makes dirt floors not flammable, easy to smash and only dropping
a bit of soil when broken.

#### Describe alternatives you've considered

Making dirt floors have EASY_DECONSTRUCT instead of smashing. Either
or is fine with me.  It makes sense to me to mess up tamped ground by
just kicking it around a bit, but I don't know if it's the "proper"
way to do it.

#### Testing

1. Making dirt floors and smashing them 

2. Spawning structures containing dirt floors and checking for issues 
(none found but i didnt check all of them)

#### Additional Information

There is some duplicate of a dirt floor that drops straw when broken.
I have mostly left it alone except for sounds and durability. Not sure
if it dropping straw needs changing.

