### PR TITLE
Audit Overmap Terrains for correct application of Riot Damage

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -49,6 +49,13 @@
   },
   {
     "type": "overmap_terrain",
+    "abstract": "generic_city_building_roof",
+    "copy-from": "generic_city_building_no_sidewalk",
+    "extend": { "flags": [ "SIDEWALK" ] },
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+  },
+  {
+    "type": "overmap_terrain",
     "id": "solid_earth",
     "name": "solid earth",
     "sym": "#",
@@ -74,7 +81,8 @@
     "copy-from": "generic_city_building",
     "name": "garage roof",
     "sym": "O",
-    "color": "white"
+    "color": "white",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -786,7 +786,8 @@
     "name": "desolate barn",
     "sym": "B",
     "color": "brown",
-    "extend": { "flags": [ "RISK_LOW", "SOURCE_SAFETY" ] }
+    "extend": { "flags": [ "RISK_LOW", "SOURCE_SAFETY" ] },
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
@@ -30,7 +30,7 @@
     "sym": "#",
     "color": "i_brown",
     "vision_levels": "isolated_building",
-    "delete": { "flags": [ "RISK_HIGH" ] },
+    "delete": { "flags": [ "RISK_HIGH", "PP_GENERATE_RIOT_DAMAGE" ] },
     "extend": { "flags": [ "SOURCE_FOOD", "SOURCE_SAFETY", "RISK_LOW", "SOURCE_FARMING" ] }
   },
   {
@@ -39,7 +39,8 @@
     "copy-from": "generic_rural_building",
     "name": "sugar house",
     "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 1, 4 ], "chance": 20 },
-    "sym": "S"
+    "sym": "S",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
@@ -65,7 +65,8 @@
     "type": "overmap_terrain",
     "id": [ "pottery_cottage_basement", "farm_stills_3_basement", "ranch_camp_68_basement" ],
     "spawns": { "group": "GROUP_BASEMENT_HOUSE", "population": [ 1, 1 ], "chance": 80 },
-    "copy-from": "generic_city_house_basement"
+    "copy-from": "generic_city_house_basement",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -409,7 +410,8 @@
     "name": "orchard",
     "sym": "#",
     "color": "i_green",
-    "extend": { "flags": [ "SOURCE_FOOD" ] }
+    "extend": { "flags": [ "SOURCE_FOOD" ] },
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -20,7 +20,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "s_gas_rural"],
+    "id": [ "s_gas_rural" ],
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "gas station",
     "looks_like": "s_gas",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -37,7 +37,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_gas_roof_1", "s_gas_g1_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "gas station roof",
     "color": "light_blue"
   },
@@ -61,7 +61,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_pharm_roof", "s_pharm_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_pharm_roof",
     "name": "pharmacy roof",
     "color": "light_red"
@@ -69,7 +69,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "office_doctor", "office_doctor_1", "office_doctor_2" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "office_doctor",
     "name": "doctor's office",
     "color": "i_light_red",
@@ -85,7 +85,7 @@
       "office_doctor_roof_2",
       "office_doctor_upper_roof_2"
     ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "office_doctor_roof",
     "name": "doctor's office roof",
     "color": "i_light_red"
@@ -101,7 +101,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "office_cubical_roof", "office_cubical_roof_1", "small_office_roof", "small_office_upper_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "office_cubical_roof",
     "name": "office roof",
     "color": "light_gray"
@@ -145,7 +145,7 @@
       "office_tower_roof_ne_roof",
       "office_tower_roof_se_roof"
     ],
-    "copy-from": "generic_city_building_no_sidewalk",
+    "copy-from": "generic_city_building_roof",
     "vision_levels": "roof_or_air",
     "name": "office building roof",
     "sym": "t",
@@ -185,7 +185,7 @@
     "color": "i_light_gray",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK" ]
   },
   {
     "type": "overmap_terrain",
@@ -261,7 +261,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_grocery_roof", "s_grocery_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_grocery_roof",
     "name": "grocery store roof",
     "color": "green"
@@ -290,7 +290,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_cosmetic_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_grocery_roof",
     "name": "cosmetics store roof",
     "color": "green"
@@ -307,7 +307,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_hardware_roof", "s_hardware_roof_1", "s_hardware_roof_2", "s_hardware_roof_3" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_hardware_roof",
     "name": "hardware store roof",
     "color": "cyan"
@@ -322,7 +322,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_weldingstore_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "welding store roof",
     "color": "light_blue"
   },
@@ -338,7 +338,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_electronics_roof", "s_electronics_roof_1", "s_electronicstore_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_electronics_roof",
     "name": "electronics store roof",
     "color": "yellow"
@@ -362,7 +362,7 @@
     "type": "overmap_terrain",
     "id": "s_sports_roof",
     "name": "sporting goods store roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "light_cyan"
   },
   {
@@ -377,7 +377,7 @@
     "type": "overmap_terrain",
     "id": "s_liquor_roof",
     "name": "liquor store roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "magenta"
   },
   {
@@ -394,7 +394,7 @@
     "id": [ "s_gun_a_roof", "s_gun_b_roof", "s_gun_b_range_roof" ],
     "name": "gun store roof",
     "looks_like": "s_gun_roof_a",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "red"
   },
   {
@@ -418,7 +418,7 @@
       "s_clothes_roof_6",
       "s_clothes_upper_roof_4"
     ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_clothes_roof",
     "name": "clothing store",
     "color": "blue"
@@ -435,7 +435,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_fabricstore_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_clothes_roof",
     "name": "fabric store roof",
     "color": "blue"
@@ -452,7 +452,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_bookstore_roof", "s_bookstore_roof_1", "s_bookstore_roof_2", "s_bookstore_upper_roof", "s_bookstore_upper_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_bookstore_roof",
     "name": "bookstore roof",
     "color": "i_brown"
@@ -470,7 +470,7 @@
     "type": "overmap_terrain",
     "id": [ "s_diner_2ndfloor", "s_diner_roof" ],
     "name": "diner",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_restaurant",
     "color": "pink"
   },
@@ -494,7 +494,7 @@
       "s_restaurant_upper_roof_2",
       "s_restaurant_roof_3"
     ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_restaurant_roof",
     "name": "restaurant roof",
     "color": "pink"
@@ -511,7 +511,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_restaurant_fast_roof", "s_restaurant_fast_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_restaurant_fast_roof",
     "name": "fast food restaurant roof",
     "color": "yellow_magenta"
@@ -528,7 +528,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_restaurant_coffee_roof", "s_restaurant_coffee_roof_1", "s_restaurant_coffee_roof_2" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_restaurant_coffee_roof",
     "name": "coffee shop",
     "color": "white_magenta"
@@ -545,7 +545,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_teashop_roof", "s_teashop_roof_1", "s_teashop_upper_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_teashop_roof",
     "name": "teashop roof",
     "color": "light_cyan_magenta"
@@ -562,7 +562,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "bar_roof", "bar_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "bar_roof",
     "name": "bar roof",
     "color": "i_magenta"
@@ -580,7 +580,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_butcher_roof", "s_butcher_roof_1", "s_butcher_roof_2", "s_butcher_upper_roof", "s_butcher_upper_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_butcher_roof",
     "name": "butcher shop roof",
     "color": "i_red"
@@ -597,7 +597,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_bike_shop_roof", "s_bike_shop_roof_1", "s_bike_shop_roof_1_shack_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_bike_shop_roof",
     "name": "bike shop roof",
     "color": "i_cyan"
@@ -614,7 +614,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_pizza_parlor_roof", "s_pizza_parlor_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_pizza_parlor_roof",
     "name": "pizza parlor roof",
     "color": "pink_magenta"
@@ -640,8 +640,7 @@
     "sym": "$",
     "color": "light_gray",
     "see_cost": "none",
-    "mondensity": 2,
-    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
+    "mondensity": 2
   },
   {
     "type": "overmap_terrain",
@@ -655,7 +654,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "pawn_roof", "pawn_roof_1", "pawn_pf_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "pawn_roof",
     "name": "pawn shop roof",
     "color": "white"
@@ -674,7 +673,7 @@
     "type": "overmap_terrain",
     "id": [ "mil_surplus_roof", "mil_surplus_roof_1", "mil_surplus_roof_2" ],
     "looks_like": "mil_surplus_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": { "str": "mil. surplus roof", "//NOLINT(cata-text-style)": "not a period" },
     "sym": "M",
     "color": "i_light_gray"
@@ -690,7 +689,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "furniture_roof", "furniture_upper_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "furniture store roof",
     "color": "brown"
   },
@@ -706,7 +705,7 @@
   {
     "type": "overmap_terrain",
     "id": "s_music_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "music store roof",
     "sym": "m",
     "color": "brown"
@@ -813,16 +812,14 @@
     "sym": "M",
     "color": "blue",
     "extras": "build",
-    "see_cost": "full_high",
-    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
+    "see_cost": "full_high"
   },
   {
     "type": "overmap_terrain",
     "id": "megastore_1_1_roof",
     "copy-from": "megastore_0_0_roof",
     "mondensity": 2,
-    "spawns": { "group": "GROUP_VANILLA", "population": [ 8, 12 ], "chance": 100 },
-    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
+    "spawns": { "group": "GROUP_VANILLA", "population": [ 8, 12 ], "chance": 100 }
   },
   {
     "type": "overmap_terrain",
@@ -896,7 +893,8 @@
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "hotel basement",
     "sym": "B",
-    "color": "light_blue"
+    "color": "light_blue",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -988,8 +986,7 @@
     "name": "home improvement superstore roof",
     "sym": "H",
     "color": "light_green_yellow",
-    "see_cost": "full_high",
-    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
+    "see_cost": "full_high"
   },
   {
     "type": "overmap_terrain",
@@ -1012,7 +1009,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "garage_gas_roof_1", "garage_gas_roof_2", "garage_gas_roof_3" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "garage_gas_roof_1",
     "name": "garage roof",
     "sym": "O",
@@ -1031,7 +1028,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "dispensary_roof", "dispensary_roof_1", "dispensary_roof_2" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "dispensary_roof",
     "name": "dispensary roof",
     "sym": "D",
@@ -1050,7 +1047,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "candy_shop_roof", "candy_shop_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "candy_shop_roof",
     "name": "candy shop roof",
     "color": "red_white"
@@ -1068,14 +1065,14 @@
     "type": "overmap_terrain",
     "id": "bakery_roof",
     "name": "bakery roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "yellow_white"
   },
   {
     "type": "overmap_terrain",
     "id": "bakery_upper_roof",
     "name": "bakery roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "yellow_white"
   },
   {
@@ -1091,7 +1088,7 @@
     "type": "overmap_terrain",
     "id": "icecream_shop_roof",
     "name": "icecream shop roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "blue_white"
   },
   {
@@ -1106,7 +1103,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "dollarstore_roof", "dollarstore_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "dollarstore_roof",
     "name": "dollar store roof",
     "sym": "$",
@@ -1125,7 +1122,7 @@
     "type": "overmap_terrain",
     "id": "lancenter_roof",
     "name": "LAN center roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "L",
     "color": "light_gray"
   },
@@ -1142,7 +1139,7 @@
     "type": "overmap_terrain",
     "id": "lancenter_roof_1",
     "name": "LAN center roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "L",
     "color": "light_gray"
   },
@@ -1166,7 +1163,7 @@
   {
     "type": "overmap_terrain",
     "id": "landscapingsupplyco_1b_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "landscaping supply co roof",
     "sym": "L",
     "color": "i_green"
@@ -1182,7 +1179,7 @@
   {
     "type": "overmap_terrain",
     "id": "s_vfw_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "veterans of foreign wars center roof",
     "sym": "w",
     "color": "i_green"
@@ -1198,7 +1195,7 @@
   {
     "type": "overmap_terrain",
     "id": "s_thrift_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "thrift store roof",
     "color": "light_gray"
   },
@@ -1212,7 +1209,7 @@
   {
     "type": "overmap_terrain",
     "id": "s_daycare_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "daycare center roof",
     "color": "blue"
   },
@@ -1227,7 +1224,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_petstore_roof", "s_petstore_roof_1", "s_petstore_roof_2" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_petstore_roof",
     "name": "pet supply store roof",
     "color": "i_yellow"
@@ -1268,7 +1265,8 @@
       "s_shoppingplaza_B6"
     ],
     "copy-from": "s_shoppingplaza_a6",
-    "name": "abandoned shopping plaza roof"
+    "name": "abandoned shopping plaza roof",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -1282,7 +1280,7 @@
     "type": "overmap_terrain",
     "id": "veterinarian_roof",
     "name": "veterinarian clinic roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "i_pink"
   },
   {
@@ -1297,7 +1295,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "s_laundromat_roof", "s_laundromat_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "s_laundromat_roof",
     "name": "laundromat roof",
     "color": "white_white"
@@ -1326,7 +1324,7 @@
     "type": "overmap_terrain",
     "id": "s_jewelry_roof",
     "name": "jewelry store roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "J",
     "color": "white"
   },
@@ -1363,7 +1361,7 @@
     "id": "home_improvement_roof",
     "name": "home improvement store roof",
     "vision_levels": "roof_or_air",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "yellow_green"
   },
   {
@@ -1453,7 +1451,7 @@
     "type": "overmap_terrain",
     "id": "s_antique_roof",
     "name": "antique store roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "A",
     "color": "brown"
   },
@@ -1469,7 +1467,7 @@
     "type": "overmap_terrain",
     "id": "s_dive_shop_roof",
     "name": "dive shop roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "D",
     "color": "blue"
   },
@@ -1486,7 +1484,7 @@
     "type": "overmap_terrain",
     "id": "s_arcade_roof",
     "name": "arcade roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "A",
     "color": "cyan"
   },
@@ -1503,7 +1501,7 @@
     "type": "overmap_terrain",
     "id": "s_gardening_roof",
     "name": "gardening supply roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "F",
     "color": "green"
   },
@@ -1521,14 +1519,14 @@
     "type": "overmap_terrain",
     "id": "craft_shop_upper_roof",
     "name": "craft shop upper roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "s",
     "color": "cyan"
   },
   {
     "type": "overmap_terrain",
     "id": [ "craft_shop_roof", "craft_shop_roof_1", "craft_shop_roof_2", "craft_shop_roof_3" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "craft_shop_roof",
     "name": "craft shop roof",
     "sym": "s",
@@ -1573,7 +1571,7 @@
   {
     "type": "overmap_terrain",
     "id": "cs_sex_shop_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "sex shop roof",
     "sym": "x",
     "color": "i_pink"
@@ -1590,7 +1588,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "cs_internet_cafe_roof", "cs_internet_cafe_upper_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "internet cafe roof",
     "sym": "i",
     "color": "light_green_cyan"
@@ -1615,7 +1613,7 @@
   {
     "type": "overmap_terrain",
     "id": "cs_car_showroom_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "car showroom roof",
     "sym": "c",
     "color": "i_cyan"
@@ -1633,7 +1631,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "cs_car_dealership_roof", "s_cardealer_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "cs_car_dealership_roof",
     "name": "car dealership",
     "sym": "c",
@@ -1651,7 +1649,7 @@
   {
     "type": "overmap_terrain",
     "id": "cs_tire_shop_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "tire shop roof",
     "sym": "O",
     "color": "white"
@@ -1668,7 +1666,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "headshop_roof", "headshop_upper_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "head shop roof",
     "sym": "0",
     "color": "i_white"
@@ -1684,7 +1682,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "abstorefront_roof", "abstorefront_roof_1", "abstorefront_roof_2" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "abstorefront_roof",
     "name": "abandoned storefront roof",
     "color": "h_dark_gray"
@@ -1701,7 +1699,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "station_radio_roof", "station_radio_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "looks_like": "station_radio_roof",
     "name": "radio station roof",
     "sym": "X",
@@ -1735,7 +1733,7 @@
   {
     "type": "overmap_terrain",
     "id": "cs_gardening_allotment_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "gardening allotment roof",
     "sym": "a",
     "color": "brown_green"
@@ -1752,7 +1750,7 @@
     "type": "overmap_terrain",
     "id": "animalpound_roof",
     "name": "animal pound roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "T",
     "color": "i_brown"
   },
@@ -1767,7 +1765,7 @@
     "type": "overmap_terrain",
     "id": "animalshelter_roof",
     "name": "animal shelter roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "i_pink"
   },
   {
@@ -1790,7 +1788,7 @@
   {
     "type": "overmap_terrain",
     "id": "s_hunting_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "hunting supply store roof",
     "sym": "H",
     "color": "brown"
@@ -1808,7 +1806,7 @@
     "type": "overmap_terrain",
     "id": "s_camping_roof",
     "name": "outdoorsman's store",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "o",
     "color": "brown"
   },
@@ -1916,7 +1914,8 @@
     "type": "overmap_terrain",
     "id": "s_games_roof",
     "name": "gaming store roof",
-    "copy-from": "s_games"
+    "copy-from": "s_games",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -1947,7 +1946,7 @@
   {
     "type": "overmap_terrain",
     "id": "salon_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "salon roof",
     "looks_like": "salon_roof",
     "sym": "s",
@@ -1969,7 +1968,7 @@
     "name": "strip mall roof",
     "sym": "v",
     "color": "light_red",
-    "copy-from": "generic_city_building"
+    "copy-from": "generic_city_building_roof"
   },
   {
     "type": "overmap_terrain",
@@ -1985,7 +1984,7 @@
     "type": "overmap_terrain",
     "id": "strip_mall_roof_5",
     "name": "open air",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": ".",
     "color": "blue"
   },
@@ -2055,7 +2054,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "barber_shop_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "barber shop roof",
     "looks_like": "barber_shop_roof",
     "sym": "b",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -11,12 +11,22 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "s_gas", "s_gas_rural", "s_gas_g1" ],
+    "id": [ "s_gas", "s_gas_g1" ],
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "gas station",
     "looks_like": "s_gas",
     "color": "light_blue",
     "extend": { "flags": [ "SOURCE_FUEL", "SOURCE_VEHICLES" ] }
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "s_gas_rural"],
+    "copy-from": "generic_city_building_no_sidewalk",
+    "name": "gas station",
+    "looks_like": "s_gas",
+    "color": "light_blue",
+    "extend": { "flags": [ "SOURCE_FUEL", "SOURCE_VEHICLES" ] },
+    "delete": { "flags": [ "RISK_HIGH", "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -26,10 +36,18 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "s_gas_roof_1", "s_gas_rural_roof", "s_gas_g1_roof" ],
+    "id": [ "s_gas_roof_1", "s_gas_g1_roof" ],
     "copy-from": "generic_city_building",
     "name": "gas station roof",
     "color": "light_blue"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "s_gas_rural_roof" ],
+    "copy-from": "generic_city_building",
+    "name": "gas station roof",
+    "color": "light_blue",
+    "delete": { "flags": [ "RISK_HIGH", "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -167,7 +185,7 @@
     "color": "i_light_gray",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -178,7 +196,7 @@
     "color": "light_gray",
     "see_cost": "low",
     "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -198,7 +216,7 @@
     "color": "i_light_gray",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -209,7 +227,7 @@
     "color": "light_gray",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -220,7 +238,7 @@
     "color": "light_gray",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -611,7 +629,7 @@
     "color": "light_gray",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "SOURCE_LUXURY" ]
+    "flags": [ "SIDEWALK", "SOURCE_LUXURY", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -622,7 +640,8 @@
     "sym": "$",
     "color": "light_gray",
     "see_cost": "none",
-    "mondensity": 2
+    "mondensity": 2,
+    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -774,7 +793,8 @@
     "sym": "M",
     "color": "blue",
     "extras": "build",
-    "see_cost": "full_high"
+    "see_cost": "full_high",
+    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -793,14 +813,16 @@
     "sym": "M",
     "color": "blue",
     "extras": "build",
-    "see_cost": "full_high"
+    "see_cost": "full_high",
+    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
     "id": "megastore_1_1_roof",
     "copy-from": "megastore_0_0_roof",
     "mondensity": 2,
-    "spawns": { "group": "GROUP_VANILLA", "population": [ 8, 12 ], "chance": 100 }
+    "spawns": { "group": "GROUP_VANILLA", "population": [ 8, 12 ], "chance": 100 },
+    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -949,7 +971,7 @@
     "sym": "H",
     "color": "light_green_yellow",
     "see_cost": "full_high",
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -966,7 +988,8 @@
     "name": "home improvement superstore roof",
     "sym": "H",
     "color": "light_green_yellow",
-    "see_cost": "full_high"
+    "see_cost": "full_high",
+    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -131,7 +131,8 @@
     "sym": "L",
     "color": "i_green",
     "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 1, 3 ], "chance": 10 },
-    "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] }
+    "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] },
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -140,7 +141,8 @@
     "name": "lumberyard",
     "vision_levels": "industrial_building",
     "sym": "L",
-    "color": "i_green"
+    "color": "i_green",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -151,7 +153,8 @@
     "sym": "L",
     "color": "i_green",
     "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 1, 3 ], "chance": 10 },
-    "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] }
+    "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] },
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -298,7 +301,8 @@
     "vision_levels": "large_industrial_building",
     "name": "steel mill",
     "sym": "S",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -315,7 +319,8 @@
     "looks_like": "road",
     "name": "steel mill depot",
     "sym": "│",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -98,7 +98,7 @@
   {
     "type": "overmap_terrain",
     "id": "warehouse_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "small warehouse roof",
     "vision_levels": "warehouse",
     "sym": "w",
@@ -116,7 +116,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "small_storage_units_roof", "small_storage_units_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "small storage units roof",
     "vision_levels": "warehouse",
     "sym": "#",
@@ -160,7 +160,7 @@
     "type": "overmap_terrain",
     "id": [ "lumbermill_0_0_roof", "lumbermill_0_1_roof", "lumbermill_1_0_roof", "lumbermill_1_1_roof" ],
     "vision_levels": "roof_or_air",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "lumbermill roof",
     "sym": "L",
     "color": "i_green"
@@ -203,7 +203,7 @@
       "abandonedwarehouse_3_roof",
       "abandonedwarehouse_4_roof"
     ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "abandoned warehouse roof",
     "vision_levels": "warehouse",
     "sym": "w",
@@ -233,7 +233,7 @@
       "medium_storage_units_roof_1",
       "medium_storage_units_roof_2"
     ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "storage units roof",
     "vision_levels": "warehouse",
     "sym": "#",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_mall.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_mall.json
@@ -8,7 +8,7 @@
     "sym": "M",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_FOOD", "SOURCE_DRINK", "SOURCE_MEDICINE", "SOURCE_FABRICATION" ]
+    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_FOOD", "SOURCE_DRINK", "SOURCE_MEDICINE", "SOURCE_FABRICATION", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_mall.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_mall.json
@@ -8,7 +8,15 @@
     "sym": "M",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_FOOD", "SOURCE_DRINK", "SOURCE_MEDICINE", "SOURCE_FABRICATION", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [
+      "SIDEWALK",
+      "RISK_EXTREME",
+      "SOURCE_FOOD",
+      "SOURCE_DRINK",
+      "SOURCE_MEDICINE",
+      "SOURCE_FABRICATION",
+      "PP_GENERATE_RIOT_DAMAGE"
+    ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_mall.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_mall.json
@@ -102,13 +102,15 @@
     "id": [ "mall_a_3_roof", "mall_upper_roof_3" ],
     "copy-from": "generic_mall",
     "name": "mall - loading bay roof",
-    "color": "i_light_red"
+    "color": "i_light_red",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
     "id": "mall_upper_roof_4",
     "copy-from": "generic_mall",
-    "name": "mall - loading bay roof"
+    "name": "mall - loading bay roof",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -120,7 +122,8 @@
     "type": "overmap_terrain",
     "id": [ "mall_a_4_roof", "mall_a_5_roof" ],
     "copy-from": "generic_mall",
-    "name": "mall - utilities roof"
+    "name": "mall - utilities roof",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -339,6 +342,7 @@
     "vision_levels": "underground_stone",
     "copy-from": "generic_mall",
     "name": "mall - subway station",
-    "color": "i_light_red"
+    "color": "i_light_red",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_military.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_military.json
@@ -8,7 +8,7 @@
     "color": "blue",
     "see_cost": "high",
     "extras": "build",
-    "flags": [ "RISK_EXTREME", "SOURCE_GUN", "SOURCE_AMMO", "SOURCE_FOOD" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_GUN", "SOURCE_AMMO", "SOURCE_FOOD", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -30,7 +30,7 @@
     "color": "i_blue",
     "see_cost": "spaced_high",
     "extras": "build",
-    "flags": [ "RISK_EXTREME", "SOURCE_GUN", "SOURCE_AMMO", "SOURCE_FOOD" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_GUN", "SOURCE_AMMO", "SOURCE_FOOD", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_public_institutional.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_public_institutional.json
@@ -99,14 +99,14 @@
     "color": "i_light_red",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
     "id": [ "cathedral_b_NW", "cathedral_b_NE", "cathedral_b_SW", "cathedral_b_SE" ],
     "copy-from": "cathedral_1_NW",
     "name": "cathedral basement",
-    "delete": { "flags": [ "SIDEWALK" ] }
+    "delete": { "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -122,7 +122,7 @@
     ],
     "copy-from": "cathedral_1_NW",
     "name": "cathedral tower",
-    "delete": { "flags": [ "SIDEWALK" ] }
+    "delete": { "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -317,7 +317,7 @@
     "color": "light_blue",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_BOOKS" ]
+    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_BOOKS", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -328,7 +328,7 @@
     "color": "light_blue",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_BOOKS" ]
+    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_BOOKS", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -365,7 +365,7 @@
     "color": "light_blue",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SOURCE_BOOKS", "RISK_EXTREME" ]
+    "flags": [ "SOURCE_BOOKS", "RISK_EXTREME", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -570,7 +570,7 @@
     "color": "green",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -588,7 +588,8 @@
     "sym": "H",
     "color": "green",
     "see_cost": "high",
-    "mondensity": 2
+    "mondensity": 2,
+    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -598,7 +599,7 @@
     "sym": "^",
     "color": "i_black",
     "see_cost": "full_high",
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -608,7 +609,8 @@
     "sym": "^",
     "color": "i_black",
     "see_cost": "full_high",
-    "mondensity": 2
+    "mondensity": 2,
+    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -618,7 +620,8 @@
     "sym": "^",
     "color": "i_black",
     "see_cost": "none",
-    "mondensity": 1
+    "mondensity": 1,
+    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_public_institutional.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_public_institutional.json
@@ -11,7 +11,7 @@
     "type": "overmap_terrain",
     "id": [ "church_roof", "church_2ndfloor_1", "church_3rdfloor_1", "church_roof_1" ],
     "vision_levels": "roof_or_air",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "church roof",
     "sym": "C",
     "color": "light_red"
@@ -19,7 +19,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "church_steeple", "church_steeple_end", "church_steeple_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "church steeple",
     "sym": "C",
     "extras": "none",
@@ -72,7 +72,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "synagogue_roof", "synagogue_upper_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "synagogue roof",
     "sym": "S",
     "color": "blue"
@@ -158,7 +158,7 @@
       "urban_library_roof_4"
     ],
     "name": "library roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "i_brown"
   },
   {
@@ -173,7 +173,7 @@
     "type": "overmap_terrain",
     "id": [ "police_roof", "police_roof_1", "police_roof_2", "police_upper_roof_2" ],
     "name": "police station roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "h_yellow"
   },
   {
@@ -524,7 +524,7 @@
     "type": "overmap_terrain",
     "id": [ "post_office_roof", "post_office_roof_1" ],
     "name": "post office roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "blue"
   },
   {
@@ -540,7 +540,7 @@
     "type": "overmap_terrain",
     "id": "mortuary_roof",
     "name": "mortuary roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "M",
     "color": "i_blue",
     "mondensity": 6
@@ -557,7 +557,7 @@
     "type": "overmap_terrain",
     "id": [ "fire_station_roof", "fire_station_roof_1" ],
     "name": "fire station roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "F",
     "color": "red"
   },
@@ -620,8 +620,7 @@
     "sym": "^",
     "color": "i_black",
     "see_cost": "none",
-    "mondensity": 1,
-    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
+    "mondensity": 1
   },
   {
     "type": "overmap_terrain",
@@ -812,7 +811,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "small_kindergarten_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "small kindergarten roof",
     "sym": "K",
     "color": "i_light_blue"

--- a/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
@@ -97,7 +97,8 @@
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "state park",
     "sym": "S",
-    "color": "i_green"
+    "color": "i_green",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -276,7 +277,8 @@
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "miniature railway",
     "sym": "R",
-    "color": "green"
+    "color": "green",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -298,7 +300,8 @@
     "vision_levels": "isolated_building",
     "name": "miniature railway park",
     "sym": "P",
-    "color": "light_green"
+    "color": "light_green",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -318,7 +321,8 @@
     "vision_levels": "open_land",
     "name": "golf course",
     "sym": "G",
-    "color": "green"
+    "color": "green",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -327,7 +331,8 @@
     "name": "golf course parking lot",
     "vision_levels": "large_pavement",
     "sym": "G",
-    "color": "light_gray"
+    "color": "light_gray",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -344,7 +349,8 @@
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "golf course bar",
     "sym": "G",
-    "color": "light_gray"
+    "color": "light_gray",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -352,7 +358,8 @@
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "golf course service building roof",
     "sym": "G",
-    "color": "light_gray"
+    "color": "light_gray",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -1121,7 +1128,8 @@
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "marina",
     "color": "cyan",
-    "sym": "m"
+    "sym": "m",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -1129,7 +1137,8 @@
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "marina parking",
     "color": "cyan",
-    "sym": "m"
+    "sym": "m",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
@@ -73,7 +73,7 @@
     "vision_levels": "single_water",
     "see_cost": "none",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "SOURCE_DRINK" ]
+    "flags": [ "SIDEWALK", "SOURCE_DRINK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -187,7 +187,7 @@
     "vision_levels": "blends_till_details",
     "see_cost": "low",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "SOURCE_FARMING" ],
+    "flags": [ "SIDEWALK", "SOURCE_FARMING", "PP_GENERATE_RIOT_DAMAGE" ],
     "extras": "park"
   },
   {
@@ -209,7 +209,7 @@
     "vision_levels": "city_building",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "SOURCE_FARMING" ]
+    "flags": [ "SIDEWALK", "SOURCE_FARMING", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -219,7 +219,8 @@
     "sym": "g",
     "color": "i_green",
     "see_cost": "none",
-    "mondensity": 2
+    "mondensity": 2,
+    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -341,7 +342,8 @@
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "golf course service building",
     "sym": "G",
-    "color": "light_gray"
+    "color": "light_gray",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -681,7 +683,7 @@
     "color": "dark_gray",
     "see_cost": "none",
     "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -1111,7 +1113,8 @@
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "marina",
     "color": "cyan",
-    "sym": "~"
+    "sym": "~",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
@@ -86,7 +86,7 @@
   {
     "type": "overmap_terrain",
     "id": "art_gallery_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "art gallery roof",
     "sym": "a",
     "color": "i_yellow"
@@ -145,7 +145,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "pavilion_roof", "pavilion_roof_1", "trailer_public_10_roof" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "pavilion roof",
     "sym": "A",
     "color": "i_green"
@@ -219,8 +219,7 @@
     "sym": "g",
     "color": "i_green",
     "see_cost": "none",
-    "mondensity": 2,
-    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
+    "mondensity": 2
   },
   {
     "type": "overmap_terrain",
@@ -406,7 +405,8 @@
     "copy-from": "generic_city_building",
     "name": "zoo cave",
     "sym": "Z",
-    "color": "light_gray"
+    "color": "light_gray",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -428,7 +428,7 @@
       "zoo_2_3_roof",
       "zoo_3_3_roof"
     ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "zoo roof",
     "sym": "Z",
     "color": "i_green"
@@ -846,7 +846,7 @@
       "movietheater_roof_1_2",
       "movietheater_roof_2_2"
     ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "vision_levels": "large_building",
     "name": "movie theater roof",
     "sym": "M",
@@ -905,7 +905,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "paintball_field_roof", "paintball_field_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "paintball field roof",
     "sym": "p",
     "color": "red"
@@ -921,7 +921,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "smoke_lounge_roof", "smoke_lounge_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "smoking lounge roof",
     "sym": "s",
     "color": "white"
@@ -937,7 +937,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "music_venue_roof", "music_venue_1_roof", "music_venue_1_roof_top" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "music venue roof",
     "sym": "M",
     "color": "i_light_blue"
@@ -953,7 +953,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "gambling_hall_roof", "gambling_hall_upper_roof", "gambling_hall_roof_1" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "gambling hall roof",
     "sym": "g",
     "color": "blue"
@@ -969,7 +969,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "stripclub_roof", "stripclub_roof_1", "stripclub_roof_2" ],
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "strip club roof",
     "sym": "s",
     "color": "i_red"
@@ -987,7 +987,7 @@
     "type": "overmap_terrain",
     "id": "museum_roof",
     "name": "museum roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "M",
     "color": "white"
   },
@@ -1003,7 +1003,7 @@
     "type": "overmap_terrain",
     "id": "bowling_alley_roof",
     "name": "bowling alley roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "sym": "B",
     "color": "red"
   },
@@ -1018,7 +1018,7 @@
     "type": "overmap_terrain",
     "id": [ "gym_roof", "gym_upper_roof" ],
     "name": "boxing gym roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "yellow_cyan"
   },
   {
@@ -1032,7 +1032,7 @@
     "type": "overmap_terrain",
     "id": [ "gym_fitness_roof", "gym_fitness_roof_1" ],
     "name": "fitness gym roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "i_light_cyan"
   },
   {
@@ -1046,7 +1046,7 @@
     "type": "overmap_terrain",
     "id": [ "dojo_roof", "dojo_upper_roof", "dojo_roof_1", "dojo_upper_roof_1" ],
     "name": "dojo roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "color": "i_light_cyan"
   },
   {
@@ -1060,7 +1060,7 @@
   {
     "type": "overmap_terrain",
     "id": "cs_private_park_roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_roof",
     "name": "private park roof",
     "sym": "p",
     "color": "light_green_red",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_residential.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_residential.json
@@ -605,7 +605,7 @@
     "mondensity": 2,
     "extras": "build",
     "spawns": { "group": "GROUP_VANILLA", "population": [ 4, 10 ], "chance": 80 },
-    "flags": [ "SIDEWALK", "GENERIC_LOOT" ]
+    "flags": [ "SIDEWALK", "GENERIC_LOOT", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -616,7 +616,8 @@
     "color": "light_green",
     "see_cost": "none",
     "mondensity": 2,
-    "extras": "build"
+    "extras": "build",
+    "flags": [ "SIDEWALK", "GENERIC_LOOT", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_residential.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_residential.json
@@ -30,7 +30,7 @@
     "copy-from": "generic_city_house_no_sidewalk",
     "name": "house roof",
     "spawns": { "group": "GROUP_ROOF_ANIMAL", "population": [ 0, 3 ], "chance": 2 },
-    "delete": { "flags": [ "GENERIC_LOOT" ] }
+    "delete": { "flags": [ "GENERIC_LOOT", "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -617,7 +617,7 @@
     "see_cost": "none",
     "mondensity": 2,
     "extras": "build",
-    "flags": [ "SIDEWALK", "GENERIC_LOOT", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK", "GENERIC_LOOT" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_speedway.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_speedway.json
@@ -43,7 +43,8 @@
     "abstract": "speedway_track_abstract",
     "copy-from": "generic_city_building_no_sidewalk",
     "vision_levels": "blends_till_outlines",
-    "name": "speedway"
+    "name": "speedway",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -147,7 +148,8 @@
     "vision_levels": "large_building",
     "name": "bleachers",
     "sym": "^",
-    "color": "light_blue"
+    "color": "light_blue",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -215,7 +217,8 @@
     "vision_levels": "large_pavement",
     "name": "parking lot",
     "sym": "O",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -224,7 +227,8 @@
     "vision_levels": "isolated_building",
     "name": "garage",
     "sym": "O",
-    "color": "white"
+    "color": "white",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -492,7 +492,8 @@
     "vision_levels": "large_pavement",
     "name": "parking lot",
     "sym": "O",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
@@ -170,7 +170,8 @@
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "dumpsite",
     "sym": "D",
-    "color": "brown"
+    "color": "brown",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -196,7 +197,8 @@
     "name": "recycle center",
     "sym": "R",
     "color": "i_green",
-    "extend": { "flags": [ "SOURCE_FABRICATION", "SOURCE_CONSTRUCTION" ] }
+    "extend": { "flags": [ "SOURCE_FABRICATION", "SOURCE_CONSTRUCTION" ] },
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -204,7 +206,8 @@
     "copy-from": "generic_city_building",
     "name": "recycle center roof",
     "sym": "R",
-    "color": "i_green"
+    "color": "i_green",
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",
@@ -334,6 +337,7 @@
     "copy-from": "generic_city_building",
     "name": "abandoned textile mill",
     "color": "light_blue",
-    "extend": { "flags": [ "SOURCE_CONSTRUCTION" ] }
+    "extend": { "flags": [ "SOURCE_CONSTRUCTION" ] },
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
@@ -233,7 +233,8 @@
     "name": "junkyard",
     "sym": "J",
     "color": "i_brown",
-    "extend": { "flags": [ "SOURCE_FABRICATION", "SOURCE_CONSTRUCTION", "SOURCE_VEHICLES" ] }
+    "extend": { "flags": [ "SOURCE_FABRICATION", "SOURCE_CONSTRUCTION", "SOURCE_VEHICLES" ] },
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Audit Overmap Terrains for correct application of Riot Damage"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #79587. A number of non-city maps are being affected by riot damage. Additionally a number of in-city maps are incorrectly being spared from riot damage.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Go over just about every file in the overmap terrain folder and one by one add or delete the flag.
Specials spawning in cities should all have the flag now. Specials spawning outside of cities should have the flag deleted from their terrain.

In the case of terrains used in both:
All motels currently generate riot damage. I could be miss-reading this but it looks like the same terrains are used for the in-city special as the out of city special. It's a bit of a confusing web so I left the flag on all motels.
I was able to separate out the rural gas station so it won't have the flag applied to itself. 
Some map specials make use of parking lots and s lots. I am not crazy enough to try and untangle that whole mess so for now the majority of parking lots are excluded from the flag. (The mine and sugar house notably).

FEMA camps were specifically included in the riot damage flag as the only map special I deliberately added it to. In my mind there  would likely be rioting there as well in the final days. Or at the very least chaos on par with rioting.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not adding the flag to FEMA camps.
Trying to untangle all instances of parking lots used in map specials to separate them from parking lots in city specials. 
Removing the copy from on some map specials that are clearly not in city buildings.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded up a new world. Teleported around to the locations, verifying behavior as expected. Map specials were not rioted. City Specials are.

I did notice it behaves erratically when Nested Mapgen is used. Specifically the strip mall totally overwrites the riot damage and it is never applied to the nested chunk. Something to look out and bug report I guess.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
