### PR TITLE
made some map operations consistent

### DIFF
--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -19,6 +19,7 @@
 class Character;
 class item;
 class item_location;
+class map;
 class player_activity;
 
 template<typename Point, typename Container>
@@ -184,6 +185,8 @@ enum class item_drop_reason : int {
 };
 
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items );
+void put_into_vehicle_or_drop( map *here, Character &you, item_drop_reason,
+                               const std::list<item> &items );
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
                                const tripoint_bub_ms &where, bool force_ground = false );
 std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10466,7 +10466,7 @@ void Character::place_corpse( map *here )
         }
     }
 
-    here->add_item_or_charges( here->get_bub( pos_abs() ), body );
+    here->add_item_or_charges( pos_bub( here ), body );
 }
 
 void Character::place_corpse( const tripoint_abs_omt &om_target )
@@ -11163,7 +11163,7 @@ void Character::gravity_check()
 
 void Character::gravity_check( map *here )
 {
-    const tripoint_bub_ms pos = here->get_bub( pos_abs() );
+    const tripoint_bub_ms pos = pos_bub( here );
     if( here->is_open_air( pos ) && !in_vehicle && !has_effect_with_flag( json_flag_GLIDING ) &&
         here->try_fall( pos, this ) ) {
         here->update_visibility_cache( pos.z() );
@@ -12861,8 +12861,8 @@ void Character::leak_items()
 
 void Character::process_items( map *here )
 {
-    if( weapon.process( *here, this, here->get_bub( pos_abs() ) ) ) {
-        weapon.spill_contents( here,  here->get_bub( pos_abs() ) );
+    if( weapon.process( *here, this, pos_bub( here ) ) ) {
+        weapon.spill_contents( here,  pos_bub( here ) );
         remove_weapon();
     }
 
@@ -12871,8 +12871,8 @@ void Character::process_items( map *here )
         if( !it ) {
             continue;
         }
-        if( it->process( *here, this, here->get_bub( pos_abs() ) ) ) {
-            it->spill_contents( here, here->get_bub( pos_abs() ) );
+        if( it->process( *here, this, pos_bub( here ) ) ) {
+            it->spill_contents( here, pos_bub( here ) );
             removed_items.push_back( it );
         }
     }

--- a/src/character.h
+++ b/src/character.h
@@ -2085,6 +2085,9 @@ class Character : public Creature, public visitable
         item_location i_add( item it, bool should_stack = true, const item *avoid = nullptr,
                              const item *original_inventory_item = nullptr, bool allow_drop = true,
                              bool allow_wield = true, bool ignore_pkt_settings = false );
+        item_location i_add( map *here, item it, bool should_stack = true, const item *avoid = nullptr,
+                             const item *original_inventory_item = nullptr, bool allow_drop = true,
+                             bool allow_wield = true, bool ignore_pkt_settings = false );
         item_location i_add( item it, int &copies_remaining, bool should_stack = true,
                              const item *avoid = nullptr,
                              const item *original_inventory_item = nullptr, bool allow_drop = true,
@@ -2129,6 +2132,8 @@ class Character : public Creature, public visitable
          *  @original_inventory_item set if the item was already in the characters inventory (wielded, worn, in different pocket) and is being moved.
          */
         bool i_add_or_drop( item &it, int qty = 1, const item *avoid = nullptr,
+                            const item *original_inventory_item = nullptr );
+        bool i_add_or_drop( map *here, item &it, int qty = 1, const item *avoid = nullptr,
                             const item *original_inventory_item = nullptr );
 
         /** Drops items at player location

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -331,7 +331,8 @@ item_location Character::i_add( item it, bool should_stack, const item *avoid,
                                 const item *original_inventory_item, const bool allow_drop,
                                 const bool allow_wield, bool ignore_pkt_settings )
 {
-    return Character::i_add( &get_map(), it, should_stack, avoid, original_inventory_item, allow_drop,
+    return Character::i_add( &get_map(), std::move( it ), should_stack, avoid, original_inventory_item,
+                             allow_drop,
                              allow_wield, ignore_pkt_settings );
 }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -205,7 +205,12 @@ Creature::~Creature() = default;
 
 tripoint_bub_ms Creature::pos_bub() const
 {
-    return get_map().get_bub( location );
+    return Creature::pos_bub( &get_map() );
+}
+
+tripoint_bub_ms Creature::pos_bub( map *here ) const
+{
+    return here->get_bub( location );
 }
 
 void Creature::setpos( const tripoint_bub_ms &p, bool check_gravity/* = true*/ )

--- a/src/creature.h
+++ b/src/creature.h
@@ -306,6 +306,7 @@ class Creature : public viewer
         /** Sets a Creature's fake boolean. */
         virtual void set_fake( bool fake_value );
         tripoint_bub_ms pos_bub() const;
+        tripoint_bub_ms pos_bub( map *here ) const;
         inline int posx() const {
             return pos_bub().x();
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5264,21 +5264,30 @@ monster *game::place_critter_around( const shared_ptr_fast<monster> &mon,
                                      const int radius,
                                      bool forced )
 {
+    return game::place_critter_around( mon, &m, center, radius, forced );
+}
+
+monster *game::place_critter_around( const shared_ptr_fast<monster> &mon,
+                                     map *here,
+                                     const tripoint_bub_ms &center,
+                                     const int radius,
+                                     bool forced )
+{
     std::optional<tripoint_bub_ms> where;
-    if( forced || can_place_monster( *mon, center ) ) {
+    if( forced || can_place_monster( *mon, here, center ) ) {
         where = center;
     }
 
     // This loop ensures the monster is placed as close to the center as possible,
     // but all places that equally far from the center have the same probability.
     for( int r = 1; r <= radius && !where; ++r ) {
-        where = choose_where_to_place_monster( *mon, m.points_in_radius( center, r ) );
+        where = choose_where_to_place_monster( *mon, here, here->points_in_radius( center, r ) );
     }
 
     if( !where ) {
         return nullptr;
     }
-    mon->spawn( *where );
+    mon->spawn( here->get_abs( *where ) );
     if( critter_tracker->add( mon ) ) {
         mon->gravity_check();
         return mon.get();

--- a/src/game.h
+++ b/src/game.h
@@ -356,6 +356,9 @@ class game
         monster *place_critter_around( const mtype_id &id, const tripoint_bub_ms &center, int radius );
         monster *place_critter_around( const shared_ptr_fast<monster> &mon, const tripoint_bub_ms &center,
                                        int radius, bool forced = false );
+        monster *place_critter_around( const shared_ptr_fast<monster> &mon, map *here,
+                                       const tripoint_bub_ms &center,
+                                       int radius, bool forced = false );
         monster *place_critter_within( const mtype_id &id, const tripoint_range<tripoint_bub_ms> &range );
         monster *place_critter_within( const shared_ptr_fast<monster> &mon,
                                        const tripoint_range<tripoint_bub_ms> &range );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14070,6 +14070,12 @@ ret_val<void> item::link_to( const optional_vpart_position &first_linked_vp,
 
 ret_val<void> item::link_to( vehicle &veh, const point_rel_ms &mount, link_state link_type )
 {
+    return item::link_to( &get_map(), veh, mount, link_type );
+}
+
+ret_val<void> item::link_to( map *here, vehicle &veh, const point_rel_ms &mount,
+                             link_state link_type )
+{
     if( !can_link_up() ) {
         return ret_val<void>::make_failure( _( "The %s doesn't have a cable!" ), type_name() );
     }
@@ -14079,7 +14085,7 @@ ret_val<void> item::link_to( vehicle &veh, const point_rel_ms &mount, link_state
     if( link_type == link_state::vehicle_tow ) {
         if( veh.has_tow_attached() || veh.is_towed() || veh.is_towing() ) {
             return ret_val<void>::make_failure( _( "That vehicle already has a tow-line attached." ) );
-        } else if( !veh.is_external_part( veh.mount_to_tripoint( mount ) ) ) {
+        } else if( !veh.is_external_part( here, veh.mount_to_tripoint( here, mount ) ) ) {
             return ret_val<void>::make_failure( _( "You can't attach a tow-line to an internal part." ) );
         } else {
             const int part_at = veh.part_at( veh.coord_translate( mount ) );
@@ -14115,7 +14121,7 @@ ret_val<void> item::link_to( vehicle &veh, const point_rel_ms &mount, link_state
         link().source = bio_link ? link_state::bio_cable : link_state::no_link;
         link().target = link_type;
         link().t_veh = veh.get_safe_reference();
-        link().t_abs_pos = get_map().get_abs( link().t_veh->pos_bub() );
+        link().t_abs_pos = link().t_veh->pos_abs();
         link().t_mount = mount;
         link().s_bub_pos = tripoint_bub_ms::min; // Forces the item to check the length during process_link.
 

--- a/src/item.h
+++ b/src/item.h
@@ -1581,6 +1581,8 @@ class item : public visitable
          */
         ret_val<void> link_to( vehicle &veh, const point_rel_ms &mount,
                                link_state link_type = link_state::no_link );
+        ret_val<void> link_to( map *here, vehicle &veh, const point_rel_ms &mount,
+                               link_state link_type = link_state::no_link );
 
         /**
          * @brief Updates all parts of the item's link_data that don't have to do with its connection. Initializes the link if needed.
@@ -2898,6 +2900,7 @@ class item : public visitable
          * @return Whether the monster has been spawned (may fail if no space available).
          */
         bool release_monster( const tripoint_bub_ms &target, int radius = 0 );
+        bool release_monster( map *here, const tripoint_bub_ms &target, int radius = 0 );
         /** Add the monster at target to this item, despawning it. */
         int contain_monster( const tripoint_bub_ms &target );
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8013,6 +8013,11 @@ std::optional<int> iuse::capture_monster_veh( Character *p, item *it, const trip
 
 bool item::release_monster( const tripoint_bub_ms &target, const int radius )
 {
+    return item::release_monster( &get_map(), target, radius );
+}
+
+bool item::release_monster( map *here, const tripoint_bub_ms &target, const int radius )
+{
     shared_ptr_fast<monster> new_monster = make_shared_fast<monster>();
     try {
         ::deserialize_from_string( *new_monster, get_var( "contained_json", "" ) );
@@ -8020,7 +8025,7 @@ bool item::release_monster( const tripoint_bub_ms &target, const int radius )
         debugmsg( _( "Error restoring monster: %s" ), e.what() );
         return false;
     }
-    if( !g->place_critter_around( new_monster, target, radius ) ) {
+    if( !g->place_critter_around( new_monster, here, target, radius ) ) {
         return false;
     }
     erase_var( "contained_name" );

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1446,7 +1446,7 @@ If you wish for a field effect to do something over time (propagate, interact wi
 void map::player_in_field( Character &you )
 {
     // A copy of the current field for reference. Do not add fields to it, use map::add_field
-    field &curfield = get_field( get_bub( you.pos_abs() ) );
+    field &curfield = get_field( you.pos_bub( this ) );
     // Are we inside?
     bool inside = false;
     // If we are in a vehicle figure out if we are inside (reduces effects usually)

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -148,7 +148,7 @@ item_location mdeath::splatter( map *here, monster &z )
     const field_type_id type_gib = z.gibType();
 
     if( gibbable ) {
-        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( here->get_bub( z.pos_abs() ),
+        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( z.pos_bub( here ),
                 1 );
         int number_of_gibs = std::min( std::floor( corpse_damage ) - 1, 1 + max_hp / 5.0f );
 
@@ -207,7 +207,7 @@ item_location mdeath::splatter( map *here, monster &z )
         if( !z.has_eaten_enough() ) {
             corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
         }
-        return here->add_item_ret_loc( here->get_bub( z.pos_abs() ), corpse );
+        return here->add_item_ret_loc( z.pos_bub( here ), corpse );
     }
     return {};
 }
@@ -239,7 +239,7 @@ void mdeath::broken( map *here, monster &z )
     const float corpse_damage = 2.5 * overflow_damage / max_hp;
     broken_mon.set_damage( static_cast<int>( std::floor( corpse_damage * itype::damage_scale ) ) );
 
-    here->add_item_or_charges( here->get_bub( z.pos_abs() ), broken_mon );
+    here->add_item_or_charges( z.pos_bub( here ), broken_mon );
 
     if( z.type->has_flag( mon_flag_DROPS_AMMO ) ) {
         for( const std::pair<const itype_id, int> &ammo_entry : z.ammo ) {
@@ -262,14 +262,14 @@ void mdeath::broken( map *here, monster &z )
                                 mags.insert( mags.end(), mag );
                                 ammo_count -= mag.type->magazine->capacity;
                             }
-                            here->spawn_items( here->get_bub( z.pos_abs() ), mags );
+                            here->spawn_items( z.pos_bub( here ), mags );
                             spawned = true;
                             break;
                         }
                     }
                 }
                 if( !spawned ) {
-                    here->spawn_item( here->get_bub( z.pos_abs() ), ammo_entry.first, ammo_entry.second, 1,
+                    here->spawn_item( z.pos_bub( here ), ammo_entry.first, ammo_entry.second, 1,
                                       calendar::turn );
                 }
             }
@@ -299,5 +299,5 @@ item_location make_mon_corpse( map *here, monster &z, int damageLvl )
     if( !z.has_eaten_enough() ) {
         corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
     }
-    return here->add_item_ret_loc( here->get_bub( z.pos_abs() ), corpse );
+    return here->add_item_ret_loc( z.pos_bub( here ), corpse );
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -390,7 +390,7 @@ void monster::gravity_check()
 
 void monster::gravity_check( map *here )
 {
-    const tripoint_bub_ms pos = here->get_bub( pos_abs() );
+    const tripoint_bub_ms pos = pos_bub( here );
     if( here->is_open_air( pos ) && !flies() ) {
         here->try_fall( pos, this );
     }
@@ -2948,7 +2948,7 @@ void monster::die( map *here, Creature *nkiller )
     creature_tracker &creatures = get_creature_tracker();
     if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
         // Need to filter out which limb we were grabbing before death
-        for( const tripoint_bub_ms &player_pos : here->points_in_radius( here->get_bub( pos_abs() ), 1,
+        for( const tripoint_bub_ms &player_pos : here->points_in_radius( pos_bub( here ), 1,
                 0 ) ) {
             Creature *you = creatures.creature_at( here->get_abs( player_pos ) );
             if( !you || !you->has_effect_with_flag( json_flag_GRAB ) ) {
@@ -3083,14 +3083,14 @@ void monster::die( map *here, Creature *nkiller )
             if( corpse ) {
                 corpse->force_insert_item( it, pocket_type::CONTAINER );
             } else {
-                here->add_item_or_charges( here->get_bub( pos_abs() ), it );
+                here->add_item_or_charges( pos_bub( here ), it );
             }
         }
         for( const item &it : dissectable_inv ) {
             if( corpse ) {
                 corpse->put_in( it, pocket_type::CORPSE );
             } else {
-                here->add_item( here->get_bub( pos_abs() ), it );
+                here->add_item( pos_bub( here ), it );
             }
         }
     }
@@ -3213,7 +3213,7 @@ void monster::drop_items_on_death( map *here, item *corpse )
     // for non corpses this is much simpler
     if( !corpse ) {
         for( item &it : new_items ) {
-            here->add_item_or_charges( here->get_bub( pos_abs() ), it );
+            here->add_item_or_charges( pos_bub( here ), it );
         }
         return;
     }
@@ -3814,7 +3814,7 @@ void monster::on_hit( map *here, Creature *source, bodypart_id,
                 continue;
             }
 
-            if( here->sees( here->get_bub( critter.pos_abs() ), here->get_bub( pos_abs() ), light ) ) {
+            if( here->sees( here->get_bub( critter.pos_abs() ), pos_bub( here ), light ) ) {
                 // Anger trumps fear trumps ennui
                 if( critter.type->has_anger_trigger( mon_trigger::FRIEND_ATTACKED ) ) {
                     critter.anger += 15;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2977,7 +2977,7 @@ void npc::die( map *here, Creature *nkiller )
     // Need to unboard from vehicle before dying, otherwise
     // the vehicle code cannot find us
     if( in_vehicle ) {
-        here->unboard_vehicle( here->get_bub( pos_abs() ), true );
+        here->unboard_vehicle( pos_bub( here ), true );
     }
     if( is_mounted() ) {
         monster *critter = mounted_creature.get();
@@ -3288,14 +3288,14 @@ void npc::on_load( map *here )
 
     // for spawned npcs
     gravity_check( here );
-    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, here->get_bub( pos_abs() ) ) &&
-        !here->has_vehicle_floor( here->get_bub( pos_abs() ) ) ) {
+    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub( here ) ) &&
+        !here->has_vehicle_floor( pos_bub( here ) ) ) {
         add_effect( effect_bouldering, 1_turns,  true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
     }
     if( here->veh_at( pos_abs() ).part_with_feature( VPFLAG_BOARDABLE, true ) && !in_vehicle ) {
-        here->board_vehicle( here->get_bub( pos_abs() ), this );
+        here->board_vehicle( pos_bub( here ), this );
     }
     if( has_effect( effect_riding ) && !mounted_creature ) {
         if( const monster *const mon = get_creature_tracker().creature_at<monster>( pos_abs() ) ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -148,7 +148,7 @@ static bool is_sm_tile_over_water( const tripoint_abs_ms &real_global_pos );
 
 static const int MAX_WIRE_VEHICLE_SIZE = 24;
 
-void DefaultMapRemovePartHandler::removed( vehicle &veh, const int part )
+void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
 {
     avatar &player_character = get_avatar();
     const vehicle_part &vp = veh.part( part );
@@ -952,7 +952,7 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
                     // on the main game map. And assume that we run from some mapgen code if called on
                     // another instance.
                     if( g && &get_map() == &m ) {
-                        handler_ptr = std::make_unique<DefaultMapRemovePartHandler>( m );
+                        handler_ptr = std::make_unique<DefaultRemovePartHandler>( m );
                     } else {
                         handler_ptr = std::make_unique<MapgenRemovePartHandler>( m );
                     }
@@ -2002,7 +2002,7 @@ bool vehicle::remove_part( vehicle_part &vp )
 
 bool vehicle::remove_part( map *here, vehicle_part &vp )
 {
-    DefaultMapRemovePartHandler handler( *here );
+    DefaultRemovePartHandler handler( *here );
     return remove_part( vp, handler );
 }
 
@@ -7510,7 +7510,7 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
     };
     std::unique_ptr<RemovePartHandler> handler_ptr;
     if( g && &get_map() == &here ) {
-        handler_ptr = std::make_unique<DefaultMapRemovePartHandler>( here );
+        handler_ptr = std::make_unique<DefaultRemovePartHandler>( here );
     } else {
         handler_ptr = std::make_unique<MapgenRemovePartHandler>( here );
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7931,7 +7931,7 @@ const std::set<tripoint_bub_ms> &vehicle::get_points( const bool force_refresh,
     return occupied_points;
 }
 
-const std::set<tripoint_bub_ms> vehicle::get_points( map *here, const bool force_refresh,
+std::set<tripoint_bub_ms> vehicle::get_points( const map *here, const bool force_refresh,
         const bool no_fake ) const
 {
     if( here == &get_map() ) {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2003,8 +2003,9 @@ class vehicle
         // Update the set of occupied points and return a reference to it
         const std::set<tripoint_bub_ms> &get_points( bool force_refresh = false,
                 bool no_fake = false ) const;
-        const std::set<tripoint_bub_ms> get_points( map *here, bool force_refresh = false,
-                bool no_fake = false ) const;
+        // Call the operation above when here == get_map(). Otherwise just generate the corresponding points.
+        std::set<tripoint_bub_ms> get_points( const map *here, bool force_refresh = false,
+                                              bool no_fake = false ) const;
 
         // calculate the new projected points for all vehicle parts to move to
         void part_project_points( const tripoint_rel_ms &dp );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2465,15 +2465,15 @@ class RemovePartHandler
         virtual map &get_map_ref() = 0;
 };
 
-class DefaultMapRemovePartHandler : public RemovePartHandler
+class DefaultRemovePartHandler : public RemovePartHandler
 {
     private:
         map &m;
 
     public:
-        explicit DefaultMapRemovePartHandler( map &m ) : m( m ) {}
+        explicit DefaultRemovePartHandler( map &m ) : m( m ) {}
 
-        ~DefaultMapRemovePartHandler() override = default;
+        ~DefaultRemovePartHandler() override = default;
 
         void unboard( const tripoint_bub_ms &loc ) override {
             m.unboard_vehicle( loc );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make methods of the map class consistently work on the object map rather than the official reality bubble map.
This is the first PR of a series of unknown length, as there's quite a lot to check and modify.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Examine methods to see what operations they call, and whether these operations implicitly use the game reality bubble map (i.e. get_map() or g->m) rather than the own map object. Note that this check is transitive.
If an operation implicitly uses the wrong map, pass the map object to a an overloading version of the operation to make it possible to use the correct map, and adjust the overloading operation accordingly. Typically have the original operation call the new one, passing &get_map() as the map parameter.

Introduced Character::pos_bub(map *here) to make it easier to get the bubble coordinates you actually want and replace "here->get_bub(pos_abs())" with the shorter "pos_bub(here)".

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
This should not result in any functional changes to the existing functionality. Failing to catch all implicit usages of the official reality bubble map will, unfortunately, not result in visible bugs until the code is used with other maps.

Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkey, smash into stationary vehicle. The only oddity seen was that the zombie corpse wasn't destroyed this time (but some items were). Backed over it and the corpse was destroyed. This is attributed to normal variability.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Why am I doing this?

Madness can't be ruled out, but the longer term objective (not coordinated with senior devs, but not known to be in conflict either) is to allow for usage of other maps during game play without having to go through this upgrade at the same time as trying to produce new functionality. The first usage of additional maps (outside mapgen) was for explosion purposes, and trying to get that to work properly highlighted the underlying issue of the code simply not being consistent when it comes to the usage of map objects.

At some time it would be desirable to be able to keep multiple reality bubbles in play in order to allow activities to proceed normally e.g. in a camp while the PC is away. That's probably a fair way off due to performance issues, but it is still useful trying to make the foundation a bit sounder.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
