### PR TITLE
Magic Infrastructure: Add failure_chance field

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1343,6 +1343,11 @@ float spell::spell_fail( const Character &guy ) const
     if( has_flag( spell_flag::NO_FAIL ) ) {
         return 0.0f;
     }
+    if( type->magic_type.has_value() && type->magic_type.value()->failure_chance_formula_id.has_value() ) {
+        dialogue d( get_talker_for( guy ), nullptr );
+        return type->magic_type.value()->failure_chance_formula_id.value()->eval( d );
+    }
+
     const bool is_psi = has_flag( spell_flag::PSIONIC );
 
     // formula is based on the following:

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1344,7 +1344,7 @@ float spell::spell_fail( const Character &guy ) const
         return 0.0f;
     }
     if( type->magic_type.has_value() && type->magic_type.value()->failure_chance_formula_id.has_value() ) {
-        dialogue d( get_talker_for( guy ), nullptr );
+        const_dialogue d( get_const_talker_for( guy ), nullptr );
         return type->magic_type.value()->failure_chance_formula_id.value()->eval( d );
     }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1343,7 +1343,8 @@ float spell::spell_fail( const Character &guy ) const
     if( has_flag( spell_flag::NO_FAIL ) ) {
         return 0.0f;
     }
-    if( type->magic_type.has_value() && type->magic_type.value()->failure_chance_formula_id.has_value() ) {
+    if( type->magic_type.has_value() &&
+        type->magic_type.value()->failure_chance_formula_id.has_value() ) {
         const_dialogue d( get_const_talker_for( guy ), nullptr );
         return type->magic_type.value()->failure_chance_formula_id.value()->eval( d );
     }

--- a/src/magic_type.cpp
+++ b/src/magic_type.cpp
@@ -108,7 +108,8 @@ void magic_type::check_consistency()
         if( m_t.casting_xp_formula_id.has_value() && m_t.casting_xp_formula_id.value()->num_params != 0 ) {
             debugmsg( "ERROR: %s casting_xp_formula_id has params that != 0!", m_t.id.c_str() );
         }
-        if( m_t.failure_chance_formula_id.has_value() && m_t.failure_chance_formula_id.value()->num_params != 0 ) {
+        if( m_t.failure_chance_formula_id.has_value() &&
+            m_t.failure_chance_formula_id.value()->num_params != 0 ) {
             debugmsg( "ERROR: %s failure_chance_formula_id has params that != 0!", m_t.id.c_str() );
         }
     }

--- a/src/magic_type.cpp
+++ b/src/magic_type.cpp
@@ -108,6 +108,9 @@ void magic_type::check_consistency()
         if( m_t.casting_xp_formula_id.has_value() && m_t.casting_xp_formula_id.value()->num_params != 0 ) {
             debugmsg( "ERROR: %s casting_xp_formula_id has params that != 0!", m_t.id.c_str() );
         }
+        if( m_t.failure_chance_formula_id.has_value() && m_t.failure_chance_formula_id.value()->num_params != 0 ) {
+            debugmsg( "ERROR: %s failure_chance_formula_id has params that != 0!", m_t.id.c_str() );
+        }
     }
 }
 

--- a/src/magic_type.cpp
+++ b/src/magic_type.cpp
@@ -44,6 +44,7 @@ void magic_type::load( const JsonObject &jo, const std::string_view src )
                   id.c_str() );
     }
     optional( jo, was_loaded, "casting_xp_formula_id", casting_xp_formula_id );
+    optional( jo, was_loaded, "failure_chance_formula_id", failure_chance_formula_id );
     optional( jo, was_loaded, "energy_source", energy_source );
     if( jo.has_array( "cannot_cast_flags" ) ) {
         for( auto &cannot_cast_flag : jo.get_string_array( "cannot_cast_flags" ) ) {
@@ -80,6 +81,7 @@ void magic_type::serialize( JsonOut &json ) const
     json.member( "get_level_formula_id", get_level_formula_id );
     json.member( "exp_for_level_formula_id", exp_for_level_formula_id );
     json.member( "casting_xp_formula_id", casting_xp_formula_id );
+    json.member( "failure_chance_formula_id", failure_chance_formula_id );
     json.member( "energy_source", energy_source );
     json.member( "cannot_cast_flags", cannot_cast_flags, std::set<std::string> {} );
     json.member( "cannot_cast_message", cannot_cast_message );

--- a/src/magic_type.h
+++ b/src/magic_type.h
@@ -45,6 +45,7 @@ class magic_type
         std::optional<jmath_func_id> exp_for_level_formula_id;
 
         std::optional<jmath_func_id> casting_xp_formula_id;
+        std::optional<jmath_func_id> failure_chance_formula_id;
         std::optional<magic_energy_type> energy_source;
         std::set<std::string> cannot_cast_flags; // string flags
         std::optional<std::string> cannot_cast_message;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3976,3 +3976,9 @@ std::unique_ptr<talker> get_talker_for( npc *guy )
 {
     return std::make_unique<talker_npc>( guy );
 }
+std::unique_ptr<talker> get_talker_for( const Character &guy )
+{
+    return std::make_unique<talker_npc>( guy );
+}
+
+

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3976,9 +3976,5 @@ std::unique_ptr<talker> get_talker_for( npc *guy )
 {
     return std::make_unique<talker_npc>( guy );
 }
-std::unique_ptr<talker> get_talker_for( const Character &guy )
-{
-    return std::make_unique<talker_npc>( guy );
-}
 
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1509,4 +1509,5 @@ std::ostream &operator<< ( std::ostream &os, const npc_need &need );
 npc *pick_follower();
 std::unique_ptr<talker> get_talker_for( npc &guy );
 std::unique_ptr<talker> get_talker_for( npc *guy );
+std::unique_ptr<talker> get_talker_for( const Character &guy );
 #endif // CATA_SRC_NPC_H

--- a/src/npc.h
+++ b/src/npc.h
@@ -1509,5 +1509,4 @@ std::ostream &operator<< ( std::ostream &os, const npc_need &need );
 npc *pick_follower();
 std::unique_ptr<talker> get_talker_for( npc &guy );
 std::unique_ptr<talker> get_talker_for( npc *guy );
-std::unique_ptr<talker> get_talker_for( const Character &guy );
 #endif // CATA_SRC_NPC_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Magic Infrastructure: Add failure_chance field"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I've seen this requested a couple of times on discord so may as well make the addition.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add failure_chance_formula_id to magic_type and makes spells with this defined calculate based on the formula instead of the default failure_chance.  Spells with NO_FAIL will still always succeed, but this skips other flags such as SOMANTIC.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Add a formula for MOM/Aftershock and deprecate the PSIONIC logic.  Maybe later.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Created a test func with failure_chance = 0 and applied it to MOM.
![fake failure test](https://github.com/user-attachments/assets/89e48d41-79e8-4097-8437-2c960f892c5e)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I hadn't initially added this because translating the existing failure_chance calculation to jmath would be fairly complicated, which means I wouldn't be able to deprecate the PSIONIC definition to reduce the c++ hardcoding.  Now that I look more carefully it may actually be doable though
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
