### PR TITLE
Sky Island vampire compatibility

### DIFF
--- a/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs.json
+++ b/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs.json
@@ -44,5 +44,92 @@
       }
     ],
     "false_effect": [ { "u_message": "You don't have enough ruach to dedicate any to increasing your powers!", "type": "bad" } ]
+  },
+  {
+    "type": "mutation",
+    "id": "START_AS_VAMPIRE",
+    "name": { "str": "Starting as a vampire", "//~": "NO_I18N" },
+    "description": {
+      "str": "This makes you start with the vampvirus effect.  This has no effect if gained after the game started.",
+      "//~": "NO_I18N"
+    },
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": false
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XE_VAMPIRE_START",
+    "eoc_type": "EVENT",
+    "required_event": "game_start",
+    "condition": { "u_has_trait": "START_AS_VAMPIRE" },
+    "effect": [ { "u_add_effect": "vampire_virus", "intensity": 1, "duration": "PERMANENT" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UNLOCK_TIER_4_VAMPIRE_RECIPE",
+    "//": "Gives the tier 4 recipe to tier 3 vampires. The tier-up recipes are not automatically used, as the player might want to create them ASAP but pospone their use.",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_enters_omt",
+    "condition": { "and": [ { "u_has_trait": "VAMPIRE3" }, { "u_at_om_location": "sky_island_core" } ] },
+    "effect": [
+      {
+        "u_message": "Your potent vampirism has been noticed.  The island has given you the knowledge to push your vampirism even further, should you want to.\n\nBe warned that once you use this item, you will remain a vampire forevermore.",
+        "popup": true
+      },
+      { "u_learn_recipe": "upgradekey_vampire4" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SKY_ISLAND_VAMPIRE_TIER_4",
+    "effect": [
+      { "u_remove_item_with": "upgradekey_vampire4", "count": 1 },
+      { "u_forget_recipe": "upgradekey_vampire4" },
+      { "u_add_trait": "VAMPIRE4" },
+      { "run_eocs": "EOC_REMOVE_DREAM_MAGIC" },
+      { "u_add_effect": "vampire_virus_ascendant", "intensity": 1, "duration": "PERMANENT" },
+      { "u_message": "Your eyes redden even more as you pass a point of no return.", "type": "mixed" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UNLOCK_TIER_5_VAMPIRE_RECIPE",
+    "required_event": "gains_mutation",
+    "eoc_type": "EVENT",
+    "condition": { "compare_string": [ "VAMPIRE4", { "context_val": "trait" } ] },
+    "effect": [
+      { "u_learn_recipe": "upgradekey_vampire5" },
+      { "u_learn_recipe": "upgradekey_bloodgift_research" },
+      {
+        "u_message": "You have deecided to embrace your new condition, and the island has responded by giving you the knowledge to reach the apex of vampirism, should you find the required components.",
+        "popup": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SKY_ISLAND_VAMPIRE_TIER_5",
+    "effect": [
+      { "u_remove_item_with": "upgradekey_vampire5", "count": 1 },
+      { "u_forget_recipe": "upgradekey_vampire5" },
+      { "u_add_trait": "BLOOD_DRINKER" },
+      { "u_add_effect": "vampire_virus_post_mortal", "intensity": 1, "duration": "PERMANENT" },
+      {
+        "u_message": "Your thirst for blood grows, and so does your power, as you reach the final state of vampirism.",
+        "type": "mixed"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SKY_ISLAND_VAMPIRE_GIFT_RESEARCH",
+    "effect": [
+      { "u_remove_item_with": "upgradekey_bloodgift_research", "count": 1 },
+      { "u_forget_recipe": "upgradekey_bloodgift_research" },
+      { "u_learn_recipe": "xe_vampire_blood_gift_research" },
+      { "u_message": "You learn how to expand your blood gifts.", "type": "good" }
+    ]
   }
 ]

--- a/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs.json
+++ b/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs.json
@@ -72,20 +72,27 @@
     "//": "Gives the tier 4 recipe to tier 3 vampires. The tier-up recipes are not automatically used, as the player might want to create them ASAP but pospone their use.",
     "eoc_type": "EVENT",
     "required_event": "avatar_enters_omt",
-    "condition": { "and": [ { "u_has_trait": "VAMPIRE3" }, { "u_at_om_location": "sky_island_core" } ] },
+    "condition": {
+      "and": [
+        { "not": { "compare_string": [ "yes", { "u_val": "know_tier_4_recipes" } ] } },
+        { "u_has_trait": "VAMPIRE3" },
+        { "u_at_om_location": "sky_island_core" }
+      ]
+    },
     "effect": [
       {
         "u_message": "Your potent vampirism has been noticed.  The island has given you the knowledge to push your vampirism even further, should you want to.\n\nBe warned that once you use this item, you will remain a vampire forevermore.",
         "popup": true
       },
-      { "u_learn_recipe": "upgradekey_vampire4" }
+      { "u_learn_recipe": "upgradekey_vampire4" },
+      { "u_add_var": "know_tier_4_recipes", "value": "yes" }
     ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_SKY_ISLAND_VAMPIRE_TIER_4",
     "effect": [
-      { "u_remove_item_with": "upgradekey_vampire4", "count": 1 },
+      { "u_remove_item_with": "upgradekey_vampire4" },
       { "u_forget_recipe": "upgradekey_vampire4" },
       { "u_add_trait": "VAMPIRE4" },
       { "run_eocs": "EOC_REMOVE_DREAM_MAGIC" },
@@ -96,23 +103,30 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_UNLOCK_TIER_5_VAMPIRE_RECIPE",
-    "required_event": "gains_mutation",
     "eoc_type": "EVENT",
-    "condition": { "compare_string": [ "VAMPIRE4", { "context_val": "trait" } ] },
+    "required_event": "avatar_enters_omt",
+    "condition": {
+      "and": [
+        { "not": { "compare_string": [ "yes", { "u_val": "know_tier_5_recipes" } ] } },
+        { "u_has_trait": "VAMPIRE4" },
+        { "u_at_om_location": "sky_island_core" }
+      ]
+    },
     "effect": [
       { "u_learn_recipe": "upgradekey_vampire5" },
       { "u_learn_recipe": "upgradekey_bloodgift_research" },
       {
-        "u_message": "You have deecided to embrace your new condition, and the island has responded by giving you the knowledge to reach the apex of vampirism, should you find the required components.",
+        "u_message": "You have decided to embrace your new condition, and the island has responded by giving you the knowledge to reach the apex of vampirism, should you find the required components.",
         "popup": true
-      }
+      },
+      { "u_add_var": "know_tier_5_recipes", "value": "yes" }
     ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_SKY_ISLAND_VAMPIRE_TIER_5",
     "effect": [
-      { "u_remove_item_with": "upgradekey_vampire5", "count": 1 },
+      { "u_remove_item_with": "upgradekey_vampire5" },
       { "u_forget_recipe": "upgradekey_vampire5" },
       { "u_add_trait": "BLOOD_DRINKER" },
       { "u_add_effect": "vampire_virus_post_mortal", "intensity": 1, "duration": "PERMANENT" },
@@ -126,7 +140,7 @@
     "type": "effect_on_condition",
     "id": "EOC_SKY_ISLAND_VAMPIRE_GIFT_RESEARCH",
     "effect": [
-      { "u_remove_item_with": "upgradekey_bloodgift_research", "count": 1 },
+      { "u_remove_item_with": "upgradekey_bloodgift_research" },
       { "u_forget_recipe": "upgradekey_bloodgift_research" },
       { "u_learn_recipe": "xe_vampire_blood_gift_research" },
       { "u_message": "You learn how to expand your blood gifts.", "type": "good" }

--- a/data/mods/Sky_Island/mod_interactions/xedra_evolved/hobbies.json
+++ b/data/mods/Sky_Island/mod_interactions/xedra_evolved/hobbies.json
@@ -16,5 +16,16 @@
     "description": "For most or all of your life, you've had a secret; you are a predator.  While you don't need to drink blood or eat flesh or anything so crude, you must absorb the spiritual essence, the \"ruach\", of living beings in order to maintain your health and vitality.  You had to hide your condition before the Cataclysm, especially as things became stranger in the years leading up to it, but now you don't have to hide anymore.  On the other hand, your potential ruach supply has taken a drastic decline.",
     "points": 3,
     "traits": [ "LILIN_TRAITS", "LILIN_DRAIN_RUACH_MELEE" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "SKY_ISLAND_VAMPIRE",
+    "name": "Vampire",
+    "description": "As if the world ending and you being stranded on some flying island away from everything wasn't bad enough, you now feel a growing hunger for the blood of others.  Whether you decide to try and cure it or see what abilities can be gained from this condition is up to you.",
+    "//": "Doesn't give the vampire trait itself to give a grace period before that extra need kicks in.",
+    "//2": "Intentionally compatible with anything not blocking vampirism, and anything not compatible with vampirism will simply remove the effect without issue.",
+    "points": 3,
+    "traits": [ "START_AS_VAMPIRE" ]
   }
 ]

--- a/data/mods/Sky_Island/mod_interactions/xedra_evolved/recipes.json
+++ b/data/mods/Sky_Island/mod_interactions/xedra_evolved/recipes.json
@@ -27,7 +27,7 @@
     "difficulty": 0,
     "time": "15 m",
     "//": "Yes, this recipe is intended to ask for one red and one black sinister cloak, even if they can turn into each other.",
-    "//2": "This recipe isn't too costly, as it comes with the cost of being struck as a vampire forever.",
+    "//2": "This recipe isn't too costly, as it comes with the cost of being stuck as a vampire forever.",
     "flags": [ "SECRET", "BLIND_EASY" ],
     "reversible": false,
     "tools": [ [ [ "fakeitem_statue", -1 ] ] ],

--- a/data/mods/Sky_Island/mod_interactions/xedra_evolved/recipes.json
+++ b/data/mods/Sky_Island/mod_interactions/xedra_evolved/recipes.json
@@ -1,0 +1,135 @@
+[
+  {
+    "id": "upgradekey_vampire4",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Vampiric Amplificator" },
+    "description": "This strange metaphysical artifact will push your vampirism beyond the point of no return when you will use it.\n\nUnlike most things you can craft out of warp shards, this item won't be used automatically after you made it, so you can create it then take your time to decide if you really want to do this.",
+    "volume": "250 ml",
+    "weight": "150 g",
+    "longest_side": "9 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white",
+    "use_action": {
+      "type": "effect_on_conditions",
+      "description": "Empower your vampirism.",
+      "effect_on_conditions": [ "EOC_SKY_ISLAND_VAMPIRE_TIER_4" ]
+    }
+  },
+  {
+    "result": "upgradekey_vampire4",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "//": "Yes, this recipe is intended to ask for one red and one black sinister cloak, even if they can turn into each other.",
+    "//2": "This recipe isn't too costly, as it comes with the cost of being struck as a vampire forever.",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "warptoken", 25 ] ],
+      [ [ "blood", 10 ], [ "demihuman_blood", 10 ], [ "mutant_human_blood", 10 ], [ "fae_blood", 10 ] ],
+      [ [ "vacutainer", 5 ] ],
+      [ [ "sinister_gown", 1 ] ],
+      [ [ "sinister_cane", 1 ] ],
+      [ [ "sinister_dress", 1 ] ],
+      [ [ "sinister_dress_short", 1 ] ],
+      [ [ "cloak_vampire_red", 1 ] ],
+      [ [ "cloak_vampire", 1 ] ]
+    ]
+  },
+  {
+    "id": "upgradekey_vampire5",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Superior Vampiric Amplificator" },
+    "description": "This strange metaphysical artifact will push your vampirism to its absolute limit.\n\nAs per the previous vampiric amplificator, you have to decide to use the crafted item for its effect to apply.",
+    "volume": "250 ml",
+    "weight": "150 g",
+    "longest_side": "9 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white",
+    "use_action": {
+      "type": "effect_on_conditions",
+      "description": "Empower your vampirism.",
+      "effect_on_conditions": [ "EOC_SKY_ISLAND_VAMPIRE_TIER_5" ]
+    }
+  },
+  {
+    "result": "upgradekey_vampire5",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "//": "It might seem a little, but the multiple short-lived components and the rare loot make it a difficult craft.",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "warptoken", 50 ] ],
+      [ [ "blood", 10 ] ],
+      [ [ "demihuman_blood", 10 ] ],
+      [ [ "mutant_human_blood", 10 ] ],
+      [ [ "fae_blood", 10 ] ],
+      [ [ "vampire_fangs", 1 ] ],
+      [ [ "ruby_silver_ring", 1 ] ],
+      [ [ "ruby_silver_tiara", 1 ] ],
+      [ [ "ruby_silver_earring", 1 ] ],
+      [ [ "ruby_silver_bracelet", 1 ] ],
+      [ [ "ruby_silver_pendant_necklace", 1 ] ],
+      [ [ "ruby_silver_cufflinks", 1 ] ]
+    ]
+  },
+  {
+    "id": "upgradekey_bloodgift_research",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Key of Vampiric Knowledge" },
+    "description": "This strange metaphysical artifact will allow you to spend your blood to obtain new blood gifts.\n\nAs per the previous vampiric amplificator, you have to decide to use the crafted item for its effect to apply.",
+    "volume": "250 ml",
+    "weight": "150 g",
+    "longest_side": "9 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white",
+    "use_action": {
+      "type": "effect_on_conditions",
+      "description": "Empower your vampirism.",
+      "effect_on_conditions": [ "EOC_SKY_ISLAND_VAMPIRE_GIFT_RESEARCH" ]
+    }
+  },
+  {
+    "result": "upgradekey_bloodgift_research",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "//": "Books about blood and things made from blood.",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "warptoken", 20 ] ],
+      [ [ "blood", 10 ], [ "demihuman_blood", 10 ], [ "mutant_human_blood", 10 ], [ "fae_blood", 10 ] ],
+      [ [ "paperback_romance_diodes", 1 ] ],
+      [ [ "cookbook_bloodforgood", 1 ] ],
+      [ [ "blood_pancakes", 1 ] ],
+      [ [ "blood_rice_pudding", 1 ] ],
+      [ [ "blutwurst_sausage", 1 ] ],
+      [ [ "drink_bloody_mary_blood", 1 ] ],
+      [ [ "soup_blood", 1 ] ]
+    ]
+  }
+]


### PR DESCRIPTION
#### Summary
Mods "Sky Island vampire compatibility"

#### Purpose of change

You couldn't start as a vampire if using both XE and Sky Island. Now you can.
Even if you did became a vampire, post-third progression depended on very long quests and multiple NPCs, which are impractical in sky island, so I'm fixing that too.

#### Describe the solution

Add a sky island hobby to start as a vampire, which grants a trait that grants the wan effect at game start (ideally it would just give the effect but I found nothing about giving effects or directly triggering EOCs through hobbies.)
Add a recipe learned by tier 3 vampires when they come back to the island, giving an item that they can use to gain tier 4.
Reaching tier 4 gives two recipes when returning on the island: the item for the fifth tier and the item to unlock blood gift research.

#### Describe alternatives you've considered

Keeping sky island vampirism gated behind luck and long quests in a game mod that makes long quests almost impossible.

#### Testing

Spawned on the island with the hobby. Had the wan effect.
Gained tier 3 and came back to the island. Gained tier 4 recipe.
Used tier 4 item, became tier 4 and gained the other two recipes.
Used tier 5 item, became tier 5.
Used blood research item, gained the blood research recipe.

#### Additional context

Vampires still burn under the sun when on the island, but that will be for another PR.