### PR TITLE
unrack vehicle on destroyed bike rack

### DIFF
--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -271,7 +271,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "4 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "flags": [ "BIKE_RACK_VEH", "MULTISQUARE" ],
+    "flags": [ "BIKE_RACK_VEH", "MULTISQUARE", "UNMOUNT_ON_DAMAGE" ],
     "damage_reduction": { "all": 10 },
     "variants": [ { "symbols": "=", "symbols_broken": "#" } ]
   },

--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -271,7 +271,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "4 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "flags": [ "BIKE_RACK_VEH", "MULTISQUARE", "UNMOUNT_ON_DAMAGE" ],
+    "flags": [ "BIKE_RACK_VEH", "MULTISQUARE" ],
     "damage_reduction": { "all": 10 },
     "variants": [ { "symbols": "=", "symbols_broken": "#" } ]
   },

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3190,9 +3190,9 @@ int vehicle::get_next_shifted_index( int original_index, Character &you ) const
  * on the X or Y axis. Returns 0, 1, or 2 lists of indices.
  */
 std::vector<std::vector<int>> vehicle::find_lines_of_parts(
-                               int part, const std::string &flag, bool ignore_broken ) const
+                               int part, const std::string &flag, bool only_healthy ) const
 {
-    const auto possible_parts = ignore_broken ? get_avail_parts( flag ) :  get_any_parts( flag );
+    const auto possible_parts = only_healthy ? get_avail_parts( flag ) :  get_any_parts( flag );
     std::vector<std::vector<int>> ret_parts;
     if( empty( possible_parts ) ) {
         return ret_parts;
@@ -3211,7 +3211,7 @@ std::vector<std::vector<int>> vehicle::find_lines_of_parts(
     for( const vpart_reference &vpr : possible_parts ) {
         const vehicle_part &vp_other = vpr.part();
         const vpart_info &vpi_other = vp_other.info();
-        if( ( vp_other.is_broken() && ignore_broken ) ||
+        if( ( vp_other.is_broken() && only_healthy ) ||
             !vpi_other.has_flag( "MULTISQUARE" ) ||
             vpi_other.id != part_id )  {
             continue;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1358,7 +1358,7 @@ class vehicle
         // Given a part and a flag, returns the indices of all contiguously adjacent parts
         // with the same flag on the X and Y Axis
         std::vector<std::vector<int>> find_lines_of_parts( int part, const std::string &flag,
-                                   bool ignore_broken = true ) const;
+                                   bool only_healthy = true ) const;
 
         // Translate mount coordinates "p" using current pivot direction and anchor and return tile coordinates
         point_rel_ms coord_translate( const point_rel_ms &p ) const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1076,7 +1076,7 @@ class vehicle
         // attempts to find any racked vehicles that can be unracked on any of the list_of_racks
         // @returns vector of structs with data required to unrack each vehicle
         std::vector<unrackable_vehicle> find_vehicles_to_unrack( int rack,
-                bool ignore_broken = true ) const;
+                bool only_healthy = true ) const;
 
         // merge a previously found single tile vehicle into this vehicle
         bool merge_rackable_vehicle( map *here, vehicle *carry_veh, const std::vector<int> &rack_parts );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1075,7 +1075,8 @@ class vehicle
 
         // attempts to find any racked vehicles that can be unracked on any of the list_of_racks
         // @returns vector of structs with data required to unrack each vehicle
-        std::vector<unrackable_vehicle> find_vehicles_to_unrack( int rack ) const;
+        std::vector<unrackable_vehicle> find_vehicles_to_unrack( int rack,
+                bool ignore_broken = true ) const;
 
         // merge a previously found single tile vehicle into this vehicle
         bool merge_rackable_vehicle( map *here, vehicle *carry_veh, const std::vector<int> &rack_parts );
@@ -1356,7 +1357,8 @@ class vehicle
         int get_next_shifted_index( int original_index, Character &you ) const;
         // Given a part and a flag, returns the indices of all contiguously adjacent parts
         // with the same flag on the X and Y Axis
-        std::vector<std::vector<int>> find_lines_of_parts( int part, const std::string &flag ) const;
+        std::vector<std::vector<int>> find_lines_of_parts( int part, const std::string &flag,
+                                   bool ignore_broken = true ) const;
 
         // Translate mount coordinates "p" using current pivot direction and anchor and return tile coordinates
         point_rel_ms coord_translate( const point_rel_ms &p ) const;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1724,7 +1724,8 @@ void vehicle::build_bike_rack_menu( veh_menu &menu, int part )
         has_rack_actions = true;
     }
 
-    for( const unrackable_vehicle &unrackable : find_vehicles_to_unrack( part ) ) {
+    for( const unrackable_vehicle &unrackable : find_vehicles_to_unrack(
+             part, /*only_healthy=*/ false ) ) {
         menu.add( string_format( _( "Remove the %s from the rack" ), unrackable.name ) )
         .hotkey_auto()
         .skip_locked_check()

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1693,7 +1693,7 @@ void vehicle::build_bike_rack_menu( veh_menu &menu, int part )
     // @returns true if vehicle already has a vehicle with this name racked
     const auto has_veh_name_racked = [this]( const std::string & name ) {
         for( const vpart_reference &vpr : get_any_parts( "BIKE_RACK_VEH" ) ) {
-            for( const unrackable_vehicle &unrackable : find_vehicles_to_unrack( vpr.part_index() ) ) {
+            for( const unrackable_vehicle &unrackable : find_vehicles_to_unrack( vpr.part_index(), true ) ) {
                 if( unrackable.name == name ) {
                     return true;
                 }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1693,7 +1693,7 @@ void vehicle::build_bike_rack_menu( veh_menu &menu, int part )
     // @returns true if vehicle already has a vehicle with this name racked
     const auto has_veh_name_racked = [this]( const std::string & name ) {
         for( const vpart_reference &vpr : get_any_parts( "BIKE_RACK_VEH" ) ) {
-            for( const unrackable_vehicle &unrackable : find_vehicles_to_unrack( vpr.part_index(), true ) ) {
+            for( const unrackable_vehicle &unrackable : find_vehicles_to_unrack( vpr.part_index() ) ) {
                 if( unrackable.name == name ) {
                     return true;
                 }


### PR DESCRIPTION
#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fix #76613
destroying bike racks with racked vehicles would lead to not being able to unrack to, permanently merging the vehicles.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
unrack vehicle when rack is removed by any means.
~~give rack UNMOUNT_ON_DAMAGE flag, since repaired(replaced) parts apparently do not keep flags.~~
when replacing XX damaged rack, the old one gets removed, so vehicle is unmounted, UNMOUNT_ON_DAMAGE is no longer required.
allow unracking from destroyed racks by allowing find_vehicles_to_unrack to consider broken parts.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
When repairing a destroyed bike rack or installing new rack, inherit old flags.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
When directly & indirectly (destroying frame its on) destroying rack, it gets unracked.
can inspect undamaged rack to unrack vehicle, even if one of the other racks is XX damaged.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It does not fix vehicles from old saves, where the destroyed part has been replaced, since repaired parts do not have the required `vp_flag::carried_flag` flag
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
