### PR TITLE
Remove recursision from weapon_talk_hallucination

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -95,15 +95,6 @@
         "if": "u_has_weapon",
         "then": { "u_run_inv_eocs": "all", "search_data": [ { "wielded_only": true } ], "true_eocs": [ "item_talks_to_you" ] },
         "else": { "run_eocs": "minor_hallucinations" }
-      },
-      {
-        "run_eocs": {
-          "id": "determine_if_coversation",
-          "//": "85% chance for your weapon to make a conversation.  If not, try again some time later.",
-          "condition": { "x_in_y_chance": { "x": 85, "y": 100 } },
-          "effect": { "run_eocs": "weapon_talk_hallucination", "time_in_future": [ "10 seconds", "15 seconds" ] },
-          "false_effect": { "run_eocs": "weapon_talk_hallucination", "time_in_future": [ "4 hours", "6 hours" ] }
-        }
       }
     ],
     "false_effect": { "run_eocs": "minor_hallucinations" }


### PR DESCRIPTION
#### Summary
Bugfixes "Remove recursision from weapon_talk_hallucination"

#### Purpose of change
fix #76670, fix #79657, partially #79653
when #69919 JSONify'd  hallucinations, they ran `weapon_talk_hallucination`  withing `weapon_talk_hallucination`, resulting an persistent EOC. 
But new instances of `weapon_talk_hallucination` were also called from `minor_hallucinations`, so you would end up with an ever-growing queue of eoc's, which is especially annoying when having a base near the refugee center since dino dave has Kaluptic Psychosis.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove recursive calls.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Somehow check for uniqueness of the EOC?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
saves with many instances slowly lose them.
You can still get weapon_talk_hallucination events.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
from #79657 save
<details><summary>before</summary>
<p>

![image](https://github.com/user-attachments/assets/79b24f03-8f5f-417a-b921-f70f72bb725f)
![image](https://github.com/user-attachments/assets/79e24d1d-0532-4de1-8713-f7b46c38cc7c)


</p>
</details> 


<details><summary>after:</summary>
<p>

![image](https://github.com/user-attachments/assets/409d5bd7-494f-4fb6-9c26-bd87be266c47)
![image](https://github.com/user-attachments/assets/8009a592-b69d-4bf8-8e22-570c9a463073)


</p>
</details> 

![image](https://github.com/user-attachments/assets/19b58b2f-dcf3-4895-bb0d-be647bf5eb52)

This should generally improve performance in the refugee center if you have visited it often. 
I have no idea what the original author intended with it. Why have the weapon talk to you  in a short time sometimes and after a long time other times?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
