### PR TITLE
Attach some debug info to release runner errors

### DIFF
--- a/build-scripts/generate-release-notes.js
+++ b/build-scripts/generate-release-notes.js
@@ -28,7 +28,9 @@ async function main() {
         'X-GitHub-Api-Version': '2022-11-28',
       },
     }
-  );
+  ).catch((e) =>{
+    throw `${e} ...when getting latest release`;
+  })
 
   let previousTag = null;
   if (latestReleaseResponse.data) {
@@ -52,7 +54,9 @@ async function main() {
         'X-GitHub-Api-Version': '2022-11-28',
       },
     }
-  );
+  ).catch((e) =>{
+    throw `${e} ...when asking github to autogenerate release notes since tag '${previousTag}'`;
+  });
 
   const noteSections = response.data.body?.split('\n\n');
   const trimmedSections = [];


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Currently our release notes are broken (last good: [cdda-experimental-2025-02-05-1708](https://github.com/CleverRaven/Cataclysm-DDA/releases/tag/cdda-experimental-2025-02-05-1708), first bad: [cdda-experimental-2025-02-06-0250](https://github.com/CleverRaven/Cataclysm-DDA/releases/tag/cdda-experimental-2025-02-06-0250)) for no apparent reason.

The runner [logs](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/13170830524/job/36760770096) are 
```
Run npm install @actions/github
  npm install @actions/github
  node build-scripts/generate-release-notes.js '***' 'cdda-experimental-2025-02-06-0250' "$(git log -1 --format='%H')" > notes.txt
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
    REPOSITORY_NAME: Cataclysm-DDA

added 24 packages in 1s
Failed generating release notes with error: HttpError
```
unenlightening.

Somehow, the release notes work fine in my own fork (https://github.com/moxian/Cataclysm-DDA/releases)
(And also works fine locally. And also when i hackishly try it [in a pull request](https://github.com/moxian/Cataclysm-DDA/actions/runs/13189559258/job/36819586221?pr=19) )

#### Describe the solution
Add a tiny bit of context to the js errors. This does nothing to fix the issues, of course, but I have tepid hope that it might bring some light on what's going on at least

#### Describe alternatives you've considered
Idk, figure out what's happening and fix the root cause in one go.
Also, the classic: not do this.
I tried putting the context into `console.log()` but that one doesn't make its way into the CI log.
I guess i could write
```js
.catch((e) => { console.error("context here") ; throw e; } )
```
instead of what I'm doing right now, I don't think either is much better than the other. Lmk if you have strong opinions here.

#### Testing
Tried breaking it in a couple of ways. Got reasonably readable error out each time (
example - https://github.com/moxian/Cataclysm-DDA/actions/runs/13189583076/job/36819655541?pr=19
anoter example from an earlier version of the code - https://github.com/moxian/Cataclysm-DDA/actions/runs/13189397885/job/36819126328
Thinking more about it, I never got a literal `HttpError` we are seeing in CI right now, it has always been `HttpError: Something something`.

#### Additional context

The `/releases/generate-notes` endpoint seems to require write permissions to the repo so I cannot really test that one locally for CleverRaven. (specifically the docs say it requires `"Contents" repository permissions (write)` for "fine-grained tokens". I'm not sure what is the implication on the github actions runners).

~~I suspect the fix would be adding~~
```yml
permissions:
  - contents: write
```
~~to the yaml edit: *If this is a new change that's github is slowly rolling out*. And I can PR that. But idk if that's neccessary, and I'd much prefer to leave perms at default if that's an option...~~
Late edit: nevermind, we already have `contents: write` permissions, as seen in `Set up job` section of the runner log