### PR TITLE
made iuse_actor use map aware + some vehicle operation

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2196,6 +2196,8 @@ std::unique_ptr<activity_actor> read_activity_actor::deserialize( JsonValue &jsi
 
 void move_items_activity_actor::do_turn( player_activity &act, Character &who )
 {
+    map &here = get_map();
+
     const tripoint_bub_ms dest = relative_destination + who.pos_bub();
 
     while( who.get_moves() > 0 && !target_items.empty() ) {
@@ -2242,10 +2244,10 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
         const float weary_mult = who.exertion_adjusted_move_multiplier( exertion_level() );
         who.mod_moves( -Pickup::cost_to_move_item( who, newit ) * distance / weary_mult );
         if( to_vehicle ) {
-            put_into_vehicle_or_drop( who, item_drop_reason::deliberate, { newit }, dest );
+            put_into_vehicle_or_drop( who, item_drop_reason::deliberate, { newit }, &here, dest );
         } else {
             std::vector<item_location> dropped_items = drop_on_map( who, item_drop_reason::deliberate, { newit },
-                    dest );
+                    &here, dest );
             if( hauling_mode ) {
                 who.haul_list.insert( who.haul_list.end(), dropped_items.begin(), dropped_items.end() );
             }
@@ -2260,7 +2262,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
         // Nuke the current activity, leaving the backlog alone.
         act.set_to_null();
         if( hauling_mode ) {
-            std::vector<item_location> haulable_items = get_map().get_haulable_items( who.pos_bub() );
+            std::vector<item_location> haulable_items = here.get_haulable_items( who.pos_bub() );
             bool overflow = who.trim_haul_list( haulable_items );
             if( who.is_hauling() && haulable_items.empty() ) {
                 who.stop_hauling();
@@ -4684,10 +4686,11 @@ void drop_or_stash_item_info::deserialize( const JsonObject &jsobj )
 
 void drop_activity_actor::do_turn( player_activity &, Character &who )
 {
+    map &here = get_map();
     const tripoint_bub_ms pos = placement + who.pos_bub();
     put_into_vehicle_or_drop( who, item_drop_reason::deliberate,
                               obtain_activity_items( items, handler, who, current_bulk_unload ),
-                              pos, force_ground );
+                              &here, pos, force_ground );
     // Cancel activity if items is empty. Otherwise, we modified in place and we will continue
     // to resolve the drop next turn. This is different from the pickup logic which creates
     // a brand new activity every turn and cancels the old activity
@@ -7632,7 +7635,7 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
     if( it.made_of_from_type( phase_id::SOLID ) ) {
         you.mod_moves( -activity_handlers::move_cost( it, src, dest ) );
 
-        put_into_vehicle_or_drop( you, item_drop_reason::deliberate, { it }, dest );
+        put_into_vehicle_or_drop( you, item_drop_reason::deliberate, { it }, &here, dest );
         // Remove from map or vehicle.
         if( src_veh ) {
             vehicle_part &vp_src = src_veh->part( src_part );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1236,7 +1236,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                 // TODO: smarter NPC liquid handling
                 // If we're not bleeding the animal we don't care about the blood being wasted
                 if( you.is_npc() || action != butcher_type::BLEED ) {
-                    drop_on_map( you, item_drop_reason::deliberate, { obj }, you.pos_bub() );
+                    drop_on_map( you, item_drop_reason::deliberate, { obj }, &here, you.pos_bub( &here ) );
                 } else {
                     liquid_handler::handle_all_liquid( obj, 1 );
                 }
@@ -1902,6 +1902,8 @@ void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
 
 void activity_handlers::start_fire_finish( player_activity *act, Character *you )
 {
+    map &here = get_map();
+
     static const std::string iuse_name_string( "firestarter" );
 
     item &it = *act->targets.front();
@@ -1925,7 +1927,7 @@ void activity_handlers::start_fire_finish( player_activity *act, Character *you 
 
     you->practice( skill_survival, act->index, 5 );
 
-    firestarter_actor::resolve_firestarter_use( you, get_map().get_bub( act->placement ) );
+    firestarter_actor::resolve_firestarter_use( you, &here, here.get_bub( act->placement ) );
     act->set_to_null();
 }
 
@@ -2000,7 +2002,7 @@ void activity_handlers::start_fire_do_turn( player_activity *act, Character *you
 
     you->mod_moves( -you->get_moves() );
     const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
-    const float light = actor->light_mod( you->pos_bub() );
+    const float light = actor->light_mod( &here, you->pos_bub( &here ) );
     act->moves_left -= light * 100;
     if( light < 0.1 ) {
         add_msg( m_bad, _( "There is not enough sunlight to start a fire now.  You stop trying." ) );

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -19,6 +19,7 @@
 class Character;
 class item;
 class item_location;
+class map;
 class player_activity;
 
 template<typename Point, typename Container>
@@ -185,10 +186,10 @@ enum class item_drop_reason : int {
 
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items );
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
-                               const tripoint_bub_ms &where, bool force_ground = false );
+                               map *here, const tripoint_bub_ms &where, bool force_ground = false );
 std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
                                         const std::list<item> &items,
-                                        const tripoint_bub_ms &where );
+                                        map *here, const tripoint_bub_ms &where );
 // used in unit tests to avoid triggering user input
 void repair_item_finish( player_activity *act, Character *you, bool no_menu );
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11197,7 +11197,7 @@ void Character::stagger()
         const optional_vpart_position vp_there = here.veh_at( dest );
         if( vp_there ) {
             vehicle &veh = vp_there->vehicle();
-            if( veh.enclosed_at( dest ) ) {
+            if( veh.enclosed_at( &here,  dest ) ) {
                 blocked = true;
             }
         }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1657,7 +1657,7 @@ void construct::done_grave( const tripoint_bub_ms &p, Character &player_characte
     }
     if( player_character.has_quality( qual_CUT ) ) {
         iuse::handle_ground_graffiti( player_character, nullptr, _( "Inscribe something on the grave?" ),
-                                      p );
+                                      &here, p );
     } else {
         add_msg( m_neutral,
                  _( "Unfortunately you don't have anything sharp to place an inscription on the grave." ) );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2808,6 +2808,8 @@ void Character::complete_disassemble( item_location target )
 
 void Character::complete_disassemble( item_location &target, const recipe &dis )
 {
+    map &here = get_map();
+
     // Get the proper recipe - the one for disassembly, not assembly
     const requirement_data dis_requirements = dis.disassembly_requirements();
     const tripoint_bub_ms loc = target.pos_bub();
@@ -2993,7 +2995,7 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
     }
 
     // Drop all recovered components
-    put_into_vehicle_or_drop( *this, item_drop_reason::deliberate, drop_items, loc );
+    put_into_vehicle_or_drop( *this, item_drop_reason::deliberate, drop_items, &here, loc );
 
     if( !dis.learn_by_disassembly.empty() && !knows_recipe( &dis ) ) {
         if( can_decomp_learn( dis ) ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -271,7 +271,7 @@ bool Creature::will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) con
     }
     if( capacity > 0_ml ) {
         // First, we'll try to squeeze in. Open-topped vehicle parts have more room to step over cargo.
-        if( !veh.enclosed_at( here.get_bub( loc ) ) ) {
+        if( !veh.enclosed_at( loc ) ) {
             free_cargo *= 1.2;
         }
         const creature_size size = get_size();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10318,8 +10318,6 @@ void game::reload_wielded( bool prompt )
 
 void game::reload_weapon( bool try_everything )
 {
-    map &here = get_map();
-
     // As a special streamlined activity, hitting reload repeatedly should:
     // Reload wielded gun
     // First reload a magazine if necessary.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10376,7 +10376,7 @@ void game::reload_weapon( bool try_everything )
     // If we make it here and haven't found anything to reload, start looking elsewhere.
     const optional_vpart_position ovp = m.veh_at( u.pos_abs() );
     if( ovp ) {
-        const turret_data turret = ovp->vehicle().turret_query( ovp->pos_bub( &here ) );
+        const turret_data turret = ovp->vehicle().turret_query( ovp->pos_abs( ) );
         if( turret.can_reload() ) {
             item::reload_option opt = u.select_ammo( turret.base(), true );
             if( opt ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1771,8 +1771,8 @@ static void fire()
         return;
     }
     // try firing turrets
-    if( const optional_vpart_position ovp = here.veh_at( you.pos_bub() ) ) {
-        if( turret_data turret_here = ovp->vehicle().turret_query( you.pos_bub() ) ) {
+    if( const optional_vpart_position ovp = here.veh_at( you.pos_abs() ) ) {
+        if( turret_data turret_here = ovp->vehicle().turret_query( you.pos_abs() ) ) {
             if( avatar_action::fire_turret_manual( you, here, turret_here ) ) {
                 return;
             }

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -387,6 +387,12 @@ ret_val<void> iuse_actor::can_use( const Character &, const item &, const tripoi
     return ret_val<void>::make_success();
 }
 
+ret_val<void> iuse_actor::can_use( const Character &, const item &, map *,
+                                   const tripoint_bub_ms & ) const
+{
+    return ret_val<void>::make_success();
+}
+
 bool iuse_actor::is_valid() const
 {
     return item_action_generator::generator().action_exists( type );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1667,7 +1667,7 @@ class iuse_function_wrapper : public iuse_actor
         std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override {
             return cpp_function( p, &it, pos );
         }
-        std::optional<int> use( Character *p, item &it, map *here,
+        std::optional<int> use( Character *p, item &it, map */*here*/,
                                 const tripoint_bub_ms &pos ) const override {
             // TODO: Change cpp_function to be map aware.
             return cpp_function( p, &it, pos );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1942,7 +1942,7 @@ void Item_factory::init()
     add_actor( std::make_unique<cast_spell_actor>() );
     add_actor( std::make_unique<weigh_self_actor>() );
     add_actor( std::make_unique<sew_advanced_actor>() );
-    add_actor( std::make_unique<effect_on_conditons_actor>() );
+    add_actor( std::make_unique<effect_on_conditions_actor>() );
     // An empty dummy group, it will not spawn anything. However, it makes that item group
     // id valid, so it can be used all over the place without need to explicitly check for it.
     m_template_groups[Item_spawn_data_EMPTY_GROUP] =

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1667,6 +1667,11 @@ class iuse_function_wrapper : public iuse_actor
         std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override {
             return cpp_function( p, &it, pos );
         }
+        std::optional<int> use( Character *p, item &it, map *here,
+                                const tripoint_bub_ms &pos ) const override {
+            // TODO: Change cpp_function to be map aware.
+            return cpp_function( p, &it, pos );
+        }
         std::unique_ptr<iuse_actor> clone() const override {
             return std::make_unique<iuse_function_wrapper>( *this );
         }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -204,9 +204,9 @@ std::optional<int> itype::invoke( Character *p, item &it, map *here,
         return 0;
     }
     if( use_methods.find( "transform" ) != use_methods.end() ) {
-        return invoke( p, it, pos, "transform" );
+        return invoke( p, it, here, pos, "transform" );
     } else {
-        return invoke( p, it, pos, use_methods.begin()->first );
+        return invoke( p, it, here, pos, use_methods.begin()->first );
     }
 }
 

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -194,6 +194,12 @@ int itype::tick( Character *p, item &it, const tripoint_bub_ms &pos ) const
 
 std::optional<int> itype::invoke( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
+    return itype::invoke( p, it, &get_map(), pos );
+}
+
+std::optional<int> itype::invoke( Character *p, item &it, map *here,
+                                  const tripoint_bub_ms &pos ) const
+{
     if( !has_use() ) {
         return 0;
     }
@@ -207,6 +213,12 @@ std::optional<int> itype::invoke( Character *p, item &it, const tripoint_bub_ms 
 std::optional<int> itype::invoke( Character *p, item &it, const tripoint_bub_ms &pos,
                                   const std::string &iuse_name ) const
 {
+    return itype::invoke( p, it, &get_map(), pos, iuse_name );
+}
+
+std::optional<int> itype::invoke( Character *p, item &it, map *here, const tripoint_bub_ms &pos,
+                                  const std::string &iuse_name ) const
+{
     const use_function *use = get_use( iuse_name );
     if( use == nullptr ) {
         debugmsg( "Tried to invoke %s on a %s, which doesn't have this use_function",
@@ -214,7 +226,7 @@ std::optional<int> itype::invoke( Character *p, item &it, const tripoint_bub_ms 
         return 0;
     }
     if( p ) {
-        const auto ret = use->can_call( *p, it, pos );
+        const auto ret = use->can_call( *p, it, here, pos );
 
         if( !ret.success() ) {
             p->add_msg_if_player( m_info, ret.str() );
@@ -222,7 +234,7 @@ std::optional<int> itype::invoke( Character *p, item &it, const tripoint_bub_ms 
         }
     }
 
-    return use->call( p, it, pos );
+    return use->call( p, it, here, pos );
 }
 
 std::string gun_type_type::name() const

--- a/src/itype.h
+++ b/src/itype.h
@@ -34,6 +34,7 @@
 class Item_factory;
 class JsonObject;
 class item;
+class map;
 struct tripoint;
 template <typename E> struct enum_traits;
 
@@ -1594,9 +1595,15 @@ struct itype {
         const use_function *get_use( const std::string &iuse_name ) const;
 
         // Here "invoke" means "actively use". "Tick" means "active item working"
+        // TODO: Replace usage of map less overload.
         std::optional<int> invoke( Character *p, item &it,
                                    const tripoint_bub_ms &pos ) const; // Picks first method or returns 0
+        std::optional<int> invoke( Character *p, item &it,
+                                   map *here, const tripoint_bub_ms &pos ) const; // Picks first method or returns 0
+        // TODO: Replace usage of map less overload.
         std::optional<int> invoke( Character *p, item &it, const tripoint_bub_ms &pos,
+                                   const std::string &iuse_name ) const;
+        std::optional<int> invoke( Character *p, item &it, map *here, const tripoint_bub_ms &pos,
                                    const std::string &iuse_name ) const;
         int tick( Character *p, item &it, const tripoint_bub_ms &pos ) const;
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9170,8 +9170,7 @@ ret_val<void> use_function::can_call( const Character &p, const item &it,
                                             it.tname() );
     }
 
-    // TODO: Make can_use map aware
-    return actor->can_use( p, it, pos );
+    return actor->can_use( p, it, here, pos );
 }
 
 std::optional<int> use_function::call( Character *p, item &it,
@@ -9181,8 +9180,8 @@ std::optional<int> use_function::call( Character *p, item &it,
 }
 
 std::optional<int> use_function::call( Character *p, item &it,
-                                       map *here, const tripoint_bub_ms &pos ) const
+                                       map */*here*/, const tripoint_bub_ms &pos ) const
 {
-    // TODO: Make can_use map aware
+    // TODO: Make use map aware
     return actor->use( p, it, pos );
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4929,33 +4929,34 @@ std::optional<int> iuse::mop( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint_bub_ms & )
 {
+    map &here = get_map();
+
     const std::optional<tripoint_bub_ms> dest_ = choose_adjacent( _( "Spray where?" ) );
     if( !dest_ ) {
         return std::nullopt;
     }
-    return handle_ground_graffiti( *p, it, _( "Spray what?" ), dest_.value() );
+    return handle_ground_graffiti( *p, it, _( "Spray what?" ), &here, dest_.value() );
 }
 
 std::optional<int> iuse::handle_ground_graffiti( Character &p, item *it, const std::string &prefix,
-        const tripoint_bub_ms &where )
+        map *here, const tripoint_bub_ms &where )
 {
-    map &here = get_map();
     string_input_popup popup;
     std::string message = popup
                           .description( prefix + " " + _( "(To delete, clear the text and confirm)" ) )
-                          .text( here.has_graffiti_at( where ) ? here.graffiti_at( where ) : std::string() )
+                          .text( here->has_graffiti_at( where ) ? here->graffiti_at( where ) : std::string() )
                           .identifier( "graffiti" )
                           .query_string();
     if( popup.canceled() ) {
         return std::nullopt;
     }
 
-    bool grave = here.ter( where ) == ter_t_grave_new;
+    bool grave = here->ter( where ) == ter_t_grave_new;
     int move_cost;
     if( message.empty() ) {
-        if( here.has_graffiti_at( where ) ) {
-            move_cost = 3 * here.graffiti_at( where ).length();
-            here.delete_graffiti( where );
+        if( here->has_graffiti_at( where ) ) {
+            move_cost = 3 * here->graffiti_at( where ).length();
+            here->delete_graffiti( where );
             if( grave ) {
                 p.add_msg_if_player( m_info, _( "You blur the inscription on the grave." ) );
             } else {
@@ -4965,7 +4966,7 @@ std::optional<int> iuse::handle_ground_graffiti( Character &p, item *it, const s
             return std::nullopt;
         }
     } else {
-        here.set_graffiti( where, message );
+        here->set_graffiti( where, message );
         if( grave ) {
             p.add_msg_if_player( m_info, _( "You carve an inscription on the grave." ) );
         } else {
@@ -9155,6 +9156,12 @@ void use_function::dump_info( const item &it, std::vector<iteminfo> &dump ) cons
 ret_val<void> use_function::can_call( const Character &p, const item &it,
                                       const tripoint_bub_ms &pos ) const
 {
+    return use_function::can_call( p, it, &get_map(), pos );
+}
+
+ret_val<void> use_function::can_call( const Character &p, const item &it,
+                                      map *here, const tripoint_bub_ms &pos ) const
+{
     if( actor == nullptr ) {
         return ret_val<void>::make_failure( _( "You can't do anything interesting with your %s." ),
                                             it.tname() );
@@ -9163,11 +9170,19 @@ ret_val<void> use_function::can_call( const Character &p, const item &it,
                                             it.tname() );
     }
 
+    // TODO: Make can_use map aware
     return actor->can_use( p, it, pos );
 }
 
 std::optional<int> use_function::call( Character *p, item &it,
                                        const tripoint_bub_ms &pos ) const
 {
+    return use_function::call( p, it, &get_map(), pos );
+}
+
+std::optional<int> use_function::call( Character *p, item &it,
+                                       map *here, const tripoint_bub_ms &pos ) const
+{
+    // TODO: Make can_use map aware
     return actor->use( p, it, pos );
 }

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -17,6 +17,7 @@
 class Character;
 class JsonObject;
 class item;
+class map;
 class monster;
 struct iteminfo;
 template<typename T> class ret_val;
@@ -236,7 +237,7 @@ bool robotcontrol_can_target( Character *, const monster & );
 
 // Helper for handling pesky wannabe-artists
 std::optional<int> handle_ground_graffiti( Character &p, item *it, const std::string &prefix,
-        const tripoint_bub_ms &where );
+        map *here, const tripoint_bub_ms &where );
 
 //helper for lit cigs
 std::optional<std::string> can_smoke( const Character &you );
@@ -291,8 +292,13 @@ class iuse_actor
 
         virtual ~iuse_actor() = default;
         virtual void load( const JsonObject &jo, const std::string &src ) = 0;
+        // TODO: Replace usage of map unaware overload with map aware.
         virtual std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const = 0;
+        virtual std::optional<int> use( Character *, item &, map *here, const tripoint_bub_ms & ) const = 0;
+        // TODO: Replace usage of map unaware overload with map aware.
         virtual ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const;
+        virtual ret_val<void> can_use( const Character &, const item &, map *here,
+                                       const tripoint_bub_ms & ) const;
         virtual void info( const item &, std::vector<iteminfo> & ) const {}
         /**
          * Returns a deep copy of this object. Example implementation:
@@ -333,8 +339,13 @@ struct use_function {
         use_function( const std::string &type, use_function_pointer f );
         explicit use_function( std::unique_ptr<iuse_actor> f ) : actor( std::move( f ) ) {}
 
+        // TODO: Replace map unaware overload with map aware.
         std::optional<int> call( Character *, item &, const tripoint_bub_ms & ) const;
+        std::optional<int> call( Character *, item &, map *here, const tripoint_bub_ms & ) const;
+        // TODO: Replace map unaware overload with map aware.
         ret_val<void> can_call( const Character &, const item &, const tripoint_bub_ms &pos ) const;
+        ret_val<void> can_call( const Character &, const item &, map *here,
+                                const tripoint_bub_ms &pos ) const;
 
         iuse_actor *get_actor_ptr() {
             return actor.get();

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -6041,12 +6041,12 @@ std::unique_ptr<iuse_actor> change_scent_iuse::clone() const
     return std::make_unique<change_scent_iuse>( *this );
 }
 
-std::unique_ptr<iuse_actor> effect_on_conditons_actor::clone() const
+std::unique_ptr<iuse_actor> effect_on_conditions_actor::clone() const
 {
-    return std::make_unique<effect_on_conditons_actor>( *this );
+    return std::make_unique<effect_on_conditions_actor>( *this );
 }
 
-void effect_on_conditons_actor::load( const JsonObject &obj, const std::string &src )
+void effect_on_conditions_actor::load( const JsonObject &obj, const std::string &src )
 {
     obj.read( "description", description );
     obj.read( "menu_text", menu_text );
@@ -6057,7 +6057,7 @@ void effect_on_conditons_actor::load( const JsonObject &obj, const std::string &
     }
 }
 
-std::string effect_on_conditons_actor::get_name() const
+std::string effect_on_conditions_actor::get_name() const
 {
     if( !menu_text.empty() ) {
         return menu_text.translated();
@@ -6065,18 +6065,18 @@ std::string effect_on_conditons_actor::get_name() const
     return iuse_actor::get_name();
 }
 
-void effect_on_conditons_actor::info( const item &, std::vector<iteminfo> &dump ) const
+void effect_on_conditions_actor::info( const item &, std::vector<iteminfo> &dump ) const
 {
     dump.emplace_back( "DESCRIPTION", description.translated() );
 }
 
-std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
+std::optional<int> effect_on_conditions_actor::use( Character *p, item &it,
         const tripoint_bub_ms &pos ) const
 {
-    return effect_on_conditons_actor::use( p, it, &get_map(), pos );
+    return effect_on_conditions_actor::use( p, it, &get_map(), pos );
 }
 
-std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
+std::optional<int> effect_on_conditions_actor::use( Character *p, item &it,
         map *here, const tripoint_bub_ms &pos ) const
 {
     if( it.type->comestible ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -232,7 +232,13 @@ void iuse_transform::load( const JsonObject &obj, const std::string & )
     obj.read( "menu_text", menu_text );
 }
 
-std::optional<int> iuse_transform::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> iuse_transform::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
+{
+    return iuse_transform::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> iuse_transform::use( Character *p, item &it, map *,
+                                        const tripoint_bub_ms & ) const
 {
     int scale = 1;
     auto iter = it.type->ammo_scale.find( type );
@@ -281,6 +287,7 @@ std::optional<int> iuse_transform::use( Character *p, item &it, const tripoint_b
         it.count() > 1 ) {
         item take_one = it.split( 1 );
         do_transform( p, take_one, variant_type );
+        // TODO: Change to map aware operation when available
         p->i_add_or_drop( take_one );
     } else {
         do_transform( p, it, variant_type );
@@ -367,7 +374,13 @@ void iuse_transform::do_transform( Character *p, item &it, const std::string &va
 }
 
 ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
-                                       const tripoint_bub_ms & ) const
+                                       const tripoint_bub_ms &pos ) const
+{
+    return iuse_transform::can_use( p, it, &get_map(), pos );
+}
+
+ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
+                                       map *here, const tripoint_bub_ms & ) const
 {
     if( need_worn && !p.is_worn( it ) ) {
         return ret_val<void>::make_failure( _( "You need to wear the %1$s before activating it." ),
@@ -406,7 +419,7 @@ ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
 
     std::map<quality_id, int> unmet_reqs;
     inventory inv;
-    inv.form_from_map( p.pos_bub(), 1, &p, true, true );
+    inv.form_from_map( p.pos_bub( here ), 1, &p, true, true );
     for( const auto &quality : qualities_needed ) {
         if( !p.has_quality( quality.first, quality.second ) &&
             !inv.has_quality( quality.first, quality.second ) ) {
@@ -523,14 +536,18 @@ void unpack_actor::load( const JsonObject &obj, const std::string & )
     assign( obj, "filthy_volume_threshold", filthy_vol_threshold );
 }
 
-std::optional<int> unpack_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> unpack_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
+{
+    return unpack_actor::use( p, it, &get_map(), pos );
+}
+std::optional<int> unpack_actor::use( Character *p, item &it, map *here,
+                                      const tripoint_bub_ms & ) const
 {
     std::vector<item> items = item_group::items_from( unpack_group, calendar::turn );
     item last_armor;
 
     p->add_msg_if_player( _( "You unpack the %s." ), it.tname() );
 
-    map &here = get_map();
     for( item &content : items ) {
         if( content.is_armor() ) {
             if( items_fit ) {
@@ -550,7 +567,7 @@ std::optional<int> unpack_actor::use( Character *p, item &it, const tripoint_bub
             content.set_flag( flag_FILTHY );
         }
 
-        here.add_item_or_charges( p->pos_bub(), content );
+        here->add_item_or_charges( p->pos_bub( here ), content );
     }
 
     p->i_rem( &it );
@@ -578,10 +595,17 @@ void message_iuse::load( const JsonObject &obj, const std::string & )
 std::optional<int> message_iuse::use( Character *p, item &it,
                                       const tripoint_bub_ms &pos ) const
 {
+    return message_iuse::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> message_iuse::use( Character *p, item &it,
+                                      map * /*here*/, const tripoint_bub_ms &pos ) const
+{
     if( !p ) {
         return std::nullopt;
     }
 
+    // TODO: Use map aware 'sees' when available.
     if( p->sees( pos ) && !message.empty() ) {
         p->add_msg_if_player( m_info, message.translated(), it.tname() );
     }
@@ -619,6 +643,17 @@ std::optional<int> sound_iuse::use( Character *, item &,
     return 0;
 }
 
+std::optional<int> sound_iuse::use( Character *, item &,
+                                    map *here, const tripoint_bub_ms &pos ) const
+{
+    if( get_map().inbounds( here->get_abs( pos ) ) ) {
+        sounds::sound( get_map().get_bub( here->get_abs( pos ) ), sound_volume, sounds::sound_t::alarm,
+                       sound_message.translated(), true,
+                       sound_id, sound_variant );
+    }
+    return 0;
+}
+
 std::string sound_iuse::get_name() const
 {
     if( !name.empty() ) {
@@ -638,17 +673,16 @@ std::unique_ptr<iuse_actor> explosion_iuse::clone() const
 // Those points must have a clear line of sight and a clear path to
 // the center of the explosion.
 // They must also be passable.
-static std::vector<tripoint_bub_ms> points_for_gas_cloud( const tripoint_bub_ms &center,
+static std::vector<tripoint_bub_ms> points_for_gas_cloud( map *here, const tripoint_bub_ms &center,
         int radius )
 {
-    map &here = get_map();
     std::vector<tripoint_bub_ms> result;
     for( const tripoint_bub_ms &p : closest_points_first( center, radius ) ) {
-        if( here.impassable( p ) ) {
+        if( here->impassable( p ) ) {
             continue;
         }
         if( p != center ) {
-            if( !here.clear_path( center, p, radius, 1, 100 ) ) {
+            if( !here->clear_path( center, p, radius, 1, 100 ) ) {
                 // Can not splatter gas from center to that point, something is in the way
                 continue;
             }
@@ -686,6 +720,11 @@ void explosion_iuse::load( const JsonObject &obj, const std::string & )
 
 std::optional<int> explosion_iuse::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
+    return explosion_iuse::use( p, it, &get_map(), pos );
+}
+std::optional<int> explosion_iuse::use( Character *p, item &it, map *here,
+                                        const tripoint_bub_ms &pos ) const
+{
     if( explosion.power >= 0.0f ) {
         Character *source = p;
         if( it.has_var( "last_act_by_char_id" ) ) {
@@ -696,30 +735,32 @@ std::optional<int> explosion_iuse::use( Character *p, item &it, const tripoint_b
                 source = g->find_npc( thrower );
             }
         }
-        explosion_handler::explosion( source, pos, explosion );
+        explosion_handler::explosion( source, here, pos, explosion );
     }
 
-    if( draw_explosion_radius >= 0 ) {
+    if( draw_explosion_radius >= 0 && get_map().inbounds( here->get_abs( pos ) ) ) {
         explosion_handler::draw_explosion( pos, draw_explosion_radius, draw_explosion_color );
     }
     if( do_flashbang ) {
+        // TODO: Use map aware 'flashbang' operation when available.
         explosion_handler::flashbang( pos, flashbang_player_immune );
     }
-    map &here = get_map();
     if( fields_radius >= 0 && fields_type.id() ) {
-        std::vector<tripoint_bub_ms> gas_sources = points_for_gas_cloud( pos, fields_radius );
+        std::vector<tripoint_bub_ms> gas_sources = points_for_gas_cloud( here, pos, fields_radius );
         for( tripoint_bub_ms &gas_source : gas_sources ) {
             const int field_intensity = rng( fields_min_intensity, fields_max_intensity );
-            here.add_field( gas_source, fields_type, field_intensity, 1_turns );
+            here->add_field( gas_source, fields_type, field_intensity, 1_turns );
         }
     }
     if( scrambler_blast_radius >= 0 ) {
-        for( const tripoint_bub_ms &dest : here.points_in_radius( pos, scrambler_blast_radius ) ) {
+        for( const tripoint_bub_ms &dest : here->points_in_radius( pos, scrambler_blast_radius ) ) {
+            // TODO: Use map aware 'scrambler_blast' when available.
             explosion_handler::scrambler_blast( dest );
         }
     }
     if( emp_blast_radius >= 0 ) {
-        for( const tripoint_bub_ms &dest : here.points_in_radius( pos, emp_blast_radius ) ) {
+        for( const tripoint_bub_ms &dest : here->points_in_radius( pos, emp_blast_radius ) ) {
+            // TODO: Use map aware 'emp_blast' when available.
             explosion_handler::emp_blast( dest );
         }
     }
@@ -810,7 +851,14 @@ void consume_drug_iuse::info( const item &, std::vector<iteminfo> &dump ) const
     }
 }
 
-std::optional<int> consume_drug_iuse::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> consume_drug_iuse::use( Character *p, item &it,
+        const tripoint_bub_ms &pos ) const
+{
+    return consume_drug_iuse::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> consume_drug_iuse::use( Character *p, item &it, map *here,
+        const tripoint_bub_ms & ) const
 {
     auto need_these = tools_needed;
 
@@ -852,12 +900,11 @@ std::optional<int> consume_drug_iuse::use( Character *p, item &it, const tripoin
     for( const auto &stat_adjustment : stat_adjustments ) {
         p->mod_stat( stat_adjustment.first, stat_adjustment.second );
     }
-    map &here = get_map();
     for( const auto &field : fields_produced ) {
         const field_type_id fid = field_type_id( field.first );
         for( int i = 0; i < 3; i++ ) {
             point_rel_ms offset( rng( -2, 2 ), rng( -2, 2 ) );
-            here.add_field( p->pos_bub() + offset, fid, field.second );
+            here->add_field( p->pos_bub( here ) + offset, fid, field.second );
         }
     }
 
@@ -882,6 +929,7 @@ std::optional<int> consume_drug_iuse::use( Character *p, item &it, const tripoin
 
     if( !used_up_item.is_null() ) {
         item used_up( used_up_item, it.birthday() );
+        // TODO: Use map aware 'i_add_or_drop' when available
         p->i_add_or_drop( used_up );
     }
 
@@ -911,11 +959,17 @@ int delayed_transform_iuse::time_to_do( const item &it ) const
 std::optional<int> delayed_transform_iuse::use( Character *p, item &it,
         const tripoint_bub_ms &pos ) const
 {
+    return delayed_transform_iuse::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> delayed_transform_iuse::use( Character *p, item &it,
+        map *here, const tripoint_bub_ms &pos ) const
+{
     if( time_to_do( it ) > 0 ) {
         p->add_msg_if_player( m_info, "%s", not_ready_msg );
         return std::nullopt;
     }
-    return iuse_transform::use( p, it, pos );
+    return iuse_transform::use( p, it, here, pos );
 }
 
 std::unique_ptr<iuse_actor> place_monster_iuse::clone() const
@@ -943,8 +997,20 @@ void place_monster_iuse::load( const JsonObject &obj, const std::string & )
     }
 }
 
-std::optional<int> place_monster_iuse::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> place_monster_iuse::use( Character *p, item &it,
+        const tripoint_bub_ms &pos ) const
 {
+    return place_monster_iuse::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> place_monster_iuse::use( Character *p, item &it, map *here,
+        const tripoint_bub_ms & ) const
+{
+    if( here != &get_map() ) { // Because of the g usage below
+        debugmsg( "Not supported for maps other than the reality bubble" );
+        return std::nullopt;
+    }
+
     if( it.ammo_remaining() < need_charges ) {
         p->add_msg_if_player( m_info, _( "This requires %d charges to activate." ), need_charges );
         return std::nullopt;
@@ -955,7 +1021,7 @@ std::optional<int> place_monster_iuse::use( Character *p, item &it, const tripoi
     newmon.init_from_item( it );
     if( place_randomly ) {
         // place_critter_around returns the same pointer as its parameter (or null)
-        if( !g->place_critter_around( newmon_ptr, p->pos_bub(), 1 ) ) {
+        if( !g->place_critter_around( newmon_ptr, p->pos_bub( here ), 1 ) ) {
             p->add_msg_if_player( m_info, _( "There is no adjacent square to release the %s in!" ),
                                   newmon.name() );
             return std::nullopt;
@@ -1037,16 +1103,21 @@ void place_npc_iuse::load( const JsonObject &obj, const std::string & )
     obj.read( "place_randomly", place_randomly );
 }
 
-std::optional<int> place_npc_iuse::use( Character *p, item &, const tripoint_bub_ms & ) const
+std::optional<int> place_npc_iuse::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
-    map &here = get_map();
+    return place_npc_iuse::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> place_npc_iuse::use( Character *p, item &, map *here,
+                                        const tripoint_bub_ms & ) const
+{
     const tripoint_range<tripoint_bub_ms> target_range = place_randomly ?
-            points_in_radius( p->pos_bub(), radius ) :
-            points_in_radius( choose_adjacent( _( "Place NPC where?" ) ).value_or( p->pos_bub() ), 0 );
+            points_in_radius( p->pos_bub( here ), radius ) :
+            points_in_radius( choose_adjacent( _( "Place NPC where?" ) ).value_or( p->pos_bub( here ) ), 0 );
 
     const std::optional<tripoint_bub_ms> target_pos =
-    random_point( target_range, [&here]( const tripoint_bub_ms & t ) {
-        return here.passable( t ) && here.has_floor_or_support( t ) &&
+    random_point( target_range, [here]( const tripoint_bub_ms & t ) {
+        return here->passable( t ) && here->has_floor_or_support( t ) &&
                !get_creature_tracker().creature_at( t );
     } );
 
@@ -1055,7 +1126,7 @@ std::optional<int> place_npc_iuse::use( Character *p, item &, const tripoint_bub
         return std::nullopt;
     }
 
-    here.place_npc( target_pos.value().xy(), npc_class_id );
+    here->place_npc( target_pos.value().xy(), npc_class_id );
     p->mod_moves( -moves );
     p->add_msg_if_player( m_info, "%s", summon_msg );
     return 1;
@@ -1116,13 +1187,14 @@ void deploy_furn_actor::load( const JsonObject &obj, const std::string & )
 
 
 static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
-        const tripoint_bub_ms &pos )
+        map *here, const tripoint_bub_ms &pos )
 {
     if( p->cant_do_mounted() ) {
         return ret_val<tripoint_bub_ms>::make_failure( pos );
     }
     tripoint_bub_ms pnt( pos );
-    if( pos == p->pos_bub() ) {
+    if( pos == p->pos_bub( here ) ) {
+        // TODO: Use map aware 'choose_adjacent' when available, or reject operation if not reality bubble map
         if( const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Deploy where?" ) ) ) {
             pnt = *pnt_;
         } else {
@@ -1130,22 +1202,20 @@ static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
         }
     }
 
-    if( pnt == p->pos_bub() ) {
+    if( pnt == p->pos_bub( here ) ) {
         return ret_val<tripoint_bub_ms>::make_failure( pos,
                 _( "You attempt to become one with the %s.  It doesn't work." ), it.tname() );
     }
 
-    map &here = get_map();
-
     tripoint_bub_ms where = pnt;
     tripoint_bub_ms below = pnt + tripoint::below;
-    while( here.valid_move( where, below, false, true ) ) {
+    while( here->valid_move( where, below, false, true ) ) {
         where += tripoint::below;
         below += tripoint::below;
     }
 
     const int height = pnt.z() - where.z();
-    if( height > 1 && here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_FLOOR, pnt ) ) {
+    if( height > 1 && here->has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_FLOOR, pnt ) ) {
         if( !query_yn(
                 _( "Deploying %s there will make it fall down %i stories.  Do you still want to deploy it?" ),
                 it.tname(), height ) ) {
@@ -1153,7 +1223,7 @@ static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
         }
     }
 
-    optional_vpart_position veh_there = here.veh_at( pnt );
+    optional_vpart_position veh_there = here->veh_at( pnt );
     if( veh_there.has_value() ) {
         // TODO: check for protrusion+short furniture, wheels+tiny furniture, NOCOLLIDE flag, etc.
         // and/or integrate furniture deployment with construction (which already seems to perform these checks sometimes?)
@@ -1163,22 +1233,21 @@ static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
     }
 
     // For example: dirt = 2, long grass = 3
-    if( here.move_cost( pnt ) != 2 && here.move_cost( pnt ) != 3 ) {
+    if( here->move_cost( pnt ) != 2 && here->move_cost( pnt ) != 3 ) {
         return ret_val<tripoint_bub_ms>::make_failure( pos, _( "You can't deploy a %s there." ),
                 it.tname() );
     }
 
-    if( here.has_furn( pnt ) ) {
+    if( here->has_furn( pnt ) ) {
         return ret_val<tripoint_bub_ms>::make_failure( pos,
                 _( "The %s at that location is blocking the %s." ),
-                here.furnname( pnt ), it.tname() );
+                here->furnname( pnt ), it.tname() );
     }
 
-    if( here.has_items( pnt ) ) {
+    if( here->has_items( pnt ) ) {
         // Check that there are no other people's belongings in the place where the furniture is placed.
         // Avoid easy theft of NPC items (e.g. carton theft).
-        map &temp = get_map();
-        for( item &i : temp.i_at( pnt ) ) {
+        for( item &i : here->i_at( pnt ) ) {
             if( !i.is_owned_by( *p, true ) ) {
                 return ret_val<tripoint_bub_ms>::make_failure( pos,
                         _( "You can't deploy the %s on other people's belongings!" ), it.tname() );
@@ -1187,9 +1256,9 @@ static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
 
         // Check that there is no liquid on the floor.
         // If there is, it needs to be mopped dry with a mop.
-        if( here.terrain_moppable( pnt ) ) {
+        if( here->terrain_moppable( pnt ) ) {
             if( get_avatar().crafting_inventory().has_quality( qual_MOP ) ) {
-                here.mop_spills( pnt );
+                here->mop_spills( pnt );
                 p->add_msg_if_player( m_info, _( "You mopped up the spill with a nearby mop when deploying a %s." ),
                                       it.tname() );
                 p->mod_moves( -to_moves<int>( 15_seconds ) );
@@ -1206,7 +1275,13 @@ static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
 std::optional<int> deploy_furn_actor::use( Character *p, item &it,
         const tripoint_bub_ms &pos ) const
 {
-    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, pos );
+    return deploy_furn_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> deploy_furn_actor::use( Character *p, item &it,
+        map *here, const tripoint_bub_ms &pos ) const
+{
+    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, here, pos );
     if( !suitable.success() ) {
         p->add_msg_if_player( m_info, suitable.str() );
         return std::nullopt;
@@ -1238,14 +1313,22 @@ void deploy_appliance_actor::load( const JsonObject &obj, const std::string & )
 std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
         const tripoint_bub_ms &pos ) const
 {
-    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, pos );
+    return deploy_appliance_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
+        map *here, const tripoint_bub_ms &pos ) const
+{
+    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, here, pos );
     if( !suitable.success() ) {
         p->add_msg_if_player( m_info, suitable.str() );
         return std::nullopt;
     }
 
+    // TODO: Use map aware operation when available
     it.spill_contents( suitable.value() );
-    if( !place_appliance( tripoint_bub_ms( suitable.value() ),
+    // TODO: Use map aware operation when available
+    if( !place_appliance( suitable.value(),
                           vpart_appliance_from_item( appliance_base ), *p, it ) ) {
         // failed to place somehow, cancel!!
         return 0;
@@ -1294,7 +1377,13 @@ void reveal_map_actor::reveal_targets( const tripoint_abs_omt &center,
     }
 }
 
-std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
+{
+    return reveal_map_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> reveal_map_actor::use( Character *p, item &it, map *,
+        const tripoint_bub_ms & ) const
 {
     if( it.already_used_by_player( *p ) ) {
         p->add_msg_if_player( _( "There isn't anything new on the %s." ), it.tname() );
@@ -1334,34 +1423,38 @@ std::unique_ptr<iuse_actor> firestarter_actor::clone() const
     return std::make_unique<firestarter_actor>( *this );
 }
 
-bool firestarter_actor::prep_firestarter_use( const Character &p, tripoint_bub_ms &pos )
+bool firestarter_actor::prep_firestarter_use( const Character &p, map *here, tripoint_bub_ms &pos )
 {
+    if( here != &get_map() ) { // Unless 'choose_adjacent' gets map aware.
+        debugmsg( "Usage outside reality bubble is not supported" );
+        return false;
+    }
+
     // checks for fuel are handled by use and the activity, not here
-    if( pos == p.pos_bub() ) {
+    if( pos == p.pos_bub( here ) ) {
         if( const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Light where?" ) ) ) {
             pos = *pnt_;
         } else {
             return false;
         }
     }
-    if( pos == p.pos_bub() ) {
+    if( pos == p.pos_bub( here ) ) {
         p.add_msg_if_player( m_info, _( "You would set yourself on fire." ) );
         p.add_msg_if_player( _( "But you're already smokin' hot." ) );
         return false;
     }
-    map &here = get_map();
-    if( here.get_field( pos, fd_fire ) ) {
+    if( here->get_field( pos, fd_fire ) ) {
         // check if there's already a fire
         p.add_msg_if_player( m_info, _( "There is already a fire." ) );
         return false;
     }
     // check if there's a fire fuel source spot
     bool target_is_firewood = false;
-    if( here.tr_at( pos ).id == tr_firewood_source ) {
+    if( here->tr_at( pos ).id == tr_firewood_source ) {
         target_is_firewood = true;
     } else {
         zone_manager &mgr = zone_manager::get_manager();
-        auto zones = mgr.get_zones( zone_type_SOURCE_FIREWOOD, here.get_abs( pos ) );
+        auto zones = mgr.get_zones( zone_type_SOURCE_FIREWOOD, here->get_abs( pos ) );
         if( !zones.empty() ) {
             target_is_firewood = true;
         }
@@ -1372,16 +1465,16 @@ bool firestarter_actor::prep_firestarter_use( const Character &p, tripoint_bub_m
         }
     }
     // Check for an adjacent fire container
-    for( const tripoint_bub_ms &query : here.points_in_radius( pos, 1 ) ) {
+    for( const tripoint_bub_ms &query : here->points_in_radius( pos, 1 ) ) {
         // Don't ask if we're setting a fire on top of a fireplace
-        if( here.has_flag_furn( "FIRE_CONTAINER", pos ) ) {
+        if( here->has_flag_furn( "FIRE_CONTAINER", pos ) ) {
             break;
         }
         // Skip the position we're trying to light on fire
         if( query == pos ) {
             continue;
         }
-        if( here.has_flag_furn( "FIRE_CONTAINER", query ) ) {
+        if( here->has_flag_furn( "FIRE_CONTAINER", query ) ) {
             if( !query_yn( _( "Are you sure you want to start fire here?  There's a fireplace adjacent." ) ) ) {
                 return false;
             } else {
@@ -1392,7 +1485,7 @@ bool firestarter_actor::prep_firestarter_use( const Character &p, tripoint_bub_m
     }
     // Check for a brazier.
     bool has_unactivated_brazier = false;
-    for( const item &i : here.i_at( pos ) ) {
+    for( const item &i : here->i_at( pos ) ) {
         if( i.typeId() == itype_brazier ) {
             has_unactivated_brazier = true;
         }
@@ -1402,9 +1495,10 @@ bool firestarter_actor::prep_firestarter_use( const Character &p, tripoint_bub_m
                _( "There's a brazier there but you haven't set it up to contain the fire.  Continue?" ) );
 }
 
-void firestarter_actor::resolve_firestarter_use( Character *p, const tripoint_bub_ms &pos )
+void firestarter_actor::resolve_firestarter_use( Character *p, map *here,
+        const tripoint_bub_ms &pos )
 {
-    if( get_map().add_field( pos, fd_fire, 1, 10_minutes ) ) {
+    if( here->add_field( pos, fd_fire, 1, 10_minutes ) ) {
         if( !p->has_trait( trait_PYROMANIA ) ) {
             p->add_msg_if_player( _( "You successfully light a fire." ) );
         } else {
@@ -1421,7 +1515,13 @@ void firestarter_actor::resolve_firestarter_use( Character *p, const tripoint_bu
 }
 
 ret_val<void> firestarter_actor::can_use( const Character &p, const item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return firestarter_actor::can_use( p, it, &get_map(), pos );
+}
+
+ret_val<void> firestarter_actor::can_use( const Character &p, const item &it,
+        map *here, const tripoint_bub_ms & ) const
 {
     if( p.is_underwater() ) {
         return ret_val<void>::make_failure( _( "You can't do that while underwater." ) );
@@ -1431,15 +1531,19 @@ ret_val<void> firestarter_actor::can_use( const Character &p, const item &it,
         return ret_val<void>::make_failure( _( "This tool doesn't have enough charges." ) );
     }
 
-    if( need_sunlight && light_mod( p.pos_bub() ) <= 0.0f ) {
+    if( need_sunlight && light_mod( here, p.pos_bub( here ) ) <= 0.0f ) {
         return ret_val<void>::make_failure( _( "You need direct sunlight to light a fire with this." ) );
     }
 
     return ret_val<void>::make_success();
 }
 
-float firestarter_actor::light_mod( const tripoint_bub_ms &pos ) const
+float firestarter_actor::light_mod( map *here, const tripoint_bub_ms &pos ) const
 {
+    if( here != &get_map() ) {
+        debugmsg( "not supported outside the reality bubble" );
+        return 0.0f;
+    }
     if( !need_sunlight ) {
         return 1.0f;
     }
@@ -1469,7 +1573,13 @@ int firestarter_actor::moves_cost_by_fuel( const tripoint_bub_ms &pos ) const
 }
 
 std::optional<int> firestarter_actor::use( Character *p, item &it,
-        const tripoint_bub_ms &spos ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return firestarter_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> firestarter_actor::use( Character *p, item &it,
+        map *here,  const tripoint_bub_ms &spos ) const
 {
     if( !p ) {
         debugmsg( "%s called action firestarter that requires character but no character is present",
@@ -1477,9 +1587,10 @@ std::optional<int> firestarter_actor::use( Character *p, item &it,
         return std::nullopt;
     }
 
-    tripoint_bub_ms pos( spos );
-    float light = light_mod( p->pos_bub() );
-    if( !prep_firestarter_use( *p, pos ) ) {
+    tripoint_bub_ms pos = spos;
+
+    float light = light_mod( here, p->pos_bub( here ) );
+    if( !prep_firestarter_use( *p, here, pos ) ) {
         return std::nullopt;
     }
 
@@ -1500,9 +1611,9 @@ std::optional<int> firestarter_actor::use( Character *p, item &it,
                               n_gettext( "At your skill level, it will take around %d minute to light a fire.",
                                          "At your skill level, it will take around %d minutes to light a fire.", minutes ),
                               minutes );
-    } else if( moves < to_moves<int>( 2_turns ) && get_map().is_flammable( pos ) ) {
+    } else if( moves < to_moves<int>( 2_turns ) && here->is_flammable( pos ) ) {
         // If less than 2 turns, don't start a long action
-        resolve_firestarter_use( p, pos );
+        resolve_firestarter_use( p, here,  pos );
         p->mod_moves( -moves );
         return 1;
     }
@@ -1513,7 +1624,7 @@ std::optional<int> firestarter_actor::use( Character *p, item &it,
                         0, it.tname() );
     p->activity.targets.emplace_back( *p, &it );
     p->activity.values.push_back( g->natural_light_level( pos.z() ) );
-    p->activity.placement = get_map().get_abs( pos );
+    p->activity.placement = here->get_abs( pos );
     // charges to use are handled by the activity
     return 0;
 }
@@ -1530,6 +1641,36 @@ std::unique_ptr<iuse_actor> salvage_actor::clone() const
 }
 
 std::optional<int> salvage_actor::use( Character *p, item &cutter, const tripoint_bub_ms & ) const
+{
+    if( !p ) {
+        debugmsg( "%s called action salvage that requires character but no character is present",
+                  cutter.typeId().str() );
+        return std::nullopt;
+    }
+
+    item_location item_loc = game_menus::inv::salvage( *p, this );
+    if( !item_loc ) {
+        add_msg( _( "Never mind." ) );
+        return std::nullopt;
+    }
+
+    const item &to_cut = *item_loc;
+    if( !to_cut.is_owned_by( *p, true ) ) {
+        if( !query_yn( _( "Cutting the %s may anger the people who own it, continue?" ),
+                       to_cut.tname() ) ) {
+            return false;
+        } else {
+            if( to_cut.get_owner() ) {
+                g->on_witness_theft( to_cut );
+            }
+        }
+    }
+
+    return salvage_actor::try_to_cut_up( *p, cutter, item_loc );
+}
+
+std::optional<int> salvage_actor::use( Character *p, item &cutter, map *,
+                                       const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action salvage that requires character but no character is present",
@@ -1695,6 +1836,8 @@ static std::optional<recipe> find_uncraft_recipe( const item &x )
 
 void salvage_actor::cut_up( Character &p, item_location &cut ) const
 {
+    map &here = get_map();
+
     // Map of salvaged items (id, count)
     std::map<itype_id, int> salvage;
     std::map<material_id, units::mass> mat_to_weight;
@@ -1848,7 +1991,7 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
                 p.i_add_or_drop( result, amount );
             } else {
                 for( int i = 0; i < amount; i++ ) {
-                    put_into_vehicle_or_drop( p, item_drop_reason::deliberate, { result }, pos );
+                    put_into_vehicle_or_drop( p, item_drop_reason::deliberate, { result }, &here, pos );
                 }
             }
         } else {
@@ -1953,8 +2096,20 @@ bool inscribe_actor::item_inscription( item &tool, item &cut ) const
     return true;
 }
 
-std::optional<int> inscribe_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> inscribe_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
+    return inscribe_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> inscribe_actor::use( Character *p, item &it, map *here,
+                                        const tripoint_bub_ms & ) const
+{
+    if( here != &get_map() ) { // or make 'choose_adjacent' map aware.
+        debugmsg( "%s called action inscribe that can only be performed in the reality bubble",
+                  it.typeId().str() );
+        return std::nullopt;
+    }
+
     if( !p ) {
         debugmsg( "%s called action inscribe that requires character but no character is present",
                   it.typeId().str() );
@@ -1985,7 +2140,7 @@ std::optional<int> inscribe_actor::use( Character *p, item &it, const tripoint_b
             return std::nullopt;
         }
         return iuse::handle_ground_graffiti( *p, &it, string_format( _( "%s what?" ), verb ),
-                                             dest_.value() );
+                                             here, dest_.value() );
     }
 
     item_location loc = game_menus::inv::titled_menu( get_avatar(), _( "Inscribe which item?" ) );
@@ -2023,7 +2178,13 @@ std::unique_ptr<iuse_actor> fireweapon_off_actor::clone() const
 }
 
 std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return fireweapon_off_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
+        map *here, const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action fireweapon_off that requires character but no character is present",
@@ -2035,7 +2196,9 @@ std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
     p->mod_moves( -moves );
     if( rng( 0, 10 ) - it.damage_level() > success_chance && !p->is_underwater() ) {
         if( noise > 0 ) {
-            sounds::sound( p->pos_bub(), noise, sounds::sound_t::combat, success_message );
+            if( here == &get_map() ) { // or make 'sound' map aware
+                sounds::sound( p->pos_bub( here ), noise, sounds::sound_t::combat, success_message );
+            }
         } else {
             p->add_msg_if_player( "%s", success_message );
         }
@@ -2050,7 +2213,13 @@ std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
 }
 
 ret_val<void> fireweapon_off_actor::can_use( const Character &p, const item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return fireweapon_off_actor::can_use( p, it, &get_map(), pos );
+}
+
+ret_val<void> fireweapon_off_actor::can_use( const Character &p, const item &it,
+        map *, const tripoint_bub_ms & ) const
 {
     if( !it.ammo_sufficient( &p ) ) {
         return ret_val<void>::make_failure( _( "This tool doesn't have enough charges." ) );
@@ -2079,6 +2248,12 @@ std::unique_ptr<iuse_actor> fireweapon_on_actor::clone() const
 std::optional<int> fireweapon_on_actor::use( Character *p, item &it,
         const tripoint_bub_ms &pos ) const
 {
+    return fireweapon_on_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> fireweapon_on_actor::use( Character *p, item &it,
+        map *here, const tripoint_bub_ms &pos ) const
+{
     bool extinguish = true;
     translation deactivation_msg;
     if( !it.ammo_sufficient( p ) ) {
@@ -2090,8 +2265,7 @@ std::optional<int> fireweapon_on_actor::use( Character *p, item &it,
     }
 
     if( !p ) {
-        map &here = get_map();
-        if( here.is_water_shallow_current( pos ) || here.is_divable( pos ) ) {
+        if( here->is_water_shallow_current( pos ) || here->is_divable( pos ) ) {
             // Item is on ground on water
             extinguish = true;
         }
@@ -2126,12 +2300,25 @@ std::unique_ptr<iuse_actor> manualnoise_actor::clone() const
     return std::make_unique<manualnoise_actor>( *this );
 }
 
-std::optional<int> manualnoise_actor::use( Character *p, item &, const tripoint_bub_ms & ) const
+std::optional<int> manualnoise_actor::use( Character *p, item &it,
+        const tripoint_bub_ms &pos ) const
 {
+    return manualnoise_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> manualnoise_actor::use( Character *p, item &, map *here,
+        const tripoint_bub_ms & ) const
+{
+    if( here !=
+        &get_map() ) { // or make 'sound' work outside the reality bubble, or translate position to bubble
+        debugmsg( "manualnoise action can only be performed in the reality bubble" );
+        return std::nullopt;
+    }
+
     // Uses the moves specified by iuse_actor's definition
     p->mod_moves( -moves );
     if( noise > 0 ) {
-        sounds::sound( p->pos_bub(), noise, sounds::sound_t::activity,
+        sounds::sound( p->pos_bub( here ), noise, sounds::sound_t::activity,
                        noise_message.empty() ? _( "Hsss" ) : noise_message.translated(), true, noise_id, noise_variant );
     }
     p->add_msg_if_player( "%s", use_message );
@@ -2139,7 +2326,13 @@ std::optional<int> manualnoise_actor::use( Character *p, item &, const tripoint_
 }
 
 ret_val<void> manualnoise_actor::can_use( const Character &p, const item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return manualnoise_actor::can_use( p, it, &get_map(), pos );
+}
+
+ret_val<void> manualnoise_actor::can_use( const Character &p, const item &it,
+        map *, const tripoint_bub_ms & ) const
 {
     if( !it.ammo_sufficient( &p ) ) {
         return ret_val<void>::make_failure( _( "This tool doesn't have enough charges." ) );
@@ -2158,7 +2351,13 @@ std::unique_ptr<iuse_actor> play_instrument_iuse::clone() const
 }
 
 std::optional<int> play_instrument_iuse::use( Character *p, item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return play_instrument_iuse::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> play_instrument_iuse::use( Character *p, item &it,
+        map *, const tripoint_bub_ms & ) const
 {
     if( it.active ) {
         it.active = false;
@@ -2178,7 +2377,13 @@ std::optional<int> play_instrument_iuse::use( Character *p, item &it,
 }
 
 ret_val<void> play_instrument_iuse::can_use( const Character &p, const item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return play_instrument_iuse::can_use( p, it, &get_map(), pos );
+}
+
+ret_val<void> play_instrument_iuse::can_use( const Character &p, const item &it,
+        map *, const tripoint_bub_ms & ) const
 {
     // TODO (maybe): Mouth encumbrance? Smoke? Lack of arms? Hand encumbrance?
     if( p.is_underwater() ) {
@@ -2221,8 +2426,19 @@ void musical_instrument_actor::load( const JsonObject &obj, const std::string & 
 }
 
 std::optional<int> musical_instrument_actor::use( Character *p, item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
 {
+    return musical_instrument_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> musical_instrument_actor::use( Character *p, item &it,
+        map *here, const tripoint_bub_ms & ) const
+{
+    if( here != &get_map() ) { // Or change 'sound', 'can_hear', and 'play' below
+        debugmsg( "musical instrument used outside of the reality bubble" );
+        return std::nullopt;
+    }
+
     if( !p ) {
         it.active = false;
         return std::nullopt;
@@ -2315,14 +2531,15 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
     }
 
     if( morale_effect >= 0 ) {
-        sounds::sound( p->pos_bub(), volume, sounds::sound_t::music, desc, true, "musical_instrument",
+        sounds::sound( p->pos_bub( here ), volume, sounds::sound_t::music, desc, true, "musical_instrument",
                        it.typeId().str() );
     } else {
-        sounds::sound( p->pos_bub(), volume, sounds::sound_t::music, desc, true, "musical_instrument_bad",
+        sounds::sound( p->pos_bub( here ), volume, sounds::sound_t::music, desc, true,
+                       "musical_instrument_bad",
                        it.typeId().str() );
     }
 
-    if( !p->has_effect( effect_music ) && p->can_hear( p->pos_bub(), volume ) ) {
+    if( !p->has_effect( effect_music ) && p->can_hear( p->pos_bub( here ), volume ) ) {
         // Sound code doesn't describe noises at the player position
         if( desc != "music" ) {
             p->add_msg_if_player( m_info, desc );
@@ -2330,13 +2547,19 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
     }
 
     // We already played the sounds, just handle applying effects now
-    iuse::play_music( p, p->pos_bub(), volume, morale_effect, /*play_sounds=*/false );
+    iuse::play_music( p, p->pos_bub( here ), volume, morale_effect, /*play_sounds=*/false );
 
     return 0;
 }
 
+ret_val<void> musical_instrument_actor::can_use( const Character &p, const item &it,
+        const tripoint_bub_ms &pos ) const
+{
+    return musical_instrument_actor::can_use( p, it, &get_map(), pos );
+}
+
 ret_val<void> musical_instrument_actor::can_use( const Character &p, const item &,
-        const tripoint_bub_ms & ) const
+        map *, const tripoint_bub_ms & ) const
 {
     // TODO: (maybe): Mouth encumbrance? Smoke? Lack of arms? Hand encumbrance?
     if( p.is_underwater() ) {
@@ -2398,7 +2621,14 @@ void learn_spell_actor::info( const item &, std::vector<iteminfo> &dump ) const
     }
 }
 
-std::optional<int> learn_spell_actor::use( Character *p, item &, const tripoint_bub_ms & ) const
+std::optional<int> learn_spell_actor::use( Character *p, item &it,
+        const tripoint_bub_ms &pos ) const
+{
+    return learn_spell_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> learn_spell_actor::use( Character *p, item &, map *,
+        const tripoint_bub_ms & ) const
 {
     //TODO: combine/replace the checks below with "checks for conditions" from Character::check_read_condition
 
@@ -2536,6 +2766,12 @@ std::string cast_spell_actor::get_name() const
 
 std::optional<int> cast_spell_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
+    return cast_spell_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> cast_spell_actor::use( Character *p, item &it, map * /*here*/,
+        const tripoint_bub_ms &pos ) const
+{
     if( need_worn && !p->is_worn( it ) ) {
         p->add_msg_if_player( m_info, _( "You need to wear the %1$s before activating it." ), it.tname() );
         return std::nullopt;
@@ -2549,7 +2785,8 @@ std::optional<int> cast_spell_actor::use( Character *p, item &it, const tripoint
 
     // Spell is being cast from a non-held item
     if( p == nullptr ) {
-        casting.cast_all_effects( tripoint_bub_ms( pos ) );
+        // TODO: Pass map when cast_all_effects is map aware.
+        casting.cast_all_effects( pos );
         return 0;
     }
 
@@ -2629,17 +2866,16 @@ static item_location form_loc_recursive( T &loc, item &it )
     return item_location( loc, &it );
 }
 
-static item_location form_loc( Character &you, const tripoint_bub_ms &p, item &it )
+static item_location form_loc( Character &you, map *here, const tripoint_bub_ms &p, item &it )
 {
     if( you.has_item( it ) ) {
         return form_loc_recursive( you, it );
     }
-    map_cursor mc( p );
+    map_cursor mc( here, p );
     if( mc.has_item( it ) ) {
         return form_loc_recursive( mc, it );
     }
-    map &here = get_map();
-    const optional_vpart_position vp = here.veh_at( p );
+    const optional_vpart_position vp = here->veh_at( p );
     if( vp ) {
         vehicle_cursor vc( vp->vehicle(), vp->part_index() );
         if( vc.has_item( it ) ) {
@@ -2653,6 +2889,12 @@ static item_location form_loc( Character &you, const tripoint_bub_ms &p, item &i
 }
 
 std::optional<int> holster_actor::use( Character *you, item &it, const tripoint_bub_ms &p ) const
+{
+    return holster_actor::use( you, it, &get_map(), p );
+}
+
+std::optional<int> holster_actor::use( Character *you, item &it, map *here,
+                                       const tripoint_bub_ms &p ) const
 {
     if( you->is_wielding( it ) ) {
         you->add_msg_if_player( _( "You need to unwield your %s before using it." ), it.tname() );
@@ -2718,7 +2960,7 @@ std::optional<int> holster_actor::use( Character *you, item &it, const tripoint_
         }
 
         // iuse_actor really needs to work with item_location
-        item_location item_loc = form_loc( *you, p, it );
+        item_location item_loc = form_loc( *you, here, p, it );
         game_menus::inv::insert_items( item_loc );
     }
 
@@ -2747,7 +2989,12 @@ void ammobelt_actor::info( const item &, std::vector<iteminfo> &dump ) const
                        item::nname( belt ) ) );
 }
 
-std::optional<int> ammobelt_actor::use( Character *p, item &, const tripoint_bub_ms & ) const
+std::optional<int> ammobelt_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
+{
+    return ammobelt_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> ammobelt_actor::use( Character *p, item &, map *, const tripoint_bub_ms & ) const
 {
     item mag( belt );
     mag.ammo_unset();
@@ -2821,7 +3068,8 @@ bool repair_item_actor::can_use_tool( const Character &p, const item &tool, bool
     return true;
 }
 
-static item_location get_item_location( Character &p, item &it, const tripoint_bub_ms &pos )
+static item_location get_item_location( Character &p, item &it, map *here,
+                                        const tripoint_bub_ms &pos )
 {
     // Item on a character
     if( p.has_item( it ) ) {
@@ -2829,7 +3077,7 @@ static item_location get_item_location( Character &p, item &it, const tripoint_b
     }
 
     // Item in a vehicle
-    if( const optional_vpart_position &vp = get_map().veh_at( pos ) ) {
+    if( const optional_vpart_position &vp = here->veh_at( pos ) ) {
         vehicle_cursor vc( vp->vehicle(), vp->part_index() );
         bool found_in_vehicle = false;
         vc.visit_items( [&]( const item * e, item * ) {
@@ -2845,11 +3093,17 @@ static item_location get_item_location( Character &p, item &it, const tripoint_b
     }
 
     // Item on the map
-    return item_location( map_cursor( pos ), &it );
+    return item_location( map_cursor( here, pos ), &it );
 }
 
 std::optional<int> repair_item_actor::use( Character *p, item &it,
-        const tripoint_bub_ms &position ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return repair_item_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> repair_item_actor::use( Character *p, item &it,
+        map *here, const tripoint_bub_ms &pos ) const
 {
     if( !can_use_tool( *p, it, true ) ) {
         return std::nullopt;
@@ -2859,7 +3113,7 @@ std::optional<int> repair_item_actor::use( Character *p, item &it,
     // We also need to store the repair actor subtype in the activity
     p->activity.str_values.push_back( type );
     // storing of item_location to support repairs by tools on the ground
-    p->activity.targets.emplace_back( get_item_location( *p, it, position ) );
+    p->activity.targets.emplace_back( get_item_location( *p, it, here, pos ) );
     // All repairs are done in the activity, including charge cost and target item selection
     return 0;
 }
@@ -3171,6 +3425,8 @@ repair_item_actor::repair_type repair_item_actor::default_action( const item &fi
 
 static bool damage_item( Character &pl, item_location &fix )
 {
+    map &here = get_map();
+
     const std::string startdurability = fix->durability_indicator( true );
     const bool destroyed = fix->inc_damage();
     const std::string resultdurability = fix->durability_indicator( true );
@@ -3185,7 +3441,7 @@ static bool damage_item( Character &pl, item_location &fix )
                 if( it->has_flag( flag_NO_DROP ) ) {
                     continue;
                 }
-                put_into_vehicle_or_drop( pl, item_drop_reason::tumbling, { *it }, fix.pos_bub() );
+                put_into_vehicle_or_drop( pl, item_drop_reason::tumbling, { *it }, &here, fix.pos_bub() );
             }
             fix.remove_item();
         }
@@ -3409,13 +3665,13 @@ void heal_actor::load( const JsonObject &obj, const std::string & )
     }
 }
 
-static Character &get_patient( Character &healer, const tripoint_bub_ms &pos )
+static Character &get_patient( Character &healer, map *here, const tripoint_bub_ms &pos )
 {
-    if( healer.pos_bub() == pos ) {
+    if( healer.pos_bub( here ) == pos ) {
         return healer;
     }
 
-    Character *const person = get_creature_tracker().creature_at<Character>( pos );
+    Character *const person = get_creature_tracker().creature_at<Character>( here->get_abs( pos ) );
     if( !person ) {
         // Default to heal self on failure not to break old functionality
         add_msg_debug( debugmode::DF_IUSE, "No heal target at position %d,%d,%d", pos.x(), pos.y(),
@@ -3428,6 +3684,12 @@ static Character &get_patient( Character &healer, const tripoint_bub_ms &pos )
 
 std::optional<int> heal_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
+    return heal_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> heal_actor::use( Character *p, item &it, map *here,
+                                    const tripoint_bub_ms &pos ) const
+{
     if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
@@ -3439,7 +3701,7 @@ std::optional<int> heal_actor::use( Character *p, item &it, const tripoint_bub_m
         return std::nullopt;
     }
 
-    Character &patient = get_patient( *p, pos );
+    Character &patient = get_patient( *p, here, pos );
     const bodypart_str_id hpp = use_healing_item( *p, patient, it, false ).id();
     if( hpp == bodypart_str_id::NULL_ID() ) {
         return std::nullopt;
@@ -3974,8 +4236,19 @@ static void place_and_add_as_known( Character &p, const tripoint_bub_ms &pos,
     }
 }
 
-std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
+    return place_trap_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> place_trap_actor::use( Character *p, item &it, map *here,
+        const tripoint_bub_ms & ) const
+{
+    if( here != &get_map() ) { // Or make 'choose_adjacent' and 'is_allowed' map aware.
+        debugmsg( "place_trap_actor::use cannot act on non reality bubble map." );
+        return std::nullopt;
+    }
+
     const bool could_bury = !bury_question.empty();
     if( !allow_underwater && p->cant_do_underwater() ) {
         return std::nullopt;
@@ -3995,14 +4268,13 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
         return std::nullopt;
     }
 
-    map &here = get_map();
     int distance_to_trap_center = unburied_data.trap.obj().get_trap_radius() +
                                   outer_layer_trap.obj().get_trap_radius() + 1;
     if( unburied_data.trap.obj().get_trap_radius() > 0 ) {
         // Math correction for multi-tile traps
         pos.x() = ( pos.x() - p->posx() ) * distance_to_trap_center + p->posx();
         pos.y() = ( pos.y() - p->posy() ) * distance_to_trap_center + p->posy();
-        for( const tripoint_bub_ms &t : here.points_in_radius( pos,
+        for( const tripoint_bub_ms &t : here->points_in_radius( pos,
                 outer_layer_trap.obj().get_trap_radius(),
                 0 ) ) {
             if( !is_allowed( *p, t, it.tname() ) ) {
@@ -4015,14 +4287,14 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
     }
 
     const bool has_shovel = p->has_quality( qual_DIG, 3 );
-    const bool is_diggable = here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, pos );
+    const bool is_diggable = here->has_flag( ter_furn_flag::TFLAG_DIGGABLE, pos );
     bool bury = false;
     if( could_bury && has_shovel && is_diggable ) {
         bury = query_yn( "%s", bury_question );
     }
     const place_trap_actor::data &data = bury ? buried_data : unburied_data;
 
-    p->add_msg_if_player( m_info, data.done_message.translated(), here.tername( pos ) );
+    p->add_msg_if_player( m_info, data.done_message.translated(), here->tername( pos ) );
     p->practice( skill_traps, data.practice );
     p->practice_proficiency( proficiency_prof_traps,
                              time_duration::from_seconds( data.practice * 30 ) );
@@ -4044,11 +4316,11 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
     p->mod_moves( -move_cost_final );
 
     place_and_add_as_known( *p, pos, data.trap );
-    const trap &placed_trap = here.tr_at( pos );
+    const trap &placed_trap = here->tr_at( pos );
     if( !placed_trap.is_null() ) {
         const_cast<trap &>( placed_trap ).set_trap_data( it.typeId() );
     }
-    for( const tripoint_bub_ms &t : here.points_in_radius( pos, data.trap.obj().get_trap_radius(),
+    for( const tripoint_bub_ms &t : here->points_in_radius( pos, data.trap.obj().get_trap_radius(),
             0 ) ) {
         if( t != pos ) {
             place_and_add_as_known( *p, t, outer_layer_trap );
@@ -4063,12 +4335,17 @@ void emit_actor::load( const JsonObject &obj, const std::string & )
     assign( obj, "scale_qty", scale_qty );
 }
 
-std::optional<int> emit_actor::use( Character *, item &it, const tripoint_bub_ms &pos ) const
+std::optional<int> emit_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
 {
-    map &here = get_map();
+    return emit_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> emit_actor::use( Character *, item &it, map *here,
+                                    const tripoint_bub_ms &pos ) const
+{
     const float scaling = scale_qty ? it.charges : 1.0f;
     for( const auto &e : emits ) {
-        here.emit_field( pos, e, scaling );
+        here->emit_field( pos, e, scaling );
     }
 
     return 1;
@@ -4103,7 +4380,13 @@ void saw_barrel_actor::load( const JsonObject &jo, const std::string & )
 }
 
 //Todo: Make this consume charges if performed with a tool that uses charges.
-std::optional<int> saw_barrel_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> saw_barrel_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
+{
+    return saw_barrel_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> saw_barrel_actor::use( Character *p, item &it, map *,
+        const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action saw_barrel that requires character but no character is present",
@@ -4164,7 +4447,13 @@ void saw_stock_actor::load( const JsonObject &jo, const std::string & )
 }
 
 //Todo: Make this consume charges if performed with a tool that uses charges.
-std::optional<int> saw_stock_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> saw_stock_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
+{
+    return saw_stock_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> saw_stock_actor::use( Character *p, item &it, map *,
+        const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action saw_stock that requires character but no character is present",
@@ -4240,7 +4529,13 @@ void molle_attach_actor::load( const JsonObject &jo, const std::string & )
 }
 
 std::optional<int> molle_attach_actor::use( Character *p, item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return molle_attach_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> molle_attach_actor::use( Character *p, item &it,
+        map *, const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action molle_attach that requires character but no character is present",
@@ -4272,7 +4567,13 @@ std::unique_ptr<iuse_actor> molle_attach_actor::clone() const
 }
 
 std::optional<int> molle_detach_actor::use( Character *p, item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return molle_detach_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> molle_detach_actor::use( Character *p, item &it,
+        map *, const tripoint_bub_ms & ) const
 {
 
     std::vector<const item *> items_attached = it.get_contents().get_added_pockets();
@@ -4306,7 +4607,13 @@ void molle_detach_actor::load( const JsonObject &jo, const std::string & )
 }
 
 std::optional<int> install_bionic_actor::use( Character *p, item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return install_bionic_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> install_bionic_actor::use( Character *p, item &it,
+        map *, const tripoint_bub_ms & ) const
 {
     if( p->can_install_bionics( *it.type, *p, false ) ) {
         if( !p->has_trait( trait_DEBUG_BIONICS ) && !p->has_flag( json_flag_MANUAL_CBM_INSTALLATION ) ) {
@@ -4321,7 +4628,13 @@ std::optional<int> install_bionic_actor::use( Character *p, item &it,
 }
 
 ret_val<void> install_bionic_actor::can_use( const Character &p, const item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return install_bionic_actor::can_use( p, it, &get_map(), pos );
+}
+
+ret_val<void> install_bionic_actor::can_use( const Character &p, const item &it,
+        map *, const tripoint_bub_ms & ) const
 {
     if( !it.is_bionic() ) {
         return ret_val<void>::make_failure();
@@ -4378,7 +4691,13 @@ void install_bionic_actor::finalize( const itype_id &my_item_type )
 }
 
 std::optional<int> detach_gunmods_actor::use( Character *p, item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return detach_gunmods_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> detach_gunmods_actor::use( Character *p, item &it,
+        map *, const tripoint_bub_ms & ) const
 {
     auto filter_irremovable = []( std::vector<item *> &gunmods ) {
         gunmods.erase(
@@ -4431,7 +4750,13 @@ std::optional<int> detach_gunmods_actor::use( Character *p, item &it,
 }
 
 ret_val<void> detach_gunmods_actor::can_use( const Character &p, const item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return detach_gunmods_actor::can_use( p, it, &get_map(), pos );
+}
+
+ret_val<void> detach_gunmods_actor::can_use( const Character &p, const item &it,
+        map *, const tripoint_bub_ms & ) const
 {
     const std::vector<const item *> mods = it.gunmods();
 
@@ -4470,7 +4795,13 @@ void detach_gunmods_actor::finalize( const itype_id &my_item_type )
 }
 
 std::optional<int> modify_gunmods_actor::use( Character *p, item &it,
-        const tripoint_bub_ms &pnt ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return modify_gunmods_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> modify_gunmods_actor::use( Character *p, item &it,
+        map */*here*/, const tripoint_bub_ms &pos ) const
 {
 
     std::vector<item *> mods;
@@ -4493,7 +4824,8 @@ std::optional<int> modify_gunmods_actor::use( Character *p, item &it,
     if( prompt.ret >= 0 ) {
         // set gun to default in case this changes anything
         it.gun_set_mode( gun_mode_DEFAULT );
-        p->invoke_item( mods[prompt.ret], "transform", tripoint_bub_ms( pnt ) );
+        // TODO: make 'invoke_item' map aware.
+        p->invoke_item( mods[prompt.ret], "transform", pos );
         it.on_contents_changed();
         return 0;
     }
@@ -4503,7 +4835,13 @@ std::optional<int> modify_gunmods_actor::use( Character *p, item &it,
 }
 
 ret_val<void> modify_gunmods_actor::can_use( const Character &p, const item &it,
-        const tripoint_bub_ms & ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return modify_gunmods_actor::can_use( p, it, &get_map(), pos );
+}
+
+ret_val<void> modify_gunmods_actor::can_use( const Character &p, const item &it,
+        map *, const tripoint_bub_ms & ) const
 {
     if( !p.is_wielding( it ) ) {
         return ret_val<void>::make_failure( _( "Need to be wielding." ) );
@@ -4628,7 +4966,13 @@ void link_up_actor::info( const item &it, std::vector<iteminfo> &dump ) const
     }
 }
 
-std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint_bub_ms &pnt ) const
+std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
+{
+    return link_up_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> link_up_actor::use( Character *p, item &it, map *here,
+                                       const tripoint_bub_ms &pos ) const
 {
     if( !p ) {
         debugmsg( "%s called action link_up that requires character but no character is present",
@@ -4840,14 +5184,12 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint_bu
 
     } else if( choice == 30 ) {
         // Selection: Attach to another cable, resulting in a longer one.
-        return link_extend_cable( p, it, pnt );
+        return link_extend_cable( p, it, here, pos );
 
     } else if( choice == 31 ) {
         // Selection: Remove all cable extensions and give the individual cables to the player.
         return remove_extensions( p, it );
     }
-
-    map &here = get_map();
 
     if( choice == 20 ) {
         // Selection: Attach electrical cable to Cable Charger System CBM.
@@ -4867,7 +5209,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint_bu
         }
 
         it.update_link_traits();
-        it.process( here, p, p->pos_bub() );
+        it.process( *here, p, p->pos_bub( here ) );
         p->mod_moves( -move_cost );
         return 0;
 
@@ -4903,7 +5245,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint_bu
         it.link().source = link_state::ups;
         loc->set_var( "cable", "plugged_in" );
         it.update_link_traits();
-        it.process( here, p, p->pos_bub() );
+        it.process( *here, p, p->pos_bub( here ) );
         p->mod_moves( -move_cost );
         return 0;
 
@@ -4939,7 +5281,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint_bu
         it.link().source = link_state::solarpack;
         loc->set_var( "cable", "plugged_in" );
         it.update_link_traits();
-        it.process( here, p, p->pos_bub() );
+        it.process( *here, p, p->pos_bub( here ) );
         p->mod_moves( -move_cost );
         return 0;
     }
@@ -5114,7 +5456,7 @@ std::optional<int> link_up_actor::link_tow_cable( Character *p, item &it,
 }
 
 std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
-        const tripoint_bub_ms &pnt ) const
+        map *here, const tripoint_bub_ms &pnt ) const
 {
     avatar *you = p->as_avatar();
     if( !you ) {
@@ -5153,8 +5495,8 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
         return std::nullopt;
     }
 
-    item_location extension = is_cable_item ? form_loc( *p, pnt, it ) : selected;
-    item_location extended = is_cable_item ? selected : form_loc( *p, pnt, it );
+    item_location extension = is_cable_item ? form_loc( *p, here, pnt, it ) : selected;
+    item_location extended = is_cable_item ? selected : form_loc( *p, here, pnt, it );
     std::optional<item> extended_copy;
 
     // We'll make a copy of the extended item and check pocket weight/volume capacity if:
@@ -5186,7 +5528,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
         extended_ptr->link() = extension->link();
     }
     extended_ptr->update_link_traits();
-    extended_ptr->process( get_map(), p, p->pos_bub() );
+    extended_ptr->process( *here, p, p->pos_bub( here ) );
 
     if( extended_copy ) {
         // Check if there's another pocket on the same container that can hold the extended item, respecting pocket settings.
@@ -5282,8 +5624,20 @@ void deploy_tent_actor::load( const JsonObject &obj, const std::string & )
     assign( obj, "broken_type", broken_type );
 }
 
-std::optional<int> deploy_tent_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> deploy_tent_actor::use( Character *p, item &it,
+        const tripoint_bub_ms &pos ) const
 {
+    return deploy_tent_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> deploy_tent_actor::use( Character *p, item &it, map *here,
+        const tripoint_bub_ms & ) const
+{
+    if( here != &get_map() ) { // Or make 'choose_direction' map aware.
+        debugmsg( "deply_tent_actor::use can only be called from the reality bubble" );
+        return std::nullopt;
+    }
+
     int diam = 2 * radius + 1;
     if( p->cant_do_mounted() ) {
         return std::nullopt;
@@ -5295,15 +5649,14 @@ std::optional<int> deploy_tent_actor::use( Character *p, item &it, const tripoin
     }
     const tripoint_rel_ms direction = *dir;
 
-    map &here = get_map();
     // We place the center of the structure (radius + 1)
     // spaces away from the player.
     // First check there's enough room.
-    const tripoint_bub_ms center = p->pos_bub() + point_rel_ms( ( radius + 1 ) * direction.x(),
+    const tripoint_bub_ms center = p->pos_bub( here ) + point_rel_ms( ( radius + 1 ) * direction.x(),
                                    ( radius + 1 ) * direction.y() );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint_bub_ms &dest : here.points_in_radius( center, radius ) ) {
-        if( const optional_vpart_position vp = here.veh_at( dest ) ) {
+    for( const tripoint_bub_ms &dest : here->points_in_radius( center, radius ) ) {
+        if( const optional_vpart_position vp = here->veh_at( dest ) ) {
             add_msg( m_info, _( "The %s is in the way." ), vp->vehicle().name );
             return std::nullopt;
         }
@@ -5311,13 +5664,13 @@ std::optional<int> deploy_tent_actor::use( Character *p, item &it, const tripoin
             add_msg( m_info, _( "The %s is in the way." ), c->disp_name() );
             return std::nullopt;
         }
-        if( here.impassable( dest ) || !here.has_flag( ter_furn_flag::TFLAG_FLAT, dest ) ) {
+        if( here->impassable( dest ) || !here->has_flag( ter_furn_flag::TFLAG_FLAT, dest ) ) {
             add_msg( m_info, _( "The %s in that direction isn't suitable for placing the %s." ),
-                     here.name( dest ), it.tname() );
+                     here->name( dest ), it.tname() );
             return std::nullopt;
         }
-        if( here.has_furn( dest ) ) {
-            add_msg( m_info, _( "There is already furniture (%s) there." ), here.furnname( dest ) );
+        if( here->has_furn( dest ) ) {
+            add_msg( m_info, _( "There is already furniture (%s) there." ), here->furnname( dest ) );
             return std::nullopt;
         }
     }
@@ -5360,7 +5713,13 @@ void weigh_self_actor::info( const item &, std::vector<iteminfo> &dump ) const
                        _( "Use this item to weigh yourself.  Includes everything you are wearing." ) );
 }
 
-std::optional<int> weigh_self_actor::use( Character *p, item &, const tripoint_bub_ms & ) const
+std::optional<int> weigh_self_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
+{
+    return weigh_self_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> weigh_self_actor::use( Character *p, item &, map *,
+        const tripoint_bub_ms & ) const
 {
     if( p->is_mounted() ) {
         p->add_msg_if_player( m_info, _( "You cannot weigh yourself while mounted." ) );
@@ -5404,7 +5763,14 @@ void sew_advanced_actor::load( const JsonObject &obj, const std::string & )
     }
 }
 
-std::optional<int> sew_advanced_actor::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> sew_advanced_actor::use( Character *p, item &it,
+        const tripoint_bub_ms &pos ) const
+{
+    return sew_advanced_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> sew_advanced_actor::use( Character *p, item &it, map *here,
+        const tripoint_bub_ms & ) const
 {
     if( p->is_npc() ) {
         return std::nullopt;
@@ -5454,7 +5820,7 @@ std::optional<int> sew_advanced_actor::use( Character *p, item &it, const tripoi
     // Cache available materials
     std::map< itype_id, bool > has_enough;
     const int items_needed = mod.base_volume() / 750_ml + 1;
-    const inventory &crafting_inv = p->crafting_inventory();
+    const inventory &crafting_inv = p->crafting_inventory( here );
     const std::function<bool( const item & )> is_filthy_filter = is_crafting_component;
 
     // Go through all discovered repair items and see if we have any of them available
@@ -5645,7 +6011,14 @@ void change_scent_iuse::load( const JsonObject &obj, const std::string & )
     assign( obj, "waterproof", waterproof );
 }
 
-std::optional<int> change_scent_iuse::use( Character *p, item &it, const tripoint_bub_ms & ) const
+std::optional<int> change_scent_iuse::use( Character *p, item &it,
+        const tripoint_bub_ms &pos ) const
+{
+    return change_scent_iuse::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> change_scent_iuse::use( Character *p, item &it, map *,
+        const tripoint_bub_ms & ) const
 {
     p->set_value( "prev_scent", p->get_type_of_scent().c_str() );
     if( waterproof ) {
@@ -5698,7 +6071,13 @@ void effect_on_conditons_actor::info( const item &, std::vector<iteminfo> &dump 
 }
 
 std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
-        const tripoint_bub_ms &point ) const
+        const tripoint_bub_ms &pos ) const
+{
+    return effect_on_conditons_actor::use( p, it, &get_map(), pos );
+}
+
+std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
+        map *here, const tripoint_bub_ms &pos ) const
 {
     if( it.type->comestible ) {
         debugmsg( "Comestibles are not properly consumed via effect_on_conditions and effect_on_conditions should not be used on items of type comestible until/unless this is resolved.  Rather than a use_action, use the consumption_effect_on_conditions JSON parameter on the comestible" );
@@ -5723,7 +6102,7 @@ std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
         }
         loc = item_location( *p->as_character(), &it );
     } else {
-        loc = item_location( map_cursor( point ), &it );
+        loc = item_location( map_cursor( here, pos ), &it );
     }
 
     dialogue d( ( char_ptr == nullptr ? nullptr : get_talker_for( char_ptr ) ), get_talker_for( loc ) );

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1250,7 +1250,7 @@ class sew_advanced_actor : public iuse_actor
 /**
  * Activate an array of effect_on_conditions
  */
-class effect_on_conditons_actor : public iuse_actor
+class effect_on_conditions_actor : public iuse_actor
 {
     public:
         std::vector<effect_on_condition_id> eocs;
@@ -1260,10 +1260,11 @@ class effect_on_conditons_actor : public iuse_actor
         bool need_worn = false;
         /**does the item requires to be wielded to be activable*/
         bool need_wielding = false;
-        explicit effect_on_conditons_actor( const std::string &type = "effect_on_conditions" ) : iuse_actor(
+        explicit effect_on_conditions_actor( const std::string &type = "effect_on_conditions" ) :
+            iuse_actor(
                 type ) {}
 
-        ~effect_on_conditons_actor() override = default;
+        ~effect_on_conditions_actor() override = default;
         void load( const JsonObject &obj, const std::string &src ) override;
         std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
         std::optional<int> use( Character *p, item &it, map *here,

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -113,8 +113,11 @@ class iuse_transform : public iuse_actor
 
         ~iuse_transform() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *, item &, map *, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms &pos ) const override;
+        ret_val<void> can_use( const Character &, const item &, map *here,
+                               const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
         void finalize( const itype_id &my_item_type ) override;
@@ -142,7 +145,8 @@ class unpack_actor : public iuse_actor
 
         ~unpack_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> &dump ) const override;
 };
@@ -160,7 +164,8 @@ class message_iuse : public iuse_actor
 
         ~message_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *, item &, map *here, const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
 };
@@ -182,7 +187,8 @@ class sound_iuse : public iuse_actor
 
         ~sound_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *, item &, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *, item &, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
 };
@@ -220,7 +226,9 @@ class explosion_iuse : public iuse_actor
 
         ~explosion_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here,
+                                const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -268,7 +276,8 @@ class consume_drug_iuse : public iuse_actor
 
         ~consume_drug_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 
@@ -303,7 +312,9 @@ class delayed_transform_iuse : public iuse_transform
 
         ~delayed_transform_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here,
+                                const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -336,7 +347,8 @@ class place_monster_iuse : public iuse_actor
         place_monster_iuse() : iuse_actor( "place_monster" ) { }
         ~place_monster_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &, map *here, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -364,7 +376,8 @@ class change_scent_iuse : public iuse_actor
         change_scent_iuse() : iuse_actor( "change_scent" ) { }
         ~change_scent_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -383,7 +396,8 @@ class place_npc_iuse : public iuse_actor
         place_npc_iuse() : iuse_actor( "place_npc" ) { }
         ~place_npc_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &, map *here, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -402,7 +416,9 @@ class deploy_furn_actor : public iuse_actor
 
         ~deploy_furn_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here,
+                                const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -419,7 +435,9 @@ class deploy_appliance_actor : public iuse_actor
         ~deploy_appliance_actor() override = default;
 
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here,
+                                const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -455,7 +473,8 @@ class reveal_map_actor : public iuse_actor
 
         ~reveal_map_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -480,11 +499,11 @@ class firestarter_actor : public iuse_actor
          */
         bool need_sunlight = false;
 
-        static bool prep_firestarter_use( const Character &p, tripoint_bub_ms &pos );
+        static bool prep_firestarter_use( const Character &p, map *here, tripoint_bub_ms &pos );
         /** Player here isn't const because pyromaniacs gain a mood boost from it */
-        static void resolve_firestarter_use( Character *p, const tripoint_bub_ms &pos );
+        static void resolve_firestarter_use( Character *p, map *here, const tripoint_bub_ms &pos );
         /** Modifier on speed - higher is better, 0 means it won't work. */
-        float light_mod( const tripoint_bub_ms &pos ) const;
+        float light_mod( map *here, const tripoint_bub_ms &pos ) const;
         /** Checks quality of fuel on the tile and interpolates move cost based on that. */
         int moves_cost_by_fuel( const tripoint_bub_ms &pos ) const;
 
@@ -492,8 +511,13 @@ class firestarter_actor : public iuse_actor
 
         ~firestarter_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here,
+                                const tripoint_bub_ms &spos ) const override;
+        ret_val<void> can_use( const Character &p, const item &it,
+                               const tripoint_bub_ms &pos ) const override;
+        ret_val<void> can_use( const Character &p, const item &it, map *,
+                               const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -515,6 +539,7 @@ class salvage_actor : public iuse_actor
         ~salvage_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *, item &, map *here, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
     private:
         void cut_up( Character &p, item_location &cut ) const;
@@ -557,7 +582,8 @@ class inscribe_actor : public iuse_actor
 
         ~inscribe_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -580,8 +606,12 @@ class fireweapon_off_actor : public iuse_actor
 
         ~fireweapon_off_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &p, const item &it,
+                               const tripoint_bub_ms &pos ) const override;
+        ret_val<void> can_use( const Character &p, const item &it, map *,
+                               const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -602,6 +632,7 @@ class fireweapon_on_actor : public iuse_actor
         ~fireweapon_on_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *, item &, map *here, const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -622,8 +653,12 @@ class manualnoise_actor : public iuse_actor
 
         ~manualnoise_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &, map *here, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &p, const item &it,
+                               const tripoint_bub_ms &pos ) const override;
+        ret_val<void> can_use( const Character &p, const item &it, map *,
+                               const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -634,8 +669,12 @@ class play_instrument_iuse : public iuse_actor
 
         ~play_instrument_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &p, const item &it,
+                               const tripoint_bub_ms &pos ) const override;
+        ret_val<void> can_use( const Character &p, const item &it, map *,
+                               const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -679,8 +718,12 @@ class musical_instrument_actor : public iuse_actor
 
         ~musical_instrument_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
-        ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &p, const item &it,
+                               const tripoint_bub_ms &pos ) const override;
+        ret_val<void> can_use( const Character &p, const item &, map *,
+                               const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -697,7 +740,8 @@ class learn_spell_actor : public iuse_actor
 
         ~learn_spell_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *p, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -724,7 +768,9 @@ class cast_spell_actor : public iuse_actor
 
         ~cast_spell_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map * /*here*/,
+                                const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
         std::string get_name() const override;
@@ -751,7 +797,9 @@ class holster_actor : public iuse_actor
 
         ~holster_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *you, item &it, const tripoint_bub_ms &p ) const override;
+        std::optional<int> use( Character *you, item &it, map *here,
+                                const tripoint_bub_ms &p ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -765,7 +813,8 @@ class ammobelt_actor : public iuse_actor
 
         ~ammobelt_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -856,7 +905,9 @@ class repair_item_actor : public iuse_actor
 
         ~repair_item_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here,
+                                const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
         std::string get_name() const override;
@@ -923,7 +974,9 @@ class heal_actor : public iuse_actor
 
         ~heal_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here,
+                                const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -970,7 +1023,8 @@ class place_trap_actor : public iuse_actor
         explicit place_trap_actor( const std::string &type = "place_trap" );
         ~place_trap_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -984,7 +1038,9 @@ class emit_actor : public iuse_actor
         explicit emit_actor( const std::string &type = "emit_actor" ) : iuse_actor( type ) {}
         ~emit_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *, item &it, map *here,
+                                const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void finalize( const itype_id &my_item_type ) override;
 };
@@ -995,7 +1051,8 @@ class saw_barrel_actor : public iuse_actor
         explicit saw_barrel_actor( const std::string &type = "saw_barrel" ) : iuse_actor( type ) {}
 
         void load( const JsonObject &jo, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
         ret_val<void> can_use_on( const Character &you, const item &it, const item &target ) const;
@@ -1007,7 +1064,8 @@ class saw_stock_actor : public iuse_actor
         explicit saw_stock_actor( const std::string &type = "saw_stock" ) : iuse_actor( type ) {}
 
         void load( const JsonObject &jo, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
         ret_val<void> can_use_on( const Character &you, const item &it, const item &target ) const;
@@ -1023,7 +1081,8 @@ class molle_attach_actor : public iuse_actor
         int moves;
 
         void load( const JsonObject &jo, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -1036,7 +1095,8 @@ class molle_detach_actor : public iuse_actor
         int moves;
 
         void load( const JsonObject &jo, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -1046,8 +1106,12 @@ class install_bionic_actor : public iuse_actor
         explicit install_bionic_actor( const std::string &type = "install_bionic" ) : iuse_actor( type ) {}
 
         void load( const JsonObject &, const std::string & ) override {}
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
-        ret_val<void> can_use( const Character &, const item &it, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &, const item &it,
+                               const tripoint_bub_ms &pos ) const override;
+        ret_val<void> can_use( const Character &, const item &it, map *,
+                               const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void finalize( const itype_id &my_item_type ) override;
 };
@@ -1058,8 +1122,12 @@ class detach_gunmods_actor : public iuse_actor
         explicit detach_gunmods_actor( const std::string &type = "detach_gunmods" ) : iuse_actor( type ) {}
 
         void load( const JsonObject &, const std::string & ) override {}
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
-        ret_val<void> can_use( const Character &, const item &it, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *, const tripoint_bub_ms & ) const override;
+        ret_val<void> can_use( const Character &, const item &it,
+                               const tripoint_bub_ms &pos ) const override;
+        ret_val<void> can_use( const Character &, const item &it, map *,
+                               const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void finalize( const itype_id &my_item_type ) override;
 };
@@ -1070,8 +1138,13 @@ class modify_gunmods_actor : public iuse_actor
         explicit modify_gunmods_actor( const std::string &type = "modify_gunmods" ) : iuse_actor( type ) {}
 
         void load( const JsonObject &, const std::string & ) override {}
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
-        ret_val<void> can_use( const Character &, const item &it, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map */*here*/,
+                                const tripoint_bub_ms &pos ) const override;
+        ret_val<void> can_use( const Character &, const item &it,
+                               const tripoint_bub_ms &pos ) const override;
+        ret_val<void> can_use( const Character &, const item &it, map *,
+                               const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void finalize( const itype_id &my_item_type ) override;
 };
@@ -1095,7 +1168,8 @@ class link_up_actor : public iuse_actor
 
         std::optional<int> link_to_veh_app( Character *p, item &it, bool to_ports ) const;
         std::optional<int> link_tow_cable( Character *p, item &it, bool to_towing ) const;
-        std::optional<int> link_extend_cable( Character *p, item &it, const tripoint_bub_ms &pnt ) const;
+        std::optional<int> link_extend_cable( Character *p, item &it, map *here,
+                                              const tripoint_bub_ms &pnt ) const;
         std::optional<int> remove_extensions( Character *p, item &it ) const;
 
         link_up_actor() : iuse_actor( "link_up" ) {}
@@ -1105,7 +1179,9 @@ class link_up_actor : public iuse_actor
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pnt ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here,
+                                const tripoint_bub_ms &pos ) const override;
 };
 
 class deploy_tent_actor : public iuse_actor
@@ -1123,7 +1199,8 @@ class deploy_tent_actor : public iuse_actor
 
         ~deploy_tent_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *, item &, map *here, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
         bool check_intact( const tripoint_bub_ms &center ) const;
@@ -1142,7 +1219,8 @@ class weigh_self_actor : public iuse_actor
 
         ~weigh_self_actor() override = default;
         void load( const JsonObject &jo, const std::string & ) override;
-        std::optional<int> use( Character *p, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
@@ -1164,7 +1242,8 @@ class sew_advanced_actor : public iuse_actor
 
         ~sew_advanced_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
@@ -1186,7 +1265,9 @@ class effect_on_conditons_actor : public iuse_actor
 
         ~effect_on_conditons_actor() override = default;
         void load( const JsonObject &obj, const std::string &src ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &point ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
+        std::optional<int> use( Character *p, item &it, map *here,
+                                const tripoint_bub_ms &pos ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;

--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -78,12 +78,22 @@ std::optional<tripoint_bub_ms> random_point( const tripoint_range<tripoint_bub_m
 map_cursor::map_cursor( const tripoint_bub_ms &pos ) : pos_abs_( g ? get_map().get_abs(
                 pos ) : tripoint_abs_ms::zero ), pos_bub_( g ? tripoint_bub_ms::zero : pos ) { }
 
+map_cursor::map_cursor( map *here, const tripoint_bub_ms &pos ) : pos_abs_( g ? here->get_abs(
+                pos ) : tripoint_abs_ms::zero ), pos_bub_( g ? tripoint_bub_ms::zero : pos )
+{
+}
+
 map_cursor::map_cursor( const tripoint_abs_ms &pos ) : pos_abs_( pos ),
     pos_bub_( tripoint_bub_ms::zero ) { }
 
 tripoint_bub_ms map_cursor::pos_bub() const
 {
     return g ? get_map().get_bub( pos_abs_ ) : pos_bub_;
+}
+
+tripoint_bub_ms map_cursor::pos_bub( map *here ) const
+{
+    return g ? here->get_bub( pos_abs_ ) : pos_bub_;
 }
 
 tripoint_abs_ms map_cursor::pos_abs() const

--- a/src/map_selector.h
+++ b/src/map_selector.h
@@ -12,6 +12,7 @@
 #include "visitable.h"
 
 class item;
+class map;
 
 class map_cursor : public visitable
 {
@@ -21,9 +22,11 @@ class map_cursor : public visitable
 
     public:
         explicit map_cursor( const tripoint_bub_ms &pos );
+        explicit map_cursor( map *here, const tripoint_bub_ms &pos );
         // Marginally faster than the previous operation if you have the absolute coordinates at hand.
         explicit map_cursor( const tripoint_abs_ms &pos );
         tripoint_bub_ms pos_bub() const;
+        tripoint_bub_ms pos_bub( map *here ) const;
         // Will return tripoint_abs_ms::invalid if g hasn't been defined.
         tripoint_abs_ms pos_abs() const;
 

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -1071,9 +1071,12 @@ void talk_function::player_weapon_away( npc &/*p*/ )
 
 void talk_function::player_weapon_drop( npc &/*p*/ )
 {
+    map &here = get_map();
+
     Character &player_character = get_player_character();
     item weap = player_character.remove_weapon();
-    drop_on_map( player_character, item_drop_reason::deliberate, {weap}, player_character.pos_bub() );
+    drop_on_map( player_character, item_drop_reason::deliberate, {weap}, &here,
+                 player_character.pos_bub( &here ) );
 }
 
 void talk_function::lead_to_safety( npc &p )

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -56,9 +56,14 @@ turret_data vehicle::turret_query( vehicle_part &pt )
     return turret_data( this, &pt );
 }
 
-turret_data vehicle::turret_query( const tripoint_bub_ms &pos )
+turret_data vehicle::turret_query( map *here, const tripoint_bub_ms &pos )
 {
-    auto res = get_parts_at( &get_map(), pos, "TURRET", part_status_flag::any );
+    return vehicle::turret_query( here->get_abs( pos ) );
+}
+
+turret_data vehicle::turret_query( const tripoint_abs_ms &pos )
+{
+    const std::vector<vehicle_part *> res = get_parts_at( pos, "TURRET", part_status_flag::any );
     return !res.empty() ? turret_query( *res.front() ) : turret_data();
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7259,11 +7259,15 @@ void vehicle::unlink_cables( const point_rel_ms &mount, Character &remover,
     }
 }
 
-bool vehicle::enclosed_at( const tripoint_bub_ms &pos )
+bool vehicle::enclosed_at( map *here, const tripoint_bub_ms &pos )
 {
-    map &here = get_map();
+    return vehicle::enclosed_at( here->get_abs( pos ) );
+}
+
+bool vehicle::enclosed_at( const tripoint_abs_ms &pos )
+{
     refresh_insides();
-    std::vector<vehicle_part *> parts_here = get_parts_at( &here, pos, "BOARDABLE",
+    std::vector<vehicle_part *> parts_here = get_parts_at( pos, "BOARDABLE",
             part_status_flag::working );
     if( !parts_here.empty() ) {
         return parts_here.front()->inside;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1435,7 +1435,9 @@ class vehicle
         // get monster on a boardable part at p
         monster *get_monster( int p ) const;
 
-        bool enclosed_at( const tripoint_bub_ms &pos ); // not const because it calls refresh_insides
+        bool enclosed_at( map *here, const tripoint_bub_ms
+                          &pos ); // not const because it calls refresh_insides
+        bool enclosed_at( const tripoint_abs_ms &pos ); // not const because it calls refresh_insides
         // Returns the location of the vehicle in global map square coordinates.
         tripoint_abs_ms pos_abs() const;
         // Returns the location of the vehicle in global overmap terrain coordinates.
@@ -1951,7 +1953,8 @@ class vehicle
 
         /** Get firing data for a turret */
         turret_data turret_query( vehicle_part &pt );
-        turret_data turret_query( const tripoint_bub_ms &pos );
+        turret_data turret_query( map *here,  const tripoint_bub_ms &pos );
+        turret_data turret_query( const tripoint_abs_ms &pos );
 
         /** Set targeting mode for specific turrets */
         void turrets_set_targeting();
@@ -2059,7 +2062,7 @@ class vehicle
 
         // Honk the vehicle's horn, if there are any
         void honk_horn() const;
-        void reload_seeds( const tripoint_bub_ms &pos );
+        void reload_seeds( map *here, const tripoint_bub_ms &pos );
         void beeper_sound() const;
         void play_music() const;
         void play_chimes() const;
@@ -2145,7 +2148,7 @@ class vehicle
         void use_autoclave( int p );
         void use_washing_machine( int p );
         void use_dishwasher( int p );
-        void use_monster_capture( int part, const tripoint_bub_ms &pos );
+        void use_monster_capture( int part, map *here, const tripoint_bub_ms &pos );
         void use_harness( int part, const tripoint_bub_ms &pos );
 
         void build_electronics_menu( veh_menu &menu );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1575,7 +1575,7 @@ void vehicle::use_dishwasher( int p )
     }
 }
 
-void vehicle::use_monster_capture( int part, map *here, const tripoint_bub_ms &pos )
+void vehicle::use_monster_capture( int part, map */*here*/, const tripoint_bub_ms &pos )
 {
     if( parts[part].is_broken() || parts[part].removed ) {
         return;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -887,7 +887,7 @@ void vehicle::honk_horn() const
     }
 }
 
-void vehicle::reload_seeds( const tripoint_bub_ms &pos )
+void vehicle::reload_seeds( map *here, const tripoint_bub_ms &pos )
 {
     Character &player_character = get_player_character();
     std::vector<item *> seed_inv = player_character.cache_get_items_with( "is_seed", &item::is_seed );
@@ -920,7 +920,7 @@ void vehicle::reload_seeds( const tripoint_bub_ms &pos )
             used_seed.front().set_age( 0_turns );
             //place seeds into the planter
             put_into_vehicle_or_drop( player_character, item_drop_reason::deliberate, used_seed,
-                                      pos );
+                                      here, pos );
         }
     }
 }
@@ -1575,12 +1575,13 @@ void vehicle::use_dishwasher( int p )
     }
 }
 
-void vehicle::use_monster_capture( int part, const tripoint_bub_ms &pos )
+void vehicle::use_monster_capture( int part, map *here, const tripoint_bub_ms &pos )
 {
     if( parts[part].is_broken() || parts[part].removed ) {
         return;
     }
     item base = item( parts[part].get_base() );
+    // TODO: Use map aware invoke when available
     base.type->invoke( &get_avatar(), base, pos );
     if( base.has_var( "contained_name" ) ) {
         parts[part].set_flag( vp_flag::animal_flag );
@@ -2043,14 +2044,14 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
         } );
     }
 
-    const turret_data turret = turret_query( vp.pos_bub( &here ) );
+    const turret_data turret = turret_query( vp.pos_abs( ) );
 
     if( turret.can_unload() ) {
         menu.add( string_format( _( "Unload %s" ), turret.name() ) )
         .hotkey( "UNLOAD_TURRET" )
         .skip_locked_check()
-        .on_submit( [this, vppos] {
-            item_location loc = turret_query( vppos ).base();
+        .on_submit( [this, vppos, &here] {
+            item_location loc = turret_query( &here, vppos ).base();
             get_player_character().unload( loc );
         } );
     }
@@ -2059,8 +2060,8 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
         menu.add( string_format( _( "Reload %s" ), turret.name() ) )
         .hotkey( "RELOAD_TURRET" )
         .skip_locked_check()
-        .on_submit( [this, vppos] {
-            item_location loc = turret_query( vppos ).base();
+        .on_submit( [this, vppos, &here] {
+            item_location loc = turret_query( &here, vppos ).base();
             item::reload_option opt = get_player_character().select_ammo( loc, true );
             if( opt )
             {
@@ -2324,7 +2325,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
         const size_t mc_idx = vp_monster_capture->part_index();
         menu.add( _( "Capture or release a creature" ) )
         .hotkey( "USE_CAPTURE_MONSTER_VEH" )
-        .on_submit( [this, mc_idx, vppos] { use_monster_capture( mc_idx, vppos ); } );
+        .on_submit( [this, mc_idx, vppos, &here] { use_monster_capture( mc_idx, &here, vppos ); } );
     }
 
     const std::optional<vpart_reference> vp_bike_rack = vp.avail_part_with_feature( "BIKE_RACK_VEH" );
@@ -2343,7 +2344,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
     if( vp.avail_part_with_feature( "PLANTER" ) ) {
         menu.add( _( "Reload seed drill with seeds" ) )
         .hotkey( "USE_PLANTER" )
-        .on_submit( [this, vppos] { reload_seeds( vppos ); } );
+        .on_submit( [this, vppos, &here] { reload_seeds( &here, vppos ); } );
     }
 
     const std::optional<vpart_reference> vp_workbench = vp.avail_part_with_feature( "WORKBENCH" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make vehicle operations map aware. Ended up in iuse_actor...

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Convert bubble coordinate using vehicle operations to take a map parameter as a reference and feed it down to operations called recursively as needed.
Ended up in iuse_actor operations use and can_use, and provided map aware versions of these.
Some affected operations are inherently reality bubble oriented (sound and direction selections, for instance) and were give checks to reject usage with other maps.
Ended up in iuse_function_wrapper, where its cpp_function should be converted to be map aware, but called it a day and left a TODO comment behind instead (thus using the reality bubble map for everything downstream, which should be the case currently anyway).
Renamed "effect_on_conditons_actor" to "effect_on_conditions_actor".

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
There should be no functional changes, and nothing strange was seen when testing:
Load save, walk up ramp, jump into car, run through hay bales, run over zombie corpse with inventory, run over turkey, crash into stationary vehicle.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
