### PR TITLE
a small handful of random insignificant code cleanups

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -99,6 +99,7 @@
 #include "translation.h"
 #include "translations.h"
 #include "trap.h"
+#include "type_id.h"
 #include "try_parse_integer.h"
 #include "ui.h"
 #include "uistate.h"

--- a/src/activity_type.h
+++ b/src/activity_type.h
@@ -16,8 +16,6 @@ class activity_type;
 class player_activity;
 template <typename T> struct enum_traits;
 
-using activity_id = string_id<activity_type>;
-
 /** @relates string_id */
 template<>
 const activity_type &string_id<activity_type>::obj() const;

--- a/src/anatomy.h
+++ b/src/anatomy.h
@@ -14,8 +14,6 @@ class Creature;
 class JsonObject;
 class anatomy;
 
-using anatomy_id = string_id<anatomy>;
-
 /**
  * A structure that contains body parts.
  * Keeps caches for weighted selections.

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -44,8 +44,6 @@ class zone_data;
 struct MonsterGroupResult;
 enum class farm_ops;
 
-using faction_id = string_id<faction>;
-
 const int work_day_hours = 10;
 const int work_day_rest_hours = 8;
 const int work_day_idle_hours = 6;

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -28,7 +28,6 @@ struct localized_comparator;
 template <typename E> struct enum_traits;
 template <typename T> class generic_factory;
 
-using bodypart_str_id = string_id<body_part_type>;
 using bodypart_id = int_id<body_part_type>;
 
 extern const bodypart_str_id body_part_bp_null;

--- a/src/build_reqs.h
+++ b/src/build_reqs.h
@@ -39,7 +39,6 @@ struct parameterized_build_reqs {
 };
 
 build_reqs get_build_reqs_for_furn_ter_ids(
-    const std::pair<std::map<ter_id, int>, std::map<furn_id, int>> &changed_ids,
-    ter_id const &base_ter = ter_str_id( "t_dirt" ).id() );
+    const std::pair<std::map<ter_id, int>, std::map<furn_id, int>> &changed_ids );
 
 #endif // CATA_SRC_BUILD_REQS_H

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -34,7 +34,6 @@ class JsonObject;
 class pixel_minimap;
 
 extern void set_displaybuffer_rendertarget();
-using ter_str_id = string_id<ter_t>;
 
 /** Structures */
 struct tile_type {

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -30,7 +30,6 @@ class item;
 class map;
 struct construction;
 
-using faction_id = string_id<faction>;
 inline const faction_id your_fac( "your_followers" );
 const std::string type_fac_hash_str = "__FAC__";
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2520,9 +2520,9 @@ void finalize_constructions()
 }
 
 build_reqs get_build_reqs_for_furn_ter_ids(
-    const std::pair<std::map<ter_id, int>, std::map<furn_id, int>> &changed_ids,
-    ter_id const &base_ter )
+    const std::pair<std::map<ter_id, int>, std::map<furn_id, int>> &changed_ids )
 {
+    ter_id const &base_ter = ter_t_dirt.id();
     build_reqs total_reqs;
 
     if( !finalized ) {

--- a/src/creature.h
+++ b/src/creature.h
@@ -64,8 +64,6 @@ struct projectile_attack_results;
 struct trap;
 template <typename T> struct enum_traits;
 
-using anatomy_id = string_id<anatomy>;
-
 enum class creature_size : int {
     // Keep it starting at 1 - damage done to monsters depends on it
     // Squirrel, cat, human toddler

--- a/src/faction.h
+++ b/src/faction.h
@@ -41,8 +41,6 @@ class JsonValue;
 class faction;
 class npc;
 
-using faction_id = string_id<faction>;
-
 namespace npc_factions
 {
 void finalize();

--- a/src/item.h
+++ b/src/item.h
@@ -3360,8 +3360,6 @@ inline bool is_crafting_component( const item &component )
  */
 bool is_preferred_component( const item &component );
 
-#endif // CATA_SRC_ITEM_H
-
 struct disp_mod_by_barrel {
     units::length barrel_length;
     int dispersion_modifier;
@@ -3380,3 +3378,5 @@ struct disp_mod_by_barrel {
  */
 std::vector<std::pair<const item *, int>> get_item_duplicate_counts(
         const std::list<const item *> &items );
+
+#endif // CATA_SRC_ITEM_H

--- a/src/item.h
+++ b/src/item.h
@@ -75,7 +75,6 @@ enum class mod : int;
 } // namespace enchant_vals
 
 using bodytype_id = std::string;
-using faction_id = string_id<faction>;
 class item_category;
 struct islot_armor;
 struct use_function;

--- a/src/map.h
+++ b/src/map.h
@@ -104,8 +104,6 @@ struct field_proc_data;
 
 class PathfindingFlags;
 
-using relic_procgen_id = string_id<relic_procgen_data>;
-
 class map_stack : public item_stack
 {
     private:

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -8,13 +8,11 @@
 #include "mdarray.h"
 #include "memory_fast.h"
 #include "point.h" // IWYU pragma: keep
+#include "type_id.h"
 
 class JsonObject;
 class JsonOut;
 class JsonValue;
-
-struct ter_t;
-using ter_str_id = string_id<ter_t>;
 
 class memorized_tile
 {

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -21,10 +21,6 @@
 #include "units.h"
 #include "value_ptr.h"
 
-struct ter_t;
-
-using ter_str_id = string_id<ter_t>;
-
 class JsonObject;
 class Character;
 struct iexamine_actor;

--- a/src/npc.h
+++ b/src/npc.h
@@ -77,10 +77,6 @@ struct pathfinding_settings;
 enum game_message_type : int;
 class gun_mode;
 
-using bionic_id = string_id<bionic_data>;
-using npc_class_id = string_id<npc_class>;
-using mission_type_id = string_id<mission_type>;
-using mfaction_id = int_id<monfaction>;
 using overmap_location_str_id = string_id<overmap_location>;
 using drop_location = std::pair<item_location, int>;
 using drop_locations = std::list<drop_location>;

--- a/src/relic.h
+++ b/src/relic.h
@@ -26,8 +26,6 @@ struct relic_charge_info;
 struct relic_charge_template;
 struct tripoint;
 
-using relic_procgen_id = string_id<relic_procgen_data>;
-
 class relic_procgen_data
 {
     public:

--- a/src/subbodypart.h
+++ b/src/subbodypart.h
@@ -24,7 +24,6 @@ class JsonValue;
 struct sub_body_part_type;
 struct body_part_type;
 
-using sub_bodypart_str_id = string_id<sub_body_part_type>;
 using sub_bodypart_id = int_id<sub_body_part_type>;
 
 enum class side : int {

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -23,6 +23,9 @@ struct ammo_effect;
 using ammo_effect_id = int_id<ammo_effect>;
 using ammo_effect_str_id = string_id<ammo_effect>;
 
+class anatomy;
+using anatomy_id = string_id<anatomy>;
+
 struct attack_vector;
 using attack_vector_id = string_id<attack_vector>;
 
@@ -272,6 +275,9 @@ using proficiency_category_id = string_id<proficiency_category>;
 
 class proficiency;
 using proficiency_id = string_id<proficiency>;
+
+class relic_procgen_data;
+using relic_procgen_id = string_id<relic_procgen_data>;
 
 struct ter_t;
 using ter_id = int_id<ter_t>;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
These are the "contentful" changes lifted from #79239. These address the parts of the codebase that IWYU gets very confused on, where the fixes cannot be summarized as "just shuffle some includes around". The fixes are still super trivial. I thought it's better to PR them now, given the unclear state of #79239. 

#### Describe the solution

- a couple of files (re)define their own type ids, i.e. `clzones.h` has `using faction_id = string_id<faction>;`. This is not a problem per se, but it makes IWYU confused on what is that authoritative file providing said type, and it then tries to add things like `#include "clzones.h"` for any file that uses `faction_id`, which is silly. (or, worse, suggests including `cata_tiles.h` for anything referencing `ter_str_id`)
  So I just moved a couple of those `using thing_id = string_id<thing>;` into `type_id.h`, and added the missing `#include "type_id.h"` where neccessary
- `get_build_reqs_for_furn_ter_ids` in `build_reqs.h` has a default argument `ter_id const &base_ter = ter_str_id( "t_dirt" ).id()` . This is a bit problematic because (and i forget the *exact* reasoning, but roughly speaking) ideally the file that defines `ter_t` ends up wanting to have `#include "build_reqs.h"` at the top, but that means that we *call* `ter::id()` (somewhere along the beginning of the file, in the include block) before we *declare* it (somewhere more down the line inside `class ter_t {`), and the compiler doesn't like that.
  The argument is never used anyway, it's always default, so I just remove it.
- item.h has poorly closed `#endif` at the end of file, so just move that one as appropriate.


#### Describe alternatives you've considered
Leave things be given that they don't actively hurt anybody, idk.

#### Testing
None other than checking that the game builds.

#### Additional context
N/A