### PR TITLE
Vehicle position -> absolute

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1356,8 +1356,9 @@ bikerack_racking_activity_actor::bikerack_racking_activity_actor( const vehicle 
         const vehicle &racked_vehicle, const std::vector<int> &racks )
     : racks( racks )
 {
-    parent_vehicle_pos = parent_vehicle.bub_part_pos( 0 );
-    racked_vehicle_pos = racked_vehicle.bub_part_pos( 0 );
+    map &here = get_map();
+    parent_vehicle_pos = parent_vehicle.bub_part_pos( &here,  0 );
+    racked_vehicle_pos = racked_vehicle.bub_part_pos( &here, 0 );
 }
 
 void bikerack_racking_activity_actor::start( player_activity &act, Character & )
@@ -1582,7 +1583,8 @@ bikerack_unracking_activity_actor::bikerack_unracking_activity_actor( const vehi
         const std::vector<int> &parts, const std::vector<int> &racks )
     : parts( parts ), racks( racks )
 {
-    parent_vehicle_pos = parent_vehicle.bub_part_pos( 0 );
+    map &here = get_map();
+    parent_vehicle_pos = parent_vehicle.bub_part_pos( &here,  0 );
 }
 
 void bikerack_unracking_activity_actor::start( player_activity &act, Character & )
@@ -8008,8 +8010,9 @@ bool vehicle_folding_activity_actor::fold_vehicle( Character &p, bool check_only
 
 vehicle_folding_activity_actor::vehicle_folding_activity_actor( const vehicle &target )
 {
+    map &here = get_map();
     folding_time = target.folding_time();
-    target_pos = target.bub_part_pos( 0 );
+    target_pos = target.bub_part_pos( &here,  0 );
 }
 
 void vehicle_folding_activity_actor::start( player_activity &act, Character &p )

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -219,14 +219,14 @@ static bool handle_spillable_contents( Character &c, item &it, map &m )
 static void put_into_vehicle( Character &c, item_drop_reason reason, const std::list<item> &items,
                               const vpart_reference &vpr )
 {
+    map &here = get_map();
     if( items.empty() ) {
         return;
     }
     c.invalidate_weight_carried_cache();
     vehicle_part &vp = vpr.part();
     vehicle &veh = vpr.vehicle();
-    const tripoint_bub_ms where = veh.bub_part_pos( vp );
-    map &here = get_map();
+    const tripoint_bub_ms where = veh.bub_part_pos( &here, vp );
     int items_did_not_fit_count = 0;
     int into_vehicle_count = 0;
     const std::string part_name = vp.info().name();

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3731,6 +3731,8 @@ static void vehicle_battery_charge()
 
 static void vehicle_export()
 {
+    map &here = get_map();
+
     if( optional_vpart_position ovp = get_map().veh_at( get_avatar().pos_bub() ) ) {
         cata_path export_dir{ cata_path::root_path::user,  "export_dir" };
         assure_dir_exist( export_dir );
@@ -3742,7 +3744,7 @@ static void vehicle_export()
         try {
             write_to_file( veh_path, [&]( std::ostream & fout ) {
                 JsonOut jsout( fout );
-                ovp->vehicle().refresh();
+                ovp->vehicle().refresh( &here );
                 vehicle_prototype::save_vehicle_as_prototype( ovp->vehicle(), jsout );
             } );
         } catch( const std::exception &err ) {

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1929,7 +1929,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
                         std::swap( *destsm, *srcsm );
 
                         for( auto &veh : destsm->vehicles ) {
-                            veh->sm_pos = rebase_bub( dest_pos );
+                            veh->sm_pos = here.get_abs_sub().xy() + dest_pos;
                         }
 
                         if( !destsm->spawns.empty() ) {                             // trigger spawnpoints

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1219,8 +1219,8 @@ vehicle *game::place_vehicle_nearby(
             vehicle *veh = target_map.add_vehicle( id, tinymap_center, random_entry( angles ),
                                                    rng( 50, 80 ), 0, false );
             if( veh ) {
-                const tripoint_bub_ms abs_local = m.get_bub( target_map.get_abs( tinymap_center ) );
-                tripoint_bub_sm quotient;
+                const tripoint_abs_ms abs_local = target_map.get_abs( tinymap_center );
+                tripoint_abs_sm quotient;
                 point_sm_ms remainder;
                 std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( abs_local );
                 veh->sm_pos = quotient;

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -19,7 +19,8 @@
 
 bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 {
-    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos_bub() + u.grab_point );
+    map &here = get_map();
+    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos_bub( &here ) + u.grab_point );
     if( !grabbed_vehicle_vp ) {
         add_msg( m_info, _( "No vehicle at grabbed point." ) );
         u.grab( object_type::NONE );
@@ -37,7 +38,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         u.grab( object_type::NONE );
         return false;
     }
-    const vehicle *veh_under_player = veh_pointer_or_null( m.veh_at( u.pos_bub() ) );
+    const vehicle *veh_under_player = veh_pointer_or_null( m.veh_at( u.pos_bub( &here ) ) );
     if( grabbed_vehicle == veh_under_player ) {
         u.grab_point = - dp;
         return false;
@@ -106,7 +107,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
             units::angle face_delta = angle_delta( grabbed_vehicle->face.dir(), my_dir.dir() );
 
             tileray my_pos_dir;
-            tripoint_rel_ms my_angle = u.pos_bub() - grabbed_vehicle->pos_bub();
+            tripoint_rel_ms my_angle = u.pos_bub( &here ) - grabbed_vehicle->pos_bub( &here );
             my_pos_dir.init( my_angle.xy() );
             back_of_vehicle = ( angle_delta( grabbed_vehicle->face.dir(), my_pos_dir.dir() ) > 90_degrees );
             invalid_veh_face = ( face_delta > vehicles::steer_increment * 2 - 1_degrees &&
@@ -120,7 +121,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         } else {
             str_req = max_str_req / 10;
             //determine movecost for terrain touching wheels
-            const tripoint_bub_ms vehpos = grabbed_vehicle->pos_bub();
+            const tripoint_bub_ms vehpos = grabbed_vehicle->pos_bub( &here );
             for( int p : wheel_indices ) {
                 const tripoint_bub_ms wheel_pos = vehpos + grabbed_vehicle->part( p ).precalc[0];
                 const int mapcost = m.move_cost( wheel_pos, grabbed_vehicle );
@@ -147,7 +148,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     if( str_req <= str ) {
         if( str_req == max_str_req ) {
             //if vehicle has no wheels, make a noise.
-            sounds::sound( grabbed_vehicle->pos_bub(), str_req * 2, sounds::sound_t::movement,
+            sounds::sound( grabbed_vehicle->pos_bub( &here ), str_req * 2, sounds::sound_t::movement,
                            _( "a scraping noise." ), true, "misc", "scraping" );
         }
         //calculate exertion factor and movement penalty
@@ -220,9 +221,9 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 
         // Grabbed part has to stay at distance 1 to the player
         // and in roughly the same direction.
-        const tripoint_bub_ms new_part_pos = grabbed_vehicle->pos_bub() +
+        const tripoint_bub_ms new_part_pos = grabbed_vehicle->pos_bub( &here ) +
                                              grabbed_vehicle->part( grabbed_part ).precalc[1];
-        const tripoint_bub_ms expected_pos = u.pos_bub() + dp + md_next_grab;
+        const tripoint_bub_ms expected_pos = u.pos_bub( &here ) + dp + md_next_grab;
         tripoint_rel_ms actual_dir = tripoint_rel_ms( ( expected_pos - new_part_pos ).xy(), 0 );
 
         bool failed = false;
@@ -234,8 +235,8 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
             while( !no_player_collision ) {
                 no_player_collision = true;
                 for( const vpart_reference &vp : grabbed_vehicle->get_all_parts() ) {
-                    if( grabbed_vehicle->pos_bub() +
-                        vp.part().precalc[1] + actual_dir == u.pos_bub() + skip ) {
+                    if( grabbed_vehicle->pos_bub( &here ) +
+                        vp.part().precalc[1] + actual_dir == u.pos_bub( &here ) + skip ) {
                         no_player_collision = false;
                         break;
                     }
@@ -253,7 +254,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
             }
         }
         // Set player location to illegal value so it can't collide with vehicle.
-        const tripoint_bub_ms player_prev = u.pos_bub();
+        const tripoint_bub_ms player_prev = u.pos_bub( &here );
         u.setpos( tripoint_bub_ms::zero, false );
         std::vector<veh_collision> colls;
         failed = grabbed_vehicle->collision( colls, actual_dir, true );
@@ -296,7 +297,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
             add_msg( _( "You let go of the %1$s as it starts to fall." ), grabbed_vehicle->disp_name() );
             u.grab( object_type::NONE );
             u.grab_point = tripoint_rel_ms::zero;
-            m.set_seen_cache_dirty( grabbed_vehicle->pos_bub() );
+            m.set_seen_cache_dirty( grabbed_vehicle->pos_bub( &here ) );
             return true;
         }
     } else {
@@ -307,7 +308,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     for( int p : wheel_indices ) {
         if( one_in( 2 ) ) {
             vehicle_part &vp_wheel = grabbed_vehicle->part( p );
-            tripoint_bub_ms wheel_p = grabbed_vehicle->bub_part_pos( vp_wheel );
+            tripoint_bub_ms wheel_p = grabbed_vehicle->bub_part_pos( &here, vp_wheel );
             grabbed_vehicle->handle_trap( wheel_p, vp_wheel );
         }
     }

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -52,10 +52,11 @@ static const flag_id json_flag_FROM_FROZEN_LIQUID( "FROM_FROZEN_LIQUID" );
 static void serialize_liquid_source( player_activity &act, const vehicle &veh, const int part_num,
                                      const item &liquid )
 {
+    map &here = get_map();
     act.values.push_back( static_cast<int>( liquid_source_type::VEHICLE ) );
     act.values.push_back( part_num );
     if( part_num != -1 ) {
-        act.coords.push_back( get_map().get_abs( veh.bub_part_pos( part_num ) ) );
+        act.coords.push_back( here.get_abs( veh.bub_part_pos( &here, part_num ) ) );
     } else {
         act.coords.push_back( veh.pos_abs() );
     }
@@ -84,9 +85,10 @@ static void serialize_liquid_source( player_activity &act, const tripoint_bub_ms
 
 static void serialize_liquid_target( player_activity &act, const vpart_reference &vp )
 {
+    map &here = get_map();
     act.values.push_back( static_cast<int>( liquid_target_type::VEHICLE ) );
     act.values.push_back( 0 ); // dummy
-    act.coords.push_back( get_map().get_abs( vp.vehicle().bub_part_pos( 0 ) ) );
+    act.coords.push_back( here.get_abs( vp.vehicle().bub_part_pos( &here,  0 ) ) );
     act.values.push_back( vp.part_index() ); // tank part index
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14086,7 +14086,7 @@ ret_val<void> item::link_to( vehicle &veh, const point_rel_ms &mount, link_state
     if( link_type == link_state::vehicle_tow ) {
         if( veh.has_tow_attached() || veh.is_towed() || veh.is_towing() ) {
             return ret_val<void>::make_failure( _( "That vehicle already has a tow-line attached." ) );
-        } else if( !veh.is_external_part( veh.mount_to_tripoint( mount ) ) ) {
+        } else if( !veh.is_external_part( mount ) ) {
             return ret_val<void>::make_failure( _( "You can't attach a tow-line to an internal part." ) );
         } else {
             const int part_at = veh.part_at( veh.coord_translate( mount ) );
@@ -14122,7 +14122,7 @@ ret_val<void> item::link_to( vehicle &veh, const point_rel_ms &mount, link_state
         link().source = bio_link ? link_state::bio_cable : link_state::no_link;
         link().target = link_type;
         link().t_veh = veh.get_safe_reference();
-        link().t_abs_pos = get_map().get_abs( link().t_veh->pos_bub() );
+        link().t_abs_pos = link().t_veh->pos_abs();
         link().t_mount = mount;
         link().s_bub_pos = tripoint_bub_ms::min; // Forces the item to check the length during process_link.
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -485,7 +485,8 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         }
 
         tripoint_bub_ms pos_bub() const override {
-            return cur.veh.bub_part_pos( cur.part );
+            map &here = get_map();
+            return cur.veh.bub_part_pos( &here, cur.part );
         }
 
         Character *carrier() const override {
@@ -532,9 +533,10 @@ class item_location::impl::item_on_vehicle : public item_location::impl
                 return 0;
             }
 
+            map &here = get_map();
             item *obj = target();
             int mv = ch.item_handling_cost( *obj, true, VEHICLE_HANDLING_PENALTY, qty );
-            mv += 100 * rl_dist( ch.pos_bub(), cur.veh.bub_part_pos( cur.part ) );
+            mv += 100 * rl_dist( ch.pos_bub( &here ), cur.veh.bub_part_pos( &here, cur.part ) );
 
             // TODO: handle unpacking costs
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5056,7 +5056,7 @@ std::optional<int> link_up_actor::link_tow_cable( Character *p, item &it,
 
     const auto can_link = [&here]( const tripoint_bub_ms & point ) {
         const optional_vpart_position ovp = here.veh_at( point );
-        return ovp && ovp->vehicle().is_external_part(&here,  point );
+        return ovp && ovp->vehicle().is_external_part( &here,  point );
     };
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5056,7 +5056,7 @@ std::optional<int> link_up_actor::link_tow_cable( Character *p, item &it,
 
     const auto can_link = [&here]( const tripoint_bub_ms & point ) {
         const optional_vpart_position ovp = here.veh_at( point );
-        return ovp && ovp->vehicle().is_external_part( point );
+        return ovp && ovp->vehicle().is_external_part(&here,  point );
     };
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -589,7 +589,7 @@ void map::generate_lightmap( const int zlev )
 
         for( const vehicle_part *pt : lights ) {
             const vpart_info &vp = pt->info();
-            tripoint_bub_ms src = v->bub_part_pos( *pt );
+            tripoint_bub_ms src = v->bub_part_pos( this, *pt );
 
             if( !inbounds( src ) ) {
                 continue;
@@ -1123,7 +1123,7 @@ void map::build_seen_cache( const tripoint_bub_ms &origin, const int target_z, i
             continue; // Player not at camera control, so cameras don't work
         }
 
-        const tripoint_bub_ms mirror_pos = veh->bub_part_pos( vp_mirror );
+        const tripoint_bub_ms mirror_pos = veh->bub_part_pos( this, vp_mirror );
 
         // Determine how far the light has already traveled so mirrors
         // don't cheat the light distance falloff.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -470,7 +470,7 @@ void map::add_vehicle_to_cache( vehicle *veh )
         if( vpr.part().removed ) {
             continue;
         }
-        const tripoint_bub_ms p = veh->bub_part_pos( vpr.part() );
+        const tripoint_bub_ms p = veh->bub_part_pos( this, vpr.part() );
         level_cache &ch = get_cache( p.z() );
         ch.set_veh_cached_parts( p, *veh, static_cast<int>( vpr.part_index() ) );
         if( inbounds( p ) ) {
@@ -957,7 +957,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
         for( const int vp_wheel_idx : wheel_indices ) {
             vehicle_part &vp_wheel = veh.part( vp_wheel_idx );
             const vpart_info &vpi_wheel = vp_wheel.info();
-            const tripoint_bub_ms wheel_p = veh.bub_part_pos( vp_wheel );
+            const tripoint_bub_ms wheel_p = veh.bub_part_pos( this, vp_wheel );
             if( one_in( 2 ) && displace_water( wheel_p ) ) {
                 sounds::sound( wheel_p, 4, sounds::sound_t::movement, _( "splash!" ), false,
                                "environment", "splash" );
@@ -1026,8 +1026,8 @@ float map::vehicle_vehicle_collision( vehicle &veh, vehicle &veh2,
 
     // Check whether avatar sees the collision, and log a message if so
     const avatar &you = get_avatar();
-    const tripoint_bub_ms part1_pos = veh.bub_part_pos( vp1 );
-    const tripoint_bub_ms part2_pos = veh2.bub_part_pos( vp2 );
+    const tripoint_bub_ms part1_pos = veh.bub_part_pos( this, vp1 );
+    const tripoint_bub_ms part2_pos = veh2.bub_part_pos( this, vp2 );
     if( you.sees( part1_pos ) || you.sees( part2_pos ) ) {
         //~ %1$s: first vehicle name (without "the")
         //~ %2$s: first part name
@@ -1304,7 +1304,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
                     elem->sm_pos.z() = cz;
                     wrapped_vehicle w;
                     w.v = elem.get();
-                    w.pos = w.v->pos_bub();
+                    w.pos = w.v->pos_bub( this );
                     vehs.push_back( w );
                 }
             }
@@ -1529,7 +1529,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const bool 
                 continue;
             }
             Creature *psg = r.psg;
-            const tripoint_bub_ms part_pos = veh.bub_part_pos( prt );
+            const tripoint_bub_ms part_pos = veh.bub_part_pos( this, prt );
             if( psg == nullptr ) {
                 debugmsg( "Empty passenger for part #%d at %d,%d,%d player at %d,%d,%d?",
                           prt, part_pos.x(), part_pos.y(), part_pos.z(),
@@ -8171,7 +8171,7 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
             vehicle *veh = iter->get();
             if( veh->part_count() > 0 ) {
                 // Always fix submap coordinates for easier Z-level-related operations
-                veh->sm_pos = abs_sub.xy() + tripoint_rel_sm{ rebase_rel(grid), z};
+                veh->sm_pos = abs_sub.xy() + tripoint_rel_sm{ rebase_rel( grid ), z};
                 iter++;
                 if( main_inbounds ) {
                     _main_requires_cleanup = true;
@@ -8593,7 +8593,7 @@ void map::actualize( const tripoint_rel_sm &grid )
             const item &base_const = vp.part().get_base();
             const_cast<item &>( base_const ).overflow( vp.pos_bub() );
         }
-        veh->refresh();
+        veh->refresh( this );
     }
 
     const time_duration time_since_last_actualize = calendar::turn - tmpsub->last_touched;
@@ -9428,12 +9428,14 @@ void map::build_floor_caches()
 
 static void vehicle_caching_internal( level_cache &zch, const vpart_reference &vp, vehicle *v )
 {
+    map &here =
+        get_map(); // TODO: Check is this is actually reasonable. Probably need to feed the map in.
     auto &outside_cache = zch.outside_cache;
     auto &transparency_cache = zch.transparency_cache;
     auto &floor_cache = zch.floor_cache;
 
     const size_t part = vp.part_index();
-    const tripoint_bub_ms part_pos =  v->bub_part_pos( vp.part() );
+    const tripoint_bub_ms part_pos =  v->bub_part_pos( &here, vp.part() );
 
     bool vehicle_is_opaque = vp.has_feature( VPFLAG_OPAQUE ) && !vp.part().is_broken();
 
@@ -9458,8 +9460,10 @@ static void vehicle_caching_internal( level_cache &zch, const vpart_reference &v
 static void vehicle_caching_internal_above( level_cache &zch_above, const vpart_reference &vp,
         vehicle *v )
 {
+    map &here =
+        get_map(); // TODO: Check is this is actually reasonable. Probably need to feed the map in.
     if( vp.has_feature( VPFLAG_ROOF ) || vp.has_feature( VPFLAG_OPAQUE ) ) {
-        const tripoint_bub_ms part_pos = v->bub_part_pos( vp.part() );
+        const tripoint_bub_ms part_pos = v->bub_part_pos( &here, vp.part() );
         zch_above.floor_cache[part_pos.x()][part_pos.y()] = true;
     }
 }
@@ -9472,7 +9476,7 @@ void map::do_vehicle_caching( int z )
     }
     for( vehicle *v : ch->vehicle_list ) {
         for( const vpart_reference &vp : v->get_all_parts_with_fakes() ) {
-            const tripoint_bub_ms part_pos = v->bub_part_pos( vp.part() );
+            const tripoint_bub_ms part_pos = v->bub_part_pos( this, vp.part() );
             if( !inbounds( part_pos.xy() ) ) {
                 continue;
             }

--- a/src/map.h
+++ b/src/map.h
@@ -803,7 +803,7 @@ class map
         // Returns the wheel area of the vehicle multiplied by traction of the surface
         // When ignore_movement_modifiers is set to true, it returns the area of the wheels touching the ground
         // TODO: Remove the ugly sinking vehicle hack
-        float vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modifiers = false ) const;
+        float vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modifiers = false );
 
         // Executes vehicle-vehicle collision based on vehicle::collision results
         // Returns impulse of the executed collision

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6914,7 +6914,7 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, cons
     tripoint_bub_sm quotient;
     point_sm_ms remainder;
     std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( p_ms );
-    veh->sm_pos = abs_sub.xy() + rebase_rel(quotient);
+    veh->sm_pos = abs_sub.xy() + rebase_rel( quotient );
     veh->pos = remainder;
     veh->init_state( *this, veh_fuel, veh_status, force_status );
     veh->place_spawn_items();
@@ -6929,7 +6929,7 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, cons
     vehicle *placed_vehicle = placed_vehicle_up.get();
 
     if( placed_vehicle != nullptr ) {
-        submap *place_on_submap = get_submap_at_grid( placed_vehicle->sm_pos -abs_sub.xy() );
+        submap *place_on_submap = get_submap_at_grid( placed_vehicle->sm_pos - abs_sub.xy() );
         if( place_on_submap == nullptr ) {
             debugmsg( "Tried to add vehicle at %s but the submap is not loaded",
                       placed_vehicle->sm_pos.to_string() );
@@ -6973,7 +6973,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
 
     for( std::vector<int>::const_iterator part = frame_indices.begin();
          part != frame_indices.end(); part++ ) {
-        const tripoint_bub_ms p = veh_to_add->bub_part_pos( *part );
+        const tripoint_bub_ms p = veh_to_add->bub_part_pos( this, *part );
 
         if( veh_to_add->part( *part ).is_fake ) {
             continue;
@@ -7016,13 +7016,13 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
             std::unique_ptr<RemovePartHandler> handler_ptr;
             bool did_merge = false;
             for( const tripoint_abs_ms &map_pos : first_veh->get_points( true ) ) {
-                const tripoint_bub_ms map_bub_pos = get_bub( map_pos ); // TODO: Make usages use this map.
-                std::vector<vehicle_part *> parts_to_move = veh_to_add->get_parts_at( map_bub_pos, "",
+                const tripoint_bub_ms map_bub_pos = get_bub( map_pos );
+                std::vector<vehicle_part *> parts_to_move = veh_to_add->get_parts_at( this, map_bub_pos, "",
                         part_status_flag::any );
                 if( !parts_to_move.empty() ) {
                     // Store target_point by value because first_veh->parts may reallocate
                     // to a different address after install_part()
-                    std::vector<vehicle_part *> first_veh_parts = first_veh->get_parts_at( map_bub_pos, "",
+                    std::vector<vehicle_part *> first_veh_parts = first_veh->get_parts_at( this, map_bub_pos, "",
                             part_status_flag:: any );
                     // This happens if this location is occupied by a fake part.
                     if( first_veh_parts.empty() || first_veh_parts.front()->is_fake ) {
@@ -7058,6 +7058,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
                         // This is a heuristic: we just assume the default handler is good enough when called
                         // on the main game map. And assume that we run from some mapgen code if called on
                         // another instance.
+                        // TODO: Update logic to be able to work outside of mapgen and in the reality bubble.
                         if( !g || &get_map() != this ) {
                             handler_ptr = std::make_unique<MapgenRemovePartHandler>( *this );
                         }
@@ -7111,7 +7112,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
         veh_to_add->smash( *this );
     }
 
-    veh_to_add->refresh();
+    veh_to_add->refresh( this );
     return veh_to_add;
 }
 
@@ -7227,7 +7228,7 @@ void map::rotate( int turns )
                 sm->rotate( turns );
 
                 for( auto &veh : sm->vehicles ) {
-                    veh->sm_pos = { abs_sub.xy()+ p, z_level };
+                    veh->sm_pos = { abs_sub.xy() + p, z_level };
                 }
 
                 update_vehicle_list( sm, z_level );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6914,7 +6914,7 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, cons
     tripoint_bub_sm quotient;
     point_sm_ms remainder;
     std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( p_ms );
-    veh->sm_pos = quotient;
+    veh->sm_pos = abs_sub.xy() + rebase_rel(quotient);
     veh->pos = remainder;
     veh->init_state( *this, veh_fuel, veh_status, force_status );
     veh->place_spawn_items();
@@ -6929,7 +6929,7 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, cons
     vehicle *placed_vehicle = placed_vehicle_up.get();
 
     if( placed_vehicle != nullptr ) {
-        submap *place_on_submap = get_submap_at_grid( rebase_rel( placed_vehicle->sm_pos ) );
+        submap *place_on_submap = get_submap_at_grid( placed_vehicle->sm_pos -abs_sub.xy() );
         if( place_on_submap == nullptr ) {
             debugmsg( "Tried to add vehicle at %s but the submap is not loaded",
                       placed_vehicle->sm_pos.to_string() );
@@ -7227,7 +7227,7 @@ void map::rotate( int turns )
                 sm->rotate( turns );
 
                 for( auto &veh : sm->vehicles ) {
-                    veh->sm_pos = { rebase_bub( p ), z_level };
+                    veh->sm_pos = { abs_sub.xy()+ p, z_level };
                 }
 
                 update_vehicle_list( sm, z_level );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1810,7 +1810,7 @@ void npc::execute_action( npc_action action )
                 }
                 // A seat is available if we can move there and it's either unassigned or assigned to us
                 auto available_seat = [&]( const vehicle_part & pt ) {
-                    tripoint_bub_ms target = veh->bub_part_pos( pt );
+                    tripoint_bub_ms target = veh->bub_part_pos( &here, pt );
                     if( !pt.is_seat() ) {
                         return false;
                     }
@@ -1875,7 +1875,7 @@ void npc::execute_action( npc_action action )
 
                 const int cur_part = seats[i].second;
 
-                tripoint_bub_ms pp = veh->bub_part_pos( cur_part );
+                tripoint_bub_ms pp = veh->bub_part_pos( &here, cur_part );
                 update_path( pp, true );
                 if( !path.empty() ) {
                     // All is fine

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -514,13 +514,14 @@ target_handler::trajectory target_handler::mode_turret_manual( avatar &you, turr
 target_handler::trajectory target_handler::mode_turrets( avatar &you, vehicle &veh,
         const std::vector<vehicle_part *> &turrets )
 {
+    map &here = get_map();
     // Find radius of a circle centered at u encompassing all points turrets can aim at
     // FIXME: this calculation is fine for square distances, but results in an underestimation
     //        when used with real circles
     int range_total = 0;
     for( vehicle_part *t : turrets ) {
         int range = veh.turret_query( *t ).range();
-        tripoint_bub_ms pos = veh.bub_part_pos( *t );
+        tripoint_bub_ms pos = veh.bub_part_pos( &here, *t );
 
         int res = 0;
         res = std::max( res, rl_dist( you.pos_bub(), pos + point( range, 0 ) ) );
@@ -3387,7 +3388,7 @@ void target_ui::update_turrets_in_range()
     for( vehicle_part *t : *vturrets ) {
         turret_data td = veh->turret_query( *t );
         if( td.in_range( here.get_abs( dst ) ) ) {
-            tripoint_bub_ms src = veh->bub_part_pos( *t );
+            tripoint_bub_ms src = veh->bub_part_pos( &here, *t );
             turrets_in_range.push_back( {t, line_to( src, dst )} );
         }
     }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3418,6 +3418,8 @@ void smart_controller_config::serialize( JsonOut &json ) const
 
 void vehicle::deserialize( const JsonObject &data )
 {
+    map &here = get_map();
+
     data.allow_omitted_members();
 
     int fdir = 0;
@@ -3496,7 +3498,7 @@ void vehicle::deserialize( const JsonObject &data )
     data.read( "fuel_remainder", fuel_remainder );
     data.read( "fuel_used_last_turn", fuel_used_last_turn );
 
-    refresh();
+    refresh( &here );
 
     point p;
     zone_data zd;
@@ -3540,6 +3542,7 @@ void vehicle::deserialize_parts( const JsonArray &data )
 
 void vehicle::serialize( JsonOut &json ) const
 {
+    map &here = get_map();
     json.start_object();
     json.member( "type", type );
     json.member( "posx", pos.x() );
@@ -3583,7 +3586,7 @@ void vehicle::serialize( JsonOut &json ) const
     if( is_towed() ) {
         vehicle *tower = tow_data.get_towed_by();
         if( tower ) {
-            other_tow_temp_point = tower->bub_part_pos( tower->get_tow_part() );
+            other_tow_temp_point = tower->bub_part_pos( &here, tower->get_tow_part() );
         }
     }
     json.member( "other_tow_point", other_tow_temp_point );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -114,7 +114,7 @@ bool place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
                 continue;
             }
             if( connected_vehicles.find( &veh_target ) == connected_vehicles.end() ) {
-                veh->connect(&here, p, trip );
+                veh->connect( &here, p, trip );
                 connected_vehicles.insert( &veh_target );
             }
         }
@@ -528,8 +528,9 @@ void veh_app_interact::disconnect()
 
 void veh_app_interact::plug()
 {
+    map &here = get_map();
     const int part = veh->part_at( veh->coord_translate( a_point ) );
-    const tripoint_bub_ms pos = veh->bub_part_pos( part );
+    const tripoint_bub_ms pos = veh->bub_part_pos( &here, part );
     item cord( itype_power_cord );
     cord.link_to( *veh, a_point, link_state::automatic );
     if( cord.get_use( "link_up" ) ) {

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -114,7 +114,7 @@ bool place_appliance( const tripoint_bub_ms &p, const vpart_id &vpart,
                 continue;
             }
             if( connected_vehicles.find( &veh_target ) == connected_vehicles.end() ) {
-                veh->connect( p, trip );
+                veh->connect(&here, p, trip );
                 connected_vehicles.insert( &veh_target );
             }
         }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3334,7 +3334,7 @@ void veh_interact::complete_vehicle( Character &you )
 
             // Save these values now so they aren't lost when parts or vehicles are destroyed.
             const point_rel_ms part_mount = vp->mount;
-            const tripoint_bub_ms part_pos = veh.bub_part_pos( *vp );
+            const tripoint_bub_ms part_pos = veh.bub_part_pos( &here, *vp );
 
             veh.unlink_cables( part_mount, you,
                                false, /* unneeded as items will be unlinked if the connected part is removed */

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -15,9 +15,10 @@ veh_shape::veh_shape( vehicle &vehicle ): veh( vehicle ) { }
 
 player_activity veh_shape::start( const tripoint_bub_ms &pos )
 {
+    map &here = get_map();
     avatar &you = get_avatar();
-    on_out_of_scope cleanup( []() {
-        get_map().invalidate_map_cache( get_avatar().view_offset.z() );
+    on_out_of_scope cleanup( [&here]() {
+        here.invalidate_map_cache( get_avatar().view_offset.z() );
     } );
     restore_on_out_of_scope view_offset_prev( you.view_offset );
 
@@ -28,13 +29,13 @@ player_activity veh_shape::start( const tripoint_bub_ms &pos )
 
     if( !set_cursor_pos( pos ) ) {
         debugmsg( "failed to set cursor at given part" );
-        set_cursor_pos( veh.bub_part_pos( 0 ) );
+        set_cursor_pos( veh.bub_part_pos( &here, 0 ) );
     }
 
     const auto target_ui_cb = make_shared_fast<game::draw_callback_t>(
     [&]() {
         const avatar &you = get_avatar();
-        g->draw_cursor_unobscuring( you.pos_bub() + you.view_offset );
+        g->draw_cursor_unobscuring( you.pos_bub( &here ) + you.view_offset );
     } );
     g->add_draw_callback( target_ui_cb );
     ui_adaptor ui;
@@ -83,11 +84,13 @@ player_activity veh_shape::start( const tripoint_bub_ms &pos )
 
 std::vector<vpart_reference> veh_shape::parts_under_cursor() const
 {
+    map &here = get_map();
+
     std::vector<vpart_reference> res;
     // TODO: tons of methods getting parts from vehicle but all of them seem inadequate?
     for( int part_idx = 0; part_idx < veh.part_count_real(); part_idx++ ) {
         const vehicle_part &p = veh.part( part_idx );
-        if( veh.bub_part_pos( p ) == get_cursor_pos() && !p.is_fake ) {
+        if( veh.bub_part_pos( &here, p ) == get_cursor_pos() && !p.is_fake ) {
             res.emplace_back( veh, part_idx );
         }
     }
@@ -127,6 +130,7 @@ std::optional<vpart_reference> veh_shape::select_part_at_cursor(
 
 void veh_shape::change_part_shape( vpart_reference vpr ) const
 {
+    map &here = get_map();
     vehicle_part &part = vpr.part();
     const vpart_info &vpi = part.info();
     veh_menu menu( this->veh, _( "Choose cosmetic variant:" ) );
@@ -141,7 +145,7 @@ void veh_shape::change_part_shape( vpart_reference vpr ) const
             .keep_menu_open()
             .skip_locked_check()
             .skip_theft_check()
-            .location( veh.bub_part_pos( part ).raw() )
+            .location( veh.bub_part_pos( &here, part ).raw() )
             .select( part.variant == vvid )
             .desc( _( "Confirm to save or exit to revert" ) )
             .symbol( vv.get_symbol_curses( 0_degrees, false ) )

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -483,8 +483,8 @@ bool veh_menu::query()
 
     chosen._on_submit();
 
-    veh.refresh();
     map &m = get_map();
+    veh.refresh( &m );
     m.invalidate_visibility_cache();
     m.invalidate_map_cache( m.get_abs_sub().z() );
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -970,7 +970,8 @@ class vehicle
         bool is_towing() const;
         bool has_tow_attached() const;
         int get_tow_part() const;
-        bool is_external_part( const tripoint_bub_ms &part_pt ) const;
+        bool is_external_part( map *here, const tripoint_bub_ms &part_pt ) const;
+        bool is_external_part(const point_rel_ms& mount) const;
         bool is_towed() const;
         void set_tow_directions();
         /// @return true if vehicle is an appliance
@@ -1015,7 +1016,7 @@ class vehicle
         // Stop any kind of automatic vehicle control and apply the brakes.
         void stop_autodriving( bool apply_brakes = true );
 
-        void connect( const tripoint_bub_ms &source_pos, const tripoint_bub_ms &target_pos );
+        void connect( map *here, const tripoint_bub_ms &source_pos, const tripoint_bub_ms &target_pos );
 
         bool precollision_check( units::angle &angle, map &here, bool follow_protocol );
         // Try select any fuel for engine, returns true if some fuel is available
@@ -2132,7 +2133,7 @@ class vehicle
          * This should be called only when the vehicle has actually been moved, not when
          * the map is just shifted (in the later case simply set smx/smy directly).
          */
-        void set_submap_moved( const tripoint_bub_sm &p );
+        void set_submap_moved( map *here, const tripoint_bub_sm &p );
         void use_autoclave( int p );
         void use_washing_machine( int p );
         void use_dishwasher( int p );
@@ -2307,18 +2308,11 @@ class vehicle
 
     public:
         /**
-         * Submap coordinates of the currently loaded submap (see game::m)
-         * that contains this vehicle. These values are changed when the map
-         * shifts (but the vehicle is not actually moved than, it also stays on
-         * the same submap, only the relative coordinates in map::grid have changed).
-         * These coordinates must always refer to the submap in map::grid that contains
-         * this vehicle.
+         * Submap coordinates of the currently loaded submap that contains this vehicle.
          * When the vehicle is really moved (by map::displace_vehicle), set_submap_moved
-         * is called and updates these values, when the map is only shifted or when a submap
-         * is loaded into the map the values are directly set. The vehicles position does
-         * not change therefore no call to set_submap_moved is required.
+         * is called and updates these values.
          */
-        tripoint_bub_sm sm_pos = tripoint_bub_sm::zero; // NOLINT(cata-serialize)
+        tripoint_abs_sm sm_pos = tripoint_abs_sm::zero; // NOLINT(cata-serialize)
 
         // alternator load as a percentage of engine power, in units of 0.1% so 1000 is 100.0%
         int alternator_load = 0; // NOLINT(cata-serialize)

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -911,7 +911,7 @@ class vehicle
         void suspend_refresh();
         void enable_refresh();
         //Refresh all caches and re-locate all parts
-        void refresh( bool remove_fakes = true );
+        void refresh( map *here, bool remove_fakes = true );
 
         // Refresh active_item cache for vehicle parts
         void refresh_active_item_cache();
@@ -971,7 +971,7 @@ class vehicle
         bool has_tow_attached() const;
         int get_tow_part() const;
         bool is_external_part( map *here, const tripoint_bub_ms &part_pt ) const;
-        bool is_external_part(const point_rel_ms& mount) const;
+        bool is_external_part( const point_rel_ms &mount ) const;
         bool is_towed() const;
         void set_tow_directions();
         /// @return true if vehicle is an appliance
@@ -1289,7 +1289,11 @@ class vehicle
          *  @param flag if set only flags with this part will be considered
          *  @param condition enum to include unabled, unavailable, and broken parts
          */
+        // TODO: Get rid of map less overload.
         std::vector<vehicle_part *> get_parts_at( const tripoint_bub_ms &pos, const std::string &flag,
+                part_status_flag condition );
+        std::vector<vehicle_part *> get_parts_at( map *here, const tripoint_bub_ms &pos,
+                const std::string &flag,
                 part_status_flag condition );
         std::vector<const vehicle_part *> get_parts_at( const tripoint_bub_ms &pos,
                 const std::string &flag, part_status_flag condition ) const;
@@ -1434,12 +1438,14 @@ class vehicle
         tripoint_abs_omt pos_abs_omt() const;
         // Returns the coordinates (in map squares) of the vehicle relative to the local map.
         // Warning: Don't assume this position contains a vehicle part
+        // TODO: Replace usage of map less version.
         tripoint_bub_ms pos_bub() const;
+        tripoint_bub_ms pos_bub( map *here ) const;
         /**
          * Get the coordinates of the studied part of the vehicle
          */
-        tripoint_bub_ms bub_part_pos( int index ) const;
-        tripoint_bub_ms bub_part_pos( const vehicle_part &pt ) const;
+        tripoint_bub_ms bub_part_pos( map *here, int index ) const;
+        tripoint_bub_ms bub_part_pos( map *here, const vehicle_part &pt ) const;
         tripoint_abs_ms abs_part_pos( int index ) const;
         tripoint_abs_ms abs_part_pos( const vehicle_part &pt ) const;
         /**

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -555,17 +555,16 @@ void vehicle::toggle_tracking()
     }
 }
 
-void vehicle::connect( const tripoint_bub_ms &source_pos, const tripoint_bub_ms &target_pos )
+void vehicle::connect( map *here, const tripoint_bub_ms &source_pos, const tripoint_bub_ms &target_pos )
 {
-    map &here = get_map();
-    const optional_vpart_position sel_vp = here.veh_at( target_pos );
-    const optional_vpart_position prev_vp = here.veh_at( source_pos );
+    const optional_vpart_position sel_vp = here->veh_at( target_pos );
+    const optional_vpart_position prev_vp = here->veh_at( source_pos );
 
     if( !sel_vp ) {
         return;
     }
     if( &sel_vp->vehicle() == &prev_vp->vehicle() ) {
-        return ;
+        return;
     }
 
     item cord( itype_power_cord );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -137,6 +137,8 @@ void handbrake()
 
 void vehicle::control_doors()
 {
+    map &here = get_map();
+
     const auto open_or_close_all = [this]( bool new_open, const std::string & require_flag ) {
         for( const vpart_reference &vpr_motor : get_avail_parts( "DOOR_MOTOR" ) ) {
             const int motorized_idx = new_open
@@ -170,7 +172,7 @@ void vehicle::control_doors()
         }
     };
 
-    const auto add_openable = [this]( veh_menu & menu, int vp_idx ) {
+    const auto add_openable = [this, &here]( veh_menu & menu, int vp_idx ) {
         if( vp_idx == -1 ) {
             return;
         }
@@ -179,7 +181,7 @@ void vehicle::control_doors()
         const bool open = !vp.open;
         menu.add( string_format( "%s %s", actname, vp.name() ) )
         .hotkey_auto()
-        .location( bub_part_pos( vp ).raw() )
+        .location( bub_part_pos( &here, vp ).raw() )
         .keep_menu_open()
         .on_submit( [this, vp_idx, open] {
             if( can_close( vp_idx, get_player_character() ) )
@@ -189,7 +191,7 @@ void vehicle::control_doors()
         } );
     };
 
-    const auto add_lockable = [this]( veh_menu & menu, int vp_idx ) {
+    const auto add_lockable = [this, &here]( veh_menu & menu, int vp_idx ) {
         if( vp_idx == -1 ) {
             return;
         }
@@ -198,7 +200,7 @@ void vehicle::control_doors()
         const bool lock = !vp.locked;
         menu.add( string_format( "%s %s", actname, vp.name() ) )
         .hotkey_auto()
-        .location( bub_part_pos( vp ).raw() )
+        .location( bub_part_pos( &here, vp ).raw() )
         .keep_menu_open()
         .on_submit( [this, vp_idx, lock] {
             lock_or_unlock( vp_idx, lock );
@@ -555,7 +557,8 @@ void vehicle::toggle_tracking()
     }
 }
 
-void vehicle::connect( map *here, const tripoint_bub_ms &source_pos, const tripoint_bub_ms &target_pos )
+void vehicle::connect( map *here, const tripoint_bub_ms &source_pos,
+                       const tripoint_bub_ms &target_pos )
 {
     const optional_vpart_position sel_vp = here->veh_at( target_pos );
     const optional_vpart_position prev_vp = here->veh_at( source_pos );
@@ -575,11 +578,13 @@ void vehicle::connect( map *here, const tripoint_bub_ms &source_pos, const tripo
 
 double vehicle::engine_cold_factor( const vehicle_part &vp ) const
 {
+    map &here = get_map();
+
     if( !vp.info().has_flag( "E_COLD_START" ) ) {
         return 0.0;
     }
 
-    const tripoint_bub_ms pos = bub_part_pos( vp );
+    const tripoint_bub_ms pos = bub_part_pos( &here, vp );
     double eff_temp = units::to_fahrenheit( get_weather().get_temperature( pos ) );
     if( !vp.has_fault_flag( "BAD_COLD_START" ) ) {
         eff_temp = std::min( eff_temp, 20.0 );
@@ -629,6 +634,8 @@ bool vehicle::auto_select_fuel( vehicle_part &vp )
 
 bool vehicle::start_engine( vehicle_part &vp )
 {
+    map &here = get_map();
+
     const vpart_info &vpi = vp.info();
     if( !is_engine_on( vp ) ) {
         return false;
@@ -669,7 +676,7 @@ bool vehicle::start_engine( vehicle_part &vp )
 
     const double dmg = vp.damage_percent();
     const time_duration start_time = engine_start_time( vp );
-    const tripoint_bub_ms pos = bub_part_pos( vp );
+    const tripoint_bub_ms pos = bub_part_pos( &here, vp );
 
     if( ( 1 - dmg ) < vpi.engine_info->backfire_threshold &&
         one_in( vpi.engine_info->backfire_freq ) ) {
@@ -746,6 +753,7 @@ bool vehicle::start_engine( vehicle_part &vp )
 
 void vehicle::stop_engines()
 {
+    map &here = get_map();
     vehicle_noise = 0;
     engine_on = false;
     for( const int p : engines ) {
@@ -754,7 +762,8 @@ void vehicle::stop_engines()
             continue;
         }
 
-        sounds::sound( bub_part_pos( vp ), 2, sounds::sound_t::movement, _( "the engine go silent" ) );
+        sounds::sound( bub_part_pos( &here, vp ), 2, sounds::sound_t::movement,
+                       _( "the engine go silent" ) );
 
         std::string variant = vp.info().id.str();
 
@@ -773,11 +782,13 @@ void vehicle::stop_engines()
         sfx::play_variant_sound( "engine_stop", variant, vp.info().engine_info->noise_factor );
     }
     sfx::do_vehicle_engine_sfx();
-    refresh();
+    refresh( &here );
 }
 
 void vehicle::start_engines( Character *driver, const bool take_control, const bool autodrive )
 {
+    map &here = get_map();
+
     bool has_engine = std::any_of( engines.begin(), engines.end(), [&]( int idx ) {
         return parts[ idx ].enabled && !parts[ idx ].is_broken();
     } );
@@ -797,7 +808,7 @@ void vehicle::start_engines( Character *driver, const bool take_control, const b
     for( const int p : engines ) {
         const vehicle_part &vp = parts[p];
         if( !has_starting_engine_position && !vp.is_broken() && vp.enabled ) {
-            starting_engine_position = bub_part_pos( vp );
+            starting_engine_position = bub_part_pos( &here, vp );
             has_starting_engine_position = true;
         }
         has_engine = has_engine || is_engine_on( vp );
@@ -810,7 +821,7 @@ void vehicle::start_engines( Character *driver, const bool take_control, const b
 
     if( !has_engine ) {
         add_msg( m_info, _( "The %s doesn't have an engine!" ), name );
-        refresh();
+        refresh( &here );
         return;
     }
 
@@ -823,7 +834,7 @@ void vehicle::start_engines( Character *driver, const bool take_control, const b
         driver->activity.relative_placement = starting_engine_position - driver->pos_bub();
         driver->activity.values.push_back( take_control );
     }
-    refresh();
+    refresh( &here );
 }
 
 void vehicle::enable_patrol()
@@ -1115,12 +1126,12 @@ void vehicle::operate_scoop()
                 _( "Whirrrr" ), _( "Ker-chunk" ), _( "Swish" ), _( "Cugugugugug" )
             }
         };
-        sounds::sound( bub_part_pos( scoop ), rng( 20, 35 ), sounds::sound_t::combat,
+        sounds::sound( bub_part_pos( &here, scoop ), rng( 20, 35 ), sounds::sound_t::combat,
                        random_entry_ref( sound_msgs ), false, "vehicle", "scoop" );
         std::vector<tripoint_bub_ms> parts_points;
         parts_points.reserve( 8 );
         for( const tripoint_bub_ms &current :
-             here.points_in_radius( bub_part_pos( scoop ), 1 ) ) {
+             here.points_in_radius( bub_part_pos( &here, scoop ), 1 ) ) {
             parts_points.push_back( current );
         }
         for( const tripoint_bub_ms &position : parts_points ) {
@@ -1260,7 +1271,7 @@ bool vehicle::can_close( int part_index, Character &who )
         for( int partID : vec ) {
             // Check the part for collisions, then if there's a fake part present check that too.
             while( partID >= 0 ) {
-                const Creature *const mon = creatures.creature_at( bub_part_pos( parts[partID] ) );
+                const Creature *const mon = creatures.creature_at( abs_part_pos( parts[partID] ) );
                 if( mon ) {
                     if( mon->is_avatar() ) {
                         who.add_msg_if_player( m_info, _( "There's some buffoon in the way!" ) );

--- a/tests/vehicle_export_test.cpp
+++ b/tests/vehicle_export_test.cpp
@@ -33,6 +33,7 @@ static bool operator==( const vehicle_item_spawn &l, const vehicle_item_spawn &r
 TEST_CASE( "export_vehicle_test" )
 {
     clear_map();
+    map &here = get_map();
     // Spawn the vehicle with fuel.
     vehicle *veh_ptr = get_map().add_vehicle( vehicle_prototype_veh_export_test, tripoint_bub_ms::zero,
                        0_degrees, -1, 0 );
@@ -40,8 +41,8 @@ TEST_CASE( "export_vehicle_test" )
 
     // To ensure the zones get placed.
     veh_ptr->set_owner( get_player_character() );
-    veh_ptr->place_zones( get_map() );
-    veh_ptr->refresh();
+    veh_ptr->place_zones( here );
+    veh_ptr->refresh( &here );
     veh_ptr->refresh_zones();
 
     std::ostringstream os;

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -333,7 +333,7 @@ TEST_CASE( "vehicle_with_fake_obstacle_parts_block_movement", "[vehicle][vehicle
     vehicle *veh = here.add_vehicle( vehicle_prototype_obstacle_test,
                                      test_origin, 315_degrees, 100, 0 );
     REQUIRE( veh != nullptr );
-    veh->refresh();
+    veh->refresh( &here );
     here.set_seen_cache_dirty( 0 );
     here.build_map_cache( 0 );
     validate_part_count( *veh, 0, 315_degrees, 11, 6, 5 );

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
         REQUIRE( frame_part_idx != -1 );
         const int bat_part_idx = veh->install_part( point_rel_ms::zero, vpart_small_storage_battery );
         REQUIRE( bat_part_idx != -1 );
-        veh->refresh();
+        veh->refresh( &here );
         here.add_vehicle_to_cache( veh );
         batteries.emplace_back( *veh, bat_part_idx );
     }

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -280,7 +280,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
     }
     std::set<int> z_span;
     for( vehicle_part *prt : all_parts ) {
-        z_span.insert( veh.bub_part_pos( *prt ).z() );
+        z_span.insert( veh.abs_part_pos( *prt ).z() );
     }
     REQUIRE( z_span.size() > 1 );
 
@@ -306,7 +306,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
 
     here.vehmove();
     for( vehicle_part *prt : all_parts ) {
-        CHECK( veh.bub_part_pos( *prt ).z() == 0 );
+        CHECK( veh.abs_part_pos( *prt ).z() == 0 );
     }
     CHECK( dmon.posz() == 0 );
     CHECK( veh.pos_bub().z() == 0 );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -591,7 +591,7 @@ static void rack_check( const rack_preset &preset )
         vehicle *veh_ptr = m.add_vehicle( preset.vehicles[i], preset.positions[i],
                                           preset.facings[i], 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        veh_ptr->refresh();
+        veh_ptr->refresh( &m );
         vehs.push_back( veh_ptr );
         veh_names.push_back( veh_ptr->name );
     }
@@ -743,13 +743,13 @@ static int test_autopilot_moving( const vproto_id &veh_id, const vpart_id &extra
 {
     clear_avatar();
     clear_map();
+    map &here = get_map();
     Character &player_character = get_player_character();
     // Move player somewhere safe
     REQUIRE_FALSE( player_character.in_vehicle );
     player_character.setpos( tripoint_bub_ms::zero );
 
     const tripoint_bub_ms map_starting_point( 60, 60, 0 );
-    map &here = get_map();
     vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 100, 0, false );
 
     REQUIRE( veh_ptr != nullptr );
@@ -765,7 +765,7 @@ static int test_autopilot_moving( const vproto_id &veh_id, const vpart_id &extra
     veh.is_following = true;
     veh.is_patrolling = false;
     veh.engine_on = true;
-    veh.refresh();
+    veh.refresh( &here );
 
     int turns_left = 10;
     int tiles_travelled = 0;

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -100,7 +100,7 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             REQUIRE( qry.query() == turret_data::status::ready );
             REQUIRE( qry.range() > 0 );
 
-            player_character.setpos( veh->bub_part_pos( vp ) );
+            player_character.setpos( &here, veh->bub_part_pos( &here, vp ) );
             int shots_fired = 0;
             // 3 attempts to fire, to account for possible misfires
             for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Convert code to keep track of which map it operates on rather than (almost) always assume it's the reality bubble.
This time the focus was on changing the vehicle position to absolute rather than bubble coordinates relative to some undefined map (typically a local mapgen one or the reality bubble). Code sort of happened to work for some reason when mapgen maps were used to generate bubble ones.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Convert a few vehicle operations, but mainly change the vehicle position data.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Spend additional effort trying to work around the need for map references. That was possible in a few cases (getting the absolute position, which gets what's stored, and thus doesn't need any map reference, to feed an operation that can take either an absolute or a bubble coordinate, such as getting a monster at a location). Thus far only easy cases have been spotted.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Running tests locally (a number of errors were shown before being found, including the one stumping me on an earlier attempt).
Play testing, i.e. a couple of hours of normal game play with a lot of driving around (and thus generation of vehicles on new maps) without seeing anything odd.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
