### PR TITLE
Fix Chainsmoker Perk making accuracy worse instead of better.

### DIFF
--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -796,7 +796,7 @@
     "description": "Smoking is bad, but damn it's badass.  You deal more damage and shoot more accurately when you smoke.",
     "enchantments": [
       { "condition": { "u_has_effect": "cig" }, "values": [ { "value": "MELEE_DAMAGE", "multiply": 0.25 } ] },
-      { "condition": { "u_has_effect": "cig" }, "values": [ { "value": "WEAPON_DISPERSION", "multiply": 0.25 } ] }
+      { "condition": { "u_has_effect": "cig" }, "values": [ { "value": "WEAPON_DISPERSION", "multiply": -0.25 } ] }
     ]
   },
   {


### PR DESCRIPTION
#### Summary

Bugfixes "Fix Chainsmoker having wrong effect on accuracy."

#### Purpose of change

Chainsmoker made your character more innacurate with ranged weapons when under the affects of nicotine, the opposite of what it said it did.

#### Describe the solution

Add a negative symbol.

#### Describe alternatives you've considered

Adding a flat negative dispersion instead of multiplying.

#### Testing

Looked at aim values with and without the perk while having the nicotine effect. Made sure they were better instead of worse.

#### Additional context

One character change first Pull wow.