### PR TITLE
Convert some vehicle operations to be map aware

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -439,6 +439,8 @@ void aim_activity_actor::do_turn( player_activity &act, Character &who )
 
 void aim_activity_actor::finish( player_activity &act, Character &who )
 {
+    map &here = get_map();
+
     act.set_to_null();
     item_location weapon = get_weapon();
     if( !weapon ) {
@@ -457,7 +459,7 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
     }
 
     gun_mode gun = weapon->gun_current_mode();
-    who.fire_gun( fin_trajectory.back(), gun.qty, *gun, reload_loc );
+    who.fire_gun( &here, fin_trajectory.back(), gun.qty, *gun, reload_loc );
 
     if( !get_option<bool>( "AIM_AFTER_FIRING" ) ) {
         restore_view();

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -843,7 +843,7 @@ bool avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret
     target_handler::trajectory trajectory = target_handler::mode_turret_manual( you, turret );
 
     if( !trajectory.empty() ) {
-        turret.fire( you, trajectory.back() );
+        turret.fire( you, &m, trajectory.back() );
     }
     g->reenter_fullscreen();
     return true;

--- a/src/ballistics.h
+++ b/src/ballistics.h
@@ -45,6 +45,11 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                         const dispersion_sources &dispersion, Creature *origin = nullptr, const vehicle *in_veh = nullptr,
                         const weakpoint_attack &wp_attack = weakpoint_attack() );
 
+void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_arg,
+                        map *here, const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
+                        const dispersion_sources &dispersion, Creature *origin = nullptr, const vehicle *in_veh = nullptr,
+                        const weakpoint_attack &wp_attack = weakpoint_attack() );
+
 /* Used for selecting which part to target in a projectile attack
  * Primarily a template for ease of testing, but can be reused!
  * To use:

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10466,7 +10466,7 @@ void Character::place_corpse( map *here )
         }
     }
 
-    here->add_item_or_charges( here->get_bub( pos_abs() ), body );
+    here->add_item_or_charges( pos_bub( here ), body );
 }
 
 void Character::place_corpse( const tripoint_abs_omt &om_target )
@@ -11163,7 +11163,7 @@ void Character::gravity_check()
 
 void Character::gravity_check( map *here )
 {
-    const tripoint_bub_ms pos = here->get_bub( pos_abs() );
+    const tripoint_bub_ms pos = pos_bub( here );
     if( here->is_open_air( pos ) && !in_vehicle && !has_effect_with_flag( json_flag_GLIDING ) &&
         here->try_fall( pos, this ) ) {
         here->update_visibility_cache( pos.z() );
@@ -12861,8 +12861,8 @@ void Character::leak_items()
 
 void Character::process_items( map *here )
 {
-    if( weapon.process( *here, this, here->get_bub( pos_abs() ) ) ) {
-        weapon.spill_contents( here,  here->get_bub( pos_abs() ) );
+    if( weapon.process( *here, this, pos_bub( here ) ) ) {
+        weapon.spill_contents( here,  pos_bub( here ) );
         remove_weapon();
     }
 
@@ -12871,8 +12871,8 @@ void Character::process_items( map *here )
         if( !it ) {
             continue;
         }
-        if( it->process( *here, this, here->get_bub( pos_abs() ) ) ) {
-            it->spill_contents( here, here->get_bub( pos_abs() ) );
+        if( it->process( *here, this, pos_bub( here ) ) ) {
+            it->spill_contents( here, pos_bub( here ) );
             removed_items.push_back( it );
         }
     }

--- a/src/character.h
+++ b/src/character.h
@@ -3186,7 +3186,7 @@ class Character : public Creature, public visitable
          *  @param gun item to fire (which does not necessary have to be in the players possession)
          *  @return number of shots actually fired
          */
-        int fire_gun( const tripoint_bub_ms &target, int shots, item &gun,
+        int fire_gun( map *here, const tripoint_bub_ms &target, int shots, item &gun,
                       item_location ammo = item_location() );
         /** Execute a throw */
         dealt_projectile_attack throw_item( const tripoint_bub_ms &target, const item &to_throw,
@@ -3508,6 +3508,9 @@ class Character : public Creature, public visitable
         * @returns Craftable inventory items found.
         * */
         const inventory &crafting_inventory( const tripoint_bub_ms &src_pos = tripoint_bub_ms::zero,
+                                             int radius = PICKUP_RANGE, bool clear_path = true ) const;
+        const inventory &crafting_inventory( map *here,
+                                             const tripoint_bub_ms &src_pos = tripoint_bub_ms::zero,
                                              int radius = PICKUP_RANGE, bool clear_path = true ) const;
         void invalidate_crafting_inventory();
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -641,9 +641,16 @@ const inventory &Character::crafting_inventory( bool clear_path ) const
 const inventory &Character::crafting_inventory( const tripoint_bub_ms &src_pos, int radius,
         bool clear_path ) const
 {
+    return Character::crafting_inventory( &get_map(), src_pos, radius, clear_path );
+}
+
+const inventory &Character::crafting_inventory( map *here, const tripoint_bub_ms &src_pos,
+        int radius,
+        bool clear_path ) const
+{
     tripoint_bub_ms inv_pos = src_pos;
     if( src_pos == tripoint_bub_ms::zero ) {
-        inv_pos = pos_bub();
+        inv_pos = pos_bub( here );
     }
     if( crafting_cache.valid
         && moves == crafting_cache.moves
@@ -655,7 +662,7 @@ const inventory &Character::crafting_inventory( const tripoint_bub_ms &src_pos, 
     }
     crafting_cache.crafting_inventory->clear();
     if( radius >= 0 ) {
-        crafting_cache.crafting_inventory->form_from_map( inv_pos, radius, this, false, clear_path );
+        crafting_cache.crafting_inventory->form_from_map( here, inv_pos, radius, this, false, clear_path );
     }
 
     std::map<itype_id, int> tmp_liq_list;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -208,6 +208,11 @@ tripoint_bub_ms Creature::pos_bub() const
     return get_map().get_bub( location );
 }
 
+tripoint_bub_ms Creature::pos_bub( map *here ) const
+{
+    return here->get_bub( location );
+}
+
 void Creature::setpos( const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
 {
     const tripoint_abs_ms old_loc = pos_abs();

--- a/src/creature.h
+++ b/src/creature.h
@@ -306,6 +306,7 @@ class Creature : public viewer
         /** Sets a Creature's fake boolean. */
         virtual void set_fake( bool fake_value );
         tripoint_bub_ms pos_bub() const;
+        tripoint_bub_ms pos_bub( map *here ) const;
         inline int posx() const {
             return pos_bub().x();
         }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -523,6 +523,12 @@ void explosion( const Creature *source, const tripoint_bub_ms &p, const explosio
     _explosions.emplace_back( source, get_map().get_abs( p ), ex );
 }
 
+void explosion( const Creature *source, map *here, const tripoint_bub_ms &p,
+                const explosion_data &ex )
+{
+    _explosions.emplace_back( source, here->get_abs( p ), ex );
+}
+
 void _make_explosion( map *m, const Creature *source, const tripoint_bub_ms &p,
                       const explosion_data &ex )
 {

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -84,6 +84,8 @@ void explosion(
 // until triggered normally.
 bool explosion_processing_active();
 void explosion( const Creature *source, const tripoint_bub_ms &p, const explosion_data &ex );
+void explosion( const Creature *source, map *here, const tripoint_bub_ms &p,
+                const explosion_data &ex );
 void _make_explosion( map *m, const Creature *source, const tripoint_bub_ms &p,
                       const explosion_data &ex );
 

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -486,21 +486,28 @@ void inventory::form_from_map( const tripoint_bub_ms &origin, int range, const C
                                bool assign_invlet,
                                bool clear_path )
 {
-    map &m = get_map();
+    inventory::form_from_map( &get_map(), origin, range, pl, assign_invlet, clear_path );
+}
+
+void inventory::form_from_map( map *here, const tripoint_bub_ms &origin, int range,
+                               const Character *pl,
+                               bool assign_invlet,
+                               bool clear_path )
+{
     // Populate a grid of spots that can be reached
     // If we need a clear path we care about the reachability of points
     if( clear_path ) {
-        const std::vector<tripoint_bub_ms> &reachable_pts = m.reachable_flood_steps( origin, range, 1,
+        const std::vector<tripoint_bub_ms> &reachable_pts = here->reachable_flood_steps( origin, range, 1,
                 100 );
-        form_from_map( m, reachable_pts, pl, assign_invlet );
+        form_from_map( *here, reachable_pts, pl, assign_invlet );
     } else {
         std::vector<tripoint_bub_ms> reachable_pts;
         // Fill reachable points with points_in_radius
-        tripoint_range<tripoint_bub_ms> in_radius = m.points_in_radius( origin, range );
+        tripoint_range<tripoint_bub_ms> in_radius = here->points_in_radius( origin, range );
         for( const tripoint_bub_ms &p : in_radius ) {
             reachable_pts.emplace_back( p );
         }
-        form_from_map( m, reachable_pts, pl, assign_invlet );
+        form_from_map( *here, reachable_pts, pl, assign_invlet );
     }
 }
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -165,6 +165,10 @@ class inventory : public visitable
         void form_from_map( const tripoint_bub_ms &origin, int range, const Character *pl = nullptr,
                             bool assign_invlet = true,
                             bool clear_path = true );
+        void form_from_map( map *here, const tripoint_bub_ms &origin, int range,
+                            const Character *pl = nullptr,
+                            bool assign_invlet = true,
+                            bool clear_path = true );
         void form_from_map( map &m, std::vector<tripoint_bub_ms> pts, const Character *pl,
                             bool assign_invlet = true );
         /**

--- a/src/item.h
+++ b/src/item.h
@@ -2581,6 +2581,7 @@ class item : public visitable
          * @return amount of ammo consumed which will be between 0 and qty
          */
         int ammo_consume( int qty, const tripoint_bub_ms &pos, Character *carrier );
+        int ammo_consume( int qty, map *here, const tripoint_bub_ms &pos, Character *carrier );
 
         /**
          * Consume energy (if available) and return the amount of energy that was consumed
@@ -2592,6 +2593,9 @@ class item : public visitable
          * @return amount of energy consumed which will be between 0 kJ and qty+1 kJ
          */
         units::energy energy_consume( units::energy qty, const tripoint_bub_ms &pos, Character *carrier,
+                                      float fuel_efficiency = -1.0 );
+        units::energy energy_consume( units::energy qty, map *here, const tripoint_bub_ms &pos,
+                                      Character *carrier,
                                       float fuel_efficiency = -1.0 );
 
         /**

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1255,6 +1255,12 @@ void item_contents::heat_up()
 
 int item_contents::ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel_efficiency )
 {
+    return item_contents::ammo_consume( qty, &get_map(), pos, fuel_efficiency );
+}
+
+int item_contents::ammo_consume( int qty, map *here, const tripoint_bub_ms &pos,
+                                 float fuel_efficiency )
+{
     int consumed = 0;
     for( item_pocket &pocket : contents ) {
         if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
@@ -1264,12 +1270,12 @@ int item_contents::ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel
             }
             // assuming only one mag
             item &mag = pocket.front();
-            const int res = mag.ammo_consume( qty, pos, nullptr );
+            const int res = mag.ammo_consume( qty, here, pos, nullptr );
             if( res && mag.ammo_remaining() == 0 ) {
                 if( mag.has_flag( STATIC( flag_id( "MAG_DESTROY" ) ) ) ) {
                     pocket.remove_item( mag );
                 } else if( mag.has_flag( STATIC( flag_id( "MAG_EJECT" ) ) ) ) {
-                    get_map().add_item( pos, mag );
+                    here->add_item( pos, mag );
                     pocket.remove_item( mag );
                 }
             }

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -328,6 +328,7 @@ class item_contents
         void heat_up();
         /** Return the amount of ammo consumed. */
         int ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel_efficiency = -1.0 );
+        int ammo_consume( int qty, map *here, const tripoint_bub_ms &pos, float fuel_efficiency = -1.0 );
         item *magazine_current();
         std::set<ammotype> ammo_types() const;
         int ammo_capacity( const ammotype &ammo ) const;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9324,7 +9324,7 @@ void map::build_obstacle_cache(
     }
     // Iterate over creatures and set them to block their squares relative to their size.
     for( Creature &critter : g->all_creatures() ) {
-        const tripoint_bub_ms loc = get_bub( critter.pos_abs() );
+        const tripoint_bub_ms loc = critter.pos_bub( this );
         if( loc.z() != start.z() || !inbounds( loc ) ) {
             continue;
         }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1446,7 +1446,7 @@ If you wish for a field effect to do something over time (propagate, interact wi
 void map::player_in_field( Character &you )
 {
     // A copy of the current field for reference. Do not add fields to it, use map::add_field
-    field &curfield = get_field( get_bub( you.pos_abs() ) );
+    field &curfield = get_field( you.pos_bub( this ) );
     // Are we inside?
     bool inside = false;
     // If we are in a vehicle figure out if we are inside (reduces effects usually)
@@ -1514,7 +1514,7 @@ void map::player_in_field( Character &you )
             // Sap does nothing to cars.
             if( !you.in_vehicle ) {
                 // Use up sap.
-                mod_field_intensity( get_bub( you.pos_abs() ), ft, -1 );
+                mod_field_intensity( you.pos_bub( this ), ft, -1 );
             }
         }
         if( ft == fd_sludge ) {

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -100,10 +100,10 @@ static void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt
     int placed_chunks = 0;
     while( placed_chunks < chunk_amt ) {
         bool drop_chunks = true;
-        tripoint_bub_ms tarp( here->get_bub( z.pos_abs() ) + point( rng( -distance, distance ),
+        tripoint_bub_ms tarp( z.pos_bub( here ) + point( rng( -distance, distance ),
                               rng( -distance,
                                    distance ) ) );
-        const std::vector<tripoint_bub_ms> traj = line_to( here->get_bub( z.pos_abs() ), tarp );
+        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub( here ), tarp );
 
         for( size_t j = 0; j < traj.size(); j++ ) {
             tarp = traj[j];
@@ -148,7 +148,7 @@ item_location mdeath::splatter( map *here, monster &z )
     const field_type_id type_gib = z.gibType();
 
     if( gibbable ) {
-        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( here->get_bub( z.pos_abs() ),
+        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( z.pos_bub( here ),
                 1 );
         int number_of_gibs = std::min( std::floor( corpse_damage ) - 1, 1 + max_hp / 5.0f );
 
@@ -207,7 +207,7 @@ item_location mdeath::splatter( map *here, monster &z )
         if( !z.has_eaten_enough() ) {
             corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
         }
-        return here->add_item_ret_loc( here->get_bub( z.pos_abs() ), corpse );
+        return here->add_item_ret_loc( z.pos_bub( here ), corpse );
     }
     return {};
 }
@@ -239,7 +239,7 @@ void mdeath::broken( map *here, monster &z )
     const float corpse_damage = 2.5 * overflow_damage / max_hp;
     broken_mon.set_damage( static_cast<int>( std::floor( corpse_damage * itype::damage_scale ) ) );
 
-    here->add_item_or_charges( here->get_bub( z.pos_abs() ), broken_mon );
+    here->add_item_or_charges( z.pos_bub( here ), broken_mon );
 
     if( z.type->has_flag( mon_flag_DROPS_AMMO ) ) {
         for( const std::pair<const itype_id, int> &ammo_entry : z.ammo ) {
@@ -262,14 +262,14 @@ void mdeath::broken( map *here, monster &z )
                                 mags.insert( mags.end(), mag );
                                 ammo_count -= mag.type->magazine->capacity;
                             }
-                            here->spawn_items( here->get_bub( z.pos_abs() ), mags );
+                            here->spawn_items( z.pos_bub( here ), mags );
                             spawned = true;
                             break;
                         }
                     }
                 }
                 if( !spawned ) {
-                    here->spawn_item( here->get_bub( z.pos_abs() ), ammo_entry.first, ammo_entry.second, 1,
+                    here->spawn_item( z.pos_bub( here ), ammo_entry.first, ammo_entry.second, 1,
                                       calendar::turn );
                 }
             }
@@ -299,5 +299,5 @@ item_location make_mon_corpse( map *here, monster &z, int damageLvl )
     if( !z.has_eaten_enough() ) {
         corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
     }
-    return here->add_item_ret_loc( here->get_bub( z.pos_abs() ), corpse );
+    return here->add_item_ret_loc( z.pos_bub( here ), corpse );
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2948,7 +2948,7 @@ void monster::die( map *here, Creature *nkiller )
     creature_tracker &creatures = get_creature_tracker();
     if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
         // Need to filter out which limb we were grabbing before death
-        for( const tripoint_bub_ms &player_pos : here->points_in_radius( here->get_bub( pos_abs() ), 1,
+        for( const tripoint_bub_ms &player_pos : here->points_in_radius( pos_bub( here ), 1,
                 0 ) ) {
             Creature *you = creatures.creature_at( here->get_abs( player_pos ) );
             if( !you || !you->has_effect_with_flag( json_flag_GRAB ) ) {
@@ -3083,14 +3083,14 @@ void monster::die( map *here, Creature *nkiller )
             if( corpse ) {
                 corpse->force_insert_item( it, pocket_type::CONTAINER );
             } else {
-                here->add_item_or_charges( here->get_bub( pos_abs() ), it );
+                here->add_item_or_charges( pos_bub( here ), it );
             }
         }
         for( const item &it : dissectable_inv ) {
             if( corpse ) {
                 corpse->put_in( it, pocket_type::CORPSE );
             } else {
-                here->add_item( here->get_bub( pos_abs() ), it );
+                here->add_item( pos_bub( here ), it );
             }
         }
     }
@@ -3213,7 +3213,7 @@ void monster::drop_items_on_death( map *here, item *corpse )
     // for non corpses this is much simpler
     if( !corpse ) {
         for( item &it : new_items ) {
-            here->add_item_or_charges( here->get_bub( pos_abs() ), it );
+            here->add_item_or_charges( pos_bub( here ), it );
         }
         return;
     }
@@ -3814,7 +3814,7 @@ void monster::on_hit( map *here, Creature *source, bodypart_id,
                 continue;
             }
 
-            if( here->sees( here->get_bub( critter.pos_abs() ), here->get_bub( pos_abs() ), light ) ) {
+            if( here->sees( critter.pos_bub( here ), pos_bub( here ), light ) ) {
                 // Anger trumps fear trumps ennui
                 if( critter.type->has_anger_trigger( mon_trigger::FRIEND_ATTACKED ) ) {
                     critter.anger += 15;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2977,7 +2977,7 @@ void npc::die( map *here, Creature *nkiller )
     // Need to unboard from vehicle before dying, otherwise
     // the vehicle code cannot find us
     if( in_vehicle ) {
-        here->unboard_vehicle( here->get_bub( pos_abs() ), true );
+        here->unboard_vehicle( pos_bub( here ), true );
     }
     if( is_mounted() ) {
         monster *critter = mounted_creature.get();
@@ -3288,14 +3288,14 @@ void npc::on_load( map *here )
 
     // for spawned npcs
     gravity_check( here );
-    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, here->get_bub( pos_abs() ) ) &&
-        !here->has_vehicle_floor( here->get_bub( pos_abs() ) ) ) {
+    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub( here ) ) &&
+        !here->has_vehicle_floor( pos_bub( here ) ) ) {
         add_effect( effect_bouldering, 1_turns,  true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
     }
     if( here->veh_at( pos_abs() ).part_with_feature( VPFLAG_BOARDABLE, true ) && !in_vehicle ) {
-        here->board_vehicle( here->get_bub( pos_abs() ), this );
+        here->board_vehicle( pos_bub( here ), this );
     }
     if( has_effect( effect_riding ) && !mounted_creature ) {
         if( const monster *const mon = get_creature_tracker().creature_at<monster>( pos_abs() ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1732,7 +1732,7 @@ void npc::execute_action( npc_action action )
             if( is_hallucination() ) {
                 pretend_fire( this, mode.qty, *mode );
             } else {
-                fire_gun( tar, mode.qty, *mode );
+                fire_gun( &here, tar, mode.qty, *mode );
                 // "discard" the fake bio weapon after shooting it
                 if( is_using_bionic_weapon() ) {
                     discharge_cbm_weapon();

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1605,8 +1605,8 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p, bool spawn_nonlocal
     std::for_each( monster_bucket.first, monster_bucket.second,
     [&]( std::pair<const tripoint_om_sm, monster> &monster_entry ) {
         monster &this_monster = monster_entry.second;
-        const map &here = get_map();
-        const tripoint_bub_ms local = here.get_bub( this_monster.pos_abs() );
+        map &here = get_map();
+        const tripoint_bub_ms local = this_monster.pos_bub( &here );
         // The monster position must be local to the main map when added to the game
         if( !spawn_nonlocal ) {
             cata_assert( here.inbounds( local ) );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -192,7 +192,6 @@ static int RAS_time( const Character &p, const item_location &loc );
 * @param ammo   Ammo used.
 * @param pos    Character position.
 */
-static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_ms &pos );
 static void cycle_action( item &weap, const itype_id &ammo, map *here, const tripoint_bub_ms &pos );
 static void make_gun_sound_effect( const Character &p, bool burst, item *weapon );
 
@@ -2229,11 +2228,6 @@ int RAS_time( const Character &p, const item_location &loc )
         time += opt.moves();
     }
     return time;
-}
-
-static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_ms &pos )
-{
-    cycle_action( weap, ammo, &get_map(), pos );
 }
 
 static void cycle_action( item &weap, const itype_id &ammo, map *here, const tripoint_bub_ms &pos )

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -193,6 +193,7 @@ static int RAS_time( const Character &p, const item_location &loc );
 * @param pos    Character position.
 */
 static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_ms &pos );
+static void cycle_action( item &weap, const itype_id &ammo, map *here, const tripoint_bub_ms &pos );
 static void make_gun_sound_effect( const Character &p, bool burst, item *weapon );
 
 class target_ui
@@ -950,15 +951,18 @@ void npc::pretend_fire( npc *source, int shots, item &gun )
 
 int Character::fire_gun( const tripoint_bub_ms &target, int shots )
 {
+    map &here = get_map();
+
     item_location gun = get_wielded_item();
     if( !gun ) {
         debugmsg( "%s doesn't have a gun to fire", get_name() );
         return 0;
     }
-    return fire_gun( target, shots, *gun, item_location() );
+    return fire_gun( &here, target, shots, *gun, item_location() );
 }
 
-int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, item_location ammo )
+int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, item &gun,
+                         item_location ammo )
 {
     if( !gun.is_gun() ) {
         debugmsg( "%s tried to fire non-gun (%s).", get_name(), gun.tname() );
@@ -992,12 +996,12 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         return 0;
     }
 
-    map &here = get_map();
     // usage of any attached bipod is dependent upon terrain or on being prone
-    bool bipod = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, pos_bub() ) || is_prone();
+    bool bipod = here->has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, pos_bub( here ) ) ||
+                 is_prone();
     if( !bipod ) {
-        if( const optional_vpart_position vp = here.veh_at( pos_bub() ) ) {
-            bipod = vp->vehicle().has_part( pos_bub(), "MOUNTABLE" );
+        if( const optional_vpart_position vp = here->veh_at( pos_bub( here ) ) ) {
+            bipod = vp->vehicle().has_part( pos_bub( here ), "MOUNTABLE" );
         }
     }
 
@@ -1036,8 +1040,8 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         }
 
         // If this is a vehicle mounted turret, which vehicle is it mounted on?
-        const vehicle *in_veh = has_effect( effect_on_roof ) ? veh_pointer_or_null( here.veh_at(
-                                    pos_bub() ) ) : nullptr;
+        const vehicle *in_veh = has_effect( effect_on_roof ) ? veh_pointer_or_null( here->veh_at(
+                                    pos_bub( here ) ) ) : nullptr;
 
         // Add gunshot noise
         make_gun_sound_effect( *this, shots > 1, &gun );
@@ -1056,7 +1060,7 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         dispersion_sources dispersion = total_gun_dispersion( gun, recoil_total(), proj.shot_spread );
 
         dealt_projectile_attack shot;
-        projectile_attack( shot, proj, pos_bub(), aim, dispersion, this, in_veh, wp_attack );
+        projectile_attack( shot, proj, here, pos_bub( here ), aim, dispersion, this, in_veh, wp_attack );
         if( !shot.targets_hit.empty() ) {
             hits++;
         }
@@ -1114,7 +1118,7 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         }
 
         const int required = gun.ammo_required();
-        if( gun.ammo_consume( required, pos_bub(), this ) != required ) {
+        if( gun.ammo_consume( required, here, pos_bub( here ), this ) != required ) {
             debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname() );
             break;
         }
@@ -1122,7 +1126,7 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         // Vehicle turrets drain vehicle battery and do not care about this
         if( !gun.has_flag( flag_VEHICLE ) ) {
             const units::energy energ_req = gun.get_gun_energy_drain();
-            const units::energy drained = gun.energy_consume( energ_req, pos_bub(), this );
+            const units::energy drained = gun.energy_consume( energ_req, here, pos_bub( here ), this );
             if( drained < energ_req ) {
                 debugmsg( "Unexpected shortage of energy whilst firing %s. Required: %i J, drained: %i J",
                           gun.tname(), units::to_joule( energ_req ), units::to_joule( drained ) );
@@ -1131,7 +1135,7 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         }
 
         if( !current_ammo.is_null() ) {
-            cycle_action( gun, current_ammo, pos_bub() );
+            cycle_action( gun, current_ammo, here, pos_bub( here ) );
         }
 
         if( gun_skill == skill_launcher ) {
@@ -2229,18 +2233,22 @@ int RAS_time( const Character &p, const item_location &loc )
 
 static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_ms &pos )
 {
-    map &here = get_map();
+    cycle_action( weap, ammo, &get_map(), pos );
+}
+
+static void cycle_action( item &weap, const itype_id &ammo, map *here, const tripoint_bub_ms &pos )
+{
     // eject casings and linkages in random direction avoiding walls using player position as fallback
     std::vector<tripoint_bub_ms> tiles = closest_points_first( pos, 1 );
     tiles.erase( tiles.begin() );
     tiles.erase( std::remove_if( tiles.begin(), tiles.end(), [&]( const tripoint_bub_ms & e ) {
-        return !here.passable( e );
+        return !here->passable( e );
     } ), tiles.end() );
     tripoint_bub_ms eject{ tiles.empty() ? pos : random_entry( tiles ) };
 
     // for turrets try and drop casings or linkages directly to any CARGO part on the same tile
     const std::optional<vpart_reference> ovp_cargo = weap.has_flag( flag_VEHICLE )
-            ? here.veh_at( pos ).cargo()
+            ? here->veh_at( pos ).cargo()
             : std::nullopt;
 
     item *brass_catcher = weap.gunmod_find_by_flag( flag_BRASS_CATCHER );
@@ -2260,11 +2268,14 @@ static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_m
             } else if( ovp_cargo ) {
                 ovp_cargo->vehicle().add_item( ovp_cargo->part(), casing );
             } else {
-                here.add_item_or_charges( eject, casing );
+                here->add_item_or_charges( eject, casing );
             }
 
-            sfx::play_variant_sound( "fire_gun", "brass_eject", sfx::get_heard_volume( eject ),
-                                     sfx::get_heard_angle( eject ) );
+            // TODO: Refine critera to handle overlapping maps.
+            if( here == &get_map() ) {
+                sfx::play_variant_sound( "fire_gun", "brass_eject", sfx::get_heard_volume( eject ),
+                                         sfx::get_heard_angle( eject ) );
+            }
         }
     }
 
@@ -2277,7 +2288,7 @@ static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_m
             if( ovp_cargo ) {
                 ovp_cargo->items().insert( linkage );
             } else {
-                here.add_item_or_charges( eject, linkage );
+                here->add_item_or_charges( eject, linkage );
             }
         }
     }
@@ -3376,10 +3387,12 @@ void target_ui::set_view_offset( const tripoint_rel_ms &new_offset ) const
 
 void target_ui::update_turrets_in_range()
 {
+    map &here = get_map();
+
     turrets_in_range.clear();
     for( vehicle_part *t : *vturrets ) {
         turret_data td = veh->turret_query( *t );
-        if( td.in_range( dst ) ) {
+        if( td.in_range( here.get_abs( dst ) ) ) {
             tripoint_bub_ms src = veh->bub_part_pos( *t );
             turrets_in_range.push_back( {t, line_to( src, dst )} );
         }

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -201,13 +201,13 @@ int turret_data::range() const
     return res;
 }
 
-bool turret_data::in_range( const tripoint_bub_ms &target ) const
+bool turret_data::in_range( const tripoint_abs_ms &target ) const
 {
     if( !veh || !part ) {
         return false;
     }
     int range = veh->turret_query( *part ).range();
-    int dist = rl_dist( veh->bub_part_pos( *part ), target );
+    int dist = rl_dist( veh->abs_part_pos( *part ), target );
     return range >= dist;
 }
 
@@ -279,7 +279,7 @@ void turret_data::prepare_fire( Character &you )
     }
 }
 
-void turret_data::post_fire( Character &you, int shots )
+void turret_data::post_fire( map *here, Character &you, int shots )
 {
     // remove any temporary recoil adjustments
     you.remove_effect( effect_on_roof );
@@ -310,7 +310,7 @@ void turret_data::post_fire( Character &you, int shots )
     veh->drain( fuel_type_battery, units::to_kilojoule( mode->get_gun_energy_drain() * shots ) );
 }
 
-int turret_data::fire( Character &c, const tripoint_bub_ms &target )
+int turret_data::fire( Character &c, map *here, const tripoint_bub_ms &target )
 {
     if( !veh || !part ) {
         return 0;
@@ -319,8 +319,8 @@ int turret_data::fire( Character &c, const tripoint_bub_ms &target )
     gun_mode mode = base()->gun_current_mode();
 
     prepare_fire( c );
-    shots = c.fire_gun( target, mode.qty, *mode );
-    post_fire( c, shots );
+    shots = c.fire_gun( here, target, mode.qty, *mode );
+    post_fire( here, c, shots );
     return shots;
 }
 
@@ -385,6 +385,8 @@ void vehicle::turrets_override_automatic_aim()
 
 int vehicle::turrets_aim_and_fire( std::vector<vehicle_part *> &turrets )
 {
+    map &here = get_map();
+
     int shots = 0;
     if( turrets_aim( turrets ) ) {
         for( vehicle_part *t : turrets ) {
@@ -392,8 +394,8 @@ int vehicle::turrets_aim_and_fire( std::vector<vehicle_part *> &turrets )
             if( has_target ) {
                 turret_data turret = turret_query( *t );
                 npc &cpu = t->get_targeting_npc( *this );
-                shots += turret.fire( cpu, get_map().get_bub( t->target.second ) );
-                t->reset_target( bub_part_pos( *t ) );
+                shots += turret.fire( cpu, &here, here.get_bub( t->target.second ) );
+                t->reset_target( abs_part_pos( *t ) );
             }
         }
     }
@@ -402,13 +404,15 @@ int vehicle::turrets_aim_and_fire( std::vector<vehicle_part *> &turrets )
 
 bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
 {
+    map &here = get_map();
+
     // Clear existing targets
     for( vehicle_part *t : turrets ) {
         if( !turret_query( *t ) ) {
             debugmsg( "Expected a valid vehicle turret" );
             return false;
         }
-        t->reset_target( bub_part_pos( *t ) );
+        t->reset_target( abs_part_pos( *t ) );
     }
 
     avatar &player_character = get_avatar();
@@ -431,9 +435,11 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
     if( got_target ) {
         tripoint_bub_ms target = trajectory.back();
         // Set target for any turret in range
+        const tripoint_abs_ms abs_target = here.get_abs( target );
+
         for( vehicle_part *t : turrets ) {
-            if( turret_query( *t ).in_range( target ) ) {
-                t->target.second = get_map().get_abs( target );
+            if( turret_query( *t ).in_range( abs_target ) ) {
+                t->target.second = abs_target;
             }
         }
 
@@ -459,6 +465,8 @@ std::vector<vehicle_part *> vehicle::find_all_ready_turrets( bool manual, bool a
 
 void vehicle::turrets_set_targeting()
 {
+    map &here = get_map();
+
     std::vector<vehicle_part *> turrets;
     std::vector<tripoint_bub_ms> locations;
 
@@ -508,7 +516,7 @@ void vehicle::turrets_set_targeting()
 
         // clear the turret's current targets to prevent unwanted auto-firing
         tripoint_bub_ms pos = locations[ sel ];
-        turrets[ sel ]->reset_target( pos );
+        turrets[ sel ]->reset_target( here.get_abs( pos ) );
     }
 }
 
@@ -577,6 +585,8 @@ npc &vehicle_part::get_targeting_npc( vehicle &veh )
 
 int vehicle::automatic_fire_turret( vehicle_part &pt )
 {
+    map &here = get_map();
+
     turret_data gun = turret_query( pt );
 
     int shots = 0;
@@ -622,7 +632,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
         // Manual target not set, find one automatically.
         // BEWARE: Calling turret_data.fire on tripoint min coordinates starts a crash
         //      triggered at `trajectory.insert( trajectory.begin(), source )` at ranged.cpp:236
-        pt.reset_target( pos );
+        pt.reset_target( here.get_abs( pos ) );
         int boo_hoo;
 
         // TODO: calculate chance to hit and cap range based upon this
@@ -653,7 +663,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
 
     } else {
         // Target is already set, make sure we didn't move after aiming (it's a bug if we did).
-        if( pos != get_map().get_bub( target.first ) ) {
+        if( pos != here.get_bub( target.first ) ) {
             target.second = target.first;
             debugmsg( "%s moved after aiming but before it could fire.", cpu.get_name() );
             return shots;
@@ -661,10 +671,10 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
     }
 
     // Get the turret's target and reset it
-    tripoint_bub_ms targ( get_map().get_bub( target.second ) );
-    pt.reset_target( pos );
+    tripoint_bub_ms targ( here.get_bub( target.second ) );
+    pt.reset_target( here.get_abs( pos ) );
 
-    shots = gun.fire( cpu, targ );
+    shots = gun.fire( cpu, &here, targ );
 
     if( shots && u_see ) {
         add_msg_if_player_sees( targ, _( "The %1$s fires its %2$s!" ), name, pt.name() );

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -301,13 +301,13 @@ void turret_data::post_fire( map *here, Character &you, int shots )
 
     // handle draining of vehicle tanks or batteries, if applicable
     if( uses_vehicle_tanks_or_batteries() ) {
-        veh->drain( ammo_current(), mode->ammo_required() * shots );
+        veh->drain( here, ammo_current(), mode->ammo_required() * shots );
         mode->ammo_unset();
 
         clear_mag_wells( *base() );
     }
 
-    veh->drain( fuel_type_battery, units::to_kilojoule( mode->get_gun_energy_drain() * shots ) );
+    veh->drain( here, fuel_type_battery, units::to_kilojoule( mode->get_gun_energy_drain() * shots ) );
 }
 
 int turret_data::fire( Character &c, map *here, const tripoint_bub_ms &target )

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -337,7 +337,7 @@ struct vehicle_part {
          * @param pos current reality bubble location of part from which ammo is being consumed
          * @return amount consumed which will be between 0 and specified qty
          */
-        int ammo_consume( int qty, const tripoint_bub_ms &pos );
+        int ammo_consume( int qty, map *here, const tripoint_bub_ms &pos );
 
         /**
          * Consume fuel by energy content.
@@ -394,7 +394,7 @@ struct vehicle_part {
         void unset_crew();
 
         /** Reset the target for this part. */
-        void reset_target( const tripoint_bub_ms &pos );
+        void reset_target( const tripoint_abs_ms &pos );
 
         /**
          * @name Part capabilities
@@ -641,7 +641,7 @@ class turret_data
          * Check if target is in range of this turret (considers current ammo)
          * Assumes this turret's status is 'ready'
          */
-        bool in_range( const tripoint_bub_ms &target ) const;
+        bool in_range( const tripoint_abs_ms &target ) const;
 
         /**
          * Prepare the turret for firing, called by firing function.
@@ -656,7 +656,7 @@ class turret_data
          * @param p the player that just fired (or attempted to fire) the turret.
          * @param shots the number of shots fired by the most recent call to turret::fire.
          */
-        void post_fire( Character &you, int shots );
+        void post_fire( map *here, Character &you, int shots );
 
         /**
          * Fire the turret's gun at a given target.
@@ -664,7 +664,7 @@ class turret_data
          * @param target coordinates that will be fired on.
          * @return the number of shots actually fired (may be zero).
          */
-        int fire( Character &c, const tripoint_bub_ms &target );
+        int fire( Character &c, map *here, const tripoint_bub_ms &target );
 
         bool can_reload() const;
         bool can_unload() const;
@@ -1465,6 +1465,9 @@ class vehicle
         // drains a fuel type (e.g. for the kitchen unit)
         // returns amount actually drained, does not engage reactor
         int drain( const itype_id &ftype, int amount,
+                   const std::function<bool( vehicle_part & )> &filter = return_true< vehicle_part &>,
+                   bool apply_loss = true );
+        int drain( map *here, const itype_id &ftype, int amount,
                    const std::function<bool( vehicle_part & )> &filter = return_true< vehicle_part &>,
                    bool apply_loss = true );
         int drain( int index, int amount, bool apply_loss = true );

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -361,7 +361,7 @@ void vehicle_part::ammo_unset()
     }
 }
 
-int vehicle_part::ammo_consume( int qty, const tripoint_bub_ms &pos )
+int vehicle_part::ammo_consume( int qty, map *here, const tripoint_bub_ms &pos )
 {
     if( is_tank() && !base.empty() ) {
         const int res = std::min( ammo_remaining(), qty );
@@ -372,7 +372,7 @@ int vehicle_part::ammo_consume( int qty, const tripoint_bub_ms &pos )
         }
         return res;
     }
-    return base.ammo_consume( qty, pos, nullptr );
+    return base.ammo_consume( qty, here, pos, nullptr );
 }
 
 units::energy vehicle_part::consume_energy( const itype_id &ftype, units::energy wanted_energy )
@@ -553,11 +553,10 @@ void vehicle_part::unset_crew()
     crew_id = character_id();
 }
 
-void vehicle_part::reset_target( const tripoint_bub_ms &pos )
+void vehicle_part::reset_target( const tripoint_abs_ms &pos )
 {
-    const tripoint_abs_ms tgt = get_map().get_abs( pos );
-    target.first = tgt;
-    target.second = tgt;
+    target.first = pos;
+    target.second = pos;
 }
 
 bool vehicle_part::is_engine() const

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -75,7 +75,7 @@ TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
     clear_vehicles(); // extra safety
     here.add_vehicle( vehicle_prototype_character_volume_test_car, test_pos, 0_degrees, 0, 0 );
     you.setpos( test_pos );
-    const optional_vpart_position vp_there = here.veh_at( here.get_bub( you.pos_abs() ) );
+    const optional_vpart_position vp_there = here.veh_at( you.pos_bub( &here ) );
     REQUIRE( vp_there );
     tripoint_abs_ms dest_loc = you.pos_abs();
 

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -1240,7 +1240,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     for( loop = 0; loop < 1000; loop++ ) {
         arm_shooter( get_avatar(), itype_shotgun_s );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( target_pos, 1, *get_avatar().get_wielded_item() );
+        get_avatar().fire_gun( &here, target_pos, 1, *get_avatar().get_wielded_item() );
         if( !npc_dst_ranged.get_value( "test_event_last_event" ).empty() ) {
             break;
         }
@@ -1259,7 +1259,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     for( loop = 0; loop < 1000; loop++ ) {
         arm_shooter( get_avatar(), itype_shotgun_s );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( mon_dst_ranged.pos_bub(), 1, *get_avatar().get_wielded_item() );
+        get_avatar().fire_gun( &here, mon_dst_ranged.pos_bub(), 1, *get_avatar().get_wielded_item() );
         if( !mon_dst_ranged.get_value( "test_event_last_event" ).empty() ) {
             break;
         }

--- a/tests/morale_test.cpp
+++ b/tests/morale_test.cpp
@@ -257,6 +257,8 @@ TEST_CASE( "player_morale_kills_hostile_bandit", "[player_morale]" )
 
 TEST_CASE( "player_morale_ranged_kill_of_unaware_hostile_bandit", "[player_morale]" )
 {
+    map &here = get_map();
+
     clear_avatar();
     avatar &player = get_avatar();
     // Set the time to midnight to ensure the bandit doesn't notice the player.
@@ -275,7 +277,7 @@ TEST_CASE( "player_morale_ranged_kill_of_unaware_hostile_bandit", "[player_moral
         player.set_body();
         arm_shooter( player, itype_shotgun_s );
         player.recoil = 0;
-        player.fire_gun( bandit_pos, 1, *player.get_wielded_item() );
+        player.fire_gun( &here, bandit_pos, 1, *player.get_wielded_item() );
         if( badguy.is_dead_state() ) {
             break;
         }

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -508,7 +508,7 @@ static void shoot_monster( const itype_id &gun_type, const std::vector<itype_id>
         shooter->recoil = 0;
         monster &mon = spawn_test_monster( monster_type, monster_pos, false );
         const int prev_HP = mon.get_hp();
-        shooter->fire_gun( monster_pos, 1, *shooter->get_wielded_item() );
+        shooter->fire_gun( &here, monster_pos, 1, *shooter->get_wielded_item() );
         damage.add( prev_HP - mon.get_hp() );
         if( other_checks ) {
             other_check_success += other_checks( *shooter, mon );

--- a/tests/reload_time_test.cpp
+++ b/tests/reload_time_test.cpp
@@ -32,6 +32,8 @@ static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
 static void check_reload_time( const itype_id &weapon, const itype_id &ammo,
                                const itype_id &container, int expected_moves )
 {
+    map &here = get_map();
+
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     const tripoint_bub_ms spot( 61, 60, 0 );
     clear_map();
@@ -59,7 +61,7 @@ static void check_reload_time( const itype_id &weapon, const itype_id &ammo,
     CAPTURE( shooter.used_weapon()->get_reload_time() );
     aim_activity_actor act = aim_activity_actor::use_wielded();
     int moves_before = shooter.get_moves();
-    REQUIRE( shooter.fire_gun( spot, 1, *shooter.used_weapon(), shooter.ammo_location ) );
+    REQUIRE( shooter.fire_gun( &here, spot, 1, *shooter.used_weapon(), shooter.ammo_location ) );
     int moves_after = shooter.get_moves();
     int spent_moves = moves_before - moves_after;
     int expected_upper = expected_moves * 1.05;

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -188,7 +188,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
     // Remove all items from cargo to normalize weight.
     for( const vpart_reference &vp : veh.get_all_parts() ) {
         veh_ptr->get_items( vp.part() ).clear();
-        vp.part().ammo_consume( vp.part().ammo_remaining(), vp.pos_bub() );
+        vp.part().ammo_consume( vp.part().ammo_remaining(), &here, vp.pos_bub() );
     }
     for( const vpart_reference &vp : veh.get_avail_parts( "OPENABLE" ) ) {
         veh.close( vp.part_index() );

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -104,7 +104,8 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             int shots_fired = 0;
             // 3 attempts to fire, to account for possible misfires
             for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {
-                shots_fired += qry.fire( player_character, player_character.pos_bub() + point( qry.range(), 0 ) );
+                shots_fired += qry.fire( player_character, &here, player_character.pos_bub() + point( qry.range(),
+                                         0 ) );
             }
             CHECK( shots_fired > 0 );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Convert operations to be aware of which map they act on, rather than just assume it's the reality bubble one.
This PR starts with a few vehicle related operations which are converted to take a map parameter together with a relative position on that map. Usages are converted (frequently by fetching the reality bubble map at the top of their operations to signal that this is the assumed map (for further conversion at a later stage).
The process involves digging through the operations called from the now map aware operations to make those operations map aware as well, frequently by introducing an overload of the original operation that, again, is assumed to use the reality bubble map. This is done transitively until everything downstream has been converted.
The transitive conversion effort makes the flawed assumption that map methods actually work on the object itself rather than sometimes and spottily at the reality bubble. Handling of that is left for later PRs.

It should be noted that no functional changes should happen when the map operated on is the reality bubble, while operations on the correct map might affect mapgen and explosions (the two cases of usages of other maps). It's unlikely the operations modified this time are used in those contexts, though.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Mostly described in the previous section.
A few bub coordinate using operations in vehicle.h were converted.
In addition to that, a new `pos_bub (map* here)` operation was introduced for creatures for convenience and usages of `here->get_bub(critter.pos_abs())` were converted to use this shorter but equivalent pattern instead.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkey, smash into stationary vehicle. Nothing odd seen. Not a great test, though, as little to nothing of the changed code would be executed by it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
