### PR TITLE
Ask to wield container if parent container is too small to insert items

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5111,7 +5111,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
         ret = holster.parents_can_contain_recursive( &it );
         if( !ret.success() ) {
             if( carrier->is_avatar() && query_yn(
-                    _( "The parent container does not have enough space to fit more items.  Would you like to wield %s first to fit more?" ),
+                    _( "The parent container does not have enough space to fit more items.  Would you like to first wield %s to fit more?" ),
                     holster->tname() )
                 &&
                 // wield the container
@@ -5140,7 +5140,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
     } else if( carrier->is_avatar() && max_parent_charges.value() < holstered_item.second ) {
         // if you cannot fit all items because parent container is too small
         if( query_yn(
-                _( "The parent container does not have enough space to fit more than %i %s.  Would you like to wield %s first to fit more?" ),
+                _( "The parent container does not have enough space to fit more than %i %s.  Would you like to first wield %s to fit more?" ),
                 max_parent_charges.value(), it.tname( max_parent_charges.value() ), holster->tname() )
             &&
             // wield the container

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5111,7 +5111,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
         ret = holster.parents_can_contain_recursive( &it );
         if( !ret.success() ) {
             if( carrier->is_avatar() && query_yn(
-                    _( "The parent container does not have enough space to fit more items.  Would you like to wield %s first to fit more?" ),
+                    _( "The parent container does not have enough space to fit more items.  Would you like to wield %s first, to fit more?" ),
                     holster->tname() )
                 &&
                 // wield the container
@@ -5140,8 +5140,8 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
     } else if( carrier->is_avatar() && max_parent_charges.value() < holstered_item.second ) {
         // if you cannot fit all items because parent container is too small
         if( query_yn(
-                _( "The parent container does not have enough space to fit more than %s.  Would you like to wield %s first to fit more?" ),
-                it.tname( max_parent_charges.value() ), holster->tname() )
+                _( "The parent container does not have enough space to fit more than %i %s.  Would you like to wield %s first, to fit more?" ),
+                max_parent_charges.value(), it.tname( max_parent_charges.value() ), holster->tname() )
             &&
             // wield the container
             carrier->wield_contents( *holster.parent_item(), holster.get_item() ) ) {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5111,7 +5111,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
         ret = holster.parents_can_contain_recursive( &it );
         if( !ret.success() ) {
             if( !carrier->is_npc() && query_yn(
-                    _( "No more items can be added due to the parent container being too small. Would you like to wield %s to fit more items?" ),
+                    _( "No more items can be added due to the parent container being too small.  Would you like to wield %s to fit more items?" ),
                     holster->tname() )
                 &&
                 // wield the container
@@ -5140,7 +5140,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
     } else if( !carrier->is_npc() && max_parent_charges.value() < holstered_item.second ) {
         // if you cannot fit all items because parent container is too small
         if( query_yn(
-                _( "Only %i items fit into %s due tu the parent container being too small. Would you like to wield %s to fit more items?" ),
+                _( "Only %i items fit into %s due tu the parent container being too small.  Would you like to wield %s to fit more items?" ),
                 max_parent_charges.value(), holster->tname(), holster->tname() )
             &&
             // wield the container

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5110,7 +5110,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
         }
         ret = holster.parents_can_contain_recursive( &it );
         if( !ret.success() ) {
-            if( !carrier->is_npc() && query_yn(
+            if( carrier->is_avatar() && query_yn(
                     _( "The parent container does not have enough space to fit more items.  Would you like to wield %s first to fit more?" ),
                     holster->tname() )
                 &&
@@ -5137,7 +5137,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
     ret_val<int> max_parent_charges = holster.max_charges_by_parent_recursive( it );
     if( !max_parent_charges.success() ) {
         return ret_val<void>::make_failure( max_parent_charges.str() );
-    } else if( !carrier->is_npc() && max_parent_charges.value() < holstered_item.second ) {
+    } else if( carrier->is_avatar() && max_parent_charges.value() < holstered_item.second ) {
         // if you cannot fit all items because parent container is too small
         if( query_yn(
                 _( "The parent container does not have enough space to fit more than %s.  Would you like to wield %s first to fit more?" ),

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5111,11 +5111,11 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
         ret = holster.parents_can_contain_recursive( &it );
         if( !ret.success() ) {
             if( carrier->is_avatar() && query_yn(
-                    _( "The parent container does not have enough space to fit more items.  Would you like to wield %s first, to fit more?" ),
+                    _( "The parent container does not have enough space to fit more items.  Would you like to wield %s first to fit more?" ),
                     holster->tname() )
                 &&
                 // wield the container
-                carrier->wield_contents( *holster.parent_item(), holster.get_item() ) ) {
+                carrier->wield( *holster.get_item() ) ) {
                 holster = carrier->get_wielded_item();
 
                 // and recheck if parent can hold (there should be no parent)
@@ -5140,11 +5140,11 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
     } else if( carrier->is_avatar() && max_parent_charges.value() < holstered_item.second ) {
         // if you cannot fit all items because parent container is too small
         if( query_yn(
-                _( "The parent container does not have enough space to fit more than %i %s.  Would you like to wield %s first, to fit more?" ),
+                _( "The parent container does not have enough space to fit more than %i %s.  Would you like to wield %s first to fit more?" ),
                 max_parent_charges.value(), it.tname( max_parent_charges.value() ), holster->tname() )
             &&
             // wield the container
-            carrier->wield_contents( *holster.parent_item(), holster.get_item() ) ) {
+            carrier->wield( *holster.get_item() ) ) {
             holster = carrier->get_wielded_item();
 
             // and recalc max_parent_charges

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5111,7 +5111,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
         ret = holster.parents_can_contain_recursive( &it );
         if( !ret.success() ) {
             if( !carrier->is_npc() && query_yn(
-                    _( "No more items can be added due to the parent container being too small.  Would you like to wield %s to fit more items?" ),
+                    _( "The parent container does not have enough space to fit more items.  Would you like to wield %s first to fit more?" ),
                     holster->tname() )
                 &&
                 // wield the container
@@ -5140,8 +5140,8 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
     } else if( !carrier->is_npc() && max_parent_charges.value() < holstered_item.second ) {
         // if you cannot fit all items because parent container is too small
         if( query_yn(
-                _( "Only %i items fit into %s due tu the parent container being too small.  Would you like to wield %s to fit more items?" ),
-                max_parent_charges.value(), holster->tname(), holster->tname() )
+                _( "The parent container does not have enough space to fit more than %s.  Would you like to wield %s first to fit more?" ),
+                it.tname( max_parent_charges.value() ), holster->tname() )
             &&
             // wield the container
             carrier->wield_contents( *holster.parent_item(), holster.get_item() ) ) {


### PR DESCRIPTION
#### Summary
Features "Ask to wield container if parent container is too small to insert items"

#### Purpose of change
It is quite annoying to try to insert items into a non-rigid container in your pocket, but it only inserts one because your pocket is too small. It would be handy to be able to wield the container first and then insert the items.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
In the insert activity actor, if the container could hold more items, but the parent cannot, query if you would like to wield the container first, then continue inserting.


Demo:

https://github.com/user-attachments/assets/626305f0-f39c-4b7f-9279-d83fb81a4552


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
searched where insert_item_activity_actor and unload_activity_actor is used and use those actions. They behaved as expected or never use that part of the code (check for space before inserting).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Currently only works if the items would partially fit. To query if a single item is too large would require a bigger re-write.
Actions that use insert activity actor and are therefore have this feature:
AIM [u]nload
[I]nsert
Pour into container
AIM move stack/all
etc...

Actions that check for free space before inserting are not affected.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
