### PR TITLE
Disable riot damage in city (without removing code support)

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -39,7 +39,7 @@
     "extras": "build",
     "mondensity": 2,
     "see_cost": "high",
-    "flags": [ "RISK_HIGH", "GENERIC_LOOT", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "RISK_HIGH", "GENERIC_LOOT" ]
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This is an alternative to #79580 which effectively reverts the #79535 changes as far as user experience goes, but leaves the code support in so that it can be further worked on behind the curtains until it's in better shape (see #79584 and #79575)

tagging #79565, although this does not technically fix the core issue

#### Describe the solution
JSON-only change. With this PR no overmap has `PP_GENERATE_RIOT_DAMAGE` flag so the riot damage generator never runs.
But it can still be enabled locally for testing very easily.

#### Describe alternatives you've considered
Completely revert the code as #79580 does. That would be preferable if this feature is fundamentally unfixable (since the current PR effectively creates dead code, and having dead code is not ideal)

#### Testing
![20250207-131512-cataclysm-tiles](https://github.com/user-attachments/assets/78601b02-6b75-491e-8f49-b4adbb776cac)
![20250207-131630-cataclysm-tiles](https://github.com/user-attachments/assets/d7d4d467-64b0-402c-ac09-ca118123787f)


#### Additional context
