### PR TITLE
fix query popup not wrapping

### DIFF
--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -75,7 +75,6 @@ void query_popup_impl::draw_controls()
             }
             if( keyboard_selected_option != last_keyboard_selected_option &&
                 keyboard_selected_option == short( ind ) && ImGui::IsWindowFocused() ) {
-
                 ImGui::SetKeyboardFocusHere( -1 );
             }
             current_line = parent->buttons[ind].pos.y;

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -75,7 +75,8 @@ void query_popup_impl::draw_controls()
             }
             if( keyboard_selected_option != last_keyboard_selected_option &&
                 keyboard_selected_option == short( ind ) && ImGui::IsWindowFocused() ) {
-                ImGui::SetItemDefaultFocus();
+
+                ImGui::SetKeyboardFocusHere( -1 );
             }
             current_line = parent->buttons[ind].pos.y;
         }


### PR DESCRIPTION
#### Summary
Bugfixes "fix query popup selector not wrapping"

#### Purpose of change
fix #79374
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
after reading [this](https://github.com/ocornut/imgui/discussions/5867#discussioncomment-4087688) thread, I've tried replacing https://github.com/CleverRaven/Cataclysm-DDA/blob/e43389302cc002ed591ccfebc35ecb39c8ba6d91/src/popup.cpp#L78 with `ImGui::SetKeyboardFocusHere( -1 );` and it worked. I have no idea how or why, so someone with actual knowledge should definitely have a look. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
exit query and distraction query both wrap correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Some more [context](https://github.com/ocornut/imgui/discussions/3945)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
