### PR TITLE
Adds large wicker baskets

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -600,6 +600,36 @@
     ]
   },
   {
+    "id": "wicker_basket_large",
+    "type": "ARMOR",
+    "name": { "str": "large wicker basket" },
+    "description": "A large handmade straw basket.  Unwieldy but spacious.",
+    "weight": "400 g",
+    "volume": "52500 ml",
+    "price": "2 USD",
+    "price_postapoc": "50 cent",
+    "material": [ "dry_plant" ],
+    "symbol": ")",
+    "looks_like": "straw_basket",
+    "color": "light_gray",
+    "armor": [
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 5, "encumbrance": [ 50, 50 ] },
+      { "covers": [ "hand_l", "hand_r" ], "coverage": 5, "encumbrance": [ 50, 50 ] }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "max_contains_volume": "50 L",
+        "max_contains_weight": "30 kg",
+        "max_item_length": "80 cm",
+        "moves": 300
+      }
+    ],
+    "material_thickness": 2,
+    "flags": [ "OVERSIZE", "RESTRICT_HANDS", "WATER_FRIENDLY", "BELTED" ]
+  },
+  {
     "id": "basket_laundry",
     "type": "ARMOR",
     "name": { "str": "laundry basket" },

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -1761,6 +1761,21 @@
     "proficiencies": [ { "proficiency": "prof_basketweaving" } ]
   },
   {
+    "result": "wicker_basket_large",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 2,
+    "time": "26 h",
+    "autolearn": true,
+    "reversible": true,
+    "components": [ [ [ "plant_cordage", 20, "LIST" ] ] ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "proficiencies": [ { "proficiency": "prof_basketweaving" } ]
+  },
+  {
     "result": "survivor_duffel_bag",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -4049,6 +4049,14 @@
     "flags": [ "BLIND_HARD" ]
   },
   {
+    "result": "wicker_basket_large",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "20 m",
+    "components": [ [ [ "withered", 12 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
     "result": "straw_doll",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds large wicker baskets"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds a craftable larger version of the straw basket that has the size and shape of a laundry basket.
This is especially useful in Innawood, where large storage containers are difficult to come by early game, and in Sky Island, where having large containers is important to help warp up as much stuff as possible. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds item, recipe, and deconstruction info for the large wicker basket.
It has 50 L volume capacity, same as a laundry basket. An old straw basket has a volume capacity of 10 L.
Assuming both are shaped as a half sphere, it has a surface area of 52 dm^2 compared to the straw basket with 18 dm^2.
The large wicker basket uses 0.76 withered plants per dm^2. The old straw basket uses 0.65
The large wicker basket weights 400 gram, or 7.7 gram per dm^2. The old straw basket weights 5.4 gram per dm^2.
The large wicker basket has a maximum weight capacity of 30 kg, compared to the straw baskets 3 and the laundry baskets 50.
It is meant to be slight denser and sturdier than the straw basket, but not as strong as a modern laundry basket.
It takes roughly the same amount of time to craft per component as the straw basket does, which ends up being 26 hours.
It requires tailoring 2, while the old straw basket only requires level 1.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Increased maximum weight capacity
- decreased maximum weight capacity
- Do more research on if there are problems that makes constructing large wicker baskets impractical or problematic in some way
- Disallow straws from being used in the recipe. Not sure how strong woven grass can be. But it's probably strong enough.
- Reduce the crafting time. It takes like 3 in-game days to craft when you factor in sleeping. A bit annoying from a gameplay perspective, but I think it's fair given the time straw baskets take to make, and when you really need something like this, it's definitely worth spending the time on.
- Place the uncraft data somewhere else. I put it next to the straw basket. But perhaps both should be moved to armor/storage?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I crafted one, wore it, and used it to gather a great deal of forage. I also tried deconstructing it, which worked.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![image](https://github.com/user-attachments/assets/c8e445b1-27a6-487b-a540-d79f2a0f61e7)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
