### PR TITLE
[ Xedra Evolved ] Chronomancer XP redesign: Menus and effects

### DIFF
--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -10,7 +10,6 @@
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
           { "math": [ "_chronomancer_menu_difficulty = 3" ] },
-          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_bubble')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_bubble>",
             "target_var": { "context_val": "chronomancer_menu_choice_name" }
@@ -41,6 +40,7 @@
         "text": "Level [<spell_name:xedra_chronomancer_time_bubble>]",
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_bubble')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_bubble>",
             "target_var": { "context_val": "chronomancer_menu_choice_name" }
@@ -92,6 +92,37 @@
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
       },
       {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_entropic_burst') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_entropic_burst') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_entropic_burst>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_entropic_burst')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_entropic_burst')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_entropic_burst>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_entropic_burst>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_entropic_burst",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
+      },
+      {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_revert_wound') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_revert_wound>]",
         "effect": [
@@ -119,6 +150,37 @@
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
       },
       {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_revert_wound') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_revert_wound') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_revert_wound>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_revert_wound')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_revert_wound')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_revert_wound>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_revert_wound>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_revert_wound",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
+      },
+      {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_time_loop') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_time_loop>]",
         "effect": [
@@ -143,6 +205,37 @@
           { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
         ],
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
+      },
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_time_loop') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_time_loop') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_time_loop>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_loop')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_loop')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_time_loop>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_time_loop>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_time_loop",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
       },
       {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_time_stop') <= 0" ] },
@@ -172,6 +265,37 @@
           }
         ],
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
+      },
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_time_stop') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_time_stop') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_time_stop>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_stop')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_stop')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_time_stop>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_time_stop>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_time_stop",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
       },
       {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_revert_location') <= 0" ] },
@@ -208,6 +332,37 @@
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
       },
       {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_revert_location') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_revert_location') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_revert_location>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_revert_location')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_revert_location')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_revert_location>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_revert_location>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_revert_location",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
+      },
+      {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_cement_time') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_cement_time>]",
         "effect": [
@@ -242,6 +397,37 @@
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
       },
       {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_cement_time') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_cement_time') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_cement_time>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_cement_time')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_cement_time')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_cement_time>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_cement_time>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_revert_location",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
+      },
+      {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_chronal_acceleration') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_chronal_acceleration>]",
         "effect": [
@@ -266,6 +452,37 @@
           { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
         ],
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
+      },
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_chronal_acceleration') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_chronal_acceleration') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_chronal_acceleration>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_chronal_acceleration')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_chronal_acceleration')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_chronal_acceleration>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_chronal_acceleration>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_chronal_acceleration",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
       },
       {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_stable_loop') <= 0" ] },
@@ -297,6 +514,37 @@
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
       },
       {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_stable_loop') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_stable_loop') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_stable_loop>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_stable_loop')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_stable_loop')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_stable_loop>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_stable_loop>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_stable_loop",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
+      },
+      {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_destabilizing_strikes') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_destabilizing_strikes>]",
         "effect": [
@@ -321,6 +569,37 @@
           { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
         ],
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
+      },
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_destabilizing_strikes') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_destabilizing_strikes') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_destabilizing_strikes>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_destabilizing_strikes')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_destabilizing_strikes')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_destabilizing_strikes>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_destabilizing_strikes>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_destabilizing_strikes",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
       },
       {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_stabilize_timeline') <= 0" ] },

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -10,6 +10,7 @@
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
           { "math": [ "_chronomancer_menu_difficulty = 3" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_bubble')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_bubble>",
             "target_var": { "context_val": "chronomancer_menu_choice_name" }
@@ -66,6 +67,7 @@
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = 100" ] },
           { "math": [ "_chronomancer_menu_difficulty = 8" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_entropic_burst')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_entropic_burst>",
             "target_var": { "context_val": "chronomancer_menu_choice_name" }
@@ -95,6 +97,7 @@
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
           { "math": [ "_chronomancer_menu_difficulty = 4" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_revert_wound')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_revert_wound>",
             "target_var": { "context_val": "chronomancer_menu_choice_name" }
@@ -556,7 +559,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT",
-    "dynamic_line": "<context_val:chronomancer_menu_choice_name>: \"<context_val:chronomancer_menu_choice_description>\"\nSpell Difficulty:<context_val:chronomancer_menu_difficulty>\n<context_val:chronomancer_menu_requirement_description>.\n<context_val:chronomancer_menu_additional_details>",
+    "dynamic_line": "<context_val:chronomancer_menu_choice_name>: \"<context_val:chronomancer_menu_choice_description>\"\nSpell Level:<context_val:chronomancer_spell_level>\n<context_val:chronomancer_menu_requirement_description>.\n<context_val:chronomancer_menu_additional_details>",
     "responses": [
       {
         "text": "Level Power.",

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -31,7 +31,14 @@
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
       },
       {
-        "condition": { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') <= 1" ] },
+        "condition": {
+              "and": [
+                { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') > 0" ] },
+                { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') < xedra_chronomancer_level(1) " ] }
+              ]
+            }
+          }
+        ],
         "text": "Level [<spell_name:xedra_chronomancer_time_bubble>]",
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble')*5" ] },

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -628,6 +628,37 @@
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
       },
       {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_destabilizing_strikes') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_destabilizing_strikes') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_stabilize_timeline>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_stabilize_timeline')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_stabilize_timeline')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_stabilize_timeline>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_stabilize_timeline>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_stabilize_timeline",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
+      },
+      {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_reverse_entropy') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_reverse_entropy>]",
         "effect": [
@@ -652,6 +683,37 @@
           { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
         ],
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
+      },
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_reverse_entropy') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_reverse_entropy') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_reverse_entropy>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_reverse_entropy')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_reverse_entropy')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_reverse_entropy>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_reverse_entropy>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_reverse_entropy",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
       },
       {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_rewrite_wound_causality') <= 0" ] },
@@ -683,6 +745,37 @@
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
       },
       {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_rewrite_wound_causality') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_rewrite_wound_causality') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_rewrite_wound_causality>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_wound_causality')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_rewrite_wound_causality')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_rewrite_wound_causality>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_rewrite_wound_causality>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_rewrite_wound_causality",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
+      },
+      {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_rewrite_equipment_causality') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_rewrite_equipment_causality>]",
         "effect": [
@@ -710,6 +803,37 @@
           }
         ],
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
+      },
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_rewrite_equipment_causality') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_rewrite_equipment_causality') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
+        "text": "Level [<spell_name:xedra_chronomancer_rewrite_equipment_causality>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_equipment_causality')*5" ] },
+          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_rewrite_equipment_causality')" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_rewrite_equipment_causality>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_rewrite_equipment_causality>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_rewrite_equipment_causality",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
       },
       {
         "condition": { "math": [ "u_has_trait('XEDRA_CHRONOMANCER_LOOPING_WOUND')" ] },

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -32,11 +32,11 @@
       },
       {
         "condition": {
-              "and": [
-                { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') > 0" ] },
-                { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') < xedra_chronomancer_level(1) " ] }
-              ]
-            },
+          "and": [
+            { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') < xedra_chronomancer_level(1) " ] }
+          ]
+        },
         "text": "Level [<spell_name:xedra_chronomancer_time_bubble>]",
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble')*5" ] },

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -548,7 +548,7 @@
       { "text": "Quit.", "topic": "TALK_DONE" }
     ]
   },
-    {
+  {
     "type": "talk_topic",
     "id": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT",
     "dynamic_line": "<context_val:chronomancer_menu_choice_name>: \"<context_val:chronomancer_menu_choice_description>\"\nSpell Difficulty:<context_val:chronomancer_menu_difficulty>\n<context_val:chronomancer_menu_requirement_description>.\n<context_val:chronomancer_menu_additional_details>",

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -748,7 +748,9 @@
         "condition": {
           "and": [
             { "math": [ "u_spell_level('xedra_chronomancer_rewrite_wound_causality') > 0" ] },
-            { "math": [ "u_spell_level('xedra_chronomancer_rewrite_wound_causality') < xedra_chronomancer_level(1) " ] }
+            {
+              "math": [ "u_spell_level('xedra_chronomancer_rewrite_wound_causality') < xedra_chronomancer_level(1) " ]
+            }
           ]
         },
         "text": "Level [<spell_name:xedra_chronomancer_rewrite_wound_causality>]",
@@ -808,13 +810,17 @@
         "condition": {
           "and": [
             { "math": [ "u_spell_level('xedra_chronomancer_rewrite_equipment_causality') > 0" ] },
-            { "math": [ "u_spell_level('xedra_chronomancer_rewrite_equipment_causality') < xedra_chronomancer_level(1) " ] }
+            {
+              "math": [ "u_spell_level('xedra_chronomancer_rewrite_equipment_causality') < xedra_chronomancer_level(1) " ]
+            }
           ]
         },
         "text": "Level [<spell_name:xedra_chronomancer_rewrite_equipment_causality>]",
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_equipment_causality')*5" ] },
-          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_rewrite_equipment_causality')" ] },
+          {
+            "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_rewrite_equipment_causality')" ]
+          },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_rewrite_equipment_causality>",
             "target_var": { "context_val": "chronomancer_menu_choice_name" }

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -36,9 +36,7 @@
                 { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') > 0" ] },
                 { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') < xedra_chronomancer_level(1) " ] }
               ]
-            }
-          }
-        ],
+            },
         "text": "Level [<spell_name:xedra_chronomancer_time_bubble>]",
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble')*5" ] },

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -31,6 +31,31 @@
         "topic": "TALK_CHRONOMANCER_SPELL_MENU_SELECT"
       },
       {
+        "condition": { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') <= 1" ] },
+        "text": "Level [<spell_name:xedra_chronomancer_time_bubble>]",
+        "effect": [
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble')*5" ] },
+          {
+            "set_string_var": "<spell_name:xedra_chronomancer_time_bubble>",
+            "target_var": { "context_val": "chronomancer_menu_choice_name" }
+          },
+          {
+            "set_string_var": "<spell_description:xedra_chronomancer_time_bubble>",
+            "target_var": { "context_val": "chronomancer_menu_choice_description" }
+          },
+          {
+            "set_string_var": "xedra_chronomancer_time_bubble",
+            "target_var": { "context_val": "chronomancer_menu_choice_id" }
+          },
+          {
+            "set_string_var": "<u_val:chronomancer_menu_insight_cost> Insight",
+            "target_var": { "context_val": "chronomancer_menu_requirement_description" }
+          },
+          { "set_condition": "chronomancer_menu_spell_conditions", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT"
+      },
+      {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_entropic_burst') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_entropic_burst>]",
         "effect": [
@@ -513,6 +538,41 @@
           { "math": [ "u_spell_level(u_chronomancer_menu_learn_id) = 1" ] },
           { "math": [ "u_vitamin('xedra_chronomancer_insight') -= u_chronomancer_menu_insight_cost" ] },
           { "math": [ "u_xedra_chronomancer_insight_count=u_vitamin('xedra_chronomancer_insight')" ] }
+        ]
+      },
+      {
+        "text": "Go Back.",
+        "effect": [ { "set_string_var": "", "target_var": { "context_val": "chronomancer_menu_additional_details" } } ],
+        "topic": "TALK_CHRONOMANCER_INSIGHT_MENU_MAIN"
+      },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+    {
+    "type": "talk_topic",
+    "id": "TALK_CHRONOMANCER_SPELL_LEVEL_SELECT",
+    "dynamic_line": "<context_val:chronomancer_menu_choice_name>: \"<context_val:chronomancer_menu_choice_description>\"\nSpell Difficulty:<context_val:chronomancer_menu_difficulty>\n<context_val:chronomancer_menu_requirement_description>.\n<context_val:chronomancer_menu_additional_details>",
+    "responses": [
+      {
+        "text": "Level Power.",
+        "topic": "TALK_CHRONOMANCER_INSIGHT_MENU_MAIN",
+        "condition": {
+          "and": [
+            { "math": [ "u_vitamin('xedra_chronomancer_insight') >= u_chronomancer_menu_insight_cost" ] },
+            { "get_condition": "chronomancer_menu_spell_conditions" }
+          ]
+        },
+        "failure_explanation": "Requirements Not Met",
+        "failure_topic": "TALK_CHRONOMANCER_SPELL_MENU_FAIL",
+        "effect": [
+          {
+            "set_string_var": { "context_val": "chronomancer_menu_choice_id" },
+            "target_var": { "u_val": "chronomancer_menu_learn_id" }
+          },
+          { "math": [ "u_spell_level(u_chronomancer_menu_learn_id) += 1" ] },
+          { "math": [ "u_vitamin('xedra_chronomancer_insight') -= u_chronomancer_menu_insight_cost" ] },
+          { "math": [ "u_xedra_chronomancer_insight_count=u_vitamin('xedra_chronomancer_insight')" ] },
+          { "u_message": "You improve the spell!", "type": "good" }
         ]
       },
       {

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -2900,6 +2900,15 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_chronomancy_field",
+    "name": [ "Chronomancy Field" ],
+    "desc": [ "You have engaged some of your temporal abilities and any kills you make while this is active will grant you insight." ],
+    "remove_message": "Your awareness of the 4th dimension fades.",
+    "rating": "good",
+    "show_in_info": true
+  },
+  {
+    "type": "effect_type",
     "id": "effect_xedra_time_freeze",
     "name": [ "Frozen in Time" ],
     "desc": [ "You are completely frozen in time." ],

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -2905,6 +2905,7 @@
     "desc": [
       "You have engaged some of your temporal abilities and any kills you make while this is active will grant you insight."
     ],
+    "apply_message": "You gain an increased awareness of the 4th dimension and how it interacts with the universe.",
     "remove_message": "Your awareness of the 4th dimension fades.",
     "rating": "good",
     "show_in_info": true

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -2902,7 +2902,9 @@
     "type": "effect_type",
     "id": "effect_chronomancy_field",
     "name": [ "Chronomancy Field" ],
-    "desc": [ "You have engaged some of your temporal abilities and any kills you make while this is active will grant you insight." ],
+    "desc": [
+      "You have engaged some of your temporal abilities and any kills you make while this is active will grant you insight."
+    ],
     "remove_message": "Your awareness of the 4th dimension fades.",
     "rating": "good",
     "show_in_info": true

--- a/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
@@ -942,5 +942,20 @@
       },
       { "if": { "math": [ "v_temp_var == 0" ] }, "then": { "u_lose_effect": "bleed" } }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHRONOMANCY_FIELD",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition":
+        { "compare_string": [ "XEDRA_CHRONOMANCER", { "context_val": "school" } ] },
+    "effect": [
+      {
+        "u_add_effect": "effect_chronomancy_field",
+        "intensity": { "math": [ "_difficulty * 1.5" ] },
+        "duration": { "math": [ "_difficulty * 8" ] }
+      }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
@@ -81,8 +81,10 @@
     "eoc_type": "EVENT",
     "required_event": "character_kills_monster",
     "condition": { "u_has_effect": "effect_chronomancy_field" },
-    "effect": [ { "math": [ "u_vitamin('xedra_chronomancer_insight') += 1" ] },
-      { "u_message": "You gain a tiny amount of insight into the workings of time.", "type": "info" } ]
+    "effect": [
+      { "math": [ "u_vitamin('xedra_chronomancer_insight') += 1" ] },
+      { "u_message": "You gain a tiny amount of insight into the workings of time.", "type": "info" }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
@@ -950,8 +950,7 @@
     "id": "EOC_CHRONOMANCY_FIELD",
     "eoc_type": "EVENT",
     "required_event": "spellcasting_finish",
-    "condition":
-        { "compare_string": [ "XEDRA_CHRONOMANCER", { "context_val": "school" } ] },
+    "condition": { "compare_string": [ "XEDRA_CHRONOMANCER", { "context_val": "school" } ] },
     "effect": [
       {
         "u_add_effect": "effect_chronomancy_field",

--- a/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
@@ -71,9 +71,18 @@
       ]
     },
     "effect": [
-      { "math": [ "u_vitamin('xedra_chronomancer_insight') += 1" ] },
+      { "math": [ "u_vitamin('xedra_chronomancer_insight') += 5" ] },
       { "u_message": "You gain a small amount of insight into the workings of time.", "type": "info" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_on_kill_award_chrono_exp",
+    "eoc_type": "EVENT",
+    "required_event": "character_kills_monster",
+    "condition": { "u_has_effect": "effect_chronomancy_field" },
+    "effect": [ { "math": [ "u_vitamin('xedra_chronomancer_insight') += 1" ] },
+      { "u_message": "You gain a tiny amount of insight into the workings of time.", "type": "info" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/spells/chronomancer.json
+++ b/data/mods/Xedra_Evolved/spells/chronomancer.json
@@ -7,6 +7,31 @@
     "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level"
   },
   {
+    "id": "xedra_chronomancy_field",
+    "type": "SPELL",
+    "name": "Chronomancy Field",
+    "valid_targets": [ "self" ],
+    "description": "Makes it so chronomancers can gain insight from non-chronomantic monsters.  Having this spell is a bug.",
+    "teachable": false,
+    "effect": "attack",
+    "effect_str": "effect_chronomancy_field",
+    "spell_class": "XEDRA_CHRONOMANCER",
+    "skill": "deduction",
+    "flags": [ "NO_FAIL", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX", "IGNORE_WALLS", "NO_PROJECTILE" ],
+    "min_duration": {
+      "math": [
+        "( ( 600 + (u_spell_count('school': 'XEDRA_CHRONOMANCER') * 200) + (u_skill('deduction') * 400) ) )"
+      ]
+    },
+    "difficulty": 0,
+    "max_level": 1,
+    "shape": "blast",
+    "min_range": 0,
+    "max_range": 0,
+    "base_energy_cost": 0,
+    "base_casting_time": 0
+  },
+  {
     "id": "xedra_chronomancer_time_freeze_target",
     "type": "SPELL",
     "name": "Time Freeze",
@@ -21,6 +46,7 @@
     "max_level": { "math": [ "xedra_chronomancer_level(1)" ] },
     "effect": "attack",
     "effect_str": "effect_xedra_time_freeze",
+    "extra_effects": [ { "id": "xedra_chronomancy_field" } ],
     "shape": "blast",
     "min_range": { "math": [ "min( xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_time_freeze_target'), 2, 1 ), 80 )" ] },
     "max_range": 80,

--- a/data/mods/Xedra_Evolved/spells/chronomancer.json
+++ b/data/mods/Xedra_Evolved/spells/chronomancer.json
@@ -7,31 +7,6 @@
     "exp_for_level_formula_id": "xedra_chronomancer_formula_exp_for_level"
   },
   {
-    "id": "xedra_chronomancy_field",
-    "type": "SPELL",
-    "name": "Chronomancy Field",
-    "valid_targets": [ "self" ],
-    "description": "Makes it so chronomancers can gain insight from non-chronomantic monsters.  Having this spell is a bug.",
-    "teachable": false,
-    "effect": "attack",
-    "effect_str": "effect_chronomancy_field",
-    "spell_class": "XEDRA_CHRONOMANCER",
-    "skill": "deduction",
-    "flags": [ "NO_FAIL", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX", "IGNORE_WALLS", "NO_PROJECTILE" ],
-    "min_duration": {
-      "math": [
-        "( ( 600 + (u_spell_count('school': 'XEDRA_CHRONOMANCER') * 200) + (u_skill('deduction') * 400) ) )"
-      ]
-    },
-    "difficulty": 0,
-    "max_level": 1,
-    "shape": "blast",
-    "min_range": 0,
-    "max_range": 0,
-    "base_energy_cost": 0,
-    "base_casting_time": 0
-  },
-  {
     "id": "xedra_chronomancer_time_freeze_target",
     "type": "SPELL",
     "name": "Time Freeze",
@@ -46,7 +21,6 @@
     "max_level": { "math": [ "xedra_chronomancer_level(1)" ] },
     "effect": "attack",
     "effect_str": "effect_xedra_time_freeze",
-    "extra_effects": [ { "id": "xedra_chronomancy_field" } ],
     "shape": "blast",
     "min_range": { "math": [ "min( xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_time_freeze_target'), 2, 1 ), 80 )" ] },
     "max_range": 80,

--- a/data/mods/Xedra_Evolved/spells/chronomancer.json
+++ b/data/mods/Xedra_Evolved/spells/chronomancer.json
@@ -18,11 +18,7 @@
     "spell_class": "XEDRA_CHRONOMANCER",
     "skill": "deduction",
     "flags": [ "NO_FAIL", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX", "IGNORE_WALLS", "NO_PROJECTILE" ],
-    "min_duration": {
-      "math": [
-        "( ( 600 + (u_spell_count('school': 'XEDRA_CHRONOMANCER') * 200) + (u_skill('deduction') * 400) ) )"
-      ]
-    },
+    "min_duration": { "math": [ "( ( 600 + (u_spell_count('school': 'XEDRA_CHRONOMANCER') * 200) + (u_skill('deduction') * 400) ) )" ] },
     "difficulty": 0,
     "max_level": 1,
     "shape": "blast",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "XE Chronomancer Spell XP redesign"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Remove tedium of self casting spells to level them from Chronomancer.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add new menu and eoc's to drive leveling of spells using insight points.  Make all chronomancy spells also grant an effect on the PC that lasts a short while which makes it so any kills performed while under that effect also grant insight points.

Problems at current development.  ~~The effect isn't deploying on me when I cast  time freeze.~~ Solved.  ~~Menu issues.~~Solved ~~When the effect is on pc the insight count goes up in multiples of the number of actual kills,  Possibly caused by the way I debuged the effect onto the PC or possibly because some kind of intensity cap is needed.~~ Solved
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Menu shows both so I need to set the variables differently so it only shows one at a time. Learn or Level.
![menu working](https://github.com/user-attachments/assets/65db29cc-cf06-4db0-bc8f-732ba384fd7d)

In the picture below you can see where the level time bubble stops appearing once the spell has reached level 2
![menu stops working](https://github.com/user-attachments/assets/38f71a0f-15c3-4ed0-be5f-e1397cbe78f5)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
@b3brodie letting you see I've put this WIP so you can make any suggestions you think are appropriate.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
