### PR TITLE
[Xedra Evolved] Seasonal magic casting failure adjustments

### DIFF
--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -71,7 +71,7 @@
     "id": "xe_fey_seasonal_magick_spring_failure_chance_actual",
     "//": "This and below separations are necessary to keep the 'You cannot go below 5% chance to fail in the opposite season' logic",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 3 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 2 ? 0.15 : 0 ) + (global_what_is_the_season == 3 ? 0.35 : 0 ) + (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.04) )"
   },
   {
     "type": "jmath_function",
@@ -83,7 +83,7 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_summer_failure_chance_actual",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 4 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.15 : 0 ) + (global_what_is_the_season == 3 ? 0.15 : 0 ) + (global_what_is_the_season == 4 ? 0.35 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.04) )"
   },
   {
     "type": "jmath_function",
@@ -95,7 +95,7 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_autumn_failure_chance_actual",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.35 : 0 ) + (global_what_is_the_season == 2 ? 0.15 : 0 ) + (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.04) )"
   },
   {
     "type": "jmath_function",
@@ -107,7 +107,7 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_winter_failure_chance_actual",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 2 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.15 : 0 ) + (global_what_is_the_season == 2 ? 0.35 : 0 ) + (global_what_is_the_season == 3 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.04) )"
   },
   {
     "type": "jmath_function",

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -64,25 +64,50 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_spring_failure_chance",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 3 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.08 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.03) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.04) )"
+    "return": "global_what_is_the_season == 3 ? max(xe_fey_seasonal_magick_spring_failure_chance_actual(), 0.05) : xe_fey_seasonal_magick_spring_failure_chance_actual()"
+  },
+  {
+    "type": "jmath_function",
+    "id": "xe_fey_seasonal_magick_spring_failure_chance_actual",
+    "//": "This and below separations are necessary to keep the 'You cannot go below 5% chance to fail in the opposite season' logic",
+    "num_args": 0,
+    "return": "(0.15 + (global_what_is_the_season == 3 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.04) )"
   },
   {
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_summer_failure_chance",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 4 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.08 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.03) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.04) )"
+    "return": "global_what_is_the_season == 4 ? max(xe_fey_seasonal_magick_summer_failure_chance_actual(), 0.05) : xe_fey_seasonal_magick_summer_failure_chance_actual()"
+  },
+  {
+    "type": "jmath_function",
+    "id": "xe_fey_seasonal_magick_summer_failure_chance_actual",
+    "num_args": 0,
+    "return": "(0.15 + (global_what_is_the_season == 4 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.04) )"
   },
   {
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_autumn_failure_chance",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.08 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.03) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.04) )"
+    "return": "global_what_is_the_season == 1 ? max(xe_fey_seasonal_magick_autumn_failure_chance_actual(), 0.05) : xe_fey_seasonal_magick_autumn_failure_chance_actual()"
+  },
+  {
+    "type": "jmath_function",
+    "id": "xe_fey_seasonal_magick_autumn_failure_chance_actual",
+    "num_args": 0,
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.04) )"
   },
   {
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_winter_failure_chance",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 2 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.08 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.03) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.04) )"
+    "return": "global_what_is_the_season == 2 ? max(xe_fey_seasonal_magick_winter_failure_chance_actual(), 0.05) : xe_fey_seasonal_magick_winter_failure_chance_actual()"
+  },
+  {
+    "type": "jmath_function",
+    "id": "xe_fey_seasonal_magick_winter_failure_chance_actual",
+    "num_args": 0,
+    "return": "(0.15 + (global_what_is_the_season == 2 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.04) )"
   },
   {
     "type": "jmath_function",

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -71,7 +71,7 @@
     "id": "xe_fey_seasonal_magick_spring_failure_chance_actual",
     "//": "This and below separations are necessary to keep the 'You cannot go below 5% chance to fail in the opposite season' logic",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 2 ? 0.15 : 0 ) + (global_what_is_the_season == 3 ? 0.35 : 0 ) + (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 2 ? 0.15 : 0 ) + (global_what_is_the_season == 3 ? 0.35 : 0 ) + (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.04) )"
   },
   {
     "type": "jmath_function",
@@ -83,7 +83,7 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_summer_failure_chance_actual",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.15 : 0 ) + (global_what_is_the_season == 3 ? 0.15 : 0 ) + (global_what_is_the_season == 4 ? 0.35 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.15 : 0 ) + (global_what_is_the_season == 3 ? 0.15 : 0 ) + (global_what_is_the_season == 4 ? 0.35 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.04) )"
   },
   {
     "type": "jmath_function",
@@ -95,7 +95,7 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_autumn_failure_chance_actual",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.35 : 0 ) + (global_what_is_the_season == 2 ? 0.15 : 0 ) + (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.35 : 0 ) + (global_what_is_the_season == 2 ? 0.15 : 0 ) + (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.04) )"
   },
   {
     "type": "jmath_function",
@@ -107,13 +107,19 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_winter_failure_chance_actual",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.15 : 0 ) + (global_what_is_the_season == 2 ? 0.35 : 0 ) + (global_what_is_the_season == 3 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.15 : 0 ) + (global_what_is_the_season == 2 ? 0.35 : 0 ) + (global_what_is_the_season == 3 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.04) )"
   },
   {
     "type": "jmath_function",
     "id": "xe_fey_magick_mana_penalty",
     "num_args": 0,
-    "return": "u_val('mana') < (u_val('max_mana') / 2) ? ( ( (1 - ( u_val('mana') / u_val('max_mana') ) - 0.2) / 1.5) : 0"
+    "return": "u_val('mana') < (u_val('mana_max') / 2) ? xe_fey_magick_mana_penalty_secondary() : 0"
+  },
+  {
+    "type": "jmath_function",
+    "id": "xe_fey_magick_mana_penalty_secondary",
+    "num_args": 0,
+    "return": "(1 - ( u_val('mana') / u_val('mana_max') ) - 0.2) / 1.5"
   },
   {
     "type": "jmath_function",

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -64,25 +64,31 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_spring_failure_chance",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 3 ? 0.2 : 0 ) ) - (u_skill('deduction') * 0.03)"
+    "return": "(0.15 + (global_what_is_the_season == 3 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.08 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.03) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.04) )"
   },
   {
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_summer_failure_chance",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 4 ? 0.2 : 0 ) ) - (u_skill('deduction') * 0.03)"
+    "return": "(0.15 + (global_what_is_the_season == 4 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.08 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.03) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.04) )"
   },
   {
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_autumn_failure_chance",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.2 : 0 ) ) - (u_skill('deduction') * 0.03)"
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.08 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.03) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.04) )"
   },
   {
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_winter_failure_chance",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 2 ? 0.2 : 0 ) ) - (u_skill('deduction') * 0.03)"
+    "return": "(0.15 + (global_what_is_the_season == 2 ? 0.2 : 0 ) + (u_spell_difficulty(_spell_id) * 0.08 ) + xe_fey_magick_mana_penalty() - ( (u_skill('deduction') * 0.03) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.04) )"
+  },
+  {
+    "type": "jmath_function",
+    "id": "xe_fey_magick_mana_penalty",
+    "num_args": 0,
+    "return": "u_val('mana') < (u_val('max_mana') / 2) ? ( ( (1 - ( u_val('mana') / u_val('max_mana') ) - 0.2) / 1.5) : 0"
   },
   {
     "type": "jmath_function",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Seasonal magic casting failure adjustments"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

#79554 makes more complicated custom failure formulae possible. Going to start with seasonal magic (and will eventually probably overhaul MoM--get ready for a _bunch_ of things to affect your channeling odds)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Previously, the calculation was a flat 15%, +20% if at the opposite season, -3% per level of Deduction.

Now the calculation is a flat 15%, +35% if at the opposite season, +15% if simply in a different season, +9% per point of the spell's Difficulty, -6% per level of Deduction, -4% per other spell of that season you know. All of this is also modified by your mana--if below half mana, you suffer a penalty of 1 minus the ratio of your mana to max mana, minus 20%, divided by 1.5, as a percentage So if your max mana is 1000 and you have 400 mana, your spells are ((1 - 0.4) - 0.2) / 1.5 * 100) = 27% more likely to fail, going further up as your mana goes down. 

(The logic here is that fae are innately magical beings, so spells are easier for them [they don't need to study and level individual spells] but as they use their magical reserves, using more of it becomes harder)

As before, your failure chance cannot go below 5% in the opposing season.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Gave myself various seasonal spells, added and removed spells, changed the season, and observed failure rates go up and down.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

At the moment with only three spells per season this is going to make them very difficult to cast, which is why I'm already working on more spells

When I have more time I might go back and revamp all the elemental fae spells so they also don't have levels and scale off your total power the way changeling magic does, for Fair Folk consistency.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
