### PR TITLE
Fill the void left by the Giant Mole Rat's departure with a new nether monster

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -1038,6 +1038,7 @@
   {
     "id": "dweller",
     "type": "harvest",
+	"//": "the nether monster corpse teeth being here are not an oversight or a mistake - I want to imply that these things and that giant dead kaiju are somehow related",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.36 },
       { "drop": "mutant_blood", "type": "blood", "mass_ratio": 0.1 },

--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -1036,6 +1036,22 @@
     ]
   },
   {
+    "id": "dweller",
+    "type": "harvest",
+    "entries": [
+      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.36 },
+      { "drop": "mutant_blood", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "mutant_brain", "type": "flesh", "mass_ratio": 0.005 },
+      { "drop": "mutant_kidney", "type": "offal", "mass_ratio": 0.002 },
+      { "drop": "mutant_heart", "type": "offal", "mass_ratio": 0.01 },
+      { "drop": "stomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.02 },
+      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 },
+      { "drop": "nm_teeth", "scale_num": [ 6, 16 ], "max": 6, "type": "bone" }
+    ]
+  },
+  {
     "id": "animal_noskin",
     "//": "for those vertebrates that don't have something you can skin off of them",
     "type": "harvest",

--- a/data/json/monsters/kraken_spawn.json
+++ b/data/json/monsters/kraken_spawn.json
@@ -84,12 +84,7 @@
     "//grab": "Not getting much more grabby than a half-ton octopus",
     "grab_strength": 100,
     "special_attacks": [
-      {
-        "id": "grab_drag",
-        "cooldown": 12,
-        "grab_data": { "drag_distance": 5, "drag_deviation": 1, "drag_movecost_mod": 0.2 }
-      },
-      { "id": "drag_followup", "grab_data": { "drag_distance": 5, "drag_deviation": 1, "drag_movecost_mod": 0.2 } },
+      { "id": "grab_2" },
       { "id": "barbed_tentacle" },
       {
         "type": "bite",

--- a/data/json/monsters/kraken_spawn.json
+++ b/data/json/monsters/kraken_spawn.json
@@ -84,7 +84,12 @@
     "//grab": "Not getting much more grabby than a half-ton octopus",
     "grab_strength": 100,
     "special_attacks": [
-      { "id": "grab_2" },
+      {
+        "id": "grab_drag",
+        "cooldown": 12,
+        "grab_data": { "drag_distance": 5, "drag_deviation": 1, "drag_movecost_mod": 0.2 }
+      },
+      { "id": "drag_followup", "grab_data": { "drag_distance": 5, "drag_deviation": 1, "drag_movecost_mod": 0.2 } },
       { "id": "barbed_tentacle" },
       {
         "type": "bite",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -190,12 +190,7 @@
     "special_attacks": [
 	  [ "SHRIEK_ALERT", 10 ],
       [ "SHRIEK_STUN", 1 ],
-      {
-        "id": "grab_drag",
-        "cooldown": 12,
-        "grab_data": { "drag_distance": 3, "drag_deviation": 1, "drag_movecost_mod": 0.2 }
-      },
-      { "id": "drag_followup", "grab_data": { "drag_distance": 3, "drag_deviation": 1, "drag_movecost_mod": 0.2 } },
+      { "grab_2" },
       { "id": "barbed_tentacle" },
       {
         "type": "bite",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -181,6 +181,7 @@
     "symbol": "A",
     "color": "white",
     "attack_cost": 70,
+    "morale": 40,
     "regen_morale": true,
     "melee_skill": 5,
     "melee_dice_sides": 6,
@@ -204,7 +205,7 @@
         "min_mul": 0.8,
         "max_mul": 1.1,
         "infection_chance": 3,
-        "effects": [ { "chance": 5, "duration": 2, "permanent": true } ]
+        "effects": [ { "id": "tetanus", "chance": 5, "duration": 2, "permanent": true } ]
       }
     ],
     "flags": [ "PUSH_MON", "BORES", "CAN_DIG", "GOODHEARING", "HEARS", "KEENNOSE", "PATH_AVOID_DANGER_1", "SMELLS" ],

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -187,6 +187,8 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 13, "armor_penetration": 20 } ],
     "grab_strength": 100,
     "special_attacks": [
+	  [ "SHRIEK_ALERT", 10 ],
+      [ "SHRIEK_STUN", 1 ],
       {
         "id": "grab_drag",
         "cooldown": 12,

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -166,6 +166,57 @@
     "flags": [ "ACIDPROOF", "ACID_BLOOD", "IMMOBILE" ]
   },
   {
+    "id": "mon_dweller",
+    "type": "MONSTER",
+    "name": { "str": "dweller" },
+    "description": "A pale, eyeless subterranean monster that resembles an octopus. At the ends of its eight tentacles are serrated blades instead of suckers, which it uses to tunnel through stone like eight chainsaws.",
+    "default_faction": "nether",
+    "bodytype": "cow",
+    "species": [ "NETHER" ],
+    "volume": "380000 ml",
+    "weight": "250 kg",
+    "hp": 120,
+    "speed": 75,
+    "material": [ "flesh" ],
+    "symbol": "A",
+    "color": "white",
+    "attack_cost": 70,
+    "regen_morale": true,
+    "melee_skill": 5,
+    "melee_dice_sides": 6,
+    "melee_damage": [ { "damage_type": "cut", "amount": 13, "armor_penetration": 20 } ],
+    "grab_strength": 100,
+    "special_attacks": [
+      {
+        "id": "grab_drag",
+        "cooldown": 12,
+        "grab_data": { "drag_distance": 3, "drag_deviation": 1, "drag_movecost_mod": 0.2 }
+      },
+      { "id": "drag_followup", "grab_data": { "drag_distance": 3, "drag_deviation": 1, "drag_movecost_mod": 0.2 } },
+      { "id": "barbed_tentacle" },
+      {
+        "type": "bite",
+        "cooldown": 5,
+        "move_cost": 100,
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 20, "armor_penetration": 20 } ],
+        "min_mul": 0.8,
+        "max_mul": 1.1,
+        "infection_chance": 3,
+        "effects": [ { "chance": 5, "duration": 2, "permanent": true } ]
+      }
+    ],
+    "flags": [ "PUSH_MON", "BORES", "CAN_DIG", "GOODHEARING", "HEARS", "KEENNOSE", "PATH_AVOID_DANGER_1", "SMELLS" ],
+    "fear_triggers": [ "FIRE" ],
+    "anger_triggers": [ "HURT", "SOUND", "STALK" ],
+    "vision_day": 0,
+    "vision_night": 0,
+    "armor": { "bash": 9, "cut": 6, "stab": 6, "bullet": 2, "electric": 3 },
+    "aggression": -4,
+    "harvest": "kraken_large",
+    "dissect": "dissect_cephalopod_sample_large",
+    "zombify_into": "mon_meat_cocoon_large"
+  },
+  {
     "id": "mon_shrapnel_swarm",
     "type": "MONSTER",
     "name": { "str": "shrapnel swarm" },

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -175,7 +175,7 @@
     "species": [ "NETHER" ],
     "volume": "380000 ml",
     "weight": "250 kg",
-    "hp": 120,
+    "hp": 200,
     "speed": 75,
     "material": [ "flesh" ],
     "symbol": "A",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -190,7 +190,7 @@
     "special_attacks": [
 	  [ "SHRIEK_ALERT", 10 ],
       [ "SHRIEK_STUN", 1 ],
-      { "grab_2" },
+      { "id": "grab_2" },
       { "id": "barbed_tentacle" },
       {
         "type": "bite",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -208,7 +208,7 @@
         "effects": [ { "id": "tetanus", "chance": 5, "duration": 2, "permanent": true } ]
       }
     ],
-    "flags": [ "PUSH_MON", "BORES", "CAN_DIG", "GOODHEARING", "HEARS", "KEENNOSE", "PATH_AVOID_DANGER_1", "SMELLS" ],
+    "flags": [ "PUSH_MON", "BORES", "CAN_DIG", "GOODHEARING", "HEARS", "KEENNOSE", "SMELLS" ],
     "fear_triggers": [ "FIRE" ],
     "anger_triggers": [ "HURT", "SOUND", "STALK" ],
     "vision_day": 0,


### PR DESCRIPTION
#### Summary
Content "A new nether monster called the dweller, a blind and ravenous octopus that digs through solid rock."

#### Purpose of change

The Gigantic naked molerat was removed in #64960 alongside some other mutants that seemed to be either pop culture references or just nonsensical. That PR got a lot of frankly undeserved flak, but I can see why some people were against the molerat's removal - it's an interesting enemy with a unique gimmick. I remember my fair share of encounters with it blindly barreling through entire laboratories like crazy and scaring the shit out of me in random basements. I've decided to reintroduce that gimmick through this guy.

#### Describe the solution

The Dweller behaves mostly the same as the molerat did, with a couple differences. For one, since it's a fucking octopus, I'm giving it attacks from the Kraken enemy. These include lash attacks and a long range grab. I like how scarier this is compared to the boring molerat.

#### Describe alternatives you've considered

No octopus.

#### Testing

Haven't tested yet! I need to get it to spawn after I make sure it behaves normally.

#### Additional context

