### PR TITLE
[Xedra Evolved/Sky Island] Elemental fae are at home on the island

### DIFF
--- a/data/mods/Xedra_Evolved/mod_interactions/skyisland/paraclesian_eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/skyisland/paraclesian_eocs.json
@@ -1,0 +1,45 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CONDITION_SKY_ISLAND_ON_THE_ISLAND",
+    "condition": {
+      "or": [
+        {
+          "and": [
+            {
+              "or": [ { "u_near_om_location": "sky_island_core", "range": 1 }, { "u_near_om_location": "sky_island_subcore", "range": 1 } ]
+            },
+            { "or": [ { "math": [ "u_val('pos_z') == 6" ] }, { "math": [ "u_val('pos_z') == 7" ] } ] }
+          ]
+        },
+        { "and": [ { "u_near_om_location": "sky_island_core", "range": 1 }, { "math": [ "u_val('pos_z') == 6" ] } ] }
+      ]
+    },
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ARVORE_FAE_BAN_SLEPT_IN_CITY",
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_FAE_BAN_DIDNT_SLEEP_UNDERGROUND",
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_FAE_BAN_DIDNT_SLEEP_NEAR_HUMANS",
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SYLPH_FAE_BAN_DIDNT_SLEEP_OUTSIDE",
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UNDINE_FAE_BAN_SLEEP_ON_LAND",
+    "effect": [  ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_spell_learning_eocs.json
@@ -28,7 +28,9 @@
             "PARACLESIAN_MAKE_GOSSAMER"
           ]
         },
-        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" },
+        {
+          "or": [ { "test_eoc": "EOC_CONDITION_SKY_ISLAND_ON_THE_ISLAND" }, { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" } ]
+        },
         {
           "or": [
             {
@@ -47,7 +49,9 @@
                 { "not": { "u_at_om_location": "field" } }
               ]
             },
-            { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_FOREST" },
+            {
+              "or": [ { "test_eoc": "EOC_CONDITION_SKY_ISLAND_ON_THE_ISLAND" }, { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_FOREST" } ]
+            },
             { "u_is_on_terrain": "t_barkfloor" }
           ]
         }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_spell_learning_eocs.json
@@ -32,6 +32,7 @@
             "condition": {
               "or": [
                 { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" },
+                { "test_eoc": "EOC_CONDITION_SKY_ISLAND_ON_THE_ISLAND" },
                 { "u_near_om_location": "FACTION_CAMP_ANY", "range": 2 },
                 { "map_in_city": { "mutator": "u_loc_relative", "target": "(0,0,0)" } }
               ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_spell_learning_eocs.json
@@ -42,7 +42,8 @@
             { "u_at_om_location": "ierde_genius_loci_NW" },
             { "u_at_om_location": "ierde_genius_loci_NE" },
             { "u_at_om_location": "ierde_genius_loci_SW" },
-            { "u_at_om_location": "ierde_genius_loci_SE" }
+            { "u_at_om_location": "ierde_genius_loci_SE" },
+            { "test_eoc": "EOC_CONDITION_SKY_ISLAND_ON_THE_ISLAND" }
           ]
         }
       ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_eocs.json
@@ -1,6 +1,13 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_CONDITION_SKY_ISLAND_ON_THE_ISLAND",
+    "//": "Used for Paraclesians so they can learn their spells on the sky island.  Always false if not on the island so it's ignored.",
+    "condition": { "math": [ "1 == 0" ] },
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PARACLESIAN_FAE_SIGHT_ON",
     "effect": [ { "u_add_effect": "effect_paraclesian_see_fae", "duration": "PERMANENT" } ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_spell_learning_eocs.json
@@ -39,7 +39,8 @@
             { "u_has_item": "cigar_lit" },
             { "u_has_item": "cig_lit" },
             { "math": [ "u_salamander_near_fire == 1" ] },
-            { "math": [ "weather('temperature') >= from_fahrenheit( 80 )" ] }
+            { "math": [ "weather('temperature') >= from_fahrenheit( 80 )" ] },
+            { "test_eoc": "EOC_CONDITION_SKY_ISLAND_ON_THE_ISLAND" }
           ]
         }
       ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/sylph_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/sylph_spell_learning_eocs.json
@@ -49,7 +49,8 @@
             { "u_at_om_location": "sylph_genius_loci_NW" },
             { "u_at_om_location": "sylph_genius_loci_NE" },
             { "u_at_om_location": "sylph_genius_loci_SW" },
-            { "u_at_om_location": "sylph_genius_loci_SE" }
+            { "u_at_om_location": "sylph_genius_loci_SE" },
+            { "test_eoc": "EOC_CONDITION_SKY_ISLAND_ON_THE_ISLAND" }
           ]
         }
       ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/undine_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/undine_spell_learning_eocs.json
@@ -26,7 +26,11 @@
           ]
         },
         {
-          "or": [ { "math": [ "u_undine_is_connected_to_waters == 1" ] }, { "test_eoc": "EOC_CONDITION_CHECK_UNDINE_IN_WATER" } ]
+          "or": [
+            { "math": [ "u_undine_is_connected_to_waters == 1" ] },
+            { "test_eoc": "EOC_CONDITION_CHECK_UNDINE_IN_WATER" },
+            { "test_eoc": "EOC_CONDITION_SKY_ISLAND_ON_THE_ISLAND" }
+          ]
         }
       ]
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved/Sky Island] Elemental fae are at home on the island"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Elemental fae have various terrain restrictions on their actions and location, but the warp entities that set up the Sky Island are merciful in this case.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Set the island as native terrain for all types of elemental fae. They can draw on their natural connection to learn their spells there and can sleep there with no problems. 

The second I did by just removing the sleep restrictions for Sky Island--if you sleep on a raid, you're probably going to die anyway when the timer runs out. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Waited a while and checked that spells were learned. Slept and saw that no fae ban was incurred.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
