### PR TITLE
Fail IWYU CI job on IWYU error

### DIFF
--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -66,4 +66,5 @@ jobs:
 
         cd Cataclysm-DDA
         FILES_LIST=$( find src/ tests/ -maxdepth 1 -name '*.cpp' | grep -v -f tools/iwyu/bad_files.txt | sort )
-        python ${IWYU_SRC_DIR}/iwyu_tool.py ${FILES_LIST} -p build --output-format clang --jobs 4  -- -Xiwyu "--mapping_file=${PWD}/tools/iwyu/cata.imp" -Xiwyu --cxx17ns -Xiwyu --comment_style=long -Xiwyu --max_line_length=1000 
+        python ${IWYU_SRC_DIR}/iwyu_tool.py ${FILES_LIST} -p build --output-format clang --jobs 4  -- -Xiwyu "--mapping_file=${PWD}/tools/iwyu/cata.imp" -Xiwyu --cxx17ns -Xiwyu --comment_style=long -Xiwyu --max_line_length=1000 -Xiwyu --error=1
+

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -18,10 +18,13 @@
 #include "options_helpers.h"
 #include "pocket_type.h"
 #include "ret_val.h"
-#include "translation_manager.h"
-#include "translations.h"
 #include "type_id.h"
 #include "value_ptr.h"
+
+#if defined(LOCALIZE)
+#include "translation_manager.h"
+#include "translations.h"
+#endif
 
 static const fault_id fault_gun_dirt( "fault_gun_dirt" );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Followup to #79631 
Currently we have an IWYU job but it always succeeds ✔️ , due to an oversight.
This PR transforms a  ✔️  in the CI to :x: when IWYU errors are found.

#### Describe the solution

Use a dedicated flag introduced specifically for this use case
```
$ include-what-you-use --help
USAGE: include-what-you-use [-Xiwyu --iwyu_opt]... <clang opts> <source file>
Here are the <iwyu_opts> you can specify (e.g. -Xiwyu --verbose=3):
<...>
   --error[=N]: exit with N (default: 1) for iwyu violations
   --error_always[=N]: always exit with N (default: 1) (for use
        with 'make -k')
```

#### Describe alternatives you've considered

N/A

#### Testing

CI.

The initial commit in this PR should fail :x: because we have an actual* IWYU violation that I missed (failed, as expected, [link](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/13303983713/job/37150722423?pr=79648)).
The next commit should fix the error and pass ✔️  (passed, as expected, [link](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/13304642541/job/37152745565?pr=79648) )

*The violation is "actual" but conditional on  *`LOCALIZE=0`*. So the fix is to move the `#include`s into the `#if defined()` block


#### Additional context
