### PR TITLE
Remove some more POLEARMS category from spears

### DIFF
--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -713,7 +713,7 @@
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
     "flags": [ "DURABLE_MELEE", "POLEARM", "SPEAR", "REACH_ATTACK", "REACH3", "NONCONDUCTIVE", "ALWAYS_TWOHAND" ],
-    "weapon_category": [ "POLEARMS" ],
+    "weapon_category": [ "SPEARS" ],
     "category": "weapons",
     "melee_damage": { "bash": 9, "stab": 28 }
   },

--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -217,7 +217,7 @@
     "qualities": [ [ "CUT", 1 ], [ "COOK", 1 ], [ "BUTCHER", -28 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
     "flags": [ "SPEAR", "REACH_ATTACK", "NONCONDUCTIVE", "SHEATH_SPEAR" ],
-    "weapon_category": [ "POLEARMS", "SPEARS" ],
+    "weapon_category": [ "SPEARS" ],
     "melee_damage": { "bash": 4, "stab": 26 }
   },
   {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Same as #76590 

#### Describe the solution

Remove polearms category from makeshift knife spear and pike.

#### Describe alternatives you've considered


#### Testing

`make style-json`

Launched the game, learned silat via debug, checked that makeshift knife spear didn't appear in polearms list

#### Additional context
