### PR TITLE
Don't hardcode help text: List Items filter popup

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8431,7 +8431,16 @@ void game::list_items_monsters()
 
 static std::string list_items_filter_history_help()
 {
-    return colorize( _( "UP: history, CTRL-U: clear line, ESC: abort, ENTER: save" ), c_green );
+    input_context ctxt( "STRING_INPUT" );
+    std::vector<std::string> act_descs;
+    const auto add_action_desc = [&]( const std::string & act, const std::string & txt ) {
+        act_descs.emplace_back( ctxt.get_desc( act, txt, input_context::allow_all_keys ) );
+    };
+    add_action_desc( "HISTORY_UP", pgettext( "string input", "History" ) );
+    add_action_desc( "TEXT.CLEAR", pgettext( "string input", "Clear text" ) );
+    add_action_desc( "TEXT.QUIT", pgettext( "string input", "Abort" ) );
+    add_action_desc( "TEXT.CONFIRM", pgettext( "string input", "Save" ) );
+    return colorize( enumerate_as_string( act_descs, enumeration_conjunction::none ), c_green );
 }
 
 /// return content_newness based on if item is known and nested items are known


### PR DESCRIPTION
#### Summary
`SUMMARY: Interface "Don't hardcode help text: List Items filter popup"`

#### Purpose of change

Help text should not be hardcoded as, if end user changes their keybinds, it will cause discrepancies in the UI.  
This PR targets the filter pop up window for the List Items UI and partially addresses #78986

#### Describe the solution

Pull the currently set keybind for each command, then replace the help text string with a function that enumerates the keybinds.
I'm using the same implementation as #79325 which is fundamentally the same type of popup.

#### Describe alternatives you've considered

On these filter popups, the keybindings window is opened with `F1` instead of `?`. I think most end users wouldn't realize this. 
I did a quick implementation to get a feel for it (though I'd have to adjust the wrapping from this example), and it makes sense when considering the concept of this PR... ...but I didn't think it was worth the screen space.
![Screenshot 2025-01-26 095825](https://github.com/user-attachments/assets/d351dd52-b0bf-4e5a-8933-7e6f833a93c2)  
I could add the text if anyone feels strongly about it.

#### Testing

Game compiles and loads.  
Open the List Items window, open filter popup.  
Confirm all filter commands work.
Use the `Increase priority` and `Decrease priority` commands (these also open the filter popup)
Change keybind for `TEXT.CLEAR` and confirm it updates.

#### Additional context

Before and After screenshot (in the latter, I already changed the `TEXT.CLEAR` keybind)
![Screenshot 2025-01-26 093045](https://github.com/user-attachments/assets/cc5300cc-fa63-4947-8602-2b600f654c83)
