### PR TITLE
make some vehicle operations map aware

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1081,12 +1081,12 @@ void hotwire_car_activity_actor::finish( player_activity &act, Character &who )
     } else if( skill > rng( 0, 4 ) ) {
         // Soft fail
         who.add_msg_if_player( _( "You found a wire that looks like the right one." ) );
-        veh.is_alarm_on = veh.has_security_working();
+        veh.is_alarm_on = veh.has_security_working( here );
         veh.is_locked = false;
     } else if( !veh.is_alarm_on ) {
         // Hard fail
         who.add_msg_if_player( _( "The red wire always starts the engine, doesn't it?" ) );
-        veh.is_alarm_on = veh.has_security_working();
+        veh.is_alarm_on = veh.has_security_working( here );
     } else {
         // Already failed
         who.add_msg_if_player(
@@ -1388,7 +1388,7 @@ void bikerack_racking_activity_actor::finish( player_activity &act, Character & 
     vehicle &parent_veh = ovp_parent->vehicle();
     vehicle &racked_veh = ovp_racked->vehicle();
 
-    if( !parent_veh.merge_rackable_vehicle( &racked_veh, racks ) ) {
+    if( !parent_veh.merge_rackable_vehicle( &here, &racked_veh, racks ) ) {
         debugmsg( "racking actor failed: failed racking %s on %s, racks: [%s].",
                   racked_veh.name, parent_veh.name, enumerate_ints_to_string( racks ) );
     }
@@ -1595,7 +1595,9 @@ void bikerack_unracking_activity_actor::start( player_activity &act, Character &
 
 void bikerack_unracking_activity_actor::finish( player_activity &act, Character & )
 {
-    const optional_vpart_position ovp = get_map().veh_at( parent_vehicle_pos );
+    map &here = get_map();
+
+    const optional_vpart_position ovp = here.veh_at( parent_vehicle_pos );
     if( !ovp ) {
         debugmsg( "unracking actor lost vehicle." );
         act.set_to_null();
@@ -1604,7 +1606,7 @@ void bikerack_unracking_activity_actor::finish( player_activity &act, Character 
 
     vehicle &parent_vehicle = ovp->vehicle();
 
-    if( !parent_vehicle.remove_carried_vehicle( parts, racks ) ) {
+    if( !parent_vehicle.remove_carried_vehicle( here, parts, racks ) ) {
         debugmsg( "unracking actor failed on %s, parts: [%s], racks: [%s]", parent_vehicle.name,
                   enumerate_ints_to_string( parts ), enumerate_ints_to_string( racks ) );
     }
@@ -7650,7 +7652,7 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
     if( leftovers.charges > 0 ) {
         if( src_veh ) {
             vehicle_part &vp_src = src_veh->part( src_part );
-            if( !src_veh->add_item( vp_src, leftovers ) ) {
+            if( !src_veh->add_item( here, vp_src, leftovers ) ) {
                 debugmsg( "SortLoot: Source vehicle failed to receive leftover charges." );
             }
         } else {
@@ -7907,7 +7909,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                                     item link( *it->first->type->magazine->linkage, calendar::turn, contained->count() );
                                     if( this_veh != nullptr ) {
                                         vehicle_part &vp_this = this_veh->part( this_part );
-                                        this_veh->add_item( vp_this, link );
+                                        this_veh->add_item( here, vp_this, link );
                                     } else {
                                         here.add_item_or_charges( src_loc, link );
                                     }
@@ -8228,9 +8230,10 @@ std::unique_ptr<activity_actor> vehicle_unfolding_activity_actor::deserialize( J
 
 int heat_activity_actor::get_available_heater( Character &p, item_location &loc ) const
 {
+    map &here = get_map();
     int available_heater = 0;
     if( !loc->has_no_links() ) {
-        available_heater = loc->link().t_veh->connected_battery_power_level().first;
+        available_heater = loc->link().t_veh->connected_battery_power_level( here ).first;
     } else if( !loc->has_flag( flag_USE_UPS ) ) {
         available_heater = loc->ammo_remaining();
     } else if( loc->has_flag( flag_USE_UPS ) ) {
@@ -8247,18 +8250,20 @@ void heat_activity_actor::start( player_activity &act, Character & )
 
 void heat_activity_actor::do_turn( player_activity &act, Character &p )
 {
+    map &here = get_map();
+
     // use a hack in use_vehicle_tool vehicle_use.cpp
     if( !act.coords.empty() ) {
         h.vpt = act.coords[0];
     }
-    std::optional<vpart_position> vp = get_map().veh_at( h.vpt );
+    std::optional<vpart_position> vp = here.veh_at( h.vpt );
     if( h.pseudo_flag ) {
         if( !vp ) {
             p.add_msg_if_player( _( "You can't find the appliance any more." ) );
             act.set_to_null();
             return;
         }
-        if( vp.value().vehicle().connected_battery_power_level().first < requirements.ammo *
+        if( vp.value().vehicle().connected_battery_power_level( here ).first < requirements.ammo *
             h.heating_effect ) {
             p.add_msg_if_player( _( "You need more energy to heat these items." ) );
             act.set_to_null();
@@ -8287,6 +8292,8 @@ void heat_activity_actor::do_turn( player_activity &act, Character &p )
 
 void heat_activity_actor::finish( player_activity &act, Character &p )
 {
+    map &here = get_map();
+
     for( drop_location &ait : to_heat ) {
         item_location cold_item = ait.first;
         if( cold_item->count_by_charges() ) {
@@ -8316,7 +8323,7 @@ void heat_activity_actor::finish( player_activity &act, Character &p )
     }
     if( h.consume_flag ) {
         if( h.pseudo_flag ) {
-            get_map().veh_at( h.vpt ).value().vehicle().discharge_battery( requirements.ammo *
+            here.veh_at( h.vpt ).value().vehicle().discharge_battery( here, requirements.ammo *
                     h.heating_effect );
         } else {
             h.loc->activation_consume( requirements.ammo, h.loc.pos_bub(), &p );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1664,11 +1664,11 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
                     veh = &vp->vehicle();
                     part = act_ref.values[4];
                     if( source_veh &&
-                        source_veh->fuel_left( liquid.typeId(), ( veh ? std::function<bool( const vehicle_part & )> { [&]( const vehicle_part & pa )
+                        source_veh->fuel_left( here, liquid.typeId(), ( veh ? std::function<bool( const vehicle_part & )> { [&]( const vehicle_part & pa )
                 {
                     return &veh->part( part ) != &pa;
                     }
-                                                                                                                    } : return_true<const vehicle_part &> ) ) <= 0 ) {
+                                                                                                                          } : return_true<const vehicle_part &> ) ) <= 0 ) {
                         act_ref.set_to_null();
                         return;
                     }
@@ -1712,7 +1712,7 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
                         act_ref.set_to_null(); // leaky tank spilled while we were transferring
                         return;
                     }
-                    source_veh->drain( part_num, removed_charges );
+                    source_veh->drain( here, part_num, removed_charges );
                     liquid.charges = veh_charges - removed_charges;
                     // If there's no liquid left in this tank we're done, otherwise
                     // we need to update our liquid serialization to reflect how
@@ -1727,11 +1727,12 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
                         act_ref.str_values[0] = serialize( liquid );
                     }
                 } else {
-                    source_veh->drain( liquid.typeId(), removed_charges, ( veh ? std::function<bool( vehicle_part & )> { [&]( vehicle_part & pa )
+                    source_veh->drain( here, liquid.typeId(), removed_charges,
+                                       ( veh ? std::function<bool( vehicle_part & )> { [&]( vehicle_part & pa )
                     {
                         return &veh->part( part ) != &pa;
                     }
-                                                                                                                       } : return_true<vehicle_part &> ) );
+                                                                                     } : return_true<vehicle_part &> ) );
                 }
                 break;
             case liquid_source_type::MAP_ITEM:
@@ -2408,6 +2409,8 @@ struct weldrig_hack {
     }
 
     item &get_item() {
+        map &here = get_map();
+
         if( !part ) {
             // null item should be handled just fine
             return null_item_reference();
@@ -2432,7 +2435,7 @@ struct weldrig_hack {
                       mag.typeId().str(), pseudo.typeId().str() );
             return null_item_reference();
         }
-        pseudo.ammo_set( itype_battery, part->vehicle().drain( itype_battery,
+        pseudo.ammo_set( itype_battery, part->vehicle().drain( here,  itype_battery,
                          pseudo.ammo_capacity( ammo_battery ),
                          return_true< vehicle_part &>, false ) ); // no cable loss since all of this is virtual
         return pseudo;
@@ -2443,7 +2446,9 @@ struct weldrig_hack {
             return;
         }
 
-        part->vehicle().charge_battery( pseudo.ammo_remaining(),
+        map &here = get_map();
+
+        part->vehicle().charge_battery( here, pseudo.ammo_remaining(),
                                         false ); // return unused charges without cable loss
     }
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -242,12 +242,12 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
             it.charges = 0;
         }
 
-        if( veh.add_item( vp, it ) ) {
+        if( veh.add_item( here, vp, it ) ) {
             into_vehicle_count += it.count();
         } else {
             if( it.count_by_charges() ) {
                 // Maybe we can add a few charges in the trunk and the rest on the ground.
-                const int charges_added = veh.add_charges( vp, it );
+                const int charges_added = veh.add_charges( here, vp, it );
                 it.mod_charges( -charges_added );
                 into_vehicle_count += charges_added;
             }
@@ -653,7 +653,7 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
     // If we didn't pick up a whole stack, put the remainder back where it came from.
     if( leftovers.charges > 0 ) {
         if( vpr_src ) {
-            if( !vpr_src->vehicle().add_item( vpr_src->part(), leftovers ) ) {
+            if( !vpr_src->vehicle().add_item( here, vpr_src->part(), leftovers ) ) {
                 debugmsg( "SortLoot: Source vehicle failed to receive leftover charges." );
             }
         } else {
@@ -991,7 +991,7 @@ static bool are_requirements_nearby(
             const std::optional<vpart_reference> &vp = here.veh_at( elem ).part_with_tool( itype_welder );
 
             if( vp ) {
-                const int veh_battery = vp->vehicle().fuel_left( itype_battery );
+                const int veh_battery = vp->vehicle().fuel_left( here, itype_battery );
 
                 item welder( itype_welder, calendar::turn_zero );
                 welder.charges = veh_battery;
@@ -1024,7 +1024,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
         // if the vehicle is moving or player is controlling it.
-        if( std::abs( veh->velocity ) > 100 || veh->player_in_control( player_character ) ) {
+        if( std::abs( veh->velocity ) > 100 || veh->player_in_control( here, player_character ) ) {
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
         for( const npc &guy : g->all_npcs() ) {
@@ -2419,7 +2419,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                                     if( it->first->type->magazine->linkage ) {
                                         item link( *it->first->type->magazine->linkage, calendar::turn, contained->count() );
                                         if( vpr_src ) {
-                                            vpr_src->vehicle().add_item( vpr_src->part(), link );
+                                            vpr_src->vehicle().add_item( here, vpr_src->part(), link );
                                         } else {
                                             here.add_item_or_charges( src_loc, link );
                                         }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1396,7 +1396,7 @@ void Character::burn_fuel( bionic &bio )
     if( !result.connected_vehicles.empty() ) {
         // Cable bionic charging from connected vehicle(s)
         for( vehicle *veh : result.connected_vehicles ) {
-            int undrained = veh->discharge_battery( 1 );
+            int undrained = veh->discharge_battery( here, 1 );
             if( undrained == 0 ) {
                 energy_gain = 1_kJ;
                 break;

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -212,6 +212,8 @@ char get_free_invlet( Character &p )
 static void draw_bionics_titlebar( const catacurses::window &window, avatar *p,
                                    bionic_menu_mode mode )
 {
+    map &here = get_map();
+
     input_context ctxt( "BIONICS", keyboard_mode::keychar );
 
     werase( window );
@@ -236,7 +238,7 @@ static void draw_bionics_titlebar( const catacurses::window &window, avatar *p,
         fuel_string += fuel->tname() + ": " + colorize( std::to_string( fuel->charges ), c_green ) + " ";
     }
     for( vehicle *veh : p->get_cable_vehicle() ) {
-        int64_t charges = veh->connected_battery_power_level().first;
+        int64_t charges = veh->connected_battery_power_level( here ).first;
         if( charges > 0 ) {
             found_fuel = true;
             fuel_string += item( itype_battery ).tname() + ": " + colorize( std::to_string( charges ),

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3934,7 +3934,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
             const int subtile = vd.is_open ? open_ : vd.is_broken ? broken : 0;
             const int rotation = angle_to_dir4( 270_degrees - veh.face.dir() );
             avatar &you = get_avatar();
-            if( !veh.forward_velocity() && !veh.player_in_control( you )
+            if( !veh.forward_velocity() && !veh.player_in_control( here, you )
                 && !( you.get_grab_type() == object_type::VEHICLE
                       && veh.get_points().count( ( you.pos_abs() + you.grab_point ) ) )
                 && here.memory_cache_dec_is_dirty( p ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4042,7 +4042,7 @@ std::pair<int, int> Character::climate_control_strength() const
                                  // Also check for a working alternator. Muscle or animal could be powering it.
                                  (
                                      vp->is_inside() &&
-                                     vp->vehicle().total_alternator_epower() > 0_W
+                                     vp->vehicle().total_alternator_epower( here ) > 0_W
                                  )
                              );
         }
@@ -11977,8 +11977,9 @@ int Character::count_flag( const json_character_flag &flag ) const
 
 bool Character::is_driving() const
 {
-    const optional_vpart_position vp = get_map().veh_at( pos_bub() );
-    return vp && vp->vehicle().is_moving() && vp->vehicle().player_in_control( *this );
+    map &here = get_map();
+    const optional_vpart_position vp = here.veh_at( pos_bub() );
+    return vp && vp->vehicle().is_moving() && vp->vehicle().player_in_control( here, *this );
 }
 
 time_duration Character::estimate_effect_dur( const skill_id &relevant_skill,
@@ -12076,12 +12077,14 @@ bool Character::beyond_final_warning( const faction_id &id )
 
 read_condition_result Character::check_read_condition( const item &book ) const
 {
+    map &here = get_map();
+
     read_condition_result result = read_condition_result::SUCCESS;
     if( !book.is_book() ) {
         result |= read_condition_result::NOT_BOOK;
     } else {
-        const optional_vpart_position vp = get_map().veh_at( pos_bub() );
-        if( vp && vp->vehicle().player_in_control( *this ) ) {
+        const optional_vpart_position vp = here.veh_at( pos_bub() );
+        if( vp && vp->vehicle().player_in_control( here, *this ) ) {
             result |= read_condition_result::DRIVING;
         }
 
@@ -13347,7 +13350,7 @@ void Character::pause()
         vehicle *veh = nullptr;
         for( wrapped_vehicle &v : vehs ) {
             veh = v.v;
-            if( veh && veh->is_moving() && veh->player_in_control( *this ) ) {
+            if( veh && veh->is_moving() && veh->player_in_control( here, *this ) ) {
                 double exp_temp = 1 + veh->total_mass() / 400.0_kilogram +
                                   std::abs( veh->velocity / 3200.0 );
                 int experience = static_cast<int>( exp_temp );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -289,7 +289,7 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
                 crafter->i_add_or_drop( iit );
             }
             for( auto &vit : veh_items ) {
-                vit.first.vehicle().add_item( vit.first.part(), vit.second );
+                vit.first.vehicle().add_item( m, vit.first.part(), vit.second );
             }
         };
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -509,10 +509,10 @@ bool Character::check_eligible_containers_for_crafting( const recipe &rec, int b
 
         // also check if we're currently in a vehicle that has the necessary storage
         if( charges_to_store > 0 ) {
-            if( optional_vpart_position vp = here.veh_at( pos_bub() ) ) {
+            if( optional_vpart_position vp = here.veh_at( pos_bub( &here ) ) ) {
                 const itype_id &ftype = prod.typeId();
-                int fuel_cap = vp->vehicle().fuel_capacity( ftype );
-                int fuel_amnt = vp->vehicle().fuel_left( ftype );
+                int fuel_cap = vp->vehicle().fuel_capacity( here, ftype );
+                int fuel_amnt = vp->vehicle().fuel_left( here, ftype );
 
                 if( fuel_cap >= 0 ) {
                     int fuel_space_left = fuel_cap - fuel_amnt;
@@ -796,7 +796,7 @@ static item_location set_item_map_or_vehicle( const Character &p, const tripoint
     map &here = get_map();
     if( const std::optional<vpart_reference> vp = here.veh_at( loc ).cargo() ) {
         vehicle &veh = vp->vehicle();
-        if( const std::optional<vehicle_stack::iterator> it = veh.add_item( vp->part(), newit ) ) {
+        if( const std::optional<vehicle_stack::iterator> it = veh.add_item( here, vp->part(), newit ) ) {
             p.add_msg_player_or_npc(
                 //~ %1$s: name of item being placed, %2$s: vehicle part name
                 pgettext( "item, furniture", "You put the %1$s on the %2$s." ),

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3706,8 +3706,9 @@ static void unlock_all()
 
 static void vehicle_battery_charge()
 {
+    map &here = get_map();
 
-    optional_vpart_position v_part_pos = get_map().veh_at( player_picks_tile() );
+    optional_vpart_position v_part_pos = here.veh_at( player_picks_tile() );
     if( !v_part_pos ) {
         add_msg( m_bad, _( "There's no vehicle there." ) );
         return;
@@ -3722,9 +3723,9 @@ static void vehicle_battery_charge()
     if( !popup.canceled() ) {
         vehicle &veh = v_part_pos->vehicle();
         if( amount >= 0 ) {
-            veh.charge_battery( amount, false );
+            veh.charge_battery( here, amount, false );
         } else {
-            veh.discharge_battery( -amount, false );
+            veh.discharge_battery( here, -amount, false );
         }
     }
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -929,6 +929,8 @@ std::string display::vehicle_azimuth_text( const Character &u )
 
 std::pair<std::string, nc_color> display::vehicle_cruise_text_color( const Character &u )
 {
+    map &here = get_map();
+
     // Defaults in case no vehicle is found
     std::string vel_text;
     nc_color vel_color = c_light_gray;
@@ -946,7 +948,7 @@ std::pair<std::string, nc_color> display::vehicle_cruise_text_color( const Chara
         const std::string units = get_option<std::string> ( "USE_METRIC_SPEEDS" );
         vel_text = string_format( "%d < %d %s", target, current, units );
 
-        const float strain = veh->strain();
+        const float strain = veh->strain( here );
         if( strain <= 0 ) {
             vel_color = c_light_blue;
         } else if( strain <= 0.2 ) {
@@ -962,6 +964,8 @@ std::pair<std::string, nc_color> display::vehicle_cruise_text_color( const Chara
 
 std::pair<std::string, nc_color> display::vehicle_fuel_percent_text_color( const Character &u )
 {
+    map &here = get_map();
+
     // Defaults in case no vehicle is found
     std::string fuel_text;
     nc_color fuel_color = c_light_gray;
@@ -979,8 +983,8 @@ std::pair<std::string, nc_color> display::vehicle_fuel_percent_text_color( const
                 fuel_type = vp.fuel_current();
             }
         }
-        int max_fuel = veh->fuel_capacity( fuel_type );
-        int cur_fuel = veh->fuel_left( fuel_type );
+        int max_fuel = veh->fuel_capacity( here, fuel_type );
+        int cur_fuel = veh->fuel_left( here, fuel_type );
         if( max_fuel != 0 ) {
             int percent = cur_fuel * 100 / max_fuel;
             // Simple percent indicator, yellow under 25%, red under 10%

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -20,6 +20,7 @@
 bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 {
     map &here = get_map();
+
     const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos_bub( &here ) + u.grab_point );
     if( !grabbed_vehicle_vp ) {
         add_msg( m_info, _( "No vehicle at grabbed point." ) );
@@ -101,7 +102,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     valid_wheels = grabbed_vehicle->valid_wheel_config();
     if( valid_wheels ) {
         //check for bad push/pull angle
-        if( veh_has_solid && !veh_single_tile && grabbed_vehicle->steering_effectiveness() > 0 ) {
+        if( veh_has_solid && !veh_single_tile && grabbed_vehicle->steering_effectiveness( here ) > 0 ) {
             tileray my_dir;
             my_dir.init( dp.xy() );
             units::angle face_delta = angle_delta( grabbed_vehicle->face.dir(), my_dir.dir() );
@@ -135,7 +136,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
                 str_req = mc / wheel_indices.size() + 1;
             }
             //finally, adjust by the off-road coefficient (always 1.0 on a road, as low as 0.1 off road.)
-            str_req /= grabbed_vehicle->k_traction( get_map().vehicle_wheel_traction( *grabbed_vehicle ) );
+            str_req /= grabbed_vehicle->k_traction( here, here.vehicle_wheel_traction( *grabbed_vehicle ) );
             // If it would be easier not to use the wheels, don't use the wheels.
             str_req = std::min( str_req, max_str_req );
         }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -749,7 +749,7 @@ static void grab()
                 return;
             }
             get_player_character().pause();
-            vp->vehicle().separate_from_grid( vp.value().mount_pos() );
+            vp->vehicle().separate_from_grid( &here, vp.value().mount_pos() );
             if( const optional_vpart_position &split_vp = here.veh_at( grabp ) ) {
                 veh_name = split_vp->vehicle().name;
             } else {
@@ -1167,7 +1167,7 @@ static void wait()
 
     if( player_character.controlling_vehicle ) {
         const vehicle &veh = here.veh_at( player_character.pos_bub() )->vehicle();
-        if( !veh.can_use_rails() && (   // control optional if on rails
+        if( !veh.can_use_rails( here ) && ( // control optional if on rails
                 veh.is_flying_in_air() ||   // control required: fuel is consumed even at hover
                 veh.is_falling ||           // *not* vertical_velocity, which is only used for collisions
                 veh.velocity ||             // is moving
@@ -2110,11 +2110,13 @@ static void handle_debug_mode()
 
 static bool has_vehicle_control( avatar &player_character )
 {
+    map &here = get_map();
+
     if( player_character.is_dead_state() ) {
         return false;
     }
-    const optional_vpart_position vp = get_map().veh_at( player_character.pos_bub() );
-    if( vp && vp->vehicle().player_in_control( player_character ) ) {
+    const optional_vpart_position vp = here.veh_at( player_character.pos_bub() );
+    if( vp && vp->vehicle().player_in_control( here, player_character ) ) {
         return true;
     }
     return g->remoteveh() != nullptr;
@@ -2355,7 +2357,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
                 if( get_option<bool>( "AUTO_FEATURES" ) && get_option<bool>( "AUTO_MOPPING" ) &&
                     weapon && weapon->has_flag( json_flag_MOP ) ) {
-                    map &here = get_map();
                     const bool is_blind = player_character.is_blind();
                     for( const tripoint_bub_ms &point : here.points_in_radius( player_character.pos_bub(), 1 ) ) {
                         bool did_mop = false;
@@ -2387,8 +2388,8 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             }
 
             if( has_vehicle_control( player_character ) ) {
-                const optional_vpart_position vp = get_map().veh_at( player_character.pos_bub() );
-                if( vp->vehicle().is_rotorcraft() ) {
+                const optional_vpart_position vp = here.veh_at( player_character.pos_bub() );
+                if( vp->vehicle().is_rotorcraft( here ) ) {
                     pldrive( tripoint_rel_ms::below );
                     break;
                 }
@@ -2445,8 +2446,8 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             if( !player_character.in_vehicle ) {
                 vertical_move( 1, false );
             } else if( has_vehicle_control( player_character ) ) {
-                const optional_vpart_position vp = get_map().veh_at( player_character.pos_bub() );
-                if( vp->vehicle().is_rotorcraft() ) {
+                const optional_vpart_position vp = here.veh_at( player_character.pos_bub() );
+                if( vp->vehicle().is_rotorcraft( here ) ) {
                     pldrive( tripoint_rel_ms::above );
                 }
             }

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -560,7 +560,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         }
 
         void make_active( item_location &head ) {
-            cur.veh.make_active( head );
+            cur.veh.make_active( get_map(), head );
         }
 
         units::volume volume_capacity() const override {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5365,8 +5365,8 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
                                               it.link().t_mount ) +
                                           it.link().t_abs_pos ).xy();
             if( selection.xy().raw().distance( prev_pos.raw() ) <= 1.5f &&
-                it.link().t_veh->merge_appliance_into_grid( sel_vp->vehicle() ) ) {
-                it.link().t_veh->part_removal_cleanup();
+                it.link().t_veh->merge_appliance_into_grid( &here,  sel_vp->vehicle() ) ) {
+                it.link().t_veh->part_removal_cleanup( here );
                 p->add_msg_if_player( _( "You merge the two power grids." ) );
                 return 1;
             }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1387,9 +1387,9 @@ void spell_effect::recharge_vehicle( const spell &sp, Creature &caster,
     }
     vehicle &veh = v_part_pos->vehicle();
     if( sp.damage( caster ) >= 0 ) {
-        veh.charge_battery( sp.damage( caster ), false );
+        veh.charge_battery( here, sp.damage( caster ), false );
     } else {
-        veh.discharge_battery( -sp.damage( caster ), false );
+        veh.discharge_battery( here, -sp.damage( caster ), false );
     }
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -656,12 +656,12 @@ void map::vehmove()
         level_cache &cache = *cache_lazy;
         for( vehicle *veh : cache.vehicle_list ) {
             if( veh->is_following ) {
-                veh->drive_to_local_target( player_pos, true );
+                veh->drive_to_local_target( this, player_pos, true );
             } else if( veh->is_patrolling ) {
-                veh->autopilot_patrol();
+                veh->autopilot_patrol( this );
             }
             veh->gain_moves();
-            veh->slow_leak();
+            veh->slow_leak( *this );
             wrapped_vehicle w;
             w.v = veh;
             vehicle_list.push_back( w );
@@ -684,7 +684,7 @@ void map::vehmove()
         };
         if( std::find_if( vehicle_list.begin(), vehicle_list.end(), same_ptr ) !=
             vehicle_list.end() ) {
-            elem->part_removal_cleanup();
+            elem->part_removal_cleanup( *this );
         }
     }
     dirty_vehicle_list.clear();
@@ -697,14 +697,14 @@ void map::vehmove()
         }
         for( vehicle *veh : cache->vehicle_list ) {
             vehs[veh] = true; // force on map vehicles to true
-            veh->get_connected_vehicles( connected_vehs );
+            veh->get_connected_vehicles( *this, connected_vehs );
         }
     }
     for( vehicle *connected_veh : connected_vehs ) {
         vehs.emplace( connected_veh, false ); // add with 'false' if does not exist (off map)
     }
     for( const std::pair<vehicle *const, bool> &veh_pair : vehs ) {
-        veh_pair.first->idle( /* on_map = */ veh_pair.second );
+        veh_pair.first->idle( *this, /* on_map = */ veh_pair.second );
     }
 
     // refresh vehicle zones for moved vehicles
@@ -726,7 +726,8 @@ bool map::vehproceed( VehicleList &vehicle_list )
     // Then vertical-only movement
     if( cur_veh == nullptr ) {
         for( wrapped_vehicle &vehs_v : vehicle_list ) {
-            if( vehs_v.v->is_falling || ( vehs_v.v->is_rotorcraft() && vehs_v.v->get_z_change() != 0 ) ) {
+            if( vehs_v.v->is_falling || ( vehs_v.v->is_rotorcraft( *this ) &&
+                                          vehs_v.v->get_z_change() != 0 ) ) {
                 cur_veh = &vehs_v;
                 break;
             }
@@ -803,7 +804,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
     // Split into vertical and horizontal movement
     const int &coll_velocity = vertical ? veh.vertical_velocity : veh.velocity;
     const int velocity_before = coll_velocity;
-    if( velocity_before == 0 && !veh.is_rotorcraft() && !veh.is_flying_in_air() ) {
+    if( velocity_before == 0 && !veh.is_rotorcraft( *this ) && !veh.is_flying_in_air() ) {
         debugmsg( "%s tried to move %s with no velocity",
                   veh.name, vertical ? "vertically" : "horizontally" );
         return &veh;
@@ -866,7 +867,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
 
     const int velocity_after = coll_velocity;
     bool can_move = velocity_after != 0 && sgn( velocity_after ) == sgn( velocity_before );
-    if( dp.z() != 0 && veh.is_rotorcraft() ) {
+    if( dp.z() != 0 && veh.is_rotorcraft( *this ) ) {
         can_move = true;
     }
     units::angle coll_turn = 0_degrees;
@@ -926,7 +927,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
             veh.skidding = true;
             veh.turn( coll_turn );
         }
-        veh.on_move();
+        veh.on_move( *this );
         // Actually change position
         displace_vehicle( veh, dp1 );
         level_vehicle( veh );
@@ -1579,7 +1580,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const bool 
     }
 
     veh.shed_loose_parts( trinary::SOME, this, &dst );
-    smzs = veh.advance_precalc_mounts( dst_offset, src, dp, ramp_offset,
+    smzs = veh.advance_precalc_mounts( dst_offset, this, src, dp, ramp_offset,
                                        adjust_pos, parts_to_move );
     veh.update_active_fakes();
 
@@ -5400,6 +5401,8 @@ static bool process_map_items( map &here, item_stack &items, safe_reference<item
 
 static void process_vehicle_items( vehicle &cur_veh, int part )
 {
+    map &here = get_map();
+
     vehicle_part &vp = cur_veh.part( part );
     const vpart_info &vpi = vp.info();
 
@@ -5468,7 +5471,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
         recharge_part.last_charged = calendar::turn;
 
         if( !recharge_part.removed && recharge_part.enabled  && ( turns_elapsed > 0 ) &&
-            cur_veh.is_battery_available() ) {
+            cur_veh.is_battery_available( here ) ) {
 
             int dischargeable = turns_elapsed * recharge_part.info().bonus;
             // Convert to kilojoule
@@ -5511,7 +5514,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                     // Around 85% efficient; a few of the discharges don't actually recharge
                     const int needed_for_full_charge = ( chargeable * 7 / 6 ) + x_in_y( chargeable * 7 % 6, 6 );
                     const int to_discharge = std::min( needed_for_full_charge, dischargeable );
-                    const int discharged = to_discharge - cur_veh.discharge_battery( to_discharge );
+                    const int discharged = to_discharge - cur_veh.discharge_battery( here, to_discharge );
 
                     int charged = {};
                     if( discharged < to_discharge  || needed_for_full_charge >= dischargeable ) {
@@ -7137,7 +7140,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
         tercol = vd.color;
         item_sym.clear(); // clear the item symbol so `sym` is used instead.
 
-        if( !veh->forward_velocity() && !veh->player_in_control( player_character )
+        if( !veh->forward_velocity() && !veh->player_in_control( *this, player_character )
             && !( player_character.get_grab_type() == object_type::VEHICLE
                   && veh->get_points().count( ( player_character.pos_abs() +
                                                 player_character.grab_point ) ) ) ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1840,7 +1840,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
                 ( to_swimmable && to_deepwater ) || // Dive into deep water
                 is_mounted() ||
                 ( veh0 != nullptr && std::abs( veh0->velocity ) > 100 ) || // Diving from moving vehicle
-                ( veh0 != nullptr && veh0->player_in_control( get_avatar() ) ) || // Player is driving
+                ( veh0 != nullptr && veh0->player_in_control( here, get_avatar() ) ) || // Player is driving
                 has_effect( effect_amigara ) ||
                 has_flag( json_flag_GRAB );
             if( !move_issue ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -948,7 +948,7 @@ void monster::move()
     const std::optional<vpart_reference> vp_boardable = ovp.part_with_feature( "BOARDABLE", true );
     if( vp_boardable && friendly != 0 ) {
         const vehicle &veh = vp_boardable->vehicle();
-        if( veh.is_moving() && veh.get_monster( vp_boardable->part_index() ) ) {
+        if( veh.is_moving() && veh.get_monster( here,  vp_boardable->part_index() ) ) {
             moves = 0;
             return; // don't move if friendly and passenger in a moving vehicle
         }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1748,9 +1748,11 @@ void npc::mutiny()
 
 float npc::vehicle_danger( int radius ) const
 {
+    map &here = get_map();
+
     const tripoint_bub_ms from( posx() - radius, posy() - radius, posz() );
     const tripoint_bub_ms to( posx() + radius, posy() + radius, posz() );
-    VehicleList vehicles = get_map().get_vehicles( from, to );
+    VehicleList vehicles = here.get_vehicles( from, to );
 
     int danger = -1;
 
@@ -1758,8 +1760,8 @@ float npc::vehicle_danger( int radius ) const
     for( size_t i = 0; i < vehicles.size(); ++i ) {
         const wrapped_vehicle &wrapped_veh = vehicles[i];
         if( wrapped_veh.v->is_moving() ) {
-            const auto &points_to_check = wrapped_veh.v->immediate_path();
-            point_abs_ms p( get_map().get_abs( pos_bub() ).xy() );
+            const auto &points_to_check = wrapped_veh.v->immediate_path( &here );
+            point_abs_ms p( here.get_abs( pos_bub() ).xy() );
             if( points_to_check.find( p ) != points_to_check.end() ) {
                 danger = i;
             }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -919,11 +919,13 @@ static void tell_veh_stop_following()
 
 static void assign_veh_to_follow()
 {
+    map &here = get_map();
+
     Character &player_character = get_player_character();
-    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle &veh : here.get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( player_character ) ) {
-            v->activate_animal_follow();
+            v->activate_animal_follow( here );
         }
     }
 }

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -67,8 +67,10 @@ bool _to_map( item const &it, map &here, tripoint_bub_ms const &dpoint_here )
 
 bool _to_veh( item const &it, std::optional<vpart_reference> const &vp )
 {
+    map &here = get_map();
+
     if( vp->items().free_volume() >= it.volume() ) {
-        std::optional<vehicle_stack::iterator> const ret = vp->vehicle().add_item( vp->part(), it );
+        std::optional<vehicle_stack::iterator> const ret = vp->vehicle().add_item( here, vp->part(), it );
         return !ret.has_value();
     }
     return true;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1792,7 +1792,7 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
         }
         player_veh = &vp->vehicle();
         // for now we can only handle flyers if already in the air
-        const bool can_fly = player_veh->is_rotorcraft() && player_veh->is_flying_in_air();
+        const bool can_fly = player_veh->is_rotorcraft( here ) && player_veh->is_flying_in_air();
         const bool can_float = player_veh->can_float();
         const bool can_drive = player_veh->valid_wheel_config();
         // TODO: check engines/fuel
@@ -1801,7 +1801,7 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
         } else if( can_float && !can_drive ) {
             params = overmap_path_params::for_watercraft();
         } else if( can_drive ) {
-            const float offroad_coeff = player_veh->k_traction( player_veh->wheel_area() *
+            const float offroad_coeff = player_veh->k_traction( here, player_veh->wheel_area() *
                                         player_veh->average_offroad_rating() );
             const bool tiny = player_veh->get_points().size() <= 3;
             params = overmap_path_params::for_land_vehicle( offroad_coeff, tiny, can_float );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2262,7 +2262,7 @@ static void cycle_action( item &weap, const itype_id &ammo, map *here, const tri
             if( brass_catcher && brass_catcher->can_contain( casing ).success() ) {
                 brass_catcher->put_in( casing, pocket_type::CONTAINER );
             } else if( ovp_cargo ) {
-                ovp_cargo->vehicle().add_item( ovp_cargo->part(), casing );
+                ovp_cargo->vehicle().add_item( *here, ovp_cargo->part(), casing );
             } else {
                 here->add_item_or_charges( eject, casing );
             }
@@ -4203,7 +4203,7 @@ bool gunmode_checks_common( avatar &you, const map &m, std::vector<std::string> 
     }
 
     const optional_vpart_position vp = m.veh_at( you.pos_bub() );
-    if( vp && vp->vehicle().player_in_control( you ) && ( gmode->is_two_handed( you ) ||
+    if( vp && vp->vehicle().player_in_control( m, you ) && ( gmode->is_two_handed( you ) ||
             gmode->has_flag( flag_FIRE_TWOHAND ) ) ) {
         messages.push_back( string_format( _( "You can't fire your %s while driving." ),
                                            gmode->tname() ) );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -881,6 +881,8 @@ int sfx::set_channel_volume( channel channel, int volume )
 
 void sfx::do_vehicle_engine_sfx()
 {
+    map &here = get_map();
+
     if( test_mode ) {
         return;
     }
@@ -899,7 +901,7 @@ void sfx::do_vehicle_engine_sfx()
     } else if( player_character.in_sleep_state() && audio_muted ) {
         return;
     }
-    optional_vpart_position vpart_opt = get_map().veh_at( player_character.pos_bub() );
+    optional_vpart_position vpart_opt = here.veh_at( player_character.pos_bub( &here ) );
     vehicle *veh;
     if( vpart_opt.has_value() ) {
         veh = &vpart_opt->vehicle();
@@ -955,9 +957,9 @@ void sfx::do_vehicle_engine_sfx()
     // Getting the safe speed for a stationary vehicle is expensive and unnecessary, so the calculation
     // is delayed until it is needed.
     std::optional<int> safe_speed_cached;
-    auto safe_speed = [veh, &safe_speed_cached]() {
+    auto safe_speed = [veh, &safe_speed_cached, &here]() {
         if( !safe_speed_cached ) {
-            safe_speed_cached = veh->safe_velocity();
+            safe_speed_cached = veh->safe_velocity( here );
         }
         return *safe_speed_cached;
     };

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -743,7 +743,9 @@ void talker_character::set_thirst( int value )
 
 bool talker_character_const::is_in_control_of( const vehicle &veh ) const
 {
-    return veh.player_in_control( *me_chr_const );
+    map &here = get_map();
+
+    return veh.player_in_control( here, *me_chr_const );
 }
 
 void talker_character::shout( const std::string &speech, bool order )

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -91,11 +91,13 @@ bool turret_data::uses_vehicle_tanks_or_batteries() const
 
 int turret_data::ammo_remaining() const
 {
+    map &here = get_map();
+
     if( !veh || !part ) {
         return 0;
     }
     if( uses_vehicle_tanks_or_batteries() ) {
-        return veh->fuel_left( ammo_current() );
+        return veh->fuel_left( here, ammo_current() );
     }
     return part->base.ammo_remaining();
 }
@@ -231,6 +233,8 @@ bool turret_data::can_unload() const
 
 turret_data::status turret_data::query() const
 {
+    map &here = get_map();
+
     if( !veh || !part ) {
         return status::invalid;
     }
@@ -238,7 +242,7 @@ turret_data::status turret_data::query() const
     const item &gun = part->base;
 
     if( uses_vehicle_tanks_or_batteries() ) {
-        if( veh->fuel_left( ammo_current() ) < gun.ammo_required() ) {
+        if( veh->fuel_left( here, ammo_current() ) < gun.ammo_required() ) {
             return status::no_ammo;
         }
     } else {
@@ -248,7 +252,7 @@ turret_data::status turret_data::query() const
     }
 
     const units::energy energy_drain = gun.get_gun_energy_drain() * gun.gun_current_mode().qty;
-    if( energy_drain > units::from_kilojoule( veh->fuel_left( fuel_type_battery ) ) ) {
+    if( energy_drain > units::from_kilojoule( veh->fuel_left( here, fuel_type_battery ) ) ) {
         return status::no_power;
     }
 
@@ -257,6 +261,8 @@ turret_data::status turret_data::query() const
 
 void turret_data::prepare_fire( Character &you )
 {
+    map &here = get_map();
+
     // prevent turrets from shooting their own vehicles
     you.add_effect( effect_on_roof, 1_turns );
 
@@ -268,7 +274,7 @@ void turret_data::prepare_fire( Character &you )
     if( uses_vehicle_tanks_or_batteries() ) {
         gun_mode mode = base()->gun_current_mode();
         int qty  = mode->ammo_required();
-        int fuel_left = veh->fuel_left( ammo_current() );
+        int fuel_left = veh->fuel_left( here, ammo_current() );
         mode->ammo_set( ammo_current(), std::min( qty * mode.qty, fuel_left ) );
     }
 }

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -93,6 +93,8 @@ vehicle_part *most_repairable_part( vehicle &veh, Character &who )
 
 bool repair_part( vehicle &veh, vehicle_part &pt, Character &who )
 {
+    map &here = get_map();
+
     const vpart_info &vp = pt.info();
 
     const requirement_data reqs = pt.is_broken()
@@ -140,7 +142,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who )
         const point_rel_ms mount = pt.mount;
         const units::angle direction = pt.direction;
         const std::string variant = pt.variant;
-        get_map().spawn_items( who.pos_bub(), pt.pieces_for_broken_part() );
+        here.spawn_items( who.pos_bub( &here ), pt.pieces_for_broken_part() );
         veh.remove_part( pt );
         const int partnum = veh.install_part( mount, vpid, std::move( base ) );
         if( partnum >= 0 ) {
@@ -148,7 +150,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who )
             vp.direction = direction;
             vp.variant = variant;
         }
-        veh.part_removal_cleanup();
+        veh.part_removal_cleanup( here );
         who.add_msg_if_player( m_good, _( "You replace the %1$s's %2$s. (was %3$s)" ),
                                veh.name, partname, startdurability );
     } else {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1091,7 +1091,7 @@ void vehicle::backfire( map *here, const vehicle_part &vp ) const
     const std::string text = _( "a loud BANG! from the %s" ); // NOLINT(cata-text-style);
     const tripoint_bub_ms pos = bub_part_pos( here, vp );
     const int volume = 40 + units::to_watt( part_vpower_w( *here, vp, true ) ) / 10000;
-    if( here = &get_map() ) { // TODO: Make sound handling map aware.
+    if( here == &get_map() ) { // TODO: Make sound handling map aware.
         sounds::sound( pos, volume, sounds::sound_t::movement,
                        string_format( text, vp.name() ), true, "vehicle", "engine_backfire" );
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -148,18 +148,17 @@ static bool is_sm_tile_over_water( const tripoint_abs_ms &real_global_pos );
 
 static const int MAX_WIRE_VEHICLE_SIZE = 24;
 
-void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
+void DefaultRemovePartHandler::removed( map *here, vehicle &veh, const int part )
 {
-    map &here = get_map();
     avatar &player_character = get_avatar();
     const vehicle_part &vp = veh.part( part );
-    const tripoint_bub_ms part_pos = veh.bub_part_pos( &here, vp );
+    const tripoint_bub_ms part_pos = veh.bub_part_pos( here, vp );
 
     // If the player is currently working on the removed part, stop them as it's futile now.
     const player_activity &act = player_character.activity;
     if( act.id() == ACT_VEHICLE && act.moves_left > 0 && act.values.size() > 6 ) {
-        if( veh_pointer_or_null( here.veh_at( tripoint_bub_ms( act.values[0], act.values[1],
-                                              player_character.posz() ) ) ) == &veh ) {
+        if( veh_pointer_or_null( here->veh_at( tripoint_bub_ms( act.values[0], act.values[1],
+                                               player_character.posz() ) ) ) == &veh ) {
             if( act.values[6] >= part ) {
                 player_character.cancel_activity();
                 add_msg( m_info, _( "The vehicle part you were working on has gone!" ) );
@@ -175,12 +174,12 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
         }
     }
 
-    here.dirty_vehicle_list.insert( &veh );
-    here.clear_vehicle_point_from_cache( &veh, part_pos );
-    here.add_vehicle_to_cache( &veh );
-    here.memory_cache_dec_set_dirty( part_pos, true );
+    here->dirty_vehicle_list.insert( &veh );
+    here->clear_vehicle_point_from_cache( &veh, part_pos );
+    here->add_vehicle_to_cache( &veh );
+    here->memory_cache_dec_set_dirty( part_pos, true );
     player_character.memorize_clear_decoration(
-        here.get_abs( part_pos ), "vp_" + vp.info().id.str() );
+        here->get_abs( part_pos ), "vp_" + vp.info().id.str() );
 }
 
 // Vehicle stack methods.
@@ -194,7 +193,9 @@ vehicle_stack::iterator vehicle_stack::erase( vehicle_stack::const_iterator it )
 
 void vehicle_stack::insert( const item &newitem )
 {
-    veh.add_item( vp, newitem );
+    map &here = get_map();
+
+    veh.add_item( here, vp, newitem );
 }
 
 int vehicle_stack::count_limit() const
@@ -253,7 +254,7 @@ safe_reference<vehicle> vehicle::get_safe_reference()
     return anchor.reference_to( this );
 }
 
-bool vehicle::player_in_control( const Character &p ) const
+bool vehicle::player_in_control( const map &here, const Character &p ) const
 {
     // Debug switch to prevent vehicles from skidding
     // without having to place the player in them.
@@ -261,7 +262,7 @@ bool vehicle::player_in_control( const Character &p ) const
         return true;
     }
 
-    const optional_vpart_position vp = get_map().veh_at( p.pos_bub() );
+    const optional_vpart_position vp = here.veh_at( p.pos_bub() );
     if( vp && &vp->vehicle() == this &&
         p.controlling_vehicle &&
         ( ( part_with_feature( vp->mount_pos(), "CONTROL_ANIMAL", true ) >= 0 &&
@@ -274,7 +275,7 @@ bool vehicle::player_in_control( const Character &p ) const
     return remote_controlled( p );
 }
 
-bool vehicle::player_is_driving_this_veh() const
+bool vehicle::player_is_driving_this_veh( map *here ) const
 {
     // Unfortunate code duplication for tests
     // Debug switch to prevent vehicles from skidding
@@ -285,7 +286,7 @@ bool vehicle::player_is_driving_this_veh() const
 
     Character &player_character = get_player_character();
     // Check if the player is controlling *this* vehicle
-    return player_in_control( player_character );
+    return player_in_control( *here,  player_character );
 }
 
 bool vehicle::remote_controlled( const Character &p ) const
@@ -612,12 +613,12 @@ void vehicle::activate_magical_follow()
     }
 }
 
-void vehicle::activate_animal_follow()
+void vehicle::activate_animal_follow( map &here )
 {
     for( size_t e = 0; e < parts.size(); e++ ) {
         vehicle_part &vp = parts[ e ];
         if( vp.info().fuel_type == fuel_type_animal ) {
-            monster *mon = get_monster( e );
+            monster *mon = get_monster( here,  e );
             if( mon && mon->has_effect( effect_harnessed ) ) {
                 vp.enabled = true;
                 is_following = true;
@@ -629,7 +630,7 @@ void vehicle::activate_animal_follow()
     }
 }
 
-void vehicle::autopilot_patrol()
+void vehicle::autopilot_patrol( map *here )
 {
     /** choose one single zone ( multiple zones too complex for now )
      * choose a point at the far edge of the zone
@@ -643,19 +644,18 @@ void vehicle::autopilot_patrol()
      * in a criss-cross fashion.
      * in an auto-tractor, this would eventually cover the entire rectangle.
      */
-    map &here = get_map();
     // if we are close to a waypoint, then return to come back to this function next turn.
     if( autodrive_local_target != tripoint_abs_ms::zero ) {
         if( rl_dist( pos_abs(), autodrive_local_target ) <= 3 ) {
             autodrive_local_target = tripoint_abs_ms::zero;
             return;
         }
-        if( !here.inbounds( here.get_bub( autodrive_local_target ) ) ) {
+        if( !here->inbounds( here->get_bub( autodrive_local_target ) ) ) {
             autodrive_local_target = tripoint_abs_ms::zero;
             is_patrolling = false;
             return;
         }
-        drive_to_local_target( autodrive_local_target, false );
+        drive_to_local_target( here, autodrive_local_target, false );
         return;
     }
     zone_manager &mgr = zone_manager::get_manager();
@@ -693,10 +693,10 @@ void vehicle::autopilot_patrol()
         chosen_tri = max_tri;
     }
     autodrive_local_target = chosen_tri;
-    drive_to_local_target( autodrive_local_target, false );
+    drive_to_local_target( here, autodrive_local_target, false );
 }
 
-std::set<point_abs_ms> vehicle::immediate_path( const units::angle &rotate )
+std::set<point_abs_ms> vehicle::immediate_path( map *here, const units::angle &rotate )
 {
     std::set<point_abs_ms> points_to_check;
     const int distance_to_check = 10 + ( velocity / 800 );
@@ -705,11 +705,10 @@ std::set<point_abs_ms> vehicle::immediate_path( const units::angle &rotate )
     adjusted_angle = round_to_multiple_of( adjusted_angle, vehicles::steer_increment );
     tileray collision_vector;
     collision_vector.init( adjusted_angle );
-    map &here = get_map();
-    point_bub_ms top_left_actual = pos_bub( &here ).xy() + coord_translate( front_left );
-    point_bub_ms top_right_actual = pos_bub( &here ).xy() + coord_translate( front_right );
-    std::vector<point_abs_ms> front_row = line_to( here.get_abs( tripoint_bub_ms{top_left_actual.x(), top_left_actual.y(), here.get_abs_sub().z()} ).xy(),
-                                          here.get_abs( tripoint_bub_ms{ top_right_actual.x(), top_right_actual.y(), here.get_abs_sub().z()} ).xy() );
+    point_bub_ms top_left_actual = pos_bub( here ).xy() + coord_translate( front_left );
+    point_bub_ms top_right_actual = pos_bub( here ).xy() + coord_translate( front_right );
+    std::vector<point_abs_ms> front_row = line_to( here->get_abs( tripoint_bub_ms{top_left_actual.x(), top_left_actual.y(), here->get_abs_sub().z()} ).xy(),
+                                          here->get_abs( tripoint_bub_ms{ top_right_actual.x(), top_right_actual.y(), here->get_abs_sub().z()} ).xy() );
     for( const point_abs_ms &elem : front_row ) {
         for( int i = 0; i < distance_to_check; ++i ) {
             collision_vector.advance( i );
@@ -744,14 +743,16 @@ static int get_turn_from_angle( const units::angle &angle, const tripoint_abs_ms
     return 0;
 }
 
-void vehicle::drive_to_local_target( const tripoint_abs_ms &target, bool follow_protocol )
+void vehicle::drive_to_local_target( map *here, const tripoint_abs_ms &target,
+                                     bool follow_protocol )
 {
-    map &here = get_map();
     Character &player_character = get_player_character();
     if( follow_protocol && player_character.in_vehicle ) {
-        sounds::sound( pos_bub( &here ), 30, sounds::sound_t::alert,
-                       string_format( _( "the %s emitting a beep and saying \"Autonomous driving protocols suspended!\"" ),
-                                      name ) );
+        if( here == &get_map() ) { // TODO: Make sound handling map aware
+            sounds::sound( pos_bub( here ), 30, sounds::sound_t::alert,
+                           string_format( _( "the %s emitting a beep and saying \"Autonomous driving protocols suspended!\"" ),
+                                          name ) );
+        }
         stop_autodriving();
         return;
     }
@@ -759,12 +760,14 @@ void vehicle::drive_to_local_target( const tripoint_abs_ms &target, bool follow_
     tripoint_abs_ms vehpos = pos_abs();
     units::angle angle = get_angle_from_targ( target );
 
-    bool stop = precollision_check( angle, here, follow_protocol );
+    bool stop = precollision_check( angle, *here, follow_protocol );
     if( stop ) {
         if( autopilot_on ) {
-            sounds::sound( pos_bub( &here ), 30, sounds::sound_t::alert,
-                           string_format( _( "the %s emitting a beep and saying \"Obstacle detected!\"" ),
-                                          name ) );
+            if( here == &get_map() ) { // TODO: Make sound handling map aware
+                sounds::sound( pos_bub( here ), 30, sounds::sound_t::alert,
+                               string_format( _( "the %s emitting a beep and saying \"Obstacle detected!\"" ),
+                                              name ) );
+            }
         }
         stop_autodriving();
         return;
@@ -781,12 +784,12 @@ void vehicle::drive_to_local_target( const tripoint_abs_ms &target, bool follow_
                                          player_character.current_movement_mode()->move_speed_mult();
     if( follow_protocol ) {
         if( ( ( turn_x > 0 || turn_x < 0 ) && velocity > safe_player_follow_speed ) ||
-            rl_dist( vehpos, here.get_abs( player_character.pos_bub() ) ) < 7 + ( (
+            rl_dist( vehpos, here->get_abs( player_character.pos_bub( here ) ) ) < 7 + ( (
                         mount_max.y() * 3 ) + 4 ) ) {
             accel_y = 1;
         }
-        if( ( velocity < std::min( safe_velocity(), safe_player_follow_speed ) && turn_x == 0 &&
-              rl_dist( vehpos, here.get_abs( player_character.pos_bub() ) ) > 8 + ( (
+        if( ( velocity < std::min( safe_velocity( *here ), safe_player_follow_speed ) && turn_x == 0 &&
+              rl_dist( vehpos, here->get_abs( player_character.pos_bub( here ) ) ) > 8 + ( (
                           mount_max.y() * 3 ) + 4 ) ) ||
             velocity < 100 ) {
             accel_y = -1;
@@ -795,7 +798,7 @@ void vehicle::drive_to_local_target( const tripoint_abs_ms &target, bool follow_
         if( ( turn_x > 0 || turn_x < 0 ) && velocity > 1000 ) {
             accel_y = 1;
         }
-        if( ( velocity < std::min( safe_velocity(), is_rotorcraft() &&
+        if( ( velocity < std::min( safe_velocity( *here ), is_rotorcraft( *here ) &&
                                    is_flying_in_air() ? 12000 : 32 * 100 ) && turn_x == 0 ) || velocity < 500 ) {
             accel_y = -1;
         }
@@ -814,7 +817,7 @@ bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_pr
     Character &player_character = get_player_character();
     // now we got the angle to the target, we can work out when we are heading towards disaster.
     // Check the tileray in the direction we need to head towards.
-    std::set<point_abs_ms> points_to_check = immediate_path( angle );
+    std::set<point_abs_ms> points_to_check = immediate_path( &here, angle );
     bool stop = false;
     creature_tracker &creatures = get_creature_tracker();
     for( const point_abs_ms &pt_elem : points_to_check ) {
@@ -844,7 +847,7 @@ bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_pr
                 break;
             }
             for( const vehicle_part &p : parts ) {
-                monster *mon = get_monster( index_of_part( &p ) );
+                monster *mon = get_monster( here,  index_of_part( &p ) );
                 if( mon && mon->pos_bub().xy() == elem ) {
                     its_a_pet = true;
                     break;
@@ -946,6 +949,7 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
                     // This is a heuristic: we just assume the default handler is good enough when called
                     // on the main game map. And assume that we run from some mapgen code if called on
                     // another instance.
+                    // TODO: Make this capable of distinguishing between mapgen and non bubble active maps.
                     if( g && &get_map() == &m ) {
                         handler_ptr = std::make_unique<DefaultRemovePartHandler>();
                     } else {
@@ -1036,7 +1040,7 @@ bool vehicle::is_engine_on( const vehicle_part &vp ) const
     return vp.is_available() && vp.enabled;
 }
 
-bool vehicle::is_alternator_on( const vehicle_part &vp ) const
+bool vehicle::is_alternator_on( map &here, const vehicle_part &vp ) const
 {
     if( vp.is_unavailable() ) {
         return false;
@@ -1046,7 +1050,7 @@ bool vehicle::is_alternator_on( const vehicle_part &vp ) const
         if( vp_engine.mount == vp.mount
             && vp_engine.is_available()
             && vp_engine.enabled
-            && fuel_left( vp_engine.fuel_current() )
+            && fuel_left( here, vp_engine.fuel_current() )
             && !vp_engine.has_fault_flag( "NO_ALTERNATOR_CHARGE" ) ) {
             return true; // the engine can drive its alternator
         }
@@ -1054,9 +1058,9 @@ bool vehicle::is_alternator_on( const vehicle_part &vp ) const
     return false;
 }
 
-bool vehicle::has_security_working() const
+bool vehicle::has_security_working( map &here ) const
 {
-    if( fuel_left( fuel_type_battery ) > 0 ) {
+    if( fuel_left( here, fuel_type_battery ) > 0 ) {
         for( const int s : speciality ) {
             const vehicle_part &vp = part( s );
             if( vp.info().has_flag( "SECURITY" ) && vp.is_available() ) {
@@ -1080,21 +1084,23 @@ void vehicle::unlock()
     }
 }
 
-void vehicle::backfire( const vehicle_part &vp ) const
+void vehicle::backfire( map *here, const vehicle_part &vp ) const
 {
-    map &here = get_map();
     // single space after the exclamation mark because it does not end the sentence
     //~ backfire sound
     const std::string text = _( "a loud BANG! from the %s" ); // NOLINT(cata-text-style);
-    const tripoint_bub_ms pos = bub_part_pos( &here, vp );
-    const int volume = 40 + units::to_watt( part_vpower_w( vp, true ) ) / 10000;
-    sounds::sound( pos, volume, sounds::sound_t::movement,
-                   string_format( text, vp.name() ), true, "vehicle", "engine_backfire" );
+    const tripoint_bub_ms pos = bub_part_pos( here, vp );
+    const int volume = 40 + units::to_watt( part_vpower_w( *here, vp, true ) ) / 10000;
+    if( here = &get_map() ) { // TODO: Make sound handling map aware.
+        sounds::sound( pos, volume, sounds::sound_t::movement,
+                       string_format( text, vp.name() ), true, "vehicle", "engine_backfire" );
+    }
 }
 
 // engines & alternators all have power.
 // engines provide, whilst alternators consume.
-units::power vehicle::part_vpower_w( const vehicle_part &vp, const bool at_full_hp ) const
+units::power vehicle::part_vpower_w( map &here, const vehicle_part &vp,
+                                     const bool at_full_hp ) const
 {
     const vpart_info &vpi = vp.info();
     const int vp_index = index_of_part( &vp );
@@ -1102,7 +1108,8 @@ units::power vehicle::part_vpower_w( const vehicle_part &vp, const bool at_full_
     if( vpi.has_flag( VPFLAG_ENGINE ) ) {
         if( vpi.fuel_type == fuel_type_animal ) {
             int factor = 0;
-            if( const monster *mon = get_monster( vp_index ); mon && mon->has_effect( effect_harnessed ) ) {
+            if( const monster *mon = get_monster( here, vp_index ); mon &&
+                mon->has_effect( effect_harnessed ) ) {
                 factor += mon->get_size() - 1;
                 factor *= mon->get_speed();
                 factor *= mon->get_mountable_weight_ratio();
@@ -1545,9 +1552,8 @@ int vehicle::install_part( const point_rel_ms &dp, vehicle_part &&vp )
     return vp_installed_index;
 }
 
-std::vector<vehicle::rackable_vehicle> vehicle::find_vehicles_to_rack( int rack ) const
+std::vector<vehicle::rackable_vehicle> vehicle::find_vehicles_to_rack( map *here, int rack ) const
 {
-    map &here = get_map();
     std::vector<rackable_vehicle> rackables;
     for( const std::vector<int> &maybe_rack : find_lines_of_parts( rack, "BIKE_RACK_VEH" ) ) {
         std::vector<int> filtered_rack; // only empty racks
@@ -1560,8 +1566,8 @@ std::vector<vehicle::rackable_vehicle> vehicle::find_vehicles_to_rack( int rack 
             vehicle *veh_matched = nullptr;
             std::set<tripoint_bub_ms> parts_matched;
             for( const int &rack_part : filtered_rack ) {
-                const tripoint_bub_ms search_pos = bub_part_pos( &here, rack_part ) + offset;
-                const optional_vpart_position ovp = here.veh_at( search_pos );
+                const tripoint_bub_ms search_pos = bub_part_pos( here, rack_part ) + offset;
+                const optional_vpart_position ovp = here->veh_at( search_pos );
                 if( !ovp || &ovp->vehicle() == this || ovp->vehicle().is_appliance() ) {
                     continue;
                 }
@@ -1575,7 +1581,7 @@ std::vector<vehicle::rackable_vehicle> vehicle::find_vehicles_to_rack( int rack 
                 std::set<tripoint_bub_ms> test_veh_points;
                 for( const vpart_reference &vpr : test_veh->get_all_parts() ) {
                     if( !vpr.part().removed && !vpr.part().is_fake ) {
-                        test_veh_points.insert( vpr.pos_bub( &here ) );
+                        test_veh_points.insert( vpr.pos_bub( here ) );
                     }
                 }
 
@@ -1678,9 +1684,9 @@ std::vector<vehicle::unrackable_vehicle> vehicle::find_vehicles_to_unrack( int r
     return unrackables;
 }
 
-bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int> &rack_parts )
+bool vehicle::merge_rackable_vehicle( map *here, vehicle *carry_veh,
+                                      const std::vector<int> &rack_parts )
 {
-    map &here = get_map();
     for( const vpart_reference &vpr : this->get_any_parts( "BIKE_RACK_VEH" ) ) {
         const auto unrackables = find_vehicles_to_unrack( vpr.part_index() );
         for( const unrackable_vehicle &unrackable : unrackables ) {
@@ -1827,12 +1833,12 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
 
         //~ %1$s is the vehicle being loaded onto the bicycle rack
         add_msg( _( "You load the %1$s on the rack." ), carry_veh->name );
-        here.destroy_vehicle( carry_veh );
-        here.dirty_vehicle_list.insert( this );
-        here.set_transparency_cache_dirty( sm_pos.z() );
-        here.set_seen_cache_dirty( tripoint_bub_ms::zero );
-        here.invalidate_map_cache( here.get_abs_sub().z() );
-        here.rebuild_vehicle_level_caches();
+        here->destroy_vehicle( carry_veh );
+        here->dirty_vehicle_list.insert( this );
+        here->set_transparency_cache_dirty( sm_pos.z() );
+        here->set_seen_cache_dirty( tripoint_bub_ms::zero );
+        here->invalidate_map_cache( here->get_abs_sub().z() );
+        here->rebuild_vehicle_level_caches();
     } else {
         //~ %1$s is the vehicle being loaded onto the bicycle rack
         add_msg( m_bad, _( "You can't get the %1$s on the rack." ), carry_veh->name );
@@ -1840,9 +1846,8 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
     return found_all_parts;
 }
 
-bool vehicle::merge_vehicle_parts( vehicle *veh )
+bool vehicle::merge_vehicle_parts( map *here, vehicle *veh )
 {
-    map &here = get_map();
     for( const vehicle_part &part : veh->parts ) {
         if( part.is_fake || part.removed ) {
             continue;
@@ -1853,9 +1858,9 @@ bool vehicle::merge_vehicle_parts( vehicle *veh )
             item drop = veh->part_to_item( part );
             if( drop.link().t_veh.get() == this ) {
                 if( !veh->magic && part.info().id != vpart_power_cord ) {
-                    const tripoint_bub_ms drop_pos = veh->bub_part_pos( &here, part );
+                    const tripoint_bub_ms drop_pos = veh->bub_part_pos( here, part );
                     drop.reset_link( false, nullptr, -1, true, drop_pos );
-                    here.add_item_or_charges( drop_pos, drop );
+                    here->add_item_or_charges( drop_pos, drop );
                 }
                 veh->remove_remote_part( part );
                 continue;
@@ -1871,22 +1876,20 @@ bool vehicle::merge_vehicle_parts( vehicle *veh )
         refresh( );
     }
 
-    here.destroy_vehicle( veh );
+    here->destroy_vehicle( veh );
 
     return true;
 }
 
-bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
+bool vehicle::merge_appliance_into_grid( map *here, vehicle &veh_target )
 {
-    map &here = get_map();
-
     if( &veh_target == this ) {
         return false;
     }
     // Release grab if player is dragging either appliance
     if( get_avatar().get_grab_type() == object_type::VEHICLE ) {
-        const tripoint_bub_ms grab_point = get_avatar().pos_bub( &here ) + get_avatar().grab_point;
-        const optional_vpart_position grabbed_veh = here.veh_at( grab_point );
+        const tripoint_bub_ms grab_point = get_avatar().pos_bub( here ) + get_avatar().grab_point;
+        const optional_vpart_position grabbed_veh = here->veh_at( grab_point );
         if( grabbed_veh && ( &grabbed_veh->vehicle() == this || &grabbed_veh->vehicle() == &veh_target ) ) {
             add_msg( _( "You release the %s." ), grabbed_veh->vehicle().name );
             get_avatar().grab( object_type::NONE );
@@ -1897,15 +1900,15 @@ bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
     veh_target.turn_dir = 0_degrees;
 
     // Ensure both vehicles have the correct position and a part at 0,0. get_bounding_box will update precalcs.
-    shift_if_needed( here );
+    shift_if_needed( *here );
     pos -= pivot_anchor[0];
-    veh_target.shift_if_needed( here );
+    veh_target.shift_if_needed( *here );
     veh_target.pos -= veh_target.pivot_anchor[0];
 
     bounding_box vehicle_box = get_bounding_box( false, true );
     bounding_box target_vehicle_box = veh_target.get_bounding_box( false, true );
-    const tripoint_bub_ms veh_pos = pos_bub( &here );
-    const tripoint_bub_ms target_pos = veh_target.pos_bub( &here );
+    const tripoint_bub_ms veh_pos = pos_bub( here );
+    const tripoint_bub_ms target_pos = veh_target.pos_bub( here );
     const point_bub_ms min = { std::min( veh_pos.x() + vehicle_box.p1.x(), target_pos.x() + target_vehicle_box.p1.x() ),
                                std::min( veh_pos.y() + vehicle_box.p1.y(), target_pos.y() + target_vehicle_box.p1.y() )
                              };
@@ -1919,14 +1922,14 @@ bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
     //Make sure the resulting vehicle would not be too large
     if( size.x() <= MAX_WIRE_VEHICLE_SIZE && size.y() <= MAX_WIRE_VEHICLE_SIZE ) {
         // Find all item connections to the merging network so they can be updated after merge.
-        std::vector<item_reference> network_connections = here.item_network_connections( &veh_target );
-        tripoint_bub_ms old_grid_reference{veh_target.pos_bub( &here )};
-        if( !merge_vehicle_parts( &veh_target ) ) {
+        std::vector<item_reference> network_connections = here->item_network_connections( &veh_target );
+        tripoint_bub_ms old_grid_reference{veh_target.pos_bub( here )};
+        if( !merge_vehicle_parts( here, &veh_target ) ) {
             debugmsg( "failed to merge vehicle parts" );
         } else {
             //  Adjust the connections after the change of the power_grid origo.
             for( const item_reference &item_ref : network_connections ) {
-                item_ref.item_ref->link().t_mount += ( old_grid_reference - this->pos_bub( &here ) ).xy();
+                item_ref.item_ref->link().t_mount += ( old_grid_reference - this->pos_bub( here ) ).xy();
             }
 
             //Keep wall wiring sections from losing their flag
@@ -1942,11 +1945,11 @@ bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
     return false;
 }
 
-void vehicle::separate_from_grid( const point_rel_ms mount )
+void vehicle::separate_from_grid( map *here, const point_rel_ms mount )
 {
     // Disconnect items and power cords
     unlink_cables( mount, get_player_character(), true, true, true );
-    part_removal_cleanup();
+    part_removal_cleanup( *here );
     if( part_count() <= 1 ) {
         // No need to split the power grid up.
         return;
@@ -1958,28 +1961,27 @@ void vehicle::separate_from_grid( const point_rel_ms mount )
         debugmsg( "no part at mount point %s", mount.to_string() );
         return;
     }
-    map &here = get_map();
     const std::string part_name = part( idx ).name();
     std::vector<std::vector<int>> split_indices( { { idx } } );
     const std::vector<vehicle *> null_vehicles( 2, nullptr );
     const std::vector<std::vector<point_rel_ms>> null_mounts( 2, std::vector<point_rel_ms>() );
-    if( !split_vehicles( here, split_indices, null_vehicles, null_mounts ) ) {
+    if( !split_vehicles( *here, split_indices, null_vehicles, null_mounts ) ) {
         debugmsg( "unable to split %s from power grid", part( idx ).name( false ) );
         return;
     }
 
     // Split again if removing the target part separated the power grid into multiple sections.
-    find_and_split_vehicles( here, {} );
+    find_and_split_vehicles( *here, {} );
 
     // Ensure the position, pivot, and precalc points are up-to-date.
-    shift_if_needed( get_map() );
+    shift_if_needed( *here );
     pos -= pivot_anchor[0];
     precalc_mounts( 0, turn_dir, point_rel_ms::zero );
 
     add_msg( _( "You separate the %s from the power grid" ), part_name );
 
-    part_removal_cleanup();
-    here.rebuild_vehicle_level_caches();
+    part_removal_cleanup( *here );
+    here->rebuild_vehicle_level_caches();
 }
 
 bool vehicle::is_powergrid() const
@@ -2029,11 +2031,11 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
 
     // Unboard any entities standing on removed boardable parts
     if( vpi.has_flag( "BOARDABLE" ) && vp.has_flag( vp_flag::passenger_flag ) ) {
-        handler.unboard( part_loc );
+        handler.unboard( &handler.get_map_ref(), part_loc );
     }
 
     for( const item &it : vp.tools ) {
-        handler.add_item_or_charges( part_loc, it, false );
+        handler.add_item_or_charges( &handler.get_map_ref(), part_loc, it, false );
     }
 
     // If `p` has flag `parent_flag`, remove child with flag `child_flag`
@@ -2045,7 +2047,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
             return false;
         }
         vehicle_part &vp_dep = parts[dep];
-        handler.add_item_or_charges( part_loc, part_to_item( vp_dep ), false );
+        handler.add_item_or_charges( &handler.get_map_ref(), part_loc, part_to_item( vp_dep ), false );
         remove_part( vp_dep, handler );
         return true;
     };
@@ -2067,7 +2069,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
     // Release any animal held by the part
     if( vp.has_flag( vp_flag::animal_flag ) ) {
         item base = vp.get_base();
-        handler.spawn_animal_from_part( base, part_loc );
+        handler.spawn_animal_from_part( base, &handler.get_map_ref(), part_loc );
         vp.set_base( std::move( base ) );
         vp.remove_flag( vp_flag::animal_flag );
     }
@@ -2109,7 +2111,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
     }
 
     const int vp_idx = index_of_part( &vp, /* include_removed = */ true );
-    handler.removed( *this, vp_idx );
+    handler.removed( &handler.get_map_ref(), *this, vp_idx );
 
     const point_rel_ms &vp_mount = vp.mount;
     const auto iter = labels.find( label( vp_mount ) );
@@ -2127,7 +2129,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
             // so we pass true here to cause such points to be clamped to the
             // valid bounds without printing an error (as would normally
             // occur).
-            handler.add_item_or_charges( dest, i, true );
+            handler.add_item_or_charges( &handler.get_map_ref(), dest, i, true );
         }
     }
     refresh( false );
@@ -2135,10 +2137,9 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
     return shift_if_needed( handler.get_map_ref() );
 }
 
-bool vehicle::do_remove_part_actual()
+bool vehicle::do_remove_part_actual( map *here )
 {
     bool changed = false;
-    map &here = get_map();
     for( std::vector<vehicle_part>::iterator it = parts.end(); it != parts.begin(); /*noop*/ ) {
         --it;
         vehicle_part &vp = *it;
@@ -2154,8 +2155,8 @@ bool vehicle::do_remove_part_actual()
                 get_items( vp ).clear();
             }
             if( vp.is_real_or_active_fake() ) {
-                const tripoint_bub_ms pt = bub_part_pos( &here, vp );
-                here.clear_vehicle_point_from_cache( this, pt );
+                const tripoint_bub_ms pt = bub_part_pos( here, vp );
+                here->clear_vehicle_point_from_cache( this, pt );
             }
             it = parts.erase( it );
             changed = true;
@@ -2163,11 +2164,10 @@ bool vehicle::do_remove_part_actual()
     }
     return changed;
 }
-void vehicle::part_removal_cleanup()
+void vehicle::part_removal_cleanup( map &here )
 {
-    map &here = get_map();
     remove_fake_parts( false );
-    const bool changed =  do_remove_part_actual();
+    const bool changed =  do_remove_part_actual( &here );
     if( changed || parts.empty() ) {
         refresh( );
         if( parts.empty() ) {
@@ -2187,11 +2187,9 @@ void vehicle::part_removal_cleanup()
     coeff_air_changed = false;
 }
 
-bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts,
+bool vehicle::remove_carried_vehicle( map &here, const std::vector<int> &carried_parts,
                                       const std::vector<int> &racks )
 {
-    map &here = get_map();
-
     if( carried_parts.empty() || racks.empty() ) {
         return false;
     }
@@ -2286,7 +2284,7 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts,
             new_vehicle->toggle_tracking();
         }
         here.dirty_vehicle_list.insert( this );
-        part_removal_cleanup();
+        part_removal_cleanup( here );
         new_vehicle->enable_refresh();
         for( const int p : new_vehicle->engines ) {
             vehicle_part &vp = new_vehicle->parts[p];
@@ -3484,25 +3482,24 @@ Character *vehicle::get_passenger( int you ) const
     return nullptr;
 }
 
-bool vehicle::has_driver() const
+bool vehicle::has_driver( map &here ) const
 {
-    return get_driver();
+    return get_driver( here );
 }
 
-Character *vehicle::get_driver() const
+Character *vehicle::get_driver( map &here ) const
 {
     for( const int vp : boarded_parts() ) {
         Character *occupant = get_passenger( vp );
-        if( occupant && player_in_control( *occupant ) ) {
+        if( occupant && player_in_control( here, *occupant ) ) {
             return occupant;
         }
     }
     return nullptr;
 }
 
-monster *vehicle::get_monster( int p ) const
+monster *vehicle::get_monster( map &here, int p ) const
 {
-    map &here = get_map();
     p = part_with_feature( p, VPFLAG_BOARDABLE, false );
     if( p >= 0 ) {
         return get_creature_tracker().creature_at<monster>( bub_part_pos( &here, p ), true );
@@ -3567,14 +3564,14 @@ units::mass vehicle::total_mass() const
     return mass_cache;
 }
 
-units::mass vehicle::weight_on_wheels() const
+units::mass vehicle::weight_on_wheels( map &here ) const
 {
     const units::mass vehicle_mass = total_mass();
     units::mass animal_mass = 0_gram;
     for( const int e : engines ) {
         const vehicle_part &vp = parts[e];
         if( vp.info().fuel_type == fuel_type_animal ) {
-            monster *mon = get_monster( e );
+            monster *mon = get_monster( here, e );
             if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
                 animal_mass += mon->get_weight();
             }
@@ -3615,12 +3612,12 @@ point_rel_ms vehicle::pivot_displacement() const
     return dp.xy();
 }
 
-int64_t vehicle::fuel_left( const itype_id &ftype,
+int64_t vehicle::fuel_left( map &here, const itype_id &ftype,
                             const std::function<bool( const vehicle_part & )> &filter ) const
 {
     int64_t fl = 0;
     if( ftype == fuel_type_battery ) {
-        for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles() ) {
+        for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles( here ) ) {
             const vehicle &veh = *pair.first;
             const float loss = pair.second;
             for( const int part_idx : veh.batteries ) {
@@ -3647,12 +3644,12 @@ int64_t vehicle::fuel_left( const itype_id &ftype,
 
     //muscle engines have infinite fuel
     if( ftype == fuel_type_muscle ) {
-        Character *driver = get_driver();
+        Character *driver = get_driver( here );
         if( !driver ) {
             // FIXME: Should return fl, not arbitrarily assume player
             driver = &get_player_character();
         }
-        const optional_vpart_position vp = get_map().veh_at( driver->pos_bub() );
+        const optional_vpart_position vp = here.veh_at( driver->pos_bub() );
 
         //if the engine in the tile is a muscle engine, and someone is ready to control this vehicle
         // TODO: Allow NPCs to power those
@@ -3678,16 +3675,16 @@ int64_t vehicle::fuel_left( const itype_id &ftype,
     return fl;
 }
 
-int vehicle::engine_fuel_left( const vehicle_part &vp ) const
+int vehicle::engine_fuel_left( map &here, const vehicle_part &vp ) const
 {
-    return fuel_left( vp.fuel_current() );
+    return fuel_left( here, vp.fuel_current() );
 }
 
-int vehicle::fuel_capacity( const itype_id &ftype ) const
+int vehicle::fuel_capacity( map &here, const itype_id &ftype ) const
 {
     if( ftype == fuel_type_battery ) { // batteries get special treatment due to power cables
         int64_t capacity = 0;
-        for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles() ) {
+        for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles( here ) ) {
             const vehicle &veh = *pair.first;
             for( const int part_idx : veh.batteries ) {
                 const vehicle_part &vp = veh.parts[part_idx];
@@ -3706,11 +3703,11 @@ int vehicle::fuel_capacity( const itype_id &ftype ) const
     } );
 }
 
-int vehicle::drain( const itype_id &ftype, int amount,
+int vehicle::drain( map &here, const itype_id &ftype, int amount,
                     const std::function<bool( vehicle_part & )> &filter,
                     bool apply_loss )
 {
-    return vehicle::drain( &get_map(), ftype, amount, filter, apply_loss );
+    return vehicle::drain( &here, ftype, amount, filter, apply_loss );
 }
 
 int vehicle::drain( map *here, const itype_id &ftype, int amount,
@@ -3721,7 +3718,7 @@ int vehicle::drain( map *here, const itype_id &ftype, int amount,
         // Batteries get special handling to take advantage of jumper
         // cables -- discharge_battery knows how to recurse properly
         // (including taking cable power loss into account).
-        int remnant = discharge_battery( amount, apply_loss );
+        int remnant = discharge_battery( *here, amount, apply_loss );
 
         // discharge_battery returns amount of charges that were not
         // found anywhere in the power network, whereas this function
@@ -3748,10 +3745,8 @@ int vehicle::drain( map *here, const itype_id &ftype, int amount,
     return drained;
 }
 
-int vehicle::drain( const int index, int amount, bool apply_loss )
+int vehicle::drain( map &here, const int index, int amount, bool apply_loss )
 {
-    map &here = get_map();
-
     if( index < 0 || index >= static_cast<int>( parts.size() ) ) {
         debugmsg( "Tried to drain an invalid part index: %d", index );
         return 0;
@@ -3762,7 +3757,7 @@ int vehicle::drain( const int index, int amount, bool apply_loss )
         //to not break existing code, but C++ requires you also invoke all optional
         //arguments to the left of any invoked. make sure to change this if the default for
         //filters in the function above ever changes
-        return drain( fuel_type_battery, amount, return_true< vehicle_part &>, apply_loss );
+        return drain( here, fuel_type_battery, amount, return_true< vehicle_part &>, apply_loss );
     }
     if( !pt.is_tank() || !pt.ammo_remaining() ) {
         debugmsg( "Tried to drain something without any liquid: %s amount: %d ammo: %d",
@@ -3775,7 +3770,7 @@ int vehicle::drain( const int index, int amount, bool apply_loss )
     return drained;
 }
 
-units::power vehicle::basic_consumption( const itype_id &ftype ) const
+units::power vehicle::basic_consumption( map &here, const itype_id &ftype ) const
 {
     units::power fcon = 0_W;
     for( const int p : engines ) {
@@ -3786,7 +3781,7 @@ units::power vehicle::basic_consumption( const itype_id &ftype ) const
         if( vp.ammo_current() == fuel_type_battery && part_epower( vp ) >= 0_W ) {
             fcon -= part_epower( vp ); // Electric engine - use epower instead
         } else if( !is_perpetual_type( vp ) ) {
-            fcon += part_vpower_w( vp );
+            fcon += part_vpower_w( here,  vp );
             if( vp.has_fault_flag( "DOUBLE_FUEL_CONSUMPTION" ) ) {
                 fcon *= 2;
             }
@@ -3808,27 +3803,27 @@ int vehicle::consumption_per_hour( const itype_id &ftype, units::energy fuel_per
     return -1000 * energy_per_h / energy_per_liter;
 }
 
-units::power vehicle::total_power( const bool fueled, const bool safe ) const
+units::power vehicle::total_power( map &here, const bool fueled, const bool safe ) const
 {
     units::power pwr = 0_W;
     int count = 0;
 
     for( const int p : engines ) {
         const vehicle_part &vp = parts[p];
-        if( is_engine_on( vp ) && ( !fueled || engine_fuel_left( vp ) ) ) {
+        if( is_engine_on( vp ) && ( !fueled || engine_fuel_left( here, vp ) ) ) {
             int m2c = safe ? vp.info().engine_info->m2c : 100;
             if( vp.has_fault_flag( "REDUCE_ENG_POWER" ) ) {
                 m2c *= 0.6;
             }
-            pwr += part_vpower_w( vp ) * m2c / 100;
+            pwr += part_vpower_w( here, vp ) * m2c / 100;
             count++;
         }
     }
 
     for( const int p : alternators ) {
         const vehicle_part &vp = parts[p];
-        if( is_alternator_on( vp ) ) {
-            pwr += part_vpower_w( vp ); // alternators have negative power
+        if( is_alternator_on( here, vp ) ) {
+            pwr += part_vpower_w( here, vp ); // alternators have negative power
         }
     }
     pwr = std::max( 0_W, pwr );
@@ -3844,14 +3839,13 @@ bool vehicle::is_moving() const
     return velocity != 0;
 }
 
-bool vehicle::can_use_rails() const
+bool vehicle::can_use_rails( map &here ) const
 {
     // do not allow vehicles without rail wheels or with mixed wheels
     bool can_use = !rail_wheelcache.empty() && wheelcache.size() == rail_wheelcache.size();
     if( !can_use ) {
         return false;
     }
-    map &here = get_map();
     bool is_wheel_on_rail = false;
     for( int part_index : rail_wheelcache ) {
         // at least one wheel should be on track
@@ -3863,12 +3857,12 @@ bool vehicle::can_use_rails() const
     return is_wheel_on_rail;
 }
 
-int vehicle::ground_acceleration( const bool fueled, int at_vel_in_vmi ) const
+int vehicle::ground_acceleration( map &here, const bool fueled, int at_vel_in_vmi ) const
 {
     if( !( engine_on || skidding ) ) {
         return 0;
     }
-    int target_vmiph = std::max( at_vel_in_vmi, std::max( 1000, max_velocity( fueled ) / 4 ) );
+    int target_vmiph = std::max( at_vel_in_vmi, std::max( 1000, max_velocity( here, fueled ) / 4 ) );
     int cmps = vmiph_to_cmps( target_vmiph );
     double weight = to_kilogram( total_mass() );
     if( is_towing() ) {
@@ -3877,30 +3871,31 @@ int vehicle::ground_acceleration( const bool fueled, int at_vel_in_vmi ) const
             weight = weight + to_kilogram( other_veh->total_mass() );
         }
     }
-    int engine_power_ratio = units::to_watt( total_power( fueled ) ) / weight;
+    int engine_power_ratio = units::to_watt( total_power( here, fueled ) ) / weight;
     int accel_at_vel = 100 * 100 * engine_power_ratio / cmps;
     add_msg_debug( debugmode::DF_VEHICLE, "%s: accel at %d vimph is %d", name, target_vmiph,
                    cmps_to_vmiph( accel_at_vel ) );
     return cmps_to_vmiph( accel_at_vel );
 }
 
-int vehicle::rotor_acceleration( const bool fueled, int at_vel_in_vmi ) const
+int vehicle::rotor_acceleration( map &here, const bool fueled, int at_vel_in_vmi ) const
 {
     ( void )at_vel_in_vmi;
     if( !( engine_on || is_flying ) ) {
         return 0;
     }
-    const int accel_at_vel = 100 * lift_thrust_of_rotorcraft( fueled ) / to_kilogram( total_mass() );
+    const int accel_at_vel = 100 * lift_thrust_of_rotorcraft( here,
+                             fueled ) / to_kilogram( total_mass() );
     return cmps_to_vmiph( accel_at_vel );
 }
 
-int vehicle::water_acceleration( const bool fueled, int at_vel_in_vmi ) const
+int vehicle::water_acceleration( map &here, const bool fueled, int at_vel_in_vmi ) const
 {
     if( !( engine_on || skidding ) ) {
         return 0;
     }
     int target_vmiph = std::max( at_vel_in_vmi, std::max( 1000,
-                                 max_water_velocity( fueled ) / 4 ) );
+                                 max_water_velocity( here, fueled ) / 4 ) );
     int cmps = vmiph_to_cmps( target_vmiph );
     double weight = to_kilogram( total_mass() );
     if( is_towing() ) {
@@ -3909,7 +3904,7 @@ int vehicle::water_acceleration( const bool fueled, int at_vel_in_vmi ) const
             weight = weight + to_kilogram( other_veh->total_mass() );
         }
     }
-    int engine_power_ratio = units::to_watt( total_power( fueled ) ) / weight;
+    int engine_power_ratio = units::to_watt( total_power( here, fueled ) ) / weight;
     int accel_at_vel = 100 * 100 * engine_power_ratio / cmps;
     add_msg_debug( debugmode::DF_VEHICLE, "%s: water accel at %d vimph is %d", name, target_vmiph,
                    cmps_to_vmiph( accel_at_vel ) );
@@ -3950,19 +3945,19 @@ static double simple_cubic_solution( double a, double b, double c, double d )
     }
 }
 
-int vehicle::acceleration( const bool fueled, int at_vel_in_vmi ) const
+int vehicle::acceleration( map &here, const bool fueled, int at_vel_in_vmi ) const
 {
     if( is_watercraft() ) {
-        return water_acceleration( fueled, at_vel_in_vmi );
-    } else if( is_rotorcraft() && is_flying ) {
-        return rotor_acceleration( fueled, at_vel_in_vmi );
+        return water_acceleration( here, fueled, at_vel_in_vmi );
+    } else if( is_rotorcraft( here ) && is_flying ) {
+        return rotor_acceleration( here, fueled, at_vel_in_vmi );
     }
-    return ground_acceleration( fueled, at_vel_in_vmi );
+    return ground_acceleration( here, fueled, at_vel_in_vmi );
 }
 
-int vehicle::current_acceleration( const bool fueled ) const
+int vehicle::current_acceleration( map &here, const bool fueled ) const
 {
-    return acceleration( fueled, std::abs( velocity ) );
+    return acceleration( here, fueled, std::abs( velocity ) );
 }
 
 // Ugly physics below:
@@ -3990,9 +3985,9 @@ int vehicle::current_acceleration( const bool fueled ) const
 // c_air_drag * v^3 + c_rolling_drag * v^2 + c_rolling_drag * 33.3 * v - engine power = 0
 // solve for v with the simplified cubic equation solver
 // got it? quiz on Wednesday.
-int vehicle::max_ground_velocity( const bool fueled ) const
+int vehicle::max_ground_velocity( map &here, const bool fueled ) const
 {
-    int total_engine_w = units::to_watt( total_power( fueled ) );
+    int total_engine_w = units::to_watt( total_power( here, fueled ) );
     double c_rolling_drag = coeff_rolling_drag();
     double max_in_mps = simple_cubic_solution( coeff_air_drag(), c_rolling_drag,
                         c_rolling_drag * vehicles::rolling_constant_to_variable,
@@ -4013,9 +4008,9 @@ int vehicle::max_ground_velocity( const bool fueled ) const
 // engine_power = ( c_water_drag + c_air_drag ) * velocity^3
 // velocity^3 = engine_power / ( c_water_drag + c_air_drag )
 // velocity = cube root( engine_power / ( c_water_drag + c_air_drag ) )
-int vehicle::max_water_velocity( const bool fueled ) const
+int vehicle::max_water_velocity( map &here, const bool fueled ) const
 {
-    int total_engine_w = units::to_watt( total_power( fueled ) );
+    int total_engine_w = units::to_watt( total_power( here, fueled ) );
     double total_drag = coeff_water_drag() + coeff_air_drag();
     double max_in_mps = std::cbrt( total_engine_w / total_drag );
     add_msg_debug( debugmode::DF_VEHICLE,
@@ -4024,29 +4019,30 @@ int vehicle::max_water_velocity( const bool fueled ) const
     return mps_to_vmiph( max_in_mps );
 }
 
-int vehicle::max_rotor_velocity( const bool fueled ) const
+int vehicle::max_rotor_velocity( map &here, const bool fueled ) const
 {
-    const double max_air_mps = std::sqrt( lift_thrust_of_rotorcraft( fueled ) / coeff_air_drag() );
+    const double max_air_mps = std::sqrt( lift_thrust_of_rotorcraft( here,
+                                          fueled ) / coeff_air_drag() );
     // helicopters just cannot go over 250mph at very maximum
     // weird things start happening to their rotors if they do.
     // due to the rotor tips going supersonic.
     return std::min( 25501, mps_to_vmiph( max_air_mps ) );
 }
 
-int vehicle::max_velocity( const bool fueled ) const
+int vehicle::max_velocity( map &here, const bool fueled ) const
 {
-    if( is_flying && is_rotorcraft() ) {
-        return max_rotor_velocity( fueled );
+    if( is_flying && is_rotorcraft( here ) ) {
+        return max_rotor_velocity( here, fueled );
     } else if( is_watercraft() ) {
-        return max_water_velocity( fueled );
+        return max_water_velocity( here, fueled );
     } else {
-        return max_ground_velocity( fueled );
+        return max_ground_velocity( here, fueled );
     }
 }
 
-int vehicle::max_reverse_velocity( const bool fueled ) const
+int vehicle::max_reverse_velocity( map &here, const bool fueled ) const
 {
-    int max_vel = max_velocity( fueled );
+    int max_vel = max_velocity( here, fueled );
     if( has_engine_type( fuel_type_battery, true ) ) {
         // Electric motors can go in reverse as well as forward
         return -max_vel;
@@ -4057,9 +4053,9 @@ int vehicle::max_reverse_velocity( const bool fueled ) const
 }
 
 // the same physics as max_ground_velocity, but with a smaller engine power
-int vehicle::safe_ground_velocity( const bool fueled ) const
+int vehicle::safe_ground_velocity( map &here, const bool fueled ) const
 {
-    int effective_engine_w = units::to_watt( total_power( fueled, true ) );
+    int effective_engine_w = units::to_watt( total_power( here, fueled, true ) );
     double c_rolling_drag = coeff_rolling_drag();
     double safe_in_mps = simple_cubic_solution( coeff_air_drag(), c_rolling_drag,
                          c_rolling_drag * vehicles::rolling_constant_to_variable,
@@ -4067,37 +4063,36 @@ int vehicle::safe_ground_velocity( const bool fueled ) const
     return mps_to_vmiph( safe_in_mps );
 }
 
-int vehicle::safe_rotor_velocity( const bool fueled ) const
+int vehicle::safe_rotor_velocity( map &here, const bool fueled ) const
 {
-    const double max_air_mps = std::sqrt( lift_thrust_of_rotorcraft( fueled,
+    const double max_air_mps = std::sqrt( lift_thrust_of_rotorcraft( here, fueled,
                                           true ) / coeff_air_drag() );
     return std::min( 22501, mps_to_vmiph( max_air_mps ) );
 }
 
 // the same physics as max_water_velocity, but with a smaller engine power
-int vehicle::safe_water_velocity( const bool fueled ) const
+int vehicle::safe_water_velocity( map &here, const bool fueled ) const
 {
-    int total_engine_w = units::to_watt( total_power( fueled, true ) );
+    int total_engine_w = units::to_watt( total_power( here, fueled, true ) );
     double total_drag = coeff_water_drag() + coeff_air_drag();
     double safe_in_mps = std::cbrt( total_engine_w / total_drag );
     return mps_to_vmiph( safe_in_mps );
 }
 
-int vehicle::safe_velocity( const bool fueled ) const
+int vehicle::safe_velocity( map &here, const bool fueled ) const
 {
-    if( is_flying && is_rotorcraft() ) {
-        return safe_rotor_velocity( fueled );
+    if( is_flying && is_rotorcraft( here ) ) {
+        return safe_rotor_velocity( here, fueled );
     } else if( is_watercraft() ) {
-        return safe_water_velocity( fueled );
+        return safe_water_velocity( here, fueled );
     } else {
-        return safe_ground_velocity( fueled );
+        return safe_ground_velocity( here, fueled );
     }
 }
 
-bool vehicle::do_environmental_effects() const
+bool vehicle::do_environmental_effects( map &here ) const
 {
     bool needed = false;
-    map &here = get_map();
     // check for smoking parts
     for( const vpart_reference &vp : get_all_parts() ) {
         /* Only lower blood level if:
@@ -4114,14 +4109,15 @@ bool vehicle::do_environmental_effects() const
     return needed;
 }
 
-void vehicle::spew_field( double joules, int part, field_type_id type, int intensity ) const
+void vehicle::spew_field( map &here, double joules, int part, field_type_id type,
+                          int intensity ) const
 {
     if( rng( 1, 10000 ) > joules ) {
         return;
     }
     intensity = std::max( joules / 10000, static_cast<double>( intensity ) );
-    const tripoint_bub_ms dest = exhaust_dest( part );
-    get_map().mod_field_intensity( dest, type, intensity );
+    const tripoint_bub_ms dest = exhaust_dest( &here, part );
+    here.mod_field_intensity( dest, type, intensity );
 }
 
 /**
@@ -4129,10 +4125,8 @@ void vehicle::spew_field( double joules, int part, field_type_id type, int inten
  * load = how hard the engines are working, from 0.0 until 1.0
  * time = how many seconds to generated smoke for
  */
-void vehicle::noise_and_smoke( int load, time_duration time )
+void vehicle::noise_and_smoke( map &here, int load, time_duration time )
 {
-    map &here = get_map();
-
     static const std::array<std::pair<std::string, int>, 8> sounds = { {
             { translate_marker( "hmm" ), 0 }, { translate_marker( "hummm!" ), 15 },
             { translate_marker( "whirrr!" ), 30 }, { translate_marker( "vroom!" ), 60 },
@@ -4153,10 +4147,10 @@ void vehicle::noise_and_smoke( int load, time_duration time )
     this->vehicle_noise = 0; // reset noise, in case all combustion engines are dead
     for( const int p : engines ) {
         const vehicle_part &vp = parts[p];
-        if( engine_on && is_engine_on( vp ) && engine_fuel_left( vp ) ) {
+        if( engine_on && is_engine_on( vp ) && engine_fuel_left( here, vp ) ) {
             // convert current engine load to units of watts/40K
             // then spew more smoke and make more noise as the engine load increases
-            int part_watts = units::to_watt( part_vpower_w( vp, true ) );
+            int part_watts = units::to_watt( part_vpower_w( here,  vp, true ) );
             double max_stress = static_cast<double>( part_watts / 40000.0 );
             double cur_stress = load / 1000.0 * max_stress;
             // idle stress = 1.0 resulting in nominal working engine noise = engine_noise_factor()
@@ -4171,7 +4165,7 @@ void vehicle::noise_and_smoke( int load, time_duration time )
                     health = 0.0;
                 }
                 if( health < vp.info().engine_info->backfire_threshold && one_in( 50 + 150 * health ) ) {
-                    backfire( vp );
+                    backfire( &here, vp );
                 }
                 double j = cur_stress * to_turns<int>( time ) * muffle * 1000;
 
@@ -4181,7 +4175,7 @@ void vehicle::noise_and_smoke( int load, time_duration time )
                 }
 
                 if( ( exhaust_part == -1 ) && engine_on ) {
-                    spew_field( j, p, fd_smoke, bad_filter ? fd_smoke->get_max_intensity() : 1 );
+                    spew_field( here, j, p, fd_smoke, bad_filter ? fd_smoke->get_max_intensity() : 1 );
                 } else {
                     mufflesmoke += j;
                 }
@@ -4196,10 +4190,10 @@ void vehicle::noise_and_smoke( int load, time_duration time )
     /// TODO: handle other engine types: muscle / animal / wind / coal / ...
 
     if( exhaust_part != -1 && engine_on ) {
-        spew_field( mufflesmoke, exhaust_part, fd_smoke,
+        spew_field( here, mufflesmoke, exhaust_part, fd_smoke,
                     bad_filter ? fd_smoke->get_max_intensity() : 1 );
     }
-    if( is_rotorcraft() ) {
+    if( is_rotorcraft( here ) ) {
         noise *= 2;
     }
     // Cap engine noise to avoid deafening.
@@ -4215,7 +4209,7 @@ void vehicle::noise_and_smoke( int load, time_duration time )
     add_msg_debug( debugmode::DF_VEHICLE, "VEH NOISE final: %d", static_cast<int>( noise ) );
     vehicle_noise = static_cast<unsigned char>( noise );
     sounds::sound( pos_bub( &here ), noise, sounds::sound_t::movement,
-                   _( is_rotorcraft() ? heli_noise : sounds[lvl].first ), true );
+                   _( is_rotorcraft( here ) ? heli_noise : sounds[lvl].first ), true );
 }
 
 int vehicle::wheel_area() const
@@ -4479,7 +4473,7 @@ bool vehicle::can_float() const
 // thrust loading [lb/hp]= 8.6859 * Power loading^(-0.3107)
 // Lift = Thrust loading * power >>>[lb] = [lb/hp] * [hp]
 
-double vehicle::lift_thrust_of_rotorcraft( const bool fuelled, const bool safe ) const
+double vehicle::lift_thrust_of_rotorcraft( map &here, const bool fuelled, const bool safe ) const
 {
     int rotor_area_in_feet = 0;
     for( const int rotor : rotors ) {
@@ -4488,7 +4482,7 @@ double vehicle::lift_thrust_of_rotorcraft( const bool fuelled, const bool safe )
         rotor_area_in_feet += ( M_PI / 4 ) * std::pow( rotor_diameter_in_feet, 2 );
     }
     // take off 15 % due to the imaginary tail rotor power.
-    double engine_power_in_hp = 0.00134102 * units::to_watt( total_power( fuelled, safe ) );
+    double engine_power_in_hp = 0.00134102 * units::to_watt( total_power( here, fuelled, safe ) );
     // lift_thrust in lbthrust
     double lift_thrust = ( 8.8658 * std::pow( engine_power_in_hp / rotor_area_in_feet,
                            -0.3107 ) ) * engine_power_in_hp;
@@ -4499,16 +4493,16 @@ double vehicle::lift_thrust_of_rotorcraft( const bool fuelled, const bool safe )
     return lift_thrust * 4.45;
 }
 
-bool vehicle::has_sufficient_rotorlift() const
+bool vehicle::has_sufficient_rotorlift( map &here ) const
 {
     // comparison of newton to newton - convert kg to newton.
-    return lift_thrust_of_rotorcraft( true ) > to_kilogram( total_mass() ) * 9.8;
+    return lift_thrust_of_rotorcraft( here, true ) > to_kilogram( total_mass() ) * 9.8;
 }
 
-bool vehicle::is_rotorcraft() const
+bool vehicle::is_rotorcraft( map &here ) const
 {
-    return !rotors.empty() && has_driver() &&
-           has_sufficient_rotorlift();
+    return !rotors.empty() && has_driver( here ) &&
+           has_sufficient_rotorlift( here );
 }
 
 bool vehicle::is_flyable() const
@@ -4672,13 +4666,13 @@ double vehicle::coeff_water_drag() const
     return coefficient_water_resistance;
 }
 
-float vehicle::k_traction( float wheel_traction_area ) const
+float vehicle::k_traction( map &here, float wheel_traction_area ) const
 {
     if( in_deep_water ) {
         return can_float() ? 1.0f : -1.0f;
     }
     if( is_flying ) {
-        return is_rotorcraft() ? 1.0f : -1.0f;
+        return is_rotorcraft( here ) ? 1.0f : -1.0f;
     }
     if( is_watercraft() && can_float() ) {
         return 1.0f;
@@ -4688,7 +4682,7 @@ float vehicle::k_traction( float wheel_traction_area ) const
     if( fraction_without_traction == 0 ) {
         return 1.0f;
     }
-    const float mass_penalty = fraction_without_traction * to_kilogram( weight_on_wheels() );
+    const float mass_penalty = fraction_without_traction * to_kilogram( weight_on_wheels( here ) );
     float traction = std::min( 1.0f, wheel_traction_area / mass_penalty );
     add_msg_debug( debugmode::DF_VEHICLE, "%s has traction %.2f", name, traction );
 
@@ -4712,10 +4706,9 @@ units::power vehicle::static_drag( bool actual ) const
                 if( other_tow_index == -1 ) {
                     is_actively_towed = false;
                 } else {
-                    map &here = get_map();
-                    const tripoint_abs_ms towed_tow_point = here.get_abs( bub_part_pos( &here, tow_index ) );
-                    const tripoint_abs_ms tower_tow_point = here.get_abs( towing_veh->bub_part_pos( &here,
-                                                            other_tow_index ) );
+                    const tripoint_abs_ms towed_tow_point = abs_part_pos( tow_index );
+                    const tripoint_abs_ms tower_tow_point =  towing_veh->abs_part_pos(
+                                other_tow_index );
                     is_actively_towed = rl_dist( towed_tow_point, tower_tow_point ) >= 6;
                 }
             }
@@ -4725,13 +4718,13 @@ units::power vehicle::static_drag( bool actual ) const
     return extra_drag + ( actual && !engine_on && !is_actively_towed ? -1500_W : 0_W );
 }
 
-float vehicle::strain() const
+float vehicle::strain( map &here ) const
 {
     if( velocity == 0.0 ) {
         return 0.0f;
     }
-    int mv = max_velocity();
-    int sv = safe_velocity();
+    int mv = max_velocity( here );
+    int sv = safe_velocity( here );
     if( mv <= sv ) {
         mv = sv + 1;
     }
@@ -4882,7 +4875,7 @@ bool vehicle::valid_wheel_config() const
     return sufficient_wheel_config() && balanced_wheel_config();
 }
 
-float vehicle::steering_effectiveness() const
+float vehicle::steering_effectiveness( map &here ) const
 {
     if( in_deep_water ) {
         // I'M ON A BOAT
@@ -4890,7 +4883,7 @@ float vehicle::steering_effectiveness() const
     }
     if( is_flying ) {
         // I'M IN THE AIR
-        return is_rotorcraft() ? 1.0f : 0.0f;
+        return is_rotorcraft( here ) ? 1.0f : 0.0f;
     }
     // irksome special case for boats in shallow water
     if( is_watercraft() && can_float() ) {
@@ -4920,10 +4913,10 @@ float vehicle::steering_effectiveness() const
     return 0.0f;
 }
 
-float vehicle::handling_difficulty() const
+float vehicle::handling_difficulty( map &here ) const
 {
-    const float steer = std::max( 0.0f, steering_effectiveness() );
-    const float ktraction = k_traction( get_map().vehicle_wheel_traction( *this ) );
+    const float steer = std::max( 0.0f, steering_effectiveness( here ) );
+    const float ktraction = k_traction( here, here.vehicle_wheel_traction( *this ) );
     const float aligned = std::max( 0.0f, 1.0f - ( face_vec() - dir_vec() ).magnitude() );
 
     // TestVehicle: perfect steering, moving on road at 100 mph (25 tiles per turn) = 0.0
@@ -4977,9 +4970,9 @@ units::energy vehicle::drain_energy( const itype_id &ftype, units::energy wanted
     return drained;
 }
 
-void vehicle::consume_fuel( int load, bool idling )
+void vehicle::consume_fuel( map &here, int load, bool idling )
 {
-    double st = strain();
+    double st = strain( here );
     for( const auto &fuel_pr : fuel_usage() ) {
         const itype_id &ft = fuel_pr.first;
         if( idling && ft == fuel_type_battery ) {
@@ -5003,7 +4996,7 @@ void vehicle::consume_fuel( int load, bool idling )
     if( idling ) {
         return;
     }
-    Character *driver = get_driver();
+    Character *driver = get_driver( here );
 
     // Only process muscle power and training things when someone is actually driving.
     // Note that the vehicle can be moving even if nobody is driving it.
@@ -5018,7 +5011,7 @@ void vehicle::consume_fuel( int load, bool idling )
         practice_pilot_proficiencies( *driver, in_deep_water );
     }
 
-    if( load > 0 && fuel_left( fuel_type_muscle ) > 0 &&
+    if( load > 0 && fuel_left( here, fuel_type_muscle ) > 0 &&
         driver->has_effect( effect_winded ) ) {
         cruise_velocity = 0;
         if( velocity == 0 ) {
@@ -5026,7 +5019,7 @@ void vehicle::consume_fuel( int load, bool idling )
         }
     }
     // we want this to update the activity level whenever we're using muscle power to move
-    if( load > 0 && fuel_left( fuel_type_muscle ) > 0 ) {
+    if( load > 0 && fuel_left( here, fuel_type_muscle ) > 0 ) {
         driver->set_activity_level( ACTIVE_EXERCISE );
         //do this as a function of current load
         // But only if the player is actually there!
@@ -5147,12 +5140,12 @@ std::pair<int, int> vehicle::battery_power_level() const
     return std::make_pair( remaining_epower, total_epower_capacity );
 }
 
-std::pair<int, int> vehicle::connected_battery_power_level() const
+std::pair<int, int> vehicle::connected_battery_power_level( map &here ) const
 {
     int total_epower_remaining = 0;
     int total_epower_capacity = 0;
 
-    for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles() ) {
+    for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles( here ) ) {
         int epower_remaining;
         int epower_capacity;
         std::tie( epower_remaining, epower_capacity ) = pair.first->battery_power_level();
@@ -5184,7 +5177,7 @@ bool vehicle::start_engine( vehicle_part &vp, bool turn_on )
     return res;
 }
 
-units::power vehicle::total_alternator_epower() const
+units::power vehicle::total_alternator_epower( map &here ) const
 {
     if( !engine_on ) {
         return 0_W;
@@ -5192,7 +5185,7 @@ units::power vehicle::total_alternator_epower() const
     units::power epower = 0_W;
     for( const int p : alternators ) {
         const vehicle_part &vp = parts[p];
-        if( is_alternator_on( vp ) ) {
+        if( is_alternator_on( here, vp ) ) {
             epower += part_epower( vp );
         }
     }
@@ -5217,10 +5210,9 @@ units::power vehicle::total_engine_epower() const
     return epower;
 }
 
-units::power vehicle::total_solar_epower() const
+units::power vehicle::total_solar_epower( map &here ) const
 {
     units::power epower = 0_W;
-    map &here = get_map();
     for( const int p : solar_panels ) {
         const vehicle_part &vp = parts[p];
         const tripoint_bub_ms pos = bub_part_pos( &here, vp );
@@ -5237,9 +5229,8 @@ units::power vehicle::total_solar_epower() const
     return epower * intensity;
 }
 
-units::power vehicle::total_wind_epower() const
+units::power vehicle::total_wind_epower( map &here ) const
 {
-    map &here = get_map();
     const oter_id &cur_om_ter = overmap_buffer.ter( pos_abs_omt() );
     weather_manager &weather = get_weather();
     const w_point weatherPoint = *weather.weather_precise;
@@ -5261,10 +5252,9 @@ units::power vehicle::total_wind_epower() const
     return epower;
 }
 
-units::power vehicle::total_water_wheel_epower() const
+units::power vehicle::total_water_wheel_epower( map &here ) const
 {
     units::power epower = 0_W;
-    map &here = get_map();
     for( const int p : water_wheels ) {
         const vehicle_part &vp = parts[p];
         const tripoint_bub_ms pos = bub_part_pos( &here, vp );
@@ -5278,15 +5268,15 @@ units::power vehicle::total_water_wheel_epower() const
     return epower;
 }
 
-units::power vehicle::net_battery_charge_rate( bool include_reactors ) const
+units::power vehicle::net_battery_charge_rate( map &here, bool include_reactors ) const
 {
-    return total_engine_epower() + total_alternator_epower() + total_accessory_epower() +
-           total_solar_epower() + total_wind_epower() + total_water_wheel_epower() +
+    return total_engine_epower() + total_alternator_epower( here ) + total_accessory_epower() +
+           total_solar_epower( here ) + total_wind_epower( here ) + total_water_wheel_epower( here ) +
            linked_item_epower_this_turn + recharge_epower_this_turn + ( include_reactors ?
-                   active_reactor_epower() : 0_W );
+                   active_reactor_epower( here ) : 0_W );
 }
 
-units::power vehicle::active_reactor_epower() const
+units::power vehicle::active_reactor_epower( map &here ) const
 {
     units::power reactors_flow = 0_W;
     for( const int p : reactors ) {
@@ -5303,12 +5293,12 @@ units::power vehicle::active_reactor_epower() const
 
     // Reactors are providing power, but not all of it will really be used.
     // Only count as much power as will be drawn from the reactor to fill the batteries.
-    const auto [bat_remaining, bat_capacity] = connected_battery_power_level();
+    const auto [bat_remaining, bat_capacity] = connected_battery_power_level( here );
     // max power flow into batteries for next turn
     const units::power max_battery_flow = units::from_kilowatt( static_cast<std::int64_t>
                                           ( bat_capacity - bat_remaining ) );
     // power flow by all parts except reactors
-    const units::power non_reactor_flow = net_battery_charge_rate( false );
+    const units::power non_reactor_flow = net_battery_charge_rate( here, false );
 
     if( non_reactor_flow >= max_battery_flow ) {
         return 0_W; // other parts will fully charge battery without a reactor involved
@@ -5327,7 +5317,7 @@ units::power vehicle::max_reactor_epower() const
     return epower;
 }
 
-void vehicle::update_alternator_load()
+void vehicle::update_alternator_load( map &here )
 {
     if( !engine_on ) {
         alternator_load = 0;
@@ -5337,7 +5327,7 @@ void vehicle::update_alternator_load()
     for( const int p : engines ) {
         const vehicle_part &vp = parts[p];
         if( is_engine_on( vp ) && vp.info().has_flag( "E_ALTERNATOR" ) ) {
-            engine_vpower += part_vpower_w( vp );
+            engine_vpower += part_vpower_w( here,  vp );
         }
     }
 
@@ -5349,8 +5339,8 @@ void vehicle::update_alternator_load()
     units::power alternators_power = 0_W;
     for( const int p : alternators ) {
         const vehicle_part &vp = parts[p];
-        if( is_alternator_on( vp ) ) {
-            alternators_power += part_vpower_w( vp );
+        if( is_alternator_on( here, vp ) ) {
+            alternators_power += part_vpower_w( here,  vp );
         }
     }
     alternators_power += extra_drag;
@@ -5358,14 +5348,12 @@ void vehicle::update_alternator_load()
     alternator_load = std::abs( 1000 * alternators_power / engine_vpower );
 }
 
-void vehicle::power_parts()
+void vehicle::power_parts( map &here )
 {
-    map &here = get_map();
-
-    update_alternator_load();
+    update_alternator_load( here );
     // Things that drain energy: engines and accessories.
     units::power engine_epower = total_engine_epower();
-    units::power epower = engine_epower + total_accessory_epower() + total_alternator_epower();
+    units::power epower = engine_epower + total_accessory_epower() + total_alternator_epower( here );
 
     int delta_energy_bat = power_to_energy_bat( epower, 1_turns );
     Character &player_character = get_player_character();
@@ -5375,7 +5363,7 @@ void vehicle::power_parts()
         // Check the entire graph of connected vehicles to determine power output.
         int battery_left;
         int battery_capacity;
-        std::tie( battery_left, battery_capacity ) = connected_battery_power_level();
+        std::tie( battery_left, battery_capacity ) = connected_battery_power_level( here );
         int storage_deficit_bat = std::max( 0, battery_capacity - battery_left - delta_energy_bat );
         if( storage_deficit_bat > 0 ) {
             // Still not enough surplus epower to fully charge battery
@@ -5420,7 +5408,7 @@ void vehicle::power_parts()
                 for( int elem : reactors ) {
                     parts[ elem ].enabled = false;
                 }
-                if( player_is_driving_this_veh() || player_character.sees( pos_bub( &here ) ) ) {
+                if( player_is_driving_this_veh( &here ) || player_character.sees( pos_bub( &here ) ) ) {
                     add_msg( _( "The %s's reactor dies!" ), name );
                 }
             }
@@ -5430,10 +5418,10 @@ void vehicle::power_parts()
     int battery_deficit = 0;
     if( delta_energy_bat > 0 ) {
         // store epower surplus in battery
-        charge_battery( delta_energy_bat );
+        charge_battery( here, delta_energy_bat );
     } else if( epower < 0_W ) {
         // draw epower deficit from battery
-        battery_deficit = discharge_battery( std::abs( delta_energy_bat ) );
+        battery_deficit = discharge_battery( here, std::abs( delta_energy_bat ) );
     }
 
     if( battery_deficit != 0 ) {
@@ -5455,22 +5443,21 @@ void vehicle::power_parts()
 
         is_alarm_on = false;
         camera_on = false;
-        if( player_is_driving_this_veh() || player_character.sees( pos_bub( &here ) ) ) {
+        if( player_is_driving_this_veh( &here ) || player_character.sees( pos_bub( &here ) ) ) {
             add_msg( _( "The %s's battery dies!" ), name );
         }
         if( engine_epower < 0_W ) {
             // Not enough epower to run gas engine ignition system
             engine_on = false;
-            if( player_is_driving_this_veh() || player_character.sees( pos_bub( &here ) ) ) {
+            if( player_is_driving_this_veh( &here ) || player_character.sees( pos_bub( &here ) ) ) {
                 add_msg( _( "The %s's engine dies!" ), name );
             }
         }
-        noise_and_smoke( 0, 1_turns ); // refreshes this->vehicle_noise
+        noise_and_smoke( here, 0, 1_turns ); // refreshes this->vehicle_noise
     }
 }
-vehicle *vehicle::find_vehicle( const tripoint_abs_ms &where )
+vehicle *vehicle::find_vehicle( map &here, const tripoint_abs_ms &where )
 {
-    map &here = get_map();
     // Is it in the reality bubble?
     if( const optional_vpart_position vp = here.veh_at( where ) ) {
         return &vp->vehicle();
@@ -5494,9 +5481,8 @@ vehicle *vehicle::find_vehicle( const tripoint_abs_ms &where )
     return nullptr;
 }
 
-vehicle *vehicle::find_vehicle_using_parts( const tripoint_abs_ms &where )
+vehicle *vehicle::find_vehicle_using_parts( map &here,  const tripoint_abs_ms &where )
 {
-    map &here = get_map();
     // Is it in the reality bubble?
     if( const optional_vpart_position vp = here.veh_at( where ) ) {
         return &vp->vehicle();
@@ -5526,7 +5512,7 @@ vehicle *vehicle::find_vehicle_using_parts( const tripoint_abs_ms &where )
 }
 
 template<typename Vehicle> // Templated to support const and non-const vehicle*
-std::map<Vehicle *, float> vehicle::search_connected_vehicles( Vehicle *start )
+std::map<Vehicle *, float> vehicle::search_connected_vehicles( map &here, Vehicle *start )
 {
     std::map<Vehicle *, float> distances; // distance represents sum of cable losses
     std::vector<Vehicle *> queue;
@@ -5549,7 +5535,7 @@ std::map<Vehicle *, float> vehicle::search_connected_vehicles( Vehicle *start )
                 continue;
             }
 
-            Vehicle *const v_next = find_vehicle_using_parts( tripoint_abs_ms( vp.target.second ) );
+            Vehicle *const v_next = find_vehicle_using_parts( here,  vp.target.second );
             if( v_next == nullptr ) { // vehicle's rolled away or off-map
                 continue;
             }
@@ -5567,24 +5553,24 @@ std::map<Vehicle *, float> vehicle::search_connected_vehicles( Vehicle *start )
     return distances;
 }
 
-std::map<vehicle *, float> vehicle::search_connected_vehicles()
+std::map<vehicle *, float> vehicle::search_connected_vehicles( map &here )
 {
-    return search_connected_vehicles( this );
+    return search_connected_vehicles( here, this );
 }
 
-std::map<const vehicle *, float> vehicle::search_connected_vehicles() const
+std::map<const vehicle *, float> vehicle::search_connected_vehicles( map &here ) const
 {
-    return search_connected_vehicles( this );
+    return search_connected_vehicles( here, this );
 }
 
-void vehicle::get_connected_vehicles( std::unordered_set<vehicle *> &dest )
+void vehicle::get_connected_vehicles( map &here, std::unordered_set<vehicle *> &dest )
 {
     for( const int part_idx : loose_parts ) {
         const vehicle_part &vp = part( part_idx );
         if( !vp.info().has_flag( VPFLAG_POWER_TRANSFER ) ) {
             continue;
         }
-        vehicle *v_next = find_vehicle( vp.target.second );
+        vehicle *v_next = find_vehicle( here, vp.target.second );
         if( v_next == nullptr ) {
             continue;
         }
@@ -5592,15 +5578,15 @@ void vehicle::get_connected_vehicles( std::unordered_set<vehicle *> &dest )
             continue; // Already found
         }
         dest.insert( v_next );
-        v_next->get_connected_vehicles( dest );
+        v_next->get_connected_vehicles( here, dest );
     }
 }
 
-std::map<vpart_reference, float> vehicle::search_connected_batteries()
+std::map<vpart_reference, float> vehicle::search_connected_batteries( map &here )
 {
     std::map<vpart_reference, float> result;
 
-    for( const std::pair<vehicle *const, float> &pair : search_connected_vehicles() ) {
+    for( const std::pair<vehicle *const, float> &pair : search_connected_vehicles( here ) ) {
         vehicle *veh = pair.first;
         const float efficiency = pair.second;
         for( const int part_idx : veh->batteries ) {
@@ -5661,9 +5647,9 @@ static void distribute_charge_evenly( const std::map<vpart_reference, float> &ba
     }
 }
 
-bool vehicle::is_battery_available() const
+bool vehicle::is_battery_available( map &here ) const
 {
-    for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles() ) {
+    for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles( here ) ) {
         const vehicle &veh = *pair.first;
         for( const int part_idx : veh.batteries ) {
             const vehicle_part &vp = veh.parts[part_idx];
@@ -5675,10 +5661,10 @@ bool vehicle::is_battery_available() const
     return false;
 }
 
-int64_t vehicle::battery_left( bool apply_loss ) const
+int64_t vehicle::battery_left( map &here, bool apply_loss ) const
 {
     int64_t ret = 0;
-    for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles() ) {
+    for( const std::pair<const vehicle *const, float> &pair : search_connected_vehicles( here ) ) {
         const vehicle &veh = *pair.first;
         const float efficiency = 1.0f - ( apply_loss ? pair.second : 0.0f );
         for( const int part_idx : veh.batteries ) {
@@ -5689,7 +5675,7 @@ int64_t vehicle::battery_left( bool apply_loss ) const
     return ret;
 }
 
-int vehicle::charge_battery( int amount, bool apply_loss )
+int vehicle::charge_battery( map &here, int amount, bool apply_loss )
 {
     if( amount < 0 ) {
         debugmsg( "called vehicle::charge_battery(%d), potential bug", amount );
@@ -5698,7 +5684,7 @@ int vehicle::charge_battery( int amount, bool apply_loss )
     if( amount == 0 ) {
         return 0;
     }
-    const std::map<vpart_reference, float> batteries = search_connected_batteries();
+    const std::map<vpart_reference, float> batteries = search_connected_batteries( here );
     if( batteries.empty() ) {
         return amount;
     }
@@ -5732,7 +5718,7 @@ int vehicle::charge_battery( int amount, bool apply_loss )
     return amount; // non zero if batteries couldn't absorb the entire amount
 }
 
-int vehicle::discharge_battery( int amount, bool apply_loss )
+int vehicle::discharge_battery( map &here, int amount, bool apply_loss )
 {
     if( amount < 0 ) {
         debugmsg( "called vehicle::discharge_battery(%d), potential bug", amount );
@@ -5741,7 +5727,7 @@ int vehicle::discharge_battery( int amount, bool apply_loss )
     if( amount == 0 ) {
         return 0;
     }
-    const std::map<vpart_reference, float> batteries = search_connected_batteries();
+    const std::map<vpart_reference, float> batteries = search_connected_batteries( here );
     if( batteries.empty() ) {
         return amount;
     }
@@ -5776,13 +5762,13 @@ int vehicle::discharge_battery( int amount, bool apply_loss )
     return amount; // non zero if batteries couldn't provide the entire amount
 }
 
-void vehicle::do_engine_damage( vehicle_part &vp, int strain )
+void vehicle::do_engine_damage( map &here, vehicle_part &vp, int strain )
 {
     strain = std::min( 25, strain );
-    if( is_engine_on( vp ) && !is_perpetual_type( vp ) && engine_fuel_left( vp ) &&
+    if( is_engine_on( vp ) && !is_perpetual_type( vp ) && engine_fuel_left( here, vp ) &&
         rng( 1, 100 ) < strain ) {
         const int dmg = rng( 0, strain * 4 );
-        damage_direct( get_map(), vp, dmg );
+        damage_direct( here, vp, dmg );
         if( one_in( 2 ) ) {
             add_msg( _( "Your engine emits a high pitched whine." ) );
         } else {
@@ -5791,29 +5777,27 @@ void vehicle::do_engine_damage( vehicle_part &vp, int strain )
     }
 }
 
-void vehicle::idle( bool on_map )
+void vehicle::idle( map &here, bool on_map )
 {
-    map &here = get_map();
-
     avg_velocity = ( velocity + avg_velocity ) / 2;
 
-    power_parts();
+    power_parts( here );
     Character &player_character = get_player_character();
-    if( engine_on && total_power() > 0_W ) {
+    if( engine_on && total_power( here ) > 0_W ) {
         // Consume fuel at here only if the vehicle is not thrusting.
         // See the condition under which vehicle::thrust() is called in vehicle::gain_moves().
-        if( !( ( player_in_control( player_character ) || is_following || is_patrolling ) &&
+        if( !( ( player_in_control( here, player_character ) || is_following || is_patrolling ) &&
                cruise_velocity != 0 ) ) {
             int idle_rate = alternator_load;
             if( idle_rate < 10 ) {
                 idle_rate = 10;    // minimum idle is 1% of full throttle
             }
             if( has_engine_type_not( fuel_type_muscle, true ) ) {
-                consume_fuel( idle_rate, true );
+                consume_fuel( here, idle_rate, true );
             }
 
             if( on_map ) {
-                noise_and_smoke( idle_rate, 1_turns );
+                noise_and_smoke( here, idle_rate, 1_turns );
             }
         }
     } else {
@@ -5860,7 +5844,7 @@ void vehicle::idle( bool on_map )
             if( exhaust_and_muffle.first == -1 ) {
                 here.emit_field( bub_part_pos( &here, pt ), e );
             } else {
-                here.emit_field( exhaust_dest( exhaust_and_muffle.first ), e );
+                here.emit_field( exhaust_dest( &here, exhaust_and_muffle.first ), e );
             }
         }
     }
@@ -5898,7 +5882,7 @@ void vehicle::idle( bool on_map )
     }
 }
 
-void vehicle::on_move()
+void vehicle::on_move( map &here )
 {
     tiny_bitset part_flags = has_parts( { "TRANSFORM_TERRAIN", "SCOOP", "PLANTER", "REAPER" }, true );
     if( part_flags.test( 0 ) ) {
@@ -5917,16 +5901,15 @@ void vehicle::on_move()
     Character &pc = get_player_character();
     // TODO: Send ID of driver
     get_event_bus().send<event_type::vehicle_moves>(
-        is_passenger( pc ), player_is_driving_this_veh(), remote_controlled( pc ),
-        is_flying_in_air(), is_watercraft() && can_float(), can_use_rails(),
+        is_passenger( pc ), player_is_driving_this_veh( &here ), remote_controlled( pc ),
+        is_flying_in_air(), is_watercraft() && can_float(), can_use_rails( here ),
         is_falling, is_in_water( true ) && !can_float(),
         skidding, velocity, sm_pos.z()
     );
 }
 
-void vehicle::slow_leak()
+void vehicle::slow_leak( map &here )
 {
-    map &here = get_map();
     // for each badly damaged tanks (lower than 50% health), leak a small amount
     for( int part : fuel_containers ) {
         vehicle_part &p = parts[part];
@@ -5999,9 +5982,8 @@ void vehicle::disable_smart_controller_if_needed()
     }
 }
 
-void vehicle::make_active( item_location &loc )
+void vehicle::make_active( map &here, item_location &loc )
 {
-    map &here = get_map();
     item &target = *loc;
     auto cargo_parts = get_parts_at( &here, loc.pos_bub(), "CARGO", part_status_flag::any );
     if( cargo_parts.empty() ) {
@@ -6012,7 +5994,7 @@ void vehicle::make_active( item_location &loc )
     active_items.add( target, cargo_part->mount );
 }
 
-int vehicle::add_charges( vehicle_part &vp, const item &itm )
+int vehicle::add_charges( map &here, vehicle_part &vp, const item &itm )
 {
     if( !itm.count_by_charges() ) {
         debugmsg( "Add charges was called for an item not counted by charges!" );
@@ -6025,12 +6007,12 @@ int vehicle::add_charges( vehicle_part &vp, const item &itm )
 
     item itm_copy = itm;
     itm_copy.charges = ret;
-    return add_item( vp, itm_copy ) ? ret : 0;
+    return add_item( here, vp, itm_copy ) ? ret : 0;
 }
 
-std::optional<vehicle_stack::iterator> vehicle::add_item( vehicle_part &vp, const item &itm )
+std::optional<vehicle_stack::iterator> vehicle::add_item( map &here, vehicle_part &vp,
+        const item &itm )
 {
-    map &here = get_map();
     // const int max_weight = ?! // TODO: weight limit, calculation per vpart & vehicle stats, not a hard user limit.
     // add creaking sounds and damage to overloaded vpart, outright break it past a certain point, or when hitting bumps etc
     if( vp.is_broken() ) {
@@ -6131,6 +6113,8 @@ std::map<item, int> vehicle::prepare_tools( const vehicle_part &vp ) const
 
 void vehicle::place_spawn_items()
 {
+    map &here = get_map();
+
     if( !type.is_valid() ) {
         return;
     }
@@ -6210,7 +6194,7 @@ void vehicle::place_spawn_items()
                     e.set_owner( get_owner() );
                 }
 
-                add_item( vp, e );
+                add_item( here, vp, e );
             }
         }
     }
@@ -6230,9 +6214,11 @@ void vehicle::place_zones( map &pmap ) const
 
 void vehicle::gain_moves()
 {
+    map &here = get_map();
+
     fuel_used_last_turn.clear();
     check_falling_or_floating();
-    const bool pl_control = player_is_driving_this_veh();
+    const bool pl_control = player_is_driving_this_veh( &here );
     if( is_moving() || is_falling ) {
         if( !loose_parts.empty() ) {
             shed_loose_parts();
@@ -6258,7 +6244,7 @@ void vehicle::gain_moves()
     // cruise control TODO: enable for NPC?
     if( ( pl_control || is_following || is_patrolling ) && cruise_velocity != velocity ) {
         thrust( cruise_velocity > velocity ? 1 : -1 );
-    } else if( is_rotorcraft() && velocity == 0 ) {
+    } else if( is_rotorcraft( here ) && velocity == 0 ) {
         // rotorcraft uses fuel for hover
         // whether it's flying or not is checked inside thrust function
         thrust( 0 );
@@ -6268,11 +6254,11 @@ void vehicle::gain_moves()
     // This is expensive so we allow a slightly stale result
     if( calendar::once_every( 5_turns ) ) {
         std::unordered_set<vehicle *> vehs;
-        get_connected_vehicles( vehs );
+        get_connected_vehicles( here, vehs );
     }
 
     if( check_environmental_effects ) {
-        check_environmental_effects = do_environmental_effects();
+        check_environmental_effects = do_environmental_effects( here );
     }
 
     // turrets which are enabled will try to reload and then automatically fire
@@ -6695,6 +6681,8 @@ vpart_edge_info vehicle::get_edge_info( const point_rel_ms &mount ) const
 
 void vehicle::remove_fake_parts( const bool cleanup )
 {
+    map &here = get_map();
+
     if( fake_parts.empty() ) {
         edges.clear();
         return;
@@ -6720,7 +6708,7 @@ void vehicle::remove_fake_parts( const bool cleanup )
     edges.clear();
     fake_parts.clear();
     if( cleanup ) {
-        do_remove_part_actual();
+        do_remove_part_actual( &here );
     }
 }
 
@@ -7139,7 +7127,9 @@ bool vehicle::no_towing_slack() const
 
 std::optional<vpart_reference> vehicle::get_remote_part( const vehicle_part &vp_local ) const
 {
-    vehicle *veh = find_vehicle( vp_local.target.second );
+    map &here = get_map();
+
+    vehicle *veh = find_vehicle( here, vp_local.target.second );
     // If the target vehicle is still there, ask it to remove its part
     if( veh != nullptr ) {
         const tripoint_abs_ms local_abs = abs_part_pos( vp_local );
@@ -7724,7 +7714,7 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         explode_fuel( vp, type );
     } else if( vp.is_broken() && vpi.has_flag( "UNMOUNT_ON_DAMAGE" ) ) {
         const int vp_idx = index_of_part( &vp, /* include_removed = */ true );
-        monster *mon = get_monster( vp_idx );
+        monster *mon = get_monster( here, vp_idx );
         if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
             mon->remove_effect( effect_harnessed );
         }
@@ -8002,7 +7992,7 @@ std::list<item> vehicle::use_charges( const vpart_position &vp, const itype_id &
         const itype_id &fuel_type = tool_fuel_type.is_null() ? type : tool_fuel_type;
         item tmp( type, calendar::turn_zero ); // TODO: add a sane birthday arg
         // TODO: Handle water poison when crafting starts respecting it
-        tmp.charges = tool_vp->vehicle().drain( fuel_type, quantity );
+        tmp.charges = tool_vp->vehicle().drain( here, fuel_type, quantity );
         quantity -= tmp.charges;
         ret.push_back( tmp );
         add_msg_debug( debugmode::DF_VEHICLE, "drained %d %s from %s",
@@ -8180,9 +8170,9 @@ void vehicle::update_time( const time_point &update_to )
             const std::optional<vpart_reference> vp_purifier = vpart_position( *this, idx )
                     .part_with_tool( itype_water_purifier );
 
-            if( vp_purifier && ( fuel_left( itype_battery ) > cost_to_purify ) ) {
+            if( vp_purifier && ( fuel_left( here, itype_battery ) > cost_to_purify ) ) {
                 tank->ammo_set( itype_water_clean, c_qty );
-                discharge_battery( cost_to_purify );
+                discharge_battery( here, cost_to_purify );
             } else {
                 tank->ammo_set( itype_water, tank->ammo_remaining() + qty );
             }
@@ -8205,25 +8195,25 @@ void vehicle::update_time( const time_point &update_to )
         int energy_bat = power_to_energy_bat( epower * intensity, elapsed );
         if( energy_bat > 0 ) {
             add_msg_debug( debugmode::DF_VEHICLE, "%s got %d kJ energy from solar panels", name, energy_bat );
-            charge_battery( energy_bat );
+            charge_battery( here, energy_bat );
         }
     }
     if( !wind_turbines.empty() ) {
         // TODO: use accum_weather wind data to backfill wind turbine
         // generation capacity.
-        units::power epower = total_wind_epower();
+        units::power epower = total_wind_epower( here );
         int energy_bat = power_to_energy_bat( epower, elapsed );
         if( energy_bat > 0 ) {
             add_msg_debug( debugmode::DF_VEHICLE, "%s got %d kJ energy from wind turbines", name, energy_bat );
-            charge_battery( energy_bat );
+            charge_battery( here, energy_bat );
         }
     }
     if( !water_wheels.empty() ) {
-        units::power epower = total_water_wheel_epower();
+        units::power epower = total_water_wheel_epower( here );
         int energy_bat = power_to_energy_bat( epower, elapsed );
         if( energy_bat > 0 ) {
             add_msg_debug( debugmode::DF_VEHICLE, "%s got %d kJ energy from water wheels", name, energy_bat );
-            charge_battery( energy_bat );
+            charge_battery( here, energy_bat );
         }
     }
 }
@@ -8241,6 +8231,8 @@ void vehicle::invalidate_mass()
 
 void vehicle::calc_mass_center( bool use_precalc ) const
 {
+    map &here = get_map();
+
     units::quantity<float, units::mass::unit_type> xf;
     units::quantity<float, units::mass::unit_type> yf;
     units::mass m_total = 0_gram;
@@ -8266,7 +8258,7 @@ void vehicle::calc_mass_center( bool use_precalc ) const
 
         if( vp.has_feature( VPFLAG_BOARDABLE ) ) {
             const Character *p = get_passenger( i );
-            const monster *z = get_monster( i );
+            const monster *z = get_monster( here,  i );
             // Sometimes flag is wrongly set, don't crash!
             m_part += p != nullptr ? p->get_weight() : 0_gram;
             m_part += z != nullptr ? z->get_weight() : 0_gram;
@@ -8396,11 +8388,10 @@ std::vector<std::reference_wrapper<const vehicle_part>> vehicle::real_parts() co
     return ret;
 }
 std::set<int> vehicle::advance_precalc_mounts( const point_sm_ms &new_pos,
-        const tripoint_bub_ms &src,
+        map *here, const tripoint_bub_ms &src,
         const tripoint_rel_ms &dp, int ramp_offset, const bool adjust_pos,
         std::set<int> parts_to_move )
 {
-    map &here = get_map();
     std::set<int> smzs;
     // when a vehicle part enters the low end of a down ramp, or the high end of an up ramp,
     // it immediately translates down or up a z-level, respectively, ending up on the low
@@ -8430,7 +8421,7 @@ std::set<int> vehicle::advance_precalc_mounts( const point_sm_ms &new_pos,
     for( vehicle_part &prt : parts ) {
         index += 1;
         if( prt.is_real_or_active_fake() ) {
-            here.clear_vehicle_point_from_cache( this, src + prt.precalc[0] );
+            here->clear_vehicle_point_from_cache( this, src + prt.precalc[0] );
         }
         // no parts means this is a normal horizontal or vertical move
         if( parts_to_move.empty() ) {
@@ -8441,9 +8432,9 @@ std::set<int> vehicle::advance_precalc_mounts( const point_sm_ms &new_pos,
         } else if( !adjust_pos &&  parts_to_move.find( index ) != parts_to_move.end() ) {
             prt.precalc[0].z() += dp.z();
         }
-        if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, src + dp + prt.precalc[0] ) ) {
+        if( here->has_flag( ter_furn_flag::TFLAG_RAMP_UP, src + dp + prt.precalc[0] ) ) {
             prt.precalc[0].z() += 1;
-        } else if( here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, src + dp + prt.precalc[0] ) ) {
+        } else if( here->has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, src + dp + prt.precalc[0] ) ) {
             prt.precalc[0].z() -= 1;
         }
         prt.precalc[0].z() -= ramp_offset;
@@ -8549,17 +8540,15 @@ std::pair<int, double> vehicle::get_exhaust_part() const
     return std::make_pair( exhaust_part, muffle );
 }
 
-tripoint_bub_ms vehicle::exhaust_dest( int part ) const
+tripoint_bub_ms vehicle::exhaust_dest( map *here, int part ) const
 {
-    map &here = get_map();
-
     point_rel_ms p = parts[part].mount;
     // Move back from engine/muffler until we find an open space
     while( relative_parts.find( p ) != relative_parts.end() ) {
         p.x() += ( velocity < 0 ? 1 : -1 );
     }
     point_rel_ms q = coord_translate( p );
-    return pos_bub( &here ) + tripoint_rel_ms( q, 0 );
+    return pos_bub( here ) + tripoint_rel_ms( q, 0 );
 }
 
 void vehicle::add_tag( const std::string &tag )
@@ -8605,18 +8594,18 @@ bool vehicle_part_with_fakes_range::matches( const size_t part ) const
 }
 
 void MapgenRemovePartHandler::add_item_or_charges(
-    const tripoint_bub_ms &loc, item it, bool permit_oob )
+    map *here, const tripoint_bub_ms &loc, item it, bool permit_oob )
 {
-    if( !m.inbounds( loc ) ) {
+    if( !here->inbounds( loc ) ) {
         if( !permit_oob ) {
             debugmsg( "Tried to put item %s on invalid tile %s during mapgen!",
                       it.tname(), loc.to_string() );
         }
         tripoint_bub_ms copy = loc;
-        m.clip_to_bounds( copy );
-        cata_assert( m.inbounds( copy ) ); // prevent infinite recursion
-        add_item_or_charges( copy, std::move( it ), false );
+        here->clip_to_bounds( copy );
+        cata_assert( here->inbounds( copy ) ); // prevent infinite recursion
+        add_item_or_charges( here, copy, std::move( it ), false );
         return;
     }
-    m.add_item_or_charges( loc, std::move( it ) );
+    here->add_item_or_charges( loc, std::move( it ) );
 }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -827,7 +827,7 @@ class vehicle
         //damages vehicle controls and security system
         void smash_security_system();
         // get vpart powerinfo for part number, accounting for variable-sized parts and hps.
-        units::power part_vpower_w( const vehicle_part &vp, bool at_full_hp = false ) const;
+        units::power part_vpower_w( map &here, const vehicle_part &vp, bool at_full_hp = false ) const;
 
         // Get part power consumption/production for part number.
         units::power part_epower( const vehicle_part &vp ) const;
@@ -836,7 +836,7 @@ class vehicle
         int power_to_energy_bat( units::power power, const time_duration &d ) const;
 
         // Do stuff like clean up blood and produce smoke from broken parts. Returns false if nothing needs doing.
-        bool do_environmental_effects() const;
+        bool do_environmental_effects( map &here ) const;
 
         // Vehicle fuel indicator (by fuel)
         // TODO: Figure out what coordinate system "point" is in and type it.
@@ -869,7 +869,7 @@ class vehicle
         /// May load the connected vehicles' submaps
         /// Templated to support const and non-const vehicle*
         template<typename Vehicle>
-        static std::map<Vehicle *, float> search_connected_vehicles( Vehicle *start );
+        static std::map<Vehicle *, float> search_connected_vehicles( map &here, Vehicle *start );
     public:
         /**
          * Find a possibly off-map vehicle. If necessary, loads up its submap through
@@ -877,22 +877,22 @@ class vehicle
          * give it the coordinates of the origin tile of a target vehicle.
          * @param where Location of the other vehicle's origin tile.
          */
-        static vehicle *find_vehicle( const tripoint_abs_ms &where );
+        static vehicle *find_vehicle( map &here, const tripoint_abs_ms &where );
         // find_vehicle, but it compares the provided position to the position of
         // every vehicle part instead of just the vehicle's position
-        static vehicle *find_vehicle_using_parts( const tripoint_abs_ms &where );
+        static vehicle *find_vehicle_using_parts( map &here,  const tripoint_abs_ms &where );
         //! @copydoc vehicle::search_connected_vehicles( Vehicle *start )
-        std::map<vehicle *, float> search_connected_vehicles();
+        std::map<vehicle *, float> search_connected_vehicles( map &here );
         //! @copydoc vehicle::search_connected_vehicles( Vehicle *start )
-        std::map<const vehicle *, float> search_connected_vehicles() const;
+        std::map<const vehicle *, float> search_connected_vehicles( map &here ) const;
         //! @copydoc vehicle::search_connected_vehicles( Vehicle *start )
-        void get_connected_vehicles( std::unordered_set<vehicle *> &dest );
+        void get_connected_vehicles( map &here, std::unordered_set<vehicle *> &dest );
 
         /// Returns a map of connected battery references to power loss factor
         /// Keys are batteries in vehicles (includes self) connected by POWER_TRANSFER parts
         /// Values are line loss, 0.01 corresponds to 1% charge loss to wire resistance
         /// May load the connected vehicles' submaps
-        std::map<vpart_reference, float> search_connected_batteries();
+        std::map<vpart_reference, float> search_connected_batteries( map &here );
 
         // constructs a vehicle, if the given \p proto_id is an empty string the vehicle is
         // constructed empty, invalid proto_id will construct empty and raise a debugmsg,
@@ -935,9 +935,9 @@ class vehicle
         bool mod_hp( vehicle_part &pt, int qty );
 
         // check if given character controls this vehicle
-        bool player_in_control( const Character &p ) const;
+        bool player_in_control( const map &here, const Character &p ) const;
         // check if the *player* character controls this vehicle
-        bool player_is_driving_this_veh() const;
+        bool player_is_driving_this_veh( map *here ) const;
         // check if the given character controls this vehicle remotely
         bool remote_controlled( const Character &p ) const;
 
@@ -1006,11 +1006,11 @@ class vehicle
         }
         bool handle_potential_theft( Character const &you, bool check_only = false, bool prompt = true );
         // project a tileray forward to predict obstacles
-        std::set<point_abs_ms> immediate_path( const units::angle &rotate = 0_degrees );
+        std::set<point_abs_ms> immediate_path( map *here, const units::angle &rotate = 0_degrees );
         std::set<point_abs_ms> collision_check_points; // NOLINT(cata-serialize)
-        void autopilot_patrol();
+        void autopilot_patrol( map *here );
         units::angle get_angle_from_targ( const tripoint_abs_ms &targ ) const;
-        void drive_to_local_target( const tripoint_abs_ms &target, bool follow_protocol );
+        void drive_to_local_target( map *here, const tripoint_abs_ms &target, bool follow_protocol );
         // Drive automatically towards some destination for one turn.
         autodrive_result do_autodrive( Character &driver );
         // Stop any kind of automatic vehicle control and apply the brakes.
@@ -1030,7 +1030,7 @@ class vehicle
                             bool autodrive = false );
 
         // Engine backfire, making a loud noise
-        void backfire( const vehicle_part &vp ) const;
+        void backfire( map *here, const vehicle_part &vp ) const;
 
         /**
          * @param dp The coordinate to mount at (in vehicle mount point coords)
@@ -1071,18 +1071,18 @@ class vehicle
 
         // attempts to find any nearby vehicles that can be racked on any of the list_of_racks
         // @returns vector of structs with data required to rack each vehicle
-        std::vector<rackable_vehicle> find_vehicles_to_rack( int rack ) const;
+        std::vector<rackable_vehicle> find_vehicles_to_rack( map *here, int rack ) const;
 
         // attempts to find any racked vehicles that can be unracked on any of the list_of_racks
         // @returns vector of structs with data required to unrack each vehicle
         std::vector<unrackable_vehicle> find_vehicles_to_unrack( int rack ) const;
 
         // merge a previously found single tile vehicle into this vehicle
-        bool merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int> &rack_parts );
+        bool merge_rackable_vehicle( map *here, vehicle *carry_veh, const std::vector<int> &rack_parts );
         // merges vehicles together by copying parts, does not account for any vehicle complexities
-        bool merge_vehicle_parts( vehicle *veh );
-        bool merge_appliance_into_grid( vehicle &veh_target );
-        void separate_from_grid( point_rel_ms mount );
+        bool merge_vehicle_parts( map *here, vehicle *veh );
+        bool merge_appliance_into_grid( map *here, vehicle &veh_target );
+        void separate_from_grid( map *here, point_rel_ms mount );
 
         bool is_powergrid() const;
 
@@ -1100,13 +1100,14 @@ class vehicle
         // @returns true if the vehicle's 0,0 point shifted.
         bool remove_part( vehicle_part &vp, RemovePartHandler &handler );
 
-        void part_removal_cleanup();
+        void part_removal_cleanup( map &here );
         // inner look for part_removal_cleanup.  returns true if a part is removed
         // also called by remove_fake_parts
-        bool do_remove_part_actual();
+        bool do_remove_part_actual( map *here );
 
         // remove a vehicle specified by a list of part indices
-        bool remove_carried_vehicle( const std::vector<int> &carried_parts, const std::vector<int> &racks );
+        bool remove_carried_vehicle( map &here, const std::vector<int> &carried_parts,
+                                     const std::vector<int> &racks );
         // split the current vehicle into up to four vehicles if they have no connection other
         // than the structure part at exclude
         bool find_and_split_vehicles( map &here, std::set<int> exclude );
@@ -1429,11 +1430,11 @@ class vehicle
         bool is_passenger( Character &c ) const;
         // get passenger at part p
         Character *get_passenger( int you ) const;
-        bool has_driver() const;
+        bool has_driver( map &here ) const;
         // get character that is currently controlling the vehicle's motion
-        Character *get_driver() const;
+        Character *get_driver( map &here ) const;
         // get monster on a boardable part at p
-        monster *get_monster( int p ) const;
+        monster *get_monster( map &here, int p ) const;
 
         bool enclosed_at( map *here, const tripoint_bub_ms
                           &pos ); // not const because it calls refresh_insides
@@ -1465,23 +1466,23 @@ class vehicle
         std::list<item *> fuel_items_left();
 
         // Checks how much certain fuel left in tanks.
-        int64_t fuel_left( const itype_id &ftype,
+        int64_t fuel_left( map &here, const itype_id &ftype,
                            const std::function<bool( const vehicle_part & )> &filter = return_true<const vehicle_part &> )
         const;
         // Checks how much of an engine's current fuel is left in the tanks.
-        int engine_fuel_left( const vehicle_part &vp ) const;
+        int engine_fuel_left( map &here, const vehicle_part &vp ) const;
         // Returns total vehicle fuel capacity for the given fuel type
-        int fuel_capacity( const itype_id &ftype ) const;
+        int fuel_capacity( map &here, const itype_id &ftype ) const;
 
         // drains a fuel type (e.g. for the kitchen unit)
         // returns amount actually drained, does not engage reactor
-        int drain( const itype_id &ftype, int amount,
+        int drain( map &here, const itype_id &ftype, int amount,
                    const std::function<bool( vehicle_part & )> &filter = return_true< vehicle_part &>,
                    bool apply_loss = true );
         int drain( map *here, const itype_id &ftype, int amount,
                    const std::function<bool( vehicle_part & )> &filter = return_true< vehicle_part &>,
                    bool apply_loss = true );
-        int drain( int index, int amount, bool apply_loss = true );
+        int drain( map &here, int index, int amount, bool apply_loss = true );
         /**
          * Consumes enough fuel by energy content. Does not support cable draining.
          * @param ftype Type of fuel
@@ -1491,11 +1492,11 @@ class vehicle
         units::energy drain_energy( const itype_id &ftype, units::energy wanted_energy );
 
         // fuel consumption of vehicle engines of given type
-        units::power basic_consumption( const itype_id &ftype ) const;
+        units::power basic_consumption( map &here, const itype_id &ftype ) const;
         // Fuel consumption mL/hour
         int consumption_per_hour( const itype_id &ftype, units::energy fuel_per_s ) const;
 
-        void consume_fuel( int load, bool idling );
+        void consume_fuel( map &here, int load, bool idling );
 
         /**
          * Maps used fuel to its basic (unscaled by load/strain) consumption.
@@ -1510,18 +1511,18 @@ class vehicle
         // Returns all active, available, non-destroyed vehicle lights
         std::vector<vehicle_part *> lights();
 
-        void update_alternator_load();
+        void update_alternator_load( map &here );
 
         // Total drain or production of electrical power from engines.
         units::power total_engine_epower() const;
         // Total production of electrical power from alternators.
-        units::power total_alternator_epower() const;
+        units::power total_alternator_epower( map &here ) const;
         // Total power (W) currently being produced by all solar panels.
-        units::power total_solar_epower() const;
+        units::power total_solar_epower( map &here ) const;
         // Total power currently being produced by all wind turbines.
-        units::power total_wind_epower() const;
+        units::power total_wind_epower( map &here ) const;
         // Total power currently being produced by all water wheels.
-        units::power total_water_wheel_epower() const;
+        units::power total_water_wheel_epower( map &here ) const;
         // Total power drain across all vehicle accessories.
         units::power total_accessory_epower() const;
         // Total power draw from all cable-connected devices. Is cleared every turn during idle().
@@ -1529,32 +1530,32 @@ class vehicle
         // Total power draw from all battery chargers. Is cleared every turn during idle().
         units::power recharge_epower_this_turn; // NOLINT(cata-serialize)
         // Net power draw or drain on batteries.
-        units::power net_battery_charge_rate( bool include_reactors ) const;
+        units::power net_battery_charge_rate( map &here, bool include_reactors ) const;
         // Maximum available power available from all reactors. Power from
         // reactors is only drawn when batteries are empty.
         units::power max_reactor_epower() const;
         // Active power from reactors that is actually being drained by batteries.
-        units::power active_reactor_epower() const;
+        units::power active_reactor_epower( map &here ) const;
         // Produce and consume electrical power, with excess power stored or
         // taken from batteries.
-        void power_parts();
+        void power_parts( map &here );
 
         // Current and total battery power (kJ) level as a pair
         std::pair<int, int> battery_power_level() const;
 
         // Current and total battery power (kJ) level of all connected vehicles as a pair
-        std::pair<int, int> connected_battery_power_level() const;
+        std::pair<int, int> connected_battery_power_level( map &here ) const;
 
         /**
         * @return true if at least one of the connected batteries has any charge left
         */
-        bool is_battery_available() const;
+        bool is_battery_available( map &here ) const;
 
         /**
         * @param apply_loss if true apply wire loss when charge crosses vehicle power cables
         * @return battery charge in kJ from all connected batteries
         */
-        int64_t battery_left( bool apply_loss = true ) const;
+        int64_t battery_left( map &here, bool apply_loss = true ) const;
 
         /**
          * Charges batteries in connected vehicles/appliances
@@ -1562,7 +1563,7 @@ class vehicle
          * @param apply_loss if true apply wire loss when charge crosses vehicle power cables
          * @return 0 or left over charge in kJ which does not fit in any connected batteries
          */
-        int charge_battery( int amount, bool apply_loss = true );
+        int charge_battery( map &here, int amount, bool apply_loss = true );
 
         /**
          * Discharges batteries in connected vehicles/appliances
@@ -1570,7 +1571,7 @@ class vehicle
          * @param apply_loss if true apply wire loss when charge crosses vehicle power cables
          * @return 0 or unfulfilled part of \p amount in kJ
          */
-        int discharge_battery( int amount, bool apply_loss = true );
+        int discharge_battery( map &here, int amount, bool apply_loss = true );
 
         /**
          * Mark mass caches and pivot cache as dirty
@@ -1581,7 +1582,7 @@ class vehicle
         units::mass total_mass() const;
         // Get the total mass of the vehicle minus the weight of any creatures that are
         // powering it; ie, the mass of the vehicle that the wheels are supporting
-        units::mass weight_on_wheels() const;
+        units::mass weight_on_wheels( map &here ) const;
 
         // Gets the center of mass calculated for precalc[0] coordinates
         const point_rel_ms &rotated_center_of_mass() const;
@@ -1600,59 +1601,59 @@ class vehicle
         // Get combined power of all engines. If fueled == true, then only engines which
         // vehicle have fuel for are accounted.  If safe == true, then limit engine power to
         // their safe power.
-        units::power total_power( bool fueled = true, bool safe = false ) const;
+        units::power total_power( map &here, bool fueled = true, bool safe = false ) const;
 
         // Get ground acceleration gained by combined power of all engines. If fueled == true,
         // then only engines which the vehicle has fuel for are included
-        int ground_acceleration( bool fueled = true, int at_vel_in_vmi = -1 ) const;
+        int ground_acceleration( map &here, bool fueled = true, int at_vel_in_vmi = -1 ) const;
         // Get water acceleration gained by combined power of all engines. If fueled == true,
         // then only engines which the vehicle has fuel for are included
-        int water_acceleration( bool fueled = true, int at_vel_in_vmi = -1 ) const;
+        int water_acceleration( map &here, bool fueled = true, int at_vel_in_vmi = -1 ) const;
         // get air acceleration gained by combined power of all engines. If fueled == true,
         // then only engines which the vehicle hs fuel for are included
-        int rotor_acceleration( bool fueled = true, int at_vel_in_vmi = -1 ) const;
+        int rotor_acceleration( map &here, bool fueled = true, int at_vel_in_vmi = -1 ) const;
         // Get acceleration for the current movement mode
-        int acceleration( bool fueled = true, int at_vel_in_vmi = -1 ) const;
+        int acceleration( map &here, bool fueled = true, int at_vel_in_vmi = -1 ) const;
 
         // Get the vehicle's actual current acceleration
-        int current_acceleration( bool fueled = true ) const;
+        int current_acceleration( map &here, bool fueled = true ) const;
 
         // is the vehicle currently moving?
         bool is_moving() const;
 
         // can the vehicle use rails?
-        bool can_use_rails() const;
+        bool can_use_rails( map &here ) const;
 
         // Get maximum ground velocity gained by combined power of all engines.
         // If fueled == true, then only the engines which the vehicle has fuel for are included
-        int max_ground_velocity( bool fueled = true ) const;
+        int max_ground_velocity( map &here, bool fueled = true ) const;
         // Get maximum water velocity gained by combined power of all engines.
         // If fueled == true, then only the engines which the vehicle has fuel for are included
-        int max_water_velocity( bool fueled = true ) const;
+        int max_water_velocity( map &here, bool fueled = true ) const;
         // get maximum air velocity based on rotor physics
-        int max_rotor_velocity( bool fueled = true ) const;
+        int max_rotor_velocity( map &here, bool fueled = true ) const;
         // Get maximum velocity for the current movement mode
-        int max_velocity( bool fueled = true ) const;
+        int max_velocity( map &here, bool fueled = true ) const;
         // Get maximum reverse velocity for the current movement mode
-        int max_reverse_velocity( bool fueled = true ) const;
+        int max_reverse_velocity( map &here, bool fueled = true ) const;
 
         // Get safe ground velocity gained by combined power of all engines.
         // If fueled == true, then only the engines which the vehicle has fuel for are included
-        int safe_ground_velocity( bool fueled = true ) const;
+        int safe_ground_velocity( map &here, bool fueled = true ) const;
         // get safe air velocity gained by combined power of all engines.
         // if fueled == true, then only the engines which the vehicle hs fuel for are included
-        int safe_rotor_velocity( bool fueled = true ) const;
+        int safe_rotor_velocity( map &here, bool fueled = true ) const;
         // Get safe water velocity gained by combined power of all engines.
         // If fueled == true, then only the engines which the vehicle has fuel for are included
-        int safe_water_velocity( bool fueled = true ) const;
+        int safe_water_velocity( map &here, bool fueled = true ) const;
         // Get maximum velocity for the current movement mode
-        int safe_velocity( bool fueled = true ) const;
+        int safe_velocity( map &here, bool fueled = true ) const;
 
         // Generate field from a part, either at front or back of vehicle depending on velocity.
-        void spew_field( double joules, int part, field_type_id type, int intensity = 1 ) const;
+        void spew_field( map &here,  double joules, int part, field_type_id type, int intensity = 1 ) const;
 
         // Loop through engines and generate noise and smoke for each one
-        void noise_and_smoke( int load, time_duration time = 1_turns );
+        void noise_and_smoke( map &here, int load, time_duration time = 1_turns );
 
         /**
          * Calculates the sum of the area under the wheels of the vehicle.
@@ -1720,12 +1721,12 @@ class vehicle
         /**
          * is the vehicle flying? is it a rotorcraft?
          */
-        double lift_thrust_of_rotorcraft( bool fuelled, bool safe = false ) const;
-        bool has_sufficient_rotorlift() const;
+        double lift_thrust_of_rotorcraft( map &here, bool fuelled, bool safe = false ) const;
+        bool has_sufficient_rotorlift( map &here ) const;
         int get_z_change() const;
         bool is_flying_in_air() const;
         void set_flying( bool new_flying_value );
-        bool is_rotorcraft() const;
+        bool is_rotorcraft( map &here ) const;
         // Can the vehicle safely fly? E.g. there haven't been any player modifications
         // of non-simple parts
         bool is_flyable() const;
@@ -1744,7 +1745,7 @@ class vehicle
          *
          * Affects safe velocity, acceleration and handling difficulty.
          */
-        float k_traction( float wheel_traction_area ) const;
+        float k_traction( map &here, float wheel_traction_area ) const;
         /*@}*/
 
         // Extra drag on the vehicle from components other than wheels.
@@ -1752,7 +1753,7 @@ class vehicle
         units::power static_drag( bool actual = true ) const;
 
         // strain of engine(s) if it works higher that safe speed (0-1.0)
-        float strain() const;
+        float strain( map &here ) const;
 
         // Calculate if it can move using its wheels
         bool sufficient_wheel_config() const;
@@ -1761,18 +1762,18 @@ class vehicle
 
         // return the relative effectiveness of the steering (1.0 is normal)
         // <0 means there is no steering installed at all.
-        float steering_effectiveness() const;
+        float steering_effectiveness( map &here ) const;
 
         /** Returns roughly driving skill level at which there is no chance of fumbling. */
-        float handling_difficulty() const;
+        float handling_difficulty( map &here ) const;
 
         // idle fuel consumption
         // @param on_map if true vehicle processes noise/smoke and updates time
-        void idle( bool on_map );
+        void idle( map &here, bool on_map );
         // continuous processing for running vehicle alarms
         void alarm();
         // leak from broken tanks
-        void slow_leak();
+        void slow_leak( map &here );
 
         // thrust (1) or brake (-1) vehicle
         // @param z = z thrust for helicopters etc
@@ -1816,7 +1817,7 @@ class vehicle
         // Process the trap beneath
         void handle_trap( map *here, const tripoint_bub_ms &p, vehicle_part &vp_wheel );
         void activate_magical_follow();
-        void activate_animal_follow();
+        void activate_animal_follow( map &here );
         /**
          * vehicle is driving itself
          */
@@ -1863,19 +1864,19 @@ class vehicle
          * Update an item's active status, for example when adding
          * hot or perishable liquid to a container.
          */
-        void make_active( item_location &loc );
+        void make_active( map &here, item_location &loc );
         /**
          * Try to add an item to part's cargo.
          * @return iterator to added item or std::nullopt if it can't be put here (not a cargo part, adding
          * this would violate the volume limit or item count limit, not all charges can fit, etc.)
          */
-        std::optional<vehicle_stack::iterator> add_item( vehicle_part &vp, const item &itm );
+        std::optional<vehicle_stack::iterator> add_item( map &here, vehicle_part &vp, const item &itm );
         /**
          * Add an item counted by charges to the part's cargo.
          *
          * @returns The number of charges added.
          */
-        int add_charges( vehicle_part &vp, const item &itm );
+        int add_charges( map &here, vehicle_part &vp, const item &itm );
 
         // remove item from part's cargo
         bool remove_item( vehicle_part &vp, item *it );
@@ -2052,7 +2053,7 @@ class vehicle
         bool restore_folded_parts( const item &it );
 
         //true if an alarm part is installed on the vehicle
-        bool has_security_working() const;
+        bool has_security_working( map &here ) const;
         // unlocks the vehicle, turns off SECURITY parts, clears engine immobilizer faults
         void unlock();
         /**
@@ -2088,7 +2089,7 @@ class vehicle
         //returns whether the engine uses one of specific "combustion" fuel types (gas, diesel and diesel substitutes)
         bool is_engine_type_combustion( const vehicle_part &vp ) const;
         //returns whether the alternator is operational
-        bool is_alternator_on( const vehicle_part &vp ) const;
+        bool is_alternator_on( map &here, const vehicle_part &vp ) const;
         // try to turn engine on or off
         // (tries to start it and toggles it on if successful, shutdown is always a success)
         // returns true if engine status was changed
@@ -2105,7 +2106,7 @@ class vehicle
         //returns true if the engine doesn't consume fuel
         bool is_perpetual_type( const vehicle_part &vp ) const;
         //if necessary, damage this engine
-        void do_engine_damage( vehicle_part &vp, int strain );
+        void do_engine_damage( map &here, vehicle_part &vp, int strain );
         //remotely open/close doors
         void control_doors();
         // return a vector w/ 'direction' & 'magnitude', in its own sense of the words.
@@ -2116,7 +2117,7 @@ class vehicle
         // As above, but calculated for the actually used variable `dir`
         rl_vec2d dir_vec() const;
         // update vehicle parts as the vehicle moves
-        void on_move();
+        void on_move( map &here );
         // move the vehicle on the map. Returns updated pointer to self.
         vehicle *act_on_map();
         // check if the vehicle should be falling or is in water
@@ -2149,12 +2150,12 @@ class vehicle
         void use_washing_machine( int p );
         void use_dishwasher( int p );
         void use_monster_capture( int part, map *here, const tripoint_bub_ms &pos );
-        void use_harness( int part, const tripoint_bub_ms &pos );
+        void use_harness( int part, map *here, const tripoint_bub_ms &pos );
 
         void build_electronics_menu( veh_menu &menu );
         void build_bike_rack_menu( veh_menu &menu, int part );
-        void build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, bool with_pickup );
-        void interact_with( const tripoint_bub_ms &p, bool with_pickup = false );
+        void build_interact_menu( veh_menu &menu, map *here, const tripoint_bub_ms &p, bool with_pickup );
+        void interact_with( map *here, const tripoint_bub_ms &p, bool with_pickup = false );
 
         std::string disp_name() const;
 
@@ -2232,7 +2233,8 @@ class vehicle
 
         // Updates the internal precalculated mount offsets after the vehicle has been displaced
         // used in map::displace_vehicle()
-        std::set<int> advance_precalc_mounts( const point_sm_ms &new_pos, const tripoint_bub_ms &src,
+        std::set<int> advance_precalc_mounts( const point_sm_ms &new_pos, map *here,
+                                              const tripoint_bub_ms &src,
                                               const tripoint_rel_ms &dp, int ramp_offset,
                                               bool adjust_pos, std::set<int> parts_to_move );
         // make sure the vehicle is supported across z-levels or on the same z-level
@@ -2442,7 +2444,7 @@ class vehicle
         std::pair<int, double> get_exhaust_part() const;
 
         // destination for exhaust emissions
-        tripoint_bub_ms exhaust_dest( int part ) const;
+        tripoint_bub_ms exhaust_dest( map *here, int part ) const;
 
         // Returns debug data to overlay on the screen, a vector of {map tile position
         // relative to vehicle pos, color and text}.
@@ -2457,12 +2459,13 @@ class RemovePartHandler
     public:
         virtual ~RemovePartHandler() = default;
 
-        virtual void unboard( const tripoint_bub_ms &loc ) = 0;
-        virtual void add_item_or_charges( const tripoint_bub_ms &loc, item it, bool permit_oob ) = 0;
+        virtual void unboard( map *here, const tripoint_bub_ms &loc ) = 0;
+        virtual void add_item_or_charges( map *here, const tripoint_bub_ms &loc, item it,
+                                          bool permit_oob ) = 0;
         virtual void set_transparency_cache_dirty( int z ) = 0;
         virtual void set_floor_cache_dirty( int z ) = 0;
-        virtual void removed( vehicle &veh, int part ) = 0;
-        virtual void spawn_animal_from_part( item &base, const tripoint_bub_ms &loc ) = 0;
+        virtual void removed( map *here, vehicle &veh, int part ) = 0;
+        virtual void spawn_animal_from_part( item &base, map *here, const tripoint_bub_ms &loc ) = 0;
         virtual map &get_map_ref() = 0;
 };
 
@@ -2471,11 +2474,12 @@ class DefaultRemovePartHandler : public RemovePartHandler
     public:
         ~DefaultRemovePartHandler() override = default;
 
-        void unboard( const tripoint_bub_ms &loc ) override {
-            get_map().unboard_vehicle( loc );
+        void unboard( map *here, const tripoint_bub_ms &loc ) override {
+            here->unboard_vehicle( loc );
         }
-        void add_item_or_charges( const tripoint_bub_ms &loc, item it, bool /*permit_oob*/ ) override {
-            get_map().add_item_or_charges( loc, std::move( it ) );
+        void add_item_or_charges( map *here, const tripoint_bub_ms &loc, item it,
+                                  bool /*permit_oob*/ ) override {
+            here->add_item_or_charges( loc, std::move( it ) );
         }
         void set_transparency_cache_dirty( const int z ) override {
             map &here = get_map();
@@ -2485,8 +2489,8 @@ class DefaultRemovePartHandler : public RemovePartHandler
         void set_floor_cache_dirty( const int z ) override {
             get_map().set_floor_cache_dirty( z );
         }
-        void removed( vehicle &veh, int part ) override;
-        void spawn_animal_from_part( item &base, const tripoint_bub_ms &loc ) override {
+        void removed( map *here, vehicle &veh, int part ) override;
+        void spawn_animal_from_part( item &base, map *here, const tripoint_bub_ms &loc ) override {
             base.release_monster( loc, 1 );
         }
         map &get_map_ref() override {
@@ -2504,23 +2508,25 @@ class MapgenRemovePartHandler : public RemovePartHandler
 
         ~MapgenRemovePartHandler() override = default;
 
-        void unboard( const tripoint_bub_ms &/*loc*/ ) override {
+        void unboard( map *here, const tripoint_bub_ms &/*loc*/ ) override {
             debugmsg( "Tried to unboard during mapgen!" );
             // Ignored. Will almost certainly not be called anyway, because
             // there are no creatures that could have been mounted during mapgen.
         }
-        void add_item_or_charges( const tripoint_bub_ms &loc, item it, bool permit_oob ) override;
+        void add_item_or_charges( map *here, const tripoint_bub_ms &loc, item it,
+                                  bool permit_oob ) override;
         void set_transparency_cache_dirty( const int /*z*/ ) override {
             // Ignored for now. We don't initialize the transparency cache in mapgen anyway.
         }
         void set_floor_cache_dirty( const int /*z*/ ) override {
             // Ignored for now. We don't initialize the floor cache in mapgen anyway.
         }
-        void removed( vehicle &veh, const int /*part*/ ) override {
+        void removed( map *here, vehicle &veh, const int /*part*/ ) override {
             // TODO: check if this is necessary, it probably isn't during mapgen
-            m.dirty_vehicle_list.insert( &veh );
+            here->dirty_vehicle_list.insert( &veh );
         }
-        void spawn_animal_from_part( item &/*base*/, const tripoint_bub_ms &/*loc*/ ) override {
+        void spawn_animal_from_part( item &/*base*/, map */*here*/,
+                                     const tripoint_bub_ms &/*loc*/ ) override {
             debugmsg( "Tried to spawn animal from vehicle part during mapgen!" );
             // Ignored. The base item will not be changed and will spawn as is:
             // still containing the animal.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2490,7 +2490,7 @@ class DefaultRemovePartHandler : public RemovePartHandler
             get_map().set_floor_cache_dirty( z );
         }
         void removed( map *here, vehicle &veh, int part ) override;
-        void spawn_animal_from_part( item &base, map * /*here*/ , const tripoint_bub_ms& loc) override {
+        void spawn_animal_from_part( item &base, map * /*here*/, const tripoint_bub_ms &loc ) override {
             base.release_monster( loc, 1 );
         }
         map &get_map_ref() override {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2508,7 +2508,7 @@ class MapgenRemovePartHandler : public RemovePartHandler
 
         ~MapgenRemovePartHandler() override = default;
 
-        void unboard( map * /*here*/, const tripoint_bub_ms&/*loc*/) override {
+        void unboard( map * /*here*/, const tripoint_bub_ms &/*loc*/ ) override {
             debugmsg( "Tried to unboard during mapgen!" );
             // Ignored. Will almost certainly not be called anyway, because
             // there are no creatures that could have been mounted during mapgen.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2490,7 +2490,7 @@ class DefaultRemovePartHandler : public RemovePartHandler
             get_map().set_floor_cache_dirty( z );
         }
         void removed( map *here, vehicle &veh, int part ) override;
-        void spawn_animal_from_part( item &base, map *here, const tripoint_bub_ms &loc ) override {
+        void spawn_animal_from_part( item &base, map * /*here*/ , const tripoint_bub_ms& loc) override {
             base.release_monster( loc, 1 );
         }
         map &get_map_ref() override {
@@ -2508,7 +2508,7 @@ class MapgenRemovePartHandler : public RemovePartHandler
 
         ~MapgenRemovePartHandler() override = default;
 
-        void unboard( map *here, const tripoint_bub_ms &/*loc*/ ) override {
+        void unboard( map * /*here*/, const tripoint_bub_ms&/*loc*/) override {
             debugmsg( "Tried to unboard during mapgen!" );
             // Ignored. Will almost certainly not be called anyway, because
             // there are no creatures that could have been mounted during mapgen.

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -148,6 +148,8 @@ int vehicle::slowdown( int at_velocity ) const
 
 void vehicle::smart_controller_handle_turn( const std::optional<float> &k_traction_cache )
 {
+    map &here = get_map();
+
     // get settings or defaults
     smart_controller_config cfg = smart_controller_cfg.value_or( smart_controller_config() );
 
@@ -168,7 +170,7 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
         const vehicle_part &vp = parts[engines[i]];
         const bool is_electric = is_engine_type( vp, fuel_type_battery );
         if( ( is_electric || is_engine_type_combustion( vp ) ) &&
-            ( ( vp.is_available() && engine_fuel_left( vp ) ) || vp.enabled ) ) {
+            ( ( vp.is_available() && engine_fuel_left( here, vp ) ) || vp.enabled ) ) {
             c_engines.push_back( i );
             if( is_electric ) {
                 has_electric_engine = true;
@@ -176,7 +178,7 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
         }
     }
 
-    bool rotorcraft = is_flying && is_rotorcraft();
+    bool rotorcraft = is_flying && is_rotorcraft( here );
 
     // bail and shut down
     if( rotorcraft || c_engines.empty() || ( has_electric_engine && c_engines.size() == 1 ) ||
@@ -185,7 +187,7 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
             vp.part().enabled = false;
         }
 
-        if( player_is_driving_this_veh() ) {
+        if( player_is_driving_this_veh( &here ) ) {
             if( rotorcraft ) {
                 add_msg( _( "Smart controller does not support flying vehicles." ) );
             } else if( c_engines.empty() ) {
@@ -249,16 +251,16 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
     smart_controller_cache cur_state;
 
     float traction = is_stationary ? 1.0f :
-                     ( k_traction_cache ? *k_traction_cache : k_traction( get_map().vehicle_wheel_traction( *this ) ) );
+                     ( k_traction_cache ? *k_traction_cache : k_traction( here, here.vehicle_wheel_traction( *this ) ) );
 
     int prev_mask = 0;
     // opt_ prefix denotes values for currently found "optimal" engine configuration
-    units::power opt_net_echarge_rate = net_battery_charge_rate( /* include_reactors = */ true );
+    units::power opt_net_echarge_rate = net_battery_charge_rate( here, /* include_reactors = */ true );
     // total engine fuel energy usage (J)
     units::power opt_fuel_usage = 0_W;
 
-    int opt_accel = is_stationary ? 1 : current_acceleration() * traction;
-    int opt_safe_vel = is_stationary ? 1 : safe_ground_velocity( true );
+    int opt_accel = is_stationary ? 1 : current_acceleration( here ) * traction;
+    int opt_safe_vel = is_stationary ? 1 : safe_ground_velocity( here, true );
     float cur_load_approx = static_cast<float>( std::min( accel_demand,
                             opt_accel ) )  / std::max( opt_accel, 1 );
     float cur_load_alternator = std::min( 0.01f, static_cast<float>( alternator_load ) / 1000 );
@@ -304,7 +306,7 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
     // turn on/off combustion engines when necessary
     if( !has_electric_engine ) {
         if( !discharge_forbidden_soft && is_stationary && engine_on && !autopilot_on &&
-            !player_is_driving_this_veh() ) {
+            !player_is_driving_this_veh( &here ) ) {
             stop_engines();
             sfx::do_vehicle_engine_sfx();
             // temporary solution
@@ -337,12 +339,12 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
             continue; // skip checking this state
         }
 
-        int safe_vel =  is_stationary ? 1 : safe_ground_velocity( true );
-        int accel = is_stationary ? 1 : current_acceleration() * traction;
+        int safe_vel =  is_stationary ? 1 : safe_ground_velocity( here, true );
+        int accel = is_stationary ? 1 : current_acceleration( here ) * traction;
         units::power fuel_usage = 0_W;
-        units::power net_echarge_rate = net_battery_charge_rate( /* include_reactors = */ true );
+        units::power net_echarge_rate = net_battery_charge_rate( here, /* include_reactors = */ true );
         float load_approx = static_cast<float>( std::min( accel_demand, accel ) ) / std::max( accel, 1 );
-        update_alternator_load();
+        update_alternator_load( here );
         float load_approx_alternator  = std::min( 0.01f, static_cast<float>( alternator_load ) / 1000 );
 
         for( int e : c_engines ) {
@@ -415,7 +417,7 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
             for( const vpart_reference &vp : get_avail_parts( "SMART_ENGINE_CONTROLLER" ) ) {
                 vp.part().enabled = false;
             }
-            if( player_is_driving_this_veh() ) {
+            if( player_is_driving_this_veh( &here ) ) {
                 add_msg( m_bad, _( "Smart controller failed to start an engine." ) );
                 add_msg( m_bad, _( "Smart controller is shutting down." ) );
             }
@@ -434,7 +436,7 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
             }
             smart_controller_state = cur_state;
 
-            if( player_is_driving_this_veh() ) {
+            if( player_is_driving_this_veh( &here ) ) {
                 add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Smart controller optimizes engine state." );
             }
         }
@@ -442,21 +444,23 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
         // as the optimization was performed (even without state change), cache needs to be updated as well
         smart_controller_state = cur_state;
     }
-    update_alternator_load();
+    update_alternator_load( here );
 }
 
 void vehicle::thrust( int thd, int z )
 {
+    map &here = get_map();
+
     //if vehicle is stopped, set target direction to forward.
     //ensure it is not skidding. Set turns used to 0.
     if( !is_moving() && z == 0 ) {
         turn_dir = face.dir();
         stop();
     }
-    bool pl_ctrl = player_is_driving_this_veh();
+    bool pl_ctrl = player_is_driving_this_veh( &here );
 
     // No need to change velocity if there are no wheels
-    if( ( is_watercraft() && can_float() ) || ( is_rotorcraft() && ( z != 0 || is_flying ) ) ) {
+    if( ( is_watercraft() && can_float() ) || ( is_rotorcraft( here ) && ( z != 0 || is_flying ) ) ) {
         // we're good
     } else if( in_deep_water && !can_float() ) {
         stop();
@@ -479,13 +483,13 @@ void vehicle::thrust( int thd, int z )
     }
 
     // TODO: Pass this as an argument to avoid recalculating
-    float traction = k_traction( get_map().vehicle_wheel_traction( *this ) );
+    float traction = k_traction( here, here.vehicle_wheel_traction( *this ) );
 
     if( thrusting ) {
         smart_controller_handle_turn( traction );
     }
 
-    int accel = current_acceleration() * traction;
+    int accel = current_acceleration( here ) * traction;
     if( accel < 200 && velocity > 0 && is_towing() ) {
         if( pl_ctrl ) {
             add_msg( _( "The %s struggles to pull the %s on this surface!" ), name,
@@ -505,7 +509,7 @@ void vehicle::thrust( int thd, int z )
         }
         return;
     }
-    const int max_vel = traction * max_velocity();
+    const int max_vel = traction * max_velocity( here );
     // maximum braking is 20 mph/s, assumes high friction tires
     const int max_brake = 20 * 100;
     //pos or neg if accelerator or brake
@@ -536,7 +540,7 @@ void vehicle::thrust( int thd, int z )
         load = ( thrusting ? 1000 : 0 );
     }
     // rotorcraft need to spend 15% of load to hover, 30% to change z
-    if( is_rotorcraft() && ( z > 0 || is_flying_in_air() ) ) {
+    if( is_rotorcraft( here ) && ( z > 0 || is_flying_in_air() ) ) {
         load = std::max( load, z > 0 ? 300 : 150 );
         thrusting = true;
     }
@@ -544,9 +548,9 @@ void vehicle::thrust( int thd, int z )
     // only consume resources if engine accelerating
     if( load >= 1 && thrusting ) {
         //abort if engines not operational
-        if( total_power() <= 0_W || !engine_on || ( z == 0 && accel == 0 ) ) {
+        if( total_power( here ) <= 0_W || !engine_on || ( z == 0 && accel == 0 ) ) {
             if( pl_ctrl ) {
-                if( total_power( false ) <= 0_W ) {
+                if( total_power( here, false ) <= 0_W ) {
                     add_msg( m_info, _( "The %s doesn't have an engine!" ), name );
                 } else if( has_engine_type( fuel_type_muscle, true ) ) {
                     add_msg( m_info, _( "The %s's mechanism is out of reach!" ), name );
@@ -564,7 +568,7 @@ void vehicle::thrust( int thd, int z )
         // helicopters improve efficiency the closer they get to 50-70 knots
         // then it drops off as they go over that.
         // see https://i.stack.imgur.com/0zIO7.jpg
-        if( is_rotorcraft() && is_flying_in_air() ) {
+        if( is_rotorcraft( here ) && is_flying_in_air() ) {
             const int velocity_kt = velocity * 0.01;
             int value;
             if( velocity_kt < 70 ) {
@@ -577,15 +581,15 @@ void vehicle::thrust( int thd, int z )
             load = std::max( 200, std::min( 1000, ( ( value / 2 ) + 100 ) ) );
         }
         //make noise and consume fuel
-        noise_and_smoke( load + alternator_load );
-        consume_fuel( load + alternator_load, false );
-        if( z != 0 && is_rotorcraft() ) {
+        noise_and_smoke( here, load + alternator_load );
+        consume_fuel( here, load + alternator_load, false );
+        if( z != 0 && is_rotorcraft( here ) ) {
             requested_z_change = z;
         }
         //break the engines a bit, if going too fast.
-        const int strn = static_cast<int>( strain() * strain() * 100 );
+        const int strn = static_cast<int>( strain( here ) * strain( here ) * 100 );
         for( const int p : engines ) {
-            do_engine_damage( parts[p], strn );
+            do_engine_damage( here, parts[p], strn );
         }
     }
 
@@ -601,7 +605,7 @@ void vehicle::thrust( int thd, int z )
         stop();
     } else {
         // Increase velocity up to max_vel or min_vel, but not above.
-        const int min_vel = max_reverse_velocity();
+        const int min_vel = max_reverse_velocity( here );
         if( vel_inc > 0 ) {
             // Don't allow braking by accelerating (could happen with damaged engines)
             velocity = std::max( velocity, std::min( velocity + vel_inc, max_vel ) );
@@ -614,12 +618,12 @@ void vehicle::thrust( int thd, int z )
     for( size_t e = 0; e < parts.size(); e++ ) {
         vehicle_part &vp = parts[e];
         if( vp.info().fuel_type == fuel_type_animal && engines.size() != 1 ) {
-            monster *mon = get_monster( e );
+            monster *mon = get_monster( here, e );
             if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
                 if( velocity > mon->get_speed() * 12 ) {
                     add_msg( m_bad, _( "Your %s is not fast enough to keep up with the %s" ), mon->get_name(), name );
                     int dmg = rng( 0, 10 );
-                    damage_direct( get_map(), vp, dmg );
+                    damage_direct( here, vp, dmg );
                 }
             }
         }
@@ -628,12 +632,14 @@ void vehicle::thrust( int thd, int z )
 
 void vehicle::cruise_thrust( int amount )
 {
+    map &here = get_map();
+
     if( amount == 0 ) {
         return;
     }
-    int safe_vel = safe_velocity();
-    int max_vel = autopilot_on ? safe_velocity() : max_velocity();
-    int max_rev_vel = max_reverse_velocity();
+    int safe_vel = safe_velocity( here );
+    int max_vel = autopilot_on ? safe_velocity( here ) : max_velocity( here );
+    int max_rev_vel = max_reverse_velocity( here );
 
     //if the safe velocity is between the cruise velocity and its next value, set to safe velocity
     if( ( cruise_velocity < safe_vel && safe_vel < ( cruise_velocity + amount ) ) ||
@@ -698,7 +704,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
                          const tripoint_rel_ms &dp,
                          bool just_detect, bool bash_floor )
 {
-
+    map &here = get_map();
     /*
      * Big TODO:
      * Rewrite this function so that it has "pre-collision" phase (detection)
@@ -730,7 +736,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
     const bool vertical = bash_floor || dp.z() != 0;
     const int &coll_velocity = vertical ? vertical_velocity : velocity;
     // Skip collisions when there is no apparent movement, except verticially moving rotorcraft.
-    if( coll_velocity == 0 && !is_rotorcraft() ) {
+    if( coll_velocity == 0 && !is_rotorcraft( here ) ) {
         just_detect = true;
     }
 
@@ -738,7 +744,6 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
     int lowest_velocity = coll_velocity;
     const int sign_before = sgn( velocity_before );
     bool empty = true;
-    map &here = get_map();
     part_project_points( dp );
     for( int p = 0; p < part_count(); p++ ) {
         const vehicle_part &vp = parts.at( p );
@@ -841,7 +846,7 @@ veh_collision vehicle::part_collision( int part, const tripoint_abs_ms &p,
     Creature *critter = get_creature_tracker().creature_at( p, true );
     Character *ph = dynamic_cast<Character *>( critter );
 
-    Character *driver = get_driver();
+    Character *driver = get_driver( here );
 
     // If in a vehicle assume it's this one
     if( ph != nullptr && ph->in_vehicle ) {
@@ -882,7 +887,7 @@ veh_collision vehicle::part_collision( int part, const tripoint_abs_ms &p,
 
     if( is_body_collision ) {
         // critters on a BOARDABLE part in this vehicle aren't colliding
-        if( ovp && ( &ovp->vehicle() == this ) && get_monster( ovp->part_index() ) ) {
+        if( ovp && ( &ovp->vehicle() == this ) && get_monster( here, ovp->part_index() ) ) {
             return ret;
         }
         // we just ran into a fish, so move it out of the way
@@ -952,7 +957,8 @@ veh_collision vehicle::part_collision( int part, const tripoint_abs_ms &p,
                  // These are bashable, but don't interact with vehicles.
                  !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NOCOLLIDE, pos ) &&
                  // Do not collide with track tiles if we can use rails
-                 !( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_RAIL, pos ) && this->can_use_rails() ) ) ) {
+                 !( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_RAIL, pos ) &&
+                    this->can_use_rails( here ) ) ) ) {
         // Movecost 2 indicates flat terrain like a floor, no collision there.
         ret.type = veh_coll_bashable;
         terrain_collision_data( pos, bash_floor, mass2, part_dens, e );
@@ -1168,7 +1174,7 @@ veh_collision vehicle::part_collision( int part, const tripoint_abs_ms &p,
     // Apply special effects from collision.
     if( critter != nullptr ) {
         if( !critter->is_hallucination() ) {
-            if( player_is_driving_this_veh() ) {
+            if( player_is_driving_this_veh( &here ) ) {
                 if( time_stunned > 0_turns ) {
                     //~ 1$s - vehicle name, 2$s - part name, 3$s - NPC or monster
                     add_msg( m_warning, _( "Your %1$s's %2$s rams into %3$s and stuns it!" ),
@@ -1187,7 +1193,7 @@ veh_collision vehicle::part_collision( int part, const tripoint_abs_ms &p,
             }
         }
     } else {
-        if( player_is_driving_this_veh() ) {
+        if( player_is_driving_this_veh( &here ) ) {
             if( !snd.empty() ) {
                 //~ 1$s - vehicle name, 2$s - part name, 3$s - collision object name, 4$s - sound message
                 add_msg( m_warning, _( "Your %1$s's %2$s rams into %3$s with a %4$s" ),
@@ -1247,7 +1253,7 @@ void vehicle::handle_trap( map *here, const tripoint_bub_ms &p, vehicle_part &vp
     }
 
     Character &player_character = get_player_character();
-    const Character *driver = get_driver();
+    const Character *driver = get_driver( *here );
     const bool seen = player_character.sees( p );
     const bool known = tr.can_see( p, player_character );
     const bool damage_done = vp_wheel.info().durability <= veh_data.damage;
@@ -1287,7 +1293,7 @@ void vehicle::handle_trap( map *here, const tripoint_bub_ms &p, vehicle_part &vp
             here->trap_set( p, veh_data.set_trap.id() );
             still_has_trap = true;
         }
-        if( still_has_trap && player_is_driving_this_veh() ) {
+        if( still_has_trap && player_is_driving_this_veh( here ) ) {
             const trap &tr = here->tr_at( p );
             if( seen || known ) {
                 // known status has been reset by map::trap_set()
@@ -1304,10 +1310,12 @@ void vehicle::handle_trap( map *here, const tripoint_bub_ms &p, vehicle_part &vp
 
 monster *vehicle::get_harnessed_animal() const
 {
+    map &here = get_map();
+
     for( size_t e = 0; e < parts.size(); e++ ) {
         const vehicle_part &vp = parts[ e ];
         if( vp.info().fuel_type == fuel_type_animal ) {
-            monster *mon = get_monster( e );
+            monster *mon = get_monster( here, e );
             if( mon && mon->has_effect( effect_harnessed ) && mon->has_effect( effect_pet ) ) {
                 return mon;
             }
@@ -1318,12 +1326,14 @@ monster *vehicle::get_harnessed_animal() const
 
 void vehicle::selfdrive( const int trn, const int acceleration )
 {
+    map &here = get_map();
+
     if( !is_towed() && !magic && !get_harnessed_animal() && !has_part( "AUTOPILOT" ) ) {
         is_following = false;
         return;
     }
     if( trn != 0 ) {
-        if( steering_effectiveness() <= 0 ) {
+        if( steering_effectiveness( here ) <= 0 ) {
             return; // no steering
         }
         turn( trn * vehicles::steer_increment );
@@ -1338,7 +1348,7 @@ void vehicle::selfdrive( const int trn, const int acceleration )
     }
     // TODO: Actually check if we're on land on water (or disable water-skidding)
     if( skidding && valid_wheel_config() ) {
-        const float handling_diff = handling_difficulty();
+        const float handling_diff = handling_difficulty( here );
         if( handling_diff * rng( 1, 10 ) < 15 ) {
             velocity = static_cast<int>( forward_velocity() );
             skidding = false;
@@ -1363,13 +1373,14 @@ bool vehicle::check_is_heli_landed()
 
 bool vehicle::check_heli_descend( Character &p ) const
 {
-    if( !is_rotorcraft() ) {
+    map &here = get_map();
+
+    if( !is_rotorcraft( here ) ) {
         debugmsg( "A vehicle is somehow flying without being an aircraft" );
         return true;
     }
     int count = 0;
     int air_count = 0;
-    map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
     for( const tripoint_abs_ms &pt : get_points( true ) ) {
         const tripoint_bub_ms pos = here.get_bub( pt );
@@ -1399,7 +1410,9 @@ bool vehicle::check_heli_descend( Character &p ) const
 
 bool vehicle::check_heli_ascend( Character &p ) const
 {
-    if( !is_rotorcraft() ) {
+    map &here = get_map();
+
+    if( !is_rotorcraft( here ) ) {
         debugmsg( "A vehicle is somehow flying without being an aircraft" );
         return true;
     }
@@ -1410,7 +1423,6 @@ bool vehicle::check_heli_ascend( Character &p ) const
     if( sm_pos.z() + 1 >= OVERMAP_HEIGHT ) {
         return false; // don't allow trying to ascend to max zlevel
     }
-    map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
     for( const tripoint_abs_ms &pt : get_points( true ) ) {
         const tripoint_bub_ms pos = here.get_bub( pt );
@@ -1430,6 +1442,8 @@ bool vehicle::check_heli_ascend( Character &p ) const
 
 void vehicle::pldrive( Character &driver, const int trn, const int acceleration, const int z )
 {
+    map &here = get_map();
+
     bool is_non_proficient = false;
     float effective_driver_skill = driver.get_skill_level( skill_driving );
     float vehicle_proficiency;
@@ -1460,14 +1474,14 @@ void vehicle::pldrive( Character &driver, const int trn, const int acceleration,
         // - 50% Skill at Per/Dex 8: 1-in-16 chance
         // - 50% Skill at Per/Dex 12: 1-in-18 chance
     }
-    if( z != 0 && is_rotorcraft() ) {
+    if( z != 0 && is_rotorcraft( here ) ) {
         driver.set_moves( std::min( driver.get_moves(), 0 ) );
         thrust( 0, z );
     }
     units::angle turn_delta = vehicles::steer_increment * trn;
-    const float handling_diff = handling_difficulty() + non_prof_penalty;
+    const float handling_diff = handling_difficulty( here ) + non_prof_penalty;
     if( turn_delta != 0_degrees ) {
-        float eff = steering_effectiveness();
+        float eff = steering_effectiveness( here );
         if( eff == -2 ) {
             driver.add_msg_if_player( m_info,
                                       _( "You cannot steer an animal-drawn vehicle with no animal harnessed." ) );
@@ -1844,7 +1858,7 @@ vehicle *vehicle::act_on_map()
     if( decrement_summon_timer() ) {
         return nullptr;
     }
-    const bool pl_ctrl = player_is_driving_this_veh();
+    const bool pl_ctrl = player_is_driving_this_veh( &here );
     // TODO: Remove this hack, have vehicle sink a z-level
     if( in_deep_water && !can_float() ) {
         add_msg( m_bad, _( "Your %s sank." ), name );
@@ -1892,7 +1906,7 @@ vehicle *vehicle::act_on_map()
     }
 
     const float wheel_traction_area = here.vehicle_wheel_traction( *this );
-    const float traction = k_traction( wheel_traction_area );
+    const float traction = k_traction( here, wheel_traction_area );
     if( traction < 0.001f ) {
         of_turn = 0;
         if( !should_fall ) {
@@ -1910,7 +1924,8 @@ vehicle *vehicle::act_on_map()
     // Can't afford it this turn?
     // Low speed shouldn't prevent vehicle from falling, though
     bool falling_only = false;
-    if( turn_cost >= of_turn && ( ( !is_flying && requested_z_change == 0 ) || !is_rotorcraft() ) ) {
+    if( turn_cost >= of_turn && ( ( !is_flying && requested_z_change == 0 ) ||
+                                  !is_rotorcraft( here ) ) ) {
         if( !should_fall ) {
             of_turn_carry = of_turn;
             of_turn = 0;
@@ -1924,7 +1939,7 @@ vehicle *vehicle::act_on_map()
         of_turn -= turn_cost;
     }
 
-    bool can_use_rails = this->can_use_rails();
+    bool can_use_rails = this->can_use_rails( here );
     if( one_in( 10 ) ) {
         bool controlled = false;
         // It can even be a NPC, but must be at the controls
@@ -1995,7 +2010,7 @@ vehicle *vehicle::act_on_map()
     } else {
         dp.z() = requested_z_change;
         requested_z_change = 0;
-        if( dp.z() > 0 && is_rotorcraft() ) {
+        if( dp.z() > 0 && is_rotorcraft( here ) ) {
             is_flying = true;
         }
     }
@@ -2006,7 +2021,7 @@ vehicle *vehicle::act_on_map()
 bool vehicle::level_vehicle()
 {
     map &here = get_map();
-    if( is_flying && is_rotorcraft() ) {
+    if( is_flying && is_rotorcraft( here ) ) {
         return true;
     }
     is_on_ramp = false;
@@ -2061,8 +2076,10 @@ bool vehicle::level_vehicle()
 
 void vehicle::check_falling_or_floating()
 {
+    map &here = get_map();
+
     // If we're flying none of the rest of this matters.
-    if( is_flying && is_rotorcraft() ) {
+    if( is_flying && is_rotorcraft( here ) ) {
         is_falling = false;
         in_deep_water = false;
         in_water = false;
@@ -2071,7 +2088,6 @@ void vehicle::check_falling_or_floating()
 
     is_falling = true;
     is_flying = false;
-    map &here = get_map();
 
     auto has_support = [&here]( const tripoint_bub_ms & position, const bool water_supports ) {
         // if we're at the bottom of the z-levels, we're supported
@@ -2268,7 +2284,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
             }
         }
 
-        if( psg && veh.player_in_control( *psg ) ) {
+        if( psg && veh.player_in_control( here, *psg ) ) {
             const int lose_ctrl_roll = rng( 0, d_vel );
             ///\EFFECT_DEX reduces chance of losing control of vehicle when shaken
 

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -662,6 +662,8 @@ bool vehicle::mod_hp( vehicle_part &pt, int qty )
 
 bool vehicle::can_enable( const vehicle_part &pt, bool alert ) const
 {
+    map &here = get_map();
+
     if( std::none_of( parts.begin(), parts.end(), [&pt]( const vehicle_part & e ) {
     return &e == &pt;
 } ) || pt.removed ) {
@@ -681,7 +683,7 @@ bool vehicle::can_enable( const vehicle_part &pt, bool alert ) const
 
     // TODO: check fuel for combustion engines
 
-    if( pt.info().epower < 0_W && fuel_left( fuel_type_battery ) <= 0 ) {
+    if( pt.info().epower < 0_W && fuel_left( here, fuel_type_battery ) <= 0 ) {
         if( alert ) {
             add_msg( m_bad, _( "Insufficient power to enable %s" ), pt.name() );
         }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -288,6 +288,8 @@ static void add_electronic_toggle( vehicle &veh, veh_menu &menu, const std::stri
 
 void vehicle::build_electronics_menu( veh_menu &menu )
 {
+    map &here = get_map();
+
     if( has_part( "DOOR_MOTOR" ) ) {
         menu.add( _( "Control doors and curtains" ) )
         .hotkey( "TOGGLE_DOORS" )
@@ -298,7 +300,7 @@ void vehicle::build_electronics_menu( veh_menu &menu )
         menu.add( camera_on
                   ? colorize( _( "Turn off camera system" ), c_pink )
                   : _( "Turn on camera system" ) )
-        .enable( fuel_left( fuel_type_battery ) )
+        .enable( fuel_left( here, fuel_type_battery ) )
         .hotkey( "TOGGLE_CAMERA" )
         .keep_menu_open()
         .on_submit( [&] {
@@ -383,6 +385,8 @@ void vehicle::build_electronics_menu( veh_menu &menu )
 
 void vehicle::control_engines()
 {
+    map &here = get_map();
+
     bool dirty = false;
 
     veh_menu menu( this, _( "Toggle which?" ) );
@@ -392,7 +396,7 @@ void vehicle::control_engines()
             const vehicle_part &vp = parts[engine_idx];
             for( const itype_id &fuel_type : vp.info().engine_info->fuel_opts ) {
                 const bool is_active = vp.enabled && vp.fuel_current() == fuel_type;
-                const bool has_fuel = is_perpetual_type( vp ) || fuel_left( fuel_type );
+                const bool has_fuel = is_perpetual_type( vp ) || fuel_left( here, fuel_type );
                 menu.add( string_format( "[%s] %s %s", is_active ? "x" : " ", vp.name(), fuel_type->nname( 1 ) ) )
                 .enable( vp.is_available() && has_fuel )
                 .keep_menu_open()
@@ -423,7 +427,7 @@ void vehicle::control_engines()
 
     // if current velocity greater than new configuration safe speed
     // drop down cruise velocity.
-    int safe_vel = safe_velocity();
+    int safe_vel = safe_velocity( here );
     if( velocity > safe_vel ) {
         cruise_velocity = safe_vel;
     }
@@ -595,8 +599,11 @@ double vehicle::engine_cold_factor( const vehicle_part &vp ) const
 
 time_duration vehicle::engine_start_time( const vehicle_part &vp ) const
 {
+    map &here = get_map();
+
     time_duration result = 0_seconds;
-    if( !is_engine_on( vp ) || vp.info().has_flag( "E_STARTS_INSTANTLY" ) || !engine_fuel_left( vp ) ) {
+    if( !is_engine_on( vp ) || vp.info().has_flag( "E_STARTS_INSTANTLY" ) ||
+        !engine_fuel_left( here, vp ) ) {
         return result;
     }
 
@@ -608,7 +615,7 @@ time_duration vehicle::engine_start_time( const vehicle_part &vp ) const
 
     // divided by magic 16 = watts / 6000
     const double watts_per_time = 6000;
-    const double engine_watts = units::to_watt( part_vpower_w( vp, true ) );
+    const double engine_watts = units::to_watt( part_vpower_w( here, vp, true ) );
     result += time_duration::from_moves( engine_watts / watts_per_time );
     return result;
 }
@@ -616,15 +623,17 @@ time_duration vehicle::engine_start_time( const vehicle_part &vp ) const
 // NOLINTNEXTLINE(readability-make-member-function-const)
 bool vehicle::auto_select_fuel( vehicle_part &vp )
 {
+    map &here = get_map();
+
     const vpart_info &vp_engine_info = vp.info();
     if( !vp.is_available() || !vp.is_engine() ) {
         return false;
     }
-    if( vp_engine_info.fuel_type == fuel_type_none || engine_fuel_left( vp ) > 0 ) {
+    if( vp_engine_info.fuel_type == fuel_type_none || engine_fuel_left( here, vp ) > 0 ) {
         return true;
     }
     for( const itype_id &fuel_id : vp_engine_info.engine_info->fuel_opts ) {
-        if( fuel_left( fuel_id ) > 0 ) {
+        if( fuel_left( here, fuel_id ) > 0 ) {
             vp.fuel_set( fuel_id );
             return true;
         }
@@ -680,7 +689,7 @@ bool vehicle::start_engine( vehicle_part &vp )
 
     if( ( 1 - dmg ) < vpi.engine_info->backfire_threshold &&
         one_in( vpi.engine_info->backfire_freq ) ) {
-        backfire( vp );
+        backfire( &here, vp );
     } else {
         sounds::sound( pos, to_seconds<int>( start_time ) * 10, sounds::sound_t::movement,
                        string_format( _( "the %s bang as it starts!" ), vp.name() ), true, "vehicle",
@@ -707,7 +716,7 @@ bool vehicle::start_engine( vehicle_part &vp )
         const double cold_factor = engine_cold_factor( vp );
         const units::power start_power = -part_epower( vp ) * ( dmg * 5 + cold_factor * 2 + 10 );
         const int start_bat = power_to_energy_bat( start_power, start_time );
-        if( discharge_battery( start_bat ) != 0 ) {
+        if( discharge_battery( here, start_bat ) != 0 ) {
             sounds::sound( pos, vpi.engine_info->noise_factor, sounds::sound_t::alarm,
                            string_format( _( "the %s rapidly clicking." ), vp.name() ), true, "vehicle",
                            "engine_multi_click_fail" );
@@ -851,7 +860,7 @@ void vehicle::honk_horn() const
 {
     map &here = get_map();
 
-    const bool no_power = !fuel_left( fuel_type_battery );
+    const bool no_power = !fuel_left( here, fuel_type_battery );
     bool honked = false;
 
     for( const vpart_reference &vp : get_avail_parts( "HORN" ) ) {
@@ -930,7 +939,7 @@ void vehicle::beeper_sound() const
     map &here = get_map();
 
     // No power = no sound
-    if( fuel_left( fuel_type_battery ) == 0 ) {
+    if( fuel_left( here, fuel_type_battery ) == 0 ) {
         return;
     }
 
@@ -974,10 +983,11 @@ void vehicle::play_chimes() const
 
 void vehicle::crash_terrain_around()
 {
-    if( total_power() <= 0_W ) {
+    map &here = get_map();
+
+    if( total_power( here ) <= 0_W ) {
         return;
     }
-    map &here = get_map();
     for( const vpart_reference &vp : get_enabled_parts( "CRASH_TERRAIN_AROUND" ) ) {
         tripoint_bub_ms crush_target( 0, 0, -OVERMAP_LAYERS );
         const tripoint_bub_ms start_pos = vp.pos_bub( &here );
@@ -1074,7 +1084,7 @@ void vehicle::operate_reaper()
         if( vp.info().has_flag( VPFLAG_CARGO ) ) {
             for( map_stack::iterator iter = items.begin(); iter != items.end(); ) {
                 if( ( iter->volume() <= max_pickup_volume ) &&
-                    add_item( vp.part(), *iter ) ) {
+                    add_item( here, vp.part(), *iter ) ) {
                     iter = items.erase( iter );
                 } else {
                     ++iter;
@@ -1171,7 +1181,7 @@ void vehicle::operate_scoop()
                                sounds::sound_t::combat, _( "BEEEThump" ), false, "vehicle", "scoop_thump" );
             }
             //This attempts to add the item to the scoop inventory and if successful, removes it from the map.
-            if( add_item( vp.part(), *that_item_there ) ) {
+            if( add_item( here, vp.part(), *that_item_there ) ) {
                 here.i_rem( position, that_item_there );
             } else {
                 break;
@@ -1186,7 +1196,7 @@ void vehicle::alarm()
 
     if( one_in( 4 ) ) {
         //first check if the alarm is still installed
-        bool found_alarm = has_security_working();
+        bool found_alarm = has_security_working( here );
 
         //if alarm found, make noise, else set alarm disabled
         if( found_alarm ) {
@@ -1388,6 +1398,8 @@ void vehicle::lock_or_unlock( const int part_index, const bool locking )
 
 void vehicle::use_autoclave( int p )
 {
+    map &here = get_map();
+
     vehicle_part &vp = parts[p];
     vehicle_stack items = get_items( vp );
     bool filthy_items = std::any_of( items.begin(), items.end(), []( const item & i ) {
@@ -1408,7 +1420,7 @@ void vehicle::use_autoclave( int p )
                  _( "You turn the autoclave off before it's finished the program, and open its door." ) );
     } else if( items.empty() ) {
         add_msg( m_bad, _( "The autoclave is empty; there's no point in starting it." ) );
-    } else if( fuel_left( itype_water ) < 8 && fuel_left( itype_water_clean ) < 8 ) {
+    } else if( fuel_left( here, itype_water ) < 8 && fuel_left( here, itype_water_clean ) < 8 ) {
         add_msg( m_bad, _( "You need 8 charges of water in the tanks of the %s for the autoclave to run." ),
                  name );
     } else if( filthy_items ) {
@@ -1424,18 +1436,21 @@ void vehicle::use_autoclave( int p )
             n.set_age( 0_turns );
         }
 
-        if( fuel_left( itype_water ) >= 8 ) {
-            drain( itype_water, 8 );
+        if( fuel_left( here, itype_water ) >= 8 ) {
+            drain( here, itype_water, 8 );
         } else {
-            drain( itype_water_clean, 8 );
+            drain( here, itype_water_clean, 8 );
         }
 
         add_msg( m_good, _( "You turn the autoclave on and it starts its cycle." ) );
     }
 }
 
+// TODO: Organize magic number consumption.
 void vehicle::use_washing_machine( int p )
 {
+    map &here = get_map();
+
     vehicle_part &vp = parts[p];
     avatar &player_character = get_avatar();
     // Get all the items that can be used as detergent
@@ -1459,7 +1474,7 @@ void vehicle::use_washing_machine( int p )
                  _( "You turn the washing machine off before it's finished its cycle, and open its lid." ) );
     } else if( items.empty() ) {
         add_msg( m_bad, _( "The washing machine is empty; there's no point in starting it." ) );
-    } else if( fuel_left( itype_water ) < 24 && fuel_left( itype_water_clean ) < 24 ) {
+    } else if( fuel_left( here, itype_water ) < 24 && fuel_left( here, itype_water_clean ) < 24 ) {
         add_msg( m_bad,
                  _( "You need 24 charges of water in the tanks of the %s to fill the washing machine." ), name );
     } else if( detergents.empty() ) {
@@ -1503,10 +1518,10 @@ void vehicle::use_washing_machine( int p )
             n.set_age( 0_turns );
         }
 
-        if( fuel_left( itype_water ) >= 24 ) {
-            drain( itype_water, 24 );
+        if( fuel_left( here, itype_water ) >= 24 ) {
+            drain( here, itype_water, 24 );
         } else {
-            drain( itype_water_clean, 24 );
+            drain( here, itype_water_clean, 24 );
         }
 
         std::vector<item_comp> detergent;
@@ -1518,8 +1533,11 @@ void vehicle::use_washing_machine( int p )
     }
 }
 
+// TODO: Organize magic number consumption.
 void vehicle::use_dishwasher( int p )
 {
+    map &here = get_map();
+
     vehicle_part &vp = parts[p];
     avatar &player_character = get_avatar();
     bool detergent_is_enough = player_character.crafting_inventory().has_charges( itype_detergent, 5 );
@@ -1544,7 +1562,7 @@ void vehicle::use_dishwasher( int p )
                  _( "You turn the dishwasher off before it's finished its cycle, and open its lid." ) );
     } else if( items.empty() ) {
         add_msg( m_bad, _( "The dishwasher is empty, there's no point in starting it." ) );
-    } else if( fuel_left( itype_water ) < 24 && fuel_left( itype_water_clean ) < 24 ) {
+    } else if( fuel_left( here, itype_water ) < 24 && fuel_left( here, itype_water_clean ) < 24 ) {
         add_msg( m_bad, _( "You need 24 charges of water in the tanks of the %s to fill the dishwasher." ),
                  name );
     } else if( !detergent_is_enough ) {
@@ -1560,10 +1578,10 @@ void vehicle::use_dishwasher( int p )
             n.set_age( 0_turns );
         }
 
-        if( fuel_left( itype_water ) >= 24 ) {
-            drain( itype_water, 24 );
+        if( fuel_left( here, itype_water ) >= 24 ) {
+            drain( here, itype_water, 24 );
         } else {
-            drain( itype_water_clean, 24 );
+            drain( here, itype_water_clean, 24 );
         }
 
         std::vector<item_comp> detergent;
@@ -1592,8 +1610,14 @@ void vehicle::use_monster_capture( int part, map */*here*/, const tripoint_bub_m
     invalidate_mass();
 }
 
-void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
+void vehicle::use_harness( int part, map *here, const tripoint_bub_ms &pos )
 {
+    if( here !=
+        &get_map() ) { // TODO: Work needed on used operations for this to be possible to remove.
+        debugmsg( "vehicle::use_harness can only be used with the reality bubble." );
+        return;
+    }
+
     const vehicle_part &vp = parts[part];
     const vpart_info &vpi = vp.info();
 
@@ -1601,10 +1625,12 @@ void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
         debugmsg( "use_harness called on invalid part" );
         return;
     }
+    // TODO: Make 'is_empty' map aware.
     if( !g->is_empty( pos ) ) {
         add_msg( m_info, _( "The harness is blocked." ) );
         return;
     }
+    // TODO: Make 'choose_adjacent_highlight' map aware so 'f' can be too.
     creature_tracker &creatures = get_creature_tracker();
     const std::function<bool( const tripoint_bub_ms & )> f = [&creatures](
     const tripoint_bub_ms & pnt ) {
@@ -1617,6 +1643,7 @@ void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
                                     f.has_flag( mon_flag_PET_HARNESSABLE ) );
     };
 
+    // TODO: Make 'choose_adjacent_highlight' map aware.
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
                 _( "Where is the creature to harness?" ), _( "There is no creature to harness nearby." ), f,
                 false );
@@ -1624,7 +1651,8 @@ void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
         add_msg( m_info, _( "Never mind." ) );
         return;
     }
-    const tripoint_bub_ms &target = *pnt_;
+
+    const tripoint_abs_ms &target = here->get_abs( *pnt_ );
     monster *mon_ptr = creatures.creature_at<monster>( target );
     if( mon_ptr == nullptr ) {
         add_msg( m_info, _( "No creature there." ) );
@@ -1644,7 +1672,7 @@ void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
     }
 
     m.add_effect( effect_harnessed, 1_turns, true );
-    m.setpos( pos );
+    m.setpos( here->get_abs( pos ) );
     //~ %1$s: monster name, %2$s: vehicle name
     add_msg( m_info, _( "You harness your %1$s to %2$s." ), m.get_name(), disp_name() );
     if( m.has_effect( effect_tied ) ) {
@@ -1659,6 +1687,8 @@ void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
 
 void vehicle::build_bike_rack_menu( veh_menu &menu, int part )
 {
+    map &here = get_map();
+
     // prevent racking two vehicles with same name on single vehicle
     // @returns true if vehicle already has a vehicle with this name racked
     const auto has_veh_name_racked = [this]( const std::string & name ) {
@@ -1675,7 +1705,7 @@ void vehicle::build_bike_rack_menu( veh_menu &menu, int part )
     menu.desc_lines_hint = std::max( 1, menu.desc_lines_hint );
     bool has_rack_actions = false;
 
-    for( const rackable_vehicle &rackable : find_vehicles_to_rack( part ) ) {
+    for( const rackable_vehicle &rackable : find_vehicles_to_rack( &here,  part ) ) {
         const bool has_this_name_racked = has_veh_name_racked( rackable.name );
 
         menu.add( string_format( _( "Attach the %s to the rack" ), rackable.name ) )
@@ -1744,6 +1774,8 @@ void vpart_position::form_inventory( inventory &inv ) const
 
 std::pair<const itype_id &, int> vehicle::tool_ammo_available( const itype_id &tool_type ) const
 {
+    map &here = get_map();
+
     if( !tool_type->tool ) {
         return { itype_id::NULL_ID(), 0 };
     }
@@ -1754,9 +1786,9 @@ std::pair<const itype_id &, int> vehicle::tool_ammo_available( const itype_id &t
     // 2 bil ought to be enough for everyone, and hopefully not overflow int
     const int64_t max = 2000000000;
     if( ft->ammo->type == ammo_battery ) {
-        return { ft, static_cast<int>( std::min<int64_t>( battery_left(), max ) ) };
+        return { ft, static_cast<int>( std::min<int64_t>( battery_left( here ), max ) ) };
     } else {
-        return { ft, static_cast<int>( std::min<int64_t>( fuel_left( ft ), max ) ) };
+        return { ft, static_cast<int>( std::min<int64_t>( fuel_left( here, ft ), max ) ) };
     }
 }
 
@@ -1839,26 +1871,26 @@ bool vehicle::use_vehicle_tool( vehicle &veh, map *here, const tripoint_bub_ms &
     if( used_charges > 0 ) {
         if( is_battery_tool ) {
             // if tool has less battery charges than it started with - discharge from vehicle batteries
-            veh.discharge_battery( used_charges );
+            veh.discharge_battery( *here, used_charges );
         } else {
-            veh.drain( tool.ammo_current(), used_charges );
+            veh.drain( here, tool.ammo_current(), used_charges );
         }
     }
     return true;
 }
 
-void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, bool with_pickup )
+void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub_ms &p,
+                                   bool with_pickup )
 {
-    map &here = get_map();
-    const optional_vpart_position ovp = here.veh_at( p );
+    const optional_vpart_position ovp = here->veh_at( p );
     if( !ovp ) {
         debugmsg( "vehicle::build_interact_menu couldn't find vehicle at %s", p.to_string() );
         return;
     }
     const vpart_position vp = *ovp;
-    const tripoint_bub_ms vppos = vp.pos_bub( &here );
+    const tripoint_bub_ms vppos = vp.pos_bub( here );
 
-    std::vector<vehicle_part *> vp_parts = get_parts_at( &here, vppos, "", part_status_flag::working );
+    std::vector<vehicle_part *> vp_parts = get_parts_at( here, vppos, "", part_status_flag::working );
 
     // @returns true if pos contains available part with a flag
     const auto has_part_here = [vp_parts]( const std::string & flag ) {
@@ -1873,8 +1905,8 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
                                          : has_part_here( "CTRL_ELECTRONIC" );
     const bool controls_here = has_part_here( "CONTROLS" );
     const bool player_is_driving = get_player_character().controlling_vehicle;
-    const bool player_inside = here.veh_at( get_player_character().pos_abs() ) ?
-                               &here.veh_at( get_player_character().pos_abs() )->vehicle() == this :
+    const bool player_inside = here->veh_at( get_player_character().pos_abs() ) ?
+                               &here->veh_at( get_player_character().pos_abs() )->vehicle() == this :
                                false;
     bool power_linked = false;
     bool item_linked = false;
@@ -1921,7 +1953,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
             } );
         }
 
-        if( !is_alarm_on && has_security_working() ) {
+        if( !is_alarm_on && has_security_working( *here ) ) {
             menu.add( _( "Trigger the alarm" ) )
             .desc( _( "Trigger the alarm to make noise." ) )
             .skip_locked_check()
@@ -2050,8 +2082,8 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
         menu.add( string_format( _( "Unload %s" ), turret.name() ) )
         .hotkey( "UNLOAD_TURRET" )
         .skip_locked_check()
-        .on_submit( [this, vppos, &here] {
-            item_location loc = turret_query( &here, vppos ).base();
+        .on_submit( [this, vppos, here] {
+            item_location loc = turret_query( here, vppos ).base();
             get_player_character().unload( loc );
         } );
     }
@@ -2060,8 +2092,8 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
         menu.add( string_format( _( "Reload %s" ), turret.name() ) )
         .hotkey( "RELOAD_TURRET" )
         .skip_locked_check()
-        .on_submit( [this, vppos, &here] {
-            item_location loc = turret_query( &here, vppos ).base();
+        .on_submit( [this, vppos, here] {
+            item_location loc = turret_query( here, vppos ).base();
             item::reload_option opt = get_player_character().select_ammo( loc, true );
             if( opt )
             {
@@ -2189,7 +2221,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
         .enable( ammo_amount >= tool_item.typeId()->charges_to_use() )
         .hotkey( hk )
         .skip_locked_check( tool_ammo.is_null() || tool_ammo->ammo->type != ammo_battery )
-        .on_submit( [this, vppos, tool_type, &here] { use_vehicle_tool( *this, &here, vppos, tool_type ); } );
+        .on_submit( [this, vppos, tool_type, here] { use_vehicle_tool( *this, here, vppos, tool_type ); } );
     }
 
     const std::optional<vpart_reference> vp_autoclave = vp.avail_part_with_feature( "AUTOCLAVE" );
@@ -2226,7 +2258,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
     const std::optional<vpart_reference> vp_cargo = vp.cargo();
     // Whether vehicle part (cargo) contains items, and whether map tile (ground) has items
     if( with_pickup && (
-            here.has_items( vp.pos_bub( &here ) ) ||
+            here->has_items( vp.pos_bub( here ) ) ||
             ( vp_cargo && !vp_cargo->items().empty() ) ) ) {
         menu.add( _( "Get items" ) )
         .hotkey( "GET_ITEMS" )
@@ -2287,11 +2319,11 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
 
     if( vp.part_with_tool( itype_water_purifier ) ) {
         menu.add( _( "Purify water in vehicle tank" ) )
-        .enable( fuel_left( itype_water ) &&
-                 fuel_left( itype_battery ) >= itype_water_purifier->charges_to_use() )
+        .enable( fuel_left( *here, itype_water ) &&
+                 fuel_left( *here, itype_battery ) >= itype_water_purifier->charges_to_use() )
         .hotkey( "PURIFY_WATER" )
-        .on_submit( [this] {
-            const auto sel = []( const vehicle_part & pt )
+        .on_submit( [this, here] {
+            const auto sel = [here]( const vehicle_part & pt )
             {
                 return pt.is_tank() && pt.ammo_current() == itype_water;
             };
@@ -2304,7 +2336,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
             }
             vehicle_part &tank = vpr->part();
             int64_t cost = static_cast<int64_t>( itype_water_purifier->charges_to_use() );
-            if( fuel_left( itype_battery ) < tank.ammo_remaining() * cost )
+            if( fuel_left( *here, itype_battery ) < tank.ammo_remaining() * cost )
             {
                 //~ $1 - vehicle name, $2 - part name
                 add_msg( m_bad, _( "Insufficient power to purify the contents of the %1$s's %2$s" ),
@@ -2313,7 +2345,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
             {
                 //~ $1 - vehicle name, $2 - part name
                 add_msg( m_good, _( "You purify the contents of the %1$s's %2$s" ), name, tank.name() );
-                discharge_battery( tank.ammo_remaining() * cost );
+                discharge_battery( *here, tank.ammo_remaining() * cost );
                 tank.ammo_set( itype_water_clean, tank.ammo_remaining() );
             }
         } );
@@ -2325,7 +2357,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
         const size_t mc_idx = vp_monster_capture->part_index();
         menu.add( _( "Capture or release a creature" ) )
         .hotkey( "USE_CAPTURE_MONSTER_VEH" )
-        .on_submit( [this, mc_idx, vppos, &here] { use_monster_capture( mc_idx, &here, vppos ); } );
+        .on_submit( [this, mc_idx, vppos, here] { use_monster_capture( mc_idx, here, vppos ); } );
     }
 
     const std::optional<vpart_reference> vp_bike_rack = vp.avail_part_with_feature( "BIKE_RACK_VEH" );
@@ -2338,13 +2370,13 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
         const size_t hn_idx = vp_harness->part_index();
         menu.add( _( "Harness an animal" ) )
         .hotkey( "USE_ANIMAL_CTRL" )
-        .on_submit( [this, hn_idx, vppos] { use_harness( hn_idx, vppos ); } );
+        .on_submit( [this, hn_idx, here, vppos] { use_harness( hn_idx, here, vppos ); } );
     }
 
     if( vp.avail_part_with_feature( "PLANTER" ) ) {
         menu.add( _( "Reload seed drill with seeds" ) )
         .hotkey( "USE_PLANTER" )
-        .on_submit( [this, vppos, &here] { reload_seeds( &here, vppos ); } );
+        .on_submit( [this, vppos, here] { reload_seeds( here, vppos ); } );
     }
 
     const std::optional<vpart_reference> vp_workbench = vp.avail_part_with_feature( "WORKBENCH" );
@@ -2460,9 +2492,9 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint_bub_ms &p, boo
     }
 }
 
-void vehicle::interact_with( const tripoint_bub_ms &p, bool with_pickup )
+void vehicle::interact_with( map *here, const tripoint_bub_ms &p, bool with_pickup )
 {
-    const optional_vpart_position ovp = get_map().veh_at( p );
+    const optional_vpart_position ovp = here->veh_at( p );
     if( !ovp ) {
         debugmsg( "interact_with called at %s and no vehicle is found", p.to_string() );
         return;
@@ -2471,6 +2503,6 @@ void vehicle::interact_with( const tripoint_bub_ms &p, bool with_pickup )
     veh_menu menu( *this, _( "Select an action" ) );
     do {
         menu.reset();
-        build_interact_menu( menu, p, with_pickup );
+        build_interact_menu( menu, here, p, with_pickup );
     } while( menu.query() );
 }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2323,7 +2323,7 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
                  fuel_left( *here, itype_battery ) >= itype_water_purifier->charges_to_use() )
         .hotkey( "PURIFY_WATER" )
         .on_submit( [this, here] {
-            const auto sel = [here]( const vehicle_part & pt )
+            const auto sel = []( const vehicle_part & pt )
             {
                 return pt.is_tank() && pt.ammo_current() == itype_water;
             };

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -103,7 +103,7 @@ TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][u
 
     WHEN( "unloading ammo belts using UNLOAD_ALL " ) {
         if( in_vehicle ) {
-            vp->vehicle().add_item( vp->part(), ammo_belt );
+            vp->vehicle().add_item( here, vp->part(), ammo_belt );
         } else {
             here.add_item_or_charges( tripoint_bub_ms( tripoint::east ), ammo_belt );
         }

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -2370,13 +2370,13 @@ TEST_CASE( "pseudo_tools_in_crafting_inventory", "[crafting][tools]" )
         }
 
         WHEN( "the tank contains liquid" ) {
-            REQUIRE( veh->fuel_left( itype_water ) == 0 );
+            REQUIRE( veh->fuel_left( here, itype_water ) == 0 );
             int charges = 50;
             for( const vpart_reference &tank : veh->get_avail_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
                 tank.part().ammo_set( itype_water, charges );
                 charges = 0;
             }
-            REQUIRE( veh->fuel_left( itype_water ) == 50 );
+            REQUIRE( veh->fuel_left( here, itype_water ) == 50 );
 
             THEN( "crafting inventory does not contain the liquid" ) {
                 player.invalidate_crafting_inventory();

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -23,7 +23,7 @@ void check_vehicle_still_works( vehicle &veh )
 {
     map &here = get_map();
     REQUIRE( here.veh_at( get_avatar().pos_bub() ).has_value() );
-    REQUIRE( veh.player_in_control( get_avatar() ) );
+    REQUIRE( veh.player_in_control( here, get_avatar() ) );
     veh.engine_on = true;
     veh.velocity = 1000;
     veh.cruise_velocity = veh.velocity;

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -447,7 +447,7 @@ void test_scenario::run()
             std::optional<vpart_reference> vp =
                 here.veh_at( guy.pos_bub() ).part_with_feature( vpart_bitflags::VPFLAG_CARGO, true );
             REQUIRE( vp.has_value() );
-            std::optional<vehicle_stack::iterator> added = veh->add_item( vp->part(), it );
+            std::optional<vehicle_stack::iterator> added = veh->add_item( here, vp->part(), it );
             REQUIRE( added.has_value() );
             it_loc = item_location( vehicle_cursor( vp->vehicle(), vp->part_index() ), & **added );
             break;

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -85,6 +85,8 @@ static bool test_drag(
     const int expected_safe = 0, const int expected_max = 0,
     const bool test_results = false )
 {
+    map &here = get_map();
+
     vehicle *veh_ptr = setup_drag_test( veh_id );
     if( veh_ptr == nullptr ) {
         return false;
@@ -93,8 +95,8 @@ static bool test_drag(
     const double c_air = veh_ptr->coeff_air_drag();
     const double c_rolling = veh_ptr->coeff_rolling_drag();
     const double c_water = veh_ptr->coeff_water_drag();
-    const int safe_v = veh_ptr->safe_ground_velocity( false );
-    const int max_v = veh_ptr->max_ground_velocity( false );
+    const int safe_v = veh_ptr->safe_ground_velocity( here, false );
+    const int max_v = veh_ptr->max_ground_velocity( here, false );
 
     const auto d_in_bounds = [&]( const double expected, double value ) {
         double expected_high = expected * 1.05;

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -213,7 +213,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
     veh.engine_on = true;
 
     const int sign = in_reverse ? -1 : 1;
-    const int target_velocity = sign * std::min( 50 * 100, veh.safe_ground_velocity( false ) );
+    const int target_velocity = sign * std::min( 50 * 100, veh.safe_ground_velocity( here, false ) );
     veh.cruise_velocity = target_velocity;
     // If we aren't testing repeated cold starts, start the vehicle at cruising velocity.
     // Otherwise changing the amount of fuel in the tank perturbs the test results.
@@ -224,11 +224,11 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
     int tiles_travelled = 0;
     int cycles_left = cycle_limit;
     bool accelerating = true;
-    CHECK( veh.safe_velocity() > 0 );
-    while( veh.engine_on && veh.safe_velocity() > 0 && cycles_left > 0 ) {
+    CHECK( veh.safe_velocity( here ) > 0 );
+    while( veh.engine_on && veh.safe_velocity( here ) > 0 && cycles_left > 0 ) {
         cycles_left--;
         here.vehmove();
-        veh.idle( true );
+        veh.idle( here, true );
         // If the vehicle starts skidding, the effects become random and test is RUINED
         REQUIRE( !veh.skidding );
         for( const tripoint_abs_ms &pos : veh.get_points() ) {

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -156,7 +156,7 @@ TEST_CASE( "ensure_fake_parts_enable_on_turn", "[vehicle] [vehicle_fake]" )
             }
         }
         here.vehmove();
-        veh->idle( true );
+        veh->idle( here, true );
         validate_part_count( *veh, target_velocity, 0_degrees, original_parts, fake_parts,
                              active_fakes_by_angle.at( 0 ) );
     }

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -122,6 +122,7 @@ TEST_CASE( "vehicle_parts_have_at_least_one_category", "[vehicle][vehicle_parts]
 static void test_craft_via_rig( const std::vector<item> &items, int give_battery,
                                 int expect_battery, int give_water, int expect_water, const recipe &recipe, bool expect_success )
 {
+    map &here = get_map();
     clear_avatar();
     clear_map();
     clear_vehicles();
@@ -146,12 +147,12 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
     }
     character.learn_recipe( &recipe );
 
-    get_map().add_vehicle( vehicle_prototype_test_rv, test_origin, -90_degrees, 0, 0 );
-    const optional_vpart_position ovp = get_map().veh_at( test_origin );
+    here.add_vehicle( vehicle_prototype_test_rv, test_origin, -90_degrees, 0, 0 );
+    const optional_vpart_position ovp = here.veh_at( test_origin );
     REQUIRE( ovp.has_value() );
     vehicle &veh = ovp->vehicle();
 
-    REQUIRE( veh.fuel_left( itype_water_clean ) == 0 );
+    REQUIRE( veh.fuel_left( here, itype_water_clean ) == 0 );
     for( const vpart_reference &tank : veh.get_avail_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
         tank.part().ammo_set( itype_water_clean, give_water );
         break;
@@ -165,10 +166,10 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
             veh.set_hp( p.part(), 0, true );
         }
     }
-    get_map().board_vehicle( test_origin, &character );
+    here.board_vehicle( test_origin, &character );
 
-    veh.discharge_battery( 500000 );
-    veh.charge_battery( give_battery );
+    veh.discharge_battery( here, 500000 );
+    veh.charge_battery( here, give_battery );
 
     character.invalidate_crafting_inventory();
     const inventory &crafting_inv = character.crafting_inventory();
@@ -194,7 +195,7 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
     }
 
     CHECK( veh.battery_power_level().first == expect_battery );
-    CHECK( veh.fuel_left( itype_water_clean ) == expect_water );
+    CHECK( veh.fuel_left( here, itype_water_clean ) == expect_water );
 
     veh.unboard_all();
 }
@@ -217,7 +218,7 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
     REQUIRE( ovp.has_value() );
     vehicle &veh = ovp->vehicle();
 
-    REQUIRE( veh.fuel_left( itype_water_clean ) == 0 );
+    REQUIRE( veh.fuel_left( here, itype_water_clean ) == 0 );
     item *tank_it = nullptr;
     for( const vpart_reference &tank : veh.get_avail_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
         tank.part().ammo_set( itype_water_clean, water_charges );
@@ -226,7 +227,7 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
         break;
     }
     REQUIRE( tank_it != nullptr );
-    REQUIRE( veh.fuel_left( itype_water_clean ) == static_cast<int64_t>( water_charges ) );
+    REQUIRE( veh.fuel_left( here, itype_water_clean ) == static_cast<int64_t>( water_charges ) );
 
     std::optional<vpart_reference> faucet;
     for( const vpart_reference &vpr : veh.get_all_parts() ) {
@@ -239,16 +240,16 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
     here.board_vehicle( faucet->pos_bub( &here ) + tripoint::east, &character );
     veh_menu menu( veh, "TEST" );
     for( int i = 0; i < water_charges; i++ ) {
-        CAPTURE( i, veh.fuel_left( itype_water_clean ) );
+        CAPTURE( i, veh.fuel_left( here, itype_water_clean ) );
         menu.reset();
-        veh.build_interact_menu( menu, faucet->pos_bub( &here ), false );
+        veh.build_interact_menu( menu, &here, faucet->pos_bub( &here ), false );
         const std::vector<veh_menu_item> items = menu.get_items();
         const bool stomach_should_be_full = i == water_charges - 1;
         const auto drink_item_it = std::find_if( items.begin(), items.end(),
         []( const veh_menu_item & it ) {
             return it._text == "Have a drink";
         } );
-        REQUIRE( veh.fuel_left( itype_water_clean ) == ( water_charges - i ) );
+        REQUIRE( veh.fuel_left( here, itype_water_clean ) == ( water_charges - i ) );
         REQUIRE( drink_item_it != items.end() );
         REQUIRE( drink_item_it->_enabled == !stomach_should_be_full ); // stomach should be full
         REQUIRE( character.get_morale_level() == ( i != 0 ? 1 : 0 ) ); // bonus morale from cold water
@@ -260,7 +261,7 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
         process_activity( character );
         REQUIRE( character.get_morale_level() == 1 );
     }
-    REQUIRE( veh.fuel_left( itype_water_clean ) == 0 );
+    REQUIRE( veh.fuel_left( here, itype_water_clean ) == 0 );
     REQUIRE( tank_it->empty_container() );
     here.destroy_vehicle( &veh );
 }

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -120,14 +120,14 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
         { 9000, 5500, 1000, 9000, 6000 },
     };
     for( const preset_t &preset : presets ) {
-        REQUIRE( v.fuel_left( fuel_type_battery ) == 0 ); // ensure empty batteries
-        const int remainder = v.charge_battery( preset.charge );
+        REQUIRE( v.fuel_left( here, fuel_type_battery ) == 0 ); // ensure empty batteries
+        const int remainder = v.charge_battery( here, preset.charge );
         CHECK( remainder <= preset.max_charge_excess );
         for( size_t i = 0; i < batteries.size(); i++ ) {
             CAPTURE( i );
             CHECK( preset.max_charge_in_battery >= batteries[i].part().ammo_remaining() );
         }
-        const int deficit = v.discharge_battery( preset.discharge );
+        const int deficit = v.discharge_battery( here, preset.discharge );
         CHECK( deficit >= preset.min_discharge_deficit );
     }
 }
@@ -149,11 +149,11 @@ TEST_CASE( "Solar_power", "[vehicle][power]" )
     SECTION( "Summer day noon" ) {
         calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days + 12_hours;
         veh_ptr->update_time( calendar::turn );
-        veh_ptr->discharge_battery( 100000 );
-        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 0 );
+        veh_ptr->discharge_battery( here, 100000 );
+        REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
         WHEN( "30 minutes elapse" ) {
             veh_ptr->update_time( calendar::turn + 30_minutes );
-            int power = veh_ptr->fuel_left( fuel_type_battery );
+            int power = veh_ptr->fuel_left( here, fuel_type_battery );
             CHECK( power == Approx( 425 ).margin( 1 ) );
         }
     }
@@ -162,11 +162,11 @@ TEST_CASE( "Solar_power", "[vehicle][power]" )
         calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days;
         calendar::turn = sunrise( calendar::turn ) - 1_hours;
         veh_ptr->update_time( calendar::turn );
-        veh_ptr->discharge_battery( 100000 );
-        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 0 );
+        veh_ptr->discharge_battery( here, 100000 );
+        REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
         WHEN( "30 minutes elapse" ) {
             veh_ptr->update_time( calendar::turn + 30_minutes );
-            int power = veh_ptr->fuel_left( fuel_type_battery );
+            int power = veh_ptr->fuel_left( here, fuel_type_battery );
             CHECK( power == 0 );
         }
     }
@@ -174,11 +174,11 @@ TEST_CASE( "Solar_power", "[vehicle][power]" )
     SECTION( "Winter noon" ) {
         calendar::turn = calendar::turn_zero + 3 * calendar::season_length() + 1_days + 12_hours;
         veh_ptr->update_time( calendar::turn );
-        veh_ptr->discharge_battery( 100000 );
-        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 0 );
+        veh_ptr->discharge_battery( here, 100000 );
+        REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
         WHEN( "30 minutes elapse" ) {
             veh_ptr->update_time( calendar::turn + 30_minutes );
-            int power = veh_ptr->fuel_left( fuel_type_battery );
+            int power = veh_ptr->fuel_left( here, fuel_type_battery );
             CHECK( power == Approx( 184 ).margin( 1 ) );
         }
     }
@@ -195,18 +195,18 @@ TEST_CASE( "Solar_power", "[vehicle][power]" )
         veh_ptr->update_time( calendar::turn );
         veh_2_ptr->update_time( calendar::turn );
 
-        veh_ptr->discharge_battery( 100000 );
-        veh_2_ptr->discharge_battery( 100000 );
-        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 0 );
-        REQUIRE( veh_2_ptr->fuel_left( fuel_type_battery ) == 0 );
+        veh_ptr->discharge_battery( here, 100000 );
+        veh_2_ptr->discharge_battery( here, 100000 );
+        REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
+        REQUIRE( veh_2_ptr->fuel_left( here, fuel_type_battery ) == 0 );
 
         // Vehicle 1 does 2x 30 minutes while vehicle 2 does 1x 60 minutes
         veh_ptr->update_time( calendar::turn + 30_minutes );
         veh_ptr->update_time( calendar::turn + 60_minutes );
         veh_2_ptr->update_time( calendar::turn + 60_minutes );
 
-        int power = veh_ptr->fuel_left( fuel_type_battery );
-        int power_2 = veh_2_ptr->fuel_left( fuel_type_battery );
+        int power = veh_ptr->fuel_left( here, fuel_type_battery );
+        int power_2 = veh_2_ptr->fuel_left( here, fuel_type_battery );
         CHECK( power == Approx( power_2 ).margin( 1 ) );
     }
 }
@@ -227,11 +227,11 @@ TEST_CASE( "Daily_solar_power", "[vehicle][power]" )
     SECTION( "Spring day 2" ) {
         calendar::turn = calendar::turn_zero + 1_days;
         veh_ptr->update_time( calendar::turn );
-        veh_ptr->discharge_battery( 100000 );
-        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 0 );
+        veh_ptr->discharge_battery( here, 100000 );
+        REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
         WHEN( "24 hours pass" ) {
             veh_ptr->update_time( calendar::turn + 24_hours );
-            int power = veh_ptr->fuel_left( fuel_type_battery );
+            int power = veh_ptr->fuel_left( here, fuel_type_battery );
             CHECK( power == Approx( 5259 ).margin( 1 ) );
         }
     }
@@ -239,11 +239,11 @@ TEST_CASE( "Daily_solar_power", "[vehicle][power]" )
     SECTION( "Summer day 1" ) {
         calendar::turn = calendar::turn_zero + calendar::season_length();
         veh_ptr->update_time( calendar::turn );
-        veh_ptr->discharge_battery( 100000 );
-        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 0 );
+        veh_ptr->discharge_battery( here, 100000 );
+        REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
         WHEN( "24 hours pass" ) {
             veh_ptr->update_time( calendar::turn + 24_hours );
-            int power = veh_ptr->fuel_left( fuel_type_battery );
+            int power = veh_ptr->fuel_left( here, fuel_type_battery );
             CHECK( power == Approx( 7925 ).margin( 1 ) );
         }
     }
@@ -251,11 +251,11 @@ TEST_CASE( "Daily_solar_power", "[vehicle][power]" )
     SECTION( "Autum day 1" ) {
         calendar::turn = calendar::turn_zero + 2 * calendar::season_length();
         veh_ptr->update_time( calendar::turn );
-        veh_ptr->discharge_battery( 100000 );
-        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 0 );
+        veh_ptr->discharge_battery( here, 100000 );
+        REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
         WHEN( "24 hours pass" ) {
             veh_ptr->update_time( calendar::turn + 24_hours );
-            int power = veh_ptr->fuel_left( fuel_type_battery );
+            int power = veh_ptr->fuel_left( here, fuel_type_battery );
             CHECK( power == Approx( 5138 ).margin( 1 ) );
         }
     }
@@ -263,11 +263,11 @@ TEST_CASE( "Daily_solar_power", "[vehicle][power]" )
     SECTION( "Winter day 1" ) {
         calendar::turn = calendar::turn_zero + 3 * calendar::season_length();
         veh_ptr->update_time( calendar::turn );
-        veh_ptr->discharge_battery( 100000 );
-        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 0 );
+        veh_ptr->discharge_battery( here, 100000 );
+        REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
         WHEN( "24 hours pass" ) {
             veh_ptr->update_time( calendar::turn + 24_hours );
-            int power = veh_ptr->fuel_left( fuel_type_battery );
+            int power = veh_ptr->fuel_left( here, fuel_type_battery );
             CHECK( power == Approx( 2137 ).margin( 1 ) );
         }
     }
@@ -285,15 +285,15 @@ TEST_CASE( "maximum_reverse_velocity", "[vehicle][power][reverse]" )
         const tripoint_bub_ms origin{ 10, 0, 0 };
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_scooter_test, origin, 0_degrees, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        veh_ptr->charge_battery( 450 );
-        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 450 );
+        veh_ptr->charge_battery( here, 450 );
+        REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 450 );
 
         WHEN( "the engine is started" ) {
             veh_ptr->start_engines();
 
             THEN( "it can go in both forward and reverse" ) {
-                int max_fwd = veh_ptr->max_velocity( false );
-                int max_rev = veh_ptr->max_reverse_velocity( false );
+                int max_fwd = veh_ptr->max_velocity( here, false );
+                int max_rev = veh_ptr->max_reverse_velocity( here, false );
 
                 CHECK( max_rev < 0 );
                 CHECK( max_fwd > 0 );
@@ -311,15 +311,15 @@ TEST_CASE( "maximum_reverse_velocity", "[vehicle][power][reverse]" )
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_scooter_electric_test, origin,
                                              0_degrees, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        veh_ptr->charge_battery( 5000 );
-        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 5000 );
+        veh_ptr->charge_battery( here, 5000 );
+        REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 5000 );
 
         WHEN( "the engine is started" ) {
             veh_ptr->start_engines();
 
             THEN( "it can go in both forward and reverse" ) {
-                int max_fwd = veh_ptr->max_velocity( false );
-                int max_rev = veh_ptr->max_reverse_velocity( false );
+                int max_fwd = veh_ptr->max_velocity( here, false );
+                int max_rev = veh_ptr->max_reverse_velocity( here, false );
 
                 CHECK( max_rev < 0 );
                 CHECK( max_fwd > 0 );

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -128,12 +128,12 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
     const int target_velocity = 400;
     veh.cruise_velocity = target_velocity;
     veh.velocity = target_velocity;
-    CHECK( veh.safe_velocity() > 0 );
+    CHECK( veh.safe_velocity( here ) > 0 );
     int cycles = 0;
     const int target_z = use_ramp ? ( up ? 1 : -1 ) : 0;
 
     std::set<tripoint_abs_ms> vpts = veh.get_points();
-    while( veh.engine_on && veh.safe_velocity() > 0 && cycles < 10 ) {
+    while( veh.engine_on && veh.safe_velocity( here ) > 0 && cycles < 10 ) {
         clear_creatures();
         CAPTURE( cycles );
         for( const tripoint_abs_ms &checkpt : vpts ) {
@@ -263,7 +263,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
     const int target_velocity = 800;
     veh.cruise_velocity = target_velocity;
     veh.velocity = target_velocity;
-    CHECK( veh.safe_velocity() > 0 );
+    CHECK( veh.safe_velocity( here ) > 0 );
 
     std::vector<vehicle_part *> all_parts;
     for( const tripoint_abs_ms &pos : veh.get_points() ) {

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -34,7 +34,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
         std::set<tripoint_abs_ms> original_points = veh_ptr->get_points( true );
 
         here.destroy_vehicle( vehicle_origin );
-        veh_ptr->part_removal_cleanup();
+        veh_ptr->part_removal_cleanup( here );
         REQUIRE( veh_ptr->get_parts_at( &here, vehicle_origin, "", part_status_flag::available ).empty() );
         vehs = here.get_vehicles();
         // destroying the center frame results in 4 new vehicles
@@ -74,7 +74,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
         veh_ptr = here.add_vehicle( vehicle_prototype_circle_split_test, vehicle_origin, dir, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
         here.destroy_vehicle( vehicle_origin );
-        veh_ptr->part_removal_cleanup();
+        veh_ptr->part_removal_cleanup( here );
         REQUIRE( veh_ptr->get_parts_at( &here, vehicle_origin, "", part_status_flag::available ).empty() );
         vehs = here.get_vehicles();
         CHECK( vehs.size() == 1 );

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -66,8 +66,8 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             if( base_itype->gun->energy_drain > 0_kJ || turret_vpi->has_flag( "USE_BATTERIES" ) ) {
                 const auto& [bat_current, bat_capacity] = veh->battery_power_level();
                 CHECK( bat_capacity > 0 );
-                veh->charge_battery( bat_capacity, /* apply_loss = */ false );
-                REQUIRE( veh->battery_left( /* apply_loss = */ false ) == bat_capacity );
+                veh->charge_battery( here, bat_capacity, /* apply_loss = */ false );
+                REQUIRE( veh->battery_left( here, /* apply_loss = */ false ) == bat_capacity );
             }
 
             const itype_id ammo_itype = vp.get_base().ammo_default();

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -442,7 +442,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
         // Empty the vehicle of any cargo.
         v->get_items( vp->part() ).clear();
         for( int i = 0; i != count; ++i ) {
-            v->add_item( vp->part(), obj );
+            v->add_item( here,  vp->part(), obj );
         }
 
         vehicle_selector sel( p.pos_bub(), 1 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make operations that use maps be explicit about which one they use, rather than grabbing get_map() somewhere down in the bowels of the call chain.
This time operations in vehicle.cpp.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

The changes should change nothing functionally in the existing game (it will if operations are called with maps other than the reality bubble for new cases).

#### Describe the solution
Convert the remaining bub ones in the header, then go through vehicle.cpp and search of get_map() to find operations using that. Convert those operations to use a map passed as a parameter (and the users of the operations to supply it).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
A bit though I decided there probably is a reason for why pre existing operations use `map&` rather than `map*` for their operations and switched to that profile. I'd be grateful for advice on which profile to use going forward.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load save, walk up ramp, be amazed by the blood soaked field outside, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkey, get killed by crashing into stationary vehicle.
The bloody field mess is a known issue of the current master, and getting killed by the crash has happened in previous tests as well (the character starts with a badly injured chest), so nothing unexpected was noticed.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
