### PR TITLE
add walls to standard_domestic_abandoned_palette

### DIFF
--- a/data/json/mapgen_palettes/house_general_abandoned.json
+++ b/data/json/mapgen_palettes/house_general_abandoned.json
@@ -49,6 +49,7 @@
         }
       }
     },
+    "palettes": [ "parametrized_walls_palette" ],
     "toilets": { "t": {  } },
     "furniture": {
       "a": "f_fireplace",


### PR DESCRIPTION
#### Summary
Bugfixes "add walls to standard_domestic_abandoned_palette"

#### Purpose of change

fix #79685
When doghouses rolled pallette_choice `standard_domestic_abandoned_palette`, they spawned without walls (bottom left):
![Image](https://github.com/user-attachments/assets/3b6f33c8-0b94-473e-b4ce-3de2e40cef68)
![Image](https://github.com/user-attachments/assets/f4d6e90c-6b10-45f2-8ace-efb02eb1d3bf)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
add `"palettes": [ "parametrized_walls_palette" ],` to it
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://github.com/user-attachments/assets/66fafde3-9a86-439e-afc8-2afaeb952e36)
![image](https://github.com/user-attachments/assets/7ed6a50f-9df1-45c3-aac9-9c7722b4557f)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Im not sure if its the correct solution, I just looked what the difference between the damaged and normal palette is. But it works, so whatever.

there is also a bug where sometimes the ground itself is missing where fences should be:
![image](https://github.com/user-attachments/assets/28fab20a-7c57-47ee-b47f-0c4fe809637b)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
