### PR TITLE
Update MSVC builds' reported version

### DIFF
--- a/msvc-full-features/prebuild.cmd
+++ b/msvc-full-features/prebuild.cmd
@@ -3,7 +3,7 @@ SETLOCAL
 
 cd ..\msvc-full-features
 set PATH=%PATH%;%VSAPPIDDIR%\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd
-for /F "tokens=*" %%i in ('git describe --tags --always --dirty --match "[0-9]*.*"') do set VERSION=%%i
+for /F "tokens=*" %%i in ('git describe --tags --always --dirty --match "cdda-experimental-*"') do set VERSION=%%i
 if "%VERSION%"=="" (
 set VERSION=Please install `git` to generate VERSION
 )


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
MSVC builds are still reporting as 0.G, despite the fact we released 0.H several months ago.

#### Describe the solution
Update the build to grab a proper tag. Exact match copied from the makefile, since that was updated more recently and hasn't had any issues

#### Describe alternatives you've considered
Figure out the arcane runes required for git to fetch tags correctly and keep pumping it up with every stable release

#### Testing
![image](https://github.com/user-attachments/assets/3ad32508-0dd5-48ef-bad4-145428abe3eb)


#### Additional context
I removed the `--tags` argument and the version reported as **0.D**, instead of falling back to the commit hash.

I have no idea how that's possible. Very fascinating though!
