### PR TITLE
Fix vehicle parts being unrepairable after removing from vehicle

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8542,7 +8542,8 @@ item vehicle::part_to_item( const vehicle_part &vp ) const
 
     // quantize damage and degradation to the middle of each damage_level so that items will stack nicely
     tmp.set_damage( ( tmp.damage_level() - 0.5 ) * itype::damage_scale );
-    tmp.set_degradation( ( static_cast<double>( tmp.degradation() ) / itype::damage_scale - 0.5 ) * itype::damage_scale );
+    tmp.set_degradation( ( static_cast<double>( tmp.degradation() ) / itype::damage_scale - 0.5 ) *
+                         itype::damage_scale );
     return tmp;
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8542,7 +8542,7 @@ item vehicle::part_to_item( const vehicle_part &vp ) const
 
     // quantize damage and degradation to the middle of each damage_level so that items will stack nicely
     tmp.set_damage( ( tmp.damage_level() - 0.5 ) * itype::damage_scale );
-    tmp.set_degradation( ( tmp.damage_level() - 0.5 ) * itype::damage_scale );
+    tmp.set_degradation( ( tmp.degradation() / itype::damage_scale - 0.5 ) * itype::damage_scale );
     return tmp;
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8542,7 +8542,7 @@ item vehicle::part_to_item( const vehicle_part &vp ) const
 
     // quantize damage and degradation to the middle of each damage_level so that items will stack nicely
     tmp.set_damage( ( tmp.damage_level() - 0.5 ) * itype::damage_scale );
-    tmp.set_degradation( ( tmp.degradation() / itype::damage_scale - 0.5 ) * itype::damage_scale );
+    tmp.set_degradation( ( static_cast<double>( tmp.degradation() ) / itype::damage_scale - 0.5 ) * itype::damage_scale );
     return tmp;
 }
 


### PR DESCRIPTION
#### Summary
`SUMMARY: Bugfixes "Fix vehicle parts being unrepairable after removing from vehicle"`

#### Purpose of change

Repairable damaged vehicle parts, when removed from their respective vehicle, can no longer be repaired.
They can't be repaired neither as an item nor when installed into a (same or different) vehicle. 
Doesn't seem like this is intended behavior to me, but idunno.
Fixes #74035

#### Describe the solution

Just applying the changes I found in #69696; the work is @lispcoc's. All I've done is the testing.
The contributor closed the PR due to not having time to test it, and hasn't followed up since. If they or anyone wants to reopen that PR, I will close this one. 

#### Describe alternatives you've considered

I tried some different approaches to fixing this behavior before digging around and finding the PR (and issue) above, which is a simple 1-line change.

#### Testing

Game compiles and loads.
Look at a damaged part in a vehicle that is repairable (a steel frame).
Remove the part, and confirm I am able to repair it.
Install the part back into the vehicle, and confirm I am able to repair it.

Look at a damaged part in a vehicle that is *not* repairable (a windshield).
Remove the part. Confirm it's still not repairable.
Reinstall the part. Confirm it's still not repairable.

#### Additional context

This issue still persists on d95d1656cbb9a1063702b65bf4b7e63c1504d1ae. I had encountered it during play when moving a motor from one vehicle to another. My character has high mechanics skill, so I thought it didn't feel right.  

The supplied save from #74035 can be used to check this behavior (just skip past the many errors on loading)