### PR TITLE
Start to make vehicle coordinates make sense

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -589,8 +589,8 @@ static bool vehicle_activity( Character &you, const tripoint_bub_ms &src_loc, in
     // so , NPCs can remove the last part on a position, then there is no vehicle there anymore,
     // for someone else who stored that position at the start of their activity.
     // so we may need to go looking a bit further afield to find it , at activities end.
-    for( const tripoint_bub_ms &pt : veh->get_points( true ) ) {
-        you.activity.coord_set.insert( here.get_abs( pt ) );
+    for( const tripoint_abs_ms &pt : veh->get_points( true ) ) {
+        you.activity.coord_set.insert( pt );
     }
     // values[0]
     you.activity.values.push_back( here.get_abs( src_loc ).x() );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -688,11 +688,11 @@ void avatar::grab( object_type grab_type_new, const tripoint_rel_ms &grab_point_
         map &m = get_map();
         if( gtype == object_type::VEHICLE ) {
             if( const optional_vpart_position ovp = m.veh_at( pos_bub() + gpoint ) ) {
-                for( const tripoint_bub_ms &target : ovp->vehicle().get_points() ) {
+                for( const tripoint_abs_ms &target : ovp->vehicle().get_points() ) {
                     if( erase ) {
-                        memorize_clear_decoration( m.get_abs( target ), /* prefix = */ "vp_" );
+                        memorize_clear_decoration( target, /* prefix = */ "vp_" );
                     }
-                    m.memory_cache_dec_set_dirty( target, true );
+                    m.memory_cache_dec_set_dirty( m.get_bub( target ), true );
                 }
             }
         } else if( gtype != object_type::NONE ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3936,7 +3936,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
             avatar &you = get_avatar();
             if( !veh.forward_velocity() && !veh.player_in_control( you )
                 && !( you.get_grab_type() == object_type::VEHICLE
-                      && veh.get_points().count( ( you.pos_bub() + you.grab_point ) ) )
+                      && veh.get_points().count( ( you.pos_abs() + you.grab_point ) ) )
                 && here.memory_cache_dec_is_dirty( p ) ) {
                 you.memorize_decoration( here.get_abs( p ), vd.get_tileset_id(), subtile, rotation );
             }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -228,6 +228,16 @@ void Creature::setpos( map *here, const tripoint_bub_ms &p, bool check_gravity/*
     }
 }
 
+void Creature::setpos( const tripoint_abs_ms &p, bool check_gravity/* = true*/ )
+{
+    const tripoint_abs_ms old_loc = pos_abs();
+    set_pos_abs_only( p );
+    on_move( old_loc );
+    if( check_gravity ) {
+        gravity_check();
+    }
+}
+
 bool Creature::will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) const
 {
     map &here = get_map();
@@ -668,10 +678,10 @@ bool Creature::sees( const tripoint_bub_ms &t, bool is_avatar, int range_mod ) c
 
 // Helper function to check if potential area of effect of a weapon overlaps vehicle
 // Maybe TODO: If this is too slow, precalculate a bounding box and clip the tested area to it
-static bool overlaps_vehicle( const std::set<tripoint_bub_ms> &veh_area, const tripoint_bub_ms &pos,
+static bool overlaps_vehicle( const std::set<tripoint_abs_ms> &veh_area, const tripoint_abs_ms &pos,
                               const int area )
 {
-    for( const tripoint_bub_ms &tmp : tripoint_range<tripoint_bub_ms>( pos - tripoint( area, area, 0 ),
+    for( const tripoint_abs_ms &tmp : tripoint_range<tripoint_abs_ms>( pos - tripoint( area, area, 0 ),
             pos + tripoint( area - 1, area - 1, 0 ) ) ) {
         if( veh_area.count( tmp ) > 0 ) {
             return true;
@@ -813,7 +823,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
             continue; // Handle this late so that boo_hoo++ can happen
         }
         // Expensive check for proximity to vehicle
-        if( self_area_iff && overlaps_vehicle( in_veh->get_points(), m->pos_bub(), area ) ) {
+        if( self_area_iff && overlaps_vehicle( in_veh->get_points(), m->pos_abs(), area ) ) {
             continue;
         }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -319,6 +319,7 @@ class Creature : public viewer
         virtual void gravity_check( map *here );
         void setpos( const tripoint_bub_ms &p, bool check_gravity = true );
         void setpos( map *here, const tripoint_bub_ms &p, bool check_gravity = true );
+        void setpos( const tripoint_abs_ms &p, bool check_gravity = true );
 
         /** Checks if the creature fits confortably into a given tile. */
         bool will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) const;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5912,9 +5912,9 @@ void game::control_vehicle()
     if( veh ) {
         // If we reached here, we gained control of a vehicle.
         // Clear the map memory for the area covered by the vehicle to eliminate ghost vehicles.
-        for( const tripoint_bub_ms &target : veh->get_points() ) {
-            u.memorize_clear_decoration( m.get_abs( target ), "vp_" );
-            m.memory_cache_dec_set_dirty( target, true );
+        for( const tripoint_abs_ms &target : veh->get_points() ) {
+            u.memorize_clear_decoration( target, "vp_" );
+            m.memory_cache_dec_set_dirty( m.get_bub( target ), true );
         }
         veh->is_following = false;
         veh->is_patrolling = false;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -760,7 +760,6 @@ static void grab()
         //solid vehicles can't be grabbed while boarded
         const optional_vpart_position vp_boarded = here.veh_at( you.pos_bub() );
         if( vp_boarded ) {
-            const std::set<tripoint_bub_ms> grabbed_veh_points = vp->vehicle().get_points();
             if( &vp_boarded->vehicle() == &vp->vehicle() &&
                 !empty( vp->vehicle().get_avail_parts( VPFLAG_OBSTACLE ) ) ) {
                 add_msg( m_info, _( "You can't move the %s while you're boarding it." ), veh_name );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7002,13 +7002,14 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
              */
             std::unique_ptr<RemovePartHandler> handler_ptr;
             bool did_merge = false;
-            for( const tripoint_bub_ms &map_pos : first_veh->get_points( true ) ) {
-                std::vector<vehicle_part *> parts_to_move = veh_to_add->get_parts_at( map_pos, "",
+            for( const tripoint_abs_ms &map_pos : first_veh->get_points( true ) ) {
+                const tripoint_bub_ms map_bub_pos = get_bub( map_pos ); // TODO: Make usages use this map.
+                std::vector<vehicle_part *> parts_to_move = veh_to_add->get_parts_at( map_bub_pos, "",
                         part_status_flag::any );
                 if( !parts_to_move.empty() ) {
                     // Store target_point by value because first_veh->parts may reallocate
                     // to a different address after install_part()
-                    std::vector<vehicle_part *> first_veh_parts = first_veh->get_parts_at( map_pos, "",
+                    std::vector<vehicle_part *> first_veh_parts = first_veh->get_parts_at( map_bub_pos, "",
                             part_status_flag:: any );
                     // This happens if this location is occupied by a fake part.
                     if( first_veh_parts.empty() || first_veh_parts.front()->is_fake ) {
@@ -7024,7 +7025,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
                                   veh_to_add->name, veh_to_add->type.str(),
                                   veh_to_add->pos_abs().to_string(),
                                   to_degrees( veh_to_add->turn_dir ),
-                                  map_pos.to_string() );
+                                  map_bub_pos.to_string() );
                     }
                     did_merge = true;
                     const point_rel_ms target_point = first_veh_parts.front()->mount;

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -406,12 +406,11 @@ void veh_app_interact::refill()
         act.targets.push_back( target );
         act.str_values.push_back( pt->info().id.str() );
         const point_rel_ms q = veh->coord_translate( pt->mount );
-        map &here = get_map();
-        for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
-            act.coord_set.insert( here.get_abs( p ) );
+        for( const tripoint_abs_ms &p : veh->get_points( true ) ) {
+            act.coord_set.insert( p );
         }
-        act.values.push_back( here.get_abs( veh->pos_bub() ).x() + q.x() );
-        act.values.push_back( here.get_abs( veh->pos_bub() ).y() + q.y() );
+        act.values.push_back( veh->pos_abs().x() + q.x() );
+        act.values.push_back( veh->pos_abs().y() + q.y() );
         act.values.push_back( a_point.x() );
         act.values.push_back( a_point.y() );
         act.values.push_back( -a_point.x() );
@@ -496,8 +495,8 @@ void veh_app_interact::remove()
     } else if( query_yn( _( "Are you sure you want to take down the %s?" ), veh->name ) ) {
         act = player_activity( ACT_VEHICLE, to_moves<int>( time ), static_cast<int>( 'O' ) );
         act.str_values.push_back( vpinfo.id.str() );
-        for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
-            act.coord_set.insert( here.get_abs( p ) );
+        for( const tripoint_abs_ms &p : veh->get_points( true ) ) {
+            act.coord_set.insert( p );
         }
         const tripoint_abs_ms a_point_abs( here.get_abs( a_point_bub ) );
         act.values.push_back( a_point_abs.x() );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -176,12 +176,11 @@ player_activity veh_interact::serialize_activity()
     // otherwise (e.g. installing a new frame), just use part 0
     const point_rel_ms q = veh->coord_translate( pt ? pt->mount : veh->part( 0 ).mount );
     const vehicle_part *vpt = pt ? pt : &veh->part( 0 );
-    map &here = get_map();
-    for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
-        res.coord_set.insert( here.get_abs( p ) );
+    for( const tripoint_abs_ms &p : veh->get_points( true ) ) {
+        res.coord_set.insert( p );
     }
-    res.values.push_back( here.get_abs( veh->pos_bub() ).x() + q.x() );   // values[0]
-    res.values.push_back( here.get_abs( veh->pos_bub() ).y() + q.y() );   // values[1]
+    res.values.push_back( veh->pos_abs().x() + q.x() );   // values[0]
+    res.values.push_back( veh->pos_abs().y() + q.y() );   // values[1]
     res.values.push_back( dd.x() );   // values[2]
     res.values.push_back( dd.y() );   // values[3]
     res.values.push_back( -dd.x() );   // values[4]

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -452,7 +452,7 @@ struct vehicle_part {
         std::array<tripoint_rel_ms, 2> precalc = { { tripoint_rel_ms( -1, -1, 0 ), tripoint_rel_ms( -1, -1, 0 ) } };
 
         /** temporarily held projected position */
-        tripoint_bub_ms next_pos = tripoint_bub_ms( -1, -1, 0 ); // NOLINT(cata-serialize)
+        tripoint_abs_ms next_pos = tripoint_abs_ms( -1, -1, 0 ); // NOLINT(cata-serialize)
 
         /** current part health with range [0,durability] */
         int hp() const;
@@ -1439,6 +1439,8 @@ class vehicle
          */
         tripoint_bub_ms bub_part_pos( int index ) const;
         tripoint_bub_ms bub_part_pos( const vehicle_part &pt ) const;
+        tripoint_abs_ms abs_part_pos( int index ) const;
+        tripoint_abs_ms abs_part_pos( const vehicle_part &pt ) const;
         /**
          * All the fuels that are in all the tanks in the vehicle, nicely summed up.
          * Note that empty tanks don't count at all. The value is the amount as it would be
@@ -1794,7 +1796,7 @@ class vehicle
 
         // Handle given part collision with vehicle, monster/NPC/player or terrain obstacle
         // Returns collision, which has type, impulse, part, & target.
-        veh_collision part_collision( int part, const tripoint_bub_ms &p,
+        veh_collision part_collision( int part, const tripoint_abs_ms &p,
                                       bool just_detect, bool bash_floor );
 
         // Process the trap beneath
@@ -1994,14 +1996,14 @@ class vehicle
         bool assign_seat( vehicle_part &pt, const npc &who );
 
         // Update the set of occupied points and return a reference to it
-        const std::set<tripoint_bub_ms> &get_points( bool force_refresh = false,
+        const std::set<tripoint_abs_ms> &get_points( bool force_refresh = false,
                 bool no_fake = false ) const;
 
         // calculate the new projected points for all vehicle parts to move to
         void part_project_points( const tripoint_rel_ms &dp );
 
         // get all vehicle parts' projected points
-        std::set<tripoint_bub_ms> get_projected_part_points() const;
+        std::set<tripoint_abs_ms> get_projected_part_points() const;
 
         /**
         * Consumes specified charges (or fewer) from the vehicle part
@@ -2164,12 +2166,12 @@ class vehicle
         mutable double draft_m = 1; // NOLINT(cata-serialize)
         mutable double hull_height = 0.3; // NOLINT(cata-serialize)
 
-        // Bubble location when cache was last refreshed.
-        mutable tripoint_bub_ms occupied_cache_pos = { -1, -1, -1 }; // NOLINT(cata-serialize)
+        // Absolute location when cache was last refreshed.
+        mutable tripoint_abs_ms occupied_cache_pos = tripoint_abs_ms::invalid; // NOLINT(cata-serialize)
         // Vehicle facing when cache was last refreshed.
         mutable units::angle occupied_cache_direction = 0_degrees; // NOLINT(cata-serialize)
         // Cached points occupied by the vehicle
-        mutable std::set<tripoint_bub_ms> occupied_points; // NOLINT(cata-serialize)
+        mutable std::set<tripoint_abs_ms> occupied_points; // NOLINT(cata-serialize)
 
         // Master list of parts installed in the vehicle.
         std::vector<vehicle_part> parts; // NOLINT(cata-serialize)

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -231,8 +231,8 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
         veh.idle( true );
         // If the vehicle starts skidding, the effects become random and test is RUINED
         REQUIRE( !veh.skidding );
-        for( const tripoint_bub_ms &pos : veh.get_points() ) {
-            REQUIRE( here.ter( pos ) );
+        for( const tripoint_abs_ms &pos : veh.get_points() ) {
+            REQUIRE( here.ter( here.get_bub( pos ) ) );
         }
         // How much it moved
         tiles_travelled += square_dist( starting_point, veh.pos_bub() );

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -132,13 +132,13 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
     int cycles = 0;
     const int target_z = use_ramp ? ( up ? 1 : -1 ) : 0;
 
-    std::set<tripoint_bub_ms> vpts = veh.get_points();
+    std::set<tripoint_abs_ms> vpts = veh.get_points();
     while( veh.engine_on && veh.safe_velocity() > 0 && cycles < 10 ) {
         clear_creatures();
         CAPTURE( cycles );
-        for( const tripoint_bub_ms &checkpt : vpts ) {
+        for( const tripoint_abs_ms &checkpt : vpts ) {
             int partnum = 0;
-            vehicle *check_veh = here.veh_at_internal( checkpt, partnum );
+            vehicle *check_veh = here.veh_at_internal( here.get_bub( checkpt ), partnum );
             CAPTURE( veh_ptr->pos_bub() );
             CAPTURE( veh_ptr->face.dir() );
             CAPTURE( checkpt );
@@ -149,8 +149,8 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
         CHECK( veh.velocity == target_velocity );
         // If the vehicle starts skidding, the effects become random and test is RUINED
         REQUIRE( !veh.skidding );
-        for( const tripoint_bub_ms &pos : veh.get_points() ) {
-            REQUIRE( here.ter( pos ) );
+        for( const tripoint_abs_ms &pos : veh.get_points() ) {
+            REQUIRE( here.ter( here.get_bub( pos ) ) );
         }
         for( const vpart_reference &vp : veh.get_all_parts() ) {
             if( vp.info().location != "structure" ) {
@@ -266,8 +266,8 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
     CHECK( veh.safe_velocity() > 0 );
 
     std::vector<vehicle_part *> all_parts;
-    for( const tripoint_bub_ms &pos : veh.get_points() ) {
-        for( vehicle_part *prt : veh.get_parts_at( pos, "", part_status_flag::any ) ) {
+    for( const tripoint_abs_ms &pos : veh.get_points() ) {
+        for( vehicle_part *prt : veh.get_parts_at( here.get_bub( pos ), "", part_status_flag::any ) ) {
             all_parts.push_back( prt );
             if( drop_pos && prt->mount.x() < 0 ) {
                 prt->precalc[0].z() = -1;

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -31,7 +31,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_cross_split_test,
                                              vehicle_origin, dir, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        std::set<tripoint_bub_ms> original_points = veh_ptr->get_points( true );
+        std::set<tripoint_abs_ms> original_points = veh_ptr->get_points( true );
 
         here.destroy_vehicle( vehicle_origin );
         veh_ptr->part_removal_cleanup();
@@ -45,21 +45,21 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
             CHECK( vehs[1].v->part_count() == 12 );
             CHECK( vehs[2].v->part_count() == 2 );
             CHECK( vehs[3].v->part_count() == 3 );
-            std::vector<std::set<tripoint_bub_ms>> all_points;
+            std::vector<std::set<tripoint_abs_ms>> all_points;
             for( int i = 0; i < 4; i++ ) {
-                const std::set<tripoint_bub_ms> &veh_points = vehs[i].v->get_points( true );
+                const std::set<tripoint_abs_ms> &veh_points = vehs[i].v->get_points( true );
                 all_points.push_back( veh_points );
             }
             for( int i = 0; i < 4; i++ ) {
-                std::set<tripoint_bub_ms> &veh_points = all_points[i];
+                std::set<tripoint_abs_ms> &veh_points = all_points[i];
                 // every point in the new vehicle was in the old vehicle
-                for( const tripoint_bub_ms &vpos : veh_points ) {
+                for( const tripoint_abs_ms &vpos : veh_points ) {
                     CHECK( original_points.find( vpos ) != original_points.end() );
                 }
                 // no point in any new vehicle is in any other new vehicle
                 for( int j = i + 1; j < 4; j++ ) {
-                    std::set<tripoint_bub_ms> &other_points = all_points[j];
-                    for( const tripoint_bub_ms &vpos : veh_points ) {
+                    std::set<tripoint_abs_ms> &other_points = all_points[j];
+                    for( const tripoint_abs_ms &vpos : veh_points ) {
                         CHECK( other_points.find( vpos ) == other_points.end() );
                     }
                 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Start the journey to allow vehicles to behave properly outside of the reality bubble (such as explosion maps).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change a bunch of vehicle properties to use absolute coordinates rather than bub coordinates of whatever map the vehicle happens to be associated with. This was then followed by adjustment to the usages of these properties to match.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There's some rather suspect code in vehicle::get_bounding_box() originally detected during typification (if you need to change a bub position into a rel one without a clear reason for why that's reasonable, that's a warning sign). The code retains the original logic in this PR, although I've added suggested changes in comments. Before changing it, there really should be some way to test the code before/after to verify it's wrong (if it is) and it's corrected (if it is). I wouldn't mind if someone took up that task, although I may try to tackle it myself at some time.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load save, walk up ramp, jump into car, drive through hay bales, run over a turkey, crash into stationary vehicle. Nothing odd seen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There's a lot to be done to ensure vehicles actually behave properly on maps other than the reality bubble one. Many operations transitively call operations that just uses get_map() to get a map reference for bub coordinates, even though the original call was done using a different map (currently some explosions and mapgen in play).
There's been some effort done to treat mapgen differently from game play, but the determination logic is weak (the map used isn't get_map()), and I don't know if the calls for the mapgen case actually manages to keep get_map() contamination out of the way transitively (the default case operations do not).

This effort is, in turn, a smaller part in an effort to get the game to be consistent in what bub coordinates refer to (i.e. which map). It's rather ugly to have map class methods that just call get_map() themselves or do so transitively, as that violates the purpose of methods on objects. Getting vehicles to behave will have to involve getting some map methods to behave, as there are a lot of calls back and forth.

I've confirmed explosion effects outside the reality bubble (but on the explosion map) do not affect vehicles properly. That's one reason behind this PR.

I made an attempt to start from the map angle, but gave up on that PR as it kept growing and I ended up with some weird trouble with the map split test, without being able to figure out where the processing might have failed. It may have been possible to push through, but I decided to start afresh with a smaller bite to try to get at the overall problem more gradually. Anyway, it was nice to see the tests actually detecting errors, rather than failing for unrelated reasons for once.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
