### PR TITLE
Dont show liquids from held or worn container in AIM [I]nventory-panel

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -914,11 +914,14 @@ bool advanced_inventory::fill_lists_with_pane_items( Character &player_character
             continue;
         }
         for( const item_location &it : listit.items ) {
+
+            // do not move liquids or gases
+            if( ( it->made_of_from_type( phase_id::LIQUID ) && !it->is_frozen_liquid() ) ||
+                it->made_of_from_type( phase_id::GAS ) ) {
+                continue;
+            }
             if( dpane.get_area() == AIM_INVENTORY ) {
-                if( ( it->made_of_from_type( phase_id::LIQUID ) && !it->is_frozen_liquid() ) ||
-                    it->made_of_from_type( phase_id::GAS ) ) {
-                    continue;
-                }
+
                 if( !player_character.can_stash_partial( *it ) ) {
                     continue;
                 }

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -135,6 +135,13 @@ std::vector<advanced_inv_listitem> outfit::get_AIM_inventory( size_t &item_index
         for( const std::vector<item_location> &it_stack : item_list_to_stack(
                  item_location( you, &worn_item ),
                  worn_item.all_items_top( pocket_type::CONTAINER ) ) ) {
+
+            // dont show if the content are liquids
+            if( !it_stack.empty() && it_stack.front()->made_of_from_type( phase_id::LIQUID ) &&
+                !it_stack.front()->is_frozen_liquid() ) {
+                continue;
+            }
+
             advanced_inv_listitem adv_it( it_stack, item_index++, square.id, false );
             if( !pane.is_filtered( *adv_it.items.front() ) ) {
                 square.volume += adv_it.volume;

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -158,6 +158,10 @@ std::vector<advanced_inv_listitem> avatar::get_AIM_inventory( const advanced_inv
     if( weapon && weapon->is_container() ) {
         for( const std::vector<item_location> &it_stack : item_list_to_stack( weapon,
                 weapon->all_items_top( pocket_type::CONTAINER ) ) ) {
+            if( !it_stack.empty() && it_stack.front()->made_of_from_type( phase_id::LIQUID ) &&
+                !it_stack.front()->is_frozen_liquid() ) {
+                continue;
+            }
             advanced_inv_listitem adv_it( it_stack, item_index++, square.id, false );
             if( !pane.is_filtered( *adv_it.items.front() ) ) {
                 square.volume += adv_it.volume;

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -158,10 +158,13 @@ std::vector<advanced_inv_listitem> avatar::get_AIM_inventory( const advanced_inv
     if( weapon && weapon->is_container() ) {
         for( const std::vector<item_location> &it_stack : item_list_to_stack( weapon,
                 weapon->all_items_top( pocket_type::CONTAINER ) ) ) {
+
+            // dont show if the content are liquids
             if( !it_stack.empty() && it_stack.front()->made_of_from_type( phase_id::LIQUID ) &&
                 !it_stack.front()->is_frozen_liquid() ) {
                 continue;
             }
+
             advanced_inv_listitem adv_it( it_stack, item_index++, square.id, false );
             if( !pane.is_filtered( *adv_it.items.front() ) ) {
                 square.volume += adv_it.volume;


### PR DESCRIPTION
#### Summary
Interface "Dont show liquids from held or worn container"

#### Purpose of change
Having liquids show up as any other item in AIM leads to some weird behavior like #79559. 
would fix #79559.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Instead of making a special case for every action, I suggest not showing the content of held or worn containers from [I]nventory pane if it's liquid, since I don't see any use-case for liquids outside of the [c]ontainer pane.

Additionally move the liquid check outside the `dpane.get_area() == AIM_INVENTORY` check for move_all in case there is another way to have liquids show up in the inventory screen. If you want to move liquids to a container you can still use the (u)nload function in AIM.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Add a query that the liquids will be spilled similar to [d]ropping liquids
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
When wielding or wearing a canteen of water you no longer see water in the inventory pane.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
