### PR TITLE
E-device selection ignores empty browsed devices when moving/copying

### DIFF
--- a/data/json/itemgroups/roof.json
+++ b/data/json/itemgroups/roof.json
@@ -60,7 +60,7 @@
       { "item": "matches", "prob": 60, "charges": [ 0, 20 ] },
       [ "syringe", 8 ],
       [ "hairpin", 1 ],
-      { "group": "used_usb_drives", "prob": 5, "contents-item": "efiles_contraband" },
+      { "group": "used_usb_drives", "prob": 5, "contents-group": "efiles_contraband" },
       [ "news_regional", 8 ],
       [ "jug_plastic", 10 ],
       { "item": "spray_can", "prob": 50, "charges": [ 0, 4 ] },

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1675,6 +1675,8 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
             bool has_use_check = !unusable_only || !efile_activity_actor::edevice_has_use( loc.get_item() );
             bool browsed_equal_check = browse_equals == loc->is_browsed();
             bool fast_transfer = compat == efile_activity_actor::edevice_compatible::ECOMPAT_FAST;
+            bool no_files_check = !( action == EF_MOVE_ONTO_THIS || action == EF_COPY_ONTO_THIS )
+                                  || ( loc->is_browsed() && !loc->efiles().empty() );
             bool compatible_check = ( action == EF_BROWSE && browse_equals ) ||
                                     //if browsing, no compatibility check
                                     ( action == EF_READ && fast_transfer ) || //if reading, only fast-compatible edevices
@@ -1683,7 +1685,8 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
                                used_edevice_check &&
                                has_use_check &&
                                browsed_equal_check &&
-                               compatible_check;
+                               compatible_check &&
+                               no_files_check;
             if( preset_bool ) {
                 add_msg_debug( debugmode::DF_ACT_EBOOK, string_format( "found edevice %s", loc->display_name() ) );
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "e-device selection ignores empty browsed devices when moving/copying"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Fixes #79503

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

For e-device selection, adds a check to include only browsed e-devices with contents when moving/copying onto a device.

So, from these devices:
![image](https://github.com/user-attachments/assets/07ce596c-c909-4aec-a866-8f96937dd63f)

now only one can be selected with "move files onto" because it's the only browsed phone with files, making #79503 impossible to reproduce:
![image](https://github.com/user-attachments/assets/fb02b47c-aee5-4226-9a95-1dcf0a7ad966)

Also, fixes an item group entry that I missed in #79471.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned in 10 `new_phones`, 10 `civilian_phones`, confirmed the following using an empty smartphone:
 - unbrowsed e-devices are still selectable with "browse+move"
 - unbrowsed e-devices are not selectable with "move/copy onto"
 - empty e-devices can't be selected with "move/copy onto"
 - e-devices with contents can be selected with "move/copy onto"


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
