### PR TITLE
Add an island-only sun protection to Sky island

### DIFF
--- a/data/mods/Sky_Island/dialog_statue.json
+++ b/data/mods/Sky_Island/dialog_statue.json
@@ -74,6 +74,7 @@
         "topic": "SKYISLAND_UPGRADE"
       },
       { "text": "Empower the warp obelisk.", "topic": "SKYISLAND_UPGRADES_RAIDS" },
+      { "text": "Make the island more hospitable.", "topic": "SKYISLAND_UPGRADES_TERRAFORM" },
       { "text": "Upgrade expeditions.", "topic": "SKYISLAND_UPGRADES_FEATURES" },
       { "text": "Construction options.", "topic": "SKYISLAND_UPGRADES_INFRASTRUCTURE" },
       { "text": "I need your services.", "topic": "SKYISLAND_SERVICES" },
@@ -244,6 +245,24 @@
         },
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_security5" } ],
         "topic": "SKYISLAND_UPGRADES_RAIDS"
+      },
+      { "text": "Nevermind.", "topic": "SKYISLAND_UPGRADE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "SKYISLAND_UPGRADES_TERRAFORM",
+    "//": "The more an upgrade makes it easier to spend a long time on the island, the more expensive it must be.",
+    "//2": "The player must always have reasons to prefer doing expeditions to staying on the island.",
+    "dynamic_line": "There are many ways that the island could be made more hospitable for you.",
+    "responses": [
+      {
+        "text": "Unlock: Personal Sunblock",
+        "condition": {
+          "and": [ { "not": { "u_has_mission": "SKYISLAND_UPGRADE_sunblock" } }, { "not": { "u_has_trait": "mut_skyisland_sunblock" } } ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_sunblock" } ],
+        "topic": "SKYISLAND_UPGRADES_TERRAFORM"
       },
       { "text": "Nevermind.", "topic": "SKYISLAND_UPGRADE" }
     ]

--- a/data/mods/Sky_Island/items.json
+++ b/data/mods/Sky_Island/items.json
@@ -547,7 +547,7 @@
   {
     "id": "sky_island_sunblock",
     "type": "ARMOR",
-    "name": { "str": "Personal sunblock" },
+    "name": { "str": "Personal Sunblock" },
     "description": "The island is protecting you against the sun as long as you are on it.",
     "weight": "1 g",
     "volume": "1 ml",

--- a/data/mods/Sky_Island/items.json
+++ b/data/mods/Sky_Island/items.json
@@ -543,5 +543,36 @@
     "material": [ "stone" ],
     "symbol": "y",
     "color": "green"
+  },
+  {
+    "id": "sky_island_sunblock",
+    "type": "ARMOR",
+    "name": { "str": "Personal sunblock" },
+    "description": "The island is protecting you against the sun as long as you are on it.",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "symbol": "o",
+    "color": "blue",
+    "material": [ "alien_resin" ],
+    "flags": [
+      "AURA",
+      "SEMITANGIBLE",
+      "OVERSIZE",
+      "ONLY_ONE",
+      "TRADER_AVOID",
+      "NO_TAKEOFF",
+      "NONCONDUCTIVE",
+      "UNBREAKABLE",
+      "RAIN_PROTECT",
+      "SUN_GLASSES",
+      "ALLOWS_NATURAL_ATTACKS"
+    ],
+    "armor": [
+      {
+        "encumbrance": 0,
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+      }
+    ]
   }
 ]

--- a/data/mods/Sky_Island/mutations.json
+++ b/data/mods/Sky_Island/mutations.json
@@ -36,5 +36,27 @@
     "id": "EOC_SKY_ISLAND_CLIMATE_RESET",
     "condition": { "u_has_trait": "mut_skyisland_temperature_adaptation" },
     "effect": [ "next_weather" ]
+  },
+  {
+    "type": "mutation",
+    "id": "mut_skyisland_sunblock",
+    "name": { "str": "Personal sunblock" },
+    "points": 0,
+    "description": "As long as you are on the island, the sun cannot affect you.",
+    "valid": false,
+    "player_display": false,
+    "purifiable": false,
+    "enchantments": [ { "condition": { "not": { "u_has_trait": "awayfromhome" } }, "mutations": [ "mut_skyisland_sunblock_real" ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "mut_skyisland_sunblock_real",
+    "name": { "str": "Personal sunblock real" },
+    "points": 0,
+    "description": "As long as you are on the island, the sun cannot affect you.",
+    "valid": false,
+    "player_display": false,
+    "purifiable": false,
+    "integrated_armor": [ "sky_island_sunblock" ]
   }
 ]

--- a/data/mods/Sky_Island/mutations.json
+++ b/data/mods/Sky_Island/mutations.json
@@ -40,7 +40,7 @@
   {
     "type": "mutation",
     "id": "mut_skyisland_sunblock",
-    "name": { "str": "Personal sunblock" },
+    "name": { "str": "Personal Sunblock" },
     "points": 0,
     "description": "As long as you are on the island, the sun cannot affect you.",
     "valid": false,

--- a/data/mods/Sky_Island/upgrade_missions.json
+++ b/data/mods/Sky_Island/upgrade_missions.json
@@ -3832,5 +3832,89 @@
     "reversible": false,
     "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
     "components": [ [ [ "warptoken", 5 ] ] ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_sunblock",
+    "type": "mission_definition",
+    "name": "Upgrade: Personal sunblock",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft a Solar Refractor from sunglasses, glass and miscellaneous parts.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: The sun's rays cannot affect you while on the island.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_sunblock",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_sunblock" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: The sun's rays cannot affect you while on the island.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "u_add_trait": "mut_skyisland_sunblock" },
+        { "u_forget_recipe": "upgradekey_sunblock" },
+        {
+          "u_message": "The sun's rays shift a little.  As long as you are on the island, any harm they could do to you will be negated.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_sunblock",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Solar Refractor" },
+    "description": "This strange metaphysical artifact will make the island protect your skin from the sun while you are not earthside.  If your skin doesn't burn as the sun shines on it, this artifact will not do much to help but still won't hinder.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: personal sunblock.",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_sunblock",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "//": "Intended to be a very early-game craft, as the bunker and constructing on the surface makes it mostly obsolete.",
+    "//2": "The amount of glass shards is equal to the amount disassembling a standing mirror would give.",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [
+        [ "sunglasses", 1 ],
+        [ "sunglasses_eye", 1 ],
+        [ "sunglasses_bifocal", 1 ],
+        [ "sunglasses_reading", 1 ],
+        [ "fitover_sunglasses", 1 ],
+        [ "fancy_sunglasses_eye", 1 ],
+        [ "fancy_sunglasses_reading", 1 ],
+        [ "fancy_sunglasses_bifocal", 1 ]
+      ],
+      [
+        [ "sunglasses", 1 ],
+        [ "sunglasses_eye", 1 ],
+        [ "sunglasses_bifocal", 1 ],
+        [ "sunglasses_reading", 1 ],
+        [ "fitover_sunglasses", 1 ],
+        [ "fancy_sunglasses_eye", 1 ],
+        [ "fancy_sunglasses_reading", 1 ],
+        [ "fancy_sunglasses_bifocal", 1 ]
+      ],
+      [ [ "umbrella", 1 ], [ "teleumbrella", 1 ] ],
+      [ [ "sundress", 1 ] ],
+      [ [ "glass_shard", 176 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Add an island-only sun protection to Sky island"

#### Purpose of change

Sun-sensitive characters burned under the sun even on the island.
Now they can craft an item that gives full sun protection as long as they're on the island but only while they're on the island.

#### Describe the solution

Add a recipe unlocked from the statue.
Making the recipe gives a mutation that gives an integrated armor while on the island.
said armor fully protects from the sun but doesn't do anything about other things.
The armor is removed while not on the island.

#### Describe alternatives you've considered

Expanding the fake air to make the entire island count as indoors, but I've been told that the cold wind is intended so I won't do something that would block it.

#### Testing

Became a naked vampire, burned under the sun.
Crafted the item, stopped burning.
Started an expedition, started burning again.
Came back, stopped burning.

#### Additional context

There is room for more upgrades like that, but the island must be the place between expeditions and not the main place, so they require caution when adding them to not undermine the gameplay loop.