### PR TITLE
Add place arc furnace recipe, obsolete industrial arc furnace

### DIFF
--- a/data/json/construction/appliances.json
+++ b/data/json/construction/appliances.json
@@ -302,6 +302,18 @@
   },
   {
     "type": "construction",
+    "id": "app_arc_furnace",
+    "group": "place_arc_furnace",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "5 m",
+    "components": [ [ [ "arc_furnace", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_special": "done_appliance",
+    "activity_level": "BRISK_EXERCISE"
+  },
+  {
+    "type": "construction",
     "id": "app_glassblowers_crucible",
     "group": "place_glassblowers_crucible",
     "category": "APPLIANCE",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -41,6 +41,11 @@
   },
   {
     "type": "construction_group",
+    "id": "place_arc_furnace",
+    "name": "Place Arc Furnace"
+  },
+  {
+    "type": "construction_group",
     "id": "build_armchair",
     "name": "Place an armchair"
   },

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -97,7 +97,7 @@
     "type": "vehicle_part",
     "id": "ap_arc_furnace",
     "name": { "str": "arc furnace" },
-    "looks_like": "f_arc_furnace",
+    "looks_like": "f_arcfurnace_empty",
     "color": "blue",
     "categories": [ "utility" ],
     "description": "An arc furnace designed to burn a powdery mix of coke and limestone to create calcium carbide.  Plugged in and ready to go.",

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -500,7 +500,7 @@
     "type": "furniture",
     "id": "f_arcfurnace_empty",
     "name": "arc furnace",
-    "looks_like": "f_arc_furnace",
+    "looks_like": "f_machinery_heavy",
     "description": "An arc furnace designed to burn a powdery mix of coke and limestone to create calcium carbide.",
     "symbol": "U",
     "color": "blue",
@@ -833,41 +833,6 @@
       "sound_fail": "whump.",
       "items": [ { "item": "scrap_aluminum", "count": [ 15, 285 ] } ]
     }
-  },
-  {
-    "type": "furniture",
-    "id": "f_arc_furnace",
-    "name": "industrial arc furnace",
-    "looks_like": "f_machinery_heavy",
-    "description": "Not the kind of furnace you'd heat your house with, this is a device for heating things to extreme temperatures as part of industrial fabrication processes.  Can be used in recipes instead of a forge, when supplied with power from a UPS.",
-    "symbol": "0",
-    "color": "white_red",
-    "move_cost_mod": -1,
-    "coverage": 40,
-    "required_str": -1,
-    "flags": [ "CONTAINER", "FIRE_CONTAINER", "PLACE_ITEM" ],
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "cable", "charges": [ 0, 4 ] },
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "steel_chunk", "count": [ 2, 4 ] },
-        { "item": "steel_plate", "count": [ 1, 2 ] }
-      ]
-    },
-    "deconstruct": {
-      "items": [
-        { "item": "cable", "charges": [ 4, 8 ] },
-        { "item": "steel_chunk", "count": [ 4, 6 ] },
-        { "item": "steel_plate", "count": [ 2, 4 ] },
-        { "item": "sheet_metal", "count": [ 4, 6 ] },
-        { "item": "element", "count": [ 10, 25 ] },
-        { "item": "scrap", "count": [ 12, 16 ] }
-      ]
-    },
-    "crafting_pseudo_item": "fake_arc_furnace"
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -508,9 +508,9 @@
     "coverage": 40,
     "required_str": -1,
     "max_volume": "200 L",
-    "flags": [ "CONTAINER", "FIRE_CONTAINER", "PLACE_ITEM" ],
+    "flags": [ "CONTAINER", "FIRE_CONTAINER", "PLACE_ITEM", "EASY_DECONSTRUCT" ],
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "arc_furnace" },
-    "deconstruct": { "items": [ { "item": "metal_tank", "count": [ 1, 4 ] }, { "item": "pipe", "count": [ 2, 4 ] } ] },
+    "deconstruct": { "items": [ { "item": "arc_furnace", "count": 1 } ] },
     "bash": {
       "str_min": 18,
       "str_max": 40,

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -44,7 +44,7 @@
   {
     "type": "GENERIC",
     "id": "arc_furnace",
-    "looks_like": "f_arc_furnace",
+    "looks_like": "f_machinery_heavy",
     "symbol": "U",
     "description": "An arc furnace designed to burn a powdery mix of coke and limestone to create calcium carbide.  Needs to be placed and plugged into a power source.",
     "color": "blue",

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -44,7 +44,7 @@
   {
     "type": "GENERIC",
     "id": "arc_furnace",
-    "looks_like": "f_machinery_heavy",
+    "looks_like": "f_arcfurnace_empty",
     "symbol": "U",
     "description": "An arc furnace designed to burn a powdery mix of coke and limestone to create calcium carbide.  Needs to be placed and plugged into a power source.",
     "color": "blue",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -20,12 +20,6 @@
     "extend": { "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ] }
   },
   {
-    "id": "fake_arcfurnace",
-    "copy-from": "fake_item",
-    "type": "TOOL",
-    "name": { "str": "arc furnace" }
-  },
-  {
     "id": "spinwheelitem",
     "copy-from": "fake_item",
     "type": "TOOL",
@@ -251,7 +245,7 @@
     "id": "fake_arc_furnace",
     "type": "TOOL",
     "copy-from": "fake_power_tool",
-    "name": { "str": "industrial arc furnace" }
+    "name": { "str": "arc furnace" }
   },
   {
     "id": "fake_beverly_shear",

--- a/data/json/obsoletion_and_migration_0.I/obsolete_furniture.json
+++ b/data/json/obsoletion_and_migration_0.I/obsolete_furniture.json
@@ -93,5 +93,10 @@
     "from_ter": "t_atm",
     "to_ter": "t_thconc_floor",
     "to_furn": "f_atm_off"
+  },
+  {
+    "type": "ter_furn_migration",
+    "from_furn": "f_machinery_heavy",
+    "to_furn": "f_arcfurnace_empty"
   }
 ]

--- a/data/json/obsoletion_and_migration_0.I/obsolete_furniture.json
+++ b/data/json/obsoletion_and_migration_0.I/obsolete_furniture.json
@@ -96,7 +96,7 @@
   },
   {
     "type": "ter_furn_migration",
-    "from_furn": "f_machinery_heavy",
+    "from_furn": "f_arc_furnace",
     "to_furn": "f_arcfurnace_empty"
   }
 ]

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -4672,6 +4672,23 @@
     ]
   },
   {
+    "result": "arc_furnace",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "360 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "DRILL", "level": 1 }, { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "fire_brick", 40 ] ],
+      [ [ "cu_pipe", 4 ] ],
+      [ [ "cable", 12 ] ],
+      [ [ "pipe", 4 ] ],
+      [ [ "clamp", 1 ] ],
+      [ [ "motor_tiny", 1 ] ],
+      [ [ "medium_storage_battery", 2 ] ],
+      [ [ "frame", 1 ] ]
+    ]
+  },
+  {
     "result": "tablesaw",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
#76788 started appliencing the arc furnace, but forgot some things.
fix #79613.
While working on this PR, I've found a furniture f_arc_furnace that did not have any recipes or spawns and did not spawn anywhere. As far as I can tell its only purpose is to provide `"crafting_pseudo_item": "fake_arc_furnace"`, which f_arcfurnace_empty also provides.

#### Describe the solution
Add place arc furnace recipe.
Add disassembly.
Obsolete f_arc_furnace.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Also move the construction recipe to crafting the disconnected item, or remove it completely (like drill press).
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
can place disconnected arc furnace.
obsoleted industrial arcfurnace is replaced.
can disassemble.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Disassembly results are same as build components minus mortar.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
