### PR TITLE
[XEDRA Evolved] Give Smoke Mephit NO_BREATHE

### DIFF
--- a/data/mods/Xedra_Evolved/monsters/elementals.json
+++ b/data/mods/Xedra_Evolved/monsters/elementals.json
@@ -645,7 +645,7 @@
     "weakpoint_sets": [ "wps_alien_biology" ],
     "families": [ "prof_alien_biology" ],
     "hp": 20,
-    "flags": [ "SEES", "SMELLS", "HEARS", "HIT_AND_RUN", "FAE_CREATURE", "PATH_AVOID_DANGER", "HARDTOSHOOT" ],
+    "flags": [ "SEES", "SMELLS", "HEARS", "HIT_AND_RUN", "FAE_CREATURE", "NO_BREATHE", "PATH_AVOID_DANGER", "HARDTOSHOOT" ],
     "harvest": "fae_furred",
     "dissect": "dissect_salamander_single",
     "emit_fields": [ { "emit_id": "emit_smoke_plume", "delay": "1 s" } ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change

Gives the smoke mephit NO_BREATHE so they wont have their eyes irritated by the smoke they make.


#### Describe the solution

Put "NO_BREATHE" to the smoke mephit's flag field.

#### Describe alternatives you've considered

Let it suffer.

#### Testing

![Screenshot_20250130_063213](https://github.com/user-attachments/assets/afae538a-1376-4be0-b51f-aaa56f562090)

#### Additional context
Thanks @RenechCDDA for mentioning about the smoke interacts with the NO_BREATHE flag.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
