### PR TITLE
Improve efile i18n

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3529,7 +3529,7 @@ std::string efile_activity_actor::efile_action_name( efile_action action_type, b
 {
     static const std::vector<std::string> base_names = { _( "browse" ), _( "read" ), _( "move" ), _( "move" ), _( "copy" ), _( "copy" ), _( "wipe" ) };
     static const std::vector<std::string> past_names = { _( "browsed" ), _( "read" ), _( "moved" ), _( "moved" ), _( "copied" ), _( "copied" ), _( "wiped" ) };
-    static const std::vector<std::string> extensions = { "", "", _( " files onto" ), _( " files off of" ), _( " files onto" ), _( " files off of" ), "" };
+    static const std::vector<std::string> extensions = { "", "", _( " files off of" ), _( " files onto" ), _( " files off of" ), _( " files onto" ), "" };
     return string_format( _( "%s%s" ), past_tense ? past_names[action_type] : base_names[action_type],
                           extended ? "" : extensions[action_type] );
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3527,15 +3527,11 @@ units::ememory efile_activity_actor::current_etransfer_rate( Character &who,
 std::string efile_activity_actor::efile_action_name( efile_action action_type, bool past_tense,
         bool extended )
 {
-    std::vector<std::string> base_names = { _( "browse" ), _( "read" ), _( "move" ), _( "move" ), _( "copy" ), _( "copy" ), _( "wipe" ) };
-    std::vector<std::string> past_names = { _( "browsed" ), _( "read" ), _( "moved" ), _( "moved" ), _( "copied" ), _( "copied" ), _( "wiped" ) };
-    std::vector<std::string> extensions = { "", "", _( " files onto" ), _( " files off of" ), _( " files onto" ), _( " files off of" ), "" };
-    std::string name_output;
-    past_tense ? name_output += past_names[action_type] : name_output += base_names[action_type];
-    if( extended ) {
-        name_output += extensions[action_type];
-    }
-    return name_output;
+    static const std::vector<std::string> base_names = { _( "browse" ), _( "read" ), _( "move" ), _( "move" ), _( "copy" ), _( "copy" ), _( "wipe" ) };
+    static const std::vector<std::string> past_names = { _( "browsed" ), _( "read" ), _( "moved" ), _( "moved" ), _( "copied" ), _( "copied" ), _( "wiped" ) };
+    static const std::vector<std::string> extensions = { "", "", _( " files onto" ), _( " files off of" ), _( " files onto" ), _( " files off of" ), "" };
+    return string_format( _( "%s%s" ), past_tense ? past_names[action_type] : base_names[action_type],
+                          extended ? "" : extensions[action_type] );
 }
 
 bool efile_activity_actor::efile_action_exclude_used( efile_action action_type )

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3524,14 +3524,55 @@ units::ememory efile_activity_actor::current_etransfer_rate( Character &who,
     return final_rate;
 }
 
+static std::string efile_action_name_lookup( const
+        std::map<efile_action, std::pair<std::string, std::string>> &names, efile_action action_type,
+        bool past_tense )
+{
+    const auto it = names.find( action_type );
+    if( it == names.end() ) {
+        debugmsg( "Invalid efile_action passed to efile_activity_actor::efile_action_name" );
+        return "";
+    }
+    return past_tense ? it->second.second : it->second.first;
+}
+
 std::string efile_activity_actor::efile_action_name( efile_action action_type, bool past_tense,
         bool extended )
 {
-    static const std::vector<std::string> base_names = { _( "browse" ), _( "read" ), _( "move" ), _( "move" ), _( "copy" ), _( "copy" ), _( "wipe" ) };
-    static const std::vector<std::string> past_names = { _( "browsed" ), _( "read" ), _( "moved" ), _( "moved" ), _( "copied" ), _( "copied" ), _( "wiped" ) };
-    static const std::vector<std::string> extensions = { "", "", _( " files off of" ), _( " files onto" ), _( " files off of" ), _( " files onto" ), "" };
-    return string_format( _( "%s%s" ), past_tense ? past_names[action_type] : base_names[action_type],
-                          extended ? "" : extensions[action_type] );
+    static const std::map<efile_action, std::pair<std::string, std::string>> efile_action_names_short{
+        {
+            EF_BROWSE, {
+                //~ Electronic file short action names, first present tense then past tense
+                _( "browse" ),
+                _( "browsed" )
+            }
+        },
+        { EF_READ, { _( "read" ), _( "read" ) } },
+        { EF_MOVE_FROM_THIS, { _( "move" ), _( "moved" ) } },
+        { EF_MOVE_ONTO_THIS, { _( "move" ), _( "moved" ) } },
+        { EF_COPY_FROM_THIS, { _( "copy" ), _( "copied" ) } },
+        { EF_COPY_ONTO_THIS, { _( "copy" ), _( "copied" ) } },
+        { EF_WIPE, { _( "wipe" ), _( "wiped" ) } }
+    };
+    static const std::map<efile_action, std::pair<std::string, std::string>>
+    efile_action_names_extended{
+
+        {
+            EF_BROWSE, {
+                //~ Electronic file extended action names, first present tense then past tense
+                _( "browse" ),
+                _( "browsed" )
+            }
+        },
+        { EF_READ, { _( "read" ), _( "read" ) } },
+        { EF_MOVE_FROM_THIS, { _( "move files off of" ), _( "moved files off of" ) } },
+        { EF_MOVE_ONTO_THIS, { _( "move files onto" ), _( "moved files onto" ) } },
+        { EF_COPY_FROM_THIS, { _( "copy files off of" ), _( "copied files off of" ) } },
+        { EF_COPY_ONTO_THIS, { _( "copy files onto" ), _( "copied files onto" ) } },
+        { EF_WIPE, { _( "wipe" ), _( "wiped" ) } }
+    };
+    return efile_action_name_lookup( extended ? efile_action_names_extended : efile_action_names_short,
+                                     action_type, past_tense );
 }
 
 bool efile_activity_actor::efile_action_exclude_used( efile_action action_type )

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3525,7 +3525,7 @@ units::ememory efile_activity_actor::current_etransfer_rate( Character &who,
 }
 
 static std::string efile_action_name_lookup( const
-        std::map<efile_action, std::pair<std::string, std::string>> &names, efile_action action_type,
+        std::map<efile_action, std::pair<translation, translation >> &names, efile_action action_type,
         bool past_tense )
 {
     const auto it = names.find( action_type );
@@ -3533,43 +3533,43 @@ static std::string efile_action_name_lookup( const
         debugmsg( "Invalid efile_action passed to efile_activity_actor::efile_action_name" );
         return "";
     }
-    return past_tense ? it->second.second : it->second.first;
+    return past_tense ? it->second.second.translated() : it->second.first.translated();
 }
 
 std::string efile_activity_actor::efile_action_name( efile_action action_type, bool past_tense,
         bool extended )
 {
-    static const std::map<efile_action, std::pair<std::string, std::string>> efile_action_names_short{
+    static const std::map<efile_action, std::pair<translation, translation>> efile_action_names_short{
         {
             EF_BROWSE, {
                 //~ Electronic file short action names, first present tense then past tense
-                _( "browse" ),
-                _( "browsed" )
+                to_translation( "browse" ),
+                to_translation( "browsed" )
             }
         },
-        { EF_READ, { _( "read" ), _( "read" ) } },
-        { EF_MOVE_FROM_THIS, { _( "move" ), _( "moved" ) } },
-        { EF_MOVE_ONTO_THIS, { _( "move" ), _( "moved" ) } },
-        { EF_COPY_FROM_THIS, { _( "copy" ), _( "copied" ) } },
-        { EF_COPY_ONTO_THIS, { _( "copy" ), _( "copied" ) } },
-        { EF_WIPE, { _( "wipe" ), _( "wiped" ) } }
+        { EF_READ, { to_translation( "read" ), to_translation( "read" ) } },
+        { EF_MOVE_FROM_THIS, { to_translation( "move" ), to_translation( "moved" ) } },
+        { EF_MOVE_ONTO_THIS, { to_translation( "move" ), to_translation( "moved" ) } },
+        { EF_COPY_FROM_THIS, { to_translation( "copy" ), to_translation( "copied" ) } },
+        { EF_COPY_ONTO_THIS, { to_translation( "copy" ), to_translation( "copied" ) } },
+        { EF_WIPE, { to_translation( "wipe" ), to_translation( "wiped" ) } }
     };
-    static const std::map<efile_action, std::pair<std::string, std::string>>
+    static const std::map<efile_action, std::pair<translation, translation>>
     efile_action_names_extended{
 
         {
             EF_BROWSE, {
                 //~ Electronic file extended action names, first present tense then past tense
-                _( "browse" ),
-                _( "browsed" )
+                to_translation( "browse" ),
+                to_translation( "browsed" )
             }
         },
-        { EF_READ, { _( "read" ), _( "read" ) } },
-        { EF_MOVE_FROM_THIS, { _( "move files off of" ), _( "moved files off of" ) } },
-        { EF_MOVE_ONTO_THIS, { _( "move files onto" ), _( "moved files onto" ) } },
-        { EF_COPY_FROM_THIS, { _( "copy files off of" ), _( "copied files off of" ) } },
-        { EF_COPY_ONTO_THIS, { _( "copy files onto" ), _( "copied files onto" ) } },
-        { EF_WIPE, { _( "wipe" ), _( "wiped" ) } }
+        { EF_READ, { to_translation( "read" ), to_translation( "read" ) } },
+        { EF_MOVE_FROM_THIS, { to_translation( "move files off of" ), to_translation( "moved files off of" ) } },
+        { EF_MOVE_ONTO_THIS, { to_translation( "move files onto" ), to_translation( "moved files onto" ) } },
+        { EF_COPY_FROM_THIS, { to_translation( "copy files off of" ), to_translation( "copied files off of" ) } },
+        { EF_COPY_ONTO_THIS, { to_translation( "copy files onto" ), to_translation( "copied files onto" ) } },
+        { EF_WIPE, { to_translation( "wipe" ), to_translation( "wiped" ) } }
     };
     return efile_action_name_lookup( extended ? efile_action_names_extended : efile_action_names_short,
                                      action_type, past_tense );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1810,12 +1810,10 @@ drop_locations game_menus::inv::efile_select( Character &who, item_location &use
             } };
     };
 
-    std::string action_name = efile_activity_actor::efile_action_name( action );
-
     if( action == EF_READ ) {
         inventory_pick_selector select_one_file( who, preset );
         select_one_file.add_contained_efiles( used_edevice );
-        select_one_file.set_title( action_name + _( " which files?" ) );
+        select_one_file.set_title( _( "Read which files?" ) );
         if( select_one_file.empty() ) {
             return drop_locations();
         }
@@ -1830,11 +1828,14 @@ drop_locations game_menus::inv::efile_select( Character &who, item_location &use
     for( item_location loc : from_edevices ) {
         select_multiple_efiles.add_contained_efiles( loc );
     }
+
+    const std::string action_name = efile_activity_actor::efile_action_name( action );
+
     if( select_multiple_efiles.empty() ) {
-        popup( std::string( _( "You have no files to " + action_name + "." ) ), PF_GET_KEY );
+        popup( string_format( _( "You have no files to %s." ), action_name ), PF_GET_KEY );
         return drop_locations();
     }
-    select_multiple_efiles.set_title( _( "Select files to " + action_name ) );
+    select_multiple_efiles.set_title( string_format( _( "Select files to %s" ), action_name ) );
     bool done = false;
     drop_locations selected_efiles;
     while( !done ) {
@@ -1846,7 +1847,7 @@ drop_locations game_menus::inv::efile_select( Character &who, item_location &use
         if( wiping || ( total_ememory < to_edevice->remaining_ememory() || selected_efiles.empty() ) ) {
             done = true;
         } else {
-            popup( std::string( _( "Selected file size exceeds available storage size." ) ), PF_GET_KEY );
+            popup( _( "Selected file size exceeds available storage size." ), PF_GET_KEY );
         }
     }
     return selected_efiles;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #79371
The onto/off of messages appear to be the wrong way around
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Hopefully makes it more pleasant and possible to translate
Fixes onto/off of order
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The "Merge the parts together" commit is probably unnecessary but seems nicer
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked the move message log messages were right (I couldn't get copying to work period in order to test it)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
