### PR TITLE
Prevent storing multiple copies of the same book

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2878,7 +2878,7 @@ void ebooksave_activity_actor::completed_scanning_current_book( player_activity 
     if( scanned_book ) {
         ereader->put_in( *scanned_book, pocket_type::E_FILE_STORAGE );
         if( who.is_avatar() ) {
-            if( !who.has_identified( scanned_book->typeId() ) ) {
+            if( scanned_book->is_identifiable() && !who.has_identified( scanned_book->typeId() ) ) {
                 who.identify( *scanned_book );
             }
         }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -730,7 +730,7 @@ void avatar::identify( const item &item )
     if( has_identified( item.typeId() ) ) {
         return;
     }
-    if( !item.is_book() ) {
+    if( !item.is_identifiable() ) {
         debugmsg( "tried to identify non-book item" );
         return;
     }

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1654,6 +1654,7 @@ drop_locations game_menus::inv::ebooksave( Character &who, item_location &ereade
                                    make_raw_stats, /*allow_select_contained=*/true );
     inv_s.add_character_items( who );
     inv_s.add_nearby_items( PICKUP_RANGE );
+    inv_s.remove_duplicate_itypes( true );
     inv_s.set_title( _( "Scan which books?" ) );
     if( inv_s.empty() ) {
         popup( std::string( _( "You have no books to scan." ) ), PF_GET_KEY );

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -24,6 +24,10 @@ using item_location_filter = std::function<bool ( const item_location & )>;
 using drop_location = std::pair<item_location, int>;
 using drop_locations = std::list<drop_location>;
 
+/**
+* A boiled-down shortcut for inventory_selector_preset.
+* @param filter - function solely determines what is shown in the item list.
+*/
 class inventory_filter_preset : public inventory_selector_preset
 {
     public:

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -63,6 +63,9 @@ struct collation_meta_t {
     bool enabled = true;
 };
 
+/**
+* A selectable entry in an inventory_selector
+*/
 class inventory_entry
 {
     public:
@@ -180,8 +183,10 @@ class inventory_entry
         item_location topmost_parent;
         std::shared_ptr<collation_meta_t> collation_meta;
         size_t generation = 0;
+        // for collation; true = header, false = entry
         bool chevron = false;
         int indent = 0;
+        // whether this entry is selectable, highlightable
         mutable bool enabled = true;
         void cache_denial( inventory_selector_preset const &preset ) const;
         mutable std::optional<std::string> denial;
@@ -217,6 +222,9 @@ class inventory_entry
 };
 
 struct inventory_selector_save_state;
+/**
+* Handles how inventory_entry are displayed and selected in an inventory_selector
+*/
 class inventory_selector_preset
 {
     public:
@@ -317,6 +325,9 @@ class inventory_selector_preset
         std::vector<cell_t> cells;
 };
 
+/**
+* Preset for putting items inside valid containers
+*/
 class inventory_holster_preset : public inventory_selector_preset
 {
     public:
@@ -335,6 +346,9 @@ class inventory_holster_preset : public inventory_selector_preset
 
 const inventory_selector_preset default_preset;
 
+/**
+* Collection of inventory_entry
+*/
 class inventory_column
 {
     public:
@@ -493,6 +507,12 @@ class inventory_column
         void uncollate();
         virtual void cycle_hide_override();
 
+        /** Call after items are added to reduce entries to a std::set of single itype_ids
+        * @param include_variants - if true, treats variants as itype_ids -- so two identical variants will
+        * still be removed but different variants of the same itype_id will not
+        */
+        void remove_duplicate_itypes( bool include_variants );
+
     protected:
         /**
          * Move the selection.
@@ -602,6 +622,10 @@ class selection_column : public inventory_column
         inventory_entry last_changed;
 };
 
+/**
+* Selects an item from one or more inventory_column
+* using an inventory_selector_preset to filter if necessary.
+*/
 class inventory_selector
 {
     public:
@@ -673,6 +697,8 @@ class inventory_selector
 
         void categorize_map_items( bool toggle );
 
+        void remove_duplicate_itypes( bool include_variants );
+
         // An array of cells for the stat lines. Example: ["Weight (kg)", "10", "/", "20"].
         using stat = std::array<std::string, 4>;
         using stats = std::array<stat, 3>;
@@ -694,6 +720,9 @@ class inventory_selector
                                     const item_category *custom_category = nullptr,
                                     size_t chosen_count = 0, item_location const &topmost_parent = {},
                                     bool chevron = false );
+        /**
+        * Recursively adds containers (and contents) as entries
+        */
         bool add_entry_rec( inventory_column &entry_column, inventory_column &children_column,
                             item_location &loc, item_category const *entry_category = nullptr,
                             item_category const *children_category = nullptr,
@@ -961,6 +990,9 @@ class ammo_inventory_selector : public inventory_selector
         const item_location reload_loc;
 };
 
+/**
+* inventory_selector, but capable of selecting multiple items.
+*/
 class inventory_multiselector : public inventory_selector
 {
     public:

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10257,6 +10257,11 @@ bool item::is_irremovable() const
     return has_flag( flag_IRREMOVABLE );
 }
 
+bool item::is_identifiable() const
+{
+    return is_book();
+}
+
 bool item::is_broken() const
 {
     return has_flag( flag_ITEM_BROKEN ) || has_fault_flag( std::string( "ITEM_BROKEN" ) );

--- a/src/item.h
+++ b/src/item.h
@@ -1692,6 +1692,9 @@ class item : public visitable
 
         bool is_irremovable() const;
 
+        /** Returns true if the item is identifiable */
+        bool is_identifiable() const;
+
         /** Returns true if the item is broken and can't be activated or used in crafting */
         bool is_broken() const;
 
@@ -2474,18 +2477,18 @@ class item : public visitable
         bool is_gun() const;
 
         /**
-         * Does this item have a gun variant associated with it
-         * If check_option, the return of this is dependent on the SHOW_GUN_VARIANTS option
+         * Does this item have a variant associated with it
+         * If check_option, the return of this is dependent on the SHOW_x_VARIANTS option
          */
         bool has_itype_variant( bool check_option = true ) const;
 
         /**
-         * The gun variant associated with this item
+         * The variant associated with this item
          */
         const itype_variant_data &itype_variant() const;
 
         /**
-         * Set the gun variant of this item
+         * Set the variant of this item
          */
         void set_itype_variant( const std::string &variant );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "prevent storing multiple copies of the same book"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #73282

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Adds a function that removes duplicate items from an inventory_selector, discriminating by itype and optionally by variant
- Adds some basic docs to inventory_selector and related classes
- Adds an `is_identifiable()` function; this is currently just `is_book()`, but it allows a check for doing the identification so that non-books can be scanned in the future

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned `textbooks` 100 times and used "Store books" option with smartphone, noted no additional copies in list, but variants were still present.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
