### PR TITLE
Amalgamation spawning audit & Two new friends :)

### DIFF
--- a/data/json/monstergroups/zombie_amalgamations.json
+++ b/data/json/monstergroups/zombie_amalgamations.json
@@ -3,46 +3,27 @@
     "id": "GROUP_COCOON_TINY",
     "type": "monstergroup",
     "//": "All cocoon groups have a token mon_null spawn, increase its weight if they turn out to be too common",
-    "monsters": [ { "monster": "mon_null", "weight": 1 }, { "monster": "mon_amalgamation_swarmer", "weight": 1, "starts": "8 days" } ]
+    "monsters": [ { "monster": "mon_null", "weight": 1 }, { "monster": "mon_amalgamation_swarmer", "weight": 4 } ]
   },
   {
     "id": "GROUP_COCOON_SMALL",
     "type": "monstergroup",
-    "monsters": [
-      { "monster": "mon_null", "weight": 1 },
-      { "group": "GROUP_AMALGAMATION_SMALL", "weight": 1, "starts": "8 days" },
-      { "group": "GROUP_AMALGAMATION_SMALL", "weight": 2, "pack_size": [ 2, 2 ], "starts": "28 days" },
-      { "group": "GROUP_AMALGAMATION_SMALL", "weight": 2, "pack_size": [ 3, 3 ], "starts": "112 days" }
-    ]
+    "monsters": [ { "monster": "mon_null", "weight": 1 }, { "group": "GROUP_AMALGAMATION_TINY", "weight": 4 } ]
   },
   {
-    "id": "GROUP_COCOON_MED_1",
+    "id": "GROUP_COCOON_MED",
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_null", "weight": 1 },
-      { "group": "GROUP_COCOON_MED_2", "weight": 1, "starts": "8 days" },
-      { "group": "GROUP_COCOON_MED_2", "weight": 1, "pack_size": [ 2, 2 ], "starts": "56 days" }
-    ]
-  },
-  {
-    "id": "GROUP_COCOON_MED_2",
-    "type": "monstergroup",
-    "monsters": [
-      { "monster": "mon_null", "weight": 1 },
-      { "group": "GROUP_AMALGAMATION_SMALL", "weight": 2, "pack_size": [ 2, 2 ], "starts": "8 days" },
-      { "group": "GROUP_AMALGAMATION_MED", "weight": 2, "pack_size": [ 3, 3 ], "starts": "56 days" }
+      { "group": "GROUP_AMALGAMATION_SMALL", "weight": 2 },
+      { "group": "GROUP_AMALGAMATION_MED", "weight": 2 }
     ]
   },
   {
     "id": "GROUP_COCOON_LARGE",
     "type": "monstergroup",
     "//": "TODO: big amalgamation line for this (and larger) groups",
-    "monsters": [
-      { "monster": "mon_null", "weight": 1 },
-      { "group": "GROUP_COCOON_MED_1", "weight": 1, "starts": "8 days" },
-      { "group": "GROUP_COCOON_MED_1", "weight": 1, "pack_size": [ 2, 2 ], "starts": "28 days" },
-      { "group": "GROUP_COCOON_MED_1", "weight": 1, "pack_size": [ 3, 3 ], "starts": "112 days" }
-    ]
+    "monsters": [ { "monster": "mon_null", "weight": 1 }, { "group": "GROUP_AMALGAMATION_MED", "weight": 4 } ]
   },
   {
     "id": "GROUP_AMALGAMATION_BREATHER_HUB_SPARSE",
@@ -50,24 +31,31 @@
     "monsters": [ { "monster": "mon_null", "weight": 9 }, { "monster": "mon_amalgamation_breather_hub" } ]
   },
   {
+    "id": "GROUP_AMALGAMATION_TINY",
+    "type": "monstergroup",
+    "//": "Same as GROUP_AMALGAMATION_SMALL, but pack sizes are roughly halved. This is because overwriting pack size in the parent group causes swarmers to not be as swarmy",
+    "monsters": [
+      { "monster": "mon_amalgamation_swarmer", "weight": 5, "pack_size": [ 2, 4 ] },
+      { "monster": "mon_amalgamation_spotter", "weight": 1, "starts": "7 days" },
+      { "monster": "mon_amalgamation_corroder", "weight": 2, "pack_size": [ 1, 2 ], "starts": "14 days" }
+    ]
+  },
+  {
     "id": "GROUP_AMALGAMATION_SMALL",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_amalgamation_swarmer", "weight": 120, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_amalgamation_spotter", "weight": 40, "starts": "28 days" },
-      { "monster": "mon_amalgamation_corroder", "weight": 80, "starts": "112 days" },
-      { "monster": "mon_amalgamation_corroder", "weight": 120, "starts": "224 days" }
+      { "monster": "mon_amalgamation_swarmer", "weight": 5, "pack_size": [ 3, 8 ] },
+      { "monster": "mon_amalgamation_spotter", "weight": 1, "pack_size": [ 1, 2 ], "starts": "7 days" },
+      { "monster": "mon_amalgamation_corroder", "weight": 2, "pack_size": [ 1, 3 ], "starts": "14 days" }
     ]
   },
   {
     "id": "GROUP_AMALGAMATION_MED",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_amalgamation_jumper", "pack_size": [ 1, 2 ], "weight": 160 },
-      { "monster": "mon_amalgamation_soldier", "weight": 40, "starts": "28 days" },
-      { "monster": "mon_amalgamation_soldier", "weight": 80, "starts": "112 days" },
-      { "monster": "mon_amalgamation_zapper", "weight": 40, "starts": "112 days" },
-      { "monster": "mon_amalgamation_zapper", "weight": 40, "starts": "224 days" }
+      { "monster": "mon_amalgamation_jumper", "pack_size": [ 1, 2 ], "weight": 5 },
+      { "monster": "mon_amalgamation_soldier", "weight": 2, "starts": "7 days" },
+      { "monster": "mon_amalgamation_zapper", "weight": 1, "starts": "28 days" }
     ]
   }
 ]

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -255,7 +255,7 @@
     "anger_triggers": [ "FRIEND_ATTACKED", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE" ],
     "fear_triggers": [ "BRIGHT_LIGHT" ],
     "special_attacks": [ [ "EAT_FOOD", 60 ], [ "EAT_CARRION", 60 ] ],
-    "zombify_into": "mon_meat_cocoon_small",
+    "zombify_into": "mon_meat_cocoon_tiny",
     "flags": [ "SEES", "HEARS", "SMELLS", "EATS", "STUMBLES", "PATH_AVOID_FIRE", "CORNERED_FIGHTER" ],
     "armor": { "bash": 5, "cut": 7, "bullet": 6 }
   },
@@ -351,7 +351,7 @@
     "biosignature": { "biosig_item": "feces_roach", "biosig_timer": 3 },
     "upgrades": { "age_grow": 35, "into": "mon_pregnant_giant_cockroach" },
     "special_attacks": [ [ "EAT_FOOD", 60 ], [ "EAT_CARRION", 60 ] ],
-    "zombify_into": "mon_meat_cocoon_small",
+    "zombify_into": "mon_meat_cocoon_tiny",
     "fear_triggers": [ "BRIGHT_LIGHT" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "EATS", "PATH_AVOID_FIRE", "SMALL_HIDER", "CORNERED_FIGHTER", "EATS" ],
     "armor": { "bash": 5, "cut": 10, "bullet": 8 }
@@ -943,6 +943,7 @@
     "vision_night": 5,
     "stomach_size": 40,
     "harvest": "arachnid",
+    "zombify_into": "mon_meat_cocoon_tiny",
     "anger_triggers": [ "PLAYER_CLOSE" ],
     "fear_triggers": [ "HURT" ],
     "flags": [ "AQUATIC", "SEES", "WATER_CAMOUFLAGE", "EATS" ],
@@ -1162,6 +1163,7 @@
     "color": "light_green",
     "special_attacks": [ [ "EAT_CARRION", 100 ] ],
     "dissect": "dissect_insect_sample_single",
+    "zombify_into": "mon_meat_cocoon_tiny",
     "extend": { "flags": [ "EATS" ] },
     "upgrades": { "age_grow": 30, "into": "mon_fly" }
   },
@@ -1666,7 +1668,6 @@
     "proportional": { "hp": 0.5, "speed": 1.1, "morale": 0.67, "melee_dice_sides": 0.67 },
     "volume": "30 L",
     "weight": "40 kg",
-    "zombify_into": "mon_meat_cocoon_small",
     "upgrades": { "age_grow": 30, "into": "mon_spider_trapdoor_giant" },
     "extend": { "flags": [ "NO_BREED" ] }
   },
@@ -1753,7 +1754,6 @@
     "proportional": { "hp": 0.5, "speed": 1.1, "morale": 0.67, "melee_dice_sides": 0.67 },
     "volume": "30 L",
     "weight": "40 kg",
-    "zombify_into": "mon_meat_cocoon_small",
     "upgrades": { "age_grow": 30, "into": "mon_spider_web" },
     "extend": { "flags": [ "NO_BREED" ] },
     "trap_avoids": [ "tr_sinkhole" ]
@@ -1936,7 +1936,6 @@
     "proportional": { "hp": 0.5, "speed": 1.1, "morale": 0.67, "melee_dice_sides": 0.67 },
     "volume": "30 L",
     "weight": "40 kg",
-    "zombify_into": "mon_meat_cocoon_small",
     "upgrades": { "age_grow": 30, "into": "mon_spider_wolf_giant" },
     "extend": { "flags": [ "NO_BREED" ] }
   },
@@ -2114,7 +2113,6 @@
     "anger_triggers": [ "FRIEND_ATTACKED", "PLAYER_CLOSE", "PLAYER_WEAK", "HOSTILE_SEEN" ],
     "fear_triggers": [ "HURT", "FIRE" ],
     "upgrades": { "age_grow": 30, "into": "mon_wasp" },
-    "zombify_into": "mon_meat_cocoon_tiny",
     "fungalize_into": "mon_wasp_small_fungus",
     "flags": [
       "SEES",
@@ -2157,6 +2155,7 @@
     "reproduction": { "baby_type": { "baby_egg": "egg_wasp" }, "baby_count": 2, "baby_timer": 5 },
     "upgrades": { "age_grow": 30, "into": "mon_wasp_mega" },
     "fungalize_into": "mon_wasp_queen_fungus",
+    "zombify_into": "mon_meat_cocoon_small",
     "armor": { "bash": 5, "cut": 14, "stab": 12, "bullet": 12, "electric": 3 }
   },
   {
@@ -2369,7 +2368,6 @@
     "weakpoint_sets": [ "wps_arthropod", "wps_arthropod_hymenoptera" ],
     "weakpoints": [ { "id": "abdomen", "name": "the abdomen", "coverage": 30 } ],
     "vision_night": 8,
-    "zombify_into": "mon_meat_cocoon_tiny",
     "delete": { "weakpoints": [ { "id": "stinger" } ], "flags": [ "FLIES" ], "special_attacks": [ "dermatik_impale" ] }
   },
   {
@@ -2440,8 +2438,7 @@
     "proportional": { "hp": 0.5, "speed": 1.1, "morale": 0.67, "melee_dice_sides": 0.67 },
     "volume": "30 L",
     "weight": "40 kg",
-    "upgrades": { "age_grow": 30, "into": "mon_ant" },
-    "zombify_into": "mon_meat_cocoon_small"
+    "upgrades": { "age_grow": 30, "into": "mon_ant" }
   },
   {
     "id": "mon_ant",
@@ -2493,7 +2490,6 @@
     "proportional": { "hp": 0.5, "speed": 1.1, "morale": 0.67, "melee_dice_sides": 0.67 },
     "volume": "30 L",
     "weight": "40 kg",
-    "zombify_into": "mon_meat_cocoon_small",
     "upgrades": { "age_grow": 30, "into": "mon_ant_acid" }
   },
   {
@@ -2593,7 +2589,7 @@
     "reproduction": { "baby_type": { "baby_egg": "ant_egg_acid" }, "baby_count": 3, "baby_timer": 1 },
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_CLOSE" ],
     "fungalize_into": "mon_ant_fungus",
-    "zombify_into": "mon_meat_cocoon_med",
+    "zombify_into": "mon_meat_cocoon_large",
     "flags": [ "ACIDPROOF", "HEARS", "QUEEN", "SEES", "SMELLS", "PATH_AVOID_FIRE", "PATH_AVOID_FALL", "BASHES", "PULP_PRYING" ],
     "armor": { "bash": 8, "cut": 10, "bullet": 8, "electric": 1 }
   },
@@ -2728,7 +2724,7 @@
     "reproduction": { "baby_type": { "baby_egg": "ant_egg" }, "baby_count": 3, "baby_timer": 1 },
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_CLOSE" ],
     "fungalize_into": "mon_ant_fungus",
-    "zombify_into": "mon_meat_cocoon_med",
+    "zombify_into": "mon_meat_cocoon_large",
     "flags": [ "SMELLS", "QUEEN", "PATH_AVOID_FIRE", "PATH_AVOID_FALL", "BASHES", "PULP_PRYING" ],
     "armor": { "bash": 8, "cut": 10, "bullet": 8, "electric": 1 }
   },
@@ -3071,6 +3067,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 3 } ],
     "vision_night": 4,
     "dissect": "dissect_insect_sample_single",
+    "zombify_into": "mon_meat_cocoon_tiny",
     "upgrades": { "age_grow": 30, "into": "mon_mantis_giant" },
     "special_attacks": [
       {
@@ -3174,6 +3171,7 @@
     "symbol": "M",
     "color": "brown",
     "dissect": "dissect_subterranean_insect_single",
+    "zombify_into": "mon_meat_cocoon_tiny",
     "upgrades": { "age_grow": 30, "into": "mon_mole_cricket" },
     "extend": { "flags": [ "CAN_DIG" ] }
   },
@@ -3286,6 +3284,7 @@
     "dodge": 3,
     "melee_damage": [ { "damage_type": "cut", "amount": 3 } ],
     "dissect": "dissect_insect_sample_single",
+    "zombify_into": "mon_meat_cocoon_tiny",
     "upgrades": { "age_grow": 30, "into": "mon_lady_bug_giant" },
     "armor": { "bash": 1, "cut": 2, "stab": 2 }
   },
@@ -3299,6 +3298,7 @@
     "volume": "750 ml",
     "weight": "1 kg",
     "stomach_size": 30,
+    "zombify_into": "",
     "upgrades": { "age_grow": 30, "into": "mon_grasshopper_giant" },
     "extend": { "flags": [ "SMALL_HIDER", "NO_BREED" ] }
   },
@@ -3424,7 +3424,6 @@
     ],
     "dissect": "dissect_insect_sample_small",
     "upgrades": { "age_grow": 60, "into": "mon_stag_beetle_giant" },
-    "zombify_into": "mon_meat_cocoon_large",
     "extend": { "flags": [ "NO_BREED" ] },
     "delete": { "flags": [ "DESTROYS", "PUSH_VEH" ] },
     "armor": { "bash": 24, "cut": 32, "acid": 8, "heat": 2, "bullet": 20 }
@@ -3526,7 +3525,6 @@
     "harvest": "arachnid_beetle_mega",
     "dissect": "dissect_insect_sample_huge",
     "reproduction": { "baby_type": { "baby_egg": "egg_stag_beetle" }, "baby_count": 1, "baby_timer": 364 },
-    "zombify_into": "mon_meat_cocoon_large",
     "upgrades": false,
     "armor": { "acid": 18, "heat": 8, "bash": 86, "cut": 100, "bullet": 75 }
   },
@@ -3657,6 +3655,7 @@
     "volume": "3 L",
     "weight": "4 kg",
     "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
+    "zombify_into": "",
     "extend": { "flags": [ "NO_BREED" ] },
     "upgrades": { "age_grow": 30, "into": "mon_strider_giant" }
   },
@@ -3691,6 +3690,7 @@
     "vision_night": 5,
     "harvest": "arachnid",
     "dissect": "dissect_insect_sample_single",
+    "zombify_into": "mon_meat_cocoon_tiny",
     "reproduction": { "baby_type": { "baby_egg": "egg_strider" }, "baby_count": 3, "baby_timer": 10 },
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
     "anger_triggers": [ "PLAYER_WEAK" ],
@@ -3774,7 +3774,8 @@
     "symbol": "L",
     "color": "yellow",
     "volume": "120 L",
-    "weight": "75 kg"
+    "weight": "75 kg",
+    "zombify_into": "mon_meat_cocoon_med"
   },
   {
     "id": "mon_moth",
@@ -3840,7 +3841,8 @@
     "symbol": "L",
     "color": "cyan",
     "volume": "120 L",
-    "weight": "75 kg"
+    "weight": "75 kg",
+    "zombify_into": "mon_meat_cocoon_med"
   },
   {
     "id": "mon_caterpillar_butterfly",
@@ -3881,7 +3883,7 @@
     "harvest": "arachnid",
     "dissect": "dissect_insect_sample_large",
     "upgrades": { "age_grow": 50, "into": "mon_butterfly_giant" },
-    "zombify_into": "mon_meat_cocoon_small",
+    "zombify_into": "mon_meat_cocoon_med",
     "flags": [ "IMMOBILE" ]
   },
   {
@@ -3924,7 +3926,7 @@
     "dissect": "dissect_insect_sample_large",
     "upgrades": { "age_grow": 50, "into": "mon_moth_giant" },
     "flags": [ "IMMOBILE" ],
-    "zombify_into": "mon_meat_cocoon_small"
+    "zombify_into": "mon_meat_cocoon_med"
   },
   {
     "id": "mon_cicada_nymph",
@@ -4088,6 +4090,7 @@
     "vision_night": 12,
     "harvest": "arachnid_beetle",
     "dissect": "dissect_insect_sample_single",
+    "zombify_into": "mon_meat_cocoon_small",
     "weakpoint_sets": [ "wps_arthropod", "wps_arthropod_beetle" ],
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_wp_basic_bug", "prof_wp_beetle" ],
     "reproduction": { "baby_type": { "baby_egg": "egg_water_beetle" }, "baby_count": 3, "baby_timer": 15 },
@@ -4124,6 +4127,7 @@
     "vision_night": 5,
     "harvest": "arachnid",
     "dissect": "dissect_insect_sample_single",
+    "zombify_into": "mon_meat_cocoon_small",
     "weakpoint_sets": [ "wps_arthropod" ],
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_wp_basic_bug" ],
     "reproduction": { "baby_type": { "baby_egg": "egg_water_bug" }, "baby_count": 3, "baby_timer": 10 },
@@ -4142,6 +4146,7 @@
     "symbol": "w",
     "volume": "10 L",
     "weight": "15 kg",
+    "zombify_into": "mon_meat_cocoon_tiny",
     "upgrades": { "age_grow": 14, "into": "mon_water_scorpion" }
   }
 ]

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -468,7 +468,7 @@
         "miss_msg_u": "%s launches a barbed tentacle at you, but you dodge!",
         "miss_msg_npc": "%s launches a barbed tentacle at <npcname>, but they dodge!",
         "no_dmg_msg_u": "%s launches a barbed tentacle at you, but it fails to embed!",
-        "no_dmg_msg_npc": "%s launches a barbed tentacle at you, but it fails to embed!"
+        "no_dmg_msg_npc": "%s launches a barbed tentacle at <npcname>, but it fails to embed!"
       }
     ],
     "dodge": 0,

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -385,6 +385,7 @@
     "melee_skill": 5,
     "melee_dice": 4,
     "melee_dice_sides": 4,
+    "aggression": 0,
     "special_attacks": [
       {
         "id": "lash_bash_attack",
@@ -411,6 +412,7 @@
     "melee_skill": 6,
     "melee_dice": 10,
     "melee_dice_sides": 2,
+    "grab_strength": 75,
     "special_attacks": [
       {
         "id": "ranged_pull",

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -428,8 +428,10 @@
     ],
     "dodge": 0,
     "vision_night": 0,
+    "bleed_rate": 5,
     "regenerates": 5,
     "//1": "I want it to regenerate but I'm not sure what exactly would be balanced enough to not make it unkillable like a shoggoth, so it's 5 for now. If it turns out it's too flimsy, increase it",
+    "harvest": "zombie_meatslug",
     "extend": { "flags": [ "GRABS" ] },
     "delete": {
       "weakpoint_sets": [ "wps_amalgamation_base" ],

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -2,7 +2,7 @@
   {
     "type": "MONSTER",
     "id": "mon_meat_cocoon_tiny",
-    "//": "10 - 35 kg corpse",
+    "//": "12-35 kg corpse",
     "copy-from": "mon_meat_cocoon_small",
     "name": { "str": "tiny meat cocoon" },
     "description": "A small, wet sack of pink skin, with something dog-sized moving around underneath the surface.  Black roots anchor it to the ground.",

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -395,5 +395,46 @@
     ],
     "dodge": 3,
     "armor": { "bash": 15, "cut": 8, "stab": 8, "acid": 8, "bullet": 4, "electric": 8 }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_amalgamation_meatball",
+    "copy-from": "mon_amalgamation_abstract_med",
+    "name": { "str": "orb amalgamation" },
+    "description": "A smooth red orb about the size of a small car.  It has no visible organs or limbs, save for an array of barbed tentacles it uses to hold itself in place when not rolling.  How do you kill something without organs?",
+    "color": "red",
+    "bodytype": "blob",
+    "volume": "450 L",
+    "weight": "450 kg",
+    "hp": 535,
+    "speed": 135,
+    "melee_skill": 6,
+    "melee_dice": 10,
+    "melee_dice_sides": 2,
+    "special_attacks": [
+      {
+        "id": "ranged_pull",
+        "range": 10,
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 10 } ],
+        "hit_dmg_u": "%s launches a barbed tentacle at you, pulling you in!",
+        "hit_dmg_npc": "%s launches a barbed tentacle at <npcname>, pulling them in!",
+        "miss_msg_u": "%s launches a barbed tentacle at you, but you dodge!",
+        "miss_msg_npc": "%s launches a barbed tentacle at <npcname>, but they dodge!",
+        "no_dmg_msg_u": "%s launches a barbed tentacle at you, but it fails to embed!",
+        "no_dmg_msg_npc": "%s launches a barbed tentacle at you, but it fails to embed!"
+      }
+    ],
+    "dodge": 0,
+    "vision_night": 0,
+    "regenerates": 5,
+    "//1": "I want it to regenerate but I'm not sure what exactly would be balanced enough to not make it unkillable like a shoggoth, so it's 5 for now. If it turns out it's too flimsy, increase it",
+    "extend": { "flags": [ "GRABS" ] },
+    "delete": {
+      "weakpoint_sets": [ "wps_amalgamation_base" ],
+      "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_wp_amalgamation" ],
+      "//2": "Read the description again before you go asking around why I removed the weakpoints from it",
+      "flags": [ "SMELLS", "HEARS" ]
+    },
+    "armor": { "bash": 50, "cut": 30, "stab": 30, "acid": 15, "bullet": 40, "electric": 12 }
   }
 ]

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -391,11 +391,56 @@
         "id": "lash_bash_attack",
         "cooldown": 10,
         "move_cost": 120,
+        "range": 4,
         "damage_max_instance": [ { "damage_type": "bash", "amount": 25 } ]
       }
     ],
     "dodge": 3,
-    "armor": { "bash": 15, "cut": 8, "stab": 8, "acid": 8, "bullet": 4, "electric": 8 }
+    "armor": { "bash": 15, "cut": 8, "stab": 8, "acid": 8, "bullet": 5, "electric": 8 }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_amalgamation_recycler_soil",
+    "copy-from": "mon_amalgamation_recycler",
+    "name": { "str": "soil-armored recycler amalgamation" },
+    "description": "A recycler amalgamation covered in armor made of different colors type of soil, with various random pieces of grass and other plants covering it in some places.",
+    "color": "brown",
+    "proportional": { "weight": 1.15, "volume": 1.15, "speed": 0.85 },
+    "melee_dice_sides": 6,
+    "aggression": 100,
+    "special_attacks": [
+      {
+        "id": "lash_bash_attack",
+        "cooldown": 10,
+        "move_cost": 130,
+        "range": 4,
+        "damage_max_instance": [ { "damage_type": "bash", "amount": 40 } ]
+      }
+    ],
+    "dodge": 1,
+    "armor": { "bash": 60, "cut": 50, "stab": 35, "acid": 10, "bullet": 50, "electric": 100 }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_amalgamation_recycler_rock",
+    "copy-from": "mon_amalgamation_recycler",
+    "name": { "str": "rock-armored recycler amalgamation" },
+    "description": "A recycler amalgamation covered in armor made of various minerals, either naturally occurring rocks, concrete, or asphalt.  It drags its heavy armored tentacles behind itself, snapping them occasionally.",
+    "color": "brown",
+    "proportional": { "weight": 1.3, "volume": 1.2, "speed": 0.75 },
+    "melee_dice_sides": 8,
+    "aggression": 100,
+    "special_attacks": [
+      {
+        "id": "lash_bash_attack",
+        "cooldown": 10,
+        "move_cost": 150,
+        "range": 4,
+        "damage_max_instance": [ { "damage_type": "bash", "amount": 55 } ]
+      }
+    ],
+    "dodge": 1,
+    "armor": { "bash": 100, "cut": 120, "stab": 120, "acid": 15, "bullet": 120, "electric": 8 }
   },
   {
     "type": "MONSTER",

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -55,7 +55,7 @@
     "volume": "200 L",
     "weight": "200 kg",
     "hp": 200,
-    "upgrades": { "age_grow": 1, "into_group": "GROUP_COCOON_MED_1", "multiple_spawns": true, "spawn_range": 5 },
+    "upgrades": { "age_grow": 1, "into_group": "GROUP_COCOON_MED", "multiple_spawns": true, "spawn_range": 5 },
     "death_drops": "explode_innards",
     "death_function": {
       "message": "The %s explodes in a shower of gore!",

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -369,5 +369,31 @@
       "flags": [ "GRABS", "PULP_PRYING" ]
     },
     "armor": { "bash": 20, "cut": 25, "stab": 30, "acid": 12, "bullet": 40, "electric": 12 }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_amalgamation_recycler",
+    "copy-from": "mon_amalgamation_abstract_med",
+    "name": { "str": "recycler amalgamation" },
+    "description": "A large white-pinkish stubby caterpillar with several tentacles protruding from its underside and an oversized fleshy hump on its back.  It moves around sluggishly, seemingly not paying you any mind.",
+    "color": "dark_gray",
+    "bodytype": "snake",
+    "volume": "325 L",
+    "weight": "325 kg",
+    "hp": 300,
+    "speed": 95,
+    "melee_skill": 5,
+    "melee_dice": 4,
+    "melee_dice_sides": 4,
+    "special_attacks": [
+      {
+        "id": "lash_bash_attack",
+        "cooldown": 10,
+        "move_cost": 120,
+        "damage_max_instance": [ { "damage_type": "bash", "amount": 25 } ]
+      }
+    ],
+    "dodge": 3,
+    "armor": { "bash": 15, "cut": 8, "stab": 8, "acid": 8, "bullet": 4, "electric": 8 }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
So I was on my merry way to finally move my ass and add aquatic amalgamations only to find out that Venera, channeling the power of the universe itself, managed to gaslight me into working on his shit even when he's inactive by making amalgamation monstergroups a clusterfuck and a half. Parts of them were overwriting one another, some parts were redundant, some parts seemed to not make sense (why did the cocoons make more mass from the same amount of mass as time progressed?). So here I am, trying to clean it back up.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
**Cocoon changes**:
- All the cocoons now have 20% chance to not hatch into anything. This used to vary before, with them having higher chances to do so earlier in the save and the number dropping down as time went on (this was pretty cool, actually, because it showed that the creation of frankensteins was becoming progressively less problematic) but some like tiny were stuck at 50% forever. I think 20% is a decent compromise, although like I said I *might* make it drop down from 50% to maybe even less than 20% with time, not quite sure yet
- Pack sizes were audited and put in different places because previously they were overwriting one another on different levels and it was all weird and I hated it. This also means now swarming amalgamations will actually appear in larger quantities when compared to other types. I know how much we all love them, no need to thank me
- Removed one of the medium groups that seemed to serve no purpose other than handling some timers and pack size overwriting
- The chances for zapper and vigilant amalgamations have been slightly decreased because they're overly specialized
- The chance for brute amalgamations has been slightly changed as well - higher in early game, lower in lategame. This is... kinda bad. I'm not terribly happy about this, honestly. I have to look into balancing the group this fella is in some more
- Corrosive amalgamations are now able to appear earlier in the game, but I'm not sure how happy I am about this change quite yet either

**New amalgamations**:
- Recycler - design wise based on a combination of velvet worms and asian semislugs with some octopus sprinkled in, while the gimmick is based off the bagworm moth larvae... or, honestly, rather it's Burmy, but Burmy is in turn based off the bagworm moths. In its base form it's a naked fleshy tank that lashes its tentacles at you but doesn't actually attack you first, because it knows its fragile. HOWEVER, after a few days (probably 2, I still have to actually implement that part) pass, the Recycler upgrades into a version covered in the materials surrounding it. Currently, I have a soil and rock/concrete version planned, but I might consider wood or metal forms down the line. At this stage, the Recycler becomes a tank with ranged attacks that will flail its armored tentacles at you in hopes of taking you down. **TODO**: Give the fellow a weakpoint for the hump on its back
- Orb - design wise it's honestly just a meatball, though I did have XCOM2's Gatekeeper and the Sailor's Eyeball algae in mind when thinking about it, while the gimmick is honestly just the general ``round man rolls around at high speeds`` trope with harpoons added. The thing about it is that it's just a smooth meatball and because of that it has zero visible or discernible organs, limbs, or weakpoints - hence it not teaching any proficiencies, not even basic biology. It's supposed to be a very rare and very tough to fight off result from the largest cocoons after some time has passed, and the idea is that it showcases the natural processes leading to amalgams forming are constantly going *beyond* just reusing biomass - the Orb is supposed to be more than the sum of its parts was. It is horrendously armored, faster than the player (though I don't think it can outspeed a running player), and has ranged attacks that can pull you in *including from Z levels above*. It also has a low level of regeneration. The downside is it has no night vision at all, as well as no smell or hearing (in my head its only sense is of sight due to the body being covered in photoreceptors, but those photoreceptors need high levels to function). This means that the Orb should effectively be turned off entirely in the darkness (it might still wander around aimlessly? I think our monsters do that. I wish I could make it not do that though). I'd say this does a very good making it an avoidable obstacle that you should NOT try to fight against, but that you should still be able to work around if you know what you're doing.

**MISC**
- Reviewed the invert mutants and what cocoons they zombify into to make sure it fits the JSON comments
- Removed useless zombification fields where it was carried over by ``copy-from`` anyways
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Giving the nude recycler a grab with its tentacles, but I don't think that tracks. They're not supposed to be grabby, they're supposed to be whips
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I still have to. By the gods don't merge it until I test it.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
**CITIZENS OF THE CDDA REPOSITORY! DO NOT PANIC! I INTEND TO ADD WEAKPOINTS TO ARMORED RECYCLERS SOON! I DO NOT EXPECT YOU TO OUTDAMAGE THEIR 120 ARMOR!**
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
