### PR TITLE
Allow EOCs to assign the character cash value

### DIFF
--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -1405,7 +1405,7 @@ These can be read or written to with `val()`.
 | `bmi_permil` | ❌ | Current BMI per mille (Body Mass Index x 1000) |
 | `body_temp` | ❌ | Current body temperature. |
 | `body_temp_delta` | ❌ | Difference in temperature between the hottest/coldest part and what feels like the hottest/coldest part. |
-| `cash` | ❌ | Amount of money |
+| `cash` | ✅ | Amount of money |
 | `dodge` | ❌ | Current effective dodge |
 | `exp` | ✅ | Total experience earned. |
 | `sleepiness` | ✅ | Current sleepiness level. |

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2421,6 +2421,7 @@ namespace
 std::unordered_map<std::string_view, void ( talker::* )( int )> const f_set_vals = {
     { "age", &talker::set_age },
     { "anger", &talker::set_anger },
+    { "cash", &talker::set_cash },
     { "dexterity_base", &talker::set_dex_max },
     { "dexterity_bonus", &talker::set_dex_bonus },
     { "exp", &talker::set_kill_xp },

--- a/src/talker.h
+++ b/src/talker.h
@@ -693,6 +693,7 @@ class talker: virtual public const_talker
         virtual void set_dex_bonus( int ) {}
         virtual void set_int_bonus( int ) {}
         virtual void set_per_bonus( int ) {}
+        virtual void set_cash( int ) {}
         virtual void set_spell_level( const spell_id &, int ) {}
         virtual void set_spell_exp( const spell_id &, int ) {}
         virtual void set_skill_level( const skill_id &, int ) {}

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -175,6 +175,11 @@ void talker_character::set_per_bonus( int value )
     me_chr->mod_per_bonus( value );
 }
 
+void talker_character::set_cash( int value )
+{
+    me_chr->cash = value;
+}
+
 int talker_character_const::get_str_max() const
 {
     return me_chr_const->str_max;

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -259,6 +259,7 @@ class talker_character: virtual public talker
         void set_dex_bonus( int value ) override;
         void set_int_bonus( int value ) override;
         void set_per_bonus( int value ) override;
+        void set_cash( int value ) override;
         void set_power_cur( units::energy value ) override;
         void set_mana_cur( int value ) override;
         void set_spell_level( const spell_id &, int ) override;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Allow EOCs to assign the character cash value"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
EOCs can read the cash value but we don't have any way to assign to it. It's outlined in the [Aftershock hacking project](https://github.com/users/John-Candlebury/projects/6) that it's desirable to hack ATMs for digital currency. In my hacking EOC overhaul #79496 I've laid the foundation for this to be possible. However to use an EOC based approach we still need to be able to assign to to cash value directly.

I would also really like to make it so many of the smaller electronics can be hacked for cash. Something like an EOC backed use action we can throw on fitting items. Like say you just killed a Reaver: you unstrap their wrist computer, and try to use exploits and personal data on the device to get into their bank, and if you do, you steal their money.

I also I just really don't like carrying cash items. Please don't make me go back to the ATM, I beg.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I allowed cash to be set in the same way age and anger are set, utilizing our existing infrastructure.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Currently it just directly sets the value of the cash variable from the talker character file. I considered and initially did add an entirely new method called set cash to character.cpp. But we currently directly read and set cash from 100+ places in the code. I'm not sure now is the time to start caring about how we set it. And honestly I'm not entirely seeing the value in creating a dedicated method anyway. At least at this point I don't see a point to forcing the EOC to use a method when everything else just edits the value directly. And I am not particularly inclined to replace all edits with a method call.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Created a test EOC. Tested reading the cash value. Setting the cash to a new value. Then reading that newly set value.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
