### PR TITLE
Fix clang-tidy plugin compilation on windows and document the process.

### DIFF
--- a/doc/c++/DEVELOPER_TOOLING.md
+++ b/doc/c++/DEVELOPER_TOOLING.md
@@ -170,6 +170,242 @@ lit -v build/tools/clang-tidy-plugin/test
 
 #### Windows
 
+If you just want to run the default clang-tidy checks, and skip the cata-specific ones, the easiest way is probably to install Clang Power Tools visual studio extension (in the `Extensions` > `Manage extensions..` menu).
+
+Otherwise it is probably faster and easier to install WSL and follow the steps described above in [Extreme tl;dr for Ubuntu Focal (including WSL)](<#extreme-tldr-for-ubuntu-focal-including-wsl>). However building on windows is still possible.
+
+You will need:
+- windows powershell console
+- Git
+- CMake
+- Python
+- A working C++ compiler that can be run from the windows console, such as MSBuild (aka "Visual Studio Build Tools"; it's part of Visual Studio, but can also be obtained without VS from [this link](https://visualstudio.microsoft.com/downloads/?q=build+tools) (scroll down)) or standalone clang or gcc
+  - notably, you *can't* use the one provided by msys2/mingw for this (or, well, you can, but you are on your own then)
+  - (optionall) specifically clang compiler. Can often be downloaded from llvm github https://github.com/llvm/llvm-project/releases . If you don't have one, you can build clang from source with the instructions below
+- Ninja build system
+- (for running tests) GNU core utilities or an msys2 install (specifically we just need the `diff` tool).
+- vcpkg
+
+There are compromises, and you can make do with a different set of tools, but these are what this doc will use.
+
+The rough outline of the process is:
+- Obtain a working set of LLVM libraries
+- Build clang-tidy with custom checks
+- (optional) Test that the checks work
+- Run the custom clang-tidy
+
+##### Build LLVM
+
+First of all you would need a working LLVM. You *might* be able to [download it](https://github.com/llvm/llvm-project/releases) from llvm-project github (look for file named something like `clang+llvm-19.1.5-x86_64-pc-windows-msvc.tar.xz`), and it *might* work, but there is no guarantee. I suggest you try it, and skip to the next section. If it works for you - great! You just saved yourself several hours of building it from source, if not - read on.
+
+Ideally you should try to match the llvm version you download with the one that we build the CI against, as different versions yield slightly different results. And also there is no stability promise so that the checks that compile against llvm-17 might stop doing so in llvm-20.
+At the time of writing we are building against llvm-17, if you are reading this in the future, check [the CI definition](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/.github/workflows/clang-tidy.yml) to know what's current.
+
+
+The instruction for building LLVM can be found at https://clang.llvm.org/get_started.html, but duplicating here with some emphasis.
+
+Clone the LLVM repo from https://github.com/llvm/llvm-project.git and checkout the appropriate branch.
+The LLVM repo is pretty big so it's recommended to fetch just the commit you want to build at:
+
+```ps1
+git clone --depth=1 --branch=release/17.x https://github.com/llvm/llvm-project.git
+```
+
+The first step to build the code is to run CMake to generate the makefile.
+On the root dir of LLVM, run the following script.
+Make sure CMake and python are on the path.
+
+```ps1
+# for visual studio
+mkdir -p build
+cd build
+cmake `
+    -G "Visual Studio 16 2019" `
+    -DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lld' `
+    -DLLVM_TARGETS_TO_BUILD='X86' `
+    ../llvm
+
+# for non-visual studio
+mkdir -p build
+cd build
+cmake `
+    -G "Ninja" `
+    -DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lld' `
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+    -DLLVM_TARGETS_TO_BUILD='X86' `
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
+    -DLLVM_HOST_TRIPLE=x86_64 `
+    ../llvm
+```
+
+If you're using a non-msvc compiler you either need its containing folder on your `PATH`, specify said containing folder in `-DCMAKE_PROGRAM_PATH=<your/path/here>` or specify the full path to the binary in `-DCMAKE_C_COMPILER` as the error message should suggest. Same goes for ninja and python.
+
+
+Now that we have the build files, we can actually build it by running:
+
+```ps1
+# for Visual Studio / MSBuild
+cmake --build . --target=clang-tidy --target=clangTidyMain --target=FileCheck   --config=RelWithDebInfo
+# for ninja
+cmake --build . --target=clang-tidy --target=clangTidyMain --target=FileCheck   --parallel 4
+```
+
+If you don't have clang already, add a `--target=clang --target=llvm-rc --target=lld --target=llvm-objdump` to the command line above.
+Remove `--target=FileCheck` if you don't intend to test custom checks.
+LLVM is a behemoth so it will take several hours to finish while using 100% of your CPU, even when building only just clang-tidy. Consider stepping out and doing something productive while it's running. (On my machine it took 2h30m to build clang-tidy itself, and 2h to build the other tools afterwards).
+
+Now, if you wanted to make things super smooth going forward, you could build all the targets (not just the select few) and then bundle the built llvm to some nice place via
+```ps1
+cmake --build . --config=RelWithDebInfo # no target specification
+cmake --install --prefix=<some-path-here> .
+```
+That *might* even only add an hour or so to the total time? Your call whether it's worth it.
+
+
+##### Build clang-tidy with custom checks
+
+After building clang-tidy as a library from the LLVM source, the next step is to
+build clang-tidy as an executable, with the custom checks from the CDDA source.
+
+We will need to run a cmake with lots of arguments, and it gets unwieldy on the command line. So create `CMakeUserPresets.json` file at the root of cataclysm project with the following contents, replacing the paths in `<>` as appropriate:
+
+```json
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "cata-clang-tidy",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}/",
+      "environment":{
+        "MY_LLVM_INSTALL_DIR": "<C:/path/to/installed-llvm>",
+        "VCPKG_ROOT": "<C:/path/to/your/vcpkg>"
+      },
+      "cacheVariables": {
+        "CATA_CLANG_TIDY_INCLUDE_DIR": "<C:/path/to/llvm-source>/clang-tools-extra/",
+        "CMAKE_PROGRAM_PATH": "<see-below>",
+
+
+        "LLVM_DIR": "$env{MY_LLVM_INSTALL_DIR}/lib/cmake/llvm",
+        "Clang_DIR": "$env{MY_LLVM_INSTALL_DIR}/lib/cmake/clang",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CATA_CHECK_CLANG_TIDY": "python ${sourceDir}/tools/clang-tidy-plugin/test/check_clang_tidy.py -clang-tidy-binary=${sourceDir}/out/build/${presetName}/tools/clang-tidy-plugin/CataAnalyzer.exe",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+        "CATA_CLANG_TIDY_EXECUTABLE": true,
+
+        "VCPKG_MANIFEST_DIR": "${sourceDir}/msvc-full-features",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "TILES": true, "SOUND": true, "BACKTRACE": true,
+        "LOCALIZE": true,
+        "GETTEXT_MSGFMT_BINARY": "cat"
+      }
+    }
+  ]
+}
+```
+
+If you downloaded the packaged llvm archive, or `install`ed it yourself, then `<C:/path/to/installed-llvm>` would point to that. Otherwise it would be `<C:/path/to/llvm-source>/build`.
+If you have a packaged version, you can omit `"Clang_DIR"` and  `"CATA_CLANG_TIDY_INCLUDE_DIR"`
+If you don't intend to run tests in the next step - skip `"CATA_CHECK_CLANG_TIDY"`.
+Adjust `"TILES"`, `"SOUND"`, `"BACKTRACE"` and `"LOCALIZE"` as you would for building the game normally, although it is strongly suggested to keep `"LOCALIZE": true` to avoid excessive translation-related false-positives.
+`CMAKE_PROGRAM_PATH` should contain the list of directories that hold compiler binaries that are not already in your PATH env variable. I.e. if you have a packaged llvm, set `CMAKE_PROGRAM_PATH` to `<C:/path/to/installed-llvm>/bin/`; otherwise set it to `<C:/path/to/llvm-source>/build/RelWithDebInfo/bin/`. You can add Ninja and python to this list (semicolon-separated).
+
+
+Run cmake to generate build files under `.\out\build\cata-clang-tidy\`:
+```ps1
+cmake --preset=cata-clang-tidy
+```
+(If you adjust the configuration, and then rerun the command but the changes don't seem to be picked up, add a `--fresh` argument)
+
+And then build it
+```ps1
+cmake --build  .\out\build\cata-clang-tidy\ --target=CataAnalyzer
+```
+
+Finally, confirm that you do, in fact, have the cata-specific checks:
+```ps1
+> .\out\build\cata-clang-tidy\tools\clang-tidy-plugin\CataAnalyzer.exe '--checks=-*,cata-*' --list-checks
+Enabled checks:
+    cata-almost-never-auto
+    cata-assert
+    cata-avoid-alternative-tokens
+    cata-combine-locals-into-point
+    cata-determinism
+    cata-header-guard
+    cata-json-translation-input
+    cata-large-inline-function
+    cata-large-stack-object
+    cata-no-long
+    cata-no-static-translation
+    cata-ot-match
+    cata-point-initialization
+    cata-redundant-parentheses
+    cata-serialize
+    cata-simplify-point-constructors
+    cata-static-declarations
+    cata-static-initialization-order
+    cata-static-int_id-constants
+    cata-static-string_id-constants
+    cata-test-filename
+    cata-tests-must-restore-global-state
+    cata-text-style
+    cata-translate-string-literal
+    cata-translations-in-debug-messages
+    cata-u8-path
+    cata-unit-overflow
+    cata-unsequenced-calls
+    cata-unused-statics
+    cata-use-localized-sorting
+    cata-use-mdarray
+    cata-use-named-point-constants
+    cata-use-point-apis
+    cata-use-point-arithmetic
+    cata-use-string_view
+    cata-utf8-no-to-lower-to-upper
+    cata-xy
+```
+
+##### (Optional) Test custom checks work
+
+LLVM folks seem to never excercise their test driver in windows console, so it has been broken since 2022 and needs a small patch to work.
+
+```ps1
+cd <path-to-llvm-source>
+git apply -v --ignore-whitespace <path-to-cata-source>\tools\clang-tidy-plugin\lit-win-console-llvm-17.patch
+```
+
+You will need to have `FileCheck` (distributed with LLVM or self-built in the above step) and `diff` (either downloaded as part of [GnuWin32 tools](https://getgnuwin32.sourceforge.net/), or if you have msys2 installed then you can find it in `<path-to-msys2>\usr\bin\`) in your PATH:
+```ps1
+$env:PATH += ';<C:\path\to\installed-llvm>\bin\;<C:\msys2>\usr\bin'
+```
+Note the leading `;`
+
+Once you have that, run the test suite
+```ps1
+cd <path-to-cata-source>
+python <path-to-llvm-source>\llvm\utils\lit\lit.py -v .\out\build\cata-clang-tidy\tools\clang-tidy-plugin\test
+```
+
+#### Run custom-built clang-tidy on your code
+
+Now you should have a clang-tidy binary at  `.\out\build\cata-clang-tidy\tools\clang-tidy-plugin\CataAnalyzer.exe` (which you can move to a more convenient place)
+and (as long as you passed `CMAKE_EXPORT_COMPILE_COMMANDS`) a compilation database at `.\out\build\cata-clang-tidy\compile_commands.json`
+
+You can now run clang-tidy on a file of your choosing as
+```ps1
+CataAnalyzer.exe -p .\out\build\cata-clang-tidy\ --header-filter='nothing'  src\ascii_art.cpp
+```
+
+
+#### Windows MinGW-w64
+
+(This section appears to be out of date, but is preserved for historical reasons, in case someone wishes to revive it)
+
 ##### Build LLVM
 
 It is probably faster and easier to install WSL and follow the steps described above in [Extreme tl;dr for Ubuntu Focal (including WSL)](<#extreme-tldr-for-ubuntu-focal-including-wsl>).

--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -4,6 +4,8 @@ include(ExternalProject)
 find_package(LLVM REQUIRED CONFIG)
 find_package(Clang REQUIRED CONFIG)
 
+set(CMAKE_CXX_STANDARD 17)
+
 set(CataAnalyzerSrc
         AlmostNeverAutoCheck.cpp
         AssertCheck.cpp
@@ -45,7 +47,8 @@ set(CataAnalyzerSrc
         UseStringViewCheck.cpp
         UTF8ToLowerUpperCheck.cpp
         Utils.cpp
-        XYCheck.cpp)
+        XYCheck.cpp
+)
 
 if (CATA_CLANG_TIDY_EXECUTABLE)
     set(CataAnalyzerName CataAnalyzer)
@@ -55,6 +58,7 @@ if (CATA_CLANG_TIDY_EXECUTABLE)
 else ()
     set(CataAnalyzerName CataAnalyzerPlugin)
     add_library(${CataAnalyzerName} MODULE ${CataAnalyzerSrc})
+    target_link_libraries(${CataAnalyzerName} PRIVATE clangTidyPlugin)
     if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
         target_link_options(${CataAnalyzerName} PRIVATE -undefined dynamic_lookup)
     endif ()

--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
+++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
@@ -59,10 +59,10 @@ class CataModule : public ClangTidyModule
             // the same version we linked against
 
             std::string RuntimeVersion = getClangFullVersion();
-            if( !StringRef( RuntimeVersion ).contains( "clang version " CLANG_VERSION_STRING ) ) {
+            if( !llvm::StringRef( RuntimeVersion ).contains( "clang version " CLANG_VERSION_STRING ) ) {
                 llvm::report_fatal_error(
-                    Twine( "clang version mismatch in CataTidyModule.  Compiled against "
-                           CLANG_VERSION_STRING " but loaded by ", RuntimeVersion ) );
+                    llvm::Twine( "clang version mismatch in CataTidyModule.  Compiled against "
+                                 CLANG_VERSION_STRING " but loaded by ", RuntimeVersion ) );
                 abort(); // NOLINT(cata-assert)
             }
             CheckFactories.registerCheck<AlmostNeverAutoCheck>( "cata-almost-never-auto" );

--- a/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp
+++ b/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp
@@ -35,8 +35,6 @@ namespace clang
 {
 namespace ast_matchers
 {
-namespace
-{
 AST_POLYMORPHIC_MATCHER_P2( hasImmediateArgument,
                             AST_POLYMORPHIC_SUPPORTED_TYPES( CallExpr, CXXConstructExpr ),
                             unsigned int, N, ast_matchers::internal::Matcher<Expr>, InnerMatcher )
@@ -53,7 +51,6 @@ AST_MATCHER_P( StringLiteral, isMarkedString, tidy::cata::TranslatorCommentsChec
     return Check->MarkedStrings.find( Loc ) != Check->MarkedStrings.end();
     static_cast<void>( Builder );
 }
-} // namespace
 } // namespace ast_matchers
 namespace tidy::cata
 {

--- a/tools/clang-tidy-plugin/lit-win-console-llvm-17.patch
+++ b/tools/clang-tidy-plugin/lit-win-console-llvm-17.patch
@@ -1,0 +1,24 @@
+index cd803f859..638313405 100644
+--- a/llvm/utils/lit/lit/TestRunner.py
++++ b/llvm/utils/lit/lit/TestRunner.py
+@@ -1085,7 +1085,7 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
+             if match:
+                 command = match.group(2)
+                 commands[i] = match.expand(
+-                    "echo '\\1' > nul && " if command else "echo '\\1' > nul"
++                    "echo '\\1' > nul && \\2" if command else "echo '\\1' > nul"
+                 )
+         if litConfig.echo_all_commands:
+             f.write("@echo on\n")
+diff --git a/llvm/utils/lit/lit/TestingConfig.py b/llvm/utils/lit/lit/TestingConfig.py
+index 76fd66502..129a5df28 100644
+--- a/llvm/utils/lit/lit/TestingConfig.py
++++ b/llvm/utils/lit/lit/TestingConfig.py
+@@ -71,6 +71,7 @@ class TestingConfig(object):
+                 "INCLUDE",
+                 "LIB",
+                 "PATHEXT",
++                "SystemDrive",
+                 "USERPROFILE",
+             ]
+             environment["PYTHONBUFFERED"] = "1"

--- a/tools/clang-tidy-plugin/test/almost-never-auto.cpp
+++ b/tools/clang-tidy-plugin/test/almost-never-auto.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-almost-never-auto %t -- --load=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-almost-never-auto %t -- --load=%cata_plugin -- -fno-delayed-template-parsing
 
 using int_alias = int;
 int_alias return_int_alias();

--- a/tools/clang-tidy-plugin/test/lit.cfg
+++ b/tools/clang-tidy-plugin/test/lit.cfg
@@ -25,7 +25,7 @@ cata_include = os.path.join( config.cata_source_dir, "./src" )
 cata_third_party_include = os.path.join( config.cata_source_dir, "./src/third-party" )
 test_include = os.path.join( config.cata_source_dir, "./tools/clang-tidy-plugin/test-include" )
 
-if config.cata_clang_tidy_executable == "ON":
+if config.cata_clang_tidy_executable in ["TRUE", "ON"]:
     cata_plugin = ''
 else:
     cata_plugin = os.path.join(

--- a/tools/clang-tidy-plugin/test/use-localized-sorting.cpp
+++ b/tools/clang-tidy-plugin/test/use-localized-sorting.cpp
@@ -14,7 +14,7 @@ bool operator<( const NonString &, const NonString &rhs ) noexcept;
 bool f0( const std::string &l, const std::string &r )
 {
     return l < r;
-    // CHECK-MESSAGES: warning: Raw comparison of 'const std::string' (aka 'const basic_string<char>').  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
+    // CHECK-MESSAGES: warning: Raw comparison of 'const std::string' (aka '{{.*basic_string.*}}').  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
 }
 
 bool f1( const NonString &l, const NonString &r )
@@ -25,7 +25,7 @@ bool f1( const NonString &l, const NonString &r )
 bool f2( const std::pair<int, std::string> &l, const std::pair<int, std::string> &r )
 {
     return l < r;
-    // CHECK-MESSAGES: warning: Raw comparison of 'const std::pair<int, std::string>' (aka 'const pair<int, basic_string<char>>'). For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
+    // CHECK-MESSAGES: warning: Raw comparison of 'const std::pair<int, std::string>' (aka '{{.*basic_string.*}}'). For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
 }
 
 bool f3( const std::pair<int, NonString> &l, const std::pair<int, NonString> &r )
@@ -36,7 +36,7 @@ bool f3( const std::pair<int, NonString> &l, const std::pair<int, NonString> &r 
 bool f4( const std::tuple<int, std::string> &l, const std::tuple<int, std::string> &r )
 {
     return l < r;
-    // CHECK-MESSAGES: warning: Raw comparison of 'const std::tuple<int, std::string>' (aka 'const tuple<int, basic_string<char>>').  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
+    // CHECK-MESSAGES: warning: Raw comparison of 'const std::tuple<int, std::string>' (aka '{{.*basic_string.*}}').  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
 }
 
 bool f5( const std::tuple<int, NonString> &l, const std::tuple<int, NonString> &r )
@@ -48,13 +48,13 @@ bool f4( const std::tuple<std::tuple<std::string>> &l,
          const std::tuple<std::tuple<std::string>> &r )
 {
     return l < r;
-    // CHECK-MESSAGES: warning: Raw comparison of 'const std::tuple<std::tuple<std::string>>' (aka 'const tuple<tuple<basic_string<char>>>'). For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
+    // CHECK-MESSAGES: warning: Raw comparison of 'const std::tuple<std::tuple<std::string>>' (aka '{{.*basic_string.*}}'). For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
 }
 
 void sort0( std::string *start, std::string *end )
 {
     std::sort( start, end );
-    // CHECK-MESSAGES: warning: Raw sort of 'std::string' (aka 'basic_string<char>').  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
+    // CHECK-MESSAGES: warning: Raw sort of 'std::string' (aka '{{.*basic_string.*}}').  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
 }
 
 void sort1( NonString *start, NonString *end )

--- a/tools/clang-tidy-plugin/test/use-string_view.cpp
+++ b/tools/clang-tidy-plugin/test/use-string_view.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -allow-stdinc %s cata-use-string_view %t -- -load=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy -allow-stdinc %s cata-use-string_view %t -- -load=%cata_plugin -- -isystem %cata_include -fno-delayed-template-parsing
 
 #include <string>
 #include <string_view>


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The knowledge on how to build clang-tidy on windows seems to have been lost to time and bitrot. Rediscover it.
Fix the build, document the findings.

#### Describe the solution

Several issues have been addressed:

1\) FOR SOME REASON which I still don't understand the AST matchers macros stop working *on windows* when shoved into an extra anonymous namespace. I.e. this
```cpp
namespace clang
{
namespace ast_matchers
{
namespace {
AST_MATCHER_P( StringLiteral, isMarkedString, tidy::cata::TranslatorCommentsCheck *, Check )
{
   // ...
}
} // anonymous namespace
} // namespace ast_matchers
```
fails because it gets confused by having both `clang::ast_matchers::internal` namespace (defined in some `ASTMatchers.h` in LLVM) and `clang::ast_matchers::(anonymous namespace)::internal` (defined by the expansion of AST_MATCHER_P macro). I have no clue why would that be a problem, because the code in `ASTMatchers.h` that tries to use `internal::PolymorphicMatcher` and stumbles on this error has no way to access the `(anonymous namespace)` anyway! Why is this even a consideration?
My best guess is some MSVC compatibility shenanigans (present in msvc for legacy reasons and enabled by default in clang for, well, compatibility).

So I just removed the extra anonymous namespace (and yes, that did make me sad).

<details>
<summary>Full error in case you're curious</summary>

```
FAILED: tools/clang-tidy-plugin/CMakeFiles/CataAnalyzer.dir/TranslatorCommentsCheck.cpp.obj
H:\work\github\llvm\build-17-msvc-repro\RelWithDebInfo\bin\clang++.exe -DBACKTRACE -DCATA_CLANG_TIDY_EXECUTABLE -DCMAKE -DGIT_VERSION -DLOCALIZE -DRELEASE -DTILES -DUNICODE -DUSE_HOME_DIR -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -isystem H:/work/github/llvm/llvm-17/llvm/include -isystem H:/work/github/llvm/build-17-msvc-repro/include -isystem H:/work/github/llvm/llvm-17/clang/include -isystem H:/work/github/llvm/build-17-msvc-repro/tools/clang/include -isystem H:/work/github/llvm/llvm-17/clang-tools-extra -Werror -Wall -Wextra -Wformat-signedness -Wlogical-op -Wmissing-declarations -Wmissing-noreturn -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wpedantic -Wsuggest-override -Wunused-macros -Wzero-as-null-pointer-constant -Wno-unknown-warning-option -Wno-dangling-reference -Wno-c++20-compat -Wno-unknown-warning-option  -fsigned-char -g1 -O2 -DNDEBUG -g -Xclang -gcodeview -std=c++17 -D_DLL -D_MT -Xclang --dependent-lib=msvcrt -fno-exceptions -fno-rtti -MD -MT tools/clang-tidy-plugin/CMakeFiles/CataAnalyzer.dir/TranslatorCommentsCheck.cpp.obj -MF tools\clang-tidy-plugin\CMakeFiles\CataAnalyzer.dir\TranslatorCommentsCheck.cpp.obj.d -o tools/clang-tidy-plugin/CMakeFiles/CataAnalyzer.dir/TranslatorCommentsCheck.cpp.obj -c H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp
In file included from H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp:1:
In file included from H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.h:5:
In file included from H:/work/github/llvm/llvm-17/clang-tools-extra\clang-tidy/ClangTidyCheck.h:14:
In file included from H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchFinder.h:43:
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchers.h:3961:17: error: reference to 'internal' is ambiguous
 3961 |   QualType QT = internal::getUnderlyingType(Node);
      |                 ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersInternal.h:1198:14: note: in instantiation of member function 'clang::ast_matchers::internal::matcher_hasType0Matcher<clang::Expr, clang::ast_matchers::internal::Matcher<clang::QualType>>::matcher_hasType0Matcher' requested here
 1198 |   return new T(std::get<I>(std::forward<Tuple>(t))...);
      |              ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersInternal.h:1372:24: note: in instantiation of function template specialization 'clang::ast_matchers::internal::PolymorphicMatcher<clang::ast_matchers::internal::matcher_hasType0Matcher, void (clang::ast_matchers::internal::TypeList<clang::Expr, clang::FriendDecl, clang::TypedefNameDecl, clang::ValueDecl, clang::CXXBaseSpecifier>), clang::ast_matchers::internal::Matcher<clang::QualType>>::operator Matcher<clang::Expr>' requested here
 1372 |     return {Matcher<T>(std::get<Is>(Params))...};
      |                        ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersInternal.h:1364:16: note: in instantiation of function template specialization 'clang::ast_matchers::internal::VariadicOperatorMatcher<clang::ast_matchers::internal::PolymorphicMatcher<clang::ast_matchers::internal::matcher_hasType0Matcher, void (clang::ast_matchers::internal::TypeList<clang::Expr, clang::FriendDecl, clang::TypedefNameDecl, clang::ValueDecl, clang::CXXBaseSpecifier>), clang::ast_matchers::internal::Matcher<clang::QualType>>, clang::ast_matchers::internal::PolymorphicMatcher<clang::ast_matchers::internal::matcher_hasType0Matcher, void (clang::ast_matchers::internal::TypeList<clang::Expr, clang::FriendDecl, clang::TypedefNameDecl, clang::ValueDecl, clang::CXXBaseSpecifier>), clang::ast_matchers::internal::Matcher<clang::QualType>>>::getMatchers<clang::Expr, 0ULL, 1ULL>' requested here
 1364 |                getMatchers<T>(std::index_sequence_for<Ps...>()))
      |                ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchers.h:4196:7: note: in instantiation of function template specialization 'clang::ast_matchers::internal::VariadicOperatorMatcher<clang::ast_matchers::internal::PolymorphicMatcher<clang::ast_matchers::internal::matcher_hasType0Matcher, void (clang::ast_matchers::internal::TypeList<clang::Expr, clang::FriendDecl, clang::TypedefNameDecl, clang::ValueDecl, clang::CXXBaseSpecifier>), clang::ast_matchers::internal::Matcher<clang::QualType>>, clang::ast_matchers::internal::PolymorphicMatcher<clang::ast_matchers::internal::matcher_hasType0Matcher, void (clang::ast_matchers::internal::TypeList<clang::Expr, clang::FriendDecl, clang::TypedefNameDecl, clang::ValueDecl, clang::CXXBaseSpecifier>), clang::ast_matchers::internal::Matcher<clang::QualType>>>::operator Matcher<clang::Expr>' requested here
 4196 |       anyOf(hasType(InnerMatcher), hasType(pointsTo(InnerMatcher))))
      |       ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchFinder.h:286:11: note: candidate found by name lookup is 'clang::ast_matchers::internal'
  286 | namespace internal {
      |           ^
H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp:48:1: note: candidate found by name lookup is 'clang::ast_matchers::(anonymous namespace)::internal'
   48 | AST_MATCHER_P( StringLiteral, isMarkedString, tidy::cata::TranslatorCommentsCheck *, Check )
      | ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersMacros.h:129:3: note: expanded from macro 'AST_MATCHER_P'
  129 |   AST_MATCHER_P_OVERLOAD(Type, DefineMatcher, ParamType, Param, 0)
      |   ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersMacros.h:133:13: note: expanded from macro 'AST_MATCHER_P_OVERLOAD'
  133 |   namespace internal {                                                         \
      |             ^
In file included from H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp:1:
In file included from H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.h:5:
In file included from H:/work/github/llvm/llvm-17/clang-tools-extra\clang-tidy/ClangTidyCheck.h:14:
In file included from H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchFinder.h:43:
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchers.h:4002:17: error: reference to 'internal' is ambiguous
 4002 |   QualType QT = internal::getUnderlyingType(Node);
      |                 ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersInternal.h:1198:14: note: in instantiation of member function 'clang::ast_matchers::internal::matcher_hasType1Matcher<clang::Expr, clang::ast_matchers::internal::Matcher<clang::Decl>>::matcher_hasType1Matcher' requested here
 1198 |   return new T(std::get<I>(std::forward<Tuple>(t))...);
      |              ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersInternal.h:1372:24: note: in instantiation of function template specialization 'clang::ast_matchers::internal::PolymorphicMatcher<clang::ast_matchers::internal::matcher_hasType1Matcher, void (clang::ast_matchers::internal::TypeList<clang::Expr, clang::FriendDecl, clang::ValueDecl, clang::CXXBaseSpecifier>), clang::ast_matchers::internal::Matcher<clang::Decl>>::operator Matcher<clang::Expr>' requested here
 1372 |     return {Matcher<T>(std::get<Is>(Params))...};
      |                        ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersInternal.h:1364:16: note: in instantiation of function template specialization 'clang::ast_matchers::internal::VariadicOperatorMatcher<clang::ast_matchers::internal::PolymorphicMatcher<clang::ast_matchers::internal::matcher_hasType1Matcher, void (clang::ast_matchers::internal::TypeList<clang::Expr, clang::FriendDecl, clang::ValueDecl, clang::CXXBaseSpecifier>), clang::ast_matchers::internal::Matcher<clang::Decl>>, clang::ast_matchers::internal::PolymorphicMatcher<clang::ast_matchers::internal::matcher_hasType0Matcher, void (clang::ast_matchers::internal::TypeList<clang::Expr, clang::FriendDecl, clang::TypedefNameDecl, clang::ValueDecl, clang::CXXBaseSpecifier>), clang::ast_matchers::internal::Matcher<clang::QualType>>>::getMatchers<clang::Expr, 0ULL, 1ULL>' requested here
 1364 |                getMatchers<T>(std::index_sequence_for<Ps...>()))
      |                ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchers.h:4204:7: note: in instantiation of function template specialization 'clang::ast_matchers::internal::VariadicOperatorMatcher<clang::ast_matchers::internal::PolymorphicMatcher<clang::ast_matchers::internal::matcher_hasType1Matcher, void (clang::ast_matchers::internal::TypeList<clang::Expr, clang::FriendDecl, clang::ValueDecl, clang::CXXBaseSpecifier>), clang::ast_matchers::internal::Matcher<clang::Decl>>, clang::ast_matchers::internal::PolymorphicMatcher<clang::ast_matchers::internal::matcher_hasType0Matcher, void (clang::ast_matchers::internal::TypeList<clang::Expr, clang::FriendDecl, clang::TypedefNameDecl, clang::ValueDecl, clang::CXXBaseSpecifier>), clang::ast_matchers::internal::Matcher<clang::QualType>>>::operator Matcher<clang::Expr>' requested here
 4204 |       anyOf(hasType(InnerMatcher), hasType(pointsTo(InnerMatcher))))
      |       ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchFinder.h:286:11: note: candidate found by name lookup is 'clang::ast_matchers::internal'
  286 | namespace internal {
      |           ^
H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp:48:1: note: candidate found by name lookup is 'clang::ast_matchers::(anonymous namespace)::internal'
   48 | AST_MATCHER_P( StringLiteral, isMarkedString, tidy::cata::TranslatorCommentsCheck *, Check )
      | ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersMacros.h:129:3: note: expanded from macro 'AST_MATCHER_P'
  129 |   AST_MATCHER_P_OVERLOAD(Type, DefineMatcher, ParamType, Param, 0)
      |   ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersMacros.h:133:13: note: expanded from macro 'AST_MATCHER_P_OVERLOAD'
  133 |   namespace internal {                                                         \
      |             ^
In file included from H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp:1:
In file included from H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.h:5:
In file included from H:/work/github/llvm/llvm-17/clang-tools-extra\clang-tidy/ClangTidyCheck.h:14:
In file included from H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchFinder.h:43:
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchers.h:5675:10: error: reference to 'internal' is ambiguous
 5675 |   return internal::PolymorphicMatcher<internal::ValueEqualsMatcher,
      |          ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchFinder.h:286:11: note: candidate found by name lookup is 'clang::ast_matchers::internal'
  286 | namespace internal {
      |           ^
H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp:48:1: note: candidate found by name lookup is 'clang::ast_matchers::(anonymous namespace)::internal'
   48 | AST_MATCHER_P( StringLiteral, isMarkedString, tidy::cata::TranslatorCommentsCheck *, Check )
      | ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersMacros.h:129:3: note: expanded from macro 'AST_MATCHER_P'
  129 |   AST_MATCHER_P_OVERLOAD(Type, DefineMatcher, ParamType, Param, 0)
      |   ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersMacros.h:133:13: note: expanded from macro 'AST_MATCHER_P_OVERLOAD'
  133 |   namespace internal {                                                         \
      |             ^
In file included from H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp:1:
In file included from H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.h:5:
In file included from H:/work/github/llvm/llvm-17/clang-tools-extra\clang-tidy/ClangTidyCheck.h:14:
In file included from H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchFinder.h:43:
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchers.h:5675:39: error: reference to 'internal' is ambiguous
 5675 |   return internal::PolymorphicMatcher<internal::ValueEqualsMatcher,
      |                                       ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchFinder.h:286:11: note: candidate found by name lookup is 'clang::ast_matchers::internal'
  286 | namespace internal {
      |           ^
H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp:48:1: note: candidate found by name lookup is 'clang::ast_matchers::(anonymous namespace)::internal'
   48 | AST_MATCHER_P( StringLiteral, isMarkedString, tidy::cata::TranslatorCommentsCheck *, Check )
      | ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersMacros.h:129:3: note: expanded from macro 'AST_MATCHER_P'
  129 |   AST_MATCHER_P_OVERLOAD(Type, DefineMatcher, ParamType, Param, 0)
      |   ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersMacros.h:133:13: note: expanded from macro 'AST_MATCHER_P_OVERLOAD'
  133 |   namespace internal {                                                         \
      |             ^
In file included from H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp:1:
In file included from H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.h:5:
In file included from H:/work/github/llvm/llvm-17/clang-tools-extra\clang-tidy/ClangTidyCheck.h:14:
In file included from H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchFinder.h:43:
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchers.h:5676:44: error: reference to 'internal' is ambiguous
 5676 |                                       void(internal::AllNodeBaseTypes), ValueT>(
      |                                            ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchFinder.h:286:11: note: candidate found by name lookup is 'clang::ast_matchers::internal'
  286 | namespace internal {
      |           ^
H:/work/github/cdda/cata-26/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp:48:1: note: candidate found by name lookup is 'clang::ast_matchers::(anonymous namespace)::internal'
   48 | AST_MATCHER_P( StringLiteral, isMarkedString, tidy::cata::TranslatorCommentsCheck *, Check )
      | ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersMacros.h:129:3: note: expanded from macro 'AST_MATCHER_P'
  129 |   AST_MATCHER_P_OVERLOAD(Type, DefineMatcher, ParamType, Param, 0)
      |   ^
H:/work/github/llvm/llvm-17/clang/include\clang/ASTMatchers/ASTMatchersMacros.h:133:13: note: expanded from macro 'AST_MATCHER_P_OVERLOAD'
  133 |   namespace internal {                                                         \
      |             ^
5 errors generated.
```

</details>

2\) tests refused to run because LLVM broke their test runner *on windows console* [back in 2022](https://github.com/llvm/llvm-project/commit/1041a9642ba035fd2685f925911d705e8edf5bb0#diff-aae22ea9c34398ab7155fa83f99f3f1303f8fd4b064f931398eda6e7b6f43904L990-R1002), and nobody was bothered by it ever since. My two options was to either abandon my beloved powershell and go to git bash/msys/mingw (which, granted, work, but they are sometimes jank, especially when it comes to building things against other things. Or, in other words, i don't understand them as well, and don't like them as such), OR to fix the test runner. So I went with the second approach. I might upstream the fix when i have the energy, but today is not that day.

3\) some of the tests failed due to actual windows comaptibility shenanigans. See, if we have the following code
```cpp
template<typename T>
void my_func(){
    int x = 12;
    other_func();
}
```
and try to examine its AST with clang, we get this nice and pretty output on linux:
```cpp
$ clang-check --ast-dump --ast-dump-filter=my_func thing.c
pp --
/mnt/h/[redacted]/thing.cpp:4:5: error: use of undeclared identifier 'other_func'
    4 |     other_func();
      |     ^
Dumping my_func:
FunctionTemplateDecl 0x564d98694b90 </mnt/h/[redacted]/thing.cpp:1:1, line:5:1> line:2:6 my_func
|-TemplateTypeParmDecl 0x564d986949e0 <line:1:10, col:19> col:19 typename depth 0 index 0 T
`-FunctionDecl 0x564d98694ae8 <line:2:1, line:5:1> line:2:6 my_func 'void ()'
  `-CompoundStmt 0x564d98694e10 <col:15, line:5:1>
    |-DeclStmt 0x564d98694d48 <line:3:5, col:15>
    | `-VarDecl 0x564d98694cc0 <col:5, col:13> col:9 x 'int' cinit
    |   `-IntegerLiteral 0x564d98694d28 <col:13> 'int' 12
    `-RecoveryExpr 0x564d98694de8 <line:4:5, col:16> '<dependent type>' contains-errors lvalue
      `-UnresolvedLookupExpr 0x564d98694d60 <col:5> '<overloaded function type>' lvalue (ADL) = 'other_func' empty

1 error generated.
Error while processing /mnt/h/[redacted]/thing.cpp.
```
and an even nicer and prettier one on windows!
```cpp
> clang-check.exe --ast-dump --ast-dump-filter=my_func thing.cpp --
Dumping my_func:
FunctionTemplateDecl 0x18b68e08be0 <H:\[redacted]\thing.cpp:1:1, line:2:14> col:6 my_func
|-TemplateTypeParmDecl 0x18b68e08a30 <line:1:10, col:19> col:19 typename depth 0 index 0 T
`-FunctionDecl 0x18b68e08b38 <line:2:1, col:14> col:6 my_func 'void ()'
  `-<<<NULL>>>
```
How come!? Well, turns out, clang completely skip templated functions and does not look inside of those until they are first instantiated. But only on windows. This behavior is reportedly there in an effort to "[accept enough invalid C++ to be able to parse most Microsoft headers](https://clang.llvm.org/docs/UsersManual.html#microsoft-extensions)". So.. I disable this compatibility layer for the tests [of the checks] that rely on this. Naturally this would lead to some false-positives in our actual code, but I'm not sure what's the proper way of handling things here. Perhaps we can try setting only just `-fno-delayed-template-parsing` for the live build of the game, and see if that works? It just might! But that would be a separate PR.

4\) Document the process of building the thing.
This was the hardest part tbh. Turns out writing tech docs is hard. You want to be accomodating and cover all the different use cases and systems, but doing so means typing more words or getting so generic you become incomprehensible.
And then you change someting to streamline the process (like switch from building CataAnalyzer with msvc but then making a compiler database with clang+ninja, to making both in one step with clang+ninja), but that turns out to build some paths you mentioned elsewhere.
But this current version tested and works. On my machine.

#### Describe alternatives you've considered

N/A

#### Testing

Yes.
Built the thing from scratch using my own instructions, and it did, in fact, work (on the third try). But there's still possibility that those are not entirely portable.

#### Additional context

cc @Brambor @Qrox since you folks have worked on windows clang-tidy before (and apologies for the ping, if this is not something you want to hear about any more)
(this is less of a "can you folks please review this PR?" and more of a "hey, I did the thing, thought you might want to know!")