### PR TITLE
Fix E_FILE_STORAGE item location serialization

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2965,18 +2965,31 @@ std::string enum_to_string<efile_combo>( efile_combo data )
 }
 } // namespace io
 
+bool efile_activity_actor::processed_edevices_remain() const
+{
+    return target_edevices.empty();
+}
+
+bool  efile_activity_actor::processed_efiles_remain() const
+{
+    return currently_processed_efiles.empty();
+}
+
 item_location &efile_activity_actor::get_currently_processed_edevice()
 {
-    return *next_edevice;
+    return target_edevices.back();
 }
 
 item_location &efile_activity_actor::get_currently_processed_efile()
 {
-    return *next_efile;
+    return currently_processed_efiles.back();
 }
 void efile_activity_actor::start( player_activity &act, Character &who )
 {
-    //handle combo move
+    if( combo_type == COMBO_MOVE_ONTO_BROWSE ) {
+        target_edevices_copy = target_edevices;
+    }
+    //handle combo move e-device (browsing may have included used e-device)
     if( action_type == EF_MOVE_ONTO_THIS ) {
         auto i = target_edevices.begin();
         while( i != target_edevices.end() ) {
@@ -2998,15 +3011,15 @@ void efile_activity_actor::start( player_activity &act, Character &who )
     }
     //only skip if loaded through deserialization
     if( !started_processing ) {
-        next_edevice = target_edevices.begin();
         started_processing = true;
         computer_low_skill = who.get_skill_level( skill_computer ) < 1;
     }
 
-    if( next_edevice != target_edevices.end() ) {
+    if( !processed_edevices_remain() ) {
         const time_duration total_time = total_processing_time( used_edevice, target_edevices,
                                          selected_efiles, action_type, who, computer_low_skill );
         act.moves_total = to_moves<int>( total_time );
+        target_edevices_count = target_edevices.size();
         add_msg_debug( debugmode::DF_ACT_EBOOK, "total processing moves: %d",
                        act.moves_total );
     } else {
@@ -3042,8 +3055,11 @@ void efile_activity_actor::do_turn( player_activity &act, Character &who )
                 do {
                     failed_processing_current_edevice();
                 } while( !done_processing );
-            } else if( !*next_edevice || !edevice_reduce_charge( get_currently_processed_edevice() ) ) {
-                failed_processing_current_edevice();
+            } else {
+                item_location next_edevice = get_currently_processed_edevice();
+                if( !next_edevice || !edevice_reduce_charge( next_edevice ) ) {
+                    failed_processing_current_edevice();
+                }
             }
         }
     }
@@ -3072,7 +3088,7 @@ void efile_activity_actor::do_turn( player_activity &act, Character &who )
     }
     if( next_edevice_booted ) { //should not be an "else" because files start processing in same turn
         //current file exists check
-        if( !*next_efile ) {
+        if( !get_currently_processed_efile() ) {
             failed_processing_current_efile( act, who );
         } else if( turns_left_on_current_efile > 0 ) {
             turns_left_on_current_efile--;
@@ -3096,14 +3112,13 @@ void efile_activity_actor::start_processing_next_edevice()
         currently_processed_efiles = ignore_filter ? selected_efiles :
                                      filter_edevice_efiles( edevice_filter, selected_efiles );
     }
-    next_efile = currently_processed_efiles.begin();
     add_msg_debug( debugmode::DF_ACT_EBOOK, string_format( "started processing edevice %s",
                    current_edevice->display_name() ) );
 }
 
 void efile_activity_actor::start_processing_next_efile( player_activity &/*act*/, Character &who )
 {
-    if( next_efile != currently_processed_efiles.end() ) {
+    if( !processed_efiles_remain() ) {
         //separate for easy debugging
         item_location &current_efile = get_currently_processed_efile();
         item_location &current_edevice = get_currently_processed_edevice();
@@ -3129,8 +3144,8 @@ void efile_activity_actor::completed_processing_current_edevice()
 
     next_edevice_booted = false;
     turns_left_on_current_edevice.reset();
-    next_edevice++;
-    if( next_edevice == target_edevices.end() ) {
+    target_edevices.pop_back();
+    if( processed_edevices_remain() ) {
         done_processing = true;
     }
 }
@@ -3221,7 +3236,7 @@ void efile_activity_actor::completed_processing_current_efile( player_activity &
             break;
     }
     processed_efiles++;
-    next_efile++;
+    currently_processed_efiles.pop_back();
 }
 
 void efile_activity_actor::failed_processing_current_edevice()
@@ -3230,8 +3245,8 @@ void efile_activity_actor::failed_processing_current_edevice()
 
     turns_left_on_current_edevice.reset();
     next_edevice_booted = false;
-    next_edevice++;
-    if( next_edevice == target_edevices.end() ) {
+    target_edevices.pop_back();
+    if( processed_edevices_remain() ) {
         done_processing = true;
     }
 }
@@ -3247,7 +3262,7 @@ void efile_activity_actor::finish( player_activity &act, Character &who )
 {
     act.set_to_null();
     std::string action_name = efile_action_name( action_type, true, true );
-    int total_edevices = target_edevices.size();
+    int total_edevices = target_edevices_count;
     if( total_edevices == 0 && processed_edevices == 0 ) {
         add_msg_if_player_sees( who, m_info, _( "No devices needed to be processed." ) );
     } else if( processed_edevices == 0 ) {
@@ -3255,22 +3270,22 @@ void efile_activity_actor::finish( player_activity &act, Character &who )
                                 efile_action_name( action_type, false, true ), total_edevices );
     } else {
         add_msg_if_player_sees( who, m_good, _( "You successfully %s %d/%d device(s)." ),
-                                action_name, processed_edevices, target_edevices.size() );
+                                action_name, processed_edevices, total_edevices );
     }
     combo_next_activity( who );
 }
 
 std::vector<item_location> efile_activity_actor::filter_edevice_efiles(
-    const item_location &edevice,
-    const std::vector<item_location> &filter_files )
+    const item_location &edevice, std::vector<item_location> &filter_files )
 {
     std::vector<item_location> filtered_efiles;
-    if( !filter_files.empty() ) {
-        //filter e-files
-        for( const item_location &i : filter_files ) {
-            if( i.parent_item() == edevice ) {
-                filtered_efiles.emplace_back( i );
-            }
+    std::vector<item_location>::iterator it = filter_files.begin();
+    while( it != filter_files.end() ) {
+        if( it->parent_item() == edevice ) {
+            filtered_efiles.emplace_back( *it );
+            it = filter_files.erase( it );
+        } else {
+            it++;
         }
     }
     return filtered_efiles;
@@ -3344,18 +3359,17 @@ void efile_activity_actor::combo_next_activity( Character &who )
 {
     efile_combo new_combo = COMBO_NONE;
     efile_action new_action = EF_INVALID;
-
-    //filter out invalidated e-files removed during prior operation
-    std::vector<item_location> valid_efiles;
-    for( const item_location &efile : selected_efiles ) {
-        if( efile ) {
-            valid_efiles.emplace_back( efile );
-        }
-    }
+    std::vector<item_location> all_updated_files;
 
     if( combo_type == COMBO_MOVE_ONTO_BROWSE ) {
+        for( item_location &edevice : target_edevices_copy ) {
+            for( item *efile : edevice->efiles() ) {
+                all_updated_files.emplace_back( edevice, efile );
+            }
+        }
+
         units::ememory total_ememory;
-        for( item_location &edevice : target_edevices ) {
+        for( item_location &edevice : target_edevices_copy ) {
             if( edevice->is_browsed() ) {
                 for( item *efile : edevice->efiles() ) {
                     total_ememory += efile->ememory_size();
@@ -3369,10 +3383,9 @@ void efile_activity_actor::combo_next_activity( Character &who )
                                     _( "File size exceeds available memory; canceling file move." ) );
         }
     }
-
     if( new_action != EF_INVALID ) {
-        const efile_activity_actor new_activity( used_edevice, target_edevices,
-                valid_efiles, new_action, new_combo );
+        const efile_activity_actor new_activity( used_edevice, target_edevices_copy,
+                all_updated_files, new_action, new_combo );
         who.assign_activity( player_activity( new_activity ) );
     }
 }
@@ -3401,12 +3414,12 @@ void efile_activity_actor::serialize( JsonOut &jsout ) const
     jsout.start_object();
     jsout.member( "used_edevice", used_edevice );
     jsout.member( "target_edevices", target_edevices );
+    jsout.member( "target_edevices_copy", target_edevices_copy );
     jsout.member( "action_type", action_type );
     jsout.member( "combo_type", combo_type );
     jsout.member( "selected_efiles", selected_efiles );
     jsout.member( "currently_processed_efiles", currently_processed_efiles );
-    jsout.member( "next_edevice", next_edevice - target_edevices.begin() );
-    jsout.member( "next_efile", next_efile - currently_processed_efiles.begin() );
+    jsout.member( "target_edevices_count", target_edevices_count );
     jsout.member( "processed_edevices", processed_edevices );
     jsout.member( "failed_edevices", failed_edevices );
     jsout.member( "processed_efiles", processed_efiles );
@@ -3416,10 +3429,7 @@ void efile_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "next_edevice_booted", next_edevice_booted );
     jsout.member( "computer_low_skill", computer_low_skill );
     jsout.member( "turns_left_on_current_edevice", turns_left_on_current_edevice );
-    jsout.member( "processed_edevices", processed_edevices );
     jsout.member( "turns_left_on_current_efile", turns_left_on_current_efile );
-
-
     jsout.end_object();
 }
 
@@ -3430,19 +3440,14 @@ std::unique_ptr<activity_actor> efile_activity_actor::deserialize( JsonValue &js
     JsonObject data = jsin.get_object();
     data.read( "used_edevice", actor.used_edevice );
     data.read( "target_edevices", actor.target_edevices );
+    data.read( "target_edevices_copy", actor.target_edevices_copy );
     data.read( "turns_left_on_current_edevice", actor.turns_left_on_current_edevice );
     data.read( "action_type", actor.action_type );
     data.read( "combo_type", actor.combo_type );
+    data.read( "target_edevices_count", actor.target_edevices_count );
     data.read( "processed_edevices", actor.processed_edevices );
     data.read( "selected_efiles", actor.selected_efiles );
     data.read( "currently_processed_efiles", actor.currently_processed_efiles );
-    if( data.has_member( "next_edevice" ) ) {
-        actor.next_edevice = actor.target_edevices.begin() + data.get_int( "next_edevice" );
-    }
-    if( data.has_member( "next_efile" ) ) {
-        actor.next_efile = actor.currently_processed_efiles.begin() + data.get_int( "next_efile" );
-    }
-    data.read( "processed_edevices", actor.processed_edevices );
     data.read( "failed_edevices", actor.failed_edevices );
     data.read( "processed_efiles", actor.processed_efiles );
     data.read( "failed_efiles", actor.failed_efiles );
@@ -3450,8 +3455,6 @@ std::unique_ptr<activity_actor> efile_activity_actor::deserialize( JsonValue &js
     data.read( "done_processing", actor.done_processing );
     data.read( "next_edevice_booted", actor.next_edevice_booted );
     data.read( "computer_low_skill", actor.computer_low_skill );
-    data.read( "turns_left_on_current_edevice", actor.turns_left_on_current_edevice );
-    data.read( "processed_edevices", actor.processed_edevices );
     data.read( "turns_left_on_current_efile", actor.turns_left_on_current_efile );
     return actor.clone();
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -852,10 +852,11 @@ class efile_activity_actor : public activity_actor
         /** Returns the effective electronic transfer rate with `external_transfer_rate` factored in */
         static units::ememory current_etransfer_rate( Character &who, const efile_transfer &transfer,
                 const item_location &efile );
-        /** Returns all e-files on this device that are in the filter_files list
-        @param filter_files list of e-files to use, usually selected_files */
+        /** Returns all e-files on this device that are in the filter_files list,
+        * and removes matching efiles from filter_files list
+        * @param filter_files list of e-files to use, usually selected_files */
         static std::vector<item_location> filter_edevice_efiles( const item_location &edevice,
-                const std::vector<item_location> &filter_files );
+                std::vector<item_location> &filter_files );
         /** Returns the most optimal estorage (if needed) for improving transfer speed given the two edevices provided */
         static item_location find_external_transfer_estorage( Character &p,
                 const item_location &efile, const item_location &ed1, const item_location &ed2 );
@@ -872,15 +873,16 @@ class efile_activity_actor : public activity_actor
     private:
         item_location used_edevice;
         std::vector<item_location> target_edevices;
+        /** Held for combo activity */
+        std::vector<item_location> target_edevices_copy;
+        /** e-files that have yet to be processed, across all devices */
         std::vector<item_location> selected_efiles;
         efile_action action_type = EF_INVALID;
         efile_combo combo_type = COMBO_NONE;
-        /** contents copy of currently processed e-device */
+        /** e-files currently processed on current e-device */
         std::vector<item_location> currently_processed_efiles;
-        /** iterator pointing to next e-file to process */
-        std::vector<item_location>::iterator next_efile;
-        /** iterator pointing to next e-device to process */
-        std::vector<item_location>::iterator next_edevice;
+        /** How many e-devices this activity started with. */
+        int target_edevices_count = 0;
         /** How many e-devices this activity has successfully processed so far. */
         int processed_edevices = 0;
         /** How many e-devices this activity has failed to process so far. */
@@ -913,6 +915,9 @@ class efile_activity_actor : public activity_actor
 
         item_location &get_currently_processed_edevice();
         item_location &get_currently_processed_efile();
+        bool processed_edevices_remain() const;
+        bool processed_efiles_remain() const;
+
         /** Segway to the next player activity for a combo type */
         void combo_next_activity( Character &who );
         time_duration charge_time( efile_action action_type );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15705,6 +15705,16 @@ std::list<item *> item::all_items_top()
     return contents.all_items_top();
 }
 
+std::list<const item *> item::all_items_container_top() const
+{
+    return contents.all_items_container_top();
+}
+
+std::list<item *> item::all_items_container_top()
+{
+    return contents.all_items_container_top();
+}
+
 std::list<const item *> item::all_items_top( pocket_type pk_type ) const
 {
     return contents.all_items_top( pk_type );

--- a/src/item.h
+++ b/src/item.h
@@ -3029,14 +3029,18 @@ class item : public visitable
         std::list<item> remove_items_with( const std::function<bool( const item & )> &filter,
                                            int count = INT_MAX ) override;
 
-        /** returns a list of pointers to all top-level items that are not mods */
+        /** returns a list of pointers to all top-level items in standard pockets */
         std::list<const item *> all_items_top() const;
-        /** returns a list of pointers to all top-level items that are not mods */
+        /** returns a list of pointers to all top-level items in standard pockets */
         std::list<item *> all_items_top();
-        /** returns a list of pointers to all top-level items */
+        /** returns a list of pointers to all top-level items in container-like pockets */
+        std::list<const item *> all_items_container_top() const;
+        /** returns a list of pointers to all top-level items in container-like pockets */
+        std::list<item *> all_items_container_top();
+        /** returns a list of pointers to all top-level items in pk_type pockets only */
         std::list<const item *> all_items_top( pocket_type pk_type ) const;
         /**
-         * Return a list of pointers to all top-level items.
+         * Return a list of pointers to all top-level items in pk_type pockets only
          * If unloading is true ignore items in pockets flagged not to be unloaded.
          */
         std::list<item *> all_items_top( pocket_type pk_type, bool unloading = false );

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1774,6 +1774,20 @@ std::list<const item *> item_contents::all_items_top() const
     } );
 }
 
+std::list<const item *> item_contents::all_items_container_top() const
+{
+    return all_items_top( []( const item_pocket & pocket ) {
+        return pocket.is_container_like_type();
+    } );
+}
+
+std::list<item *> item_contents::all_items_container_top()
+{
+    return all_items_top( []( const item_pocket & pocket ) {
+        return pocket.is_container_like_type();
+    } );
+}
+
 std::list<item *> item_contents::all_known_contents()
 {
     return all_items_top( []( const item_pocket & pocket ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -122,10 +122,14 @@ class item_contents
         /** returns a list of pointers to all top-level items */
         std::list<const item *> all_items_top( pocket_type pk_type ) const;
 
-        /** returns a list of pointers to all top-level items that are not mods */
+        /** returns a list of pointers to all top-level items in standard pockets */
         std::list<item *> all_items_top();
-        /** returns a list of pointers to all top-level items that are not mods */
+        /** returns a list of pointers to all top-level items in standard pockets */
         std::list<const item *> all_items_top() const;
+        /** returns a list of pointers to all top-level items in container-like pockets */
+        std::list<item *> all_items_container_top();
+        /** returns a list of pointers to all top-level items in container-like pockets */
+        std::list<const item *> all_items_container_top() const;
 
         /** returns a list of pointers to all visible or remembered content items that are not mods */
         std::list<item *> all_known_contents();

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -587,7 +587,7 @@ class item_location::impl::item_in_container : public item_location::impl
                 return -1;
             }
             int idx = 0;
-            for( const item *it : container->all_items_top() ) {
+            for( const item *it : container->all_items_container_top() ) {
                 if( target() == it ) {
                     return idx;
                 }
@@ -857,7 +857,7 @@ void item_location::deserialize( const JsonObject &obj )
             ptr.reset( new impl::item_on_map( map_cursor( parent.pos_bub() ), idx ) ); // drop on ground
             return;
         }
-        const std::list<item *> parent_contents = parent->all_items_top();
+        const std::list<item *> parent_contents = parent->all_items_container_top();
         if( idx > -1 && idx < static_cast<int>( parent_contents.size() ) ) {
             auto iter = parent_contents.begin();
             std::advance( iter, idx );

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2062,6 +2062,11 @@ bool item_pocket::is_standard_type() const
            data->type == pocket_type::MAGAZINE_WELL;
 }
 
+bool item_pocket::is_container_like_type() const
+{
+    return is_standard_type() || data->type == pocket_type::E_FILE_STORAGE;
+}
+
 bool item_pocket::is_forbidden() const
 {
     return data->forbidden;

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -155,8 +155,10 @@ class item_pocket
         bool allows_speedloader( const itype_id &speedloader_id ) const;
 
         // is this pocket one of the standard types?
-        // exceptions are MOD, CORPSE, SOFTWARE, MIGRATION, etc.
+        // exceptions are MOD, CORPSE, MIGRATION, etc.
         bool is_standard_type() const;
+        // is this pocket a type that acts like a container in its underlying implementation?
+        bool is_container_like_type() const;
 
         bool is_forbidden() const;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "fix E_FILE_STORAGE item location serialization"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #79489

There were three issues:
1. Duplicate members being serialized in efile_activity_actor, which isn't good
2. Invalid item locations being serialized in efile_activity_actor post-processing
3. The real issue, which was that I didn't account for `item_location::impl::item_in_container` serializing `E_FILE_STORAGE` pockets in the overhaul

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Remove duplicate entries
2. I removed the e-device/e-file iterators to simplify both serialization and the activity as a whole, so now processed e-files/e-devices are not stored/serialized
3. Add a new function `all_items_container_top` that includes E_FILE_STORAGE pockets

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Teleported to city, killed zombies, "browse+move" their devices with autosave on 10 turn intervals. Verified that the game doesn't crash while autosaving in the middle of efile_activity_actor and that the game can still load from a mid-activity autosave.
Verified that "edevices" test passes all checks

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

clang-tidy not run locally

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
