### PR TITLE
Implement riot damage in cities

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -39,7 +39,7 @@
     "extras": "build",
     "mondensity": 2,
     "see_cost": "high",
-    "flags": [ "RISK_HIGH", "GENERIC_LOOT" ]
+    "flags": [ "RISK_HIGH", "GENERIC_LOOT", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -1316,6 +1316,7 @@ See [Character](#character)
 - ```REQUIRES_PREDECESSOR``` Mapgen for this will not start from scratch; it will update the mapgen from the terrain it replaced.  This allows the corresponding json mapgen to use the `expects_predecessor` feature.
 - ```LAKE``` Consider this location to be a valid lake terrain for mapgen purposes.
 - ```LAKE_SHORE``` Consider this location to be a valid lake shore terrain for mapgen purposes.
+- ```PP_GENERATE_RIOT_DAMAGE``` Applies randomized riot damage to the local map as a last stage in generating it. Furniture and terrain will be bashed, items moved around, blood spatters are placed, and rarely spawns fires.
 - ```SOURCE_FUEL``` For NPC AI, this location may contain fuel for looting.
 - ```SOURCE_FOOD``` For NPC AI, this location may contain food for looting.
 - ```SOURCE_FARMING``` For NPC AI, this location may contain useful farming supplies for looting.

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -200,6 +200,7 @@ enum class oter_flags : int {
     ocean_shore,
     ravine,
     ravine_edge,
+    pp_generate_riot_damage,
     generic_loot,
     risk_extreme,
     risk_high,

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -729,6 +729,7 @@ std::string enum_to_string<oter_flags>( oter_flags data )
         case oter_flags::ocean_shore: return "OCEAN_SHORE";
         case oter_flags::ravine: return "RAVINE";
         case oter_flags::ravine_edge: return "RAVINE_EDGE";
+        case oter_flags::pp_generate_riot_damage: return "PP_GENERATE_RIOT_DAMAGE";
         case oter_flags::generic_loot: return "GENERIC_LOOT";
         case oter_flags::risk_extreme: return "RISK_EXTREME";
         case oter_flags::risk_high: return "RISK_HIGH";


### PR DESCRIPTION
#### Summary
Content "Riot damage in cities"

#### Purpose of change
It's the end of the world, but our cities are mostly pristine. There's very little evidence of the great damage and destruction that occurred before society collapsed.

I would like to ruin ~~the game~~ the cities.

#### Describe the solution
We introduce a new concept known as a "mapgen post-processing generator". These generators are linked to flags and applied after regular mapgen occurs. This PR adds only one.

These generators are intended to run as the last step of local map generation, applying procedural effects which are otherwise unreasonable to be made as mapgen.

This generator does the following:
-Randomly bashes terrain and furniture, currently in a random range between 6-60 inclusive. Most interior walls required 80 damage to be destroyed, so it intentionally avoids destroying walls. (For now.)

-Moves items around, randomly.
--Maximum of 3 tiles diagonally. Note that the move item function can be run repeatedly, and is randomized, so a single object could be moved more than once and end up far outside of where you'd expect it.
--Additionally, I would like to note that it only *moves* items. It does not destroy or change item spawning behavior in any way.

-Randomly places blood fields.

-Rarely places a fire field.

The generator looks for the flag `PP_GENERATE_RIOT_DAMAGE` which is copy-from chained to essentially all city buildings.

#### Describe alternatives you've considered
Making ruined variants of every building, forever.

#### Testing

Here is bungalow06_north, without this PR

![image](https://github.com/user-attachments/assets/d8298d18-1015-4d7c-8e1d-9ce706fe0094)


Here is bungalow06_north, with the generator applied.

![image](https://github.com/user-attachments/assets/08f5ab61-6732-4c1f-968d-7565a1aec53e)


#### Additional context

Known issues:
-No attempt has been made to audit the exact extent of the `PP_GENERATE_RIOT_DAMAGE` flag. Some buildings may end up having the flag that should not have the flag. Some buildings may not be copy-from chained already and not have the flag. But, generally, it should 'just work'.

-Because of the extremely low bash damage required to destroy carpets, they end up looking rather silly. If someone was destroying or ripping up a carpet, they wouldn't have destroyed random square sections in the middle of it.

-The item moving code appears to be completely non-functional. I have not been able to determine why.

-There are no "levers" or way to adjust this right now. It's simply a flag. It eithers run, or it doesn't. And all the things it does are hardcoded.