### PR TITLE
Update tools.json

### DIFF
--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -9,6 +9,7 @@
     "price": "2 kUSD",
     "price_postapoc": "25 USD",
     "material": [ "plastic", "aluminum" ],
+    "etransfer_rate": "45 MB",
     "looks_like": "cell_phone",
     "symbol": ";",
     "color": "light_green",


### PR DESCRIPTION
#### Summary
Mods "Atom smartphone dont have e-transfer information. (Aftershock mod)"

Was sending an error and wiping everything cued to transfer into the smartphone
#### Purpose of change

#### Describe the solution

Afer adding a simple adding a 45MB transfer rate, (15 more than normal smartphone to reflect the mod high-tech nature of the mod)

#### Describe alternatives you've considered

Not sending pull request?

#### Testing

Added the line and everything went well.