### PR TITLE
Chapters are Character-mapped for unique books

### DIFF
--- a/data/json/items/book/abstract.json
+++ b/data/json/items/book/abstract.json
@@ -53,6 +53,14 @@
     "melee_damage": { "bash": 1 }
   },
   {
+    "abstract": "book_fict_soft_collection_tpl",
+    "type": "BOOK",
+    "copy-from": "book_fict_soft_tpl",
+    "name": { "str": "paperback novel", "str_pl": "paperbacks" },
+    "description": "Paperback fiction novel generic collection",
+    "generic": true
+  },
+  {
     "abstract": "book_nonf_hard_tpl",
     "type": "BOOK",
     "name": { "str": "Nonfiction Book" },

--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -88,6 +88,7 @@
     "intelligence": 10,
     "time": "26 m",
     "chapters": 40,
+    "generic": true,
     "fun": 3
   },
   {
@@ -170,6 +171,7 @@
     "color": "pink",
     "time": "10 m",
     "chapters": 4,
+    "generic": true,
     "fun": 1
   },
   {
@@ -194,7 +196,7 @@
     "type": "BOOK",
     "name": { "str": "adventure novel" },
     "description": "The stirring tale of a race against time, in search of a lost city located in the heart of the African continent.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "price": "8 USD 50 cent",
     "price_postapoc": "50 cent",
     "time": "20 m",
@@ -205,7 +207,7 @@
     "type": "BOOK",
     "name": { "str": "buddy novel" },
     "description": "A gripping tale of two friends struggling to survive on the streets of New York City.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "weight": "244 g",
     "volume": "500 ml",
     "price": "6 USD 50 cent",
@@ -215,7 +217,7 @@
     "id": "novel_crime",
     "type": "BOOK",
     "name": { "str": "crime novel" },
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "description": "After their diamond heist goes wrong, the surviving criminals begin to suspect that one of them is a police informant.",
     "intelligence": 6,
     "time": "20 m",
@@ -252,7 +254,7 @@
     "type": "BOOK",
     "name": { "str": "drama novel" },
     "description": "A real book for real adults.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "intelligence": 7,
     "time": "25 m",
     "chapters": 28,
@@ -263,7 +265,7 @@
     "type": "BOOK",
     "name": { "str": "erotic novel" },
     "description": "A hackneyed fictional narrative concealing low-grade literary smut.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "weight": "200 g",
     "volume": "500 ml",
     "time": "18 m",
@@ -274,7 +276,7 @@
     "type": "BOOK",
     "name": { "str": "experimental novel" },
     "description": "A bizarre play about the philosophy of existential absurdity.  Or maybe it's about two guys waiting for their friend to show up.  It's confusing.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "weight": "142 g",
     "volume": "500 ml",
     "intelligence": 7,
@@ -286,7 +288,7 @@
     "type": "BOOK",
     "name": { "str": "fantasy novel" },
     "description": "Basic sword & sorcery.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "weight": "227 g",
     "volume": "1 L",
     "intelligence": 7,
@@ -300,7 +302,7 @@
     "type": "BOOK",
     "name": { "str": "horror novel" },
     "description": "Maybe not the best reading material considering the situation.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "weight": "227 g",
     "intelligence": 7,
     "time": "18 m",
@@ -312,7 +314,7 @@
     "type": "BOOK",
     "name": { "str": "mystery novel" },
     "description": "A detective investigates an unusual murder in a secluded location.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "intelligence": 7,
     "time": "18 m",
     "chapters": 28,
@@ -323,7 +325,7 @@
     "type": "BOOK",
     "name": { "str": "road novel" },
     "description": "A tale about a group of friends who wander the USA in the 1960s against a backdrop of jazz, poetry and drug use.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "weight": "244 g",
     "volume": "500 ml",
     "time": "20 m",
@@ -345,7 +347,7 @@
     "type": "BOOK",
     "name": { "str": "romance novel" },
     "description": "Drama and mild smut.",
-    "copy-from": "book_fict_soft_tpl"
+    "copy-from": "book_fict_soft_collection_tpl"
   },
   {
     "id": "paperback_romance_circuses",
@@ -497,7 +499,7 @@
     "type": "BOOK",
     "name": { "str": "spy novel" },
     "description": "A tale of intrigue and espionage among Nazis, no, Commies, no, Iraqis!",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "intelligence": 5,
     "time": "18 m",
     "chapters": 20,
@@ -524,7 +526,7 @@
     "description": "An exciting seventeenth century tale of how an enslaved Irish doctor and his comrades-in-chains escape and become heroic pirates of the Robin Hood variety.",
     "weight": "582 g",
     "volume": "750 ml",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "intelligence": 7,
     "time": "20 m",
     "chapters": 28,
@@ -582,7 +584,7 @@
     "type": "BOOK",
     "name": { "str": "war novel" },
     "description": "A thrilling narrative of survival in a prisoner of war camp during the Second World War, filled with riveting subplots about rat farming and dysentery.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "weight": "686 g",
     "price_postapoc": "50 cent",
     "intelligence": 7,
@@ -604,7 +606,7 @@
     "type": "BOOK",
     "name": { "str": "western novel" },
     "description": "The classic tale of a gunfighting stranger who comes to a small settlement and is hired to help the townsfolk defend themselves from a band of marauding outlaws.",
-    "copy-from": "book_fict_soft_tpl",
+    "copy-from": "book_fict_soft_collection_tpl",
     "intelligence": 5,
     "time": "20 m",
     "chapters": 28,
@@ -680,6 +682,7 @@
     "intelligence": 4,
     "time": "1 m",
     "chapters": 200,
+    "generic": true,
     "fun": -5,
     "melee_damage": { "bash": 2 }
   },
@@ -698,6 +701,7 @@
     "color": "light_gray",
     "time": "10 m",
     "chapters": 4,
+    "generic": true,
     "fun": 1,
     "flags": [ "INSPIRATIONAL" ]
   },
@@ -717,6 +721,7 @@
     "intelligence": 9,
     "time": "18 m",
     "chapters": 36,
+    "generic": true,
     "fun": 2
   },
   {
@@ -735,6 +740,7 @@
     "intelligence": 9,
     "time": "18 m",
     "chapters": 36,
+    "generic": true,
     "fun": 2
   },
   {
@@ -825,6 +831,7 @@
     "intelligence": 7,
     "time": "48 m",
     "chapters": 28,
+    "generic": true,
     "fun": 5
   },
   {
@@ -843,6 +850,7 @@
     "intelligence": 6,
     "time": "18 m",
     "chapters": 24,
+    "generic": true,
     "fun": 3
   },
   {
@@ -978,6 +986,7 @@
     "intelligence": 7,
     "time": "28 m",
     "chapters": 40,
+    "generic": true,
     "fun": 3
   },
   {
@@ -1073,6 +1082,7 @@
     "intelligence": 7,
     "time": "28 m",
     "chapters": 40,
+    "generic": true,
     "fun": 4
   },
   {

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -3905,6 +3905,7 @@ Books can be defined like this:
 "fun" : -2,           // Morale bonus/penalty for reading
 "skill" : "computer", // Skill raised
 "chapters" : 4,       // Number of chapters (for fun only books), each reading "consumes" a chapter. Books with no chapters left are less fun (because the content is already known to the character).
+"generic": false,     // This book counts chapters by item instance instead of by type (this book represents a generic variety of books, like "book of essays")
 "required_level" : 2,  // Minimum skill level required to learn
 "martial_art": "style_mma", // Martial art learned from this book; incompatible with `skill`
 "proficiencies": [    // Having this book mitigate lack of proficiency, required for crafting 

--- a/src/character.h
+++ b/src/character.h
@@ -2313,6 +2313,8 @@ class Character : public Creature, public visitable
         /** Calculates the total fun bonus relative to this character's traits and chapter progress */
         bool fun_to_read( const item &book ) const;
         int book_fun_for( const item &book, const Character &p ) const;
+        /** The number of chapters remaining for each book itype */
+        std::map<itype_id, int> book_chapters;
 
         bool can_pickVolume( const item &it, bool safe = false, const item *avoid = nullptr,
                              bool ignore_pkt_settings = true ) const;

--- a/src/item.h
+++ b/src/item.h
@@ -2407,7 +2407,7 @@ class item : public visitable
          * Mark one chapter of the book as read by the given player. May do nothing if the book has
          * no unread chapters. This is a per-character setting, see @ref get_remaining_chapters.
          */
-        void mark_chapter_as_read( const Character &u );
+        void mark_chapter_as_read( Character &u );
         /**
          * Returns recipes stored on the item (laptops, smartphones, sd cards etc)
          * Filters out !is_valid() recipes

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3264,6 +3264,7 @@ void islot_book::load( const JsonObject &jo )
     optional( jo, was_loaded, "skill", skill, skill_id::NULL_ID() );
     optional( jo, was_loaded, "martial_art", martial_art, matype_id::NULL_ID() );
     optional( jo, was_loaded, "chapters", chapters, 0 );
+    optional( jo, was_loaded, "generic", generic, false );
     optional( jo, was_loaded, "proficiencies", proficiencies );
     optional( jo, was_loaded, "scannable", is_scannable, true );
 }

--- a/src/itype.h
+++ b/src/itype.h
@@ -564,6 +564,11 @@ struct islot_book {
      */
     time_duration time = 0_turns;
     /**
+     * This book counts chapters by item instance instead of by type
+     * (i.e. this book represents a generic variety of books, like "book of essays")
+     */
+    bool generic = false;
+    /**
      * Fun books have chapters; after all are read, the book is less fun.
      */
     int chapters = 0;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1112,6 +1112,7 @@ void Character::load( const JsonObject &data )
     data.read( "male", male );
     data.read( "cash", cash );
     data.read( "recoil", recoil );
+    data.read( "book_chapters", book_chapters );
     data.read( "in_vehicle", in_vehicle );
     data.read( "last_sleep_check", last_sleep_check );
     if( data.read( "id", tmpid ) && tmpid.is_valid() ) {
@@ -1489,6 +1490,7 @@ void Character::store( JsonOut &json ) const
 
     json.member( "cash", cash );
     json.member( "recoil", recoil );
+    json.member( "book_chapters", book_chapters );
     json.member( "in_vehicle", in_vehicle );
     json.member( "id", getID() );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "chapters are character-mapped for unique books"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Closes #77920

As explained in above issue, books can be copied indefinitely for infinite fun.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Chapters read for each book itype are mapped per-Character instead of per-item *unless* `"generic": true` is added to a book specifying it as a type of book rather than a specific title (e.g. `book of essays`)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Read a copy of Dune, noted that another copy had same "chapters read"
Read a (generic = true) Playboy until all the charges were gone, noted a new copy had 4 chapters still left

Read a manual to make sure it still worked

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Not that it explains much, but you can see the copies of Dune I've read have the same chapters read and the other generic books don't:
![image](https://github.com/user-attachments/assets/c6fd8b77-2db8-4330-a97f-83c2a936a6b0)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
