### PR TITLE
Remove morale penalty from dismemberment

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -625,8 +625,8 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
                           corpse.in_species( species_HUMAN ) ||
                           corpse.in_species( species_FERAL );
 
-    // applies to all butchery actions except for dissections
-    if( is_human && action != butcher_type::DISSECT && !you.okay_with_eating_humans() ) {
+    // applies to all butchery actions except for dissections or dismemberment
+    if( is_human && action != butcher_type::DISSECT && !you.okay_with_eating_humans() && action != butcher_type::DISMEMBER) {
         //first determine if the butcherer has the dissect_humans proficiency.
         if( you.has_proficiency( proficiency_prof_dissect_humans ) ) {
             //if it's player doing the butchery, ask them first.
@@ -1395,7 +1395,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
     // therefore operations on this activity's targets and values may be invalidated.
     // reveal hidden items / hidden content
     if( action != butcher_type::FIELD_DRESS && action != butcher_type::SKIN &&
-        action != butcher_type::BLEED ) {
+        action != butcher_type::BLEED && action != butcher_tyoe:: DISMEMBER) {
         for( item *content : corpse_item->all_items_top( pocket_type::CONTAINER ) ) {
             if( ( roll_butchery_dissect( round( you.get_average_skill_level( skill_survival ) ), you.dex_cur,
                                          tool_quality ) + 10 ) * 5 > rng( 0, 100 ) ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1129,9 +1129,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
         }
         // RIP AND TEAR
         if( action == butcher_type::DISMEMBER ) {
-
             roll = 0;
-
         }
         // field dressing ignores skin, flesh, and blood
         if( action == butcher_type::FIELD_DRESS ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1130,7 +1130,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
         // RIP AND TEAR
         if( action == butcher_type::DISMEMBER ) {
             if( entry.type == harvest_drop_flesh ) {
-                roll /= 6;
+                roll == 0;
             } else {
                 continue;
             }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1129,11 +1129,9 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
         }
         // RIP AND TEAR
         if( action == butcher_type::DISMEMBER ) {
-            if( entry.type == harvest_drop_flesh ) {
+
                 roll == 0;
-            } else {
-                continue;
-            }
+
         }
         // field dressing ignores skin, flesh, and blood
         if( action == butcher_type::FIELD_DRESS ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1396,7 +1396,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
     // therefore operations on this activity's targets and values may be invalidated.
     // reveal hidden items / hidden content
     if( action != butcher_type::FIELD_DRESS && action != butcher_type::SKIN &&
-        action != butcher_type::BLEED && action != butcher_tyoe:: DISMEMBER ) {
+        action != butcher_type::BLEED && action != butcher_type:: DISMEMBER ) {
         for( item *content : corpse_item->all_items_top( pocket_type::CONTAINER ) ) {
             if( ( roll_butchery_dissect( round( you.get_average_skill_level( skill_survival ) ), you.dex_cur,
                                          tool_quality ) + 10 ) * 5 > rng( 0, 100 ) ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -626,7 +626,8 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
                           corpse.in_species( species_FERAL );
 
     // applies to all butchery actions except for dissections or dismemberment
-    if( is_human && action != butcher_type::DISSECT && !you.okay_with_eating_humans() && action != butcher_type::DISMEMBER) {
+    if( is_human && action != butcher_type::DISSECT && !you.okay_with_eating_humans() &&
+        action != butcher_type::DISMEMBER ) {
         //first determine if the butcherer has the dissect_humans proficiency.
         if( you.has_proficiency( proficiency_prof_dissect_humans ) ) {
             //if it's player doing the butchery, ask them first.
@@ -1395,7 +1396,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
     // therefore operations on this activity's targets and values may be invalidated.
     // reveal hidden items / hidden content
     if( action != butcher_type::FIELD_DRESS && action != butcher_type::SKIN &&
-        action != butcher_type::BLEED && action != butcher_tyoe:: DISMEMBER) {
+        action != butcher_type::BLEED && action != butcher_tyoe:: DISMEMBER ) {
         for( item *content : corpse_item->all_items_top( pocket_type::CONTAINER ) ) {
             if( ( roll_butchery_dissect( round( you.get_average_skill_level( skill_survival ) ), you.dex_cur,
                                          tool_quality ) + 10 ) * 5 > rng( 0, 100 ) ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1130,7 +1130,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
         // RIP AND TEAR
         if( action == butcher_type::DISMEMBER ) {
 
-            roll == 0;
+            roll = 0;
 
         }
         // field dressing ignores skin, flesh, and blood

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1130,7 +1130,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
         // RIP AND TEAR
         if( action == butcher_type::DISMEMBER ) {
 
-                roll == 0;
+            roll == 0;
 
         }
         // field dressing ignores skin, flesh, and blood


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Removed morale penalties and rare drops from dismemberment"
<!-- This section should consist of exactly one line, edit the one above.-->


#### Purpose of change

Allows dismemberment to remain a solution to keeping acid zombie corpses down for any character regardless of traits. Removing rare drops balances this change. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
There was already an exception to how the morale penalties and rare drops should be handled in the case of dissection. I simply  added dismemberment to the list of exceptions.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Reworking acid zombies, or adding a new "careful pulp" mechanic would also have worked.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opened a world, killed and dismembered a zombie.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
