### PR TITLE
Remove skill rust resist from "Flawless memory" perk

### DIFF
--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1131,9 +1131,8 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "You cannot forget anything at all, ever.  This makes your skills rustproof, grant you the ability to memorize books for you to read in your head later and make you able to store mental images so detailled it's almost as if you were taking pictures with your mind.",
+    "description": "You cannot forget anything at all, ever.  This grants you the ability to memorize books for you to read in your head later and makes you able to store mental images so detailled it's almost as if you were taking pictures with your mind.",
     "category": [ "perk" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SKILL_RUST_RESIST", "add": 100 } ] } ],
     "integrated_armor": [ "integrated_memory" ]
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "Flawless memory perk is no longer a debuff"

#### Purpose of change
For some reason this perk debuffs the player in exchange for... a smartphone knockoff in their head? That isn't remotely useful or desirable.

#### Describe the solution
Remove the noob trap. Stop throwing away bonus exp. Bonus exp is good.

The perk remains, but only functions as the smartphone in your head. It's still not useful, but at least it doesn't debuff you. If you really want to take the perk, you can! Without the downsides.

#### Describe alternatives you've considered
Adding a negative rust multiplier, i.e. giving more rust. Doesn't actually work that well, since the maximum rust you can accumulate is **very** heavily capped.

#### Testing
I actually tested this on an earlier branch when I was doing some shenanigans to manually test skill rust's effects. Removing the 'resist' does exactly what you'd expect, and allows skill rust to occur again.

#### Additional context

