### PR TITLE
made more vehicle stuff map aware

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1218,7 +1218,7 @@ void hacksaw_activity_actor::do_turn( player_activity &/*act*/, Character &who )
             return;
         }
         vehicle &veh = vp->vehicle();
-        if( vehicle::use_vehicle_tool( veh, veh_pos.value(), type.value(), true ) ) {
+        if( vehicle::use_vehicle_tool( veh, &here, veh_pos.value(), type.value(), true ) ) {
             sfx::play_activity_sound( "tool", "hacksaw", sfx::get_heard_volume( target ) );
             if( calendar::once_every( 1_minutes ) ) {
                 //~ Sound of a metal sawing tool at work!
@@ -2597,7 +2597,7 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
 
     if( veh ) {
         std::vector<vehicle_part *> parts_at_target = veh->vehicle().get_parts_at(
-                    target, "LOCKABLE_DOOR", part_status_flag::available );
+                    &here, target, "LOCKABLE_DOOR", part_status_flag::available );
         if( !parts_at_target.empty() ) {
             locked_part = veh->vehicle().next_part_to_unlock(
                               veh->vehicle().index_of_part( parts_at_target.front() ) );
@@ -8025,14 +8025,14 @@ bool vehicle_folding_activity_actor::fold_vehicle( Character &p, bool check_only
     for( const vpart_reference &vpr : veh.get_any_parts( VPFLAG_CARGO ) ) {
         vehicle_stack cargo = vpr.items();
         for( const item &elem : cargo ) {
-            here.add_item_or_charges( veh.pos_bub(), elem );
+            here.add_item_or_charges( veh.pos_bub( &here ), elem );
         }
         cargo.clear();
     }
 
     veh.unboard_all();
     p.add_msg_if_player( _( "You fold the %s." ), veh.name );
-    here.add_item_or_charges( veh.pos_bub(), veh.get_folded_item() );
+    here.add_item_or_charges( veh.pos_bub( &here ), veh.get_folded_item() );
     here.destroy_vehicle( &veh );
 
     return true;
@@ -8127,7 +8127,7 @@ bool vehicle_unfolding_activity_actor::unfold_vehicle( Character &p, bool check_
         if( vp.info().location != "structure" ) {
             continue;
         }
-        if( invalid_pos( vp.pos_bub() ) ) {
+        if( invalid_pos( vp.pos_bub( &here ) ) ) {
             p.add_msg_if_player( m_info, _( "There's no room to unfold the %s." ), it.tname() );
             here.destroy_vehicle( veh );
             return false;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1058,7 +1058,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
         if( act == ACT_VEHICLE_DECONSTRUCTION ) {
             // find out if there is a vehicle part here we can remove.
             std::vector<vehicle_part *> parts =
-                veh->get_parts_at( src_loc, "", part_status_flag::any );
+                veh->get_parts_at( &here, src_loc, "", part_status_flag::any );
             for( vehicle_part *part_elem : parts ) {
                 const int vpindex = veh->index_of_part( part_elem, true );
                 // if part is not on this vehicle, or if its attached to another part that needs to be removed first.
@@ -1101,7 +1101,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             }
         } else if( act == ACT_VEHICLE_REPAIR ) {
             // find out if there is a vehicle part here we can repair.
-            std::vector<vehicle_part *> parts = veh->get_parts_at( src_loc, "", part_status_flag::any );
+            std::vector<vehicle_part *> parts = veh->get_parts_at( &here, src_loc, "", part_status_flag::any );
             for( vehicle_part *part_elem : parts ) {
                 const vpart_info &vpinfo = part_elem->info();
                 int vpindex = veh->index_of_part( part_elem, true );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1473,7 +1473,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         if( g->display_overlay_state( ACTION_DISPLAY_VEHICLE_AI ) ) {
             for( const wrapped_vehicle &elem : here.get_vehicles() ) {
                 const vehicle &veh = *elem.v;
-                const point_bub_ms veh_pos = veh.pos_bub().xy();
+                const point_bub_ms veh_pos = veh.pos_bub( &here ).xy();
                 for( const auto &overlay_data : veh.get_debug_overlay_data() ) {
                     const point_bub_ms pt = veh_pos + std::get<0>( overlay_data );
                     const int color = std::get<1>( overlay_data );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -256,7 +256,7 @@ bool Creature::will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) con
     vehicle &veh = vp_there->vehicle();
 
     std::vector<vehicle_part *> cargo_parts;
-    cargo_parts = veh.get_parts_at( here.get_bub( loc ), "CARGO", part_status_flag::any );
+    cargo_parts = veh.get_parts_at( loc, "CARGO", part_status_flag::any );
 
     units::volume capacity = 0_ml;
     units::volume free_cargo = 0_ml;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3733,7 +3733,7 @@ static void vehicle_export()
 {
     map &here = get_map();
 
-    if( optional_vpart_position ovp = get_map().veh_at( get_avatar().pos_bub() ) ) {
+    if( optional_vpart_position ovp = here.veh_at( get_avatar().pos_abs() ) ) {
         cata_path export_dir{ cata_path::root_path::user,  "export_dir" };
         assure_dir_exist( export_dir );
         const std::string text = string_input_popup()
@@ -3744,7 +3744,7 @@ static void vehicle_export()
         try {
             write_to_file( veh_path, [&]( std::ostream & fout ) {
                 JsonOut jsout( fout );
-                ovp->vehicle().refresh( &here );
+                ovp->vehicle().refresh( );
                 vehicle_prototype::save_vehicle_as_prototype( ovp->vehicle(), jsout );
             } );
         } catch( const std::exception &err ) {

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -309,7 +309,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         if( one_in( 2 ) ) {
             vehicle_part &vp_wheel = grabbed_vehicle->part( p );
             tripoint_bub_ms wheel_p = grabbed_vehicle->bub_part_pos( &here, vp_wheel );
-            grabbed_vehicle->handle_trap( wheel_p, vp_wheel );
+            grabbed_vehicle->handle_trap( &m, wheel_p, vp_wheel );
         }
     }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1565,10 +1565,10 @@ void iexamine::elevator( Character &you, const tripoint_bub_ms &examp )
     }
 
     for( vehicle *v : vehs.v ) {
-        tripoint_bub_ms const p = _rotate_point_sm( { v->pos_bub().xy(), movez},
+        tripoint_bub_ms const p = _rotate_point_sm( { v->pos_bub( &here ).xy(), movez},
                                   erot,
                                   sm_orig );
-        here.displace_vehicle( *v, p - v->pos_bub() );
+        here.displace_vehicle( *v, p - v->pos_bub( &here ) );
         v->turn( erot * 90_degrees );
         v->face = tileray( v->turn_dir );
         v->precalc_mounts( 0, v->turn_dir, v->pivot_anchor[0] );
@@ -2064,7 +2064,7 @@ void iexamine::locked_object( Character &you, const tripoint_bub_ms &examp )
     // Check if the locked thing is a lockable door part.
     if( veh ) {
         std::vector<vehicle_part *> parts_at_target = veh->vehicle().get_parts_at(
-                    examp, "LOCKABLE_DOOR", part_status_flag::available );
+                    &here, examp, "LOCKABLE_DOOR", part_status_flag::available );
         if( !parts_at_target.empty() ) {
             locked_part = veh->vehicle().next_part_to_unlock(
                               veh->vehicle().index_of_part( parts_at_target.front() ) );
@@ -2133,7 +2133,7 @@ void iexamine::locked_object_pickable( Character &you, const tripoint_bub_ms &ex
 
     if( veh ) {
         const std::vector<vehicle_part *> parts_at_target = veh->vehicle().get_parts_at(
-                    examp, "LOCKABLE_DOOR", part_status_flag::available );
+                    &here, examp, "LOCKABLE_DOOR", part_status_flag::available );
         if( !parts_at_target.empty() ) {
             locked_part = veh->vehicle().next_part_to_unlock(
                               veh->vehicle().index_of_part( parts_at_target.front() ) );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14426,8 +14426,8 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
     link().last_processed = calendar::turn;
 
     // Set the new absolute position to the vehicle's origin.
-    tripoint_bub_ms t_veh_bub_pos = t_veh->pos_bub();
-    tripoint_abs_ms new_t_abs_pos = here.get_abs( t_veh_bub_pos );
+    tripoint_abs_ms new_t_abs_pos = t_veh->pos_abs();;
+    tripoint_bub_ms t_veh_bub_pos = here.get_bub( new_t_abs_pos );;
     if( link().t_abs_pos != new_t_abs_pos ) {
         link().t_abs_pos = new_t_abs_pos;
         length_check_needed = true;

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -509,7 +509,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
                 debugmsg( "item in vehicle part without cargo storage" );
             }
             if( ch ) {
-                res += " " + direction_suffix( ch->pos_bub(), part_pos.pos_bub() );
+                res += " " + direction_suffix( ch->pos_abs(), part_pos.pos_abs() );
             }
             return res;
         }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7306,15 +7306,16 @@ static bool hackveh( Character &p, item &it, vehicle &veh )
 
 static vehicle *pickveh( const tripoint_bub_ms &center, bool advanced )
 {
+    map &here = get_map();
     static const std::string ctrl = "CTRL_ELECTRONIC";
     static const std::string advctrl = "REMOTE_CONTROLS";
     uilist pmenu;
     pmenu.title = _( "Select vehicle to access" );
     std::vector< vehicle * > vehs;
 
-    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle &veh : here.get_vehicles() ) {
         vehicle *&v = veh.v;
-        if( rl_dist( center, v->pos_bub() ) < 40 &&
+        if( rl_dist( center, v->pos_bub( &here ) ) < 40 &&
             v->fuel_left( itype_battery ) > 0 &&
             ( !empty( v->get_avail_parts( advctrl ) ) ||
               ( !advanced && !empty( v->get_avail_parts( ctrl ) ) ) ) ) {
@@ -7324,7 +7325,7 @@ static vehicle *pickveh( const tripoint_bub_ms &center, bool advanced )
     std::vector<tripoint_bub_ms> locations;
     for( int i = 0; i < static_cast<int>( vehs.size() ); i++ ) {
         vehicle *veh = vehs[i];
-        locations.push_back( veh->pos_bub() );
+        locations.push_back( veh->pos_bub( &here ) );
         pmenu.addentry( i, true, MENU_AUTOASSIGN, veh->name );
     }
 
@@ -7371,6 +7372,8 @@ std::optional<int> iuse::remoteveh_tick( Character *p, item *it, const tripoint_
 
 std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    map &here = get_map();
+
     vehicle *remote = g->remoteveh();
 
     bool controlling = it->active && remote != nullptr;
@@ -7419,9 +7422,9 @@ std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint_bub_m
         const auto electronics_parts = veh->get_avail_parts( "CTRL_ELECTRONIC" );
         // Revert to original behavior if we can't find remote controls.
         if( empty( rctrl_parts ) ) {
-            veh->interact_with( electronics_parts.begin()->pos_bub() );
+            veh->interact_with( electronics_parts.begin()->pos_bub( &here ) );
         } else {
-            veh->interact_with( rctrl_parts.begin()->pos_bub() );
+            veh->interact_with( rctrl_parts.begin()->pos_bub( &here ) );
         }
     }
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -638,7 +638,7 @@ void map::generate_lightmap( const int zlev )
         }
 
         for( const vpart_reference &vpr : v->get_any_parts( VPFLAG_CARGO ) ) {
-            const tripoint_bub_ms pos = vpr.pos_bub();
+            const tripoint_bub_ms pos = vpr.pos_bub( this );
             if( !inbounds( pos ) || vpr.info().has_flag( "COVERED" ) ) {
                 continue;
             }
@@ -1097,8 +1097,8 @@ void map::build_seen_cache( const tripoint_bub_ms &origin, const int target_z, i
         if( vp.part().removed || vp.part().is_broken() || !vp.info().has_flag( VPFLAG_EXTENDS_VISION ) ) {
             continue;
         }
-        const tripoint_bub_ms mirror_pos = vp.pos_bub();
-        if( rl_dist( origin, vp.pos_bub() ) > extension_range ) {
+        const tripoint_bub_ms mirror_pos = vp.pos_bub( this );
+        if( rl_dist( origin, vp.pos_bub( this ) ) > extension_range ) {
             continue;
         }
         // We can utilize the current state of the seen cache to determine

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -682,6 +682,15 @@ std::string direction_suffix( const tripoint_bub_ms &p, const tripoint_bub_ms &q
     return string_format( "%d%s", dist, trim( direction_name_short( direction_from( p, q ) ) ) );
 }
 
+std::string direction_suffix( const tripoint_abs_ms &p, const tripoint_abs_ms &q )
+{
+    int dist = square_dist( p, q );
+    if( dist <= 0 ) {
+        return std::string();
+    }
+    return string_format( "%d%s", dist, trim( direction_name_short( direction_from( p, q ) ) ) );
+}
+
 // Cardinals are cardinals. Result is cardinal and adjacent sub-cardinals.
 // Sub-Cardinals are sub-cardinals && abs(x) == abs(y). Result is sub-cardinal and adjacent cardinals.
 // Sub-sub-cardinals are direction && abs(x) > abs(y) or vice versa.

--- a/src/line.h
+++ b/src/line.h
@@ -137,6 +137,7 @@ std::string direction_arrow( direction dir );
 
 /* Get suffix describing vector from p to q (e.g. 1NW, 2SE) or empty string if p == q */
 std::string direction_suffix( const tripoint_bub_ms &p, const tripoint_bub_ms &q );
+std::string direction_suffix( const tripoint_abs_ms &p, const tripoint_abs_ms &q );
 
 /**
  * The actual Bresenham algorithm in 2D and 3D, everything else should call these

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -387,9 +387,9 @@ static bool mx_helicopter( map &m, const tripoint_abs_sm &abs_sub )
 
     vehicle *wreckage = m.add_vehicle( crashed_hull, wreckage_pos, dir1, rng( 1, 33 ), 1 );
 
-    const auto controls_at = []( vehicle * wreckage, const tripoint_bub_ms & pos ) {
-        return !wreckage->get_parts_at( pos, "CONTROLS", part_status_flag::any ).empty() ||
-               !wreckage->get_parts_at( pos, "CTRL_ELECTRONIC", part_status_flag::any ).empty();
+    const auto controls_at = [&m]( vehicle * wreckage, const tripoint_bub_ms & pos ) {
+        return !wreckage->get_parts_at( &m, pos, "CONTROLS", part_status_flag::any ).empty() ||
+               !wreckage->get_parts_at( &m, pos, "CTRL_ELECTRONIC", part_status_flag::any ).empty();
     };
 
     if( wreckage != nullptr ) {
@@ -401,7 +401,7 @@ static bool mx_helicopter( map &m, const tripoint_abs_sm &abs_sub )
             case 3:
                 // Full clown car
                 for( const vpart_reference &vp : wreckage->get_any_parts( VPFLAG_SEATBELT ) ) {
-                    const tripoint_bub_ms pos = vp.pos_bub();
+                    const tripoint_bub_ms pos = vp.pos_bub( &m );
                     // Spawn pilots in seats with controls.CTRL_ELECTRONIC
                     if( controls_at( wreckage, pos ) ) {
                         m.place_spawns( GROUP_MIL_PILOT, 1, pos.xy(), pos.xy(), pos.z(), 1, true );
@@ -415,7 +415,7 @@ static bool mx_helicopter( map &m, const tripoint_abs_sm &abs_sub )
             case 5:
                 // 2/3rds clown car
                 for( const vpart_reference &vp : wreckage->get_any_parts( VPFLAG_SEATBELT ) ) {
-                    const tripoint_bub_ms pos = vp.pos_bub();
+                    const tripoint_bub_ms pos = vp.pos_bub( &m );
                     // Spawn pilots in seats with controls.
                     if( controls_at( wreckage, pos ) ) {
                         m.place_spawns( GROUP_MIL_PILOT, 1, pos.xy(), pos.xy(), pos.z(), 1, true );
@@ -428,7 +428,7 @@ static bool mx_helicopter( map &m, const tripoint_abs_sm &abs_sub )
             case 6:
                 // Just pilots
                 for( const vpart_reference &vp : wreckage->get_any_parts( VPFLAG_CONTROLS ) ) {
-                    const tripoint_bub_ms pos = vp.pos_bub();
+                    const tripoint_bub_ms pos = vp.pos_bub( &m );
                     m.place_spawns( GROUP_MIL_PILOT, 1, pos.xy(), pos.xy(), pos.z(), 1, true );
                     delete_items_at_mount( *wreckage, vp.mount_pos() ); // delete corpse items
                 }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7016,13 +7016,12 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
             std::unique_ptr<RemovePartHandler> handler_ptr;
             bool did_merge = false;
             for( const tripoint_abs_ms &map_pos : first_veh->get_points( true ) ) {
-                const tripoint_bub_ms map_bub_pos = get_bub( map_pos );
-                std::vector<vehicle_part *> parts_to_move = veh_to_add->get_parts_at( this, map_bub_pos, "",
+                std::vector<vehicle_part *> parts_to_move = veh_to_add->get_parts_at( map_pos, "",
                         part_status_flag::any );
                 if( !parts_to_move.empty() ) {
                     // Store target_point by value because first_veh->parts may reallocate
                     // to a different address after install_part()
-                    std::vector<vehicle_part *> first_veh_parts = first_veh->get_parts_at( this, map_bub_pos, "",
+                    std::vector<vehicle_part *> first_veh_parts = first_veh->get_parts_at( map_pos, "",
                             part_status_flag:: any );
                     // This happens if this location is occupied by a fake part.
                     if( first_veh_parts.empty() || first_veh_parts.front()->is_fake ) {
@@ -7038,7 +7037,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
                                   veh_to_add->name, veh_to_add->type.str(),
                                   veh_to_add->pos_abs().to_string(),
                                   to_degrees( veh_to_add->turn_dir ),
-                                  map_bub_pos.to_string() );
+                                  get_bub( map_pos ).to_string() );
                     }
                     did_merge = true;
                     const point_rel_ms target_point = first_veh_parts.front()->mount;
@@ -7112,7 +7111,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
         veh_to_add->smash( *this );
     }
 
-    veh_to_add->refresh( this );
+    veh_to_add->refresh( );
     return veh_to_add;
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1000,8 +1000,8 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
     bool bipod = here->has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, pos_bub( here ) ) ||
                  is_prone();
     if( !bipod ) {
-        if( const optional_vpart_position vp = here->veh_at( pos_bub( here ) ) ) {
-            bipod = vp->vehicle().has_part( pos_bub( here ), "MOUNTABLE" );
+        if( const optional_vpart_position vp = here->veh_at( pos_abs( ) ) ) {
+            bipod = vp->vehicle().has_part( pos_abs( ), "MOUNTABLE" );
         }
     }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3498,7 +3498,7 @@ void vehicle::deserialize( const JsonObject &data )
     data.read( "fuel_remainder", fuel_remainder );
     data.read( "fuel_used_last_turn", fuel_used_last_turn );
 
-    refresh( &here );
+    refresh( );
 
     point p;
     zone_data zd;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3418,8 +3418,6 @@ void smart_controller_config::serialize( JsonOut &json ) const
 
 void vehicle::deserialize( const JsonObject &data )
 {
-    map &here = get_map();
-
     data.allow_omitted_members();
 
     int fdir = 0;

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1017,6 +1017,7 @@ void sfx::do_vehicle_engine_sfx()
 
 void sfx::do_vehicle_exterior_engine_sfx()
 {
+    map &here = get_map();
     if( test_mode ) {
         return;
     }
@@ -1038,7 +1039,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
         return;
     }
 
-    VehicleList vehs = get_map().get_vehicles();
+    VehicleList vehs = here.get_vehicles();
     unsigned char noise_factor = 0;
     unsigned char vol = 0;
     vehicle *veh = nullptr;
@@ -1046,10 +1047,10 @@ void sfx::do_vehicle_exterior_engine_sfx()
     for( wrapped_vehicle vehicle : vehs ) {
         if( vehicle.v->vehicle_noise > 0 &&
             vehicle.v->vehicle_noise -
-            sound_distance( player_character.pos_bub(), vehicle.v->pos_bub() ) > noise_factor ) {
+            sound_distance( player_character.pos_bub( &here ), vehicle.v->pos_bub( &here ) ) > noise_factor ) {
 
-            noise_factor = vehicle.v->vehicle_noise - sound_distance( player_character.pos_bub(),
-                           vehicle.v->pos_bub() );
+            noise_factor = vehicle.v->vehicle_noise - sound_distance( player_character.pos_bub( &here ),
+                           vehicle.v->pos_bub( &here ) );
             veh = vehicle.v;
         }
     }
@@ -1088,7 +1089,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
 
     if( is_channel_playing( ch ) ) {
         if( engine_external_id_and_variant == id_and_variant ) {
-            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub() ) ), 0 );
+            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub( &here ) ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg_debug( debugmode::DF_SOUND, "PLAYING exterior_engine_sound, vol: ex:%d true:%d", vol,
                            Mix_Volume( ch_int, -1 ) );
@@ -1098,7 +1099,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
             add_msg_debug( debugmode::DF_SOUND, "STOP exterior_engine_sound, change id/var" );
             play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                         seas_str, indoors, night, 128, ch, 0 );
-            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub() ) ), 0 );
+            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub( &here ) ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg_debug( debugmode::DF_SOUND, "START exterior_engine_sound %s %s vol: %d",
                            id_and_variant.first,
@@ -1109,7 +1110,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
         play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                     seas_str, indoors, night, 128, ch, 0 );
         add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
-        Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub() ) ), 0 );
+        Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub( &here ) ) ), 0 );
         add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
         set_channel_volume( ch, vol );
         add_msg_debug( debugmode::DF_SOUND, "START exterior_engine_sound NEW %s %s vol: ex:%d true:%d",

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -463,10 +463,10 @@ void veh_app_interact::rename()
 void veh_app_interact::remove()
 {
     map &here = get_map();
-    const tripoint_bub_ms a_point_bub( veh->mount_to_tripoint( a_point ) );
+    const tripoint_abs_ms a_point_abs( veh->mount_to_tripoint_abs( a_point ) );
 
     vehicle_part *vp;
-    if( auto sel_part = here.veh_at( a_point_bub ).part_with_feature( VPFLAG_APPLIANCE, false ) ) {
+    if( auto sel_part = here.veh_at( a_point_abs ).part_with_feature( VPFLAG_APPLIANCE, false ) ) {
         vp = &sel_part->part();
     } else {
         int const part = veh->part_at( veh->coord_translate( a_point ) );
@@ -498,7 +498,6 @@ void veh_app_interact::remove()
         for( const tripoint_abs_ms &p : veh->get_points( true ) ) {
             act.coord_set.insert( p );
         }
-        const tripoint_abs_ms a_point_abs( here.get_abs( a_point_bub ) );
         act.values.push_back( a_point_abs.x() );
         act.values.push_back( a_point_abs.y() );
         act.values.push_back( a_point.x() );
@@ -549,8 +548,8 @@ void veh_app_interact::populate_app_actions()
 {
     map &here = get_map();
     vehicle_part *vp;
-    const tripoint_bub_ms a_point_bub( veh->mount_to_tripoint( a_point ) );
-    if( auto sel_part = here.veh_at( a_point_bub ).part_with_feature( VPFLAG_APPLIANCE, false ) ) {
+    const tripoint_abs_ms a_point_abs( veh->mount_to_tripoint_abs( a_point ) );
+    if( auto sel_part = here.veh_at( a_point_abs ).part_with_feature( VPFLAG_APPLIANCE, false ) ) {
         vp = &sel_part->part();
     } else {
         const int part = veh->part_at( veh->coord_translate( a_point ) );
@@ -617,7 +616,7 @@ void veh_app_interact::populate_app_actions()
 
     /*************** Get part-specific actions ***************/
     veh_menu menu( veh, "IF YOU SEE THIS IT IS A BUG" );
-    veh->build_interact_menu( menu, veh->mount_to_tripoint( a_point ), false );
+    veh->build_interact_menu( menu, veh->mount_to_tripoint( &here, a_point ), false );
     const std::vector<veh_menu_item> items = menu.get_items();
     for( size_t i = 0; i < items.size(); i++ ) {
         const veh_menu_item &it = items[i];

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -24,7 +24,7 @@ player_activity veh_shape::start( const tripoint_bub_ms &pos )
 
     cursor_allowed.clear();
     for( const vpart_reference &part : veh.get_all_parts() ) {
-        cursor_allowed.insert( part.pos_bub() );
+        cursor_allowed.insert( part.pos_bub( &here ) );
     }
 
     if( !set_cursor_pos( pos ) ) {

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -484,7 +484,7 @@ bool veh_menu::query()
     chosen._on_submit();
 
     map &m = get_map();
-    veh.refresh( &m );
+    veh.refresh( );
     m.invalidate_visibility_cache();
     m.invalidate_map_cache( m.get_abs_sub().z() );
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -216,12 +216,11 @@ units::volume vehicle_stack::max_volume() const
 
 vehicle::vehicle( const vproto_id &proto_id )
 {
-    map &here = get_map();
     face.init( 0_degrees );
     move.init( 0_degrees );
 
     if( proto_id.is_empty() ) {
-        refresh( &here ); // we're not using any blueprint, just return an empty initialized vehicle
+        refresh( ); // we're not using any blueprint, just return an empty initialized vehicle
     } else if( !proto_id.is_valid() ) {
         debugmsg( "trying to construct vehicle from invalid prototype '%s'", proto_id.str() );
     } else {
@@ -233,7 +232,7 @@ vehicle::vehicle( const vproto_id &proto_id )
         // The game language may have changed after the blueprint was created,
         // so translated the prototype name again.
         name = proto.name.translated();
-        refresh( &here );
+        refresh( );
     }
 }
 
@@ -297,7 +296,7 @@ bool vehicle::remote_controlled( const Character &p ) const
     }
 
     for( const vpart_reference &vp : get_avail_parts( "REMOTE_CONTROLS" ) ) {
-        if( rl_dist( p.pos_bub(), vp.pos_bub() ) <= 40 ) {
+        if( rl_dist( p.pos_abs(), vp.pos_abs() ) <= 40 ) {
             return true;
         }
     }
@@ -597,13 +596,11 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
         auto_select_fuel( parts[p] );
     }
 
-    refresh( &placed_on );
+    refresh( );
 }
 
 void vehicle::activate_magical_follow()
 {
-    map &here = get_map();
-
     for( vehicle_part &vp : parts ) {
         if( vp.info().fuel_type == fuel_type_mana ) {
             vp.enabled = true;
@@ -613,13 +610,10 @@ void vehicle::activate_magical_follow()
             vp.enabled = true;
         }
     }
-    refresh( &here );
 }
 
 void vehicle::activate_animal_follow()
 {
-    map &here = get_map();
-
     for( size_t e = 0; e < parts.size(); e++ ) {
         vehicle_part &vp = parts[ e ];
         if( vp.info().fuel_type == fuel_type_animal ) {
@@ -633,7 +627,6 @@ void vehicle::activate_animal_follow()
             vp.enabled = true;
         }
     }
-    refresh( &here );
 }
 
 void vehicle::autopilot_patrol()
@@ -713,8 +706,8 @@ std::set<point_abs_ms> vehicle::immediate_path( const units::angle &rotate )
     tileray collision_vector;
     collision_vector.init( adjusted_angle );
     map &here = get_map();
-    point_bub_ms top_left_actual = pos_bub().xy() + coord_translate( front_left );
-    point_bub_ms top_right_actual = pos_bub().xy() + coord_translate( front_right );
+    point_bub_ms top_left_actual = pos_bub( &here ).xy() + coord_translate( front_left );
+    point_bub_ms top_right_actual = pos_bub( &here ).xy() + coord_translate( front_right );
     std::vector<point_abs_ms> front_row = line_to( here.get_abs( tripoint_bub_ms{top_left_actual.x(), top_left_actual.y(), here.get_abs_sub().z()} ).xy(),
                                           here.get_abs( tripoint_bub_ms{ top_right_actual.x(), top_right_actual.y(), here.get_abs_sub().z()} ).xy() );
     for( const point_abs_ms &elem : front_row ) {
@@ -762,14 +755,14 @@ void vehicle::drive_to_local_target( const tripoint_abs_ms &target, bool follow_
         stop_autodriving();
         return;
     }
-    refresh( &here );
+    refresh( );
     tripoint_abs_ms vehpos = pos_abs();
     units::angle angle = get_angle_from_targ( target );
 
     bool stop = precollision_check( angle, here, follow_protocol );
     if( stop ) {
         if( autopilot_on ) {
-            sounds::sound( pos_bub(), 30, sounds::sound_t::alert,
+            sounds::sound( pos_bub( &here ), 30, sounds::sound_t::alert,
                            string_format( _( "the %s emitting a beep and saying \"Obstacle detected!\"" ),
                                           name ) );
         }
@@ -1492,7 +1485,6 @@ int vehicle::install_part( const point_rel_ms &dp, const vpart_id &type, item &&
 
 int vehicle::install_part( const point_rel_ms &dp, vehicle_part &&vp )
 {
-    map &here = get_map();
     const vpart_info &vpi = vp.info();
     const ret_val<void> valid_mount = can_mount( dp, vpi );
     if( !valid_mount.success() ) {
@@ -1548,7 +1540,7 @@ int vehicle::install_part( const point_rel_ms &dp, vehicle_part &&vp )
     vp_installed.enabled = enable;
     vp_installed.mount = dp;
     const int vp_installed_index = parts.size() - 1;
-    refresh( &here );
+    refresh( );
     coeff_air_changed = true;
     return vp_installed_index;
 }
@@ -1583,7 +1575,7 @@ std::vector<vehicle::rackable_vehicle> vehicle::find_vehicles_to_rack( int rack 
                 std::set<tripoint_bub_ms> test_veh_points;
                 for( const vpart_reference &vpr : test_veh->get_all_parts() ) {
                     if( !vpr.part().removed && !vpr.part().is_fake ) {
-                        test_veh_points.insert( vpr.pos_bub() );
+                        test_veh_points.insert( vpr.pos_bub( &here ) );
                     }
                 }
 
@@ -1744,7 +1736,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
     for( const int &carry_part : carry_veh_structs ) {
 
         // The current position on the original vehicle for this part
-        tripoint_bub_ms carry_pos = carry_veh->bub_part_pos( &here, carry_part );
+        tripoint_abs_ms carry_pos = carry_veh->abs_part_pos( carry_part );
 
         bool merged_part = false;
         for( int rack_part : rack_parts ) {
@@ -1754,7 +1746,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
             point_rel_ms carry_mount;
             for( const point &offset : four_cardinal_directions ) {
                 carry_mount = parts[ rack_part ].mount + offset;
-                tripoint_bub_ms possible_pos = mount_to_tripoint( carry_mount );
+                tripoint_abs_ms possible_pos = mount_to_tripoint_abs( carry_mount );
                 if( possible_pos == carry_pos ) {
                     break;
                 }
@@ -1831,7 +1823,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
         // update when we next interact with them
         zones_dirty = true;
         remove_fake_parts( /* cleanup = */ true );
-        refresh( &here );
+        refresh( );
 
         //~ %1$s is the vehicle being loaded onto the bicycle rack
         add_msg( _( "You load the %1$s on the rack." ), carry_veh->name );
@@ -1869,14 +1861,14 @@ bool vehicle::merge_vehicle_parts( vehicle *veh )
                 continue;
             }
         }
-        point_bub_ms part_loc = veh->mount_to_tripoint( part.mount ).xy();
+        point_abs_ms part_loc = veh->mount_to_tripoint_abs( part.mount ).xy();
 
         remove_fake_parts();
         parts.push_back( part );
         vehicle_part &copied_part = parts.back();
-        copied_part.mount = part_loc - pos_bub().xy();
+        copied_part.mount = part_loc - pos_abs().xy();
 
-        refresh( &here );
+        refresh( );
     }
 
     here.destroy_vehicle( veh );
@@ -1886,13 +1878,15 @@ bool vehicle::merge_vehicle_parts( vehicle *veh )
 
 bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
 {
+    map &here = get_map();
+
     if( &veh_target == this ) {
         return false;
     }
     // Release grab if player is dragging either appliance
     if( get_avatar().get_grab_type() == object_type::VEHICLE ) {
-        const tripoint_bub_ms grab_point = get_avatar().pos_bub() + get_avatar().grab_point;
-        const optional_vpart_position grabbed_veh = get_map().veh_at( grab_point );
+        const tripoint_bub_ms grab_point = get_avatar().pos_bub( &here ) + get_avatar().grab_point;
+        const optional_vpart_position grabbed_veh = here.veh_at( grab_point );
         if( grabbed_veh && ( &grabbed_veh->vehicle() == this || &grabbed_veh->vehicle() == &veh_target ) ) {
             add_msg( _( "You release the %s." ), grabbed_veh->vehicle().name );
             get_avatar().grab( object_type::NONE );
@@ -1903,18 +1897,20 @@ bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
     veh_target.turn_dir = 0_degrees;
 
     // Ensure both vehicles have the correct position and a part at 0,0. get_bounding_box will update precalcs.
-    shift_if_needed( get_map() );
+    shift_if_needed( here );
     pos -= pivot_anchor[0];
-    veh_target.shift_if_needed( get_map() );
+    veh_target.shift_if_needed( here );
     veh_target.pos -= veh_target.pivot_anchor[0];
 
     bounding_box vehicle_box = get_bounding_box( false, true );
     bounding_box target_vehicle_box = veh_target.get_bounding_box( false, true );
-    const point_bub_ms min = { std::min( pos_bub().x() + vehicle_box.p1.x(), veh_target.pos_bub().x() + target_vehicle_box.p1.x() ),
-                               std::min( pos_bub().y() + vehicle_box.p1.y(), veh_target.pos_bub().y() + target_vehicle_box.p1.y() )
+    const tripoint_bub_ms veh_pos = pos_bub( &here );
+    const tripoint_bub_ms target_pos = veh_target.pos_bub( &here );
+    const point_bub_ms min = { std::min( veh_pos.x() + vehicle_box.p1.x(), target_pos.x() + target_vehicle_box.p1.x() ),
+                               std::min( veh_pos.y() + vehicle_box.p1.y(), target_pos.y() + target_vehicle_box.p1.y() )
                              };
-    const point_bub_ms max = { std::max( pos_bub().x() + vehicle_box.p1.x(), veh_target.pos_bub().x() + target_vehicle_box.p1.x() ),
-                               std::max( pos_bub().y() + vehicle_box.p1.y(), veh_target.pos_bub().y() + target_vehicle_box.p1.y() )
+    const point_bub_ms max = { std::max( veh_pos.x() + vehicle_box.p1.x(), target_pos.x() + target_vehicle_box.p1.x() ),
+                               std::max( veh_pos.y() + vehicle_box.p1.y(), target_pos.y() + target_vehicle_box.p1.y() )
                              };
     point_rel_ms size;
     size.x() = std::abs( ( max - min ).x() ) + 1;
@@ -1923,14 +1919,14 @@ bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
     //Make sure the resulting vehicle would not be too large
     if( size.x() <= MAX_WIRE_VEHICLE_SIZE && size.y() <= MAX_WIRE_VEHICLE_SIZE ) {
         // Find all item connections to the merging network so they can be updated after merge.
-        std::vector<item_reference> network_connections = get_map().item_network_connections( &veh_target );
-        tripoint_bub_ms old_grid_reference{veh_target.pos_bub()};
+        std::vector<item_reference> network_connections = here.item_network_connections( &veh_target );
+        tripoint_bub_ms old_grid_reference{veh_target.pos_bub( &here )};
         if( !merge_vehicle_parts( &veh_target ) ) {
             debugmsg( "failed to merge vehicle parts" );
         } else {
             //  Adjust the connections after the change of the power_grid origo.
             for( const item_reference &item_ref : network_connections ) {
-                item_ref.item_ref->link().t_mount += ( old_grid_reference - this->pos_bub() ).xy();
+                item_ref.item_ref->link().t_mount += ( old_grid_reference - this->pos_bub( &here ) ).xy();
             }
 
             //Keep wall wiring sections from losing their flag
@@ -2134,7 +2130,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
             handler.add_item_or_charges( dest, i, true );
         }
     }
-    refresh( &handler.get_map_ref(), false );
+    refresh( false );
     coeff_air_changed = true;
     return shift_if_needed( handler.get_map_ref() );
 }
@@ -2173,7 +2169,7 @@ void vehicle::part_removal_cleanup()
     remove_fake_parts( false );
     const bool changed =  do_remove_part_actual();
     if( changed || parts.empty() ) {
-        refresh( &here );
+        refresh( );
         if( parts.empty() ) {
             here.destroy_vehicle( this );
             return;
@@ -2186,7 +2182,7 @@ void vehicle::part_removal_cleanup()
     if( is_powergrid() && name == power_grid_name.translated() && part_count() == 1 ) {
         name = parts[0].info().name();
     }
-    refresh( &here, false ); // Rebuild cached indices
+    refresh( false ); // Rebuild cached indices
     coeff_air_dirty = coeff_air_changed;
     coeff_air_changed = false;
 }
@@ -2405,7 +2401,7 @@ void vehicle::relocate_passengers( const std::vector<Character *> &passengers ) 
     for( Character *passenger : passengers ) {
         for( const vpart_reference &vp : boardables ) {
             if( vp.part().passenger_id == passenger->getID() ) {
-                passenger->setpos( vp.pos_bub() );
+                passenger->setpos( vp.pos_abs() );
             }
         }
     }
@@ -2572,7 +2568,7 @@ bool vehicle::split_vehicles( map &here,
         }
 
         if( split_mounts.empty() ) {
-            new_vehicle->refresh( &here );
+            new_vehicle->refresh( );
         } else {
             // include refresh
             new_vehicle->shift_parts( here, - mnt_offset );
@@ -2909,9 +2905,15 @@ tiny_bitset vehicle::has_parts( const std::vector<std::string> &flags, bool enab
     return ret;
 }
 
-bool vehicle::has_part( const tripoint_bub_ms &pos, const std::string &flag, bool enabled ) const
+bool vehicle::has_part( map *here, const tripoint_bub_ms &pos, const std::string &flag,
+                        bool enabled ) const
 {
-    const tripoint_rel_ms relative_pos = pos - pos_bub();
+    return vehicle::has_part( here->get_abs( pos ), flag, enabled );
+}
+
+bool vehicle::has_part( const tripoint_abs_ms &pos, const std::string &flag, bool enabled ) const
+{
+    const tripoint_rel_ms relative_pos = pos - pos_abs();
 
     for( const vpart_reference &vpr : get_all_parts() ) {
         if( vpr.part().precalc[0] != relative_pos ) {
@@ -2926,57 +2928,23 @@ bool vehicle::has_part( const tripoint_bub_ms &pos, const std::string &flag, boo
 }
 
 // NOLINTNEXTLINE(readability-make-member-function-const)
-std::vector<vehicle_part *> vehicle::get_parts_at( const tripoint_bub_ms &pos,
-        const std::string &flag,
-        const part_status_flag condition )
-{
-    // TODO: provide access to fake parts via argument ?
-    const tripoint_rel_ms relative_pos = pos - pos_bub();
-    std::vector<vehicle_part *> res;
-    for( const vpart_reference &vpr : get_all_parts() ) {
-        if( vpr.part().precalc[0] != relative_pos ) {
-            continue;
-        }
-        if( !vpr.part().removed &&
-            ( flag.empty() || vpr.part().info().has_flag( flag ) ) &&
-            ( !( condition & part_status_flag::enabled ) || vpr.part().enabled ) &&
-            ( !( condition & part_status_flag::working ) || !vpr.part().is_broken() ) ) {
-            res.push_back( &vpr.part() );
-        }
-    }
-    return res;
-}
-
-// NOLINTNEXTLINE(readability-make-member-function-const)
 std::vector<vehicle_part *> vehicle::get_parts_at( map *here, const tripoint_bub_ms &pos,
         const std::string &flag,
         const part_status_flag condition )
 {
+    return vehicle::get_parts_at( here->get_abs( pos ), flag, condition );
+}
+
+// NOLINTNEXTLINE(readability-make-member-function-const)
+std::vector<vehicle_part *> vehicle::get_parts_at( const tripoint_abs_ms &pos,
+        const std::string &flag,
+        const part_status_flag condition )
+{
     // TODO: provide access to fake parts via argument ?
-    const tripoint_rel_ms relative_pos = pos - pos_bub( here );
+    const tripoint_rel_ms relative_pos = pos - pos_abs();
     std::vector<vehicle_part *> res;
     for( const vpart_reference &vpr : get_all_parts() ) {
         if( vpr.part().precalc[0] != relative_pos ) {
-            continue;
-        }
-        if( !vpr.part().removed &&
-            ( flag.empty() || vpr.part().info().has_flag( flag ) ) &&
-            ( !( condition & part_status_flag::enabled ) || vpr.part().enabled ) &&
-            ( !( condition & part_status_flag::working ) || !vpr.part().is_broken() ) ) {
-            res.push_back( &vpr.part() );
-        }
-    }
-    return res;
-}
-
-std::vector<const vehicle_part *> vehicle::get_parts_at( const tripoint_bub_ms &pos,
-        const std::string &flag,
-        const part_status_flag condition ) const
-{
-    const tripoint_rel_ms relative_pos = pos - pos_bub();
-    std::vector<const vehicle_part *> res;
-    for( const vpart_reference &vpr : get_all_parts() ) {
-        if( vpr.part().precalc[ 0 ] != relative_pos ) {
             continue;
         }
         if( !vpr.part().removed &&
@@ -3416,17 +3384,30 @@ void vehicle::coord_translate( tileray tdir, const point_rel_ms &pivot, const po
     q.y() = tdir.dy() + tdir.ortho_dy( p.y() - pivot.y() );
 }
 
-tripoint_bub_ms vehicle::mount_to_tripoint( const point_rel_ms &mount ) const
+tripoint_bub_ms vehicle::mount_to_tripoint( map *here, const point_rel_ms &mount ) const
 {
-    return mount_to_tripoint( mount, point_rel_ms::zero );
+    return mount_to_tripoint( here, mount, point_rel_ms::zero );
 }
 
-tripoint_bub_ms vehicle::mount_to_tripoint( const point_rel_ms &mount,
+tripoint_abs_ms vehicle::mount_to_tripoint_abs( const point_rel_ms &mount ) const
+{
+    return mount_to_tripoint_abs( mount, point_rel_ms::zero );
+}
+
+tripoint_bub_ms vehicle::mount_to_tripoint( map *here, const point_rel_ms &mount,
         const point_rel_ms &offset ) const
 {
     tripoint_rel_ms mnt_translated;
     coord_translate( pivot_rotation[0], pivot_anchor[0], mount + offset, mnt_translated );
-    return pos_bub() + mnt_translated;
+    return pos_bub( here ) + mnt_translated;
+}
+
+tripoint_abs_ms vehicle::mount_to_tripoint_abs( const point_rel_ms &mount,
+        const point_rel_ms &offset ) const
+{
+    tripoint_rel_ms mnt_translated;
+    coord_translate( pivot_rotation[0], pivot_anchor[0], mount + offset, mnt_translated );
+    return pos_abs() + mnt_translated;
 }
 
 void vehicle::precalc_mounts( int idir, const units::angle &dir,
@@ -3469,7 +3450,7 @@ std::vector<rider_data> vehicle::get_riders() const
     std::vector<rider_data> res;
     creature_tracker &creatures = get_creature_tracker();
     for( const vpart_reference &vp : get_avail_parts( VPFLAG_BOARDABLE ) ) {
-        Creature *rider = creatures.creature_at( vp.pos_bub() );
+        Creature *rider = creatures.creature_at( vp.pos_abs() );
         if( rider ) {
             rider_data r;
             r.prt = vp.part_index();
@@ -3531,7 +3512,7 @@ monster *vehicle::get_monster( int p ) const
 
 tripoint_abs_ms vehicle::pos_abs() const
 {
-    return get_map().get_abs( pos_bub() );
+    return coords::project_to<coords::ms>( sm_pos ) + rebase_rel( pos );
 }
 
 tripoint_abs_omt vehicle::pos_abs_omt() const
@@ -3539,15 +3520,9 @@ tripoint_abs_omt vehicle::pos_abs_omt() const
     return project_to<coords::omt>( pos_abs() );
 }
 
-tripoint_bub_ms vehicle::pos_bub() const
-{
-    return vehicle::pos_bub( &get_map() );
-}
-
 tripoint_bub_ms vehicle::pos_bub( map *here ) const
 {
-    return coords::project_to<coords::ms>( rebase_bub( sm_pos - here->get_abs_sub().xy() ) ) +
-           rebase_rel( pos );
+    return here->get_bub( pos_abs() );
 }
 
 tripoint_bub_ms vehicle::bub_part_pos( map *here, const int index ) const
@@ -4128,7 +4103,7 @@ bool vehicle::do_environmental_effects() const
         /* Only lower blood level if:
          * - The part is outside.
          * - The weather is any effect that would cause the player to be wet. */
-        if( vp.part().blood > 0 && here.is_outside( vp.pos_bub() ) ) {
+        if( vp.part().blood > 0 && here.is_outside( vp.pos_bub( &here ) ) ) {
             needed = true;
             if( get_weather().weather_id->rains &&
                 get_weather().weather_id->precip != precip_class::very_light ) {
@@ -4156,6 +4131,8 @@ void vehicle::spew_field( double joules, int part, field_type_id type, int inten
  */
 void vehicle::noise_and_smoke( int load, time_duration time )
 {
+    map &here = get_map();
+
     static const std::array<std::pair<std::string, int>, 8> sounds = { {
             { translate_marker( "hmm" ), 0 }, { translate_marker( "hummm!" ), 15 },
             { translate_marker( "whirrr!" ), 30 }, { translate_marker( "vroom!" ), 60 },
@@ -4237,7 +4214,7 @@ void vehicle::noise_and_smoke( int load, time_duration time )
     }
     add_msg_debug( debugmode::DF_VEHICLE, "VEH NOISE final: %d", static_cast<int>( noise ) );
     vehicle_noise = static_cast<unsigned char>( noise );
-    sounds::sound( pos_bub(), noise, sounds::sound_t::movement,
+    sounds::sound( pos_bub( &here ), noise, sounds::sound_t::movement,
                    _( is_rotorcraft() ? heli_noise : sounds[lvl].first ), true );
 }
 
@@ -5443,7 +5420,7 @@ void vehicle::power_parts()
                 for( int elem : reactors ) {
                     parts[ elem ].enabled = false;
                 }
-                if( player_is_driving_this_veh() || player_character.sees( pos_bub() ) ) {
+                if( player_is_driving_this_veh() || player_character.sees( pos_bub( &here ) ) ) {
                     add_msg( _( "The %s's reactor dies!" ), name );
                 }
             }
@@ -5478,13 +5455,13 @@ void vehicle::power_parts()
 
         is_alarm_on = false;
         camera_on = false;
-        if( player_is_driving_this_veh() || player_character.sees( pos_bub() ) ) {
+        if( player_is_driving_this_veh() || player_character.sees( pos_bub( &here ) ) ) {
             add_msg( _( "The %s's battery dies!" ), name );
         }
         if( engine_epower < 0_W ) {
             // Not enough epower to run gas engine ignition system
             engine_on = false;
-            if( player_is_driving_this_veh() || player_character.sees( pos_bub() ) ) {
+            if( player_is_driving_this_veh() || player_character.sees( pos_bub( &here ) ) ) {
                 add_msg( _( "The %s's engine dies!" ), name );
             }
         }
@@ -5538,7 +5515,7 @@ vehicle *vehicle::find_vehicle_using_parts( const tripoint_abs_ms &where )
         for( const vpart_reference &vp : found_veh->get_all_parts() ) {
             point_sm_ms_ib vp_in_sm;
             tripoint_bub_sm vp_sm;
-            std::tie( vp_sm, vp_in_sm ) = project_remain<coords::sm>( vp.pos_bub() );
+            std::tie( vp_sm, vp_in_sm ) = project_remain<coords::sm>( vp.pos_bub( &here ) );
             if( vp_in_sm == veh_in_sm ) {
                 return found_veh;
             }
@@ -5816,6 +5793,8 @@ void vehicle::do_engine_damage( vehicle_part &vp, int strain )
 
 void vehicle::idle( bool on_map )
 {
+    map &here = get_map();
+
     avg_velocity = ( velocity + avg_velocity ) / 2;
 
     power_parts();
@@ -5841,16 +5820,16 @@ void vehicle::idle( bool on_map )
         if( engine_on &&
             ( has_engine_type_not( fuel_type_muscle, true ) && has_engine_type_not( fuel_type_animal, true ) &&
               has_engine_type_not( fuel_type_wind, true ) && has_engine_type_not( fuel_type_mana, true ) ) ) {
-            add_msg_if_player_sees( pos_bub(), _( "The %s's engine dies!" ), name );
+            add_msg_if_player_sees( pos_bub( &here ), _( "The %s's engine dies!" ), name );
         }
         engine_on = false;
     }
 
-    if( !warm_enough_to_plant( player_character.pos_bub() ) ) {
+    if( !warm_enough_to_plant( player_character.pos_bub( &here ) ) ) {
         for( int i : planters ) {
             vehicle_part &vp = parts[ i ];
             if( vp.enabled ) {
-                add_msg_if_player_sees( pos_bub(), _( "The %s's planter turns off due to low temperature." ),
+                add_msg_if_player_sees( pos_bub( &here ), _( "The %s's planter turns off due to low temperature." ),
                                         name );
                 vp.enabled = false;
             }
@@ -5867,7 +5846,6 @@ void vehicle::idle( bool on_map )
         update_time( calendar::turn );
     }
 
-    map &here = get_map();
     // Parts emitting fields
     const std::pair<int, double> exhaust_and_muffle = get_exhaust_part();
     for( const int emitter_idx : emitters ) {
@@ -5906,13 +5884,13 @@ void vehicle::idle( bool on_map )
     }
 
     // Notify player about status of all turrets if they're at controls
-    bool player_at_controls = !get_parts_at( player_character.pos_bub(), "CONTROLS",
+    bool player_at_controls = !get_parts_at( player_character.pos_abs(), "CONTROLS",
                               part_status_flag::working ).empty();
 
     for( vehicle_part *turret : turrets() ) {
         item_location base = turret_query( *turret ).base();
         // Notify player about status of a turret if they're on the same tile
-        if( player_at_controls || player_character.pos_bub() == base.pos_bub() ) {
+        if( player_at_controls || player_character.pos_bub( &here ) == base.pos_bub() ) {
             base->process( here, &player_character, base.pos_bub() );
         } else {
             base->process( here, nullptr, base.pos_bub() );
@@ -5960,7 +5938,7 @@ void vehicle::slow_leak()
         itype_id fuel = p.ammo_current();
         int qty = std::max( ( 0.5 - health ) * ( 0.5 - health ) * p.ammo_remaining() / 10, 1.0 );
         point_rel_ms q = coord_translate( p.mount );
-        const tripoint_bub_ms dest = pos_bub() + tripoint_rel_ms( q, 0 );
+        const tripoint_bub_ms dest = pos_bub( &here ) + tripoint_rel_ms( q, 0 );
 
         // damaged batteries self-discharge without leaking, plutonium leaks slurry
         if( fuel != fuel_type_battery && fuel != fuel_type_plutonium_cell ) {
@@ -6023,8 +6001,9 @@ void vehicle::disable_smart_controller_if_needed()
 
 void vehicle::make_active( item_location &loc )
 {
+    map &here = get_map();
     item &target = *loc;
-    auto cargo_parts = get_parts_at( loc.pos_bub(), "CARGO", part_status_flag::any );
+    auto cargo_parts = get_parts_at( &here, loc.pos_bub(), "CARGO", part_status_flag::any );
     if( cargo_parts.empty() ) {
         return;
     }
@@ -6324,7 +6303,7 @@ bool vehicle::decrement_summon_timer()
             }
             vp.items.clear();
         }
-        add_msg_if_player_sees( pos_bub(), m_info, _( "Your %s winks out of existence." ), name );
+        add_msg_if_player_sees( pos_bub( &here ), m_info, _( "Your %s winks out of existence." ), name );
         get_map().destroy_vehicle( this );
         return true;
     } else {
@@ -6348,7 +6327,6 @@ void vehicle::suspend_refresh()
 
 void vehicle::enable_refresh()
 {
-    map &here = get_map();
     // force all caches to recalculate
     no_refresh = false;
     mass_dirty = true;
@@ -6358,7 +6336,7 @@ void vehicle::enable_refresh()
     coeff_air_dirty = true;
     coeff_water_dirty = true;
     coeff_air_changed = true;
-    refresh( &here );
+    refresh( );
 }
 
 void vehicle::refresh_active_item_cache()
@@ -6378,7 +6356,7 @@ void vehicle::refresh_active_item_cache()
  * Refreshes all caches and refinds all parts. Used after the vehicle has had a part added or removed.
  * Makes indices of different part types so they're easy to find. Also calculates power drain.
  */
-void vehicle::refresh( map *here, const bool remove_fakes )
+void vehicle::refresh( const bool remove_fakes )
 {
     if( no_refresh ) {
         return;
@@ -6554,7 +6532,7 @@ void vehicle::refresh( map *here, const bool remove_fakes )
         } else if( !camera_on && vpi.has_flag( "CAMERA" ) ) {
             vp.part().enabled = false;
         }
-        if( vpi.has_flag( "TURRET" ) && !has_part( bub_part_pos( here, vp.part() ), "TURRET_CONTROLS" ) ) {
+        if( vpi.has_flag( "TURRET" ) && !has_part( abs_part_pos( vp.part() ), "TURRET_CONTROLS" ) ) {
             vp.part().enabled = false;
         }
         if( vpi.has_flag( "MUFFLER" ) ) {
@@ -6924,7 +6902,7 @@ void vehicle::do_towing_move()
             }
             const tripoint_rel_ms destination_delta( here.get_bub( tower_tow_point ).xy() -
                     nearby_destination.xy() +
-                    tripoint_rel_ms( 0, 0, towed_veh->pos_bub().z() ) );
+                    tripoint_rel_ms( 0, 0, towed_veh->pos_abs().z() ) );
             const tripoint_rel_ms move_destination( clamp( destination_delta.x(), -1, 1 ),
                                                     clamp( destination_delta.y(), -1, 1 ),
                                                     clamp( destination_delta.z(), -1, 1 ) );
@@ -7185,9 +7163,13 @@ void vehicle::remove_remote_part( const vehicle_part &vp_local ) const
     }
 }
 
-void vehicle::shed_loose_parts( const trinary shed_cables, const tripoint_bub_ms *dst )
+void vehicle::shed_loose_parts( const trinary shed_cables, map *here, const tripoint_bub_ms *dst )
 {
-    map &here = get_map();
+    if( ( here == nullptr && dst != nullptr ) || ( ( here != nullptr && dst == nullptr ) ) ) {
+        debugmsg( "map and dst have to both be nullptr or both refer to a value" );
+        return;
+    }
+
     // remove_part rebuilds the loose_parts vector, so iterate over a copy to preserve
     // power transfer lines that still have some slack to them
     std::vector<int> lp = loose_parts;
@@ -7204,13 +7186,13 @@ void vehicle::shed_loose_parts( const trinary shed_cables, const tripoint_bub_ms
                 // Skip cables if we're only calling shed_loose_parts to remove parts with UNMOUNT_ON_MOVE.
                 continue;
             }
-            tripoint_abs_ms vp_loose_dst = dst ? here.get_abs( *dst + vp_loose.precalc[1] ) : abs_part_pos(
+            tripoint_abs_ms vp_loose_dst = dst ? here->get_abs( *dst + vp_loose.precalc[1] ) : abs_part_pos(
                                                vp_loose );
             const int distance = rl_dist( vp_loose_dst, vp_loose.target.first );
             const int max_dist = vp_loose.get_base().max_link_length();
 
             if( distance > max_dist || shed_cables == trinary::ALL ) {
-                add_msg_if_player_sees( bub_part_pos( &here, vp_loose ), m_warning,
+                add_msg_if_player_sees( bub_part_pos( here, vp_loose ), m_warning,
                                         _( "The %s's %s was detached!" ), name, vp_loose.name( false ) );
                 remove_remote = true;
             } else {
@@ -7218,14 +7200,14 @@ void vehicle::shed_loose_parts( const trinary shed_cables, const tripoint_bub_ms
                 const auto remote = get_remote_part( vp_loose );
                 if( remote ) {
                     remote->part().target.first = vp_loose_dst;
-                    remote->part().target.second = here.get_abs( dst ? *dst : pos_bub() );
+                    remote->part().target.second =  dst ? here->get_abs( *dst ) : pos_abs();
                 }
                 continue;
             }
         }
         const item drop = part_to_item( vp_loose );
         if( !magic ) {
-            here.add_item_or_charges( bub_part_pos( &here, vp_loose ), drop );
+            here->add_item_or_charges( bub_part_pos( here, vp_loose ), drop );
         }
 
         if( remove_remote ) {
@@ -7279,8 +7261,9 @@ void vehicle::unlink_cables( const point_rel_ms &mount, Character &remover,
 
 bool vehicle::enclosed_at( const tripoint_bub_ms &pos )
 {
+    map &here = get_map();
     refresh_insides();
-    std::vector<vehicle_part *> parts_here = get_parts_at( pos, "BOARDABLE",
+    std::vector<vehicle_part *> parts_here = get_parts_at( &here, pos, "BOARDABLE",
             part_status_flag::working );
     if( !parts_here.empty() ) {
         return parts_here.front()->inside;
@@ -7484,7 +7467,7 @@ void vehicle::shift_parts( map &here, const point_rel_ms &delta )
     loot_zones = new_zones;
 
     pivot_anchor[0] -= delta.raw();
-    refresh( &here );
+    refresh( );
     //Need to also update the map after this
     here.rebuild_vehicle_level_caches();
 }
@@ -7507,7 +7490,7 @@ bool vehicle::shift_if_needed( map &here )
             && !vp.has_feature( "PROTRUSION" )
             && !vp.part().removed ) {
             shift_parts( here, vp.mount_pos() );
-            refresh( &here );
+            refresh( );
             return true;
         }
     }
@@ -7515,7 +7498,7 @@ bool vehicle::shift_if_needed( map &here )
     for( const vpart_reference &vp : get_all_parts() ) {
         if( !vp.part().removed ) {
             shift_parts( here, vp.mount_pos() );
-            refresh( &here );
+            refresh( );
             return true;
         }
     }
@@ -7730,7 +7713,7 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         }
         // refresh cache in case the broken part has changed the status
         // do not remove fakes parts in case external vehicle part references get invalidated
-        refresh( &here, false );
+        refresh( false );
     }
 
     if( vp.is_fuel_store() ) {
@@ -7899,7 +7882,6 @@ item vehicle::get_folded_item() const
 
 bool vehicle::restore_folded_parts( const item &it )
 {
-    map &here = get_map();
     const JsonValue jv_parts = json_loader::from_string( it.get_var( "folded_parts" ) );
     deserialize_parts( static_cast<JsonArray>( jv_parts ) );
 
@@ -7941,7 +7923,7 @@ bool vehicle::restore_folded_parts( const item &it )
         }
     }
 
-    refresh( &here );
+    refresh( );
     face.init( 0_degrees );
     turn_dir = 0_degrees;
     turn( 0_degrees );
@@ -8002,6 +7984,8 @@ std::set<tripoint_abs_ms> vehicle::get_projected_part_points() const
 std::list<item> vehicle::use_charges( const vpart_position &vp, const itype_id &type,
                                       int &quantity, const std::function<bool( const item & )> &filter, bool in_tools )
 {
+    map &here = get_map();
+
     std::list<item> ret;
     // HACK: water_faucet pseudo tool gives access to liquids in tanks
     const itype_id veh_tool_type = type.obj().phase > phase_id::SOLID
@@ -8026,7 +8010,7 @@ std::list<item> vehicle::use_charges( const vpart_position &vp, const itype_id &
     }
 
     if( const std::optional<vpart_reference> cargo_vp = vp.cargo() ) {
-        std::list<item> tmp = cargo_vp->items().use_charges( type, quantity, vp.pos_bub(), filter,
+        std::list<item> tmp = cargo_vp->items().use_charges( type, quantity, vp.pos_bub( &here ), filter,
                               in_tools );
         ret.splice( ret.end(), tmp );
         if( quantity <= 0 ) {
@@ -8070,10 +8054,14 @@ point_rel_ms vpart_position::mount_pos() const
     return vehicle().part( part_index() ).mount;
 }
 
-tripoint_bub_ms vpart_position::pos_bub() const
+tripoint_bub_ms vpart_position::pos_bub( map *here ) const
 {
-    map &here = get_map();
-    return vehicle().bub_part_pos( &here, part_index() );
+    return vehicle().bub_part_pos( here, part_index() );
+}
+
+tripoint_abs_ms vpart_position::pos_abs() const
+{
+    return vehicle().abs_part_pos( part_index() );
 }
 
 bool vpart_reference::has_feature( const std::string &f ) const
@@ -8559,13 +8547,15 @@ std::pair<int, double> vehicle::get_exhaust_part() const
 
 tripoint_bub_ms vehicle::exhaust_dest( int part ) const
 {
+    map &here = get_map();
+
     point_rel_ms p = parts[part].mount;
     // Move back from engine/muffler until we find an open space
     while( relative_parts.find( p ) != relative_parts.end() ) {
         p.x() += ( velocity < 0 ? 1 : -1 );
     }
     point_rel_ms q = coord_translate( p );
-    return pos_bub() + tripoint_rel_ms( q, 0 );
+    return pos_bub( &here ) + tripoint_rel_ms( q, 0 );
 }
 
 void vehicle::add_tag( const std::string &tag )

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7165,7 +7165,7 @@ void vehicle::remove_remote_part( const vehicle_part &vp_local ) const
 
 void vehicle::shed_loose_parts( const trinary shed_cables, map *here, const tripoint_bub_ms *dst )
 {
-    if( ( here == nullptr && dst != nullptr ) || ( ( here != nullptr && dst == nullptr ) ) ) {
+    if( ( here == nullptr && dst != nullptr ) || ( here != nullptr && dst == nullptr ) ) {
         debugmsg( "map and dst have to both be nullptr or both refer to a value" );
         return;
     }

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -1151,7 +1151,9 @@ void vehicle::autodrive_controller::check_safe_speed()
 
 collision_check_result vehicle::autodrive_controller::check_collision_zone( orientation turn_dir )
 {
-    const tripoint_bub_ms veh_pos = driven_veh.pos_bub();
+    map &here = get_map();
+
+    const tripoint_bub_ms veh_pos = driven_veh.pos_bub( &here );
 
     // first check if we have any visibility in front, to prevent blind driving
     tileray face_dir = driven_veh.face;

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -97,14 +97,8 @@ class vpart_position
         // Forms inventory for inventory::form_from_map
         void form_inventory( inventory &inv ) const;
 
-        /**
-         * Returns the position of this part in the coordinates system that @ref game::m uses.
-         * Postcondition (if the vehicle cache of the map is correct and if there are un-removed
-         * parts at this positions):
-         * `g->m.veh_at( this->pos() )` (there is a vehicle there)
-         * `g->m.veh_at( this->pos() )->vehicle() == this->vehicle()` (it's this one)
-         */
-        tripoint_bub_ms pos_bub() const;
+        tripoint_bub_ms pos_bub( map *here ) const;
+        tripoint_abs_ms pos_abs() const;
         /**
          * Returns the mount point: the point in the vehicles own coordinate system.
          * This system is independent of movement / rotation.

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -27,11 +27,11 @@ void check_vehicle_still_works( vehicle &veh )
     veh.engine_on = true;
     veh.velocity = 1000;
     veh.cruise_velocity = veh.velocity;
-    tripoint_bub_ms const startp = veh.pos_bub();
+    tripoint_bub_ms const startp = veh.pos_bub( &here );
     here.vehmove();
-    REQUIRE( veh.pos_bub() != startp );
+    REQUIRE( veh.pos_bub( &here ) != startp );
 
-    here.displace_vehicle( veh, startp - veh.pos_bub() );
+    here.displace_vehicle( veh, startp - veh.pos_bub( &here ) );
 }
 
 vehicle *add_test_vehicle( map &m, tripoint_bub_ms loc )
@@ -59,7 +59,7 @@ void local_test( vehicle *veh, tripoint_bub_ms const &test_loc, F const &fmg, ID
     vehicle *const veh2 = add_test_vehicle( here, this_test_loc );
     REQUIRE( here.veh_at( this_test_loc ).has_value() );
     REQUIRE( here.get_vehicles().size() == 2 );
-    REQUIRE( veh->pos_bub() == veh2->pos_bub() - point::east );
+    REQUIRE( veh->pos_abs() == veh2->pos_abs() - point::east );
     REQUIRE( veh->sm_pos == veh2->sm_pos );
 
     manual_mapgen( this_test_omt, fmg, id );

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -232,7 +232,7 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
 
     // vehicle is a 5x5 grid, car_door_pos is the only door/exit
     std::vector<vehicle_part *> door_parts_at_target = test_vehicle->get_parts_at(
-                car_door_pos, "LOCKABLE_DOOR", part_status_flag::available );
+                &here, car_door_pos, "LOCKABLE_DOOR", part_status_flag::available );
     REQUIRE( !door_parts_at_target.empty() );
     vehicle_part *door = door_parts_at_target.front();
     // The door must be closed for the lock to be effective.
@@ -242,7 +242,7 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
 
     // NOTE: The door lock is a separate part. We must ensure both the door exists and the door lock exists for this test.
     std::vector<vehicle_part *> door_lock_parts_at_target = test_vehicle->get_parts_at(
-                car_door_pos, "DOOR_LOCKING", part_status_flag::available );
+                &here, car_door_pos, "DOOR_LOCKING", part_status_flag::available );
     REQUIRE( !door_lock_parts_at_target.empty() );
     vehicle_part *door_lock = door_lock_parts_at_target.front();
     door_lock->locked = true;

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -188,7 +188,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
     // Remove all items from cargo to normalize weight.
     for( const vpart_reference &vp : veh.get_all_parts() ) {
         veh_ptr->get_items( vp.part() ).clear();
-        vp.part().ammo_consume( vp.part().ammo_remaining(), &here, vp.pos_bub() );
+        vp.part().ammo_consume( vp.part().ammo_remaining(), &here, vp.pos_bub( &here ) );
     }
     for( const vpart_reference &vp : veh.get_avail_parts( "OPENABLE" ) ) {
         veh.close( vp.part_index() );
@@ -208,7 +208,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
     const float starting_fuel_per = fuel_percentage_left( veh, starting_fuel );
     REQUIRE( std::abs( starting_fuel_per - 1.0f ) < 0.001f );
 
-    const tripoint_bub_ms starting_point = veh.pos_bub();
+    const tripoint_bub_ms starting_point = veh.pos_bub( &here );
     veh.tags.insert( "IN_CONTROL_OVERRIDE" );
     veh.engine_on = true;
 
@@ -235,9 +235,9 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
             REQUIRE( here.ter( here.get_bub( pos ) ) );
         }
         // How much it moved
-        tiles_travelled += square_dist( starting_point, veh.pos_bub() );
+        tiles_travelled += square_dist( starting_point, veh.pos_bub( &here ) );
         // Bring it back to starting point to prevent it from leaving the map
-        const tripoint_rel_ms displacement = starting_point - veh.pos_bub();
+        const tripoint_rel_ms displacement = starting_point - veh.pos_bub( &here );
         here.displace_vehicle( veh, displacement );
         if( reset_velocity_turn < 0 ) {
             continue;

--- a/tests/vehicle_export_test.cpp
+++ b/tests/vehicle_export_test.cpp
@@ -42,7 +42,7 @@ TEST_CASE( "export_vehicle_test" )
     // To ensure the zones get placed.
     veh_ptr->set_owner( get_player_character() );
     veh_ptr->place_zones( here );
-    veh_ptr->refresh( &here );
+    veh_ptr->refresh( );
     veh_ptr->refresh_zones();
 
     std::ostringstream os;

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -39,6 +39,7 @@ static const vproto_id vehicle_prototype_car( "car" );
 
 static void test_repair( const std::vector<item> &tools, bool plug_in_tools, bool expect_craftable )
 {
+    map &here = get_map();
     clear_avatar();
     clear_map();
 
@@ -55,7 +56,7 @@ static void test_repair( const std::vector<item> &tools, bool plug_in_tools, boo
     for( const item &gear : tools ) {
         item_location added_tool = player_character.i_add( gear );
         if( plug_in_tools && added_tool->can_link_up() ) {
-            added_tool->link_to( get_map().veh_at( player_character.pos_bub() + tripoint::north_west ),
+            added_tool->link_to( here.veh_at( player_character.pos_bub() + tripoint::north_west ),
                                  link_state::automatic );
             REQUIRE( added_tool->link().t_veh );
         }
@@ -63,13 +64,14 @@ static void test_repair( const std::vector<item> &tools, bool plug_in_tools, boo
     player_character.set_skill_level( skill_mechanics, 10 );
 
     const tripoint_bub_ms vehicle_origin = test_origin + tripoint::south_east;
-    vehicle *veh_ptr = get_map().add_vehicle( vehicle_prototype_car, vehicle_origin, -90_degrees, 0,
-                       0 );
+    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_car, vehicle_origin, -90_degrees, 0,
+                                         0 );
 
     REQUIRE( veh_ptr != nullptr );
     // Find the frame at the origin.
     vehicle_part *origin_frame = nullptr;
-    for( vehicle_part *part : veh_ptr->get_parts_at( vehicle_origin, "", part_status_flag::any ) ) {
+    for( vehicle_part *part : veh_ptr->get_parts_at( &here, vehicle_origin, "",
+            part_status_flag::any ) ) {
         if( part->info().location == "structure" ) {
             origin_frame = part;
             break;

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -205,14 +205,15 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
     clear_map();
     clear_vehicles();
     set_time( midday );
+    map &here = get_map();
 
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     const int water_charges = 8;
     Character &character = get_player_character();
     const item backpack( itype_backpack );
     character.wear_item( backpack );
-    get_map().add_vehicle( vehicle_prototype_test_rv, test_origin, -90_degrees, 0, 0 );
-    const optional_vpart_position ovp = get_map().veh_at( test_origin );
+    here.add_vehicle( vehicle_prototype_test_rv, test_origin, -90_degrees, 0, 0 );
+    const optional_vpart_position ovp = here.veh_at( test_origin );
     REQUIRE( ovp.has_value() );
     vehicle &veh = ovp->vehicle();
 
@@ -235,12 +236,12 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
         }
     }
     REQUIRE( faucet.has_value() );
-    get_map().board_vehicle( faucet->pos_bub() + tripoint::east, &character );
+    here.board_vehicle( faucet->pos_bub( &here ) + tripoint::east, &character );
     veh_menu menu( veh, "TEST" );
     for( int i = 0; i < water_charges; i++ ) {
         CAPTURE( i, veh.fuel_left( itype_water_clean ) );
         menu.reset();
-        veh.build_interact_menu( menu, faucet->pos_bub(), false );
+        veh.build_interact_menu( menu, faucet->pos_bub( &here ), false );
         const std::vector<veh_menu_item> items = menu.get_items();
         const bool stomach_should_be_full = i == water_charges - 1;
         const auto drink_item_it = std::find_if( items.begin(), items.end(),
@@ -261,7 +262,7 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
     }
     REQUIRE( veh.fuel_left( itype_water_clean ) == 0 );
     REQUIRE( tank_it->empty_container() );
-    get_map().destroy_vehicle( &veh );
+    here.destroy_vehicle( &veh );
 }
 
 TEST_CASE( "craft_available_via_vehicle_rig", "[vehicle][vehicle_craft]" )

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
         REQUIRE( frame_part_idx != -1 );
         const int bat_part_idx = veh->install_part( point_rel_ms::zero, vpart_small_storage_battery );
         REQUIRE( bat_part_idx != -1 );
-        veh->refresh( &here );
+        veh->refresh( );
         here.add_vehicle_to_cache( veh );
         batteries.emplace_back( *veh, bat_part_idx );
     }

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -139,7 +139,7 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
         for( const tripoint_abs_ms &checkpt : vpts ) {
             int partnum = 0;
             vehicle *check_veh = here.veh_at_internal( here.get_bub( checkpt ), partnum );
-            CAPTURE( veh_ptr->pos_bub() );
+            CAPTURE( veh_ptr->pos_bub( &here ) );
             CAPTURE( veh_ptr->face.dir() );
             CAPTURE( checkpt );
             CHECK( check_veh == veh_ptr );
@@ -158,7 +158,7 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
             }
             const point_rel_ms &pmount = vp.mount_pos();
             CAPTURE( pmount );
-            const tripoint_bub_ms &ppos = vp.pos_bub();
+            const tripoint_bub_ms &ppos = vp.pos_bub( &here );
             CAPTURE( ppos );
             if( cycles > ( transition_cycle - pmount.x() ) ) {
                 CHECK( ppos.z() == target_z );
@@ -267,7 +267,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
 
     std::vector<vehicle_part *> all_parts;
     for( const tripoint_abs_ms &pos : veh.get_points() ) {
-        for( vehicle_part *prt : veh.get_parts_at( here.get_bub( pos ), "", part_status_flag::any ) ) {
+        for( vehicle_part *prt : veh.get_parts_at( pos, "", part_status_flag::any ) ) {
             all_parts.push_back( prt );
             if( drop_pos && prt->mount.x() < 0 ) {
                 prt->precalc[0].z() = -1;
@@ -309,7 +309,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
         CHECK( veh.abs_part_pos( *prt ).z() == 0 );
     }
     CHECK( dmon.posz() == 0 );
-    CHECK( veh.pos_bub().z() == 0 );
+    CHECK( veh.pos_abs().z() == 0 );
 }
 
 static void test_leveling( const std::string &type )

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
 
         here.destroy_vehicle( vehicle_origin );
         veh_ptr->part_removal_cleanup();
-        REQUIRE( veh_ptr->get_parts_at( vehicle_origin, "", part_status_flag::available ).empty() );
+        REQUIRE( veh_ptr->get_parts_at( &here, vehicle_origin, "", part_status_flag::available ).empty() );
         vehs = here.get_vehicles();
         // destroying the center frame results in 4 new vehicles
         CHECK( vehs.size() == 4 );
@@ -75,7 +75,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
         REQUIRE( veh_ptr != nullptr );
         here.destroy_vehicle( vehicle_origin );
         veh_ptr->part_removal_cleanup();
-        REQUIRE( veh_ptr->get_parts_at( vehicle_origin, "", part_status_flag::available ).empty() );
+        REQUIRE( veh_ptr->get_parts_at( &here, vehicle_origin, "", part_status_flag::available ).empty() );
         vehs = here.get_vehicles();
         CHECK( vehs.size() == 1 );
         if( vehs.size() == 1 ) {

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -72,7 +72,7 @@ TEST_CASE( "destroy_grabbed_vehicle_section", "[vehicle]" )
         REQUIRE( player_character.grab_point == tripoint_rel_ms::east );
         WHEN( "The vehicle section grabbed by the player is destroyed" ) {
             here.destroy( grab_point );
-            REQUIRE( veh_ptr->get_parts_at( grab_point, "", part_status_flag::available ).empty() );
+            REQUIRE( veh_ptr->get_parts_at( &here, grab_point, "", part_status_flag::available ).empty() );
             THEN( "The player's grab is released" ) {
                 CHECK( player_character.get_grab_type() == object_type::NONE );
                 CHECK( player_character.grab_point == tripoint_rel_ms::zero );
@@ -477,7 +477,7 @@ TEST_CASE( "power_cable_stretch_disconnect" )
 
         WHEN( "displacing first appliance to the left" ) {
             for( int i = 0;
-                 rl_dist( m.get_abs( app1.pos_bub() ), m.get_abs( app2.pos_bub() ) ) <= max_dist &&
+                 rl_dist( app1.pos_abs(), app2.pos_abs() ) <= max_dist &&
                  i < max_displacement; i++ ) {
                 CHECK( app1.part_count() == 2 );
                 CHECK( app2.part_count() == 2 );
@@ -485,15 +485,15 @@ TEST_CASE( "power_cable_stretch_disconnect" )
                 app1.part_removal_cleanup();
                 app2.part_removal_cleanup();
             }
-            CAPTURE( m.get_abs( app1.pos_bub() ) );
-            CAPTURE( m.get_abs( app2.pos_bub() ) );
+            CAPTURE( app1.pos_abs() );
+            CAPTURE( app2.pos_abs() );
             CHECK( app1.part_count() == 1 );
             CHECK( app2.part_count() == 1 );
         }
 
         WHEN( "displacing second appliance to the right" ) {
             for( int i = 0;
-                 rl_dist( m.get_abs( app1.pos_bub() ), m.get_abs( app2.pos_bub() ) ) <= max_dist &&
+                 rl_dist( app1.pos_abs(), app2.pos_abs() ) <= max_dist &&
                  i < max_displacement; i++ ) {
                 CHECK( app1.part_count() == 2 );
                 CHECK( app2.part_count() == 2 );
@@ -501,8 +501,8 @@ TEST_CASE( "power_cable_stretch_disconnect" )
                 app1.part_removal_cleanup();
                 app2.part_removal_cleanup();
             }
-            CAPTURE( m.get_abs( app1.pos_bub() ) );
-            CAPTURE( m.get_abs( app2.pos_bub() ) );
+            CAPTURE( app1.pos_abs() );
+            CAPTURE( app2.pos_abs() );
             CHECK( app1.part_count() == 1 );
             CHECK( app2.part_count() == 1 );
         }
@@ -520,7 +520,7 @@ TEST_CASE( "power_cable_stretch_disconnect" )
 
         WHEN( "displacing first appliance to the left" ) {
             for( int i = 0;
-                 rl_dist( m.get_abs( app1.pos_bub() ), m.get_abs( app2.pos_bub() ) ) <= max_dist &&
+                 rl_dist( app1.pos_abs(), app2.pos_abs() ) <= max_dist &&
                  i < max_displacement; i++ ) {
                 CHECK( app1.part_count() == 2 );
                 CHECK( app2.part_count() == 2 );
@@ -528,15 +528,15 @@ TEST_CASE( "power_cable_stretch_disconnect" )
                 app1.part_removal_cleanup();
                 app2.part_removal_cleanup();
             }
-            CAPTURE( m.get_abs( app1.pos_bub() ) );
-            CAPTURE( m.get_abs( app2.pos_bub() ) );
+            CAPTURE( app1.pos_abs() );
+            CAPTURE( app2.pos_abs() );
             CHECK( app1.part_count() == 1 );
             CHECK( app2.part_count() == 1 );
         }
 
         WHEN( "displacing second appliance to the right" ) {
             for( int i = 0;
-                 rl_dist( m.get_abs( app1.pos_bub() ), m.get_abs( app2.pos_bub() ) ) <= max_dist &&
+                 rl_dist( app1.pos_abs(), app2.pos_abs() ) <= max_dist &&
                  i < max_displacement; i++ ) {
                 CHECK( app1.part_count() == 2 );
                 CHECK( app2.part_count() == 2 );
@@ -544,8 +544,8 @@ TEST_CASE( "power_cable_stretch_disconnect" )
                 app1.part_removal_cleanup();
                 app2.part_removal_cleanup();
             }
-            CAPTURE( m.get_abs( app1.pos_bub() ) );
-            CAPTURE( m.get_abs( app2.pos_bub() ) );
+            CAPTURE( app1.pos_abs() );
+            CAPTURE( app2.pos_abs() );
             CHECK( app1.part_count() == 1 );
             CHECK( app2.part_count() == 1 );
         }
@@ -591,7 +591,7 @@ static void rack_check( const rack_preset &preset )
         vehicle *veh_ptr = m.add_vehicle( preset.vehicles[i], preset.positions[i],
                                           preset.facings[i], 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        veh_ptr->refresh( &m );
+        veh_ptr->refresh( );
         vehs.push_back( veh_ptr );
         veh_names.push_back( veh_ptr->name );
     }
@@ -606,7 +606,7 @@ static void rack_check( const rack_preset &preset )
         vehicle &racking_veh = *vehs[rack_act.racking_vehicle_index];
         vehicle &racked_veh = *vehs[rack_act.racked_vehicle_index];
 
-        const std::vector<vehicle_part *> rack_parts = racking_veh.get_parts_at( rack_act.rack_pos,
+        const std::vector<vehicle_part *> rack_parts = racking_veh.get_parts_at( &m, rack_act.rack_pos,
                 "BIKE_RACK_VEH",
                 part_status_flag::available );
         REQUIRE( rack_parts.size() == 1 );
@@ -654,7 +654,7 @@ static void rack_check( const rack_preset &preset )
         const optional_vpart_position ovp_racked = m.veh_at( rack_act.rack_pos );
         REQUIRE( ovp_racked.has_value() );
 
-        const auto rack_parts = ovp_racked->vehicle().get_parts_at( rack_act.rack_pos,
+        const auto rack_parts = ovp_racked->vehicle().get_parts_at( &m, rack_act.rack_pos,
                                 "BIKE_RACK_VEH", part_status_flag::available );
         REQUIRE( rack_parts.size() == 1 );
         const int rack_idx = ovp_racked->vehicle().index_of_part( rack_parts[0] );
@@ -765,19 +765,19 @@ static int test_autopilot_moving( const vproto_id &veh_id, const vpart_id &extra
     veh.is_following = true;
     veh.is_patrolling = false;
     veh.engine_on = true;
-    veh.refresh( &here );
+    veh.refresh( );
 
     int turns_left = 10;
     int tiles_travelled = 0;
-    const tripoint_bub_ms starting_point = veh.pos_bub();
+    const tripoint_bub_ms starting_point = veh.pos_bub( &here );
     while( veh.engine_on && turns_left > 0 ) {
         turns_left--;
         here.vehmove();
         veh.idle( true );
         // How much it moved
-        tiles_travelled += square_dist( starting_point, veh.pos_bub() );
+        tiles_travelled += square_dist( starting_point, veh.pos_bub( &here ) );
         // Bring it back to starting point to prevent it from leaving the map
-        const tripoint_rel_ms displacement = starting_point - veh.pos_bub();
+        const tripoint_rel_ms displacement = starting_point - veh.pos_bub( &here );
         here.displace_vehicle( veh, displacement );
     }
     return tiles_travelled;

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -886,6 +886,8 @@ TEST_CASE( "vision_vehicle_camera", "[shadowcasting][vision][vehicle]" )
 
 TEST_CASE( "vision_vehicle_camera_skew", "[shadowcasting][vision][vehicle][vehicle_fake]" )
 {
+    map &here = get_map();
+
     clear_vehicles();
     bool const camera_on = GENERATE( true, false );
     int const fiddle = GENERATE( 0, 1, 2 );
@@ -920,8 +922,8 @@ TEST_CASE( "vision_vehicle_camera_skew", "[shadowcasting][vision][vehicle][vehic
         std::optional<units::angle> const dir = testcase_veh_dir( { 4, 0 }, t, tile );
         if( dir ) {
             units::angle const skew = *dir + 45_degrees;
-            v = get_map().add_vehicle( vehicle_prototype_vehicle_camera_test, tile.p, skew, 0,
-                                       0 );
+            v = here.add_vehicle( vehicle_prototype_vehicle_camera_test, tile.p, skew, 0,
+                                  0 );
             v->camera_on = camera_on;
         }
         return true;
@@ -929,16 +931,16 @@ TEST_CASE( "vision_vehicle_camera_skew", "[shadowcasting][vision][vehicle][vehic
 
     auto const fiddle_parts = [&]() {
         if( fiddle > 0 ) {
-            std::vector<vehicle_part *> const horns = v->get_parts_at( v->pos_bub(), "HORN", {} );
+            std::vector<vehicle_part *> const horns = v->get_parts_at( v->pos_abs(), "HORN", {} );
             v->remove_part( *horns.front() );
         }
         if( fiddle > 1 ) {
             REQUIRE( v->install_part( point_rel_ms::zero, vpart_inboard_mirror ) != -1 );
         }
         if( fiddle > 0 ) {
-            get_map().add_vehicle_to_cache( v );
-            get_map().invalidate_map_cache( get_avatar().posz() );
-            get_map().build_map_cache( get_avatar().posz() );
+            here.add_vehicle_to_cache( v );
+            here.invalidate_map_cache( get_avatar().posz() );
+            here.build_map_cache( get_avatar().posz() );
         }
     };
 
@@ -1041,6 +1043,8 @@ TEST_CASE( "vision_bright_source", "[vision]" )
 
 TEST_CASE( "vision_inside_meth_lab", "[shadowcasting][vision][moncam]" )
 {
+    map &here = get_map();
+
     clear_vehicles();
 
     bool door_open = GENERATE( false, true );
@@ -1118,7 +1122,7 @@ TEST_CASE( "vision_inside_meth_lab", "[shadowcasting][vision][moncam]" )
             return;
         }
         // open door at `door` location
-        for( const vehicle_part *vp : v->get_parts_at( *door, "OPENABLE", part_status_flag::any ) ) {
+        for( const vehicle_part *vp : v->get_parts_at( &here, *door, "OPENABLE", part_status_flag::any ) ) {
             v -> open( v->index_of_part( vp ) );
         }
     };
@@ -1141,7 +1145,7 @@ TEST_CASE( "vision_inside_meth_lab", "[shadowcasting][vision][moncam]" )
             dir = 0_degrees;
         }
         if( dir ) {
-            v = get_map().add_vehicle( vehicle_prototype_meth_lab, tile.p, *dir, 0, 0 );
+            v = here.add_vehicle( vehicle_prototype_meth_lab, tile.p, *dir, 0, 0 );
             for( const vpart_reference &vp : v->get_avail_parts( "OPENABLE" ) ) {
                 v -> close( vp.part_index() );
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Continue the process of making vehicle operations operate on the same map as their callers rather than assuming it's always the reality bubble.
Part of the process is to use absolute coordinates when available and suitable to avoid having to reference any specific map.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Migrate the users of vehicle bub operations without any map reference to map referencing ones and delete the orphaned operations.
- Convert some vehicle bub to map referencing ones and migrating their users.
- Introduce some absolute coordinate using operations that don't rely on any specific map where possible in a few cases.
- Change some usages of bub operations to corresponding abs ones where it makes sense: it doesn't matter if you fetch the abs or bub point when you then only keep the "z" coordinate, for instance, and you can just as well compare the absolute positions of a creature and a vehicle (part) for equality as you can with the corresponding bub coordinates, and using the abs ones is marginally faster as the info is stored as abs internally, and thus doesn't require any transformation.

This should not result in any functional changes for existing code, while hopefully making calls using maps other than the reality bubble one less incorrect (there's a lot to do to get rid of all buried reality bubble references in the call chains).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkey, smash into stationary vehicle. Nothing odd seen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
vpart_position::pos_bub() had some a comment claiming state updates to the reality bubble map was made when called, while no such code was found, so the comment was deleted when the operation was made to reference a map parameter (and an absolute alternative was introduced).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
