### PR TITLE
Remove keybind from move view options

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2331,55 +2331,35 @@
     "name": "Center view",
     "category": "DEFAULTMODE",
     "id": "center",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": ":" },
-      { "input_method": "keyboard_code", "key": ";", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_8" }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_8" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view north",
     "category": "DEFAULTMODE",
     "id": "shift_n",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "K" },
-      { "input_method": "keyboard_code", "key": "k", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_21" }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_21" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view east",
     "category": "DEFAULTMODE",
     "id": "shift_e",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "L" },
-      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_22" }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_22" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view south",
     "category": "DEFAULTMODE",
     "id": "shift_s",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "J" },
-      { "input_method": "keyboard_code", "key": "j", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_23" }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_23" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view west",
     "category": "DEFAULTMODE",
     "id": "shift_w",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "H" },
-      { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_24" }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_24" } ]
   },
   {
     "type": "keybinding",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
More people use it by accident and then try to find how to undo it, than people who genuinely use it
#### Describe the solution
Remove default keybind
#### Describe alternatives you've considered
Not removing keybinds