### PR TITLE
remove SCENARIO_SPECIFIC and PROFESSION_SPECIFIC eoc types

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -2,19 +2,16 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_strong_portal_storm_base",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": { "math": [ "ps_base_str = 10" ] }
   },
   {
     "type": "effect_on_condition",
     "id": "scenario_strong_portal_storm",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "math": [ "ps_base_str = 15" ] }, { "run_eocs": "EOC_CAUSE_PORTAL_STORM" }, { "math": [ "ps_base_str = 1" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "scenario_quick_portal_storm",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "math": [ "ps_min_woc = time(' 1 d')" ] }, { "math": [ "ps_max_woc = time(' 2 d')" ] } ]
   },
   {

--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -2,7 +2,6 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_bad_day",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       { "u_add_effect": "flu", "intensity": 1, "duration": "1000 minutes" },
       { "u_add_effect": "drunk", "intensity": 1, "duration": "270 minutes" },
@@ -18,7 +17,6 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_infected",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       { "u_add_effect": "infected", "intensity": 1, "duration": "PERMANENT", "target_part": "RANDOM" },
       { "assign_mission": "MISSION_INFECTED_START_FIND_ANTIBIOTICS" }
@@ -27,19 +25,16 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_fungal_infection",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "u_add_effect": "fungus", "intensity": 1, "duration": "PERMANENT", "target_part": "RANDOM" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "scenario_paralyzepoison",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "u_add_effect": "paralyzepoison", "intensity": 3, "duration": "10 minutes" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "scenario_portal_dependent",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       {
         "run_eocs": [ "EOC_PORTAL_DEPENDENT_MESSAGES_BAD", "EOC_PORTAL_DEPENDENT_FOCUS_BAD", "EOC_PORTAL_DEPENDENT_DAMAGE_CONSTANT" ]
@@ -49,7 +44,6 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_mansion_pursuit",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "//": "EOC_BANISH_MANSION_MONSTERS is not triggering/working at the moment.",
     "effect": [
       {
@@ -174,7 +168,6 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_assassin_conv",
-    "eoc_type": "PROFESSION_SPECIFIC",
     "//": "Determines which prison the assassin is in currently to correctly place the target.",
     "effect": [
       { "if": { "u_near_om_location": "prison_1_5" }, "then": { "assign_mission": "MISSION_ASSASSIN_CONVICT_PRISON" } },
@@ -189,13 +182,11 @@
   {
     "type": "effect_on_condition",
     "id": "faction_camp_start",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "mapgen_update": "faction_start_add" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "scenario_liam",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       { "open_dialogue": { "topic": "TALK_Liam_Introdialogue" } },
       { "mapgen_update": "scenario_spawn_liam", "om_terrain": "cabin_liam" }
@@ -204,19 +195,16 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_surrounded_zombie",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 5, "min_radius": 12, "max_radius": 30 } ]
   },
   {
     "type": "effect_on_condition",
     "id": "scenario_surrounded_zombie_heavy",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 10, "min_radius": 14, "max_radius": 30 } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_lone_survivor",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       {
         "u_message": "They are all dead.  The group you were surviving with has been annihilated.  Their bodies are still nearby.  You are the last one left alive and their screams will haunt you.",
@@ -235,7 +223,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_scenario_drunk",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       { "u_add_effect": "drunk", "intensity": 1, "duration": "270 minutes" },
       {
@@ -250,7 +237,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_scenario_blood",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "mapgen_update": "SCENARIO_BLOOD" } ]
   },
   {
@@ -262,7 +248,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_scenario_fire",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "mapgen_update": "SCENARIO_FIRE" } ]
   },
   {
@@ -274,7 +259,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_scenario_smoke",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "mapgen_update": "SCENARIO_SMOKE" } ]
   },
   {
@@ -300,7 +284,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_scenario_clear_weather",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       { "u_message": "The moon shines brightly." },
       { "math": [ "is_moonlit_scenario = 1" ] },

--- a/data/mods/Aftershock/effects_on_condition.json
+++ b/data/mods/Aftershock/effects_on_condition.json
@@ -74,7 +74,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CRASHING_SHIP_SETUP",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       {
         "u_location_variable": { "global_val": "new_map" },
@@ -102,7 +101,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_ESPER_SCENARIO_SETUP",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       { "math": [ "u_hp('head')", "-=", "rand(5)" ] },
       { "math": [ "u_hp('torso')", "-=", "rand(5)" ] },

--- a/data/mods/Defense_Mode/effects_on_condition/backend_eocs.json
+++ b/data/mods/Defense_Mode/effects_on_condition/backend_eocs.json
@@ -2,7 +2,6 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_defense_mode",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "deactivate_condition": { "math": [ "wave_number >= 1" ] },
     "effect": [
       { "math": [ "diffulty_modifier = 1" ] },

--- a/data/mods/Isolation-Protocol/EOC/scenario_init.json
+++ b/data/mods/Isolation-Protocol/EOC/scenario_init.json
@@ -2,7 +2,6 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_fractal_facility",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "math": [ "SAFEPOINT_INTERVAL = 5" ] }, { "math": [ "ISO_CURRENT_LEVEL = 1" ] } ]
   }
 ]

--- a/data/mods/Magiclysm/scenarios.json
+++ b/data/mods/Magiclysm/scenarios.json
@@ -15,7 +15,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICLYSM_LOST_FAITH",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       { "u_spawn_item": "priest_beginner", "suppress_message": true },
       { "u_spawn_item": "priest_advanced", "suppress_message": true }

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -424,7 +424,6 @@
     "type": "effect_on_condition",
     "id": "scenario_warp_begins",
     "//": "This EOC is triggered when the Warper scenario begins.  It initializes a few variables, and memorizes your spawn location for resurrection just in case you somehow die before using the warp obelisk.  Also learns your spell for emergencies.",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       {
         "u_message": "Welcome to Sky Islands.\n\nSpeak to the Heart of the Island to get your bearings, accept missions, manage upgrades, change your difficulty settings, and more.",

--- a/data/mods/Xedra_Evolved/eocs/scenario_specific.json
+++ b/data/mods/Xedra_Evolved/eocs/scenario_specific.json
@@ -2,20 +2,17 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_once_bitten",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "u_add_effect": "vampire_virus", "intensity": 1, "duration": "PERMANENT" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "scenario_lilin_starting_ruach",
     "//": "Starts you off with some ruach so you don't begin starving immediately",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [ { "math": [ "u_vitamin('lilin_ruach_vitamin')", "+=", "rng(550,850) " ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "scenario_paraclesian_birth",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
       { "if": { "u_has_trait": "IERDE" }, "then": { "math": [ "u_vitamin('mutagen_earthkin')", "+=", "550 " ] } },

--- a/data/mods/deadly_bites/effect_on_conditions.json
+++ b/data/mods/deadly_bites/effect_on_conditions.json
@@ -12,7 +12,6 @@
   {
     "type": "effect_on_condition",
     "id": "scenario_deadly_virus",
-    "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       { "u_add_effect": "zombie_virus", "intensity": 1, "duration": "PERMANENT" },
       { "assign_mission": "MISSION_INFECTED_START_FIND_ANTIVIRALS" }

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -38,7 +38,7 @@ An effect_on_condition is an object allowing the combination of dialog condition
 | `false_effect`        | effect     | The effect(s) caused if `condition` returns false upon activation.  See the "Dialogue Effects" section of [NPCs](NPCs.md) for the full syntax.
 | `global`              | bool       | If this is true, this recurring eoc will be run on the player and every npc from a global queue.  Deactivate conditions will work based on the avatar. If it is false the avatar and every character will have their own copy and their own deactivated list. Defaults to false.
 | `run_for_npcs`        | bool       | Can only be true if global is true. If false the EOC will only be run against the avatar. If true the eoc will be run against the avatar and all npcs.  Defaults to false.
-| `EOC_TYPE`            | string     | Can be one of `ACTIVATION`, `RECURRING`, `SCENARIO_SPECIFIC`, `AVATAR_DEATH`, `NPC_DEATH`, `PREVENT_DEATH`, `EVENT` (see details below). It defaults to `ACTIVATION` unless `recurrence` is provided in which case it defaults to `RECURRING`.
+| `EOC_TYPE`            | string     | Can be one of `ACTIVATION`, `RECURRING`, `AVATAR_DEATH`, `NPC_DEATH`, `PREVENT_DEATH`, `EVENT` (see details below). It defaults to `ACTIVATION` unless `recurrence` is provided in which case it defaults to `RECURRING`.
 
  ### EOC types
 
@@ -46,7 +46,6 @@ An effect_on_condition is an object allowing the combination of dialog condition
 
 * `ACTIVATION` - activated manually.
 * `RECURRING` - activated automatically on schedule (see `recurrence`)
-* `SCENARIO_SPECIFIC` - automatically invoked once on scenario start.
 * `AVATAR_DEATH` - automatically invoked whenever the current avatar dies (it will be run with the avatar as `u`), if after it the player is no longer dead they will not die, if there are multiple EOCs they all be run until the player is not dead.
 * `NPC_DEATH` - EOCs can only be assigned to run on the death of an npc, in which case u will be the dying npc and npc will be the killer. If after it npc is no longer dead they will not die, if there are multiple they all be run until npc is not dead.
 * `PREVENT_DEATH` - whenever the current avatar dies it will be run with the avatar as `u`, if after it the player is no longer dead they will not die, if there are multiple they all be run until the player is not dead.

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -40,9 +40,6 @@ namespace io
         switch ( data ) {
         case eoc_type::ACTIVATION: return "ACTIVATION";
         case eoc_type::RECURRING: return "RECURRING";
-            // Why we need SCENARIO_SPECIFIC / PROFESSION_SPECIFIC? they are no different from ACTIVATION
-        case eoc_type::SCENARIO_SPECIFIC: return "SCENARIO_SPECIFIC";
-        case eoc_type::PROFESSION_SPECIFIC: return "PROFESSION_SPECIFIC";
         case eoc_type::AVATAR_DEATH: return "AVATAR_DEATH";
         case eoc_type::NPC_DEATH: return "NPC_DEATH";
         case eoc_type::PREVENT_DEATH: return "PREVENT_DEATH";
@@ -144,7 +141,7 @@ void effect_on_conditions::load_new_character( Character &you )
     bool is_avatar = you.is_avatar();
     for( const effect_on_condition_id &eoc_id : get_scenario()->eoc() ) {
         effect_on_condition eoc = eoc_id.obj();
-        if( eoc.type == eoc_type::SCENARIO_SPECIFIC && ( is_avatar || eoc.run_for_npcs ) ) {
+        if( is_avatar || eoc.run_for_npcs ) {
             queued_eoc new_eoc = queued_eoc{ eoc.id, calendar::turn_zero, {} };
             you.queued_effect_on_conditions.push( new_eoc );
         }
@@ -153,7 +150,7 @@ void effect_on_conditions::load_new_character( Character &you )
     if( you.get_profession() ) {
         for( const effect_on_condition_id &eoc_id : you.get_profession()->get_eocs() ) {
             effect_on_condition eoc = eoc_id.obj();
-            if( eoc.type == eoc_type::PROFESSION_SPECIFIC && ( is_avatar || eoc.run_for_npcs ) ) {
+            if( is_avatar || eoc.run_for_npcs ) {
                 queued_eoc new_eoc = queued_eoc{ eoc.id, calendar::turn_zero, {} };
                 you.queued_effect_on_conditions.push( new_eoc );
             }

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -29,8 +29,6 @@ template <typename T> class generic_factory;
 enum eoc_type {
     ACTIVATION,
     RECURRING,
-    SCENARIO_SPECIFIC,
-    PROFESSION_SPECIFIC,
     AVATAR_DEATH,
     NPC_DEATH,
     PREVENT_DEATH,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Both SCENARIO_SPECIFIC and PROFESSION_SPECIFIC eocs are no different from activation EoCs, and we already restrict the code to run only EoCs listed in scenario/profession, no reason to do it twice
#### Describe the solution
Remove both types
#### Testing
Compiled, booted up prison asassin profession, EoC still fires properly
![image](https://github.com/user-attachments/assets/98b4674b-78b8-4169-873a-2fedc8a601fd)