### PR TITLE
[Aftershock] Augustmoon Traders use loot zones

### DIFF
--- a/data/mods/Aftershock/maps/mapgen/port_augustmoon/port_augustmoon_main.json
+++ b/data/mods/Aftershock/maps/mapgen/port_augustmoon/port_augustmoon_main.json
@@ -34,22 +34,22 @@
         ".|1111=      ||::|::||||",
         ".|1111=ò|  |Ñ|566|665||.",
         "|||||||||]]|||666|666||.",
-        "|ë,=  ],    ,||||||||||.",
-        "|ëË=  ]      %||ÑÑÑ = ||",
-        "||==  |  Í|   ]_    = Ï=",
-        "|    ,|==||,, ]_    = Ï=",
-        "|    ,|,ík|  =|| ,, =ïÏ=",
-        "||    |  l|   1| ,, = Ï=",
-        "|,   ,||!||  =||    = Ï=",
+        "|q,=  ],    ,||||||||||.",
+        "|qË=  ]      %||ÑÑÑ = ||",
+        "||==  |  Í|   ]_    = q=",
+        "|    ,|==||,, ]_    = q=",
+        "|    ,|,ík|  =|| ,, =ïq=",
+        "||    |  l|   1| ,, = q=",
+        "|,   ,||!||  =||    = q=",
         "|23|23|.,!ú,, 1|    = ||",
         "|||||||||||  ||||  ||||.",
-        ".|  |,sss,]  |ÑÑ ,, ÑÑ|.",
+        ".|q |,sss,]  |ÑÑ ,, ÑÑ|.",
         ".|qó=     ]  |Ñ,    ,Ñ|.",
         ".|, =     |||||||   ||||",
         ".| ||!!||Ñ|..|,  ,,  ,|.",
         ".|!|0  0|||..|  ====  ||",
         ".|,      ,|..| ||jÄ|| | ",
-        ".||00  00||,,|||ä,,ä||||",
+        ".||00  00||,,|||q,,q||||",
         "..|||]]|||...4||||||||..",
         "..|7á  á7|...4..........",
         "..|8 ,, 8|..............",
@@ -62,6 +62,45 @@
         "........................"
       ],
       "palettes": [ "afs_habitat_structure", "afs_habitat_residential_furnishing" ],
+      "place_zones": [
+        { "type": "LOOT_ITEM_GROUP", "filter": "NC_AUGUSTMOON_DOCTOR_stock", "faction": "mercurial", "x": 2, "y": [ 31, 32 ] },
+        {
+          "type": "LOOT_ITEM_GROUP",
+          "filter": "afs_augustmoon_tool_trader",
+          "faction": "UICA",
+          "x": 1,
+          "y": [ 22, 23 ]
+        },
+        { "type": "LOOT_ITEM_GROUP", "filter": "afs_augustmoon_outfitter", "faction": "UICA", "x": 16, "y": 37 },
+        {
+          "type": "LOOT_ITEM_GROUP",
+          "filter": "afs_augustmoon_outfitter_military",
+          "faction": "UICA",
+          "x": 19,
+          "y": 37
+        },
+        {
+          "type": "LOOT_ITEM_GROUP",
+          "filter": "afs_augustmoon_guntrader",
+          "faction": "UICA",
+          "x": 22,
+          "y": [ 24, 26 ]
+        },
+        {
+          "type": "LOOT_ITEM_GROUP",
+          "filter": "afs_augustmoon_guntrader_military",
+          "faction": "UICA",
+          "x": 22,
+          "y": [ 27, 28 ]
+        },
+        {
+          "type": "LOOT_ITEM_GROUP",
+          "filter": "NC_AUGUSTMOON_shipping_stock",
+          "faction": "UICA",
+          "x": 9,
+          "y": [ 26, 27 ]
+        }
+      ],
       "place_nested": [
         { "chunks": [ "augustmoon_concourse_vending1" ], "x": 0, "y": 0 },
         { "chunks": [ "augustmoon_concourse_vending2" ], "x": 0, "y": 24 }
@@ -90,16 +129,10 @@
         "Ï": "f_rack",
         "é": "f_bookcase",
         "Ó": "f_rack",
-        "ë": "f_rack",
         "Á": "f_screenmirror_working",
         "8": "f_autodoc_couch",
         "Ñ": "f_vending_reinforced",
         "á": "f_neuralnet_inserter"
-      },
-      "items": {
-        "Ï": { "item": "afs_civilian_armory", "chance": 100, "repeat": [ 3, 4 ] },
-        "ë": { "item": "afs_augustmoon_tool_trader", "chance": 100, "repeat": [ 10, 24 ] },
-        "ä": { "item": "afs_augustmoon_outfitter", "chance": 100, "repeat": [ 3, 4 ] }
       },
       "npcs": {
         "í": { "class": "augustmoon_shipping_chief" },

--- a/data/mods/Aftershock/maps/mapgen/port_augustmoon/port_augustmoon_main.json
+++ b/data/mods/Aftershock/maps/mapgen/port_augustmoon/port_augustmoon_main.json
@@ -64,6 +64,7 @@
       "palettes": [ "afs_habitat_structure", "afs_habitat_residential_furnishing" ],
       "place_zones": [
         { "type": "LOOT_ITEM_GROUP", "filter": "NC_AUGUSTMOON_DOCTOR_stock", "faction": "mercurial", "x": 2, "y": [ 31, 32 ] },
+        { "type": "LOOT_UNSORTED", "faction": "mercurial", "x": 2, "y": [ 31, 32 ] },
         {
           "type": "LOOT_ITEM_GROUP",
           "filter": "afs_augustmoon_tool_trader",
@@ -71,6 +72,7 @@
           "x": 1,
           "y": [ 22, 23 ]
         },
+        { "type": "LOOT_UNSORTED", "faction": "UICA", "x": 1, "y": [ 22, 23 ] },
         { "type": "LOOT_ITEM_GROUP", "filter": "afs_augustmoon_outfitter", "faction": "UICA", "x": 16, "y": 37 },
         {
           "type": "LOOT_ITEM_GROUP",
@@ -79,6 +81,7 @@
           "x": 19,
           "y": 37
         },
+        { "type": "LOOT_UNSORTED", "faction": "UICA", "x": 16, "y": 37 },
         {
           "type": "LOOT_ITEM_GROUP",
           "filter": "afs_augustmoon_guntrader",
@@ -93,13 +96,15 @@
           "x": 22,
           "y": [ 27, 28 ]
         },
+        { "type": "LOOT_UNSORTED", "faction": "UICA", "x": 22, "y": [ 24, 28 ] },
         {
           "type": "LOOT_ITEM_GROUP",
           "filter": "NC_AUGUSTMOON_shipping_stock",
           "faction": "UICA",
           "x": 9,
           "y": [ 26, 27 ]
-        }
+        },
+        { "type": "LOOT_UNSORTED", "faction": "UICA", "x": 9, "y": [ 26, 27 ] }
       ],
       "place_nested": [
         { "chunks": [ "augustmoon_concourse_vending1" ], "x": 0, "y": 0 },

--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_doctor.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_doctor.json
@@ -21,7 +21,7 @@
     "worn_override": "NC_AUGUSTMOON_DOCTOR_worn",
     "carry_override": "EMPTY_GROUP",
     "weapon_override": "EMPTY_GROUP",
-    "shopkeeper_item_group": [ { "group": "NC_AUGUSTMOON_DOCTOR_stock", "rigid": true }, { "group": "augustmoon_shop_money", "rigid": true } ],
+    "shopkeeper_item_group": [ { "group": "NC_AUGUSTMOON_DOCTOR_stock", "rigid": true } ],
     "shopkeeper_price_rules": [ { "group": "NC_AUGUSTMOON_DOCTOR_stock", "fixed_adj": 0 } ],
     "skills": [
       {
@@ -47,7 +47,8 @@
       { "item": "afs_painkiller", "prob": 100, "count": [ 3, 10 ] },
       { "item": "medical_tape", "charges": 30 },
       { "group": "quikclot_bag_plastic_5", "count": [ 4, 8 ] },
-      { "group": "drugs_analgesic", "prob": 100, "count": [ 2, 4 ] }
+      { "group": "drugs_analgesic", "prob": 100, "count": [ 2, 4 ] },
+      { "group": "augustmoon_shop_money" }
     ]
   },
   {

--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_gun_trader.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_gun_trader.json
@@ -22,7 +22,6 @@
     "//": "All guns are more expensive here.",
     "shopkeeper_item_group": [
       { "group": "afs_augustmoon_guntrader", "rigid": true },
-      { "group": "augustmoon_shop_money", "rigid": true },
       {
         "group": "afs_augustmoon_guntrader_military",
         "rigid": true,
@@ -36,7 +35,7 @@
     "type": "item_group",
     "id": "afs_augustmoon_guntrader",
     "subtype": "collection",
-    "items": [ { "group": "afs_civilian_armory", "count": [ 14, 28 ] } ]
+    "items": [ { "group": "afs_civilian_armory", "count": [ 14, 28 ] }, { "group": "augustmoon_shop_money" } ]
   },
   {
     "type": "item_group",

--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_outfitter.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_outfitter.json
@@ -17,7 +17,6 @@
     "//": "All guns are more expensive here.",
     "shopkeeper_item_group": [
       { "group": "afs_augustmoon_outfitter", "rigid": true },
-      { "group": "augustmoon_shop_money", "rigid": true },
       {
         "group": "afs_augustmoon_outfitter_military",
         "rigid": true,
@@ -43,7 +42,8 @@
       { "group": "afs_colonist_outfit", "count": [ 1, 3 ] },
       { "group": "afs_civilian_hazard_outfit", "count": [ 1, 3 ], "prob": 60 },
       { "group": "afs_pals_pieces", "count": [ 6, 12 ] },
-      { "group": "afs_augustmoon_outfitter_bags", "count": [ 10, 28 ] }
+      { "group": "afs_augustmoon_outfitter_bags", "count": [ 10, 28 ] },
+      { "group": "augustmoon_shop_money" }
     ]
   },
   {

--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_tool_trader.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_tool_trader.json
@@ -14,7 +14,7 @@
     "carry_override": "EMPTY_GROUP",
     "weapon_override": "EMPTY_GROUP",
     "skills": [ { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } } ],
-    "shopkeeper_item_group": [ { "group": "afs_augustmoon_tool_trader", "rigid": true }, { "group": "augustmoon_shop_money", "rigid": true } ],
+    "shopkeeper_item_group": [ { "group": "afs_augustmoon_tool_trader", "rigid": true } ],
     "shopkeeper_price_rules": [
       { "group": "afs_augustmoon_batteries_disposable", "markup": 10 },
       { "group": "afs_augustmoon_batteries_rechargeable", "markup": 20 },
@@ -39,7 +39,8 @@
       { "item": "afs_heavy_suit_battery_cell", "count": [ 2, 5 ] },
       { "group": "afs_tools_welding_consumable", "count": [ 6, 8 ] },
       { "group": "afs_augustmoon_batteries_disposable", "count": [ 5, 10 ] },
-      { "group": "afs_augustmoon_batteries_rechargeable", "count": [ 2, 3 ], "prob": 20 }
+      { "group": "afs_augustmoon_batteries_rechargeable", "count": [ 2, 3 ], "prob": 20 },
+      { "group": "augustmoon_shop_money" }
     ]
   },
   {

--- a/data/mods/Aftershock/npcs/UICA/augustmoon_shipping_agent.json
+++ b/data/mods/Aftershock/npcs/UICA/augustmoon_shipping_agent.json
@@ -20,14 +20,14 @@
     "worn_override": "NC_UICA_PORT_CREW_worn",
     "carry_override": "EMPTY_GROUP",
     "weapon_override": "EMPTY_GROUP",
-    "shopkeeper_item_group": [ { "group": "NC_AUGUSTMOON_shipping_stock", "rigid": true }, { "group": "augustmoon_shop_money", "rigid": true } ]
+    "shopkeeper_item_group": [ { "group": "NC_AUGUSTMOON_shipping_stock", "rigid": true } ]
   },
   {
     "type": "item_group",
     "id": "NC_AUGUSTMOON_shipping_stock",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "afs_shuttle_radiobeacon", "count": [ 4, 10 ] } ]
+    "entries": [ { "item": "afs_shuttle_radiobeacon", "count": [ 4, 10 ] }, { "group": "augustmoon_shop_money" } ]
   },
   {
     "id": "TALK_AUGUSTMOON_SHIPPING_CHIEF",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Aftershock] Augustmoon Traders use loot zones"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Occasionally the gadget trader mixes their inventory up with the shuttlemaster and ends up selling the shuttle beacons instead of the gadgets they are supposed to sell.

I looked into it and currently the NPCs just place their junk wherever they want according to the game's whims.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Define loot zones for the NPCs so hopefully they won't keep mixing up what items they are supposed to be selling to the player.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leaving things as they are. Originally the map set to spawn the shelves full of the item group to create the illusion of the traders using them properly. I removed this behavior and replaced those item spawns with regular shelves and loot groups. But we could "stuff" the shelves again if we wanted to. Not sure what it would do to the shop's inventory though.

(To be clear the NPCS do still use all their shelves. Now it's just not an illusion but their actual store merchandise)
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I generated a world 10 times over and each time talked to every NPC. No npcs mixed up their inventories. And they used the zones correctly. The port master sometimes sells the plasma torch and ammo he spawns with. I can't stop that without making a separate worn group for him and I don't want to currently.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
