### PR TITLE
typify v-w

### DIFF
--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -499,9 +499,9 @@ void veh_app_interact::remove()
         for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
             act.coord_set.insert( here.get_abs( p ) );
         }
-        const tripoint a_point_abs( here.get_abs( a_point_bub ).raw() );
-        act.values.push_back( a_point_abs.x );
-        act.values.push_back( a_point_abs.y );
+        const tripoint_abs_ms a_point_abs( here.get_abs( a_point_bub ) );
+        act.values.push_back( a_point_abs.x() );
+        act.values.push_back( a_point_abs.y() );
         act.values.push_back( a_point.x() );
         act.values.push_back( a_point.y() );
         act.values.push_back( -a_point.x() );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -970,8 +970,6 @@ class vehicle
         bool is_towing() const;
         bool has_tow_attached() const;
         int get_tow_part() const;
-        // TODO: Get rid of untyped overload.
-        bool is_external_part( const tripoint &part_pt ) const;
         bool is_external_part( const tripoint_bub_ms &part_pt ) const;
         bool is_towed() const;
         void set_tow_directions();
@@ -1038,8 +1036,6 @@ class vehicle
          * @param vpi The part type to check
          * @return true if the part can be mounted at specified position.
          */
-        // TODO: Get rid of untyped overload.
-        ret_val<void> can_mount( const point &dp, const vpart_info &vpi ) const;
         ret_val<void> can_mount( const point_rel_ms &dp, const vpart_info &vpi ) const;
 
         // @returns true if part \p vp_to_remove can be uninstalled
@@ -1047,8 +1043,6 @@ class vehicle
 
         // install a part of type \p type at mount \p dp
         // @return installed part index or -1 if can_mount(...) failed
-        // TODO: Get rid of untyped overload.
-        int install_part( const point &dp, const vpart_id &type );
         int install_part( const point_rel_ms &dp, const vpart_id &type );
 
         // install a part of type \p type at mount \p dp with \p base (std::move -ing it)
@@ -1060,8 +1054,6 @@ class vehicle
 
         // install the given part \p vp (std::move -ing it)
         // @return installed part index or -1 if can_mount(...) failed
-        // TODO: Get rid of untyped overload.
-        int install_part( const point &dp, vehicle_part &&vp );
         int install_part( const point_rel_ms &dp, vehicle_part &&vp );
 
         struct rackable_vehicle {
@@ -1089,8 +1081,6 @@ class vehicle
         // merges vehicles together by copying parts, does not account for any vehicle complexities
         bool merge_vehicle_parts( vehicle *veh );
         bool merge_appliance_into_grid( vehicle &veh_target );
-        // TODO: Get rid of untyped overload.
-        void separate_from_grid( point mount );
         void separate_from_grid( point_rel_ms mount );
 
         bool is_powergrid() const;
@@ -1197,9 +1187,6 @@ class vehicle
         /**@}*/
 
         // returns the list of indices of parts at certain position (not accounting frame direction)
-        // TODO: Get rid of untyped overload.
-        std::vector<int> parts_at_relative( const point &dp, bool use_cache,
-                                            bool include_fake = false ) const;
         std::vector<int> parts_at_relative( const point_rel_ms &dp, bool use_cache,
                                             bool include_fake = false ) const;
 
@@ -1212,9 +1199,6 @@ class vehicle
         *  @param include_fake if true fake parts are included
         *  @returns part index or -1
         */
-        // TODO: Get rid of untyped overload
-        int part_with_feature( const point &pt, const std::string &f, bool unbroken,
-                               bool include_fake = false ) const;
         int part_with_feature( const point_rel_ms &pt, const std::string &f, bool unbroken,
                                bool include_fake = false ) const;
         /**
@@ -1283,8 +1267,6 @@ class vehicle
          *  @param flag The specified flag
          *  @param enabled if set part must also be enabled to be considered
          */
-        // TODO: Get rid of untyped overload.
-        bool has_part( const tripoint &pos, const std::string &flag, bool enabled = false ) const;
         bool has_part( const tripoint_bub_ms &pos, const std::string &flag, bool enabled = false ) const;
 
         /**
@@ -1371,8 +1353,6 @@ class vehicle
         std::vector<std::vector<int>> find_lines_of_parts( int part, const std::string &flag ) const;
 
         // Translate mount coordinates "p" using current pivot direction and anchor and return tile coordinates
-        // TODO: Get rid of untyped overload.
-        point coord_translate( const point &p ) const;
         point_rel_ms coord_translate( const point_rel_ms &p ) const;
 
         // Translate mount coordinates "p" into tile coordinates "q" using given pivot direction and anchor
@@ -1383,14 +1363,10 @@ class vehicle
         void coord_translate( tileray tdir, const point_rel_ms &pivot, const point_rel_ms &p,
                               tripoint_rel_ms &q ) const;
 
-        // TODO: Get rid of untyped overload.
-        tripoint mount_to_tripoint( const point &mount ) const;
         tripoint_bub_ms mount_to_tripoint( const point_rel_ms &mount ) const;
         tripoint_bub_ms mount_to_tripoint( const point_rel_ms &mount, const point_rel_ms &offset ) const;
 
         // Seek a vehicle part which obstructs tile with given coordinates relative to vehicle position
-        // TODO: Get rid of untyped overload.
-        int part_at( const point &dp ) const;
         int part_at( const point_rel_ms &dp ) const;
         int part_displayed_at( const point_rel_ms &dp, bool include_fake = false,
                                bool below_roof = true, bool roof = true ) const;

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -178,10 +178,10 @@ enum class quad_rotation : int {
 struct vehicle_profile {
     tileray tdir;
     // Points occupied by the convex hull of the vehicle. Coordinates relative to pivot.
-    std::vector<point> occupied_zone;
+    std::vector<point_rel_ms> occupied_zone;
     // Points to check for collision when moving one step in this direction.
     // Coordinates relative to pivot.
-    std::vector<point> collision_points;
+    std::vector<point_rel_ms> collision_points;
 };
 
 /**
@@ -684,8 +684,9 @@ vehicle_profile vehicle::autodrive_controller::compute_profile( orientation faci
     // compute the subset of vehicle points that would move to previously unoccupied spots
     // (a.k.a. "moving first") when the vehicle moves one step; these are the only points
     // we need to check for collision when the vehicle is moving in this direction
-    const std::unordered_set<point> occupied_set( ret.occupied_zone.begin(), ret.occupied_zone.end() );
-    for( const point &pt : ret.occupied_zone ) {
+    const std::unordered_set<point_rel_ms> occupied_set( ret.occupied_zone.begin(),
+            ret.occupied_zone.end() );
+    for( const point_rel_ms &pt : ret.occupied_zone ) {
         if( occupied_set.find( pt + increment ) == occupied_set.end() ) {
             ret.collision_points.emplace_back( pt );
         }
@@ -868,9 +869,9 @@ void vehicle::autodrive_controller::compute_valid_positions()
             for( int my = 0; my < NAV_MAP_SIZE_Y; my++ ) {
                 const point nav_pt( mx, my );
                 bool valid = true;
-                for( const point &veh_pt : profile.occupied_zone ) {
+                for( const point_rel_ms &veh_pt : profile.occupied_zone ) {
                     const point view_pt = data.nav_to_view.transform( nav_pt ) + veh_rot.transform(
-                                              veh_pt ) - veh_rot.transform( point::zero );
+                                              veh_pt.raw() ) - veh_rot.transform( point::zero );
                     if( !data.view_bounds.contains( view_pt ) || data.is_obstacle[view_pt.x][view_pt.y] ) {
                         valid = false;
                         break;
@@ -1158,7 +1159,7 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
     const point forward_offset( face_dir.dx(), face_dir.dy() );
     bool changed_zlevel = false;
     bool blind = true;
-    for( const point &p : data.profile( to_orientation( face_dir.dir() ) ).collision_points ) {
+    for( const point_rel_ms &p : data.profile( to_orientation( face_dir.dir() ) ).collision_points ) {
         const tripoint_bub_ms next = data.adjust_z( veh_pos + forward_offset + p );
         if( driver.sees( next ) ) {
             blind = false;
@@ -1183,13 +1184,13 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
     const int speed = std::min( driven_veh.velocity + driven_veh.current_acceleration(),
                                 driven_veh.cruise_velocity );
     const int speed_tps = speed / VMIPH_PER_TPS;
-    std::unordered_set<point> collision_zone;
+    std::unordered_set<point_rel_ms> collision_zone;
     tdir.advance();
-    point offset( tdir.dx(), tdir.dy() );
-    for( const point &p : profile.occupied_zone ) {
+    point_rel_ms offset( tdir.dx(), tdir.dy() );
+    for( const point_rel_ms &p : profile.occupied_zone ) {
         collision_zone.insert( p + offset );
     }
-    for( const point &p : collision_zone ) {
+    for( const point_rel_ms &p : collision_zone ) {
         if( !check_drivable( data.adjust_z( veh_pos + p ) ) ) {
             return collision_check_result::close_obstacle;
         }
@@ -1199,12 +1200,12 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
     collision_zone.clear();
     for( int i = 1; i < speed_tps; i++ ) {
         tdir.advance();
-        offset += point( tdir.dx(), tdir.dy() );
-        for( const point &p : profile.collision_points ) {
+        offset += point_rel_ms( tdir.dx(), tdir.dy() );
+        for( const point_rel_ms &p : profile.collision_points ) {
             collision_zone.insert( p + offset );
         }
     }
-    for( const point &p : collision_zone ) {
+    for( const point_rel_ms &p : collision_zone ) {
         const tripoint_bub_ms next = data.adjust_z( veh_pos + p );
         if( !data.is_flying && !driver.sees( next ) ) {
             return collision_check_result::slow_down;
@@ -1292,15 +1293,15 @@ std::vector<std::tuple<point_rel_ms, int, std::string>> vehicle::get_debug_overl
     for( const std::string &debug_str : debug_what ) {
         if( debug_str == "profiles" ) {
             const vehicle_profile &profile = data.profile( dir );
-            for( const point &p : profile.occupied_zone ) {
-                if( p.x == 0 && p.y == 0 ) {
-                    ret.emplace_back( point_rel_ms( p ), catacurses::cyan, to_string( dir ) );
+            for( const point_rel_ms &p : profile.occupied_zone ) {
+                if( p.x() == 0 && p.y() == 0 ) {
+                    ret.emplace_back( p, catacurses::cyan, to_string( dir ) );
                 } else {
-                    ret.emplace_back( point_rel_ms( p ), catacurses::green, "x" );
+                    ret.emplace_back( p, catacurses::green, "x" );
                 }
             }
-            for( const point &p : profile.collision_points ) {
-                ret.emplace_back( point_rel_ms( p ), catacurses::red, "o" );
+            for( const point_rel_ms &p : profile.collision_points ) {
+                ret.emplace_back( p, catacurses::red, "o" );
             }
         } else if( debug_str == "is_obstacle" ) {
             for( int dx = 0; dx < NAV_VIEW_SIZE_X; dx++ ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1649,13 +1649,13 @@ void vehicle::precalculate_vehicle_turning( units::angle new_turn_dir, bool chec
     tileray mdir;
     // calculate direction after turn
     mdir.init( new_turn_dir );
-    tripoint dp;
+    tripoint_rel_ms dp;
     bool is_diagonal_movement = std::lround( to_degrees( new_turn_dir ) ) % 90 == 45;
 
     if( std::abs( velocity ) >= 20 ) {
         mdir.advance( velocity < 0 ? -1 : 1 );
-        dp.x = mdir.dx();
-        dp.y = mdir.dy();
+        dp.x() = mdir.dx();
+        dp.y() = mdir.dy();
     }
 
     // number of wheels that will land on rail
@@ -2081,7 +2081,7 @@ void vehicle::check_falling_or_floating()
         if( !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_FLOOR, position ) ) {
             return true;
         }
-        tripoint_bub_ms below( position.xy(), position.z() - 1 );
+        tripoint_bub_ms below( position + tripoint::below );
         return here.supports_above( below );
     };
     // Check under the wheels, if they're supported nothing else matters.

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -907,9 +907,8 @@ void vehicle::reload_seeds( const tripoint_bub_ms &pos )
             }
             used_seed.front().set_age( 0_turns );
             //place seeds into the planter
-            // TODO: fix point types
             put_into_vehicle_or_drop( player_character, item_drop_reason::deliberate, used_seed,
-                                      tripoint_bub_ms( pos ) );
+                                      pos );
         }
     }
 }
@@ -1324,7 +1323,7 @@ void vehicle::open_or_close( const int part_index, const bool opening )
     map &here = get_map();
     here.set_transparency_cache_dirty( sm_pos.z() );
     const tripoint_bub_ms part_location = mount_to_tripoint( parts[part_index].mount );
-    here.set_seen_cache_dirty( tripoint_bub_ms( part_location ) );
+    here.set_seen_cache_dirty( part_location );
     const int dist = rl_dist( get_player_character().pos_bub(), part_location );
     if( dist < 20 ) {
         sfx::play_variant_sound( opening ? "vehicle_open" : "vehicle_close",
@@ -2166,7 +2165,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
         .enable( ammo_amount >= tool_item.typeId()->charges_to_use() )
         .hotkey( hk )
         .skip_locked_check( tool_ammo.is_null() || tool_ammo->ammo->type != ammo_battery )
-        .on_submit( [this, vppos, tool_type] { use_vehicle_tool( *this, tripoint_bub_ms( vppos ), tool_type ); } );
+        .on_submit( [this, vppos, tool_type] { use_vehicle_tool( *this, vppos, tool_type ); } );
     }
 
     const std::optional<vpart_reference> vp_autoclave = vp.avail_part_with_feature( "AUTOCLAVE" );
@@ -2219,7 +2218,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
         .skip_locked_check()
         .on_submit( [vppos] {
             add_msg( _( "You carefully peek through the curtains." ) );
-            g->peek( tripoint_bub_ms( vppos ) );
+            g->peek( vppos );
         } );
     }
 
@@ -2419,19 +2418,19 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
             menu.add( string_format( _( "Lock %s" ), vp_lockable_door->part().name() ) )
             .hotkey( "LOCK_DOOR" )
             .on_submit( [p] {
-                doors::lock_door( get_map(), get_player_character(), tripoint_bub_ms( p ) );
+                doors::lock_door( get_map(), get_player_character(), p );
             } );
         } else if( player_inside && vp_lockable_door->part().locked ) {
             menu.add( string_format( _( "Unlock %s" ), vp_lockable_door->part().name() ) )
             .hotkey( "UNLOCK_DOOR" )
             .on_submit( [p] {
-                doors::unlock_door( get_map(), get_player_character(), tripoint_bub_ms( p ) );
+                doors::unlock_door( get_map(), get_player_character(), p );
             } );
         } else if( vp_lockable_door->part().locked ) {
             menu.add( string_format( _( "Check the lock on %s" ), vp_lockable_door->part().name() ) )
             .hotkey( "LOCKPICK" )
             .on_submit( [p] {
-                iexamine::locked_object( get_player_character(), tripoint_bub_ms( p ) );
+                iexamine::locked_object( get_player_character(), p );
             } );
         }
     }

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -757,7 +757,7 @@ static int test_autopilot_moving( const vproto_id &veh_id, const vpart_id &extra
     vehicle &veh = *veh_ptr;
     if( !extra_part.is_null() ) {
         vehicle_part vp( extra_part, item( extra_part->base_item ) );
-        const int part_index = veh.install_part( point::zero, std::move( vp ) );
+        const int part_index = veh.install_part( point_rel_ms::zero, std::move( vp ) );
         REQUIRE( part_index >= 0 );
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Change usage of untyped coordinates into typed ones. This time files v-w, reaching the end of the set.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replace usage of untyped coordinates with the corresponding typed ones. Also removing untyped operations orphaned by previous typification efforts.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkey, smash into stationary vehicle. Nothing odd seen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This should be the end of the typification effort, at least the majority of it. There are a few remaining untyped usages:
- The UI. It seems to use a bunch of different coordinate systems, some of which aren't defined as typed ones:
  - Pixels coordinates
  - Tile coordinates. Still uncertain whether these are in bubble coordinates/abs_omt coordinates or in some kind of frame coordinates.
  - Line/Row coordinates for text display.
  - Any others?
- Some mapgen stuff. It still remains to tease out what these coordinates are, and if they're always the same.
- vehicle_autodrive,cpp uses some internal untyped class looking structs that seem to be used with different types. Unclear whether there's usage of an internal coordinate system or if it's all relative coordinates tied to a vehicle.
- Missed stuff. That's always a possibility.
- Tests. Since the tests aren't using obsolete untyped operations I don't think it's worth the trouble to clean up the test internals. It would still make sense to do so when tests are modified for other reasons, but not as a dedicated task.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
