### PR TITLE
Fixing bounding box errors

### DIFF
--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -373,18 +373,16 @@ static bool mx_helicopter( map &m, const tripoint_abs_sm &abs_sub )
         // we can rotate it and calculate its bounding box, but don't place it on the map.
         vehicle veh( crashed_hull );
         veh.turn( dir1 );
-        // Get the bounding box, centered on mount(0,0), move the wreckage forward/backward
-        // half it's length so that it spawns more over the center of the debris area
+        // Find where the center of the vehicle is and adjust the spawn position to get it centered in the
+        // debris area.
         const bounding_box bbox = veh.get_bounding_box();
-        const point_rel_ms length( std::abs( bbox.p2.x() - bbox.p1.x() ),
-                                   std::abs( bbox.p2.y() - bbox.p1.y() ) );
-        const point_rel_ms offset( veh.dir_vec().x * length.x() / 2, veh.dir_vec().y * length.y() / 2 );
-        const point_rel_ms min( std::abs( bbox.p1.x() ), std::abs( bbox.p1.y() ) );
-        const int x_max = SEEX * 2 - bbox.p2.x() - 1;
-        const int y_max = SEEY * 2 - bbox.p2.y() - 1;
 
+        point_rel_ms center_offset = {( bbox.p1.x() + bbox.p2.x() ) / 2, ( bbox.p1.y() + bbox.p2.y() ) / 2};
         // Clamp x1 & y1 such that no parts of the vehicle extend over the border of the submap.
-        wreckage_pos = { clamp( c.x() + offset.x(), min.x(), x_max ), clamp( c.y() + offset.y(), min.y(), y_max ), abs_sub.z()};
+
+        wreckage_pos = { clamp( c.x() - center_offset.x(), abs( bbox.p1.x() ), SEEX * 2 - 1 - abs( bbox.p2.x() ) ),
+                         clamp( c.y() - center_offset.y(), abs( bbox.p1.y() ), SEEY * 2 - 1 - abs( bbox.p2.y() ) ), abs_sub.z()
+                       };
     }
 
     vehicle *wreckage = m.add_vehicle( crashed_hull, wreckage_pos, dir1, rng( 1, 33 ), 1 );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1902,15 +1902,15 @@ bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
 
     bounding_box vehicle_box = get_bounding_box( false, true );
     bounding_box target_vehicle_box = veh_target.get_bounding_box( false, true );
-
-    bounding_box combined_box;
-    combined_box.p1 = point_rel_ms( std::min( vehicle_box.p1.x(), target_vehicle_box.p1.x() ),
-                                    std::min( vehicle_box.p1.y(), target_vehicle_box.p1.y() ) );
-    combined_box.p2 = point_rel_ms( std::max( vehicle_box.p2.x(), target_vehicle_box.p2.x() ),
-                                    std::max( vehicle_box.p2.y(), target_vehicle_box.p2.y() ) );
+    const point_bub_ms min = { std::min( pos_bub().x() + vehicle_box.p1.x(), veh_target.pos_bub().x() + target_vehicle_box.p1.x() ),
+                               std::min( pos_bub().y() + vehicle_box.p1.y(), veh_target.pos_bub().y() + target_vehicle_box.p1.y() )
+                             };
+    const point_bub_ms max = { std::max( pos_bub().x() + vehicle_box.p1.x(), veh_target.pos_bub().x() + target_vehicle_box.p1.x() ),
+                               std::max( pos_bub().y() + vehicle_box.p1.y(), veh_target.pos_bub().y() + target_vehicle_box.p1.y() )
+                             };
     point_rel_ms size;
-    size.x() = std::abs( ( combined_box.p2 - combined_box.p1 ).x() ) + 1;
-    size.y() = std::abs( ( combined_box.p2 - combined_box.p1 ).y() ) + 1;
+    size.x() = std::abs( ( max - min ).x() ) + 1;
+    size.y() = std::abs( ( max - min ).y() ) + 1;
 
     //Make sure the resulting vehicle would not be too large
     if( size.x() <= MAX_WIRE_VEHICLE_SIZE && size.y() <= MAX_WIRE_VEHICLE_SIZE ) {
@@ -8256,17 +8256,13 @@ bounding_box vehicle::get_bounding_box( bool use_precalc, bool no_fake )
         point_rel_ms pt;
         if( use_precalc ) {
             const int i_use = 0;
-            // TODO: Check if this is correct. part_at takes a vehicle relative position, not a bub one...
-            // int part_idx = part_at((p - pos_abs()).xy()); // Suggested correction.
-            int part_idx = part_at( rebase_rel( get_map().get_bub( p ).xy() ) );
+            int part_idx = part_at( ( p - pos_abs() ).xy() );
             if( part_idx < 0 ) {
                 continue;
             }
             pt = parts[part_idx].precalc[i_use].xy();
         } else {
-            // TODO: Check if this is correct. part_at takes a vehicle relative position, not a bub one...
-            // pt = (p - pos_abs()).xy(); // Suggested correction.
-            pt = rebase_rel( get_map().get_bub( p ).xy() );
+            pt = ( p - pos_abs() ).xy();
         }
         if( pt.x() < min_x ) {
             min_x = pt.x();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Change vehicle::bounding_box to produce what it says it should produce.
- Fix heli crash mx.
- Fix appliance merge usage of bounding box to work with the corrected version.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Change bounding_box to return the stated relative boundaries of the box, rather than the bubble coordinates of the same.
- Fix the heli crash mx logic to use the bounding box rather than just assume it's symmetric around the nominal position of the craft. This wasn't strictly necessary.
- Fix the appliance merge to compensate for the missing bubble coordinates.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Generated a bunch of heli crash mx, and they look reasonable.
![Screenshot (645)](https://github.com/user-attachments/assets/2e36eb2e-6ed6-4883-ba3a-8a09954d5456)

The merging was harder to test, because the variables involved were optimized away (so I couldn't compare the original values before the change to those after). Tested by revealing a bunch of wires at a farming supply store and merged them by revealing the part in between them. However, that worked even before the bubble position compensation was added, so that doesn't show too much.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The heli crash mx just happened to work because the default position of a vehicle object is the zero point, so the offsets become the only components of the resultant coordinates.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
