### PR TITLE
Improve error reporting

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -317,11 +317,11 @@ static void debug_error_prompt(
 
     std::string formatted_report =
         string_format( // developer-facing error report. INTENTIONALLY UNTRANSLATED!
-            " DEBUG    : %s\n\n"
-            " FUNCTION : %s\n"
-            " FILE     : %s\n"
-            " LINE     : %s\n"
-            " VERSION  : %s\n",
+            " DEBUG : %s\n\n"
+            " REPORTING FUNCTION : %s\n"
+            " C++ SOURCE FILE    : %s\n"
+            " LINE               : %s\n"
+            " VERSION            : %s\n",
             text, funcname, filename, line, getVersionString()
         );
 

--- a/src/flexbuffer_json.cpp
+++ b/src/flexbuffer_json.cpp
@@ -143,7 +143,7 @@ std::string Json::str() const
 bool JsonValue::read( bool &b, bool throw_on_error ) const
 {
     if( !test_bool() ) {
-        return error_or_false( throw_on_error, "Expected bool" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected bool" );
     }
     b = get_bool();
     return true;
@@ -151,7 +151,7 @@ bool JsonValue::read( bool &b, bool throw_on_error ) const
 bool JsonValue::read( char &c, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     c = get_int();
     return true;
@@ -159,7 +159,7 @@ bool JsonValue::read( char &c, bool throw_on_error ) const
 bool JsonValue::read( signed char &c, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     // TODO: test for overflow
     c = get_int();
@@ -168,7 +168,7 @@ bool JsonValue::read( signed char &c, bool throw_on_error ) const
 bool JsonValue::read( unsigned char &c, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     // TODO: test for overflow
     c = get_int();
@@ -177,7 +177,7 @@ bool JsonValue::read( unsigned char &c, bool throw_on_error ) const
 bool JsonValue::read( short unsigned int &s, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     // TODO: test for overflow
     s = get_int();
@@ -186,7 +186,7 @@ bool JsonValue::read( short unsigned int &s, bool throw_on_error ) const
 bool JsonValue::read( short int &s, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     // TODO: test for overflow
     s = get_int();
@@ -195,7 +195,7 @@ bool JsonValue::read( short int &s, bool throw_on_error ) const
 bool JsonValue::read( int &i, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     i = get_int();
     return true;
@@ -203,7 +203,7 @@ bool JsonValue::read( int &i, bool throw_on_error ) const
 bool JsonValue::read( int64_t &i, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     i = get_int64();
     return true;
@@ -211,7 +211,7 @@ bool JsonValue::read( int64_t &i, bool throw_on_error ) const
 bool JsonValue::read( uint64_t &i, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     i = get_uint64();
     return true;
@@ -219,7 +219,7 @@ bool JsonValue::read( uint64_t &i, bool throw_on_error ) const
 bool JsonValue::read( unsigned int &u, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     u = get_uint();
     return true;
@@ -227,7 +227,7 @@ bool JsonValue::read( unsigned int &u, bool throw_on_error ) const
 bool JsonValue::read( float &f, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     f = get_float();
     return true;
@@ -235,7 +235,7 @@ bool JsonValue::read( float &f, bool throw_on_error ) const
 bool JsonValue::read( double &d, bool throw_on_error ) const
 {
     if( !test_number() ) {
-        return error_or_false( throw_on_error, "Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     d = get_float();
     return true;
@@ -243,7 +243,7 @@ bool JsonValue::read( double &d, bool throw_on_error ) const
 bool JsonValue::read( std::string &s, bool throw_on_error ) const
 {
     if( !test_string() ) {
-        return error_or_false( throw_on_error, "Expected string" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected string" );
     }
     s = get_string();
     return true;
@@ -340,7 +340,7 @@ void JsonObject::error_skipped_members( const std::vector<size_t> &skipped_membe
                     "\"//~\" should be within a text object and contain comments for translators." );
             } else {
                 jo.throw_error_at( name.c_str(),
-                                   string_format( "Invalid or misplaced field name \"%s\" in JSON data",
+                                   string_format( "Unread data.  Invalid or misplaced field name \"%s\" in JSON data",
                                                   name.c_str() ) );
             }
         } catch( const JsonError &e ) {

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -565,9 +565,11 @@ inline void mandatory( const JsonObject &jo, const bool was_loaded, const std::s
     if( !jo.read( name, member ) ) {
         if( !was_loaded ) {
             if( jo.has_member( name ) ) {
-                jo.throw_error( str_cat( "failed to read mandatory member \"", name, "\"" ) );
+                jo.throw_error( str_cat( "object beginning at next line failed to read mandatory member \"", name,
+                                         "\"" ) );
             } else {
-                jo.throw_error( str_cat( "missing mandatory member \"", name, "\"" ) );
+                jo.throw_error( str_cat( "object beginning at next line missing mandatory member \"", name,
+                                         "\"" ) );
             }
         }
     }
@@ -579,9 +581,11 @@ inline void mandatory( const JsonObject &jo, const bool was_loaded, const std::s
     if( !reader( jo, name, member, was_loaded ) ) {
         if( !was_loaded ) {
             if( jo.has_member( name ) ) {
-                jo.throw_error( str_cat( "failed to read mandatory member \"", name, "\"" ) );
+                jo.throw_error( str_cat( "object beginning at next line failed to read mandatory member \"", name,
+                                         "\"" ) );
             } else {
-                jo.throw_error( str_cat( "missing mandatory member \"", name, "\"" ) );
+                jo.throw_error( str_cat( "object beginning at next line missing mandatory member \"", name,
+                                         "\"" ) );
             }
         }
     }

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1889,7 +1889,7 @@ std::string TextJsonIn::line_number( int offset_modifier )
     std::stringstream ret;
     switch( error_log_format ) {
         case error_log_format_t::human_readable:
-            ret << name << ":" << line << ":" << offset;
+            ret << "file " << name << ", at line " << line << ", character " << offset;
             break;
         case error_log_format_t::github_action:
             ret.imbue( std::locale::classic() );
@@ -2012,7 +2012,7 @@ void TextJsonIn::error( int offset, const std::string &message )
     std::ostringstream err_header;
     switch( error_log_format ) {
         case error_log_format_t::human_readable:
-            err_header << "Json error: " << line_number( offset ) << ": ";
+            err_header << "Json error: " << line_number( offset ) << ":\n";
             break;
         case error_log_format_t::github_action:
             err_header << "::error " << line_number( offset ) << "::";

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -228,7 +228,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:5: insufficient spaces at this location.  2 required, but only 1 found.)"
+            R"(Json error: file <unknown source file>, at line 1, character 5:)" "\n"
+            R"(insufficient spaces at this location.  2 required, but only 1 found.)"
             "\n"
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
@@ -240,7 +241,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:8: insufficient spaces at this location.  2 required, but only 1 found.)"
+            R"(Json error: file <unknown source file>, at line 1, character 8:)" "\n"
+            R"(insufficient spaces at this location.  2 required, but only 1 found.)"
             "\n"
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
@@ -252,7 +254,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:11: insufficient spaces at this location.  2 required, but only 1 found.)"
+            R"(Json error: file <unknown source file>, at line 1, character 11:)" "\n"
+            R"(insufficient spaces at this location.  2 required, but only 1 found.)"
             "\n"
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
@@ -264,7 +267,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:13: insufficient spaces at this location.  2 required, but only 1 found.)"
+            R"(Json error: file <unknown source file>, at line 1, character 13:)" "\n"
+            R"(insufficient spaces at this location.  2 required, but only 1 found.)"
             "\n"
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
@@ -276,7 +280,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:16: insufficient spaces at this location.  2 required, but only 1 found.)"
+            R"(Json error: file <unknown source file>, at line 1, character 16:)" "\n"
+            R"(insufficient spaces at this location.  2 required, but only 1 found.)"
             "\n"
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
@@ -288,7 +293,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:19: insufficient spaces at this location.  2 required, but only 1 found.)"
+            R"(Json error: file <unknown source file>, at line 1, character 19:)" "\n"
+            R"(insufficient spaces at this location.  2 required, but only 1 found.)"
             "\n"
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
@@ -301,7 +307,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:11: str_sp not supported here)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 11:)" "\n"
+            R"(str_sp not supported here)" "\n"
             R"()" "\n"
             R"({"str_sp": "foo"})" "\n"
             R"(         ▲▲▲)" "\n" ),
@@ -309,7 +316,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:25: str_pl not supported here)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
+            R"(str_pl not supported here)" "\n"
             R"()" "\n"
             R"({"str": "foo", "str_pl": "foo"})" "\n"
             R"(                       ▲▲▲)" "\n" ),
@@ -329,8 +337,9 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_pl_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:EOF: Cannot autogenerate plural )"
-            R"(form.  Please specify the plural form explicitly using 'str' and )"
+            R"(Json error: <unknown source file>:EOF:)" "\n"
+            R"(Cannot autogenerate plural form.  )"
+            R"(Please specify the plural form explicitly using 'str' and )"
             R"('str_pl', or 'str_sp' if the singular and plural forms are the same.)" ),
         R"("box")" );
 
@@ -340,8 +349,9 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_pl_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:8: Cannot autogenerate plural )"
-            R"(form.  Please specify the plural form explicitly using 'str' and )"
+            R"(Json error: file <unknown source file>, at line 1, character 8:)" "\n"
+            R"(Cannot autogenerate plural form.  )"
+            R"(Please specify the plural form explicitly using 'str' and )"
             R"('str_pl', or 'str_sp' if the singular and plural forms are the same.)"
             "\n"
             R"()" "\n"
@@ -358,7 +368,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_pl_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:25: "str_pl" is not necessary here since the plural form can be automatically generated.)"
+            R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
+            R"("str_pl" is not necessary here since the plural form can be automatically generated.)"
             "\n"
             R"()" "\n"
             R"({"str": "bar", "str_pl": "bars"})" "\n"
@@ -367,7 +378,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     test_pl_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
-            R"(Json error: <unknown source file>:1:25: Please use "str_sp" instead of "str" and "str_pl" for text with identical singular and plural forms)"
+            R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
+            R"(Please use "str_sp" instead of "str" and "str_pl" for text with identical singular and plural forms)"
             "\n"
             R"()" "\n"
             R"({"str": "bar", "str_pl": "bar"})" "\n"
@@ -406,8 +418,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         test_pl_translation_text_style_check(
             Catch::Equals(
                 R"((json-error))" "\n"
-                R"(Json error: <unknown source file>:1:25: "str_pl" is not necessary here )"
-                R"(since the plural form can be automatically generated.)" "\n"
+                R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
+                R"("str_pl" is not necessary here since the plural form can be automatically generated.)" "\n"
                 R"()" "\n"
                 R"({"str": "bar", "str_pl": "bars"})" "\n"
                 R"(                       ▲▲▲)" "\n" ),
@@ -415,8 +427,9 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         test_pl_translation_text_style_check(
             Catch::Equals(
                 R"((json-error))" "\n"
-                R"(Json error: <unknown source file>:1:25: Please use "str_sp" instead of "str" )"
-                R"(and "str_pl" for text with identical singular and plural forms)" "\n"
+                R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
+                R"(Please use "str_sp" instead of "str" and "str_pl" for text with identical singular and plural forms)"
+                R"()" "\n"
                 R"()" "\n"
                 R"({"str": "bar", "str_pl": "bar"})" "\n"
                 R"(                       ▲▲▲)" "\n" ),
@@ -424,7 +437,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         test_translation_text_style_check(
             Catch::Equals(
                 R"((json-error))" "\n"
-                R"(Json error: <unknown source file>:1:11: str_sp not supported here)" "\n"
+                R"(Json error: file <unknown source file>, at line 1, character 11:)" "\n"
+                R"(str_sp not supported here)" "\n"
                 R"()" "\n"
                 R"({"str_sp": "foo"})" "\n"
                 R"(         ▲▲▲)" "\n" ),
@@ -432,7 +446,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         test_translation_text_style_check(
             Catch::Equals(
                 R"((json-error))" "\n"
-                R"(Json error: <unknown source file>:1:25: str_pl not supported here)" "\n"
+                R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
+                R"(str_pl not supported here)" "\n"
                 R"()" "\n"
                 R"({"str": "foo", "str_pl": "foo"})" "\n"
                 R"(                       ▲▲▲)" "\n" ),
@@ -440,7 +455,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         test_translation_text_style_check(
             Catch::Equals(
                 R"((json-error))" "\n"
-                R"(Json error: <unknown source file>:1:5: insufficient spaces at this location.  2 required, but only 1 found.)"
+                R"(Json error: file <unknown source file>, at line 1, character 5:)" "\n"
+                R"(insufficient spaces at this location.  2 required, but only 1 found.)"
                 "\n"
                 R"(    Suggested fix: insert " ")" "\n"
                 R"(    At the following position (marked with caret))" "\n"
@@ -490,7 +506,8 @@ TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation]" 
             dmsg,
             Catch::Equals(
                 R"((json-error))" "\n"
-                R"(Json error: <unknown source file>:2:7: insufficient spaces at this location.  2 required, but only 1 found.)"
+                R"(Json error: file <unknown source file>, at line 2, character 7:)" "\n"
+                R"(insufficient spaces at this location.  2 required, but only 1 found.)"
                 "\n"
                 R"(    Suggested fix: insert " ")" "\n"
                 R"(    At the following position (marked with caret))" "\n"
@@ -519,7 +536,8 @@ TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation]" 
             dmsg,
             Catch::Equals(
                 R"((json-error))" "\n"
-                R"(Json error: <unknown source file>:2:16: insufficient spaces at this location.  2 required, but only 1 found.)"
+                R"(Json error: file <unknown source file>, at line 2, character 16:)" "\n"
+                R"(insufficient spaces at this location.  2 required, but only 1 found.)"
                 "\n"
                 R"(    Suggested fix: insert " ")" "\n"
                 R"(    At the following position (marked with caret))" "\n"
@@ -551,7 +569,8 @@ TEST_CASE( "report_unvisited_members", "[json]" )
             dmsg,
             Catch::Equals(
                 R"((json-error))" "\n"
-                R"(Json error: <unknown source file>:1:22: Invalid or misplaced field name "bar" in JSON data)"
+                R"(Json error: file <unknown source file>, at line 1, character 22:)" "\n"
+                R"(Unread data.  Invalid or misplaced field name "bar" in JSON data)"
                 "\n\n"
                 R"({"foo": "foo", "bar": "bar"})" "\n"
                 R"(                    ▲▲▲)" "\n" ) );
@@ -576,7 +595,8 @@ TEST_CASE( "report_unvisited_members", "[json]" )
             dmsg,
             Catch::Equals(
                 R"((json-error))" "\n"
-                R"(Json error: <unknown source file>:1:22: "//~" should be within a text object and contain comments for translators.)"
+                R"(Json error: file <unknown source file>, at line 1, character 22:)" "\n"
+                R"("//~" should be within a text object and contain comments for translators.)"
                 "\n\n"
                 R"({"foo": "foo", "//~": "bar"})" "\n"
                 R"(                    ▲▲▲)" "\n" ) );
@@ -612,7 +632,9 @@ TEST_CASE( "correct_cursor_position_for_unicode_json_error", "[json]" )
         // check that the correct debug message is shown
         const std::string e_what = e.what();
         const std::string e_expected =
-            R"(Json error: <unknown source file>:1:79: illegal character: code: -28)"
+            R"(Json error: file <unknown source file>, at line 1, character 79:)"
+            "\n"
+            R"(illegal character: code: -28)"
             "\n\n"
             R"({ "两两两两两两两两两两两两两两两两两两两两两两两两": 两 })"
             "\n"
@@ -685,30 +707,31 @@ TEST_CASE( "jsonin_get_string", "[json]" )
     // empty json
     test_get_string_throws_matches(
         Catch::Message(
-            "Json error: <unknown source file>:EOF: input file is empty" ),
+            "Json error: <unknown source file>:EOF:" "\n" "input file is empty" ),
         std::string() );
     // no starting quote
     test_get_string_throws_matches(
         Catch::Message(
-            "Json error: <unknown source file>:EOF: cannot parse value starting with: abc" ),
+            "Json error: <unknown source file>:EOF:" "\n" "cannot parse value starting with: abc" ),
         R"(abc)" );
     // no ending quote
     test_get_string_throws_matches(
         Catch::Message(
-            "Json error: <unknown source file>:EOF: illegal character in string constant" ),
+            "Json error: <unknown source file>:EOF:" "\n" "illegal character in string constant" ),
         R"(")" );
     test_get_string_throws_matches(
         Catch::Message(
-            "Json error: <unknown source file>:EOF: illegal character in string constant" ),
+            "Json error: <unknown source file>:EOF:" "\n" "illegal character in string constant" ),
         R"("foo)" );
     // incomplete escape sequence and no ending quote
     test_get_string_throws_matches(
         Catch::Message(
-            "Json error: <unknown source file>:EOF: unknown escape code in string constant" ),
+            "Json error: <unknown source file>:EOF:" "\n" "unknown escape code in string constant" ),
         R"("\)" );
     test_get_string_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:3: escape code must be followed by 4 hex digits)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 3:)" "\n"
+            "escape code must be followed by 4 hex digits" "\n"
             R"()" "\n"
             R"("\u12)" "\n"
             R"( ▲▲▲)" "\n" ),
@@ -716,14 +739,16 @@ TEST_CASE( "jsonin_get_string", "[json]" )
     // incorrect escape sequence
     test_get_string_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:2: unknown escape code in string constant)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 2:)" "\n"
+            "unknown escape code in string constant" "\n"
             R"()" "\n"
             R"("\.")" "\n"
             R"(▲▲▲)" "\n" ),
         R"("\.")" );
     test_get_string_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:3: escape code must be followed by 4 hex digits)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 3:)" "\n"
+            "escape code must be followed by 4 hex digits" "\n"
             R"()" "\n"
             R"("\uDEFG")" "\n"
             R"( ▲▲▲)" "\n" ),
@@ -731,31 +756,33 @@ TEST_CASE( "jsonin_get_string", "[json]" )
     // not a valid utf8 sequence
     test_get_string_throws_matches(
         Catch::Message(
-            "Json error: <unknown source file>:EOF: illegal UTF-8 sequence" ),
+            "Json error: <unknown source file>:EOF:" "\n" "illegal UTF-8 sequence" ),
         "\"\x80\"" );
     test_get_string_throws_matches(
         Catch::Message(
-            "Json error: <unknown source file>:EOF: illegal UTF-8 sequence" ),
+            "Json error: <unknown source file>:EOF:" "\n" "illegal UTF-8 sequence" ),
         "\"\xFC\x80\"" );
     test_get_string_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:EOF: illegal UTF-8 sequence)" ),
+            R"(Json error: <unknown source file>:EOF:)" "\n" "illegal UTF-8 sequence" ),
         "\"\xFD\x80\x80\x80\x80\x80\"" );
     test_get_string_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:EOF: illegal UTF-8 sequence)" ),
+            R"(Json error: <unknown source file>:EOF:)" "\n" "illegal UTF-8 sequence" ),
         "\"\xFC\x80\x80\x80\x80\xC0\"" );
     // end of line
     test_get_string_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:2: illegal character in string constant)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 2:)" "\n"
+            "illegal character in string constant" "\n"
             R"()" "\n"
             R"("a)" "\n"
             R"(▲▲▲)" "\n\"\n" ),
         "\"a\n\"" );
     test_get_string_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:2: illegal character in string constant)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 2:)" "\n"
+            "illegal character in string constant" "\n"
             R"()" "\n"
             R"("b)" "\r\"\n"
             R"(▲▲▲)" "\n" ),
@@ -765,14 +792,16 @@ TEST_CASE( "jsonin_get_string", "[json]" )
     // ascii
     test_string_error_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:1: <message>)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 1:)" "\n"
+            "<message>" "\n"
             R"()" "\n"
             R"("foobar")" "\n"
             R"(▲▲▲)" "\n" ),
         R"("foobar")", 0 );
     test_string_error_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:4: <message>)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 4:)" "\n"
+            "<message>" "\n"
             R"()" "\n"
             R"("foobar")" "\n"
             R"(  ▲▲▲)" "\n" ),
@@ -780,21 +809,24 @@ TEST_CASE( "jsonin_get_string", "[json]" )
     // unicode
     test_string_error_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:4: <message>)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 4:)" "\n"
+            "<message>" "\n"
             R"()" "\n"
             R"("foo…bar1")" "\n"
             R"(  ▲▲▲)" "\n" ),
         R"("foo…bar1")", 3 );
     test_string_error_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:7: <message>)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 7:)" "\n"
+            "<message>" "\n"
             R"()" "\n"
             R"("foo…bar2")" "\n"
             R"(   ▲▲▲)" "\n" ),
         R"("foo…bar2")", 4 );
     test_string_error_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:8: <message>)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 8:)" "\n"
+            "<message>" "\n"
             R"()" "\n"
             R"("foo…bar3")" "\n"
             R"(    ▲▲▲)" "\n" ),
@@ -802,14 +834,16 @@ TEST_CASE( "jsonin_get_string", "[json]" )
     // escape sequence
     test_string_error_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:11: <message>)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 11:)" "\n"
+            "<message>" "\n"
             R"()" "\n"
             R"("foo\u2026bar")" "\n"
             R"(         ▲▲▲)" "\n" ),
         R"("foo\u2026bar")", 5 );
     test_string_error_throws_matches(
         Catch::Message(
-            R"(Json error: <unknown source file>:1:7: <message>)" "\n"
+            R"(Json error: file <unknown source file>, at line 1, character 7:)" "\n"
+            "<message>" "\n"
             R"()" "\n"
             R"("foo\nbar")" "\n"
             R"(     ▲▲▲)" "\n" ),


### PR DESCRIPTION
#### Summary
Infrastructure "Improve error reporting"

#### Purpose of change
Our errors aren't always helpful in explaining what they mean. This confuses users (who go looking for C++ source files which they don't have) and contributors (who may troubleshoot the wrong thing until they realize what's going on).

#### Describe the solution
Make them more helpful.

-JSON syntax errors say they are syntax errors, to help people understand how to resolve them.

-Errors which start at the *beginning of an object* instead of at a member or place of error explicitly say the reported line is the beginning of the object. This has confused many, many people. Hopefully with the changes it should confuse less people.

-The line and character offset of JSON errors has been made explicit, instead of requiring you to guess what the numbers mean.

-The C++ source file names/etc were made more explicit as well, which should hopefully reduce people asking "I can't find this .cpp file on my game, where is it"

#### Describe alternatives you've considered
The errors which point to the start of the object could be made even better. We shouldn't even show context outside of the error object. We could also try to grab the id of the object and report that explicitly, so the contributor knows exactly what object is meant.

But that seemed like it would be a lot more difficult to implement. For example the object in question might not *have* an `id` member.

#### Testing
Intentionally introduce some errors, trigger the errors.

before (image from community discord):
![image](https://github.com/user-attachments/assets/38d2d439-9e46-4980-a309-067e84f11438)

after:

![image](https://github.com/user-attachments/assets/7ae96919-a1a1-4a6d-af14-b7ae51b11281)

![image](https://github.com/user-attachments/assets/a864bd87-f000-4568-a12a-43e27def7a7f)



#### Additional context