### PR TITLE
[XE] Boann will use her magic against those who attack her.

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3097,5 +3097,13 @@
     "max_intensity": 1,
     "show_in_info": true,
     "enchantments": [ { "hit_you_effect": [ { "id": "xedra_monster_erosion_attack" } ] } ]
+  },
+  {
+    "type": "effect_type",
+    "//": "Required to make Boann banish monsters.  Without it, she will aim the banish at herself every time.",
+    "id": "boann_retaliation_mark",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "show_in_info": false
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -990,6 +990,9 @@
     "player_display": false,
     "purifiable": false,
     "valid": false,
-    "enchantments": [ { "hit_me_effect": [ { "id": "boann_retaliation", "hit_self": true } ] } ]
+    "enchantments": [
+      { "hit_me_effect": [ { "id": "boann_retaliation_mark", "hit_self": false } ] },
+      { "hit_me_effect": [ { "id": "boann_retaliation", "hit_self": true } ] }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -976,5 +976,20 @@
     "purifiable": false,
     "valid": false,
     "anger_relations": [ [ "HOMULLUS", 100 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "BOANN_RETALIATION",
+    "name": { "str": "Boann's retaliation", "//~": "NO_I18N" },
+    "points": 0,
+    "description": {
+      "str": "Intended to be hidden.  Makes Boann teleport the player away, spawns some huntsmen and hounds then cure all her ailments and injuries if she survives being hit by the player.",
+      "//~": "NO_I18N"
+    },
+    "starting_trait": false,
+    "player_display": false,
+    "purifiable": false,
+    "valid": false,
+    "enchantments": [ { "hit_me_effect": [ { "id": "boann_retaliation", "hit_self": true } ] } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/npc/boann.json
+++ b/data/mods/Xedra_Evolved/npc/boann.json
@@ -31,7 +31,8 @@
       { "trait": "PARACLESIAN_STR_DEX_2" },
       { "trait": "PARACLESIAN_MAKE_GOSSAMER" },
       { "trait": "CHANGELING_NOBLE_MOVEMENT_BUFFS" },
-      { "trait": "CHANGELING_NOBLE_BURNING_WEAPON" }
+      { "trait": "CHANGELING_NOBLE_BURNING_WEAPON" },
+      { "trait": "BOANN_RETALIATION" }
     ],
     "bonus_dex": { "rng": [ 4, 10 ] },
     "bonus_int": { "rng": [ 2, 5 ] },

--- a/data/mods/Xedra_Evolved/spells/classless_spells.json
+++ b/data/mods/Xedra_Evolved/spells/classless_spells.json
@@ -202,5 +202,58 @@
     "flags": [ "NO_LEGS", "SILENT", "NO_EXPLOSION_SFX", "NO_FAIL", "NO_HANDS", "NON_MAGICAL" ],
     "min_duration": { "math": [ "spell_time(time(' 24 h'))" ] },
     "max_duration": { "math": [ "spell_time(time(' 24 h'))" ] }
+  },
+  {
+    "id": "boann_retaliation",
+    "type": "SPELL",
+    "name": { "str": "Boann's retaliation", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "description": {
+      "str": "Intended to be hidden.  Makes Boann teleport the player away, spawns some huntsmen and hounds then cure all her ailments and injuries if she survives being hit by the player.",
+      "//~": "NO_I18N"
+    },
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "NO_FAIL" ],
+    "message": "",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_BOANN_RETALIATION",
+    "shape": "blast"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOANN_RETALIATION",
+    "condition": { "and": [ "u_is_alive", "npc_is_avatar" ] },
+    "effect": [
+      {
+        "u_location_variable": { "context_val": "Boann_teleport" },
+        "target_params": {
+          "om_terrain": "forest",
+          "om_terrain_match_type": "CONTAINS",
+          "search_range": 1200,
+          "min_distance": 250,
+          "z": 0,
+          "random": true
+        }
+      },
+      {
+        "u_message": "Boann waves her hands as you strike her, and you are enveloped by a swirl of multicolored lights.",
+        "popup": true
+      },
+      { "u_add_effect": { "id": "effect_pfruit_nobleed", "duration": "2 seconds" } },
+      { "u_add_effect": { "id": "panacea", "duration": "2 seconds" } },
+      { "u_add_effect": { "id": "cureall", "duration": "2 seconds" } },
+      {
+        "npc_spawn_monster": "mon_wild_huntsman",
+        "real_count": { "math": [ "4 + rand(2)" ] },
+        "min_radius": 2,
+        "max_radius": 7
+      },
+      {
+        "npc_spawn_monster": "mon_wild_hunt_hound",
+        "real_count": { "math": [ "8 + rand(4)" ] },
+        "min_radius": 4,
+        "max_radius": 10
+      },
+      { "u_teleport": { "context_val": "Boann_teleport" }, "force": true }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/classless_spells.json
+++ b/data/mods/Xedra_Evolved/spells/classless_spells.json
@@ -302,7 +302,7 @@
       { "u_add_effect": "panacea", "duration": 2 },
       { "u_add_effect": "cureall", "duration": 2 },
       {
-        "npc_message": "Boann waves her hands as %2$s strikes her, and %2$s vanishes in a swirl of multicolored lights."
+        "npc_message": "Boann waves her hands as her opponent strikes her, and they vanish in a swirl of multicolored lights."
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/spells/classless_spells.json
+++ b/data/mods/Xedra_Evolved/spells/classless_spells.json
@@ -204,6 +204,22 @@
     "max_duration": { "math": [ "spell_time(time(' 24 h'))" ] }
   },
   {
+    "id": "boann_retaliation_mark",
+    "type": "SPELL",
+    "name": { "str": "Boann's retaliation targeting", "//~": "NO_I18N" },
+    "valid_targets": [ "self", "hostile", "ground", "ally" ],
+    "description": { "str": "Intended to be hidden.  This is how Boann teleport away monsters that hit her.", "//~": "NO_I18N" },
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "NO_FAIL" ],
+    "message": "",
+    "effect": "attack",
+    "effect_str": "boann_retaliation_mark",
+    "min_range": 60,
+    "max_range": 60,
+    "min_duration": 500,
+    "max_duration": 500,
+    "shape": "blast"
+  },
+  {
     "id": "boann_retaliation",
     "type": "SPELL",
     "name": { "str": "Boann's retaliation", "//~": "NO_I18N" },
@@ -219,12 +235,27 @@
     "shape": "blast"
   },
   {
-    "type": "effect_on_condition",
     "id": "EOC_BOANN_RETALIATION",
+    "type": "effect_on_condition",
+    "condition": { "u_has_effect": "hit_by_player" },
+    "effect": [ { "run_eocs": [ "EOC_BOANN_RETALIATION_REAL" ], "alpha_talker": "u", "beta_talker": "avatar" } ],
+    "false_effect": {
+      "run_eocs": [
+        {
+          "id": "EOC_BOANN_RETALIATION_NON_PLAYER",
+          "//": "Needed to properly assign alpha and beta talkers",
+          "effect": [ { "run_eocs": [ "EOC_BOANN_RETALIATION_NON_PLAYER_REAL" ], "alpha_talker": "u", "beta_talker": "avatar" } ]
+        }
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOANN_RETALIATION_REAL",
     "condition": { "and": [ "u_is_alive", "npc_is_avatar" ] },
     "effect": [
       {
-        "u_location_variable": { "context_val": "Boann_teleport" },
+        "npc_location_variable": { "context_val": "Boann_teleport" },
         "target_params": {
           "om_terrain": "forest",
           "om_terrain_match_type": "CONTAINS",
@@ -235,25 +266,109 @@
         }
       },
       {
-        "u_message": "Boann waves her hands as you strike her, and you are enveloped by a swirl of multicolored lights.",
+        "npc_message": "Boann waves her hands as you strike her, and you are enveloped by a swirl of multicolored lights.",
         "popup": true
       },
-      { "u_add_effect": { "id": "effect_pfruit_nobleed", "duration": "2 seconds" } },
-      { "u_add_effect": { "id": "panacea", "duration": "2 seconds" } },
-      { "u_add_effect": { "id": "cureall", "duration": "2 seconds" } },
+      { "u_cast_spell": { "id": "boann_heal" } },
+      { "u_lose_effect": "hit_by_player" },
+      { "u_add_effect": "effect_goblin_fruit_nobleed", "duration": 2 },
+      { "u_add_effect": "panacea", "duration": 2 },
+      { "u_add_effect": "cureall", "duration": 2 },
       {
-        "npc_spawn_monster": "mon_wild_huntsman",
+        "u_spawn_monster": "mon_wild_huntsman",
         "real_count": { "math": [ "4 + rand(2)" ] },
         "min_radius": 2,
         "max_radius": 7
       },
       {
-        "npc_spawn_monster": "mon_wild_hunt_hound",
+        "u_spawn_monster": "mon_wild_hunt_hound",
         "real_count": { "math": [ "8 + rand(4)" ] },
         "min_radius": 4,
         "max_radius": 10
       },
-      { "u_teleport": { "context_val": "Boann_teleport" }, "force": true }
+      { "npc_teleport": { "context_val": "Boann_teleport" }, "force": true }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOANN_RETALIATION_NON_PLAYER_REAL",
+    "//": "You won't ever see the teleported target again, so might as well kill it.",
+    "//2": "The hunt won't spawn as you you did not strike Boann yourself.",
+    "condition": "u_is_alive",
+    "effect": [
+      { "u_cast_spell": { "id": "boann_banish_monsters_check" } },
+      { "u_cast_spell": { "id": "boann_heal" } },
+      { "u_add_effect": "effect_goblin_fruit_nobleed", "duration": 2 },
+      { "u_add_effect": "panacea", "duration": 2 },
+      { "u_add_effect": "cureall", "duration": 2 },
+      {
+        "npc_message": "Boann waves her hands as %2$s strikes her, and %2$s vanishes in a swirl of multicolored lights."
+      }
+    ]
+  },
+  {
+    "type": "SPELL",
+    "id": "boann_heal",
+    "name": { "str": "Boann Heal", "//~": "NO_I18N" },
+    "description": { "str": "Will heal injuries all over Boann's body.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "effect": "attack",
+    "flags": [ "NO_PROJECTILE", "NO_EXPLOSION_SFX", "NO_FAIL", "SILENT" ],
+    "teachable": false,
+    "shape": "blast",
+    "base_casting_time": 0,
+    "min_damage": -300,
+    "max_damage": -300,
+    "message": "",
+    "sound_description": ""
+  },
+  {
+    "id": "boann_banish_monsters_check",
+    "type": "SPELL",
+    "name": { "str": "Boann's retaliation against monsters check", "//~": "NO_I18N" },
+    "description": {
+      "str": "Boann's about to retaliate against monsters, deleting them as they are \"teleported\" away.  You shouldn't see this",
+      "//~": "NO_I18N"
+    },
+    "teachable": false,
+    "valid_targets": [ "self", "ally", "hostile" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_BOANN_RETALIATION_NON_PLAYER_TARGETING",
+    "shape": "blast",
+    "spell_class": "NONE",
+    "damage_type": "pure",
+    "skill": "deduction",
+    "min_range": 60,
+    "max_range": 60,
+    "min_aoe": 60,
+    "max_aoe": 60,
+    "base_casting_time": 0,
+    "flags": [ "SILENT", "NO_FAIL", "NO_EXPLOSION_SFX" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOANN_RETALIATION_NON_PLAYER_TARGETING",
+    "condition": { "u_has_effect": "boann_retaliation_mark" },
+    "effect": [ { "u_cast_spell": { "id": "boann_banish_monsters" } } ]
+  },
+  {
+    "id": "boann_banish_monsters",
+    "type": "SPELL",
+    "name": { "str": "Boann's retaliation against monsters", "//~": "NO_I18N" },
+    "description": {
+      "str": "Boann's retaliation against monsters, deleting them as they are \"teleported\" away.  You shouldn't see this",
+      "//~": "NO_I18N"
+    },
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "effect": "banishment",
+    "shape": "blast",
+    "spell_class": "NONE",
+    "damage_type": "pure",
+    "skill": "deduction",
+    "min_damage": 9999,
+    "max_damage": 9999,
+    "base_casting_time": 0,
+    "flags": [ "SILENT", "NO_FAIL" ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "[XE] Boann will use her magic against those who attack her."

#### Purpose of change

Boann got some new unique magical gear and a way to dispose of talkative slayers.
However, hitting her without talking to her first will make her not use any Fae magic to defend herself.

This PR gives her a magical mean of defense.

#### Describe the solution

Boann receives a new passive mutation that retaliates against players and non-players striking at her.
Player: As per the FAE_EMNITY dialogue. Teleport the player far away and spawns the wild hunt around herself.
Non-player: The attacker is killed by a banish spell (It's not like the player was likely to ever see them again due to the teleport range)
Both: Boann heals herself fully and removes any mundane debuff and health problem she has.

Only the player hitting her spawns the hunt, due to how lethal and uncontrolled they are.

Nothing happens if she is killed in a single hit, as she needs to be alive to strike back. It also prevents trying to cast stuff on a self that isn't anymore.

#### Describe alternatives you've considered

Making attacking her gives FAE_EMNITY, but that isn't for those who merely kill a noble. It's for those who devour so much stolen Fae essence they are becoming Fae themselves.

#### Testing

Spawned shoggoths near Boann: the shoggoths vanished as they hit her and she healed every time.
Attacked Boann: got teleported hundreds of overmap tiles away, came back to see Boann fully healed and protected by the wild hunt .
One-shotted Boann with the Exodii naval rifle: she died and nothing else happened.

#### Additional context

5-point anchors and other stuff using the DIMENSIONAL_ANCHOR flag can't block the teleport, but I don't know if Fae magic can bypass that or if it's just an oversight.