### PR TITLE
Implement (R)eading e-book requirements, fix etransfer_rate segfault

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -8,6 +8,7 @@
     "charges_per_use": 1,
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK_ACTIVE", "ELECTRONIC" ],
     "e_port": "camera",
+    "etransfer_rate": "20 MB",
     "melee_damage": { "bash": 1 },
     "variables": { "browsed": "true" }
   },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3304,7 +3304,7 @@ item_location efile_activity_actor::find_external_transfer_estorage( Character &
 
 bool efile_activity_actor::edevice_has_use( const item *edevice )
 {
-    return edevice->type->has_use();
+    return edevice->type->can_use( "E_FILE_DEVICE" );
 }
 
 efile_activity_actor::edevice_compatible efile_activity_actor::edevices_compatible(
@@ -3500,10 +3500,19 @@ units::ememory efile_activity_actor::current_etransfer_rate( Character &who,
     const item_location &external_transfer_edevice =
         find_external_transfer_estorage( who, efile, target_edevice, used_edevice );
 
-    units::ememory used_rate = used_edevice->type->tool->etransfer_rate;
-    units::ememory target_rate = target_edevice->type->tool->etransfer_rate;
+    auto get_etransfer_rate = []( const item_location & loc ) {
+        units::ememory rate = loc->type->tool->etransfer_rate;
+        if( rate == 0_KB ) {
+            debugmsg( "%s is candidate for transferring e-files but has no etransfer_rate", loc->tname() );
+            rate = 1_KB;
+        }
+        return rate;
+    };
+
+    units::ememory used_rate = get_etransfer_rate( used_edevice );
+    units::ememory target_rate = get_etransfer_rate( target_edevice );
     units::ememory external_transfer_rate = external_transfer_edevice ?
-                                            external_transfer_edevice->type->tool->etransfer_rate / 2 : 0_KB;
+                                            get_etransfer_rate( external_transfer_edevice ) / 2 : 0_KB;
     units::ememory slow_transfer_rate = 1_MB; //bluetooth
 
     units::ememory final_rate = std::min( used_rate, target_rate );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1461,11 +1461,8 @@ class read_inventory_preset: public pickup_inventory_preset
 
         bool is_shown( const item_location &loc ) const override {
             const item_location p_loc = loc.parent_item();
-
             return ( loc->is_book() || loc->type->can_use( "learn_spell" ) ) &&
-                   ( p_loc.where() == item_location::type::invalid || !p_loc->is_estorage() ||
-                     !p_loc->uses_energy() ||
-                     p_loc->energy_remaining( p_loc.carrier(), false ) >= 1_kJ );
+                   ( !p_loc || ( !p_loc->is_estorage() || p_loc->is_estorage_usable( you ) ) );
         }
 
         std::string get_denial( const item_location &loc ) const override {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1714,7 +1714,9 @@ static void read()
                 the_book.get_use( "learn_spell" )->call( &player_character, the_book, player_character.pos_bub() );
             } else {
                 loc = loc.obtain( player_character );
-                player_character.read( loc );
+                item_location parent_loc = loc.parent_item();
+                ( parent_loc && parent_loc->is_estorage() ) ?
+                player_character.read( loc, parent_loc ) : player_character.read( loc );
             }
         }
     } else {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8830,6 +8830,12 @@ bool item::is_estorage() const
     return contents.has_pocket_type( pocket_type::E_FILE_STORAGE );
 }
 
+bool item::is_estorage_usable( const Character &who ) const
+{
+    return is_estorage() && is_browsed() && efile_activity_actor::edevice_has_use( this ) &&
+           ammo_sufficient( &who );
+}
+
 bool item::is_estorable() const
 {
     return has_flag( flag_E_STORABLE ) || is_book();

--- a/src/item.h
+++ b/src/item.h
@@ -360,6 +360,8 @@ class item : public visitable
         bool is_cash_card() const;
 
         bool is_estorage() const;
+        /** Above, along with checks for power, browsed, use action */
+        bool is_estorage_usable( const Character &who ) const;
         bool is_estorable() const;
         bool is_browsed() const;
         void set_browsed( bool browsed );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "implement (R)eading e-book requirements, fix etransfer_rate segfault"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Closes #79011 (this was before the overhaul, but still relevant)

Reading e-devices from the (R)ead menu doesn't consume power or take into account e-device status (browsed/power/usable).

Also, somebody mentioned an error reading off of a camera on Discord, so I fixed that and added a debugmsg precaution (sorry about your save).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Make reading off of an e-device require: "has power", "is browsed", and "is a usable e-device"
- Make reading off of an e-device pass the e-device as a parameter to read() so that power is consumed
- Fix a segfault related to division by 0 for uninitialized `etransfer_rate`, add a debug message if an item that should have `etransfer_rate` is missing it

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Read normal book
- Stored book on phone and read it, noted power loss
- Ran phone out of power and confirmed book could not be read; did the same with AR bionic, atomic smartphone
- Moved book to memory card and confirmed book could not be read (this may be desirable in the future, out of scope for now)
- Confirmed files on an unbrowsed device could not be read
- Made sure camera could transfer files

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The "study from books in order" NPC activity does not account for e-books, and it should also have been broken before the e-storage overhaul.

I think I'm comfortable enough with the e-storage infrastructure now to move on to adding more item groups, so expect that next.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
