### PR TITLE
Improve blood placement on Riot Damage

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -231,7 +231,7 @@ static constexpr int MON_RADIUS = 3;
 static void science_room( map *m, const point_bub_ms &p1, const point_bub_ms &p2, int z,
                           int rotate );
 
-static enum class blood_trail_direction : int {
+enum class blood_trail_direction : int {
     first = 1,
     NORTH = 1,
     SOUTH = 2,
@@ -243,7 +243,7 @@ static enum class blood_trail_direction : int {
 static tripoint_bub_ms get_point_from_direction( int direction,
         const tripoint_bub_ms &current_tile )
 {
-    switch( ( blood_trail_direction )direction ) {
+    switch( static_cast<blood_trail_direction>( direction ) ) {
         case blood_trail_direction::NORTH:
             return tripoint_bub_ms( current_tile.x(), current_tile.y() - 1, current_tile.z() );
         case blood_trail_direction::SOUTH:
@@ -254,7 +254,7 @@ static tripoint_bub_ms get_point_from_direction( int direction,
             return tripoint_bub_ms( current_tile.x() + 1, current_tile.y(), current_tile.z() );
     }
     // This shouldn't happen unless the function is used incorrectly
-    debugmsg( "Attempted to get point from invalid direction. %d", direction );
+    debugmsg( "Attempted to get point from invalid direction.  %d", direction );
     return current_tile;
 }
 
@@ -276,7 +276,8 @@ static bool tile_can_have_blood( map &md, const tripoint_bub_ms &current_tile,
 
 static void place_blood_on_adjacent( map &md, const tripoint_bub_ms &current_tile, int chance )
 {
-    for( int i = ( int )blood_trail_direction::first; i <= ( int )blood_trail_direction::last; i++ ) {
+    for( int i = static_cast<int>( blood_trail_direction::first );
+         i <= static_cast<int>( blood_trail_direction::last ); i++ ) {
         tripoint_bub_ms adjacent_tile = get_point_from_direction( i, current_tile );
 
         if( !tile_can_have_blood( md, adjacent_tile, false ) ) {
@@ -293,8 +294,8 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
 
 
     int streak_length = rng( 3, 12 );
-    int streak_direction = rng( ( int )blood_trail_direction::first,
-                                ( int )blood_trail_direction::last );
+    int streak_direction = rng( static_cast<int>( blood_trail_direction::first ),
+                                static_cast<int>( blood_trail_direction::last ) );
 
     bool wall_streak = false;
 
@@ -317,7 +318,8 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
             // We hit a non-valid tile. Try to find a new direction otherwise just terminate the streak.
             bool terminate_streak = true;
 
-            for( int ii = ( int )blood_trail_direction::first; ii <= ( int )blood_trail_direction::last;
+            for( int ii = static_cast<int>( blood_trail_direction::first );
+                 ii <= static_cast<int>( blood_trail_direction::last );
                  ii++ ) {
                 if( ii == streak_direction ) {
                     // We don't want to check the direction we came from. No turning around!
@@ -358,13 +360,13 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
             // Floor streaks can meander and the probability of meandering increases with each step
             // Long straight streaks aren't visually interesting. So sometimes a streak will curve by meandering to the side.
             int new_direction = 0;
-            if( streak_direction == ( int )blood_trail_direction::NORTH ||
-                streak_direction == ( int )blood_trail_direction::SOUTH ) {
-                new_direction = one_in( 2 ) ? ( int )blood_trail_direction::EAST : ( int )
-                                blood_trail_direction::WEST;
+            if( streak_direction == static_cast<int>( blood_trail_direction::NORTH ) ||
+                streak_direction == static_cast<int>( blood_trail_direction::SOUTH ) ) {
+                new_direction = one_in( 2 ) ? static_cast<int>( blood_trail_direction::EAST ) : static_cast<int>(
+                                    blood_trail_direction::WEST );
             } else {
-                new_direction = one_in( 2 ) ? ( int )blood_trail_direction::NORTH : ( int )
-                                blood_trail_direction::SOUTH;
+                new_direction = one_in( 2 ) ? static_cast<int>( blood_trail_direction::NORTH ) : static_cast<int>(
+                                    blood_trail_direction::SOUTH );
             }
 
             tripoint_bub_ms adjacent_tile = get_point_from_direction( new_direction, last_tile );
@@ -386,7 +388,8 @@ static void place_bool_pools( map &md, const tripoint_bub_ms &current_tile )
     md.add_field( current_tile, field_fd_blood );
     place_blood_on_adjacent( md, current_tile, 60 );
 
-    for( int i = ( int )blood_trail_direction::first; i <= ( int )blood_trail_direction::last; i++ ) {
+    for( int i = static_cast<int>( blood_trail_direction::first );
+         i <= static_cast<int>( blood_trail_direction::last ); i++ ) {
         tripoint_bub_ms adjacent_tile = get_point_from_direction( i, current_tile );
         if( !tile_can_have_blood( md, adjacent_tile, false ) ) {
             continue;
@@ -449,8 +452,8 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
             }
         }
         // Set some fields at random!
-        if( x_in_y( 2, 100 ) ) {
-            int behavior_roll = rng( 1, 100 );
+        if( x_in_y( 1, 100 ) ) {
+            int behavior_roll = rng( 15, 1000 );
 
             if( behavior_roll <= 20 ) {
                 md.add_field( current_tile, field_fd_blood );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -245,16 +245,16 @@ static tripoint_bub_ms get_point_from_direction( int direction,
             return tripoint_bub_ms( current_tile.x() + 1, current_tile.y(), current_tile.z() );
     }
     // This shouldn't happen unless the function is used incorrectly
-    debugmsg( "Attempted to get point from invalid direction." );
+    debugmsg( "Attempted to get point from invalid direction. %d", direction );
     return current_tile;
 }
 
 static bool tile_can_have_blood( map &md, const tripoint_bub_ms &current_tile,
-                                 bool strictly_walls )
+                                 bool wall_streak )
 {
     // Wall streaks stick to walls, like blood was splattered against the surface
     // Floor streaks avoid obstacles to look more like a person left the streak behind (Not walking through walls, closed doors, windows, or furniture)
-    if( strictly_walls ) {
+    if( wall_streak ) {
         return ( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, current_tile ) );
     } else {
         return ( !md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, current_tile ) &&
@@ -350,7 +350,7 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
             int new_direction = rng( 0, 1 );
             int meander_mod = ( streak_direction >= 3 ) ? 1 : 3;
             tripoint_bub_ms adjacent_tile = get_point_from_direction( meander_mod + new_direction, last_tile );
-            if( tile_can_have_blood( md, adjacent_tile, false ) ) {
+            if( tile_can_have_blood( md, adjacent_tile, wall_streak ) ) {
                 md.add_field( adjacent_tile, field_fd_blood );
                 last_tile = adjacent_tile;
             }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -298,7 +298,7 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
     for( int i = 0; i < streak_length; i++ ) {
         tripoint_bub_ms destination_tile = get_point_from_direction( streak_direction, last_tile );
 
-        if( tile_can_have_blood( md, current_tile, wall_streak ) ) {
+        if( !tile_can_have_blood( md, destination_tile, wall_streak ) ) {
             // Wall Streaks should stay on walls, floor streaks should stay on floors
             bool terminate_streak = true;
 
@@ -308,7 +308,6 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
                     continue;
                 }
                 tripoint_bub_ms adjacent_tile = get_point_from_direction( ii, last_tile );
-                bool adjacent_is_wall = md.has_flag( ter_furn_flag::TFLAG_WALL, adjacent_tile );
 
                 if( tile_can_have_blood( md, adjacent_tile, wall_streak ) ) {
                     streak_direction = ii;
@@ -324,13 +323,13 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
             }
         }
 
-        if( rng( 1, 100 ) < 10 + i * 3 ) {
+        if( rng( 1, 100 ) < 5 + i * 3 ) {
             // Sometimes a streak should skip a tile, the chance increases the longer a streak is
             last_tile = destination_tile;
             continue;
         }
 
-        if( rng( 1, 100 ) < 10 + i * 7 ) {
+        if( rng( 1, 100 ) < 10 + i * 5 ) {
             // The longer a streak is the more likely it is to terminate early
             break;
         }
@@ -340,11 +339,11 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
         last_tile = destination_tile;
 
 
-        if( ( rng( 1, 100 ) < 30 + i * 10 ) && !wall_streak ) {
+        if( ( rng( 1, 100 ) < 30 + i * 3 ) && !wall_streak ) {
             // Floor streaks can meander and the probability of meandering increases with each step
 
             int new_direction = rng( 0, 1 );
-            int meander_mod = ( streak_direction > 3 ) ? 3 : 1;
+            int meander_mod = ( streak_direction >= 3 ) ? 1 : 3;
             tripoint_bub_ms adjacent_tile = get_point_from_direction( meander_mod + new_direction, last_tile );
             if( tile_can_have_blood( md, adjacent_tile, false ) ) {
                 md.add_field( adjacent_tile, field_fd_blood );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -236,24 +236,23 @@ static tripoint_bub_ms get_point_from_direction( int direction,
 {
     switch( direction ) {
         case 1:
-            // North
             return tripoint_bub_ms( current_tile.x(), current_tile.y() - 1, current_tile.z() );
         case 2:
-            // South
             return tripoint_bub_ms( current_tile.x(), current_tile.y() + 1, current_tile.z() );
         case 3:
-            // West
             return tripoint_bub_ms( current_tile.x() - 1, current_tile.y(), current_tile.z() );
         case 4:
-            // East
             return tripoint_bub_ms( current_tile.x() + 1, current_tile.y(), current_tile.z() );
     }
+    // This shouldn't happen unless the function is used incorrectly
+    debugmsg( "Attempted to get point from invalid direction." );
+    return current_tile;
 }
 
 static bool tile_can_have_blood( map &md, const tripoint_bub_ms &current_tile,
                                  bool strictly_walls )
 {
-    // Wall streaks stick to walls, like blood was splattered against the suface
+    // Wall streaks stick to walls, like blood was splattered against the surface
     // Floor streaks avoid obstacles to look more like a person left the streak behind (Not walking through walls, closed doors, windows, or furniture)
     if( strictly_walls ) {
         return ( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, current_tile ) );
@@ -285,7 +284,7 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
     if( tile_can_have_blood( md, current_tile, false ) ||
         tile_can_have_blood( md, current_tile, true ) ) {
         // Quick check the tile is valid. We check both because the same function places wall and floor streaks.
-        // Checking both still works to filter out non-valid tiles like windows, doors, and furntiure.
+        // Checking both still works to filter out non-valid tiles like windows, doors, and furniture.
         return;
     }
 
@@ -336,7 +335,7 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
 
         if( rng( 1, 100 ) < 10 + i * 5 ) {
             // Sometimes a streak should end early, the chance increases with each step.
-            // This is just a hack to further weight the distrubution in favor of short streaks over long ones.
+            // This is just a hack to further weight the distribution in favor of short streaks over long ones.
             break;
         }
 
@@ -366,8 +365,6 @@ static void place_bool_pools( map &md, const tripoint_bub_ms &current_tile )
         return;
     }
 
-    // Hardcoded to expand from one point across two generations of adjacent tiles.
-    // Past two generations it becomes impractically large.
     md.add_field( current_tile, field_fd_blood );
     place_blood_on_adjacent( md, current_tile, 60 );
 
@@ -435,13 +432,10 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
             int behavior_roll = rng( 1, 100 );
 
             if( behavior_roll <= 20 ) {
-                // 20% chance to place a field by itself
                 md.add_field( current_tile, field_fd_blood );
             } else if( behavior_roll <= 60 ) {
-                // 40% chance to try streaking the field
                 place_blood_streaks( md, current_tile );
             } else {
-                // 40% Chance to try pooling the field
                 place_bool_pools( md, current_tile );
             }
         }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -371,22 +371,14 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
 
                     if ((rng(1, 100) < 30 + i * 10) && !wall_streak) {
                         // Floor streaks can meander and the probability of meandering increases with each step
+
                         int new_direction = rng(0, 1);
-                        if (streak_direction < 1) {
-                            tripoint_bub_ms adjacent_tile = get_point_from_direction(3 + new_direction, last_tile);
-                            bool destination_is_wall = md.has_flag(ter_furn_flag::TFLAG_WALL, adjacent_tile);
-                            if ((destination_is_wall && wall_streak) || (!destination_is_wall && !wall_streak && !md.has_furn(adjacent_tile))) {
-                                md.add_field(adjacent_tile, field_fd_blood);
-                                last_tile = adjacent_tile;
-                            }
-                        }
-                        else if(streak_direction > 1){
-                            tripoint_bub_ms adjacent_tile = get_point_from_direction(1 + new_direction, last_tile);
-                            bool destination_is_wall = md.has_flag(ter_furn_flag::TFLAG_WALL, adjacent_tile);
-                            if ((destination_is_wall && wall_streak) || (!destination_is_wall && !wall_streak && !md.has_furn(adjacent_tile))) {
-                                md.add_field(adjacent_tile, field_fd_blood);
-                                last_tile = adjacent_tile;
-                            }
+                        int meander_mod = (streak_direction > 3) ? 3 : 1;
+                        tripoint_bub_ms adjacent_tile = get_point_from_direction(meander_mod + new_direction, last_tile);
+                        bool destination_is_wall = md.has_flag(ter_furn_flag::TFLAG_WALL, adjacent_tile);
+                        if ((destination_is_wall && wall_streak) || (!destination_is_wall && !wall_streak && !md.has_furn(adjacent_tile))) {
+                            md.add_field(adjacent_tile, field_fd_blood);
+                            last_tile = adjacent_tile;
                         }
                     }
                 }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -295,7 +295,7 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
     int streak_direction = rng( static_cast<int>( blood_trail_direction::first ),
                                 static_cast<int>( blood_trail_direction::last ) );
 
-    bool wall_streak = md.has_flag_ter_or_furn(ter_furn_flag::TFLAG_WALL, current_tile);
+    bool wall_streak = md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, current_tile );
 
     if( !tile_can_have_blood( md, current_tile, wall_streak ) ) {
         // Quick check the tile is valid.

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -303,7 +303,7 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
             bool terminate_streak = true;
 
             for( int ii = 1; ii < 5; ii++ ) {
-                // Check for adjacent wall tiles and change streak direction if we find one
+                // Check for valid adjacent tiles and change direction if we find one
                 if( ii == streak_direction ) {
                     continue;
                 }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -291,19 +291,13 @@ static void place_blood_on_adjacent( map &md, const tripoint_bub_ms &current_til
 
 static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
 {
-
-
     int streak_length = rng( 3, 12 );
     int streak_direction = rng( static_cast<int>( blood_trail_direction::first ),
                                 static_cast<int>( blood_trail_direction::last ) );
 
-    bool wall_streak = false;
+    bool wall_streak = md.has_flag_ter_or_furn(ter_furn_flag::TFLAG_WALL, current_tile);
 
-    if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, current_tile ) ) {
-        wall_streak = true;
-    }
-
-    if( tile_can_have_blood( md, current_tile, wall_streak ) ) {
+    if( !tile_can_have_blood( md, current_tile, wall_streak ) ) {
         // Quick check the tile is valid.
         return;
     }
@@ -452,8 +446,8 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
             }
         }
         // Set some fields at random!
-        if( x_in_y( 1, 100 ) ) {
-            int behavior_roll = rng( 15, 1000 );
+        if( x_in_y( 15, 1000 ) ) {
+            int behavior_roll = rng( 1, 100 );
 
             if( behavior_roll <= 20 ) {
                 md.add_field( current_tile, field_fd_blood );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Improve blood placement on Riot Damage"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently blood is just placed in single tiles randomly. Which is was fine for as a starting point. But not so great for the long term. Placing them randomly just tends to make the maps feel a bit noisy, and it doesn't quite sell the intended experience of being in a riot devasted city.

Current behavior:
![image](https://github.com/user-attachments/assets/3753c7f4-2fc2-4d54-a024-7a73316ece6a)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Implement a system of rules to give blood placement greater rationale and reduce noise in the maps.

After passing the initial check to begin placing a blood field the game will now randomly select between 1 or 3 possible behaviors: It has a 20% chance to place only a field by itself, a 40% to begin a streak of blood, and a 40% chance to begin a pool of blood.

Placing a single field behaves exactly as before.

**Streaks**
Streaks of blood randomly pick a direction to move and a length to be. After that it determines if it's a wall streak or a floor streak.

Wall streaks stick to the walls only and are intended to represent blood splattered on the surface of walls.

Floor streaks stick to floors as best as they can. They avoid obstacles like walls, furniture, doors, and windows. They are intended to give the impression of individuals trudging through buildings leaving a trail of blood. Given enough space floor streaks will meander to the side so they are rarely perfectly straight. Instead favoring a slight curve.

All streaks can terminate early and some will occasionally skip a tile to break up the line a bit.

**Blood pools**
Blood pools set the initial tile as blood and then attempt to expand to that start point's adjacent tiles. The First generation has the highest likelihood of placing blood fields. It will then attempt a second generation by trying the adjacent tiles of all tiles from the first generation. At a reduced chance of placing blood fields.

The result is a usually a blob like puddle that works quite well.

Revised Behavior:
![image](https://github.com/user-attachments/assets/b3f32838-1706-44df-8970-6c0a199c0152)
![image](https://github.com/user-attachments/assets/d94db9ca-688d-4472-baf8-f386f0749286)
![image](https://github.com/user-attachments/assets/96456eda-54ae-4c6d-b99c-cb59ffb21d87)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered making a more robust system for the blood pools. One that allows a configurable amount of generations. But since blood pools and trails already tend to combine on their own. I feel any more than two generations will turn a blood puddle into a blood sea.

I initially had the wall and floor streak code a lot more separated. But I ended up repeating the code since most of it is the same. So I settled for one function that conditional changes it's behavior slightly if it's a wall streak or a floor streak.

I strongly considered trying to create a function that could check for multiple flags at once, to avoid multiple function calls from the same condition. But it didn't seem like such an easy thing to do, and I didn't want to do it unless otherwise asked to.

I really wanted to use less magic numbers and just move the design levers to class level variables. But I held off because I didn't really see any other design levers being defined on the class. And I don't yet know what parts need to be configurable for JSON anyway.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded up and reset the world many times. Looking at many structures in the cities while pushing and pulling the levers until I got something I liked. I jumped around a lot of buildings and cities and nothing's broken yet.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Still pretty newish to C++ so all feedback, useful tips, and sage advice welcome. I probably did some really stupid stuff without realizing.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
