### PR TITLE
[Aftershock] Make UICA chit ATM-compatible

### DIFF
--- a/data/mods/Aftershock/items/currency.json
+++ b/data/mods/Aftershock/items/currency.json
@@ -40,7 +40,7 @@
     "to_hit": -3,
     "color": "red",
     "symbol": "$",
-    "flags": [ "COIN_SHAPED", "NO_UNLOAD", "NO_RELOAD" ],
+    "flags": [ "COIN_SHAPED", "NO_UNLOAD", "NO_RELOAD", "OLD_CURRENCY" ],
     "material": [ "steel" ]
   },
   {


### PR DESCRIPTION
#### Summary
Mods "[Aftershock] Make UICA chit ATM-compatible"

#### Purpose of change

Aftershock has functionnal ATMs and a still-used old-world currency, but they're not compatible.
Now they will be, as they should be.

#### Describe the solution

Add the OLD_CURRENCY flag to chit, so ATMs will accept it for their cash to ecash option. It does take a cut, but your bank account takes much less inventory space than physical currency and can still be used to trade in Aftershock, so it's worth the price.

#### Describe alternatives you've considered

Not making this desired change.

#### Testing

Spawned some chit + a cash card, used augustmoon's ATM. 

Added the chit to my bank account then from the account to my card then used the card on the vending machines.

#### Additional context

This chit cannot directly be used on vending machines, but this is not an issue due to the ATM's proximity.