### PR TITLE
[Aftershock] Fix EFile pockets on Electronics

### DIFF
--- a/data/mods/Aftershock/items/armor.json
+++ b/data/mods/Aftershock/items/armor.json
@@ -110,7 +110,7 @@
     "flags": [ "WATCH", "BELTED", "STURDY", "WATER_FRIENDLY" ],
     "ammo": [ "battery" ],
     "charges_per_use": 1,
-    "use_action": [ "E_FILE_DEVICE", "PORTABLE_GAME", { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" } ],
+    "use_action": [ "E_FILE_DEVICE", "EBOOKSAVE", "PORTABLE_GAME", { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/mods/Aftershock/items/armor.json
+++ b/data/mods/Aftershock/items/armor.json
@@ -123,7 +123,8 @@
         "rigid": true,
         "max_contains_volume": "1 ml",
         "max_contains_weight": "1 g",
-        "weight_multiplier": 0.0
+        "weight_multiplier": 0.0,
+        "ememory_max": "1 TB"
       }
     ]
   },

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -530,14 +530,6 @@
         "need_charges": 1,
         "need_charges_msg": "The laptop's batteries need more charge.",
         "type": "transform"
-      },
-      {
-        "pocket_type": "E_FILE_STORAGE",
-        "rigid": true,
-        "max_contains_volume": "1 ml",
-        "max_contains_weight": "1 g",
-        "weight_multiplier": 0.0,
-        "ememory_max": "1 TB"
       }
     ],
     "flags": [ "WATCH", "SKINTIGHT" ],
@@ -547,6 +539,14 @@
         "rigid": true,
         "flag_restriction": [ "BATTERY_MEDIUM" ],
         "default_magazine": "medium_battery_cell"
+      },
+      {
+        "pocket_type": "E_FILE_STORAGE",
+        "rigid": true,
+        "max_contains_volume": "1 ml",
+        "max_contains_weight": "1 g",
+        "weight_multiplier": 0.0,
+        "ememory_max": "1 TB"
       }
     ],
     "armor": [ { "covers": [ "eyes", "torso" ] } ]

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -33,7 +33,8 @@
         "rigid": true,
         "max_contains_volume": "1 ml",
         "max_contains_weight": "1 g",
-        "weight_multiplier": 0
+        "weight_multiplier": 0,
+        "ememory_max": "1 TB"
       }
     ]
   },
@@ -211,7 +212,8 @@
         "rigid": true,
         "max_contains_volume": "1 ml",
         "max_contains_weight": "1 g",
-        "weight_multiplier": 0
+        "weight_multiplier": 0,
+        "ememory_max": "1 TB"
       }
     ]
   },
@@ -457,6 +459,7 @@
     "use_action": [
       "ROBOTCONTROL",
       "E_FILE_DEVICE",
+      "EBOOKSAVE",
       "PORTABLE_GAME",
       {
         "target": "control_laptop_screen_lit",
@@ -475,6 +478,14 @@
         "rigid": true,
         "flag_restriction": [ "BATTERY_MEDIUM" ],
         "default_magazine": "medium_battery_cell"
+      },
+      {
+        "pocket_type": "E_FILE_STORAGE",
+        "rigid": true,
+        "max_contains_volume": "1 ml",
+        "max_contains_weight": "1 g",
+        "weight_multiplier": 0.0,
+        "ememory_max": "1 TB"
       }
     ]
   },
@@ -509,6 +520,7 @@
     "charges_per_use": 2,
     "use_action": [
       "E_FILE_DEVICE",
+      "EBOOKSAVE",
       "PORTABLE_GAME",
       {
         "target": "vr_laptop_holosuite",
@@ -518,6 +530,14 @@
         "need_charges": 1,
         "need_charges_msg": "The laptop's batteries need more charge.",
         "type": "transform"
+      },
+      {
+        "pocket_type": "E_FILE_STORAGE",
+        "rigid": true,
+        "max_contains_volume": "1 ml",
+        "max_contains_weight": "1 g",
+        "weight_multiplier": 0.0,
+        "ememory_max": "1 TB"
       }
     ],
     "flags": [ "WATCH", "SKINTIGHT" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Aftershock] Fix EFile pockets on Electronics"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
It was  going to wait until things settled down a little more with the EFile system before diving into it. But it was brought to my attention in #79358 that, in fact, people do play Aftershock without the Exo-planet. And those people would probably like for their electronics to not be broken.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix the Aftershock portion #79358 by giving all our EFile pockets a memory size. Since the file sizes are still kind of in flux (If I am understanding correctly) I just gave everything a flat 1tb storage. That might change in the future but I honestly don't currently foresee data storage size being a limitation we play with. But who knows? For now this will get electronic devices working again. 

I did also give the control laptop the ability to store books and gave it an EFILE pocket. While it's normal laptop stuff isn't it's main draw, it is described as basically being a normal laptop that can ALSO control robots.

The VR laptop got the same treatment, because if it's anything like modern day VR sets. It absolutely would have a camera capable of taking and saving images.

Finally the wrist computer can now scan as well. I figure for the kind of device it's trying to be, surely it's got some kind of camera on it somewhere. If it's your general purpose explorer computing device, surely it can take photos of things you discover. Or use a camera to identify things you've found, maybe with some basic onboard AI that identifies the thing in the photo from an existing repository of known alien flora and fauna. What I am trying to say is a frontier and scientific instrument. It'd be really weird to me if I didn't have a camera.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not giving the wrist computer a camera. Leaving the bug in until we are fully ready to integrate the new EFile system into the mod. Setting some of the electronics to a lower storage rate just in case for some reason we decide 1TB is actually too much for something.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned the items. Scanned some books. Moved files around between the items. Looking all good.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
