### PR TITLE
Add stone fireplace back

### DIFF
--- a/data/json/construction/furniture_fireplaces.json
+++ b/data/json/construction/furniture_fireplaces.json
@@ -13,6 +13,18 @@
   },
   {
     "type": "construction",
+    "id": "constr_stone_fireplace",
+    "group": "build_stone_fireplace",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 3 ], [ "survival", 2 ] ],
+    "time": "180 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "DIG", "level": 2 } ] ],
+    "components": [ [ [ "rock", 50 ] ] ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_fireplace_stone"
+  },
+  {
+    "type": "construction",
     "id": "constr_firering",
     "group": "build_fire_ring",
     "category": "FURN",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -801,6 +801,11 @@
   },
   {
     "type": "construction_group",
+    "id": "build_stone_fireplace",
+    "name": "Build Stone Fireplace"
+  },
+  {
+    "type": "construction_group",
     "id": "build_stone_wall",
     "name": "Build Stone Wall"
   },

--- a/data/json/furniture_and_terrain/furniture-fireplaces.json
+++ b/data/json/furniture_and_terrain/furniture-fireplaces.json
@@ -17,8 +17,31 @@
       "str_max": 210,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "items": [ { "item": "rock", "count": [ 15, 30 ] } ]
+      "items": [ { "item": "brick", "count": [ 15, 30 ] } ]
     }
+  },
+  {
+    "type": "furniture",
+    "id": "f_fireplace_stone",
+    "looks_like": "f_fireplace",
+    "name": "stone fireplace",
+    "symbol": "#",
+    "description": "A common fixture for safely hosting a fire indoors, with a chimney to vent the smoke to the outside.",
+    "bgcolor": "white",
+    "move_cost_mod": 2,
+    "coverage": 50,
+    "required_str": -1,
+    "crafting_pseudo_item": "fake_fireplace",
+    "flags": [ "TRANSPARENT", "CONTAINER", "FIRE_CONTAINER", "SUPPRESS_SMOKE", "PLACE_ITEM", "MINEABLE", "EASY_DECONSTRUCT" ],
+    "examine_action": "fireplace",
+    "bash": {
+      "str_min": 30,
+      "str_max": 210,
+      "sound": "crash!",
+      "sound_fail": "whump!",
+      "items": [ { "item": "rock", "count": [ 25, 50 ] } ]
+    },
+    "deconstruct": { "items": [ { "item": "rock", "count": 50 } ] }
   },
   {
     "type": "furniture",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Buildable stone fireplaces are back"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
In Innawood, and perhaps in mainline as well, having a fireplace that does not generate smoke but still gives of heat is useful for sleeping next to during cold nights. #68904 changed the fireplace to be much more difficult to build, especially for Innawood players. This PR adds a variant fireplace made with the old recipe, with some minor tweaks in accordance with suggestions made in the #68904 comment section.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Adds a fireplace variant that is made out of rocks.
- Use the old recipe to craft it, with some tweaks:
 - Survival level required to make it increased from 1 to 2
 - Rocks required to build it increased from 40 to 50
- Gave it `EASY_DECONSTRUCT` where if you deconstruct it, you get all 50 rocks back.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Have the recipe require more rocks. Depending on how large a fireplace you want to make, one could perhaps make the argument that it would require thousands of rocks. But that sounds very grindy and un-fun to me.
- Have the recipe require the same amount of rocks as before (40). This is how many a rock forge requires, to that would also be reasonable.
- Learn how to duel in Nidhogg

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran the game with the changes, made a stone fireplace, deconstructed it, it worked fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The stone variant does not currently spawn in in-game buildings.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
