### PR TITLE
Fix a build error with the object creator

### DIFF
--- a/msvc-object_creator/vcpkg.json
+++ b/msvc-object_creator/vcpkg.json
@@ -10,10 +10,5 @@
         },
         "sdl2-ttf",
         "qt5-base"
-    ],
-    "vcpkg-configuration": {
-        "overlay-ports": [
-            "../.github/vcpkg_ports"
-        ]
-    }
+    ]
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The object creator project isn't building. An override was defined in #64046, but #78548 (both @akrieger) forgot to remove it for the object creator. Easy to do since we don't even build the project with CI anymore.

#### Describe the solution
Remove the override so it stops looking for something that isn't there.

#### Describe alternatives you've considered
Maybe it's time to just remove object creator from the repo? It hasn't worked in years, as far as anyone's mentioned, and it's sucking up developer time.

Since we're not even building it with CI this kind of breakage is only going to keep happening.

#### Testing
Project still does not build due to some indeterminable error with `enum_traits` template specialization. I troubleshooted it for a while but I couldn't even figure out where the bad template was. C++ compilers do not produce very helpful error messages.

#### Additional context
