### PR TITLE
Remove the limit on concurrent build matrix jobs in forks

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -87,9 +87,9 @@ jobs:
     steps:
       - id: matrix_vars
         run: |
-          echo "fail_fast=$([ "$GITHUB_REF_NAME" = "master" ] && echo false || echo true)" >> $GITHUB_OUTPUT
+          echo "fail_fast=$([ "$GITHUB_REF_NAME" = "master" -o "$GITHUB_REPOSITORY_OWNER" != "CleverRaven" ] && echo false || echo true)" >> $GITHUB_OUTPUT
           echo "skip_tests=$([ "$GITHUB_REF_NAME" = "master" ] && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "max_parallel=$([ "$GITHUB_REF_NAME" = "master" ] && echo 20 || echo 1)" >> $GITHUB_OUTPUT
+          echo "max_parallel=$([ "$GITHUB_REF_NAME" = "master" -o "$GITHUB_REPOSITORY_OWNER" != "CleverRaven" ] && echo 20 || echo 1)" >> $GITHUB_OUTPUT
   varied_builds:
     needs: [ skip-duplicates-code, skip-duplicates-data, matrix-variables ]
     strategy:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The general build matrix jobs run one-by-one, and cancel the whole run if any of them fail. This is reasonable to do in a repository with lots of PRs and limited CI resources.
However it is somewhat annoying and limiting when working on this or that feature in your own folk and using CI as a testing tool. I would assume not many people have this as a use case but I do (possibly because i like doing sweeping infra changes more than an average person)

So this PR removes the concurrency restriction when run in user forks.
This CleverRaven/Cataclysm-DDA behavior is unchanged.

#### Describe the solution

add an "or we are not in CleverRaven" check when deciding whether to remove parallelism limits

#### Describe alternatives you've considered

#### Testing
The "remove limits" part works, judging by its behaviour in my fork (https://github.com/moxian/Cataclysm-DDA/actions/runs/13221265346)
<details><summary>pic</summary>

![20250208-181502-firefox](https://github.com/user-attachments/assets/414fce84-cb3a-43ae-be35-7e8277d081a8)

</details>

The "CleverRaven/Cataclysm-DDA is unchanged"  is tested by CI on this PR (https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/13221407146?pr=79605)
<details><summary>pic</summary>

![20250208-181432-firefox](https://github.com/user-attachments/assets/d5f71adb-8e23-4647-9e5a-30e93435ac85)

</details>

#### Additional context
