### PR TITLE
Two small changes to help IWYU review

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -183,9 +183,6 @@ struct act_item {
 };
 
 // TODO: Deliberately unified with multidrop. Unify further.
-using drop_location = std::pair<item_location, int>;
-using drop_locations = std::list<std::pair<item_location, int>>;
-
 static bool same_type( const std::list<item> &items )
 {
     return std::all_of( items.begin(), items.end(), [&items]( const item & it ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -182,7 +182,6 @@ struct act_item {
           consumed_moves( consumed_moves ) {}
 };
 
-// TODO: Deliberately unified with multidrop. Unify further.
 static bool same_type( const std::list<item> &items )
 {
     return std::all_of( items.begin(), items.end(), [&items]( const item & it ) {

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -37,6 +37,7 @@ class basecamp;
 class character_id;
 class faction;
 class item;
+class inventory_filter_preset;
 class npc;
 class recipe;
 class time_duration;

--- a/src/character.h
+++ b/src/character.h
@@ -118,9 +118,6 @@ enum class recipe_filter_flags : int;
 enum class steed_type : int;
 enum class proficiency_bonus_type : int;
 
-using drop_location = std::pair<item_location, int>;
-using drop_locations = std::list<drop_location>;
-
 using bionic_uid = unsigned int;
 
 constexpr int MAX_CLAIRVOYANCE = 40;

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -38,9 +38,6 @@ class player_morale;
 struct bodygraph_info;
 struct damage_unit;
 
-using drop_location = std::pair<item_location, int>;
-using drop_locations = std::list<drop_location>;
-
 struct item_penalties {
     std::vector<bodypart_id> body_parts_with_stacking_penalty;
     std::vector<bodypart_id> body_parts_with_out_of_order_penalty;

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -16,6 +16,7 @@
 class Character;
 struct tripoint;
 
+enum efile_action : int;
 class repair_item_actor;
 class salvage_actor;
 

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -22,8 +22,6 @@ class salvage_actor;
 
 using item_filter = std::function<bool( const item & )>;
 using item_location_filter = std::function<bool ( const item_location & )>;
-using drop_location = std::pair<item_location, int>;
-using drop_locations = std::list<drop_location>;
 
 /**
 * A boiled-down shortcut for inventory_selector_preset.

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -54,9 +54,6 @@ enum class toggle_mode : int {
 struct inventory_input;
 struct navigation_mode_data;
 
-using drop_location = std::pair<item_location, int>;
-using drop_locations = std::list<drop_location>;
-
 struct collation_meta_t {
     item_location tip;
     bool collapsed = true;

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -178,4 +178,8 @@ class item_location
 std::unique_ptr<talker> get_talker_for( item_location &it );
 std::unique_ptr<const_talker> get_const_talker_for( const item_location &it );
 std::unique_ptr<talker> get_talker_for( item_location *it );
+
+using drop_location = std::pair<item_location, int>;
+using drop_locations = std::list<drop_location>;
+
 #endif // CATA_SRC_ITEM_LOCATION_H

--- a/src/npc.h
+++ b/src/npc.h
@@ -79,8 +79,6 @@ enum game_message_type : int;
 class gun_mode;
 
 using overmap_location_str_id = string_id<overmap_location>;
-using drop_location = std::pair<item_location, int>;
-using drop_locations = std::list<drop_location>;
 
 void parse_tags( std::string &phrase, const Character &u, const Creature &me,
                  const itype_id &item_type = itype_id::NULL_ID() );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -34,6 +34,7 @@
 #include "item_stack.h"
 #include "line.h"
 #include "map.h"
+#include "npc.h"
 #include "point.h"
 #include "tileray.h"
 #include "type_id.h"
@@ -47,7 +48,6 @@ class JsonOut;
 class map;
 class monster;
 class nc_color;
-class npc;
 class vehicle;
 class vehicle_part_range;
 class veh_menu;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Minor code cleanups cherry-picked from https://github.com/CleverRaven/Cataclysm-DDA/pull/79631 to help with review

#### Describe the solution
Two changes:
- some header reshuffling around since iwyu REALLY didn't like the incomplete `npc` type used for the turret in vehicle.h
- the definition of `drop_location` / `drop_locations` got consolidated into a single file that's appropriate for those, so that IWYU stops suggesting to add "wrong" includes providing those

#### Describe alternatives you've considered
#### Testing
#### Additional context
Requested by @akrieger 