### PR TITLE
make gas masks compatible with NVG

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1977,7 +1977,7 @@
     "copy-from": "mask_gas",
     "looks_like": "mask_gas",
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 0.5 },
-    "flags": [ "OVERSIZE", "PREFIX_XL", "SLEEP_IGNORE" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "PREFIX_XL", "SLEEP_IGNORE" ]
   },
   {
     "id": "mask_gas_xs",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1974,68 +1974,18 @@
     "id": "mask_gas_xl",
     "type": "TOOL_ARMOR",
     "name": { "str": "gas mask" },
-    "category": "clothing",
-    "description": "A rather roomy mask with filters attached, designed to accommodate exotic anatomy.  Provides excellent protection from smoke, tear gas, and other contaminants.  It must be prepared before use.",
-    "weight": "1397 g",
-    "volume": "1500 ml",
-    "price": "250 USD",
-    "price_postapoc": "7 USD 50 cent",
-    "material": [ "plastic" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "armor": [
-      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 25 },
-      { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 35 }
-    ],
-    "warmth": 20,
-    "material_thickness": 2,
-    "environmental_protection": 4,
-    "environmental_protection_with_filter": 16,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "GASFILTER_MED" ],
-        "default_magazine": "gasfilter_med"
-      }
-    ],
-    "ammo": "gasfilter_m",
-    "use_action": [ "GASMASK_ACTIVATE" ],
-    "tick_action": [ "GASMASK" ],
+    "copy-from": "mask_gas",
+    "looks_like": "mask_gas",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 0.5 },
     "flags": [ "OVERSIZE", "PREFIX_XL", "SLEEP_IGNORE" ]
   },
   {
     "id": "mask_gas_xs",
     "type": "TOOL_ARMOR",
     "name": { "str": "gas mask" },
-    "category": "clothing",
-    "description": "A rather small gas mask that covers the face and eyes.  Provides excellent protection from smoke, tear gas, and other contaminants.  It must be prepared before use.",
-    "weight": "470 g",
-    "volume": "500 ml",
-    "price": "250 USD",
-    "price_postapoc": "7 USD 50 cent",
-    "material": [ "plastic" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "armor": [
-      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 25 },
-      { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 35 }
-    ],
-    "warmth": 20,
-    "material_thickness": 2,
-    "environmental_protection": 4,
-    "environmental_protection_with_filter": 16,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "GASFILTER_MED" ],
-        "default_magazine": "gasfilter_med"
-      }
-    ],
-    "ammo": "gasfilter_m",
-    "use_action": [ "GASMASK_ACTIVATE" ],
-    "tick_action": [ "GASMASK" ],
+    "copy-from": "mask_gas",
+    "looks_like": "mask_gas",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "flags": [ "VARSIZE", "UNDERSIZE", "PREFIX_XS", "SLEEP_IGNORE" ]
   },
   {
@@ -2220,6 +2170,8 @@
           { "type": "lc_steel", "covered_by_mat": 15, "thickness": 1 }
         ],
         "covers": [ "eyes" ],
+        "layers": [ "SKINTIGHT", "NORMAL" ],
+        "rigid_layer_only": true,
         "coverage": 100,
         "encumbrance": 28
       }
@@ -2336,6 +2288,8 @@
       {
         "material": [ { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 5 } ],
         "covers": [ "eyes" ],
+        "layers": [ "SKINTIGHT", "NORMAL" ],
+        "rigid_layer_only": true,
         "coverage": 100,
         "encumbrance": 25
       }


### PR DESCRIPTION
#### Summary
Bugfixes "Make more masks compatible with NVG's"

#### Purpose of change
fix #79546
You could already wear NVG's over the normal gas mask. This PR extends it to it's XS/XL variants and the survivor mask.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
#74221 only touched the basic gas mask, not its xl/xs forms; I made them copy-from.
make survivor gas mask compatible by adding 
```json
        "layers": [ "SKINTIGHT", "NORMAL" ],
        "rigid_layer_only": true,
```
to the eye piece.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Can wear NVG over survivor masks and XL/XS gas masks
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Should "varsize" be in the XL/XS sizes? the XL/XS survivor mask have them, but most other items with sizes dont. What is the standard?
Thx IdleSol for doing 90% of the research work.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
