### PR TITLE
Fix clang-tidy warning about mispositioned translation comment

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3846,8 +3846,8 @@ void map::smash_items( const tripoint_bub_ms &p, int power, const std::string &c
         add_msg_if_player_sees( get_map().get_bub( get_abs( p ) ), m_bad,
                                 _( "The %s destroys several items!" ), cause_message );
     } else if( items_destroyed == 1 && items_damaged == 1 ) {
-        //~ %1$s: the cause of destruction, %2$s: destroyed item name
         add_msg_if_player_sees( get_map().get_bub( get_abs( p ) ), m_bad,
+                                //~ %1$s: the cause of destruction, %2$s: destroyed item name
                                 _( "The %1$s destroys the %2$s!" ), cause_message,
                                 damaged_item_name );
     } else if( items_damaged > 1 ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Clang-tidy was broken for a day, so we accidentally merged in a code with warnings, and clang-tidy is now complaining about that on master (e.g. https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/12985510342/job/36216398139)
```log
 Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/map.cpp:3849:9: error: Translator comment without a matching raw string [cata-translator-comments,-warnings-as-errors]
 3849 |         //~ %1$s: the cause of destruction, %2$s: destroyed item name
      |         ^
```

#### Describe the solution
move the translation comment one line over, so that it's closer to the string it's aiming to comment on

#### Describe alternatives you've considered
N/A

#### Testing
None

#### Additional context
