### PR TITLE
Implement Riot Damage in City Roads and Subway Stations. Adjust Fire and Blood placement over time.

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2691,5 +2691,10 @@
     "id": "BANK_NETWORKED",
     "type": "json_flag",
     "//": "Vending machines with this flag will allow purchasing items with your bank balance."
+  },
+  {
+    "id": "NATURAL_UNDERGROUND",
+    "type": "json_flag",
+    "//": "Wall tiles with this flag occur naturally underground and are not manmade."
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -1789,6 +1789,7 @@
     "copy-from": "t_abstract_wall_earthen",
     "name": "solid earth",
     "description": "A wall of solid earth.",
+    "extend": { "flags": [ "NATURAL_UNDERGROUND" ] },
     "delete": { "flags": [ "AUTO_WALL_SYMBOL" ] },
     "roof": "t_dirt",
     "bash": {
@@ -1808,6 +1809,7 @@
     "name": "solid rock",
     "description": "A wall of solid rock, could be full of all kinds of interesting things.  Best grab your pickaxe or equivalent digging implement, and strike the earth!",
     "color": "white",
+    "extend": { "flags": [ "NATURAL_UNDERGROUND" ] },
     "delete": { "flags": [ "AUTO_WALL_SYMBOL" ] },
     "roof": "t_rock_floor_no_roof",
     "bash": {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -144,7 +144,7 @@
     "see_cost": "high",
     "extras": "build",
     "mondensity": 2,
-    "flags": [ "KNOWN_DOWN", "SIDEWALK" ]
+    "flags": [ "KNOWN_DOWN", "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -167,7 +167,7 @@
     "color": "yellow",
     "see_cost": "full_high",
     "extras": "subway",
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "NO_ROTATE" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "NO_ROTATE", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",
@@ -178,7 +178,7 @@
     "color": "yellow",
     "see_cost": "full_high",
     "extras": "subway",
-    "flags": [ "KNOWN_UP", "NO_ROTATE" ]
+    "flags": [ "KNOWN_UP", "NO_ROTATE", "PP_GENERATE_RIOT_DAMAGE" ]
   },
   {
     "type": "overmap_terrain",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -659,6 +659,7 @@ List of known flags, used in both `furniture` and `terrain`.  Some work for both
 - ```MINEABLE``` Can be mined with a pickaxe/jackhammer.
 - ```MOUNTABLE``` Suitable for guns with the `MOUNTED_GUN` flag.
 - ```NANOFAB_TABLE``` This is a nanofabricator, and it can generate items out of specific blueprints.  Hardcoded
+- ```NATURAL_UNDERGROUND``` This terrain occurs naturally underground and is not man made.
 - ```NOCOLLIDE``` Feature that simply doesn't collide with vehicles at all.
 - ```NOITEM``` Items cannot be added here but may overflow to adjacent tiles.  See also `DESTROY_ITEM`.
 - ```NO_FLOOR``` Things should fall when placed on this tile.

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -277,6 +277,7 @@ std::string enum_to_string<ter_furn_flag>( ter_furn_flag data )
         case ter_furn_flag::TFLAG_CLIMB_ADJACENT: return "CLIMB_ADJACENT";
         case ter_furn_flag::TFLAG_FLOATS_IN_AIR: return "FLOATS_IN_AIR";
         case ter_furn_flag::TFLAG_HARVEST_REQ_CUT1: return "HARVEST_REQ_CUT1";
+        case ter_furn_flag::TFLAG_NATURAL_UNDERGROUND: return "NATURAL_UNDERGROUND";
 
         // *INDENT-ON*
         case ter_furn_flag::NUM_TFLAG_FLAGS:

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -351,6 +351,7 @@ enum class ter_furn_flag : int {
     TFLAG_CLIMB_ADJACENT,
     TFLAG_FLOATS_IN_AIR,
     TFLAG_HARVEST_REQ_CUT1,
+    TFLAG_NATURAL_UNDERGROUND,
 
     NUM_TFLAG_FLAGS
 };

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -477,7 +477,7 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
         }
 
         // Decrease the chance of fire spawning as the Cataclysm progresses to the min fire chance of 1 in 10,000
-        if( x_in_y( 1, ( std::min(2000 + 714 * days_since_cataclysm, 10000) ) ) ) {
+        if( x_in_y( 1, ( std::min( 2000 + 714 * days_since_cataclysm, 10000 ) ) ) ) {
             if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
                 md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE_ASH, current_tile ) ||
                 md.has_flag_ter_or_furn( ter_furn_flag:: TFLAG_FLAMMABLE_HARD, current_tile ) ||

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -268,7 +268,7 @@ static bool tile_can_have_blood( map &md, const tripoint_bub_ms &current_tile,
                !md.has_flag_ter( ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile );
     } else {
         if( !md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) &&
-            !x_in_y( ( 30.0 - days_since_cataclysm ) / 30.0, 1 ) ) {
+            x_in_y( days_since_cataclysm, 30 ) ) {
             // Placement of blood outdoors scales down over the course of 30 days until no further blood is placed.
             return false;
         }
@@ -476,13 +476,16 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
             }
         }
 
-        // Decrease the chance of fire spawning as the Cataclysm progresses to the min fire chance of 1 in 10,000
-        if( x_in_y( 1,  std::min( 2000 + 714 * days_since_cataclysm, 10000 ) ) ) {
+        // Randomly spawn fires, with the chance decreasing from 1 in 2000 to 1 in 10,000 over the
+        // course of 14 days
+        if( x_in_y( 1,  std::min( 2000 + 571 * days_since_cataclysm, 10000 ) ) ) {
             if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
                 md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE_ASH, current_tile ) ||
-                md.has_flag_ter_or_furn( ter_furn_flag:: TFLAG_FLAMMABLE_HARD, current_tile ) ||
+                md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE_HARD, current_tile ) ||
                 days_since_cataclysm < 3 ) {
                 // Only place fire on flammable surfaces unless the cataclysm started very recently
+                // Note that most floors are FLAMMABLE_HARD, this is fine. This check is primarily geared
+                // at preventing fire in the middle of roads or parking lots.
                 md.add_field( current_tile, field_fd_fire );
             }
         }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -264,7 +264,8 @@ static bool tile_can_have_blood( map &md, const tripoint_bub_ms &current_tile,
     // Wall streaks stick to walls, like blood was splattered against the surface
     // Floor streaks avoid obstacles to look more like a person left the streak behind (Not walking through walls, closed doors, windows, or furniture)
     if( wall_streak ) {
-        return  md.has_flag_ter( ter_furn_flag::TFLAG_WALL, current_tile );
+        return md.has_flag_ter( ter_furn_flag::TFLAG_WALL, current_tile ) &&
+               !md.has_flag_ter( ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile );
     } else {
         if( !md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) &&
             !x_in_y( ( ( 30 - days_since_cataclysm ) / 30 ), 1 ) ) {
@@ -403,13 +404,8 @@ static void place_bool_pools( map &md, const tripoint_bub_ms &current_tile,
 
 static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
 {
-    if( p.z() < 0 ) {
-        // for the moment make sure we don't apply this to labs or other places
-        debugmsg( "Riot damage mapgen generator called on underground structure.  This is likely a bug." );
-        return;
-    }
-
     std::list<tripoint_bub_ms> all_points_in_map;
+
 
     int days_since_cataclysm = to_days<int>( calendar::turn - calendar::start_of_cataclysm );
 
@@ -427,6 +423,10 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
 
         // Do nothing at random!;
         if( x_in_y( 10, 100 ) ) {
+            continue;
+        }
+        // Skip naturally occuring underground wall tiles
+        if (md.has_flag_ter(ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile)) {
             continue;
         }
         // Bash stuff at random!

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -478,8 +478,10 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
 
         // Base + (Max Increase / Days until Max Increase ) * Days passed
         // Decrease the chance of fire spawning over the first week of the cataclysm
-        if( x_in_y( 1, ( 1000 + ( 6000 / 7 ) * days_since_cataclysm ) ) ) {
-            if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ) {
+        if( x_in_y( 1, ( 2000 + ( 6000 / 7 ) * days_since_cataclysm ) ) ) {
+            if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
+                days_since_cataclysm < 3 ) {
+                // Only place fire on flammable surfaces unless the cataclysm started very recently
                 md.add_field( current_tile, field_fd_fire );
             }
         }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -478,7 +478,7 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
 
         // Base + (Max Increase / Days until Max Increase ) * Days passed
         // Decrease the chance of fire spawning over the first week of the cataclysm
-        if( x_in_y( 1, ( 2000 + ( 6000 / 7 ) * days_since_cataclysm ) ) ) {
+        if( x_in_y( 1, ( 2000 + ( 4000 / 7 ) * days_since_cataclysm ) ) ) {
             if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
                 days_since_cataclysm < 3 ) {
                 // Only place fire on flammable surfaces unless the cataclysm started very recently

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -259,28 +259,35 @@ static tripoint_bub_ms get_point_from_direction( int direction,
 }
 
 static bool tile_can_have_blood( map &md, const tripoint_bub_ms &current_tile,
-                                 bool wall_streak )
+                                 bool wall_streak, int days_since_cataclysm )
 {
     // Wall streaks stick to walls, like blood was splattered against the surface
     // Floor streaks avoid obstacles to look more like a person left the streak behind (Not walking through walls, closed doors, windows, or furniture)
     if( wall_streak ) {
-        return  md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, current_tile );
+        return  md.has_flag_ter( ter_furn_flag::TFLAG_WALL, current_tile );
     } else {
-        return !md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, current_tile ) &&
-               !md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WINDOW, current_tile ) &&
-               !md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_DOOR, current_tile ) &&
+        if( !md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) &&
+            !x_in_y( ( ( 30 - days_since_cataclysm ) / 30 ), 1 ) ) {
+            // Placement of blood outdoors scales down over the course of 30 days until no further blood is placed.
+            return false;
+        }
+
+        return !md.has_flag_ter( ter_furn_flag::TFLAG_WALL, current_tile ) &&
+               !md.has_flag_ter( ter_furn_flag::TFLAG_WINDOW, current_tile ) &&
+               !md.has_flag_ter( ter_furn_flag::TFLAG_DOOR, current_tile ) &&
                !md.has_furn( current_tile );
     }
 
 }
 
-static void place_blood_on_adjacent( map &md, const tripoint_bub_ms &current_tile, int chance )
+static void place_blood_on_adjacent( map &md, const tripoint_bub_ms &current_tile, int chance,
+                                     int days_since_catacylsm )
 {
     for( int i = static_cast<int>( blood_trail_direction::first );
          i <= static_cast<int>( blood_trail_direction::last ); i++ ) {
         tripoint_bub_ms adjacent_tile = get_point_from_direction( i, current_tile );
 
-        if( !tile_can_have_blood( md, adjacent_tile, false ) ) {
+        if( !tile_can_have_blood( md, adjacent_tile, false, days_since_catacylsm ) ) {
             continue;
         }
         if( rng( 1, 100 ) < chance ) {
@@ -289,7 +296,8 @@ static void place_blood_on_adjacent( map &md, const tripoint_bub_ms &current_til
     }
 }
 
-static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
+static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile,
+                                 int days_since_cataclysm )
 {
     int streak_length = rng( 3, 12 );
     int streak_direction = rng( static_cast<int>( blood_trail_direction::first ),
@@ -297,7 +305,7 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
 
     bool wall_streak = md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, current_tile );
 
-    if( !tile_can_have_blood( md, current_tile, wall_streak ) ) {
+    if( !tile_can_have_blood( md, current_tile, wall_streak, days_since_cataclysm ) ) {
         // Quick check the tile is valid.
         return;
     }
@@ -308,7 +316,7 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
     for( int i = 0; i < streak_length; i++ ) {
         tripoint_bub_ms destination_tile = get_point_from_direction( streak_direction, last_tile );
 
-        if( !tile_can_have_blood( md, destination_tile, wall_streak ) ) {
+        if( !tile_can_have_blood( md, destination_tile, wall_streak, days_since_cataclysm ) ) {
             // We hit a non-valid tile. Try to find a new direction otherwise just terminate the streak.
             bool terminate_streak = true;
 
@@ -321,7 +329,7 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
                 }
                 tripoint_bub_ms adjacent_tile = get_point_from_direction( ii, last_tile );
 
-                if( tile_can_have_blood( md, adjacent_tile, wall_streak ) ) {
+                if( tile_can_have_blood( md, adjacent_tile, wall_streak, days_since_cataclysm ) ) {
                     streak_direction = ii;
                     destination_tile = adjacent_tile;
                     terminate_streak = false;
@@ -364,7 +372,7 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
             }
 
             tripoint_bub_ms adjacent_tile = get_point_from_direction( new_direction, last_tile );
-            if( tile_can_have_blood( md, adjacent_tile, wall_streak ) ) {
+            if( tile_can_have_blood( md, adjacent_tile, wall_streak, days_since_cataclysm ) ) {
                 md.add_field( adjacent_tile, field_fd_blood );
                 last_tile = adjacent_tile;
             }
@@ -372,23 +380,24 @@ static void place_blood_streaks( map &md, const tripoint_bub_ms &current_tile )
     }
 }
 
-static void place_bool_pools( map &md, const tripoint_bub_ms &current_tile )
+static void place_bool_pools( map &md, const tripoint_bub_ms &current_tile,
+                              int days_since_cataclysm )
 {
-    if( !tile_can_have_blood( md, current_tile, false ) ) {
+    if( !tile_can_have_blood( md, current_tile, false, days_since_cataclysm ) ) {
         // Quick check the first tile is valid for placement
         return;
     }
 
     md.add_field( current_tile, field_fd_blood );
-    place_blood_on_adjacent( md, current_tile, 60 );
+    place_blood_on_adjacent( md, current_tile, 60, days_since_cataclysm );
 
     for( int i = static_cast<int>( blood_trail_direction::first );
          i <= static_cast<int>( blood_trail_direction::last ); i++ ) {
         tripoint_bub_ms adjacent_tile = get_point_from_direction( i, current_tile );
-        if( !tile_can_have_blood( md, adjacent_tile, false ) ) {
+        if( !tile_can_have_blood( md, adjacent_tile, false, days_since_cataclysm ) ) {
             continue;
         }
-        place_blood_on_adjacent( md, adjacent_tile, 30 );
+        place_blood_on_adjacent( md, adjacent_tile, 30, days_since_cataclysm );
     }
 }
 
@@ -399,7 +408,11 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
         debugmsg( "Riot damage mapgen generator called on underground structure.  This is likely a bug." );
         return;
     }
+
     std::list<tripoint_bub_ms> all_points_in_map;
+
+    int days_since_cataclysm = to_days<int>( calendar::turn - calendar::start_of_cataclysm );
+
     // Placeholder / FIXME
     // This assumes that we're only dealing with regular 24x24 OMTs. That is likely not the case.
     for( int i = 0; i < SEEX * 2; i++ ) {
@@ -411,6 +424,7 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
     for( size_t i = 0; i < all_points_in_map.size(); i++ ) {
         // Pick a tile at random!
         tripoint_bub_ms current_tile = random_entry( all_points_in_map );
+
         // Do nothing at random!;
         if( x_in_y( 10, 100 ) ) {
             continue;
@@ -451,15 +465,23 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
             int behavior_roll = rng( 1, 100 );
 
             if( behavior_roll <= 20 ) {
-                md.add_field( current_tile, field_fd_blood );
+                if( tile_can_have_blood( md, current_tile, md.has_flag_ter( ter_furn_flag::TFLAG_WALL,
+                                         current_tile ), days_since_cataclysm ) ) {
+                    md.add_field( current_tile, field_fd_blood );
+                }
             } else if( behavior_roll <= 60 ) {
-                place_blood_streaks( md, current_tile );
+                place_blood_streaks( md, current_tile, days_since_cataclysm );
             } else {
-                place_bool_pools( md, current_tile );
+                place_bool_pools( md, current_tile, days_since_cataclysm );
             }
         }
-        if( x_in_y( 1, 2000 ) ) {
-            md.add_field( current_tile, field_fd_fire );
+
+        // Base + (Max Increase / Days until Max Increase ) * Days passed
+        // Decrease the chance of fire spawning over the first week of the cataclysm
+        if( x_in_y( 1, ( 1000 + ( 6000 / 7 ) * days_since_cataclysm ) ) ) {
+            if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ) {
+                md.add_field( current_tile, field_fd_fire );
+            }
         }
     }
 }
@@ -633,9 +655,12 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
         }
 
         // Apply post-process generators
-        if( ( any_missing || !save_results ) && overmap_buffer.ter( {p.x(), p.y(), gridz} )->has_flag(
-                oter_flags::pp_generate_riot_damage ) ) {
-            GENERATOR_riot_damage( *this, { p.x(), p.y(), gridz } );
+        const tripoint_abs_omt omt_point = { p.x(), p.y(), gridz };
+        oter_id omt = overmap_buffer.ter( omt_point );
+        if( ( any_missing || !save_results ) && omt->has_flag(
+                oter_flags::pp_generate_riot_damage ) || ( omt->has_flag( oter_flags::road ) &&
+                        overmap_buffer.is_in_city( omt_point ) ) ) {
+            GENERATOR_riot_damage( *this, omt_point );
         }
     }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -268,7 +268,7 @@ static bool tile_can_have_blood( map &md, const tripoint_bub_ms &current_tile,
                !md.has_flag_ter( ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile );
     } else {
         if( !md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) &&
-            !x_in_y( ( ( 30 - days_since_cataclysm ) / 30 ), 1 ) ) {
+            !x_in_y( ( 30.0 - days_since_cataclysm ) / 30.0, 1 ) ) {
             // Placement of blood outdoors scales down over the course of 30 days until no further blood is placed.
             return false;
         }
@@ -426,7 +426,7 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
             continue;
         }
         // Skip naturally occuring underground wall tiles
-        if (md.has_flag_ter(ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile)) {
+        if( md.has_flag_ter( ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile ) ) {
             continue;
         }
         // Bash stuff at random!
@@ -476,10 +476,11 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
             }
         }
 
-        // Base + (Max Increase / Days until Max Increase ) * Days passed
-        // Decrease the chance of fire spawning over the first week of the cataclysm
-        if( x_in_y( 1, ( 2000 + ( 4000 / 7 ) * days_since_cataclysm ) ) ) {
+        // Decrease the chance of fire spawning as the Cataclysm progresses to the min fire chance of 1 in 10,000
+        if( x_in_y( 1, ( std::min(2000 + 714 * days_since_cataclysm, 10000) ) ) ) {
             if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
+                md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE_ASH, current_tile ) ||
+                md.has_flag_ter_or_furn( ter_furn_flag:: TFLAG_FLAMMABLE_HARD, current_tile ) ||
                 days_since_cataclysm < 3 ) {
                 // Only place fire on flammable surfaces unless the cataclysm started very recently
                 md.add_field( current_tile, field_fd_fire );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -477,7 +477,7 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
         }
 
         // Decrease the chance of fire spawning as the Cataclysm progresses to the min fire chance of 1 in 10,000
-        if( x_in_y( 1, ( std::min( 2000 + 714 * days_since_cataclysm, 10000 ) ) ) ) {
+        if( x_in_y( 1,  std::min( 2000 + 714 * days_since_cataclysm, 10000 ) ) ) {
             if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
                 md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAMMABLE_ASH, current_tile ) ||
                 md.has_flag_ter_or_furn( ter_furn_flag:: TFLAG_FLAMMABLE_HARD, current_tile ) ||
@@ -660,10 +660,12 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
         // Apply post-process generators
         const tripoint_abs_omt omt_point = { p.x(), p.y(), gridz };
         oter_id omt = overmap_buffer.ter( omt_point );
-        if( ( any_missing || !save_results ) && omt->has_flag(
-                oter_flags::pp_generate_riot_damage ) || ( omt->has_flag( oter_flags::road ) &&
-                        overmap_buffer.is_in_city( omt_point ) ) ) {
-            GENERATOR_riot_damage( *this, omt_point );
+        if( any_missing || !save_results ) {
+            if( omt->has_flag(
+                    oter_flags::pp_generate_riot_damage ) || ( omt->has_flag( oter_flags::road ) &&
+                            overmap_buffer.is_in_city( omt_point ) ) ) {
+                GENERATOR_riot_damage( *this, omt_point );
+            }
         }
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Minor Riot Damage Tweaks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make adjustments to Riot Damage to fix a few issues:
The Riot Damage PP cannot be applied underground, even though there are structures where it would make sense to do so. Including a few Overmap terrains that were missed during the audit that attempted to remove all basements.

Riot Damage never applies to roads in cities even though it logically should.

Blood spawns outside long after the riots conclude. Even though it should have logically been washed away at that point.

Fire spawns aggressively throughout the city even long after the major fires should have died down.  And spawns on any tile it wants, regardless of whether it makes for it be there. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the safeguard against applying the PP underground.  Add a new flag for naturally occuring underground terrains that should be immune to the PP. Ensure the PP is not applied to properly flagged terrains. Subway stations are now included in the Riot Damage.

Riot Damage is now automatically applied to roads that are inside cities.

Outdoor blood spawning now scales down to 0 over the course of the first 30 days of the Cataclysm.

Fire spawn gradually scales down from 1 in 2,000 to 1 in 10,000 tiles over the first 14 days of the Catacylsm. After 3 days Fire will no longer spawn on non-flammable surfaces.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I really want to scale the intensity of the riots based on distance to the city center. But I am finding a bit challenging to pull that off. And this PR has already hit quite a few different things at once.

So I am inclined to leave that for another PR.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded a world 30 days after the Cataclysm. Noted blood no longer spawns outside. Noted reduction in fire placement. Confirmed PP working underground.

Loaded a world 14 days after the Cataclysm. Noted reduction blood spawns outside. Noted Reduction in fire placement. Confirmed blood spawning outside in city roads. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
