### PR TITLE
Fix trading: NPC no longer accept items that would be deleted.

### DIFF
--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -358,7 +358,7 @@ bool npc_trading::npc_can_fit_items( npc const &np, trade_selector::select_t con
                 break;
             }
         }
-        if( !item_stored && !np.can_wear( *it.first, false ).success() ) {
+        if( !item_stored ) {
             return false;
         }
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Trading: NPC no longer accept items that would be deleted."

#### Purpose of change

Items got deleted when trading:
 - In accept trade, `npc::can_wear` allows trading items the NPC could wear.
 - As further code didn't try to dress the NPC with the items, these items disappear (not just drop, but get deleted) in further code as they cannot fit into pockets.

Furthermore:
 - can_wear didn't dress the NPC, so they would accept 1000 socks.

History:
 - Volume is tracked since #52261.
 - The issue was probably introduced in #52572 which relaxed the condition by adding `|| npc.can_wear`.
   - My best guess is that @andrei8l implemented the UI check and then wanted to write the npc dressing functional code, but they didn't get to that part... ?

#### Describe the solution

Delete the can_wear check.

#### Describe alternatives you've considered

Implement code handling NPC wearing items from trade, this would:
1. Force the NPC to either equip the clothes or drop the clothes. Force equip would take moves from the NPC too. You could exploit this by trading horrible items to NPC and kill them as they are dressing up.
2. Make copy of NPC to wear only valid items. The items would still get deleted. But if the rest is implemented, you can at least start with my patch:

<details>

<summary>Patch: NPC partial copy</summary>

```patch
commit e994eef8063d81f236a1a827fed696d5d0670839
Author: Brambor <tondadrd@seznam.cz>
Date:   Mon Jan 27 02:46:19 2025 +0100

    add npc.partial_copy and npc_copy.wear_item on trade

diff --git a/src/npc.cpp b/src/npc.cpp
index 1ecb0b7c21..7e230b2b32 100644
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -302,6 +302,42 @@ standard_npc::standard_npc( const std::string &name, const tripoint_bub_ms &pos,
     worn.set_fitted();
 }
 
+npc npc::partial_copy() const
+{
+    npc cpy = npc();
+    cpy.name = string_format( "DEBUG PARTIAL NPC from NPC.id=%s", this->getID().get_value() );
+
+    // missing arms / legs / etc.
+    cpy.body = this->body;
+
+    // copy mutations for trait_WOOLALLERGY, trait_SQUEAMISH etc.
+    cpy.my_mutations = this->my_mutations;
+    cpy.my_traits = this->my_traits;
+    cpy.my_intrinsic_mutations = this->my_intrinsic_mutations;
+    cpy.cached_mutations = this->cached_mutations;
+    cpy.my_mutations_dirty = this->my_mutations_dirty;
+
+    // Are we so tiny/huge we cannot wear clothes?
+    cpy.recalculate_size();
+
+    // TODO copy pimpl<effects_map> effects from creature.h
+    // for effect_incorporeal
+    // TODO copy character.h pimpl<bionic_collection> my_bionics for Character::mut_cbm_encumb
+
+    // for bmi, which is for encumbrance
+    cpy.set_base_height( this->base_height() );
+    cpy.set_stored_kcal( this->get_stored_kcal() );
+    cpy.tally_organic_size();  // get_cached_organic_size
+
+    // copy equipement
+    cpy.worn = this->worn;
+    // TODO crash: set_wielded_item expects a reference
+    // cpy.set_wielded_item( item( *( this->get_wielded_item().get_item() ) ) );
+    cpy.worn.set_fitted();
+
+    return cpy;
+}
+
 npc::npc( npc && ) noexcept( map_is_noexcept ) = default;
 npc &npc::operator=( npc && ) noexcept( list_is_noexcept ) = default;
 
diff --git a/src/npc.h b/src/npc.h
index 36c6110fca..3dbcdc320e 100644
--- a/src/npc.h
+++ b/src/npc.h
@@ -767,6 +767,17 @@ class npc : public Character
         npc &operator=( npc && ) noexcept( list_is_noexcept );
         ~npc() override;
 
+        /**
+         * This is a copy constructor, not as normal copy constructor to prevent accidental copy.
+         *
+         * The copy is NOT WELL DEFINED, implementation is like default copy constructor.
+         * Specifically, it copies pointers such as member variable `chosen_mount`
+         * or pointers in `npc_short_term_cache`.
+         * However it should be safe for trying dressing the copied NPC.
+         * Designed to be valid for `Character::wear_item`.
+         */
+        npc partial_copy() const;
+
         bool is_avatar() const override {
             return false;
         }
diff --git a/src/npctrade.cpp b/src/npctrade.cpp
index 040cd98f72..71d213c10c 100644
--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -342,6 +342,9 @@ bool npc_trading::npc_will_accept_trade( npc const &np, int your_balance )
 }
 bool npc_trading::npc_can_fit_items( npc const &np, trade_selector::select_t const &to_trade )
 {
+    // copy the npc
+    npc npc_copy = np.partial_copy();
+    // copy pockets
     std::vector<item> avail_pockets = np.worn.available_pockets();
 
     if( !to_trade.empty() && avail_pockets.empty() ) {
@@ -358,7 +361,18 @@ bool npc_trading::npc_can_fit_items( npc const &np, trade_selector::select_t con
                 break;
             }
         }
-        if( !item_stored && !np.can_wear( *it.first, false ).success() ) {
+        if( item_stored ) {
+            continue;
+        }
+        // Copy of npc wears copy of the item. They will not be able to wear 1000 pairs of socks,
+        // but they probably can wear one or two pairs.
+        item itm( *it.first );
+        // might not be needed?
+        npc_copy.worn.check_rigid_sidedness( itm );
+        npc_copy.worn.one_per_layer_sidedness( itm );
+
+        auto result = npc_copy.wear_item( itm, /*interactive*/false );
+        if( !result ) {
             return false;
         }
     }
```
</details>

#### Testing

1. Try to sell socks to a naked NPC wearing only `tactical holster`. You could trade the item before and it would disappear. Now, they don't accept the trade for lack of space.

#### Additional context

 - There are still bugs with trading.
 - I didn't check #48523, but it is related.
 - I don't like `can_holster || ( can_contain && pvol > ..)`, it should just be one singular and relatable check. I ask for it here too: https://github.com/CleverRaven/Cataclysm-DDA/issues/79352#issuecomment-2614476440