### PR TITLE
Fix map cache segfault, remove omt tripoints from map items' operations

### DIFF
--- a/data/json/effects_on_condition/computer_eocs.json
+++ b/data/json/effects_on_condition/computer_eocs.json
@@ -53,13 +53,8 @@
         "if": { "compare_string": [ "read", { "npc_val": "map_cache" } ] },
         "then": [ { "u_message": "You already noted everything this map cache can offer." } ],
         "else": [
-          {
-            "location_variable_adjust": { "npc_val": "spawn_location_omt" },
-            "z_adjust": 0,
-            "z_override": true,
-            "overmap_tile": true
-          },
-          { "reveal_map": { "npc_val": "spawn_location_omt" }, "radius": { "math": [ "rng(11, 36)" ] } },
+          { "location_variable_adjust": { "npc_val": "spawn_location" }, "z_adjust": 0, "z_override": true, "overmap_tile": true },
+          { "reveal_map": { "npc_val": "spawn_location" }, "radius": { "math": [ "rng(11, 36)" ] } },
           { "npc_add_var": "map_cache", "value": "read" },
           { "u_message": "You found some useful data in the map cache and noted it.", "type": "good" }
         ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -665,14 +665,14 @@
     "//": "Designates a food that is usually undesirable but gives a morale bonus to characters with predator mutations."
   },
   {
-    "id": "PRESERVE_SPAWN_OMT",
+    "id": "PRESERVE_SPAWN_LOC",
     "type": "json_flag",
-    "//": "This item will store the OMT it spawned in the 'spawn_location_omt' var"
+    "//": "This item will store the tripoint_abs_ms it spawned in the 'spawn_location' var"
   },
   {
     "id": "HINT_THE_LOCATION",
     "type": "json_flag",
-    "//": "Same as PRESERVE_SPAWN_OMT, but aslo shows a snippet of how far the character from the `spawn_location_omt`: 1 OMT or less is `(from here)`, less than 6 OMT is `(from nearby)`, less than 30 OMT is `(from this area)`, anything more is (from far away)"
+    "//": "Same as PRESERVE_SPAWN_LOC, but also shows a snippet of how far the character from the `spawn_location`: 1 OMT or less is `(from here)`, less than 6 OMT is `(from nearby)`, less than 30 OMT is `(from this area)`, anything more is (from far away)"
   },
   {
     "id": "PROVIDES_TECHNIQUES",

--- a/data/json/items/id_cards.json
+++ b/data/json/items/id_cards.json
@@ -89,7 +89,7 @@
     "copy-from": "id_science",
     "name": { "str": "Maintenance: green zone badge" },
     "description": "An employee badge for a maintenance worker.  The reverse side describes the protocol for using it; this could grant access at green zone card readers.",
-    "flags": [ "SCIENCE_CARD_MAINTENANCE_GREEN", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
+    "flags": [ "SCIENCE_CARD_MAINTENANCE_GREEN", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -98,7 +98,7 @@
     "copy-from": "id_science",
     "name": { "str": "Maintenance: ocher zone badge" },
     "description": "An employee badge for a maintenance worker.  The reverse side describes the protocol for using it; this could grant access at ocher zone card readers.",
-    "flags": [ "SCIENCE_CARD_MAINTENANCE_YELLOW", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
+    "flags": [ "SCIENCE_CARD_MAINTENANCE_YELLOW", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -107,7 +107,7 @@
     "copy-from": "id_science",
     "name": { "str": "Maintenance: blue zone badge" },
     "description": "An employee badge for a maintenance worker.  The reverse side describes the protocol for using it; this could grant access at blue zone card readers.",
-    "flags": [ "SCIENCE_CARD_MAINTENANCE_BLUE", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
+    "flags": [ "SCIENCE_CARD_MAINTENANCE_BLUE", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -146,7 +146,7 @@
     "copy-from": "id_science",
     "name": { "str": "Security: yellow zone badge" },
     "description": "An employee badge for a security officer.  The reverse side describes the protocol for using it; this could grant access at yellow zone card readers.",
-    "flags": [ "SCIENCE_CARD_SECURITY_YELLOW", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
+    "flags": [ "SCIENCE_CARD_SECURITY_YELLOW", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -155,7 +155,7 @@
     "copy-from": "id_science",
     "name": { "str": "Security: magenta zone badge" },
     "description": "An employee badge for a security officer.  The reverse side describes the protocol for using it; this could grant access at magenta zone card readers.",
-    "flags": [ "SCIENCE_CARD_SECURITY_MAGENTA", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
+    "flags": [ "SCIENCE_CARD_SECURITY_MAGENTA", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -164,7 +164,7 @@
     "copy-from": "id_science",
     "name": { "str": "Security: black zone badge" },
     "description": "An employee badge for a security officer.  The reverse side describes the protocol for using it; this could grant access at black zone card readers.",
-    "flags": [ "SCIENCE_CARD_SECURITY_BLACK", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
+    "flags": [ "SCIENCE_CARD_SECURITY_BLACK", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -173,7 +173,7 @@
     "copy-from": "id_science",
     "name": { "str": "Researcher: light green zone badge" },
     "description": "An employee badge for a research scientist.  The reverse side describes the protocol for using it; this could grant access at light green zone card readers.",
-    "flags": [ "SCIENCE_CARD_MUTAGEN_GREEN", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
+    "flags": [ "SCIENCE_CARD_MUTAGEN_GREEN", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -182,7 +182,7 @@
     "copy-from": "id_science",
     "name": { "str": "Researcher: pink zone badge" },
     "description": "An employee badge for a research scientist.  The reverse side describes the protocol for using it; this could grant access at pink zone card readers.",
-    "flags": [ "SCIENCE_CARD_MUTAGEN_PINK", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
+    "flags": [ "SCIENCE_CARD_MUTAGEN_PINK", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -191,7 +191,7 @@
     "copy-from": "id_science",
     "name": { "str": "Researcher: cyan zone badge" },
     "description": "An employee badge for a research scientist.  The reverse side describes the protocol for using it; this could grant access at cyan zone card readers.",
-    "flags": [ "SCIENCE_CARD_MUTAGEN_CYAN", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
+    "flags": [ "SCIENCE_CARD_MUTAGEN_CYAN", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -200,7 +200,7 @@
     "copy-from": "id_science",
     "name": { "str": "Doctor: red zone badge" },
     "description": "An employee badge for a medical doctor.  The reverse side describes the protocol for using it; this could grant access at red zone card readers.",
-    "flags": [ "SCIENCE_CARD_MEDICAL_RED", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
+    "flags": [ "SCIENCE_CARD_MEDICAL_RED", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -219,7 +219,7 @@
     "looks_like": "id_science",
     "name": { "str": "LIXA ID badge" },
     "description": "An ID badge for the LIXA facility, with a photo of an awkwardly smiling scientist on the front.  Instructions on the back explain that this will grant you access to the LIXA experiment floor.",
-    "flags": [ "LIXA_SCIENCE_CARD", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ],
+    "flags": [ "LIXA_SCIENCE_CARD", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ],
     "price_postapoc": "2 USD 50 cent",
     "material": [ "plastic" ],
     "weight": "3 g",
@@ -233,7 +233,7 @@
     "looks_like": "id_science",
     "name": { "str": "defaced LIXA ID badge" },
     "description": "An ID badge for the LIXA facility, with a photo of an awkwardly smiling scientist on the front.  It is heavily scratched, and there is a line on the back in black marker.",
-    "flags": [ "LIXA_SCIENCE_CARD", "LIXA_SCIENCE_CARD_2", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ],
+    "flags": [ "LIXA_SCIENCE_CARD", "LIXA_SCIENCE_CARD_2", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ],
     "price_postapoc": "2 USD 50 cent",
     "material": [ "plastic" ],
     "weight": "3 g",
@@ -251,7 +251,7 @@
       "LIXA_SCIENCE_CARD",
       "LIXA_SCIENCE_CARD_2",
       "LIXA_SCIENCE_CARD_3",
-      "PRESERVE_SPAWN_OMT",
+      "PRESERVE_SPAWN_LOC",
       "HINT_THE_LOCATION",
       "CREDIT_CARD_SHAPED"
     ],
@@ -272,7 +272,7 @@
       "LIXA_SCIENCE_CARD",
       "LIXA_SCIENCE_CARD_2",
       "LIXA_SCIENCE_CARD_3",
-      "PRESERVE_SPAWN_OMT",
+      "PRESERVE_SPAWN_LOC",
       "HINT_THE_LOCATION",
       "CREDIT_CARD_SHAPED"
     ],
@@ -293,7 +293,7 @@
       "LIXA_SCIENCE_CARD",
       "LIXA_SCIENCE_CARD_2",
       "LIXA_SCIENCE_CARD_3",
-      "PRESERVE_SPAWN_OMT",
+      "PRESERVE_SPAWN_LOC",
       "HINT_THE_LOCATION",
       "CREDIT_CARD_SHAPED"
     ],
@@ -314,7 +314,7 @@
       "LIXA_SCIENCE_CARD",
       "LIXA_SCIENCE_CARD_2",
       "LIXA_SCIENCE_CARD_3",
-      "PRESERVE_SPAWN_OMT",
+      "PRESERVE_SPAWN_LOC",
       "HINT_THE_LOCATION",
       "CREDIT_CARD_SHAPED"
     ],
@@ -331,7 +331,7 @@
     "looks_like": "id_LIXA_mil",
     "name": { "str": "LIXA military police badge" },
     "description": "An id card bearing the name, rank, and serial number of a soldier stationed at LIXA.",
-    "flags": [ "LIXA_MILITARY_CARD", "LIXA_SCIENCE_CARD", "PRESERVE_SPAWN_OMT", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ],
+    "flags": [ "LIXA_MILITARY_CARD", "LIXA_SCIENCE_CARD", "PRESERVE_SPAWN_LOC", "HINT_THE_LOCATION", "CREDIT_CARD_SHAPED" ],
     "price_postapoc": "2 USD 50 cent",
     "material": [ "plastic" ],
     "weight": "3 g",

--- a/data/json/items/software.json
+++ b/data/json/items/software.json
@@ -157,7 +157,7 @@
     "description": "Information about nearby locations stored from previous use.",
     "ememory_size": "32 MB",
     "use_action": { "type": "effect_on_conditions", "effect_on_conditions": [ "EOC_CHECK_MAP_CACHE" ] },
-    "extend": { "flags": [ "PRESERVE_SPAWN_OMT" ] }
+    "extend": { "flags": [ "PRESERVE_SPAWN_LOC" ] }
   },
   {
     "abstract": "abstract_efile_recipes",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -842,7 +842,7 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```PERFECT_LOCKPICK``` Item is a perfect lockpick.  Takes only 5 seconds to pick a lock and never fails, but using it grants only a small amount of lock picking xp.  The item should have `LOCKPICK` quality of at least 1.
 - ```PLANTABLE_SEED``` This item is a seed, and you can plant it.
 - ```POST_UP``` This item can be placed on terrain/furniture with the WALL flag.
-- ```PRESERVE_SPAWN_OMT``` This item will store the OMT that it spawns in, in the `spawn_location_omt` item var.
+- ```PRESERVE_SPAWN_LOC``` This item will store the tripoint_abs_ms (most precise and universal point) that it spawns in, in the `spawn_location` item var.
 - ```HINT_THE_LOCATION``` if PRESERVE_SPAWN_OMT is used, shows a snippet of how far the character from the `spawn_location_omt`: 1 OMT or less is `(from here)`, less than 6 OMT is `(from nearby)`, less than 30 OMT is `(from this area)`, anything more is (from far away)
 - ```PROVIDES_TECHNIQUES``` This item will provide martial arts techniques when worn/in the character's inventory, in addition to those provided by the weapon and martial art.
 - ```PSEUDO``` Used internally to mark items that are referred to in the crafting inventory but are not actually items.  They can be used as tools, but not as components.  Implies `TRADER_AVOID`.

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -410,16 +410,6 @@ tripoint_abs_ms get_tripoint_ms_from_var( std::optional<var_info> var, const_dia
     return pt;
 }
 
-tripoint_abs_omt get_tripoint_omt_from_var( std::optional<var_info> var, const_dialogue const &d,
-        bool is_npc )
-{
-    tripoint_abs_omt pt = convert_tripoint_from_var<tripoint_abs_omt>( var, d, is_npc );
-    if( pt.is_invalid() ) {
-        return coords::project_to<coords::omt>( get_map().get_abs( d.const_actor( is_npc )->pos_bub() ) );
-    }
-    return pt;
-}
-
 template<class T>
 static T abstract_read_var_info_no_translation( std::string && );
 

--- a/src/condition.h
+++ b/src/condition.h
@@ -64,8 +64,6 @@ T convert_tripoint_from_var( std::optional<var_info> &var, const_dialogue const 
                              bool is_npc );
 tripoint_abs_ms get_tripoint_ms_from_var( std::optional<var_info> var, const_dialogue const &d,
         bool is_npc );
-tripoint_abs_omt get_tripoint_omt_from_var( std::optional<var_info> var, const_dialogue const &d,
-        bool is_npc );
 var_info read_var_info( const JsonObject &jo );
 translation_var_info read_translation_var_info( const JsonObject &jo );
 void write_var_value( var_type type, const std::string &name, dialogue *d,

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -107,7 +107,8 @@ std::vector<item_location> cardreader_examine_actor::get_cards( Character &you,
             continue;
         }
         if( omt_allowed_radius ) {
-            tripoint_abs_omt cardloc = it->get_var( "spawn_location_omt", tripoint_abs_omt::min );
+            tripoint_abs_omt cardloc = coords::project_to<coords::omt>(
+                                           it->get_var( "spawn_location", tripoint_abs_ms::min ) );
             // Cards without a location are treated as valid
             if( cardloc == tripoint_abs_omt::min ) {
                 ret.push_back( it );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1503,14 +1503,13 @@ bool _stacks_weapon_mods( item const &lhs, item const &rhs )
 
 bool _stacks_location_hint( item const &lhs, item const &rhs )
 {
-    static const std::string omt_loc_var = "spawn_location_omt";
-    const tripoint_abs_omt this_loc( lhs.get_var( omt_loc_var, tripoint_abs_omt::max ) );
-    const tripoint_abs_omt that_loc( rhs.get_var( omt_loc_var, tripoint_abs_omt::max ) );
+    static const std::string omt_loc_var = "spawn_location";
+    const tripoint_abs_ms this_loc( lhs.get_var( omt_loc_var, tripoint_abs_ms::max ) );
+    const tripoint_abs_ms that_loc( rhs.get_var( omt_loc_var, tripoint_abs_ms::max ) );
     if( this_loc == that_loc ) {
         return true;
-    } else if( this_loc != tripoint_abs_omt::max && that_loc != tripoint_abs_omt::max ) {
-        const tripoint_abs_omt player_loc( coords::project_to<coords::omt>( get_map().get_abs(
-                                               get_player_character().pos_bub() ) ) );
+    } else if( this_loc != tripoint_abs_ms::max && that_loc != tripoint_abs_ms::max ) {
+        const tripoint_abs_ms player_loc( get_map().get_abs( get_player_character().pos_bub() ) );
         const int this_dist = rl_dist( player_loc, this_loc );
         const int that_dist = rl_dist( player_loc, that_loc );
         static const auto get_bucket = []( const int dist ) {
@@ -1725,7 +1724,7 @@ stacking_info item::stacks_with( const item &rhs, bool check_components, bool co
     bits.set( tname::segments::UPS, _stacks_ups( *this, rhs ) );
     // Guns that differ only by dirt/shot_counter can still stack,
     // but other item_vars such as label/note will prevent stacking
-    static const std::set<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location_omt", "ethereal", "last_act_by_char_id" };
+    static const std::set<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location", "ethereal", "last_act_by_char_id" };
     bits.set( tname::segments::TRAITS, template_traits == rhs.template_traits );
     bits.set( tname::segments::VARS, map_equal_ignoring_keys( item_vars, rhs.item_vars, ignore_keys ) );
     bits.set( tname::segments::ETHEREAL, _stacks_ethereal( *this, rhs ) );
@@ -1904,13 +1903,13 @@ double item::get_var( const std::string &name, const double default_value ) cons
     return result;
 }
 
-void item::set_var( const std::string &name, const tripoint_abs_omt &value )
+void item::set_var( const std::string &name, const tripoint_abs_ms &value )
 {
     item_vars[name] = value.to_string();
 }
 
-tripoint_abs_omt item::get_var( const std::string &name,
-                                const tripoint_abs_omt &default_value ) const
+tripoint_abs_ms item::get_var( const std::string &name,
+                               const tripoint_abs_ms &default_value ) const
 {
     const auto it = item_vars.find( name );
     if( it == item_vars.end() ) {
@@ -1920,7 +1919,7 @@ tripoint_abs_omt item::get_var( const std::string &name,
     // todo: has to read both "(0,0,0)" and "0,0,0" formats for now, clean up after 0.I
     // first is produced by tripoint::to_string, second was old custom format
     if( it->second[0] == '(' ) {
-        return tripoint_abs_omt{tripoint::from_string( it->second )};
+        return tripoint_abs_ms{tripoint::from_string( it->second )};
     }
 
     std::vector<std::string> values = string_split( it->second, ',' );
@@ -1934,9 +1933,9 @@ tripoint_abs_omt item::get_var( const std::string &name,
             return 0;
         }
     };
-    return tripoint_abs_omt( convert_or_error( values[0] ),
-                             convert_or_error( values[1] ),
-                             convert_or_error( values[2] ) );
+    return tripoint_abs_ms( convert_or_error( values[0] ),
+                            convert_or_error( values[1] ),
+                            convert_or_error( values[2] ) );
 }
 
 void item::set_var( const std::string &name, const std::string &value )
@@ -7132,7 +7131,7 @@ std::string item::display_name( unsigned int quantity ) const
     // HACK: This is a hack to prevent possible crashing when displaying maps as items during character creation
     if( is_map() && calendar::turn != calendar::turn_zero ) {
         tripoint_abs_omt map_pos_omt =
-            get_var( "reveal_map_center_omt", player_character.pos_abs_omt() );
+            project_to<coords::omt>( get_var( "reveal_map_center", player_character.pos_abs() ) );
         tripoint_abs_sm map_pos =
             project_to<coords::sm>( map_pos_omt );
         const city *c = overmap_buffer.closest_city( map_pos ).city;

--- a/src/item.h
+++ b/src/item.h
@@ -1973,8 +1973,8 @@ class item : public visitable
         void set_var( const std::string &name, long value );
         void set_var( const std::string &name, double value );
         double get_var( const std::string &name, double default_value ) const;
-        void set_var( const std::string &name, const tripoint_abs_omt &value );
-        tripoint_abs_omt get_var( const std::string &name, const tripoint_abs_omt &default_value ) const;
+        void set_var( const std::string &name, const tripoint_abs_ms &value );
+        tripoint_abs_ms get_var( const std::string &name, const tripoint_abs_ms &default_value ) const;
         //TODO: Add cata_variant overload for value here and for get_var rather than using raw strings where appropriate?
         void set_var( const std::string &name, const std::string &value );
         std::string get_var( const std::string &name, const std::string &default_value ) const;

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -291,8 +291,9 @@ std::string food_traits( item const &it, unsigned int /* quantity */,
 std::string location_hint( item const &it, unsigned int /* quantity */,
                            segment_bitset const &/* segments */ )
 {
-    if( it.has_flag( json_flag_HINT_THE_LOCATION ) && it.has_var( "spawn_location_omt" ) ) {
-        tripoint_abs_omt loc( it.get_var( "spawn_location_omt", tripoint_abs_omt::zero ) );
+    if( it.has_flag( json_flag_HINT_THE_LOCATION ) && it.has_var( "spawn_location" ) ) {
+        tripoint_abs_omt loc( coords::project_to<coords::omt>(
+                                  it.get_var( "spawn_location", tripoint_abs_ms::zero ) ) );
         tripoint_abs_omt player_loc( coords::project_to<coords::omt>( get_map().get_abs(
                                          get_avatar().pos_bub() ) ) );
         int dist = rl_dist( player_loc, loc );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1303,8 +1303,8 @@ std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint
         p->add_msg_if_player( _( "It's too dark to read." ) );
         return std::nullopt;
     }
-    const tripoint_abs_omt center( it.get_var( "reveal_map_center_omt",
-                                   p->pos_abs_omt() ) );
+    const tripoint_abs_omt center( coords::project_to<coords::omt>( it.get_var( "reveal_map_center",
+                                   p->pos_abs() ) ) );
     // Clear highlight on previously revealed OMTs before revealing new ones
     p->map_revealed_omts.clear();
     for( const auto &omt : omt_types ) {

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -434,7 +434,7 @@ class reveal_map_actor : public iuse_actor
          * The radius of the overmap area that gets revealed.
          * This is in overmap terrain coordinates.
          * A radius of 1 means all terrains directly around center are revealed.
-         * The center is location of nearest city defined in `reveal_map_center_omt` variable of
+         * The center is location of nearest city defined in `reveal_map_center` variable of
          * activated item (or current player global omt location if variable is not set).
          */
         int radius = 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -138,7 +138,7 @@ static const field_type_str_id field_fd_clairvoyant( "fd_clairvoyant" );
 static const flag_id json_flag_AVATAR_ONLY( "AVATAR_ONLY" );
 static const flag_id json_flag_JETPACK( "JETPACK" );
 static const flag_id json_flag_LEVITATION( "LEVITATION" );
-static const flag_id json_flag_PRESERVE_SPAWN_OMT( "PRESERVE_SPAWN_OMT" );
+static const flag_id json_flag_PRESERVE_SPAWN_LOC( "PRESERVE_SPAWN_LOC" );
 static const flag_id json_flag_PROXIMITY( "PROXIMITY" );
 static const flag_id json_flag_UNDODGEABLE( "UNDODGEABLE" );
 
@@ -5265,17 +5265,16 @@ item &map::add_item( const tripoint_bub_ms &p, item new_item, int copies )
         new_item.active = true;
     }
 
-    if( new_item.is_map() && !new_item.has_var( "reveal_map_center_omt" ) ) {
-        new_item.set_var( "reveal_map_center_omt",
-                          coords::project_to<coords::omt>( get_abs( p ) ) );
+    if( new_item.is_map() && !new_item.has_var( "reveal_map_center" ) ) {
+        new_item.set_var( "reveal_map_center", get_abs( p ) );
     }
 
     std::list<item *> all_items = new_item.all_items_ptr();
     all_items.emplace_back( &new_item );
     for( item *it : all_items ) {
-        if( it->has_flag( json_flag_PRESERVE_SPAWN_OMT ) &&
-            !it->has_var( "spawn_location_omt" ) ) {
-            it->set_var( "spawn_location_omt", coords::project_to<coords::omt>( get_abs( p ) ) );
+        if( it->has_flag( json_flag_PRESERVE_SPAWN_LOC ) &&
+            !it->has_var( "spawn_location" ) ) {
+            it->set_var( "spawn_location", get_abs( p ) );
         }
     };
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7105,7 +7105,7 @@ talk_effect_fun_t::func f_reveal_map( const JsonObject &jo, std::string_view mem
     dbl_or_var radius = get_dbl_or_var( jo, "radius", false, 0 );
 
     return [ radius, target_var ]( dialogue & d ) {
-        tripoint_abs_omt omt = get_tripoint_omt_from_var( target_var, d, false );
+        tripoint_abs_omt omt = project_to<coords::omt>( get_tripoint_ms_from_var( target_var, d, false ) );
         overmap_buffer.reveal( omt, radius.evaluate( d ) );
     };
 }

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -364,8 +364,8 @@ TEST_CASE( "item_variables_round-trip_accurately", "[item]" )
     CHECK( i.get_var( "A", 0 ) == 17 );
     i.set_var( "B", 0.125 );
     CHECK( i.get_var( "B", 0.0 ) == 0.125 );
-    i.set_var( "C", tripoint_abs_omt( 2, 3, 4 ) );
-    CHECK( i.get_var( "C", tripoint_abs_omt::zero ) == tripoint_abs_omt( 2, 3, 4 ) );
+    i.set_var( "C", tripoint_abs_ms( 2, 3, 4 ) );
+    CHECK( i.get_var( "C", tripoint_abs_ms::zero ) == tripoint_abs_ms( 2, 3, 4 ) );
 }
 
 TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "fix map cache segfault, remove omt tripoints from map items' operations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix segfault on using a `map cache` item

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

#79307 didn't account for `location_variable_adjust`, which uses `tripoint_abs_ms` and not `tripoint_abs_omt`, resulting in a tripoint type mismatch. When it was submitted, the maps I used just happened to work, I guess.

I realized that EOCs pretty much exclusively use `tripoint_abs_ms`, so trying to include more point types into EOCs was probably a bad idea. SPAWN_LOCATION_OMT using `tripoint_abs_omt` was therefore the outlier, so I changed it to record `tripoint_abs_ms` and project to _omt for `reveal_map`.

There are still issues with map-related items initializing their locations, see #79536 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Serializing tripoint type and/or generalizing EOC tripoint use, either of which are overkill for maps alone

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Used both a map cache with and without an initialized location, used a road map, verified TCLF badges still display correctly

For existing saves: because the `item_var` fields' names were changed, existing unread maps/badges you still want to use can be reinitialized by dropping them near their original spawn location; using them without doing this will default to the player's position without error

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
