### PR TITLE
Martial Mastery: Duelist Combos & Five point Exploding Heart Technique

### DIFF
--- a/data/mods/Perk_melee/EOC/duelist_eocs.json
+++ b/data/mods/Perk_melee/EOC/duelist_eocs.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "EOC_PERK_duelist_insert_reach",
+    "type": "effect_on_condition",
+    "condition": {
+      "and": [
+        { "math": [ "u_effect_intensity('mabuff:buff_perk_momentum') <= 1" ] },
+        { "u_has_flag": "MELEE_PERK_DUELIST_LUNGE" },
+        {
+          "or": [
+            { "u_has_wielded_with_weapon_category": "LONG_THRUSTING_SWORDS" },
+            { "u_has_wielded_with_weapon_category": "FENCING_WEAPONRY" }
+          ]
+        }
+      ]
+    },
+    "effect": [
+      { "turn_cost": 0.05 },
+      {
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "wielded_only": true } ],
+        "true_eocs": [
+          {
+            "id": "_melee_perk_insert_reach",
+            "effect": [
+              {
+                "if": { "not": { "npc_has_flag": "REACH_ATTACK" } },
+                "then": [ { "npc_set_flag": "REACH_ATTACK" }, { "math": [ "n_duelist_reach_modified = 1" ] } ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PERK_duelist_remove_reach" } ]
+  },
+  {
+    "id": "EOC_PERK_duelist_remove_reach",
+    "type": "effect_on_condition",
+    "effect": [
+      {
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "wielded_only": true }, { "condition": { "math": [ "n_duelist_reach_modified == 1" ] } } ],
+        "true_eocs": [
+          {
+            "id": "_melee_perk_remove_reach",
+            "effect": [ { "npc_unset_flag": "REACH_ATTACK" }, { "math": [ "n_duelist_reach_modified = 0" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_duelist_remove_reach_effect",
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": { "and": [ { "compare_string": [ "mabuff:buff_perk_momentum", { "context_val": "effect" } ] } ] },
+    "effect": [ { "run_eocs": [ "EOC_PERK_duelist_remove_reach" ] } ]
+  }
+]

--- a/data/mods/Perk_melee/EOC/eoc_clears.json
+++ b/data/mods/Perk_melee/EOC/eoc_clears.json
@@ -13,5 +13,19 @@
     "id": "EOC_CLEAR_MOMENTUM",
     "type": "effect_on_condition",
     "effect": [ { "u_lose_effect": [ "mabuff:buff_perk_momentum", "perk_dex_bonus" ] } ]
+  },
+  {
+    "id": "EOC_CLEAR_MOMENTUM_DUELIST",
+    "type": "effect_on_condition",
+    "condition": {
+      "and": [
+        { "math": [ "u_effect_intensity('mabuff:buff_perk_momentum') > 1" ] },
+        { "u_has_flag": "MELEE_PERK_MOMENTUM_DUELIST" }
+      ]
+    },
+    "effect": [
+      { "u_lose_effect": [ "mabuff:buff_perk_momentum", "perk_dex_bonus" ] },
+      { "run_eocs": [ "EOC_PERK_MOMENTUM_2", "EOC_PERK_MOMENTUM_MANUAL", "EOC_PERK_duelist_insert_reach" ] }
+    ]
   }
 ]

--- a/data/mods/Perk_melee/EOC/pressure_strikes_eocs.json
+++ b/data/mods/Perk_melee/EOC/pressure_strikes_eocs.json
@@ -1,0 +1,47 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_PRESSURE_STRIKES_MONSTER",
+    "eoc_type": "EVENT",
+    "required_event": "monster_takes_damage",
+    "condition": { "and": [ "has_beta", "has_alpha", { "npc_has_flag": "MELEE_PERK_PRESSURE_STRIKES" }, { "not": "npc_has_weapon" } ] },
+    "effect": [
+      { "math": [ "u_pressure_redeal_damage", "+=", "_damage" ] },
+      {
+        "if": { "math": [ "u_pressure_redeal_queued", "!=", "1" ] },
+        "then": [ { "math": [ "u_pressure_redeal_queued = 1" ] }, { "math": [ "u_timer_pressure_redeal = time('now')" ] } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_PRESSURE_STRIKES_SCHEDULE",
+    "//": "Timing can be wonky so we also schedule ahead.",
+    "effect": [
+      { "run_eocs": "EOC_PERK_PRESSURE_STRIKES_DEAL_DAMAGE", "time_in_future": 4 },
+      { "run_eocs": "EOC_PERK_PRESSURE_STRIKES_DEAL_DAMAGE", "time_in_future": 6 }
+    ]
+  },
+  {
+    "id": "EOC_PERK_PRESSURE_STRIKES_DEAL_DAMAGE",
+    "type": "effect_on_condition",
+    "effect": [
+      {
+        "u_run_monster_eocs": [
+          {
+            "id": "_pressure_point_mon_redeal",
+            "condition": {
+              "and": [ { "math": [ "u_pressure_redeal_queued == 1" ] }, { "math": [ "time_since(u_timer_pressure_redeal) > time(' 3s')" ] } ]
+            },
+            "effect": [
+              { "math": [ "u_pressure_redeal_queued = 0" ] },
+              { "u_deal_damage": "pure", "amount": { "u_val": "pressure_redeal_damage" }, "bodypart": "torso" },
+              { "math": [ "u_timer_pressure_redeal = time('now')+ time('60h')" ] },
+              { "math": [ "u_pressure_redeal_damage = 0" ] }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/Perk_melee/EOC/shared_eocs.json
+++ b/data/mods/Perk_melee/EOC/shared_eocs.json
@@ -38,6 +38,22 @@
     ]
   },
   {
+    "id": "EOC_PERK_VICTIM_AFFLICTOR_MON",
+    "type": "effect_on_condition",
+    "eoc_type": "EVENT",
+    "required_event": "character_melee_attacks_monster",
+    "condition": { "math": [ "_hits == true" ] },
+    "effect": [ { "npc_add_effect": "perk_hit_marker", "duration": "2 seconds" } ]
+  },
+  {
+    "id": "EOC_PERK_VICTIM_AFFLICTOR_CHAR",
+    "type": "effect_on_condition",
+    "eoc_type": "EVENT",
+    "required_event": "character_melee_attacks_character",
+    "condition": { "math": [ "_hits == true" ] },
+    "effect": [ { "npc_add_effect": "perk_hit_marker", "duration": "2 seconds" } ]
+  },
+  {
     "id": "EOC_EXECUTION_EXTA_EFFECTS",
     "type": "effect_on_condition",
     "effect": [
@@ -64,6 +80,15 @@
     ]
   },
   {
+    "id": "EOC_PERK_STEP_CLOSER",
+    "type": "effect_on_condition",
+    "effect": [
+      { "run_eocs": "EOC_PERK_TRY_STEP_CLOSER", "condition": { "math": [ "u_done_step_closer != 1" ] }, "iterations": 20 },
+      { "run_eocs": "EOC_PERK_MOMENTUM_UPDATE" },
+      { "math": [ "u_done_step_closer = 0" ] }
+    ]
+  },
+  {
     "id": "EOC_PERK_DODGE_RETREAT_MANUAL",
     "type": "effect_on_condition",
     "condition": { "and": [ { "u_has_flag": "MELEE_PERK_MOVING_DODGE" } ] },
@@ -76,10 +101,23 @@
     ]
   },
   {
+    "id": "EOC_PERK_MOVEMENT_ATTACK",
+    "type": "effect_on_condition",
+    "effect": [
+      { "set_string_var": { "mutator": "valid_technique" }, "target_var": { "context_val": "random_attack" } },
+      { "u_attack": { "context_val": "random_attack" } }
+    ]
+  },
+  {
     "id": "EOC_PERK_TEMPO_MANUAL",
     "type": "effect_on_condition",
     "condition": { "u_has_trait": "MELEE_PERK_TEMPO" },
     "effect": { "u_add_effect": "mabuff:buff_perk_tempo", "duration": "2 seconds" }
+  },
+  {
+    "id": "EOC_PERK_MOMENTUM_UPDATE",
+    "type": "effect_on_condition",
+    "effect": [ { "run_eocs": [ "EOC_PERK_MOMENTUM_MANUAL", "EOC_PERK_MOMENTUM_2", "EOC_PERK_duelist_insert_reach" ] } ]
   },
   {
     "id": "EOC_PERK_MOMENTUM_MANUAL",
@@ -94,6 +132,25 @@
     "effect": { "u_add_effect": "perk_dex_bonus", "duration": "2 seconds" }
   },
   {
+    "id": "EOC_PERK_TRY_STEP_CLOSER",
+    "type": "effect_on_condition",
+    "effect": [
+      { "u_location_variable": { "context_val": "original_pos" } },
+      { "npc_location_variable": { "context_val": "attempt" }, "min_radius": 1, "max_radius": 1 },
+      { "u_teleport": { "context_val": "attempt" } },
+      {
+        "run_eocs": [
+          {
+            "id": "_VALID_STEP_CLOSER",
+            "condition": { "math": [ "distance(_original_pos, _attempt ) > 1" ] },
+            "effect": [ { "u_teleport": { "context_val": "original_pos" } } ],
+            "false_effect": [ { "math": [ "u_done_step_closer = 1" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     "id": "EOC_PERK_TRY_RETREAT",
     "type": "effect_on_condition",
     "effect": [
@@ -105,10 +162,7 @@
           {
             "id": "_VALID_RETREAT",
             "condition": { "math": [ "u_monsters_nearby('radius': 1) == 0" ] },
-            "effect": [
-              { "u_add_effect": "mabuff:buff_perk_momentum", "duration": 2 },
-              { "run_eocs": [ "EOC_PERK_MOMENTUM_2", "EOC_PERK_MOMENTUM_MANUAL" ] }
-            ],
+            "effect": [ { "run_eocs": [ "EOC_PERK_MOMENTUM_UPDATE" ] } ],
             "false_effect": [ { "u_teleport": { "context_val": "original_pos" } } ]
           }
         ]

--- a/data/mods/Perk_melee/EOC/tempo_eocs.json
+++ b/data/mods/Perk_melee/EOC/tempo_eocs.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "EOC_PERK_tempo_assault_char",
+    "type": "effect_on_condition",
+    "eoc_type": "EVENT",
+    "required_event": "character_melee_attacks_character",
+    "condition": { "and": [ { "math": [ "_hits == true" ] }, { "u_has_flag": "MELEE_PERK_TEMPO_ASSAULT" }, { "not": "npc_is_alive" } ] },
+    "effect": [
+      { "npc_location_variable": { "context_val": "pos" } },
+      { "u_location_variable": { "context_val": "pos2" } },
+      {
+        "if": { "math": [ "distance(_pos, _pos2 ) <= 1" ] },
+        "then": [ { "run_eocs": [ "EOC_PERK_tempo_assault" ] } ]
+      }
+    ]
+  },
+  {
+    "id": "EOC_PERK_tempo_assault_mon",
+    "type": "effect_on_condition",
+    "eoc_type": "EVENT",
+    "required_event": "character_kills_monster",
+    "condition": { "and": [ { "u_has_flag": "MELEE_PERK_TEMPO_ASSAULT" } ] },
+    "effect": [
+      { "npc_location_variable": { "context_val": "pos" } },
+      { "u_location_variable": { "context_val": "pos2" } },
+      {
+        "if": { "math": [ "distance(_pos, _pos2 ) <= 1" ] },
+        "then": [ { "run_eocs": [ "EOC_PERK_tempo_assault" ] } ]
+      }
+    ]
+  },
+  {
+    "id": "EOC_PERK_tempo_assault",
+    "type": "effect_on_condition",
+    "effect": [
+      { "npc_location_variable": { "context_val": "pos" } },
+      { "u_teleport": { "context_val": "pos" } },
+      { "run_eocs": [ "EOC_PERK_MOMENTUM_UPDATE" ] },
+      {
+        "u_run_monster_eocs": [
+          {
+            "id": "EOC_PERK_tempo_assault_attack",
+            "condition": { "math": [ "u_assault_attacked != 1" ] },
+            "effect": [
+              { "run_eocs": "EOC_PERK_MOVEMENT_ATTACK", "alpha_loc": "avatar", "beta_talker": "u" },
+              { "math": [ "u_assault_attacked = 1" ] }
+            ]
+          }
+        ],
+        "monster_range": 1,
+        "monster_must_see": true
+      },
+      { "math": [ "u_assault_attacked = 0" ] }
+    ]
+  },
+  {
+    "id": "EOC_PERK_tempo_zoning",
+    "type": "effect_on_condition",
+    "condition": { "and": [ { "u_has_flag": "MELEE_PERK_TEMPO_ZONING" } ] },
+    "effect": [
+      {
+        "run_eocs": "EOC_PERK_TRY_RETREAT",
+        "condition": { "math": [ "u_monsters_nearby('radius': 1) > 0" ] },
+        "iterations": 10
+      },
+      { "run_eocs": [ "EOC_CLEAR_COMBAT_TEMPO" ] }
+    ]
+  }
+]

--- a/data/mods/Perk_melee/PERKS/momentum.json
+++ b/data/mods/Perk_melee/PERKS/momentum.json
@@ -24,5 +24,13 @@
     "description": "If you have at least 4 momentum stacks, gain a 5% chance to dodge any ranged attack for every point of dexterity you have.  If you have less than 4 momentum stacks, gain a 1% chance to dodge any ranged attack for every point of dexterity you have.",
     "flags": "MELEE_PERK_MOMENTUM_BULLET_DODGE",
     "enchantments": [ "melee_perk_ench_momentum_bullet_dodge" ]
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_MOMENTUM_DUELIST",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Duelist Form" },
+    "description": "If you have more than 1 momentum stack, your momentum will be set to 1 whenever you wait a turn.",
+    "flags": "MELEE_PERK_MOMENTUM_DUELIST"
   }
 ]

--- a/data/mods/Perk_melee/PERKS/perks.json
+++ b/data/mods/Perk_melee/PERKS/perks.json
@@ -32,6 +32,14 @@
   },
   {
     "type": "mutation",
+    "id": "MELEE_PERK_PRESSURE_STRIKES",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Pressure Points" },
+    "description": "Your unarmed melee attacks will redeal damage to their targets after 4 turns.",
+    "flags": "MELEE_PERK_PRESSURE_STRIKES"
+  },
+  {
+    "type": "mutation",
     "id": "MELEE_PERK_MOVING_DODGE",
     "copy-from": "MELEE_PERK_BASE",
     "name": { "str": "Flowing Retreat" },

--- a/data/mods/Perk_melee/PERKS/tempo.json
+++ b/data/mods/Perk_melee/PERKS/tempo.json
@@ -29,7 +29,7 @@
     "id": "MELEE_PERK_TEMPO_ASSAULT",
     "copy-from": "MELEE_PERK_BASE",
     "name": { "str": "Unrelenting Assault" },
-    "description": "Whenever you kill an enemy in melee, you'll advance into their position and automatically attack an adjacent enemy. You'll gain a momentum stack if you can normally gain them.",
+    "description": "Whenever you kill an enemy in melee, you'll advance into their position and automatically attack an adjacent enemy.  You'll gain a momentum stack if you can normally gain them.",
     "flags": "MELEE_PERK_TEMPO_ASSAULT"
   },
   {

--- a/data/mods/Perk_melee/PERKS/tempo.json
+++ b/data/mods/Perk_melee/PERKS/tempo.json
@@ -9,11 +9,36 @@
   },
   {
     "type": "mutation",
+    "id": "MELEE_PERK_COMBAT_TEMPO_2",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Perfect Tempo" },
+    "description": "You gain +15 quickness as long as you have the maximum number of combat tempo stacks.",
+    "flags": "MELEE_PERK_PERFECT_TEMPO",
+    "enchantments": [ "melee_perk_ench_perfect_tempo" ]
+  },
+  {
+    "type": "mutation",
     "id": "MELEE_PERK_TEMPO_SHIFT",
     "copy-from": "MELEE_PERK_BASE",
     "name": { "str": "Tempo Shift" },
     "description": "Gain a stack of combat tempo whenever you successfully block an attack.",
     "flags": "MELEE_PERK_TEMPO_SHIFT"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_TEMPO_ASSAULT",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Unrelenting Assault" },
+    "description": "Whenever you kill an enemy in melee, you'll advance into their position and automatically attack an adjacent enemy. You'll gain a momentum stack if you can normally gain them.",
+    "flags": "MELEE_PERK_TEMPO_ASSAULT"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_TEMPO_ZONING",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Zoning" },
+    "description": "If you have the maximum number of combat tempo stacks, killing an enemy will move you away from any other adjacent enemies.  This movement action will consume all of your combat tempo stacks, and grant you a momentum stack if can normally gain them.",
+    "flags": "MELEE_PERK_TEMPO_ZONING"
   },
   {
     "type": "mutation",

--- a/data/mods/Perk_melee/enchantments.json
+++ b/data/mods/Perk_melee/enchantments.json
@@ -16,7 +16,7 @@
     "special_vision": [
       {
         "distance": 10,
-        "descriptions": [ { "id": "moving_creature", "symbol": "?", "color": "c_white", "text": "Your sixth sense point you here." } ]
+        "descriptions": [ { "id": "moving_creature", "symbol": "?", "color": "c_white", "text": "Something hides here." } ]
       }
     ]
   },
@@ -25,6 +25,14 @@
     "id": "melee_perk_ench_insight_dodge",
     "condition": { "math": [ "u_effect_intensity('perk_insight')", ">", "9" ] },
     "values": [ { "value": "DODGE_CHANCE", "add": 25 } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "melee_perk_ench_perfect_tempo",
+    "name": { "str": "Perfect Tempo" },
+    "description": " +15 quickness as long as you have the maximum number of combat tempo stacks.",
+    "condition": { "math": [ "u_effect_intensity('mabuff:buff_perk_tempo')", ">", "2" ] },
+    "values": [ { "value": "SPEED", "add": 15 } ]
   },
   {
     "type": "enchantment",

--- a/data/mods/Perk_melee/martial_arts.json
+++ b/data/mods/Perk_melee/martial_arts.json
@@ -48,6 +48,7 @@
         "description": "Successful blocking has left you in a favorable position.",
         "melee_allowed": true,
         "buff_duration": 2,
+        "required_char_flags": [ "MELEE_PERK_RIPOSTE" ],
         "flat_bonuses": [ { "stat": "hit", "scale": 1.0 } ]
       }
     ],
@@ -59,9 +60,9 @@
         "false_effect": { "u_lose_effect": "perk_blind_check" }
       }
     ],
-    "onhit_eocs": [ "EOC_PERK_SPEND_INSIGHT" ],
-    "onkill_eocs": [ "EOC_PERK_TWILIGHT_FORM" ],
-    "onmove_eocs": [ "EOC_PERK_MOMENTUM_2" ],
+    "onhit_eocs": [ "EOC_PERK_SPEND_INSIGHT", "EOC_PERK_PRESSURE_STRIKES_SCHEDULE" ],
+    "onkill_eocs": [ "EOC_PERK_TWILIGHT_FORM", "EOC_PERK_tempo_zoning" ],
+    "onmove_eocs": [ "EOC_PERK_MOMENTUM_2", "EOC_PERK_duelist_insert_reach" ],
     "ondodge_eocs": [
       {
         "id": "EOC_PERK_DODGE_RETREAT",
@@ -83,7 +84,8 @@
         "id": "EOC_PERK_CAREFREE_STANCE",
         "condition": { "u_has_flag": "MELEE_PERK_CAREFREE_STANCE" },
         "effect": { "run_eocs": "EOC_CLEAR_BUFFS" }
-      }
+      },
+      "EOC_CLEAR_MOMENTUM_DUELIST"
     ],
     "techniques": [
       "tec_perk_stagger_strike",
@@ -100,6 +102,8 @@
       "tec_perk_knife_finisher",
       "tec_perk_make_way",
       "tec_perk_estocada",
+      "tec_perk_duelist_lunge",
+      "tec_perk_duelist_combo",
       "tec_perk_staff_kick"
     ]
   }

--- a/data/mods/Perk_melee/menu.json
+++ b/data/mods/Perk_melee/menu.json
@@ -42,6 +42,25 @@
         "topic": "TALK_MA_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO_2" } },
+        "text": "Learn [<trait_name:MELEE_PERK_COMBAT_TEMPO_2>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_COMBAT_TEMPO_2>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_COMBAT_TEMPO_2>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_COMBAT_TEMPO_2", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Combat Tempo I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "MELEE_PERK_TEMPO_SHIFT" } },
         "text": "Learn [<trait_name:MELEE_PERK_TEMPO_SHIFT>]",
         "effect": [
@@ -57,6 +76,72 @@
             "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_TEMPO_ASSAULT" } },
+        "text": "Learn [<trait_name:MELEE_PERK_TEMPO_ASSAULT>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_TEMPO_ASSAULT>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_TEMPO_ASSAULT>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_TEMPO_ASSAULT", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Combat Tempo I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO" }, { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO_2" } ] }
+          }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_TEMPO_ZONING" } },
+        "text": "Learn [<trait_name:MELEE_PERK_TEMPO_ZONING>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_TEMPO_ZONING>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_TEMPO_ZONING>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_TEMPO_ZONING", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Combat Tempo I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO" }, { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO_2" } ] }
+          }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_DUELIST_COMBO" } },
+        "text": "Learn [<trait_name:MELEE_PERK_DUELIST_COMBO>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_DUELIST_COMBO>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_DUELIST_COMBO>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_DUELIST_COMBO", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Combat Tempo I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO" }, { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO_2" } ] }
+          }
         ],
         "topic": "TALK_MA_PERK_MENU_SELECT"
       },
@@ -80,15 +165,15 @@
         "topic": "TALK_MA_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "MELEE_PERK_STAGGER_STRIKE" } },
-        "text": "Learn [<trait_name:MELEE_PERK_STAGGER_STRIKE>]",
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_KNIFE_FINISHER" } },
+        "text": "Learn [<trait_name:MELEE_PERK_KNIFE_FINISHER>]",
         "effect": [
-          { "set_string_var": "<trait_name:MELEE_PERK_STAGGER_STRIKE>", "target_var": { "context_val": "trait_name" } },
+          { "set_string_var": "<trait_name:MELEE_PERK_KNIFE_FINISHER>", "target_var": { "context_val": "trait_name" } },
           {
-            "set_string_var": "<trait_description:MELEE_PERK_STAGGER_STRIKE>",
+            "set_string_var": "<trait_description:MELEE_PERK_KNIFE_FINISHER>",
             "target_var": { "context_val": "trait_description" }
           },
-          { "set_string_var": "MELEE_PERK_STAGGER_STRIKE", "target_var": { "context_val": "trait_id" } },
+          { "set_string_var": "MELEE_PERK_KNIFE_FINISHER", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires Combat Tempo I",
             "target_var": { "context_val": "trait_requirement_description" },
@@ -99,15 +184,15 @@
         "topic": "TALK_MA_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "MELEE_PERK_KNIFE_FINISHER" } },
-        "text": "Learn [<trait_name:MELEE_PERK_KNIFE_FINISHER>]",
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_STAGGER_STRIKE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_STAGGER_STRIKE>]",
         "effect": [
-          { "set_string_var": "<trait_name:MELEE_PERK_KNIFE_FINISHER>", "target_var": { "context_val": "trait_name" } },
+          { "set_string_var": "<trait_name:MELEE_PERK_STAGGER_STRIKE>", "target_var": { "context_val": "trait_name" } },
           {
-            "set_string_var": "<trait_description:MELEE_PERK_KNIFE_FINISHER>",
+            "set_string_var": "<trait_description:MELEE_PERK_STAGGER_STRIKE>",
             "target_var": { "context_val": "trait_description" }
           },
-          { "set_string_var": "MELEE_PERK_KNIFE_FINISHER", "target_var": { "context_val": "trait_id" } },
+          { "set_string_var": "MELEE_PERK_STAGGER_STRIKE", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires Combat Tempo I",
             "target_var": { "context_val": "trait_requirement_description" },
@@ -155,6 +240,25 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "MELEE_PERK_MOMENTUM_2", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Momentum I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_MOMENTUM" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_MOMENTUM_DUELIST" } },
+        "text": "Learn [<trait_name:MELEE_PERK_MOMENTUM_DUELIST>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_MOMENTUM_DUELIST>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_MOMENTUM_DUELIST>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_MOMENTUM_DUELIST", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires Momentum I",
             "target_var": { "context_val": "trait_requirement_description" },
@@ -215,6 +319,25 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "MELEE_PERK_ESTOCADA", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Momentum I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_MOMENTUM" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_DUELIST_LUNGE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_DUELIST_LUNGE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_DUELIST_LUNGE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_DUELIST_LUNGE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_DUELIST_LUNGE", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires Momentum I",
             "target_var": { "context_val": "trait_requirement_description" },
@@ -467,6 +590,25 @@
             "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_PRESSURE_STRIKES" } },
+        "text": "Learn [<trait_name:MELEE_PERK_PRESSURE_STRIKES>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_PRESSURE_STRIKES>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_PRESSURE_STRIKES>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_PRESSURE_STRIKES", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
         ],
         "topic": "TALK_MA_PERK_MENU_SELECT"
       },

--- a/data/mods/Perk_melee/perk_effects.json
+++ b/data/mods/Perk_melee/perk_effects.json
@@ -23,5 +23,15 @@
     "id": "perk_blind_check",
     "max_intensity": 15,
     "int_add_val": 1
+  },
+  {
+    "type": "effect_type",
+    "id": "perk_hit_marker",
+    "max_duration": "2 seconds",
+    "name": [ "Hit (1)", "Hit (2)", "Hit (3)", "Hit (4)", "Hit (5)", "Hit (6)", "Hit (7)", "Hit (8)", "Hit (9)", "Hit (10)" ],
+    "desc": [ "Each stack increases the damage of your weapon's main damage type by 1." ],
+    "max_intensity": 15,
+    "int_add_val": 1,
+    "show_in_info": true
   }
 ]

--- a/data/mods/Perk_melee/perk_techniques.json
+++ b/data/mods/Perk_melee/perk_techniques.json
@@ -81,6 +81,22 @@
   },
   {
     "type": "mutation",
+    "id": "MELEE_PERK_DUELIST_COMBO",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Compound finisher" },
+    "description": "If your third attack against the same target coincides with the full combat tempo bonus, you will perform a fast and powerful finishing attack.",
+    "flags": "MELEE_PERK_DUELIST_COMBO"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_DUELIST_LUNGE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Timed lunge" },
+    "description": "Perform a ranged lunge attack with fencing and thrusting swords. The attack will move you adjacent to the target or move you away from the target if you are already adjacent to them.  You must have exactly 1 momentum stack to perform this attack.",
+    "flags": "MELEE_PERK_DUELIST_LUNGE"
+  },
+  {
+    "type": "mutation",
     "id": "MELEE_PERK_TACKLE",
     "copy-from": "MELEE_PERK_BASE",
     "name": { "str": "Charging Tackle" },

--- a/data/mods/Perk_melee/perk_techniques.json
+++ b/data/mods/Perk_melee/perk_techniques.json
@@ -92,7 +92,7 @@
     "id": "MELEE_PERK_DUELIST_LUNGE",
     "copy-from": "MELEE_PERK_BASE",
     "name": { "str": "Timed lunge" },
-    "description": "Perform a ranged lunge attack with fencing and thrusting swords. The attack will move you adjacent to the target or move you away from the target if you are already adjacent to them.  You must have exactly 1 momentum stack to perform this attack.",
+    "description": "Perform a ranged lunge attack with fencing and thrusting swords.  The attack will move you adjacent to the target or move you away from the target if you are already adjacent to them.  You must have exactly 1 momentum stack to perform this attack.",
     "flags": "MELEE_PERK_DUELIST_LUNGE"
   },
   {

--- a/data/mods/Perk_melee/techniques/techniques.json
+++ b/data/mods/Perk_melee/techniques/techniques.json
@@ -189,13 +189,34 @@
     "id": "tec_perk_estocada",
     "name": "Estocada",
     "required_char_flags_all": [ "MELEE_PERK_ESTOCADA" ],
-    "messages": [ "You lunge and thrust your weapon into %s", "<npcname> lunges and thrusts their weapon into %s!" ],
+    "messages": [ "You thrust your weapon into %s", "<npcname> thrusts their weapon into %s!" ],
     "melee_allowed": true,
     "weighting": 10,
     "weapon_categories_allowed": [ "QUARTERSTAVES", "LONG_SWORDS", "MEDIUM-SWORDS", "LONG_THRUSTING_SWORDS", "FENCING_WEAPONRY" ],
     "condition": { "and": [ { "math": [ "u_effect_intensity('mabuff:buff_perk_momentum') == 1" ] } ] },
     "condition_desc": "* Requires <info>momentum(1)</info> to trigger.",
     "mult_bonuses": [ { "stat": "damage", "type": "stab", "scale": 1.1 }, { "stat": "movecost", "scale": 0.5 } ],
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_duelist_lunge",
+    "name": "Lunge",
+    "weapon_categories_allowed": [ "FENCING_WEAPONRY", "LONG_THRUSTING_SWORDS" ],
+    "melee_allowed": true,
+    "crit_ok": true,
+    "reach_tec": true,
+    "weighting": 100,
+    "required_char_flags_all": [ "MELEE_PERK_DUELIST_LUNGE" ],
+    "mult_bonuses": [
+      { "stat": "movecost", "scale": 0.8 },
+      { "stat": "damage", "type": "bash", "scale": 0.25 },
+      { "stat": "damage", "type": "cut", "scale": 0.66 },
+      { "stat": "damage", "type": "stab", "scale": 1.1 }
+    ],
+    "messages": [ "You step and stab the %s with an elegant motion", "<npcname> steps closer to %s and stabs them with a quick motion" ],
+    "description": "A quick reach attack that scales heavily with perception.",
+    "eocs": [ "EOC_PERK_STEP_CLOSER" ],
     "attack_vectors": [ "vector_null" ]
   },
   {
@@ -231,6 +252,38 @@
     "condition_desc": "* Requires <info>tempo(3)</info> to trigger.",
     "flat_bonuses": [ { "stat": "hit", "scale": 5.0 } ],
     "messages": [ "You viciously wound %s", "<npcname> viciously wounds %s!" ],
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_duelist_combo",
+    "name": "Compound strike",
+    "required_char_flags_all": [ "MELEE_PERK_DUELIST_COMBO" ],
+    "melee_allowed": true,
+    "crit_ok": true,
+    "unarmed_allowed": true,
+    "weighting": 100,
+    "condition": {
+      "and": [
+        { "math": [ "u_effect_intensity('mabuff:buff_perk_tempo') == 2" ] },
+        { "math": [ "n_effect_intensity('perk_hit_marker') >= 2" ] }
+      ]
+    },
+    "condition_desc": "* Can only trigger on the attack that achieves <info>tempo(3)</info>.  The attacked target must be the same as the previous two attacks.",
+    "mult_bonuses": [
+      { "stat": "hit", "scale": 5.0 },
+      { "stat": "movecost", "scale": 0.3 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 2.25 },
+      { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 2.25 },
+      { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 2.25 },
+      { "stat": "damage", "type": "bash", "scale": 1.55 },
+      { "stat": "damage", "type": "cut", "scale": 1.55 },
+      { "stat": "damage", "type": "stab", "scale": 1.55 }
+    ],
+    "messages": [
+      "You cleanly transition from your last attack into a powerful finishing strike against %s",
+      "<npcname> cleanly transitions their last attack into a powerful finishing strike against %s"
+    ],
     "attack_vectors": [ "vector_null" ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Martial Mastery : Many New Perks."

#### Purpose of change
Shows some love to the Tempo perkline, which was lacking in comparison to both momentum and Insight.  Also does the groundwork for a future "duelist" and "berserker" play patterns.

Includes a single unarmed combat perk.

#### Describe the solution
The new perks are:

Tempo
| Perk | Description|
|-|-|
|Perfect Tempo| Grants a 15 quickness buff when you achieve Tempo(3)  |
|Unrelenting Assault| When you kill a foe in melee range, you immediately move to their square and initiate an attack against a random target in range . Can potentially chain forever, although the attack portion of the move does consume both time and stamina.  The movement can generate Momentum stacks. |
|Zoning| You instantly move away from all adjacent enemies when you kill an enemy with Tempo(3) active. This removes the tempo bonus and can generate Momentum stacks. Meant as a finisher for duelists. |
|Compound Finisher| Your third attack against the same enemy is replaced with a fast finishing move if that attack would also give you Tempo(3) |


Momentum
| Perk | Description|
|-|-|
|Duelist Form| If you have more than 1 Momentum stacks, waiting a turn will set your Momentum stacks to 1. |
|Timed Lunge| If you have exactly 1 Momentum stack, fencing and thrusting swords gain a 1 range lunge attacks similar to those of spears. The attack will move you adjacent to the target and will generate momentum. |

Free
| Perk | Description|
|-|-|
|Pressure Points| All damage dealt in unarmed combat is redealt in 4 turns. |

#### Testing
Combat tested everything.