### PR TITLE
Only run IWYU on affected files + minor `get_affected_files.py` refactor

### DIFF
--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -25,7 +25,6 @@ jobs:
         COMPILER: clang++-19
     steps:
     - name: install LLVM 19
-      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: |
           sudo apt install llvm-19 llvm-19-dev llvm-19-tools clang-19 clang-tidy-19 clang-tools-19 libclang-19-dev
           sudo apt install python3-pip ninja-build cmake
@@ -57,14 +56,42 @@ jobs:
             -DSOUND=${SOUND:-0} \
             -DLOCALIZE=${LOCALIZE:-0} \
             Cataclysm-DDA
+    - name: determine changed files
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          var fs = require('fs');
+          const response = await github.paginate(github.rest.pulls.listFiles,
+            {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            }
+          );
+          const files = response.map(x => x.filename);
+          for (const path of files) {
+            console.log(path);
+          }
+          fs.writeFileSync("Cataclysm-DDA/files_changed", files.join('\n') + '\n');
     - name: run the thing
       env:
         IWYU_SRC_DIR: ${{ steps.build-iwyu.outputs.IWYU_SRC_DIR }}
         IWYU_BIN_DIR: ${{ steps.build-iwyu.outputs.IWYU_BIN_DIR }}
       run: |
         PATH="${PATH}:${IWYU_BIN_DIR}"
-
         cd Cataclysm-DDA
-        FILES_LIST=$( find src/ tests/ -maxdepth 1 -name '*.cpp' | grep -v -f tools/iwyu/bad_files.txt | sort )
+
+        CHECK_ALL=no
+        if [[ -f ./files_changed ]]; then
+            CHECK_ALL=$( cat ./files_changed | grep -E -i 'tools/iwyu|github/iwyu.yml|CMakeLists.txt|build-scripts/get_affected_files.py' && echo yes || echo no )
+        fi
+        if [[ "${CHECK_ALL}" = "no" ]] && [[ -f ./files_changed ]]; then
+            FILES_LIST=$( python3 build-scripts/get_affected_files.py --changed-files-list ./files_changed )
+        else
+            FILES_LIST=$( find src/ tests/ -maxdepth 1 -name '*.cpp' | sort )
+        fi
+        FILES_LIST=$( printf "%s\n" ${FILES_LIST[@]} | grep -v -f tools/iwyu/bad_files.txt )
+
         python ${IWYU_SRC_DIR}/iwyu_tool.py ${FILES_LIST} -p build --output-format clang --jobs 4  -- -Xiwyu "--mapping_file=${PWD}/tools/iwyu/cata.imp" -Xiwyu --cxx17ns -Xiwyu --comment_style=long -Xiwyu --max_line_length=1000 -Xiwyu --error=1
 

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -46,16 +46,6 @@ jobs:
         echo "IWYU_SRC_DIR=${PWD}/include-what-you-use-src">> "$GITHUB_OUTPUT"
         echo "IWYU_BIN_DIR=${PWD}/iwyu-build/bin">> "$GITHUB_OUTPUT"
     - uses: ammaraskar/gcc-problem-matcher@master
-    - name: create CDDA compilation database
-      run: |
-        cmake -B Cataclysm-DDA/build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DCMAKE_CXX_COMPILER=$COMPILER \
-            -DCMAKE_BUILD_TYPE="Release" \
-            -DTILES=${TILES:-0} \
-            -DSOUND=${SOUND:-0} \
-            -DLOCALIZE=${LOCALIZE:-0} \
-            Cataclysm-DDA
     - name: determine changed files
       if: ${{ github.event_name == 'pull_request' }}
       uses: actions/github-script@v7
@@ -74,6 +64,19 @@ jobs:
             console.log(path);
           }
           fs.writeFileSync("Cataclysm-DDA/files_changed", files.join('\n') + '\n');
+    - name: create CDDA compilation database
+      run: |
+        cd Cataclysm-DDA
+        cmake -B build \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_CXX_COMPILER=$COMPILER \
+            -DCMAKE_BUILD_TYPE="Release" \
+            -DTILES=${TILES:-0} \
+            -DSOUND=${SOUND:-0} \
+            -DLOCALIZE=${LOCALIZE:-0} \
+            .
+        # and include database too, for get_affected_files.py
+        make includes -j4 --silent TILES=${TILES:-0} SOUND=${SOUND:-0} LOCALIZE=${LOCALIZE:-0}
     - name: run the thing
       env:
         IWYU_SRC_DIR: ${{ steps.build-iwyu.outputs.IWYU_SRC_DIR }}

--- a/build-scripts/clang-tidy-run.sh
+++ b/build-scripts/clang-tidy-run.sh
@@ -75,7 +75,7 @@ else
         includes
 
     tidyable_cpp_files="$( \
-        ( test -f ./files_changed && ( build-scripts/get_affected_files.py ./files_changed ) ) || \
+        ( test -f ./files_changed && ( build-scripts/get_affected_files.py --changed-files-list ./files_changed ) ) || \
         echo unknown )"
 
     tidyable_cpp_files="$(echo -n "$tidyable_cpp_files" | grep -v third-party || true)"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Makes IWYU only analyze the files that were [transitively] affected by the changes in the PR, and not the entire codebase.
Thus, reducing the check run time, and reducing the feedback latency (and using fewer Github resources overall)

#### Describe the solution

Reuse the `get_affected_files.py` machinery that we already have for clang-tidy.

I also changed `get_affected_files.py` script so that
1) it presents the file directly changed first
2) it can determine the list of changed files itself if not explicitly specified (will not work in CI since the repo is cloned there with `--depth=0`, but might be handy for local dev? question mark?)
3) the list of changed files is now passed via `--changed-files-list` and not as a raw positional argument

#### Describe alternatives you've considered
- Not touching `get_affected_files.py` because it's technically not neccessary
- Touching `get_affected_files.py` more and propagating the (clang-tidy's) `directly-changed`/`indirectly-changed-src`/`indirectly-changed-other` arguments into it instead of handling the partitioning in bash. (Because bash is very error-prone, at least in my hands). I decide that this is a bit too out-of-scope, and left it for later.

#### Testing
Manual, and spotty. 

Made a fake `files_changed`, populated it with a small handful of file paths, run the `FILES_LIST` portion of the workflow, seemed to work fine.
`get_affected_files.py` seems to work fine both with `--changed-files-list` and without.

CI seems to work here, but it can still break in 1) PRs that don't touch "global" files 2) push to master that doesn't have `files_changed`.  It *shouldn't* break (I checked), but you never know with changes like these.

#### Additional context
Feedback and nitpicks welcome.