### PR TITLE
Set system locale decimal separator as imgui Platform_LocaleDecimalPoint

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -802,6 +802,11 @@ int main( int argc, const char *argv[] )
     // Load the colors of ImGui to match the colors set by the user.
     cataimgui::init_colors();
 
+    // set decimal point for float input widgets
+    // uses system locale, because that's what imgui uses to parse and display floats
+    ImGui::GetPlatformIO().Platform_LocaleDecimalPoint =
+        static_cast<unsigned char>( *localeconv()->decimal_point );
+
     // Override existing settings from cli  options
     if( cli.disable_ascii_art ) {
         get_options().get_option( "ENABLE_ASCII_ART" ).setValue( "false" );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #79401

#### Describe the solution

Imgui uses a function to replace `.`/`,` by whatever decimal separator you use in your operating system when typing in float input fields. However it does not initialize that value itself, so we have to do it.

#### Describe alternatives you've considered

- Remove the feature from imgui, which is a bit annoying to do, but we could opt back in when it works better.
- Fix imgui to use the locale from the selected game language. I'm not sure what's even required to do this. (And it still requires setting the value for imgui when we change languages.)

#### Testing

Typed a number using comma as a decimal separator. It both let me type the comma and correctly parsed the typed value.

#### Additional context

I'm mostly new to all the locale stuff, so I cannot guarantee this is the correct approach.