### PR TITLE
Upgrade clang-tidy to LLVM 18, and fix (some) newly firing lints

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -93,7 +93,6 @@ Checks: [
     -readability-suspicious-call-argument,
     -readability-use-anyofallof,
     # Temporarily disabled in an update to llvm 18. Untriaged.
-    -readability-redundant-member-init,
     -bugprone-chained-comparison,
     -bugprone-multi-level-implicit-pointer-conversion,
     -bugprone-optional-value-conversion,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -92,6 +92,20 @@ Checks: [
     -readability-simplify-boolean-expr,
     -readability-suspicious-call-argument,
     -readability-use-anyofallof,
+    # Temporarily disabled in an update to llvm 18. Untriaged.
+    -modernize-make-shared,
+    -readability-redundant-member-init,
+    -bugprone-chained-comparison,
+    -bugprone-multi-level-implicit-pointer-conversion,
+    -bugprone-optional-value-conversion,
+    -bugprone-unused-local-non-trivial-variable,
+    -clang-analyzer-optin.core.EnumCastOutOfRange,
+    -performance-enum-size,
+    -readability-avoid-nested-conditional-operator,
+    -readability-avoid-return-with-void-value,
+    -readability-redundant-casting,
+    -readability-redundant-inline-specifier,
+    -readability-reference-to-constructed-temporary,
 ]
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -72,10 +72,12 @@ Checks: [
     -bugprone-easily-swappable-parameters,
     -bugprone-empty-catch,
     -bugprone-implicit-widening-of-multiplication-result,
+    -bugprone-multi-level-implicit-pointer-conversion,  # untriaged since upgrade to LLVM 18
     -bugprone-narrowing-conversions,
     -bugprone-switch-missing-default-case,
     -bugprone-unchecked-optional-access,
     -bugprone-unhandled-exception-at-new,
+    -bugprone-unused-local-non-trivial-variable,  # great lint, but hard to fix
     -misc-confusable-identifiers,
     -misc-const-correctness,
     -misc-header-include-cycle,
@@ -90,8 +92,10 @@ Checks: [
     -modernize-use-default-member-init,
     -modernize-use-nodiscard,
     -performance-avoid-endl,
+    -performance-enum-size,  # untriaged since upgrade to LLVM 18
     -performance-noexcept-swap,
     -performance-no-automatic-move,
+    -readability-avoid-nested-conditional-operator,  # great lint, but hard to fix
     -readability-avoid-unconditional-preprocessor-if,
     -readability-container-data-pointer,
     -readability-convert-member-functions-to-static,
@@ -100,15 +104,10 @@ Checks: [
     -readability-implicit-bool-conversion,
     -readability-magic-numbers,
     -readability-named-parameter,
+    -readability-redundant-casting,  # probably good lint, just needs fixing
     -readability-simplify-boolean-expr,
     -readability-suspicious-call-argument,
     -readability-use-anyofallof,
-    # Temporarily disabled in an update to llvm 18. Untriaged.
-    -bugprone-multi-level-implicit-pointer-conversion,
-    -bugprone-unused-local-non-trivial-variable,
-    -performance-enum-size,
-    -readability-avoid-nested-conditional-operator,
-    -readability-redundant-casting,
 ]
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -101,7 +101,6 @@ Checks: [
     -readability-avoid-return-with-void-value,
     -readability-redundant-casting,
     -readability-redundant-inline-specifier,
-    -readability-reference-to-constructed-temporary,
 ]
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -93,7 +93,6 @@ Checks: [
     -readability-suspicious-call-argument,
     -readability-use-anyofallof,
     # Temporarily disabled in an update to llvm 18. Untriaged.
-    -bugprone-chained-comparison,
     -bugprone-multi-level-implicit-pointer-conversion,
     -bugprone-unused-local-non-trivial-variable,
     -clang-analyzer-optin.core.EnumCastOutOfRange,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -98,7 +98,6 @@ Checks: [
     -clang-analyzer-optin.core.EnumCastOutOfRange,
     -performance-enum-size,
     -readability-avoid-nested-conditional-operator,
-    -readability-avoid-return-with-void-value,
     -readability-redundant-casting,
     -readability-redundant-inline-specifier,
 ]

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -95,7 +95,6 @@ Checks: [
     # Temporarily disabled in an update to llvm 18. Untriaged.
     -bugprone-chained-comparison,
     -bugprone-multi-level-implicit-pointer-conversion,
-    -bugprone-optional-value-conversion,
     -bugprone-unused-local-non-trivial-variable,
     -clang-analyzer-optin.core.EnumCastOutOfRange,
     -performance-enum-size,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,6 +35,10 @@ Checks: [
     -clang-analyzer-core.NonNullParamChecker,
     -clang-analyzer-core.UndefinedBinaryOperatorResult,
     -clang-analyzer-cplusplus.NewDelete,
+    # We often use enums as bitsets and do things like `enum::A | enum::B`
+    # which is explicitly unsupported by this check, and it is officially recommended to disable
+    # this lint for project that use such patterns.
+    -clang-analyzer-optin.core.EnumCastOutOfRange,
     clang-diagnostic-*,
     cppcoreguidelines-slicing,
     google-explicit-constructor,
@@ -102,7 +106,6 @@ Checks: [
     # Temporarily disabled in an update to llvm 18. Untriaged.
     -bugprone-multi-level-implicit-pointer-conversion,
     -bugprone-unused-local-non-trivial-variable,
-    -clang-analyzer-optin.core.EnumCastOutOfRange,
     -performance-enum-size,
     -readability-avoid-nested-conditional-operator,
     -readability-redundant-casting,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -78,7 +78,6 @@ Checks: [
     -bugprone-easily-swappable-parameters,
     -bugprone-empty-catch,
     -bugprone-implicit-widening-of-multiplication-result,
-    -bugprone-multi-level-implicit-pointer-conversion,  # untriaged since upgrade to LLVM 18
     -bugprone-narrowing-conversions,
     -bugprone-switch-missing-default-case,
     -bugprone-unchecked-optional-access,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -44,7 +44,13 @@ Checks: [
     google-explicit-constructor,
     llvm-namespace-comment,
     misc-*,
+    # Extremely expensive, and we are not using `using` anyway, so it's not catching anything.
+    -misc-unused-using-decls,
     modernize-*,
+    # Rather expensive check, and it is unlikely that somebody
+    # would *want* to use std::auto_ptr in %CURRENT_YEAR% (2025+) when unique_ptr is both better
+    # and is a de-facto default in the codebase already.
+    -modernize-replace-auto-ptr,
     # * modernize-use-auto
     # We prefer an almost-always-avoid-auto style.
     -modernize-use-auto,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,69 +39,70 @@
 # We are not enforcing a standard identifier naming scheme in the code base.
 # This check does not bring much value at the moment and consumes a lot of CPU time.
 
-Checks: "\
-bugprone-*,\
-cata-*,\
-cert-*,\
--cert-dcl21-cpp,\
--cert-env33-c,\
--cert-dcl37-c,\
--cert-dcl51-cpp,\
--cert-err58-cpp,\
--clang-analyzer-core.CallAndMessage,\
--clang-analyzer-core.DivideZero,\
--clang-analyzer-core.NonNullParamChecker,\
--clang-analyzer-core.UndefinedBinaryOperatorResult,\
--clang-analyzer-cplusplus.NewDelete,\
-clang-diagnostic-*,\
-cppcoreguidelines-slicing,\
-google-explicit-constructor,\
-llvm-namespace-comment,\
-misc-*,\
-modernize-*,\
--modernize-use-auto,\
--modernize-use-trailing-return-type,\
-performance-*,\
-readability-*,\
--bugprone-assignment-in-if-condition,\
--bugprone-easily-swappable-parameters,\
--bugprone-empty-catch,\
--bugprone-implicit-widening-of-multiplication-result,\
--bugprone-narrowing-conversions,\
--bugprone-switch-missing-default-case,\
--bugprone-throw-keyword-missing,\
--bugprone-unchecked-optional-access,\
--bugprone-unhandled-exception-at-new,\
--misc-confusable-identifiers,\
--misc-const-correctness,\
--misc-header-include-cycle,\
--misc-include-cleaner,\
--misc-no-recursion,\
--misc-non-private-member-variables-in-classes,\
--misc-use-anonymous-namespace,\
--modernize-concat-nested-namespaces,\
--modernize-macro-to-enum,\
--modernize-pass-by-value,\
--modernize-return-braced-init-list,\
--modernize-use-default-member-init,\
--modernize-use-nodiscard,\
--performance-avoid-endl,\
--performance-noexcept-swap,\
--performance-no-automatic-move,\
--readability-avoid-unconditional-preprocessor-if,\
--readability-container-data-pointer,\
--readability-convert-member-functions-to-static,\
--readability-else-after-return,\
--readability-function-cognitive-complexity,\
--readability-identifier-length,\
--readability-identifier-naming,\
--readability-implicit-bool-conversion,\
--readability-magic-numbers,\
--readability-named-parameter,\
--readability-simplify-boolean-expr,\
--readability-suspicious-call-argument,\
--readability-use-anyofallof,\
-"
+Checks: [
+    bugprone-*,
+    cata-*,
+    cert-*,
+    -cert-dcl21-cpp,
+    -cert-env33-c,
+    -cert-dcl37-c,
+    -cert-dcl51-cpp,
+    -cert-err58-cpp,
+    -clang-analyzer-core.CallAndMessage,
+    -clang-analyzer-core.DivideZero,
+    -clang-analyzer-core.NonNullParamChecker,
+    -clang-analyzer-core.UndefinedBinaryOperatorResult,
+    -clang-analyzer-cplusplus.NewDelete,
+    clang-diagnostic-*,
+    cppcoreguidelines-slicing,
+    google-explicit-constructor,
+    llvm-namespace-comment,
+    misc-*,
+    modernize-*,
+    -modernize-use-auto,
+    -modernize-use-trailing-return-type,
+    performance-*,
+    readability-*,
+    -bugprone-assignment-in-if-condition,
+    -bugprone-easily-swappable-parameters,
+    -bugprone-empty-catch,
+    -bugprone-implicit-widening-of-multiplication-result,
+    -bugprone-narrowing-conversions,
+    -bugprone-switch-missing-default-case,
+    -bugprone-throw-keyword-missing,
+    -bugprone-unchecked-optional-access,
+    -bugprone-unhandled-exception-at-new,
+    -misc-confusable-identifiers,
+    -misc-const-correctness,
+    -misc-header-include-cycle,
+    -misc-include-cleaner,
+    -misc-no-recursion,
+    -misc-non-private-member-variables-in-classes,
+    -misc-use-anonymous-namespace,
+    -modernize-concat-nested-namespaces,
+    -modernize-macro-to-enum,
+    -modernize-pass-by-value,
+    -modernize-return-braced-init-list,
+    -modernize-use-default-member-init,
+    -modernize-use-nodiscard,
+    -performance-avoid-endl,
+    -performance-noexcept-swap,
+    -performance-no-automatic-move,
+    -readability-avoid-unconditional-preprocessor-if,
+    -readability-container-data-pointer,
+    -readability-convert-member-functions-to-static,
+    -readability-else-after-return,
+    -readability-function-cognitive-complexity,
+    -readability-identifier-length,
+    -readability-identifier-naming,
+    -readability-implicit-bool-conversion,
+    -readability-magic-numbers,
+    -readability-named-parameter,
+    -readability-simplify-boolean-expr,
+    -readability-suspicious-call-argument,
+    -readability-use-anyofallof,
+]
+
 WarningsAsErrors: '*'
 HeaderFilterRegex: '(src|test|tools).*'
 FormatStyle:     none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -93,7 +93,6 @@ Checks: [
     -readability-suspicious-call-argument,
     -readability-use-anyofallof,
     # Temporarily disabled in an update to llvm 18. Untriaged.
-    -modernize-make-shared,
     -readability-redundant-member-init,
     -bugprone-chained-comparison,
     -bugprone-multi-level-implicit-pointer-conversion,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,9 +54,16 @@ Checks: [
     # This check does not bring much value at the moment and consumes a lot of CPU time.
     -readability-identifier-length,
     -readability-identifier-naming,
+    # disabled due to behaviour change between pre-module and post-module world.
+    # Reevaluate in 2027(?) when the code is sufficiently migrated to C++20 modules
+    # or when there is a decision not perform the migration
+    -readability-redundant-inline-specifier,
   
-    # ==  Untriaged checks follow ==
-    # Either re-enable, or add a comment and move to the appropriate section above.
+    # ====  Untriaged checks follow  ====
+    # Either fix the code and re-enable the check,
+    # or add a good comment and move to the appropriate section above.
+    # Silencing the existing errors with a //NOLINT does count as a "fix", as that still
+    # prevents new issues from cropping up.
     -bugprone-assignment-in-if-condition,
     -bugprone-easily-swappable-parameters,
     -bugprone-empty-catch,
@@ -99,7 +106,6 @@ Checks: [
     -performance-enum-size,
     -readability-avoid-nested-conditional-operator,
     -readability-redundant-casting,
-    -readability-redundant-inline-specifier,
 ]
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,50 +4,32 @@
 # this codebase and we do not intend to fix.  The disabled checks appearing
 # thereafter in a separate alphabetical list have yet to be triaged.  We may
 # fix their errors or recategorise them as checks we don't care about.
-#
-# Comments on the checks we have decided are not worthwhile:
-#
-# * bugprone-throw-keyword-missing
-# This check is too time consuming.  Disable it for now to save CI time.
-#
-# * cert-dcl21-cpp (postfix operator++ and operator-- should return const objects)
-# This is an unconventional code style, and conflicts with
-# readability-const-return-type.
-#
-# * cert-env33-c (calls to system, popen)
-# Unlikely to catch bugs, and using system is convenient for portability.
-#
-# * cert-dcl37-c and cert-dcl-51-cpp (reserved identifiers)
-# These two checks are aliases for bugprone-reserved-identifier.
-# Don't repeatedly run the same check for three times.
-#
-# * cert-err58-cpp (exceptions from static variable declarations)
-# We have lots of memory allocations in static variable declarations, and
-# that's fine.
-#
-# * clang-analyzer-core.{DivideZero,NonNullParamChecker,UndefinedBinaryOperatorResult}
-# * clang-analyzer-cplusplus.NewDelete
-# They report too many false positives.
-#
-# * modernize-use-auto
-# We prefer an almost-always-avoid-auto style.
-#
-# * modernize-use-trailing-return-type
-# An arbitrary style convention we haven't adopted.
-#
-# * readability-identifier-naming
-# We are not enforcing a standard identifier naming scheme in the code base.
-# This check does not bring much value at the moment and consumes a lot of CPU time.
 
 Checks: [
     bugprone-*,
+    # This check is too time consuming.  Disable it for now to save CI time.
+    -bugprone-throw-keyword-missing,
     cata-*,
     cert-*,
+    # * cert-dcl21-cpp (postfix operator++ and operator-- should return const objects)
+    # This is an unconventional code style, and conflicts with
+    # readability-const-return-type.
     -cert-dcl21-cpp,
+    # * cert-env33-c (calls to system, popen)
+    # Unlikely to catch bugs, and using system is convenient for portability.
     -cert-env33-c,
+    # * cert-dcl37-c and cert-dcl-51-cpp (reserved identifiers)
+    # These two checks are aliases for bugprone-reserved-identifier.
+    # Don't repeatedly run the same check for three times.
     -cert-dcl37-c,
     -cert-dcl51-cpp,
+    # * cert-err58-cpp (exceptions from static variable declarations)
+    # We have lots of memory allocations in static variable declarations, and
+    # that's fine.
     -cert-err58-cpp,
+    # * clang-analyzer-core.{DivideZero,NonNullParamChecker,UndefinedBinaryOperatorResult}
+    # * clang-analyzer-cplusplus.NewDelete
+    # They report too many false positives.
     -clang-analyzer-core.CallAndMessage,
     -clang-analyzer-core.DivideZero,
     -clang-analyzer-core.NonNullParamChecker,
@@ -59,17 +41,28 @@ Checks: [
     llvm-namespace-comment,
     misc-*,
     modernize-*,
+    # * modernize-use-auto
+    # We prefer an almost-always-avoid-auto style.
     -modernize-use-auto,
+    # * modernize-use-trailing-return-type
+    # An arbitrary style convention we haven't adopted.
     -modernize-use-trailing-return-type,
     performance-*,
     readability-*,
+    # * readability-identifier-naming
+    # We are not enforcing a standard identifier naming scheme in the code base.
+    # This check does not bring much value at the moment and consumes a lot of CPU time.
+    -readability-identifier-length,
+    -readability-identifier-naming,
+  
+    # ==  Untriaged checks follow ==
+    # Either re-enable, or add a comment and move to the appropriate section above.
     -bugprone-assignment-in-if-condition,
     -bugprone-easily-swappable-parameters,
     -bugprone-empty-catch,
     -bugprone-implicit-widening-of-multiplication-result,
     -bugprone-narrowing-conversions,
     -bugprone-switch-missing-default-case,
-    -bugprone-throw-keyword-missing,
     -bugprone-unchecked-optional-access,
     -bugprone-unhandled-exception-at-new,
     -misc-confusable-identifiers,
@@ -93,8 +86,6 @@ Checks: [
     -readability-convert-member-functions-to-static,
     -readability-else-after-return,
     -readability-function-cognitive-complexity,
-    -readability-identifier-length,
-    -readability-identifier-naming,
     -readability-implicit-bool-conversion,
     -readability-magic-numbers,
     -readability-named-parameter,

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,4 +1,4 @@
-name: Clang-tidy 17
+name: Clang-tidy 18
 
 on:
   push:
@@ -36,13 +36,13 @@ jobs:
         fail-fast: true
     runs-on: ubuntu-24.04
     env:
-        COMPILER: clang++-17
+        COMPILER: clang++-18
     steps:
-    - name: install LLVM 17
+    - name: install LLVM 18
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: |
           sudo apt-get update
-          sudo apt install llvm-17 llvm-17-dev llvm-17-tools clang-17 clang-tidy-17 clang-tools-17 libclang-17-dev
+          sudo apt install llvm-18 llvm-18-dev llvm-18-tools clang-18 clang-tidy-18 clang-tools-18 libclang-18-dev
           sudo apt install python3-pip ninja-build cmake
           pip3 install --user lit
     - name: checkout repository
@@ -74,8 +74,8 @@ jobs:
 
     runs-on: ubuntu-24.04
     env:
-        COMPILER: clang++-17
-        CATA_CLANG_TIDY: clang-tidy-17
+        COMPILER: clang++-18
+        CATA_CLANG_TIDY: clang-tidy-18
         CATA_CLANG_TIDY_SUBSET: ${{ matrix.subset }}
         TILES: 1
         SOUND: 1
@@ -85,7 +85,7 @@ jobs:
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: |
           sudo apt-get update
-          sudo apt install clang-17 clang-tidy-17 cmake ccache jq
+          sudo apt install clang-18 clang-tidy-18 cmake ccache jq
           sudo apt install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext 
     - name: checkout repository
       uses: actions/checkout@v4
@@ -122,7 +122,7 @@ jobs:
       run: | # the folder may not exist if there is no file to analyze
         if [ -d clang-tidy-trace ]
         then
-          jq -n 'reduce(inputs.profile | to_entries[]) as {$key,$value} ({}; .[$key] += $value) | with_entries(select(.key|contains(".wall"))) | to_entries | sort_by(.value) | reverse | .[0:10] | from_entries' clang-tidy-trace/*.json
+          jq -n 'reduce(inputs.profile | to_entries[]) as {$key,$value} ({}; .[$key] += $value) | with_entries(select(.key|contains(".wall"))) | to_entries | sort_by(.value) | reverse | .[0:30] | from_entries' clang-tidy-trace/*.json
         else
           echo "clang-tidy-trace folder not found."
         fi

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -85,6 +85,6 @@
     "C_Cpp.formatting": "disabled",
     "astyle.astylerc": "${workspaceRoot}/.astylerc",
     "files.associations": {
-        "vector": "cpp"
+        ".clang-tidy": "yaml",
     }
 }

--- a/build-scripts/clang-tidy-build.sh
+++ b/build-scripts/clang-tidy-build.sh
@@ -15,8 +15,8 @@ cmake_extra_opts=()
 cmake_extra_opts+=("-DCATA_CLANG_TIDY_PLUGIN=ON")
 # Need to specify the particular LLVM / Clang versions to use, lest it
 # use the older LLVM that comes by default on Ubuntu.
-cmake_extra_opts+=("-DLLVM_DIR=/usr/lib/llvm-17/lib/cmake/llvm")
-cmake_extra_opts+=("-DClang_DIR=/usr/lib/llvm-17/lib/cmake/clang")
+cmake_extra_opts+=("-DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm")
+cmake_extra_opts+=("-DClang_DIR=/usr/lib/llvm-18/lib/cmake/clang")
 
 
 mkdir -p build
@@ -33,7 +33,7 @@ echo "Compiling clang-tidy plugin"
 make -j$num_jobs CataAnalyzerPlugin
 #export PATH=$PWD/tools/clang-tidy-plugin/clang-tidy-plugin-support/bin:$PATH
 # add FileCheck to the search path
-export PATH=/usr/lib/llvm-17/bin:$PATH 
+export PATH=/usr/lib/llvm-18/bin:$PATH 
 if ! which FileCheck
 then
     echo "Missing FileCheck"

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -54,7 +54,7 @@ class aim_activity_actor : public activity_actor
         bool should_unload_RAS = false;
         bool snap_to_target = false;
         /* Item location for RAS weapon reload */
-        item_location reload_loc = item_location();
+        item_location reload_loc;
         bool shifting_view = false;
         tripoint_rel_ms initial_view_offset;
         /** Target UI requested to abort aiming */
@@ -1428,8 +1428,8 @@ class milk_activity_actor : public activity_actor
 
     private:
         int total_moves {};
-        std::vector<tripoint_abs_ms> monster_coords {};
-        std::vector<std::string> string_values {};
+        std::vector<tripoint_abs_ms> monster_coords;
+        std::vector<std::string> string_values;
 };
 
 class shearing_activity_actor : public activity_actor

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -448,7 +448,7 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
 {
     map &here = get_map();
 
-    return put_into_vehicle_or_drop( you, reason, items, &here, you.pos_bub( &here ) );
+    put_into_vehicle_or_drop( you, reason, items, &here, you.pos_bub( &here ) );
 }
 
 void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,

--- a/src/cata_bitset.cpp
+++ b/src/cata_bitset.cpp
@@ -43,5 +43,6 @@ void tiny_bitset::resize_heap( size_t requested_bits ) noexcept
 
 void tiny_bitset::set_storage( block_t *data )
 {
+    // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
     memcpy( &storage_, &data, sizeof( data ) );
 }

--- a/src/cata_bitset.h
+++ b/src/cata_bitset.h
@@ -179,6 +179,7 @@ class tiny_bitset
                 // The hashtag blessed UB-avoiding way of type punning a pointer
                 // out of an integer.
                 block_t *ret;
+                // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
                 memcpy( &ret, &storage_, sizeof( storage_ ) );
                 return ret;
             }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -286,7 +286,7 @@ tileset::find_tile_type_by_season( const std::string &id, season_type season ) c
     }
     const tileset::season_tile_value &res = iter->second;
     if( res.season_tile ) {
-        return *res.season_tile;
+        return res.season_tile;
     } else if( res.default_tile ) { // can skip this check, but just in case
         return tile_lookup_res( iter->first, *res.default_tile );
     }

--- a/src/character_modifier.h
+++ b/src/character_modifier.h
@@ -60,7 +60,7 @@ struct character_modifier {
         mod_type limbscore_modop = MULT;
         std::vector<std::pair<character_modifier_id, mod_id>> src;
         body_part_type::type limbtype = body_part_type::type::num_types;
-        translation desc = translation();
+        translation desc;
         mod_type modtype = mod_type::NONE;
         float max_val = 0.0f;
         float min_val = 0.0f;

--- a/src/climbing.cpp
+++ b/src/climbing.cpp
@@ -219,7 +219,7 @@ void climbing_aid::down_t::deserialize( const JsonObject &jo )
                 jo.throw_error( str_cat( "failed to read optional member \"menu_hotkey\"" ) );
             }
         }
-        if( menu_hotkey_str.length() ) {
+        if( !menu_hotkey_str.empty() ) {
             menu_hotkey = std::uint8_t( menu_hotkey_str[ 0 ] );
         }
 

--- a/src/construction.h
+++ b/src/construction.h
@@ -31,7 +31,7 @@ class nc_color;
 
 struct partial_con {
     int counter = 0;
-    std::list<item> components = {};
+    std::list<item> components;
     construction_id id = construction_id( -1 );
 };
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1955,7 +1955,7 @@ void Creature::schedule_effect_removal( const efftype_id &eff_id, const bodypart
 }
 void Creature::schedule_effect_removal( const efftype_id &eff_id )
 {
-    return schedule_effect_removal( eff_id, bodypart_str_id::NULL_ID() );
+    schedule_effect_removal( eff_id, bodypart_str_id::NULL_ID() );
 }
 
 bool Creature::has_effect( const efftype_id &eff_id, const bodypart_id &bp ) const
@@ -3438,44 +3438,44 @@ void Creature::adjust_taken_damage_by_enchantments_post_absorbed( damage_unit &d
 
 void Creature::add_msg_if_player( const translation &msg ) const
 {
-    return add_msg_if_player( msg.translated() );
+    add_msg_if_player( msg.translated() );
 }
 
 void Creature::add_msg_if_player( const game_message_params &params, const translation &msg ) const
 {
-    return add_msg_if_player( params, msg.translated() );
+    add_msg_if_player( params, msg.translated() );
 }
 
 void Creature::add_msg_if_npc( const translation &msg ) const
 {
-    return add_msg_if_npc( msg.translated() );
+    add_msg_if_npc( msg.translated() );
 }
 
 void Creature::add_msg_if_npc( const game_message_params &params, const translation &msg ) const
 {
-    return add_msg_if_npc( params, msg.translated() );
+    add_msg_if_npc( params, msg.translated() );
 }
 
 void Creature::add_msg_player_or_npc( const translation &pc, const translation &npc ) const
 {
-    return add_msg_player_or_npc( pc.translated(), npc.translated() );
+    add_msg_player_or_npc( pc.translated(), npc.translated() );
 }
 
 void Creature::add_msg_player_or_npc( const game_message_params &params, const translation &pc,
                                       const translation &npc ) const
 {
-    return add_msg_player_or_npc( params, pc.translated(), npc.translated() );
+    add_msg_player_or_npc( params, pc.translated(), npc.translated() );
 }
 
 void Creature::add_msg_player_or_say( const translation &pc, const translation &npc ) const
 {
-    return add_msg_player_or_say( pc.translated(), npc.translated() );
+    add_msg_player_or_say( pc.translated(), npc.translated() );
 }
 
 void Creature::add_msg_player_or_say( const game_message_params &params, const translation &pc,
                                       const translation &npc ) const
 {
-    return add_msg_player_or_say( params, pc.translated(), npc.translated() );
+    add_msg_player_or_say( params, pc.translated(), npc.translated() );
 }
 
 std::vector <int> Creature::dispersion_for_even_chance_of_good_hit = { {

--- a/src/cursesport.cpp
+++ b/src/cursesport.cpp
@@ -189,7 +189,7 @@ void catacurses::wrefresh( const window &win )
 //Refreshes the main window, causing it to redraw on top.
 void catacurses::refresh()
 {
-    return wrefresh( stdscr );
+    wrefresh( stdscr );
 }
 
 void catacurses::doupdate()
@@ -349,7 +349,7 @@ void catacurses::wprintw( const window &win, const std::string &text )
         return;
     }
 
-    return printstring( win.get<cata_cursesport::WINDOW>(), text );
+    printstring( win.get<cata_cursesport::WINDOW>(), text );
 }
 
 //Prints a formatted string to a window, moves the cursor
@@ -358,7 +358,7 @@ void catacurses::mvwprintw( const window &win, const point &p, const std::string
     if( !wmove_internal( win, p ) ) {
         return;
     }
-    return printstring( win.get<cata_cursesport::WINDOW>(), text );
+    printstring( win.get<cata_cursesport::WINDOW>(), text );
 }
 
 //Resizes the underlying terminal after a Window's console resize(maybe?) Not used in TILES
@@ -387,7 +387,7 @@ void catacurses::werase( const window &win_ )
 //erases the main window of all text and attributes
 void catacurses::erase()
 {
-    return werase( stdscr );
+    werase( stdscr );
 }
 
 //pairs up a foreground and background color and puts it into the array of pairs
@@ -410,7 +410,7 @@ void catacurses::wmove( const window &win_, const point &p )
 //Clears the main window     I'm not sure if its suppose to do this?
 void catacurses::clear()
 {
-    return wclear( stdscr );
+    wclear( stdscr );
 }
 
 //adds a character to the window
@@ -419,7 +419,7 @@ void catacurses::mvwaddch( const window &win, const point &p, const chtype ch )
     if( !wmove_internal( win, p ) ) {
         return;
     }
-    return waddch( win, ch );
+    waddch( win, ch );
 }
 
 //clears a window
@@ -510,7 +510,7 @@ void catacurses::wattroff( const window &win_, nc_color )
 
 void catacurses::waddch( const window &win, const chtype ch )
 {
-    return printstring( win.get<cata_cursesport::WINDOW>(), string_from_int( ch ) );
+    printstring( win.get<cata_cursesport::WINDOW>(), string_from_int( ch ) );
 }
 
 static constexpr int A_BLINK = 0x00000800; /* Added characters are blinking. */

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1423,7 +1423,7 @@ void debug_write_backtrace( std::ostream &out )
     if( !addresses.empty() ) {
         call_addr2line( last_binary_name, addresses );
     }
-    free( funcNames );
+    free( funcNames );  // NOLINT( bugprone-multi-level-implicit-pointer-conversion )
 #   endif
 #endif
 }

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -197,10 +197,10 @@ struct talk_response {
     bool ignore_conditionals = false;
 
     mission *mission_selected = nullptr;
-    skill_id skill = skill_id();
-    matype_id style = matype_id();
-    spell_id dialogue_spell = spell_id();
-    proficiency_id proficiency = proficiency_id();
+    skill_id skill;
+    matype_id style;
+    spell_id dialogue_spell;
+    proficiency_id proficiency;
 
     talk_effect_t success;
     talk_effect_t failure;

--- a/src/dialogue_chatbin.h
+++ b/src/dialogue_chatbin.h
@@ -40,11 +40,11 @@ struct dialogue_chatbin {
     /**
      * The skill this dialogue offers to train.
      */
-    skill_id skill = skill_id();
+    skill_id skill;
     /**
      * The martial art style this dialogue offers to train.
      */
-    matype_id style = matype_id();
+    matype_id style;
     /**
      * The spell this dialogue offers to train
      */

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -90,7 +90,7 @@ struct talk_effect_fun_t {
             if( !function ) {
                 return;
             }
-            return function( d );
+            function( d );
         }
 };
 

--- a/src/effect_source.h
+++ b/src/effect_source.h
@@ -43,9 +43,9 @@ class effect_source
         void deserialize( const JsonObject &data );
 
     private:
-        std::optional<character_id> character = character_id();
-        std::optional<faction_id> fac = faction_id();
-        std::optional<mfaction_id> mfac = mfaction_id();
+        std::optional<character_id> character;
+        std::optional<faction_id> fac;
+        std::optional<mfaction_id> mfac;
 };
 
 #endif // CATA_SRC_EFFECT_SOURCE_H

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6400,7 +6400,7 @@ void game::pickup()
         return;
     }
     // Pick up items only from the selected tile
-    u.pick_up( game_menus::inv::pickup( *where_ ) );
+    u.pick_up( game_menus::inv::pickup( where_ ) );
 }
 
 void game::pickup_all()

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -569,7 +569,7 @@ static void pldrive( const tripoint_rel_ms &p )
 
 static void pldrive( point_rel_ms d )
 {
-    return pldrive( tripoint_rel_ms( d, 0 ) );
+    pldrive( tripoint_rel_ms( d, 0 ) );
 }
 
 static void open()

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5132,7 +5132,7 @@ static void reload_furniture( Character &you, const tripoint_bub_ms &examp, bool
 
 void iexamine::reload_furniture( Character &you, const tripoint_bub_ms &examp )
 {
-    return reload_furniture( you, examp, true );
+    reload_furniture( you, examp, true );
 }
 
 void iexamine::curtains( Character &you, const tripoint_bub_ms &examp )

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -6,6 +6,7 @@
 #include <iosfwd>
 #include <iterator>
 #include <list>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -835,16 +836,16 @@ void item_location::deserialize( const JsonObject &obj )
             // character item locations were assumed to be on g->u
             who_id = get_player_character().getID();
         }
-        ptr.reset( new impl::item_on_person( who_id, idx ) );
+        ptr = std::make_shared<impl::item_on_person>( who_id, idx );
 
     } else if( type == "map" ) {
-        ptr.reset( new impl::item_on_map( map_cursor( pos ), idx ) );
+        ptr = std::make_shared<impl::item_on_map>( map_cursor( pos ), idx );
 
     } else if( type == "vehicle" ) {
         vehicle *const veh = veh_pointer_or_null( get_map().veh_at( pos ) );
         int part = obj.get_int( "part" );
         if( veh && part >= 0 && part < veh->part_count() ) {
-            ptr.reset( new impl::item_on_vehicle( vehicle_cursor( *veh, part ), idx ) );
+            ptr = std::make_shared<impl::item_on_vehicle>( vehicle_cursor( *veh, part ), idx );
         }
     } else if( type == "in_container" ) {
         item_location parent;
@@ -852,18 +853,18 @@ void item_location::deserialize( const JsonObject &obj )
         if( !parent.ptr->valid() ) {
             if( parent == nowhere ) {
                 debugmsg( "parent location doesn't exist.  Item_location has lost its target over a save/load cycle." );
-                ptr.reset( new impl::nowhere );
+                ptr = std::make_shared<impl::nowhere>( );
                 return;
             }
             debugmsg( "parent location does not point to valid item" );
-            ptr.reset( new impl::item_on_map( map_cursor( parent.pos_bub() ), idx ) ); // drop on ground
+            ptr = std::make_shared<impl::item_on_map>( map_cursor( parent.pos_bub() ), idx ); // drop on ground
             return;
         }
         const std::list<item *> parent_contents = parent->all_items_container_top();
         if( idx > -1 && idx < static_cast<int>( parent_contents.size() ) ) {
             auto iter = parent_contents.begin();
             std::advance( iter, idx );
-            ptr.reset( new impl::item_in_container( parent, *iter ) );
+            ptr = std::make_shared<impl::item_in_container>( parent, *iter );
         } else {
             // probably pointing to the wrong item
             debugmsg( "contents index greater than contents size" );
@@ -1053,7 +1054,7 @@ void item_location::remove_item()
         return;
     }
     ptr->remove_item();
-    ptr.reset( new impl::nowhere() );
+    ptr = std::make_shared<impl::nowhere>( );
 }
 
 void item_location::on_contents_changed()

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1164,7 +1164,7 @@ class link_up_actor : public iuse_actor
         translation menu_text;
 
         std::set<link_state> targets = { link_state::no_link, link_state::vehicle_port };
-        std::set<std::string> can_extend = {};
+        std::set<std::string> can_extend;
 
         std::optional<int> link_to_veh_app( Character *p, item &it, bool to_ports ) const;
         std::optional<int> link_tow_cable( Character *p, item &it, bool to_towing ) const;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1937,7 +1937,7 @@ void map::set_map_damage( const tripoint_bub_ms &p, int dmg )
         debugmsg( "Called set_map_damage for unloaded submap" );
         return;
     }
-    return current_submap->set_map_damage( l, dmg );
+    current_submap->set_map_damage( l, dmg );
 }
 
 uint8_t map::get_known_connections( const tripoint_bub_ms &p,

--- a/src/map.h
+++ b/src/map.h
@@ -2394,20 +2394,20 @@ class tinymap : private map
             map::i_rem( rebase_bub( p ), it );
         }
         void i_clear( const tripoint_omt_ms &p ) {
-            return map::i_clear( rebase_bub( p ) );
+            map::i_clear( rebase_bub( p ) );
         }
         bool add_field( const tripoint_omt_ms &p, const field_type_id &type_id, int intensity = INT_MAX,
                         const time_duration &age = 0_turns, bool hit_player = true ) {
             return map::add_field( rebase_bub( p ), type_id, intensity, age, hit_player );
         }
         void delete_field( const tripoint_omt_ms &p, const field_type_id &field_to_remove ) {
-            return map::delete_field( rebase_bub( p ), field_to_remove );
+            map::delete_field( rebase_bub( p ), field_to_remove );
         }
         bool has_flag( ter_furn_flag flag, const tripoint_omt_ms &p ) const {
             return map::has_flag( flag, rebase_bub( p ) );
         }
         void destroy( const tripoint_omt_ms &p, bool silent = false ) {
-            return map::destroy( rebase_bub( p ), silent );
+            map::destroy( rebase_bub( p ), silent );
         }
         const trap &tr_at( const tripoint_omt_ms &p ) const {
             return map::tr_at( rebase_bub( p ) );
@@ -2435,7 +2435,7 @@ class tinymap : private map
         }
         void add_splatter_trail( const field_type_id &type, const tripoint_omt_ms &from,
                                  const tripoint_omt_ms &to ) {
-            return map::add_splatter_trail( type, rebase_bub( from ), rebase_bub( to ) );
+            map::add_splatter_trail( type, rebase_bub( from ), rebase_bub( to ) );
         }
         void collapse_at( const tripoint_omt_ms &p, bool silent,
                           bool was_supporting = false,

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -133,7 +133,7 @@ diag_assign_dbl_f addiction_turns_ass( char scope, std::vector<diag_value> const
                                        diag_kwargs const & /* kwargs */ )
 {
     return[ beta = is_beta( scope ), add_value = params[0]]( dialogue const & d, double val ) {
-        return d.actor( beta )->set_addiction_turns( addiction_id( add_value.str( d ) ), val );
+        d.actor( beta )->set_addiction_turns( addiction_id( add_value.str( d ) ), val );
     };
 }
 
@@ -150,7 +150,7 @@ diag_assign_dbl_f health_ass( char scope, std::vector<diag_value> const & /* par
 {
     return [beta = is_beta( scope )]( dialogue const & d, double val ) {
         const int current_health = d.actor( beta )->get_health();
-        return d.actor( beta )->mod_livestyle( val - current_health );
+        d.actor( beta )->mod_livestyle( val - current_health );
     };
 }
 
@@ -1079,7 +1079,7 @@ diag_assign_dbl_f skill_ass( char scope, std::vector<diag_value> const &params,
                              diag_kwargs const & /* kwargs */ )
 {
     return [beta = is_beta( scope ), sid = params[0] ]( dialogue const & d, double val ) {
-        return d.actor( beta )->set_skill_level( skill_id( sid.str( d ) ), val );
+        d.actor( beta )->set_skill_level( skill_id( sid.str( d ) ), val );
     };
 }
 
@@ -1112,7 +1112,7 @@ diag_assign_dbl_f skill_exp_ass( char scope, std::vector<diag_value> const &para
             throw math::runtime_error( R"(Unknown format type "%s" for skill_exp)", format );
         }
         bool raw = format == "raw";
-        return d.actor( beta )->set_skill_exp( skill, val, raw );
+        d.actor( beta )->set_skill_exp( skill, val, raw );
     };
 }
 
@@ -1183,7 +1183,7 @@ diag_assign_dbl_f spell_exp_ass( char scope, std::vector<diag_value> const &para
                                  diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope ), sid = params[0]]( dialogue const & d, double val ) {
-        return d.actor( beta )->set_spell_exp( spell_id( sid.str( d ) ), val );
+        d.actor( beta )->set_spell_exp( spell_id( sid.str( d ) ), val );
     };
 }
 
@@ -1606,7 +1606,7 @@ diag_assign_dbl_f npc_anger_ass( char scope, std::vector<diag_value> const & /* 
                                  diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d, double val ) {
-        return d.actor( beta )->set_npc_anger( val );
+        d.actor( beta )->set_npc_anger( val );
     };
 }
 
@@ -1614,7 +1614,7 @@ diag_assign_dbl_f npc_fear_ass( char scope, std::vector<diag_value> const & /* p
                                 diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d, double val ) {
-        return d.actor( beta )->set_npc_fear( val );
+        d.actor( beta )->set_npc_fear( val );
     };
 }
 
@@ -1622,7 +1622,7 @@ diag_assign_dbl_f npc_value_ass( char scope, std::vector<diag_value> const & /* 
                                  diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d, double val ) {
-        return d.actor( beta )->set_npc_value( val );
+        d.actor( beta )->set_npc_value( val );
     };
 }
 
@@ -1630,7 +1630,7 @@ diag_assign_dbl_f npc_trust_ass( char scope, std::vector<diag_value> const & /* 
                                  diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d, double val ) {
-        return d.actor( beta )->set_npc_trust( val );
+        d.actor( beta )->set_npc_trust( val );
     };
 }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1806,7 +1806,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
             new_.y() = b.y();
         }
 
-        const tripoint_bub_ms &dest{ new_, b.z()};
+        const tripoint_bub_ms dest{ new_, b.z()};
         if( g->is_empty( dest ) ) {
             t.setpos( dest );
         }

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -179,7 +179,7 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
     tripoint_abs_omt target_pos = tripoint_abs_omt::invalid;
 
     if( params.target_var.has_value() ) {
-        return project_to<coords::omt>( get_tripoint_ms_from_var( params.target_var.value(), d, false ) );
+        return project_to<coords::omt>( get_tripoint_ms_from_var( params.target_var, d, false ) );
     }
 
     omt_find_params find_params;

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -291,31 +291,31 @@ player_morale::player_morale() :
 
     mutations[trait_OPTIMISTIC] =
     mutation_data( [set_optimist]( player_morale * pm ) {
-        return set_optimist( pm, 9 );
+        set_optimist( pm, 9 );
     },
     [set_optimist]( player_morale * pm ) {
-        return set_optimist( pm, 0 );
+        set_optimist( pm, 0 );
     } );
     mutations[trait_BADTEMPER] =
     mutation_data( [set_badtemper]( player_morale * pm ) {
-        return set_badtemper( pm, -9 );
+        set_badtemper( pm, -9 );
     },
     [set_badtemper]( player_morale * pm ) {
-        return set_badtemper( pm, 0 );
+        set_badtemper( pm, 0 );
     } );
     mutations[trait_NUMB] =
     mutation_data( [set_numb]( player_morale * pm ) {
-        return set_numb( pm, -1 );
+        set_numb( pm, -1 );
     },
     [set_numb]( player_morale * pm ) {
-        return set_numb( pm, 0 );
+        set_numb( pm, 0 );
     } );
     mutations[trait_STYLISH] =
     mutation_data( [set_stylish]( player_morale * pm ) {
-        return set_stylish( pm, true );
+        set_stylish( pm, true );
     },
     [set_stylish]( player_morale * pm ) {
-        return set_stylish( pm, false );
+        set_stylish( pm, false );
     } );
     mutations[trait_FLOWERS]       = mutation_data( update_constrained );
     mutations[trait_ROOTS1]        = mutation_data( update_constrained );

--- a/src/npc.h
+++ b/src/npc.h
@@ -308,6 +308,7 @@ const std::unordered_map<std::string, cbm_reserve_rule> cbm_reserve_strs = { {
     }
 };
 
+// NOLINTBEGIN(optin.core.EnumCastOutOfRange)
 enum class ally_rule : int {
     DEFAULT = 0,
     use_guns = 1,
@@ -329,6 +330,7 @@ enum class ally_rule : int {
     lock_doors = 65536,
     avoid_locks = 131072
 };
+// NOLINTEND(optin.core.EnumCastOutOfRange)
 
 struct ally_rule_data {
     ally_rule rule;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1345,7 +1345,7 @@ class npc : public Character
         int last_seen_player_turn = 0; // Timeout to forgetting
 
         //Safe reference to an item at a specific location in case it gets deleted before pickup
-        item_location wanted_item = {};
+        item_location wanted_item;
 
         tripoint_bub_ms wanted_item_pos; // The square containing an item we want
         // These are the coordinates that a guard will return to inside of their goal tripoint

--- a/src/npctalk.h
+++ b/src/npctalk.h
@@ -14,10 +14,10 @@ namespace talk_function
 {
 
 struct teach_domain {
-    skill_id skill = skill_id();
-    matype_id style = matype_id();
-    spell_id spell = spell_id();
-    proficiency_id prof = proficiency_id();
+    skill_id skill;
+    matype_id style;
+    spell_id spell;
+    proficiency_id prof;
 };
 
 void nothing( npc & );

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -129,7 +129,7 @@ struct overmap_draw_data_t {
     // draw zone location.
     tripoint_abs_omt select = tripoint_abs_omt( -1, -1, -1 );
     int iZoneIndex = -1;
-    std::vector<tripoint_abs_omt> display_path = {};
+    std::vector<tripoint_abs_omt> display_path;
     //center of UI view; usually player OMT position
     tripoint_abs_omt origin_pos = tripoint_abs_omt( -1, -1, -1 );
     /**

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -821,7 +821,7 @@ const oter_id &overmapbuffer::ter_existing( const tripoint_abs_omt &p )
 void overmapbuffer::ter_set( const tripoint_abs_omt &p, const oter_id &id )
 {
     const overmap_with_local_coords om_loc = get_om_global( p );
-    return om_loc.om->ter_set( om_loc.local, id );
+    om_loc.om->ter_set( om_loc.local, id );
 }
 
 std::optional<mapgen_arguments> *overmapbuffer::mapgen_args( const tripoint_abs_omt &p )

--- a/src/text_style_check.h
+++ b/src/text_style_check.h
@@ -55,6 +55,7 @@ void text_style_check( Iter beg, Iter end,
             // remove unnecessary spaces before the symbol
             size_t fix_before_max = 0;
         } spaces;
+        // NOLINTBEGIN(readability-redundant-member-init)
         struct {
             bool yes = false;
             std::string str {};
@@ -62,6 +63,7 @@ void text_style_check( Iter beg, Iter end,
             std::string sym_desc {};
             std::string replace_desc {};
         } replace;
+        // NOLINTEND(readability-redundant-member-init)
     };
     // always put the longest (in u32) symbols at the front, since we'll iterate
     // and search for them in this order.

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -336,12 +336,12 @@ void trap::trigger( const tripoint_bub_ms &pos ) const
 
 void trap::trigger( const tripoint_bub_ms &pos, Creature &creature ) const
 {
-    return trigger( pos, &creature, nullptr );
+    trigger( pos, &creature, nullptr );
 }
 
 void trap::trigger( const tripoint_bub_ms &pos, item &item ) const
 {
-    return trigger( pos, nullptr, &item );
+    trigger( pos, nullptr, &item );
 }
 
 void trap::trigger( const tripoint_bub_ms &pos, Creature *creature, item *item ) const

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -359,7 +359,7 @@ class vpart_info
         item_group_id breaks_into_group = item_group_id( "EMPTY_GROUP" );
 
         /** Flat decrease of damage of a given type. */
-        std::unordered_map<damage_type_id, float> damage_reduction = {};
+        std::unordered_map<damage_type_id, float> damage_reduction;
 
         /** Tool qualities this vehicle part can provide when installed */
         std::map<quality_id, int> qualities;

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -816,7 +816,7 @@ void debug_menu::wishmonster( const std::optional<tripoint_bub_ms> &p )
         wmenu.query();
         if( wmenu.ret >= 0 ) {
             const mtype_id &mon_type = mtypes[ wmenu.ret ]->id;
-            if( std::optional<tripoint_bub_ms> spawn = p ? p.value() : g->look_around() ) {
+            if( std::optional<tripoint_bub_ms> spawn = p.has_value() ? p : g->look_around() ) {
                 int num_spawned = 0;
                 for( const tripoint_bub_ms &destination : closest_points_first( *spawn, cb.group ) ) {
                     monster *const mon = g->place_critter_at( mon_type, destination );

--- a/tests/catch/catch.hpp
+++ b/tests/catch/catch.hpp
@@ -2703,7 +2703,7 @@ namespace Catch {
         INTERNAL_CATCH_TRY { \
             CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
             CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
-            catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); \
+            catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); /* NOLINT(bugprone-chained-comparison) */ \
             CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
         } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
         INTERNAL_CATCH_REACT( catchAssertionHandler ) \

--- a/tools/clang-tidy-plugin/CombineLocalsIntoPointCheck.cpp
+++ b/tools/clang-tidy-plugin/CombineLocalsIntoPointCheck.cpp
@@ -91,7 +91,7 @@ static void CheckDecl( CombineLocalsIntoPointCheck &Check, const MatchFinder::Ma
     const VarDecl *ZDecl = dyn_cast_or_null<VarDecl>( NextDecl );
 
     // Avoid altering bool variables
-    if( StringRef( XDecl->getType().getAsString() ).endswith( "ool" ) ) {
+    if( StringRef( XDecl->getType().getAsString() ).ends_with( "ool" ) ) {
         return;
     }
 

--- a/tools/clang-tidy-plugin/HeaderGuardCheck.cpp
+++ b/tools/clang-tidy-plugin/HeaderGuardCheck.cpp
@@ -107,7 +107,7 @@ class HeaderGuardPPCallbacks : public PPCallbacks
         std::string GetFileName( SourceLocation Loc ) {
             SourceManager &SM = PP->getSourceManager();
             FileID Id = SM.getFileID( Loc );
-            if( const FileEntry *Entry = SM.getFileEntryForID( Id ) ) {
+            if( const OptionalFileEntryRef Entry = SM.getFileEntryRefForID( Id ) ) {
                 return cleanPath( Entry->getName() );
             } else {
                 return {};

--- a/tools/clang-tidy-plugin/NoLongCheck.cpp
+++ b/tools/clang-tidy-plugin/NoLongCheck.cpp
@@ -123,7 +123,7 @@ static void CheckDecl( NoLongCheck &Check, const MatchFinder::MatchResult &Resul
     if( alternatives.empty() ) {
         return;
     }
-    if( MatchedDecl->getName().startswith( "__" ) ) {
+    if( MatchedDecl->getName().starts_with( "__" ) ) {
         // Can happen for e.g. compiler-generated code inside an implicitly
         // generated function
         return;

--- a/tools/clang-tidy-plugin/SimplifyPointConstructorsCheck.cpp
+++ b/tools/clang-tidy-plugin/SimplifyPointConstructorsCheck.cpp
@@ -54,7 +54,7 @@ struct ExpressionCategory {
 
     ExpressionCategory( const MatchFinder::MatchResult &Result, const Expr *E ) :
         Replacement( getText( Result, E ) ) {
-        if( StringRef( Replacement ).endswith( "->" ) ) {
+        if( StringRef( Replacement ).ends_with( "->" ) ) {
             Replacement.erase( Replacement.end() - 2, Replacement.end() );
         }
         QualType EType = E->getType();

--- a/tools/clang-tidy-plugin/StaticIntIdConstantsCheck.cpp
+++ b/tools/clang-tidy-plugin/StaticIntIdConstantsCheck.cpp
@@ -40,7 +40,7 @@ static void CheckConstructor( StaticIntIdConstantsCheck &Check,
     }
 
     StringRef VarName = IntIdVarDecl->getName();
-    if( VarName.endswith( "null" ) || VarName.endswith( "NULL" ) ) {
+    if( VarName.ends_with( "null" ) || VarName.ends_with( "NULL" ) ) {
         // Null constants are OK because they probably don't vary
         return;
     }

--- a/tools/clang-tidy-plugin/StaticStringIdConstantsCheck.cpp
+++ b/tools/clang-tidy-plugin/StaticStringIdConstantsCheck.cpp
@@ -103,7 +103,7 @@ static std::string GetPrefixFor( const CXXRecordDecl *Type, StaticStringIdConsta
     for( const char *Suffix : {
              "_type", "_info"
          } ) {
-        if( StringRef( TypeName ).endswith( Suffix ) ) {
+        if( StringRef( TypeName ).ends_with( Suffix ) ) {
             TypeName.erase( TypeName.end() - strlen( Suffix ), TypeName.end() );
         }
     }
@@ -123,7 +123,7 @@ static std::string GetCanonicalName( const CXXRecordDecl *Type, const StringRef 
     }
 
     static const std::string anon_prefix = "_anonymous_namespace___";
-    if( StringRef( Result ).startswith( anon_prefix ) ) {
+    if( StringRef( Result ).starts_with( anon_prefix ) ) {
         Result.erase( Result.begin(), Result.begin() + anon_prefix.size() );
     }
 
@@ -200,7 +200,7 @@ void StaticStringIdConstantsCheck::CheckConstructor( const MatchFinder::MatchRes
         std::string CurrentName = VarDeclParent->getNameAsString();
         if( CurrentName != CanonicalName &&
             !PreviousDeclIsExtern &&
-            !StringRef( CurrentName ).startswith( "fuel_type_" ) ) {
+            !StringRef( CurrentName ).starts_with( "fuel_type_" ) ) {
             SourceRange Range =
                 DeclarationNameInfo( VarDeclParent->getDeclName(), VarDeclParent->getLocation()
                                    ).getSourceRange();
@@ -528,7 +528,7 @@ static void CheckDeclRef( StaticStringIdConstantsCheck &Check,
     std::string CurrentName = VarDeclParent->getNameAsString();
 
     if( CurrentName != CanonicalName &&
-        !StringRef( CurrentName ).startswith( "fuel_type_" ) ) {
+        !StringRef( CurrentName ).starts_with( "fuel_type_" ) ) {
         Check.diag(
             Ref->getBeginLoc(),
             "Use of string_id %0 should be named '%1'."

--- a/tools/clang-tidy-plugin/TestFilenameCheck.cpp
+++ b/tools/clang-tidy-plugin/TestFilenameCheck.cpp
@@ -36,7 +36,7 @@ class TestFilenameCallbacks : public PPCallbacks
 
             if( MacroName == "TEST_CASE" ) {
                 StringRef Filename = SM->getBufferName( Range.getBegin() );
-                bool IsTestFilename = Filename.endswith( "_test.cpp" );
+                bool IsTestFilename = Filename.ends_with( "_test.cpp" );
 
                 if( !IsTestFilename ) {
                     Check->diag( Range.getBegin(),

--- a/tools/clang-tidy-plugin/UnusedStaticsCheck.cpp
+++ b/tools/clang-tidy-plugin/UnusedStaticsCheck.cpp
@@ -48,7 +48,7 @@ void UnusedStaticsCheck::check( const MatchFinder::MatchResult &Result )
 
     // Ignore cases that are not static linkage
     Linkage Lnk = ThisDecl->getFormalLinkage();
-    if( Lnk != InternalLinkage && Lnk != UniqueExternalLinkage ) {
+    if( Lnk != Linkage::Internal && Lnk != Linkage::UniqueExternal ) {
         return;
     }
 

--- a/tools/clang-tidy-plugin/UseLocalizedSortingCheck.cpp
+++ b/tools/clang-tidy-plugin/UseLocalizedSortingCheck.cpp
@@ -128,7 +128,7 @@ static void CheckOpCall( UseLocalizedSortingCheck &Check, const MatchFinder::Mat
     }
 
     StringRef Arg0Text = getText( Result, Arg0Expr );
-    if( Arg0Text.endswith( "id" ) ) {
+    if( Arg0Text.ends_with( "id" ) ) {
         return;
     }
 

--- a/tools/clang-tidy-plugin/UsePointArithmeticCheck.cpp
+++ b/tools/clang-tidy-plugin/UsePointArithmeticCheck.cpp
@@ -105,7 +105,7 @@ struct ExpressionComponent {
     }
 
     void complete_init() {
-        if( StringRef( objectRef ).endswith( "->" ) ) {
+        if( StringRef( objectRef ).ends_with( "->" ) ) {
             objectRef.erase( objectRef.end() - 2, objectRef.end() );
         }
     }

--- a/tools/clang-tidy-plugin/Utils.cpp
+++ b/tools/clang-tidy-plugin/Utils.cpp
@@ -16,19 +16,19 @@ bool isPointMethod( const FunctionDecl *d )
 
 NameConvention::NameConvention( StringRef xName )
 {
-    if( xName.endswith( "x" ) ) {
+    if( xName.ends_with( "x" ) ) {
         root = xName.drop_back().str();
         capital = false;
         atEnd = true;
-    } else if( xName.endswith( "X" ) ) {
+    } else if( xName.ends_with( "X" ) ) {
         root = xName.drop_back().str();
         capital = true;
         atEnd = true;
-    } else if( xName.startswith( "x" ) ) {
+    } else if( xName.starts_with( "x" ) ) {
         root = xName.drop_front().str();
         capital = false;
         atEnd = false;
-    } else if( xName.startswith( "X" ) ) {
+    } else if( xName.starts_with( "X" ) ) {
         root = xName.drop_front().str();
         capital = true;
         atEnd = false;

--- a/tools/clang-tidy-plugin/Utils.h
+++ b/tools/clang-tidy-plugin/Utils.h
@@ -89,7 +89,7 @@ inline bool isInHeader( const SourceLocation &loc, const SourceManager &SM )
     StringRef Filename = SM.getFilename( loc );
     // The .h.tmp.cpp catches the test case; that's the style of filename used
     // by lit.
-    return !SM.isInMainFile( loc ) || Filename.endswith( ".h.tmp.cpp" );
+    return !SM.isInMainFile( loc ) || Filename.ends_with( ".h.tmp.cpp" );
 }
 
 inline bool isPointType( const CXXRecordDecl *R )


### PR DESCRIPTION
#### Summary
Infrastructure "Upgrade clang-tidy to LLVM 18"

#### Purpose of change
Upgrade clang-tidy to LLVM 18, and fix (some) newly firing lints.

#### Describe the solution
Upgrade clang-tidy to LLVM 18, and fix (some) newly firing lints. (lol)

But in seriousness, here's the new lint list and rationale for their (non-)inclusion:

Improved existing checks:
- [modernize-make-shared](https://clang.llvm.org/extra/clang-tidy/checks/modernize/make-shared.html): ✅  Fixed, reenabled.
  the new check is the `x.reset(new T(args))` form being deprecated in favor of `x=make_shared::<T>(args)` 
- [readability-redundant-member-init](https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-member-init.html): ✅  Fixed reenabled.
   I don't know why it was not firing in -17, and spent no effort investigating

Newly introduced checks:
- [bugprone-chained-comparison](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/chained-comparison.html): ✅ Fixed, reenabled
  Was only firing in tests, due to how catch2 works internally. I applied the same fix in our copy of catch2 as upstream did in  https://github.com/catchorg/Catch2/commit/1078e7e95b3a06d4dadc75188de48bc4afffb955
- [bugprone-multi-level-implicit-pointer-conversion](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/multi-level-implicit-pointer-conversion.html): ✅ Edit: Fixed, enabled, thanks!  ~~Temporarily disabled~~
  This definitely fires in cata_bitset.h https://github.com/CleverRaven/Cataclysm-DDA/blob/470e1312ee6058115b1f0136deae9144b3ab85c5/src/cata_bitset.h#L179-L182  which looks *incredibly* scary to the touch. I would like to reenable the check eventually so that perhaps the future is less scarily looking. It is possible the lint is also firing in other places, but it's hard to know (due to how spammy this particular error is). cc @akrieger  for  any input on how to rewrite it or silence it. The error message:
```
##[error]/home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/cata_bitset.h:182:25: error: multilevel pointer conversion from 'block_t **' (aka 'unsigned long **') to 'void *', please use explicit cast [bugprone-multi-level-implicit-pointer-conversion,-warnings-as-errors]
  182 |                 memcpy( &ret, &storage_, sizeof( storage_ ) );
      |  
```

- [bugprone-optional-value-conversion](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/optional-value-conversion.html): ✅ Fixed, Enabled
- [bugprone-unused-local-non-trivial-variable](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/unused-local-non-trivial-variable.html):  :x: ⌛ Temporarily disabled
  Good check, but fixing the errors fills me with dread, since I keep discovering ACTUAL bugs where the variable was *meant* to be used in some way or another, but wasn't, and the code is not doing what it means to do. But figuring out "what does code actually mean to do here" is *hard*, and I just aaaaaAAAAAA! I can't.
- [clang-analyzer-optin.core.EnumCastOutOfRange](https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-enumcastoutofrange): :x: Disabled permanently
  The lint checks that we are only using the enum variants we've declared. We are actively using enum variants outside of those we've declared (see the Limitation sections in the link above). Not applicable to our codebase. Disabled. (Cool check tho!)
- [performance-enum-size](https://clang.llvm.org/extra/clang-tidy/checks/performance/enum-size.html):  :x: 🤷  Untriaged, disabled
  I have no opinion on this lint myself, and there was some pushback when it was mentioned last time, so I'll just leave it disabled for now.
- [readability-avoid-nested-conditional-operator](https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-nested-conditional-operator.html): :x: ⌛ Temporarily disabled
  Great lint! I am positively unable to read the cursed chained ternaries, and I would much appreciated if we didn't add more. But there's too much code to fix/silence in one go, and I'm not doing it in this PR. But the lint is great!
- [readability-avoid-return-with-void-value](https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-return-with-void-value.html): ✅ Fixed, Enabled
- [readability-container-size-empty](https://clang.llvm.org/extra/clang-tidy/checks/readability/container-size-empty.html):  ✅ Fixed, Kept enabled
- [readability-redundant-casting](https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-casting.html):  :x: 🤷Untriaged, Disabled
  I've spent next to no effort thinking about this. If someone else has strong opinions - feel free to do something here. It claims to be auto-fixable.
- [readability-redundant-inline-specifier](https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-inline-specifier.html): :x: Disabled until 2027
 It suggests dropping `inline` from methods defined entirely inside the class definition (i.e. full body in a .h file). This is a no-op today, but would become a behavior change when/if we migrate to C++20 modules. Disable until then, reevaluate the decision some other day.
- [readability-reference-to-constructed-temporary](https://clang.llvm.org/extra/clang-tidy/checks/readability/reference-to-constructed-temporary.html): ✅ Fixed, Enabled

Bonus: Disabled two checks for perf reasons:
- [misc-unused-using-decls](https://clang.llvm.org/extra/clang-tidy/checks/misc/unused-using-decls.html):  :x:
  Not useful because we are not using `using`. Also it's already not catching issues when `using` a non-class-methods - see [this line](https://github.com/CleverRaven/Cataclysm-DDA/blob/028b080ff57aa4d10426065d4b72de9e9730717a/src/activity_item_handling.cpp#L187) not being complained about as an example. This is a top-1 most time consuming lint presently
- [modernize-replace-auto-ptr](https://clang.llvm.org/extra/clang-tidy/checks/modernize/replace-auto-ptr.html):  :x:
  An okay lint on its own, but it is very unlikely that someone would introduce `auto_ptr` into the codebase given that we are already using `unique_ptr` extensively which is just better. The lint is too expensive to justify its existence though

The change is granularly split by-commit, and there might be a tiny bit of extra context in the commit message.

For full logs of CI run after upgrade but before disabling the new checks - see https://github.com/moxian/Cataclysm-DDA/actions/runs/13222040516 (you will need to download the logs, because they are nigh unreadable on the web)

#### Describe alternatives you've considered

- classic "not do this"
- upgrade directly to llvm 19. The plugin code changes are not too bad, but I don't think I can handle triaging an extra bunch of checks in one go
- The list of checks i did decide to enable/disable is up to debate, lemme know if you have strong feelings on those

#### Testing

CI

#### Additional context
This is likely to conflict with #78957