### PR TITLE
also mark 'child' recipes when marking nested recipes as read

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2036,17 +2036,13 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         } else if( action == "TOGGLE_RECIPE_UNREAD" && selection_ok( current, line, true ) ) {
             const recipe_id rcp = current[line]->ident();
             if( uistate.read_recipes.count( rcp ) ) {
-                if( rcp->is_nested() ) {
-                    for( const recipe_id nested_rcp : rcp->nested_category_data ) {
-                        uistate.read_recipes.erase( nested_rcp );
-                    }
+                for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                    uistate.read_recipes.erase( nested_rcp );
                 }
                 uistate.read_recipes.erase( rcp );
             } else {
-                if( rcp->is_nested() ) {
-                    for( const recipe_id nested_rcp : rcp->nested_category_data ) {
-                        uistate.read_recipes.insert( nested_rcp );
-                    }
+                for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                    uistate.read_recipes.insert( nested_rcp );
                 }
                 uistate.read_recipes.insert( rcp );
             }
@@ -2055,12 +2051,10 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         } else if( action == "MARK_ALL_RECIPES_READ" ) {
             bool current_list_has_unread = false;
             for( const recipe *const rcp : current ) {
-                if( rcp->is_nested() ) {
-                    for( const recipe_id nested_rcp : rcp->nested_category_data ) {
-                        if( !uistate.read_recipes.count( nested_rcp->ident() ) ) {
-                            current_list_has_unread = true;
-                            break;
-                        }
+                for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                    if( !uistate.read_recipes.count( nested_rcp->ident() ) ) {
+                        current_list_has_unread = true;
+                        break;
                     }
                     if( current_list_has_unread ) {
                         break;
@@ -2088,19 +2082,15 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             if( query_yn( query_str ) ) {
                 if( current_list_has_unread ) {
                     for( const recipe *const rcp : current ) {
-                        if( rcp->is_nested() ) {
-                            for( const recipe_id nested_rcp : rcp->nested_category_data ) {
-                                uistate.read_recipes.insert( nested_rcp->ident() );
-                            }
+                        for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                            uistate.read_recipes.insert( nested_rcp->ident() );
                         }
                         uistate.read_recipes.insert( rcp->ident() );
                     }
                 } else {
                     for( const recipe *const rcp : available_recipes ) {
-                        if( rcp->is_nested() ) {
-                            for( const recipe_id nested_rcp : rcp->nested_category_data ) {
-                                uistate.read_recipes.insert( nested_rcp->ident() );
-                            }
+                        for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                            uistate.read_recipes.insert( nested_rcp->ident() );
                         }
                         uistate.read_recipes.insert( rcp->ident() );
                     }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2036,8 +2036,18 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         } else if( action == "TOGGLE_RECIPE_UNREAD" && selection_ok( current, line, true ) ) {
             const recipe_id rcp = current[line]->ident();
             if( uistate.read_recipes.count( rcp ) ) {
+                if( rcp->is_nested() ) {
+                    for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                        uistate.read_recipes.erase( nested_rcp );
+                    }
+                }
                 uistate.read_recipes.erase( rcp );
             } else {
+                if( rcp->is_nested() ) {
+                    for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                        uistate.read_recipes.insert( nested_rcp );
+                    }
+                }
                 uistate.read_recipes.insert( rcp );
             }
             recalc_unread = highlight_unread_recipes;
@@ -2045,6 +2055,17 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         } else if( action == "MARK_ALL_RECIPES_READ" ) {
             bool current_list_has_unread = false;
             for( const recipe *const rcp : current ) {
+                if( rcp->is_nested() ) {
+                    for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                        if( !uistate.read_recipes.count( nested_rcp->ident() ) ) {
+                            current_list_has_unread = true;
+                            break;
+                        }
+                    }
+                    if( current_list_has_unread ) {
+                        break;
+                    }
+                }
                 if( !uistate.read_recipes.count( rcp->ident() ) ) {
                     current_list_has_unread = true;
                     break;
@@ -2067,10 +2088,20 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             if( query_yn( query_str ) ) {
                 if( current_list_has_unread ) {
                     for( const recipe *const rcp : current ) {
+                        if( rcp->is_nested() ) {
+                            for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                                uistate.read_recipes.insert( nested_rcp->ident() );
+                            }
+                        }
                         uistate.read_recipes.insert( rcp->ident() );
                     }
                 } else {
                     for( const recipe *const rcp : available_recipes ) {
+                        if( rcp->is_nested() ) {
+                            for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                                uistate.read_recipes.insert( nested_rcp->ident() );
+                            }
+                        }
                         uistate.read_recipes.insert( rcp->ident() );
                     }
                 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
fix #73947
When marking a nested recipe as read, it did not mark recipes that belonged to it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a bunch of 
```cpp
for( const recipe_id nested_rcp : rcp->nested_category_data ) {
       // do stuff
}
```
rcp->nested_category_data is empty for non-nested recipes.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Somehow always marking a nested recipe as not read if any of its members are not read or marking members as read when the parent is read, but that would mean that newly learned recipes would not be unread which would go against its purpose. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

https://github.com/user-attachments/assets/a3c3184f-28c6-4f3a-a710-ce5187812e3d

(same for mark all)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
